### PR TITLE
[CI] Add Gemma4-E2B/E4B graph nightly coverage

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -31,6 +31,12 @@ a2:
       - name: MiniMax-M2.5-w8a8-QuaRot-A2
         os: linux-aarch64-a2b3-8
         config_file_path: MiniMax-M2.5-w8a8-QuaRot-A2.yaml
+      - name: gemma4-e2b
+        os: linux-aarch64-a2b3-1
+        config_file_path: gemma4-E2B.yaml
+      - name: gemma4-e4b
+        os: linux-aarch64-a2b3-1
+        config_file_path: gemma4-E4B.yaml
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -31,12 +31,6 @@ a2:
       - name: MiniMax-M2.5-w8a8-QuaRot-A2
         os: linux-aarch64-a2b3-8
         config_file_path: MiniMax-M2.5-w8a8-QuaRot-A2.yaml
-      - name: gemma4-e2b
-        os: linux-aarch64-a2b3-1
-        config_file_path: gemma4-E2B.yaml
-      - name: gemma4-e4b
-        os: linux-aarch64-a2b3-1
-        config_file_path: gemma4-E4B.yaml
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp
@@ -159,6 +153,12 @@ a3:
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+      - name: gemma4-e2b
+        os: linux-aarch64-nightly-a3-2
+        config_file_path: gemma4-E2B.yaml
+      - name: gemma4-e4b
+        os: linux-aarch64-nightly-a3-2
+        config_file_path: gemma4-E4B.yaml
   multi_card:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -153,10 +153,10 @@ a3:
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
-      - name: gemma4-e2b
+      - name: gemma4-e2b-a3
         os: linux-aarch64-nightly-a3-2
         config_file_path: gemma4-E2B.yaml
-      - name: gemma4-e4b
+      - name: gemma4-e4b-a3
         os: linux-aarch64-nightly-a3-2
         config_file_path: gemma4-E4B.yaml
   multi_card:

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -141,6 +141,8 @@
       "google/gemma-3n-E2B-it",
       "google/gemma-4-26B-A4B-it",
       "google/gemma-4-31B-it",
+      "google/gemma-4-E2B-it",
+      "google/gemma-4-E4B-it",
       "google/siglip2-base-patch16-224",
       "hmellor/Ilama-3.2-1B",
       "ibm-research/PowerMoE-3b",

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
@@ -57,7 +57,7 @@ _benchmarks: &benchmarks
 # ==========================================
 
 test_cases:
-  - name: "Gemma4-E2B-full-decode-graph"
+  - name: "Gemma4-E2B-A3-full-decode-graph"
     model: *model
     envs:
       <<: *envs

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
@@ -1,0 +1,75 @@
+# ==========================================
+# Shared Configurations
+# ==========================================
+
+_model: &model "google/gemma-4-E2B-it"
+
+_envs: &envs
+  VLLM_USE_MODELSCOPE: "true"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_BUFFSIZE: "1024"
+  OMP_NUM_THREADS: "1"
+  TASK_QUEUE_ENABLE: "1"
+  SERVER_PORT: "DEFAULT_PORT"
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+  VLLM_RPC_TIMEOUT: "6000"
+
+_server_cmd: &server_cmd
+  - "--no-enable-prefix-caching"
+  - "--tensor-parallel-size"
+  - "1"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--max-model-len"
+  - "32768"
+  - "--max-num-batched-tokens"
+  - "8192"
+  - "--max-num-seqs"
+  - "8"
+  - "--gpu-memory-utilization"
+  - "0.9"
+  - "--trust-remote-code"
+
+_api_keyword_args: &api_keyword_args
+  max_tokens: 64
+  temperature: 1.0
+  top_p: 0.95
+  top_k: 64
+
+_benchmarks: &benchmarks
+  acc_gpqa:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gpqa
+    request_conf: vllm_api_general_chat
+    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+    max_out_len: 8192
+    batch_size: 8
+    baseline: 30
+    threshold: 5
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    ignore_eos: false
+
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Gemma4-E2B-full-decode-graph"
+    model: *model
+    envs:
+      <<: *envs
+    prompts:
+      - "Explain briefly why ACLGraph output should match eager output."
+    api_keyword_args:
+      <<: *api_keyword_args
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+    test_content:
+      - "chat_completion"
+    benchmarks:
+      <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
@@ -68,7 +68,7 @@ test_cases:
     server_cmd: *server_cmd
     server_cmd_extra:
       - "--compilation-config"
-      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["none"],"cudagraph_capture_sizes":[1,2,4,8]}'
     test_content:
       - "chat_completion"
     benchmarks:

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml
@@ -37,21 +37,6 @@ _api_keyword_args: &api_keyword_args
   top_p: 0.95
   top_k: 64
 
-_benchmarks: &benchmarks
-  acc_gpqa:
-    case_type: accuracy
-    dataset_path: vllm-ascend/gpqa
-    request_conf: vllm_api_general_chat
-    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
-    max_out_len: 8192
-    batch_size: 8
-    baseline: 30
-    threshold: 5
-    temperature: 1.0
-    top_p: 0.95
-    top_k: 64
-    ignore_eos: false
-
 # ==========================================
 # ACTUAL TEST CASES
 # ==========================================
@@ -71,5 +56,3 @@ test_cases:
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["none"],"cudagraph_capture_sizes":[1,2,4,8]}'
     test_content:
       - "chat_completion"
-    benchmarks:
-      <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
@@ -37,21 +37,6 @@ _api_keyword_args: &api_keyword_args
   top_p: 0.95
   top_k: 64
 
