### PR TITLE
[BugFix]Fix the issue of DCP and DP services getting stuck

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -131,7 +131,7 @@ class AccuracyCase:
 
 
 def _run_accuracy_case(case: AccuracyCase) -> None:
-    runner_cls = DPVllmRunner if case.runner_kwargs.get("data_parallel_size", 1) > 2 else VllmRunner
+    runner_cls = DPVllmRunner if case.runner_kwargs.get("data_parallel_size", 1) > 1 else VllmRunner
     with runner_cls(case.model, **case.runner_kwargs) as runner:
         outputs = runner.generate_greedy(list(case.prompts), case.max_tokens)
 

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -30,7 +30,7 @@ import pytest
 from PIL import Image
 from vllm import SamplingParams
 
-from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.conftest import DPVllmRunner, VllmRunner, wait_until_npu_memory_free
 
 DEEPSEEK_V2_LITE = "vllm-ascend/DeepSeek-V2-Lite-W8A8"
 DEEPSEEK_MTP = "wemaster/deepseek_mtp_main_random_bf16"
@@ -131,7 +131,8 @@ class AccuracyCase:
 
 
 def _run_accuracy_case(case: AccuracyCase) -> None:
-    with VllmRunner(case.model, **case.runner_kwargs) as runner:
+    runner_cls = DPVllmRunner if case.runner_kwargs.get("data_parallel_size", 1) > 2 else VllmRunner
+    with runner_cls(case.model, **case.runner_kwargs) as runner:
         outputs = runner.generate_greedy(list(case.prompts), case.max_tokens)
 
     if isinstance(case.expected_outputs[0], str):

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -282,6 +282,7 @@ DSV2_PARALLEL_CASES = [
         max_tokens=10,
         runner_kwargs={
             **DSV2_COMMON_KWARGS,
+            "data_parallel_size": 2,
             "tensor_parallel_size": 2,
             "prefill_context_parallel_size": 1,
             "decode_context_parallel_size": 2,

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -283,7 +283,6 @@ DSV2_PARALLEL_CASES = [
         max_tokens=10,
         runner_kwargs={
             **DSV2_COMMON_KWARGS,
-            "data_parallel_size": 2,
             "tensor_parallel_size": 2,
             "prefill_context_parallel_size": 1,
             "decode_context_parallel_size": 2,
@@ -383,6 +382,7 @@ FULL_FEATURE_MODEL_CASES = [
             "max_model_len": 1024,
             "max_num_seqs": MAX_NUM_SEQS,
             "max_num_batched_tokens": 1024,
+            "data_parallel_size": 2,
             "tensor_parallel_size": 2,
             "prefill_context_parallel_size": 1,
             "decode_context_parallel_size": 2,

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -3922,7 +3922,7 @@ class TestEagleProposerSetInputsFirstPass:
                 long_seq_args=(expected_query_lens_d, expected_ori_token_indices_to_sample),
             )
 
-        pcp_manager.prepare_spec_decode_first_pass_inputs.side_effect = prepare_first_pass_inputs
+        pcp_manager.prepare_spec_mtp_drafting_inputs.side_effect = prepare_first_pass_inputs
 
         out_num_tokens, out_token_indices, out_cad, (query_lens_d, ori_token_indices_to_sample) = (
             proposer.set_inputs_first_pass(
@@ -3943,7 +3943,7 @@ class TestEagleProposerSetInputsFirstPass:
         # assert function computed outputs
         assert out_num_tokens == 9
         assert torch.equal(out_token_indices, expected_token_indices)
-        pcp_manager.prepare_spec_decode_first_pass_inputs.assert_called_once()
+        pcp_manager.prepare_spec_mtp_drafting_inputs.assert_called_once()
 
         # assert query_lens_d and ori_token_indices_to_sample
         assert torch.equal(query_lens_d, expected_query_lens_d)

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -3922,7 +3922,7 @@ class TestEagleProposerSetInputsFirstPass:
                 long_seq_args=(expected_query_lens_d, expected_ori_token_indices_to_sample),
             )
 
-        pcp_manager.prepare_spec_mtp_drafting_inputs.side_effect = prepare_first_pass_inputs
+        pcp_manager.prepare_spec_decode_first_pass_inputs.side_effect = prepare_first_pass_inputs
 
         out_num_tokens, out_token_indices, out_cad, (query_lens_d, ori_token_indices_to_sample) = (
             proposer.set_inputs_first_pass(
@@ -3943,7 +3943,7 @@ class TestEagleProposerSetInputsFirstPass:
         # assert function computed outputs
         assert out_num_tokens == 9
         assert torch.equal(out_token_indices, expected_token_indices)
-        pcp_manager.prepare_spec_mtp_drafting_inputs.assert_called_once()
+        pcp_manager.prepare_spec_decode_first_pass_inputs.assert_called_once()
 
         # assert query_lens_d and ori_token_indices_to_sample
         assert torch.equal(query_lens_d, expected_query_lens_d)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1181,7 +1181,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # [batch_size, 1]
             return draft_token_ids.view(-1, self.num_speculative_tokens)
 
-        if self.pcp_size * self.dcp_size > 1 and is_prefill:
+        if self.pcp_size > 1 and is_prefill:
             draft_token_ids_list = []
             for _ in range(self.num_speculative_tokens):
                 draft_token_ids_list.append(draft_token_ids)
@@ -1364,7 +1364,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             pcp_manager = getattr(self.runner, "pcp_manager", None)
             long_seq_args = None
             if pcp_manager is not None:
-                first_pass_inputs = pcp_manager.prepare_spec_decode_first_pass_inputs(
+                first_pass_inputs = pcp_manager.prepare_spec_mtp_drafting_inputs(
                     input_ids=self.input_ids[:num_tokens],
                     target_positions=target_positions,
                     target_hidden_states=target_hidden_states,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1364,7 +1364,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             pcp_manager = getattr(self.runner, "pcp_manager", None)
             long_seq_args = None
             if pcp_manager is not None:
-                first_pass_inputs = pcp_manager.prepare_spec_mtp_drafting_inputs(
+                first_pass_inputs = pcp_manager.prepare_spec_decode_first_pass_inputs(
                     input_ids=self.input_ids[:num_tokens],
                     target_positions=target_positions,
                     target_hidden_states=target_hidden_states,

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1352,7 +1352,7 @@ class PCPManager:
         slot_indices = (slot_idx_base[:, None] + self.pcp_rank_offsets[: self.pcp_world_size]).reshape(-1)
         return slot_indices, self.mtp_slot_pad
 
-    def prepare_spec_decode_first_pass_inputs(
+    def prepare_spec_decode_mtp_drafting_inputs(
         self,
         common_attn_metadata: Any,
         attn_metadata: Any,

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1364,11 +1364,7 @@ class PCPManager:
     ) -> PCPSpecDecodeMTPInputs | None:
         """Prepare CP MTP metadata for decode and DCP-prefill batches."""
         is_decode_only_batch = num_decode_reqs > 0 and not is_prefill_batch
-        is_dcp_prefill_batch = (
-            self.pcp_world_size == 1
-            and self.dcp_world_size > 1
-            and is_prefill_batch
-        )
+        is_dcp_prefill_batch = self.pcp_world_size == 1 and self.dcp_world_size > 1 and is_prefill_batch
         if num_speculative_tokens <= 1 or not (is_decode_only_batch or is_dcp_prefill_batch):
             return None
 
@@ -1708,11 +1704,7 @@ class PCPManager:
             self.async_rebuild_num_tokens_full = total_num_scheduled_tokens
 
         # For mtpx, pre-allocate mtp slot_mapping here
-        needs_dcp_prefill_slots = (
-            self.pcp_world_size == 1
-            and self.dcp_world_size > 1
-            and with_prefill
-        )
+        needs_dcp_prefill_slots = self.pcp_world_size == 1 and self.dcp_world_size > 1 and with_prefill
         if self.decode_threshold > 2 and (not with_prefill or needs_dcp_prefill_slots):
             num_tokens_ori = sum(list(num_scheduled_tokens.values()))
             num_tokens_mtp = num_tokens_ori + self.num_reqs * (self.decode_threshold - 2)

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1330,29 +1330,29 @@ class PCPManager:
         cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
         return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
 
-    def _get_spec_mtp_slot_inputs(
+    def _get_spec_decode_mtp_slot_inputs(
         self,
         ori_token_indices_to_sample: torch.Tensor,
-        num_mtp_reqs: int,
+        num_reqs: int,
         num_speculative_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Build device-side CP slot indices for MTP draft requests."""
         assert self.mtp_slot_pad is not None
-        query_start_loc = self.query_start_loc_pcp_full.gpu[: num_mtp_reqs + 1]
-        req_starts = query_start_loc[:num_mtp_reqs].to(torch.int64)
-        cu_num_tokens = query_start_loc[1 : num_mtp_reqs + 1].to(torch.int64)
+        query_start_loc = self.query_start_loc_pcp_full.gpu[: num_reqs + 1]
+        req_starts = query_start_loc[:num_reqs].to(torch.int64)
+        cu_num_tokens = query_start_loc[1 : num_reqs + 1].to(torch.int64)
         query_lens = cu_num_tokens - req_starts
         num_reject_tokens = cu_num_tokens - ori_token_indices_to_sample.to(torch.int64) - 1
         num_accept_tokens = query_lens - num_reject_tokens
         slot_idx_base = (
             req_starts * self.pcp_world_size
-            + self.pcp_req_offsets[:num_mtp_reqs] * (num_speculative_tokens - 1) * self.pcp_world_size
+            + self.pcp_req_offsets[:num_reqs] * (num_speculative_tokens - 1) * self.pcp_world_size
             + (num_accept_tokens - 1) * self.pcp_world_size
         )
         slot_indices = (slot_idx_base[:, None] + self.pcp_rank_offsets[: self.pcp_world_size]).reshape(-1)
         return slot_indices, self.mtp_slot_pad
 
-    def prepare_spec_mtp_drafting_inputs(
+    def prepare_spec_decode_first_pass_inputs(
         self,
         common_attn_metadata: Any,
         attn_metadata: Any,
@@ -1373,10 +1373,10 @@ class PCPManager:
             return None
 
         assert ori_token_indices_to_sample is not None
-        num_mtp_reqs = batch_size if is_dcp_prefill_batch else num_decode_reqs
-        slot_indices, slot_mapping = self._get_spec_mtp_slot_inputs(
+        num_reqs = batch_size if is_dcp_prefill_batch else num_decode_reqs
+        slot_indices, slot_mapping = self._get_spec_decode_mtp_slot_inputs(
             ori_token_indices_to_sample,
-            num_mtp_reqs,
+            num_reqs,
             num_speculative_tokens,
         )
 

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -1330,29 +1330,29 @@ class PCPManager:
         cu_num_tokens = torch.tensor(np.insert(np.cumsum(np.array(num_pcp_scheduled_tokens)), 0, 0))
         return num_tokens, input_ids, target_hidden_states, max_query_len, seq_lens, cu_num_tokens
 
-    def _get_spec_decode_mtp_slot_inputs(
+    def _get_spec_mtp_slot_inputs(
         self,
         ori_token_indices_to_sample: torch.Tensor,
-        num_decode_reqs: int,
+        num_mtp_reqs: int,
         num_speculative_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build device-side PCP slot indices for decode-only MTP draft steps."""
+        """Build device-side CP slot indices for MTP draft requests."""
         assert self.mtp_slot_pad is not None
-        query_start_loc = self.query_start_loc_pcp_full.gpu[: num_decode_reqs + 1]
-        decode_req_starts = query_start_loc[:num_decode_reqs].to(torch.int64)
-        cu_num_tokens = query_start_loc[1 : num_decode_reqs + 1].to(torch.int64)
-        query_lens = cu_num_tokens - decode_req_starts
+        query_start_loc = self.query_start_loc_pcp_full.gpu[: num_mtp_reqs + 1]
+        req_starts = query_start_loc[:num_mtp_reqs].to(torch.int64)
+        cu_num_tokens = query_start_loc[1 : num_mtp_reqs + 1].to(torch.int64)
+        query_lens = cu_num_tokens - req_starts
         num_reject_tokens = cu_num_tokens - ori_token_indices_to_sample.to(torch.int64) - 1
         num_accept_tokens = query_lens - num_reject_tokens
         slot_idx_base = (
-            decode_req_starts * self.pcp_world_size
-            + self.pcp_req_offsets[:num_decode_reqs] * (num_speculative_tokens - 1) * self.pcp_world_size
+            req_starts * self.pcp_world_size
+            + self.pcp_req_offsets[:num_mtp_reqs] * (num_speculative_tokens - 1) * self.pcp_world_size
             + (num_accept_tokens - 1) * self.pcp_world_size
         )
         slot_indices = (slot_idx_base[:, None] + self.pcp_rank_offsets[: self.pcp_world_size]).reshape(-1)
         return slot_indices, self.mtp_slot_pad
 
-    def prepare_spec_decode_mtp_drafting_inputs(
+    def prepare_spec_mtp_drafting_inputs(
         self,
         common_attn_metadata: Any,
         attn_metadata: Any,
@@ -1362,15 +1362,21 @@ class PCPManager:
         is_prefill_batch: bool,
         num_speculative_tokens: int,
     ) -> PCPSpecDecodeMTPInputs | None:
-        """Prepare CP-specific inputs for decode-only MTP draft metadata."""
+        """Prepare CP MTP metadata for decode and DCP-prefill batches."""
         is_decode_only_batch = num_decode_reqs > 0 and not is_prefill_batch
-        if num_speculative_tokens <= 1 or not is_decode_only_batch:
+        is_dcp_prefill_batch = (
+            self.pcp_world_size == 1
+            and self.dcp_world_size > 1
+            and is_prefill_batch
+        )
+        if num_speculative_tokens <= 1 or not (is_decode_only_batch or is_dcp_prefill_batch):
             return None
 
         assert ori_token_indices_to_sample is not None
-        slot_indices, slot_mapping = self._get_spec_decode_mtp_slot_inputs(
+        num_mtp_reqs = batch_size if is_dcp_prefill_batch else num_decode_reqs
+        slot_indices, slot_mapping = self._get_spec_mtp_slot_inputs(
             ori_token_indices_to_sample,
-            num_decode_reqs,
+            num_mtp_reqs,
             num_speculative_tokens,
         )
 
@@ -1702,7 +1708,12 @@ class PCPManager:
             self.async_rebuild_num_tokens_full = total_num_scheduled_tokens
 
         # For mtpx, pre-allocate mtp slot_mapping here
-        if self.decode_threshold > 2 and not with_prefill:
+        needs_dcp_prefill_slots = (
+            self.pcp_world_size == 1
+            and self.dcp_world_size > 1
+            and with_prefill
+        )
+        if self.decode_threshold > 2 and (not with_prefill or needs_dcp_prefill_slots):
             num_tokens_ori = sum(list(num_scheduled_tokens.values()))
             num_tokens_mtp = num_tokens_ori + self.num_reqs * (self.decode_threshold - 2)
             num_tokens_mtp_pad = num_tokens_mtp * self.pcp_world_size


### PR DESCRIPTION
### What this PR does / why we need it?
When fixing the issue of dcp overlaying dp, a curl request causes the service to get stuck.

When mtp=3 and there is only one request, for prefill, during the execution of mtp by dp0, only step0 is executed. The other two steps are copies of step0. dp1 performs a dummy run, and is_prefill is considered false, so it does not handle this special logic. As a result, all three steps are executed, leading to dp0 and dp1 executing a different number of times, ultimately causing the communication to get stuck.

The current modification method is that dcp prefill will also execute the mtp step multiple times.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