-_benchmarks: &benchmarks
-  acc_gpqa:
-    case_type: accuracy
-    dataset_path: vllm-ascend/gpqa
-    request_conf: vllm_api_general_chat
-    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
-    max_out_len: 8192
-    batch_size: 8
-    baseline: 40
-    threshold: 5
-    temperature: 1.0
-    top_p: 0.95
-    top_k: 64
-    ignore_eos: false
-
 # ==========================================
 # ACTUAL TEST CASES
 # ==========================================
@@ -71,5 +56,3 @@ test_cases:
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["none"],"cudagraph_capture_sizes":[1,2,4,8]}'
     test_content:
       - "chat_completion"
-    benchmarks:
-      <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
@@ -68,7 +68,7 @@ test_cases:
     server_cmd: *server_cmd
     server_cmd_extra:
       - "--compilation-config"
-      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["none"],"cudagraph_capture_sizes":[1,2,4,8]}'
     test_content:
       - "chat_completion"
     benchmarks:

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
@@ -1,0 +1,75 @@
+# ==========================================
+# Shared Configurations
+# ==========================================
+
+_model: &model "google/gemma-4-E4B-it"
+
+_envs: &envs
+  VLLM_USE_MODELSCOPE: "true"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_BUFFSIZE: "1024"
+  OMP_NUM_THREADS: "1"
+  TASK_QUEUE_ENABLE: "1"
+  SERVER_PORT: "DEFAULT_PORT"
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+  VLLM_RPC_TIMEOUT: "6000"
+
+_server_cmd: &server_cmd
+  - "--no-enable-prefix-caching"
+  - "--tensor-parallel-size"
+  - "1"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--max-model-len"
+  - "32768"
+  - "--max-num-batched-tokens"
+  - "8192"
+  - "--max-num-seqs"
+  - "8"
+  - "--gpu-memory-utilization"
+  - "0.9"
+  - "--trust-remote-code"
+
+_api_keyword_args: &api_keyword_args
+  max_tokens: 64
+  temperature: 1.0
+  top_p: 0.95
+  top_k: 64
+
+_benchmarks: &benchmarks
+  acc_gpqa:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gpqa
+    request_conf: vllm_api_general_chat
+    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+    max_out_len: 8192
+    batch_size: 8
+    baseline: 40
+    threshold: 5
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    ignore_eos: false
+
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Gemma4-E4B-full-decode-graph"
+    model: *model
+    envs:
+      <<: *envs
+    prompts:
+      - "Explain briefly why ACLGraph output should match eager output."
+    api_keyword_args:
+      <<: *api_keyword_args
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+    test_content:
+      - "chat_completion"
+    benchmarks:
+      <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml
@@ -57,7 +57,7 @@ _benchmarks: &benchmarks
 # ==========================================
 
 test_cases:
-  - name: "Gemma4-E4B-full-decode-graph"
+  - name: "Gemma4-E4B-A3-full-decode-graph"
     model: *model
     envs:
       <<: *envs


### PR DESCRIPTION
### What this PR does / why we need it?

Add nightly single-node graph-mode coverage for the **Gemma4-E2B-it** and **Gemma4-E4B-it** models (bf16, non-quantized dense, cross-layer KV sharing — E2B `num_kv_shared_layers=20`, E4B `num_kv_shared_layers=18`), mirroring the structure of #11856.

Each model gets one `FULL_DECODE_ONLY` graph test case with a `chat_completion` check and a `gpqa` accuracy benchmark:

- `tests/e2e/nightly/single_node/models/configs/gemma4-E2B.yaml` — `Gemma4-E2B-full-decode-graph` (ACLGraph `FULL_DECODE_ONLY`, capture sizes `[1,2,4,8]`).
- `tests/e2e/nightly/single_node/models/configs/gemma4-E4B.yaml` — `Gemma4-E4B-full-decode-graph`, same structure.
- `.github/workflows/configs/nightly_config.yaml`: register `gemma4-e2b` / `gemma4-e4b` under `a2.single_node.test_config` (`linux-aarch64-a2b3-1`).
- `.github/workflows/misc/model_dataset_list.json`: register `google/gemma-4-E2B-it` / `google/gemma-4-E4B-it`.

Serve flags follow the Gemma4 deployment tutorial: TP1 (small dense models, 9.6G / 15G bf16), `--no-enable-prefix-caching`, `--trust-remote-code`, `--gpu-memory-utilization 0.9`, `--max-model-len 32768`. No `--quantization` (bf16) and no `--enable-expert-parallel` (dense). `VLLM_USE_MODELSCOPE=true` pulls weights from ModelScope.

### Does this PR introduce _any_ user-facing change?

No. Adds nightly test configs + CI matrix entries only; no code, API, or runtime behavior change.

### How was this patch tested?

- YAML / JSON syntax validated locally.
- Config structure mirrors the sibling `Gemma4.yaml` from #11856 (`_model` / `_envs` / `_server_cmd` / `_api_keyword_args` / `_benchmarks` anchors + one `FULL_DECODE_ONLY` graph `test_case` with `prompts` / `api_keyword_args` / `test_content`).
- `model` uses HF ids (`google/gemma-4-E2B-it`, `google/gemma-4-E4B-it`), consistent with the repo convention.

Notes for reviewers:
- `baseline` values (E2B `30`, E4B `40`) for gpqa are placeholders pending real measurement on Ascend; will calibrate after the first nightly runs.
- Both models exercise cross-layer KV sharing, so this nightly also covers the KV-sharing code path (#11791).

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
