### PR TITLE
[0.23.0][BugFix] Prevent Mamba EAGLE lookup from expanding hybrid prefix hits

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -420,6 +420,7 @@ def test_mamba_eagle_lookup_does_not_expand_hybrid_hit() -> None:
     coordinator.eagle_attn_group_indices = {1}
     coordinator.dcp_world_size = 1
     coordinator.pcp_world_size = 1
+    coordinator.enable_caching = True
     coordinator.hash_block_size = 16
     coordinator.lcm_block_size = 16
     coordinator.block_pool = MagicMock()

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -386,7 +386,7 @@ def test_verify_and_split_propagates_eagle_to_merged_spec_siblings() -> None:
     assert coordinator.single_type_managers[0].use_eagle is False
 
 
-def test_mamba_eagle_lookup_does_not_expand_hybrid_hit(monkeypatch) -> None:
+def test_mamba_eagle_lookup_does_not_expand_hybrid_hit() -> None:
     """Mamba finders do not drop the EAGLE lookahead block.
 
     The coordinator must therefore keep the Mamba lookup capped at the hit
@@ -423,10 +423,6 @@ def test_mamba_eagle_lookup_does_not_expand_hybrid_hit(monkeypatch) -> None:
     coordinator.hash_block_size = 16
     coordinator.lcm_block_size = 16
     coordinator.block_pool = MagicMock()
-    monkeypatch.setattr(
-        "vllm_ascend.patch.platform.patch_kv_cache_coordinator.debug_enabled",
-        lambda: False,
-    )
 
     hit_blocks, hit_length = coordinator.find_longest_cache_hit(
         block_hashes=[MagicMock(), MagicMock(), MagicMock()],

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -386,6 +386,58 @@ def test_verify_and_split_propagates_eagle_to_merged_spec_siblings() -> None:
     assert coordinator.single_type_managers[0].use_eagle is False
 
 
+def test_mamba_eagle_lookup_does_not_expand_hybrid_hit(monkeypatch) -> None:
+    """Mamba finders do not drop the EAGLE lookahead block.
+
+    The coordinator must therefore keep the Mamba lookup capped at the hit
+    length already established by full attention.
+    """
+    kv_cache_config = _make_hybrid_kv_cache_config()
+    full_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
+    mamba_spec = kv_cache_config.kv_cache_groups[1].kv_cache_spec
+
+    class _FullHitManager:
+        @classmethod
+        def find_longest_cache_hit(cls, **kwargs):
+            return ([object(), object()],)
+
+    class _MambaHitManager:
+        lookup_max_lengths: list[int] = []
+
+        @classmethod
+        def find_longest_cache_hit(cls, **kwargs):
+            max_length = kwargs["max_length"]
+            cls.lookup_max_lengths.append(max_length)
+            block_size = kwargs["kv_cache_spec"].block_size
+            return ([object()] * (max_length // block_size),)
+
+    coordinator = AscendHybridKVCacheCoordinator.__new__(AscendHybridKVCacheCoordinator)
+    coordinator.kv_cache_config = kv_cache_config
+    coordinator.attention_groups = [
+        (full_spec, [0], _FullHitManager),
+        (mamba_spec, [1], _MambaHitManager),
+    ]
+    coordinator.eagle_attn_group_indices = {1}
+    coordinator.dcp_world_size = 1
+    coordinator.pcp_world_size = 1
+    coordinator.hash_block_size = 16
+    coordinator.lcm_block_size = 16
+    coordinator.block_pool = MagicMock()
+    monkeypatch.setattr(
+        "vllm_ascend.patch.platform.patch_kv_cache_coordinator.debug_enabled",
+        lambda: False,
+    )
+
+    hit_blocks, hit_length = coordinator.find_longest_cache_hit(
+        block_hashes=[MagicMock(), MagicMock(), MagicMock()],
+        max_cache_hit_length=48,
+    )
+
+    assert _MambaHitManager.lookup_max_lengths == [32]
+    assert [len(blocks) for blocks in hit_blocks] == [2, 2]
+    assert hit_length == 32
+
+
 def test_deepseek_v4_detection_handles_non_mapping_nested_specs() -> None:
     kv_cache_spec = SimpleNamespace(
         kv_cache_specs=[

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -300,8 +300,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                if use_eagle:
-                    # Eagle needs to match one more block and then pop the last.
+                if use_eagle and not isinstance(spec, MambaSpec):
+                    # Mamba finders do not drop the EAGLE lookahead block, so
+                    # allowing a margin here could grow the hybrid hit length.
                     _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
                 eagle_kwarg = {"drop_eagle_block": use_eagle}
                 hit_blocks = manager_cls.find_longest_cache_hit(
@@ -402,8 +403,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                if use_eagle:
-                    # Eagle needs to match one more block and then pop the last.
+                if use_eagle and not isinstance(spec, MambaSpec):
+                    # Mamba finders do not drop the EAGLE lookahead block, so
+                    # allowing a margin here could grow the hybrid hit length.
                     _max_length = min(curr_hit_length + spec.block_size, max_cache_hit_length)
                 eagle_kwarg = {"drop_eagle_block": use_eagle}
                 hit_blocks = manager_cls.find_longest_cache_hit(


### PR DESCRIPTION
  ### What this PR does / why we need it?

  The v0.23.0 hybrid KV-cache coordinator adds one cache block to the lookup upper bound for EAGLE/MTP groups.

  EAGLE drafting consumes target-model hidden states, while prefix caching stores KV/state data rather than those hidden states. EAGLE-capable cache managers therefore look up one additional block and consume `drop_eagle_block=True` by dropping the
  last matched block. This forces the target model to replay that block and regenerate the hidden states required by the drafter.

  The expected contract is:

```text
  current hybrid candidate: N blocks
  lookup upper bound:        N + 1 blocks
  manager drops lookahead:   1 block
  returned hit length:       <= N blocks
```
  Each hybrid cache group must only accept or reduce the current candidate length. No group may expand the prefix length already established by another group.

  Mamba does not implement this lookahead-and-drop behavior. A Mamba cache entry is a sparse state checkpoint at a block boundary, rather than a dense per-token KV block. A hit at boundary N is represented as:
```text
  [NULL, ..., NULL, S_N]
```
  Dropping S_N would leave only null placeholders, not a valid S_(N-1) checkpoint. Falling back to N-1 requires a new lookup bounded at N-1. Consequently, Mamba cache finders accept drop_eagle_block for interface compatibility but do not consume it.

  Giving a Mamba group the EAGLE lookup margin therefore breaks the hybrid coordinator's monotonicity invariant:
```text
  FullAttention establishes: N - 1 blocks
  Mamba lookup upper bound:  N blocks
  Mamba finds S_N:           N blocks
  Mamba performs no drop:    N blocks
  coordinator result:        N blocks
```
  This can occur naturally under cache pressure. Request release traverses all cache groups, but cached-block eviction is performed lazily and one physical block at a time from a shared queue. It is not atomic across groups.

  FullAttention stores a dense chain of KV blocks, while Mamba stores sparse boundary checkpoints. A FullAttention block can therefore be **evicted** while the corresponding **Mamba checkpoint remains cached**:
```text
  FullAttention coverage: N - 1 blocks
  Mamba coverage:         N blocks
```

  The block pool does not need to be completely exhausted for this to happen. Cache pressure and eviction expose the mismatch, but the invalid Mamba lookup expansion is the correctness bug.

  The final FullAttention truncation cannot repair this state. It only trims a dense FullAttention list to the already-computed final hit_length. Once Mamba has incorrectly raised hit_length back to N, truncating FullAttention at N is a no-op because
  its list already contains only N - 1 blocks. Mamba also cannot be safely truncated by list slicing because removing S_N does not recover S_(N-1).

  The scheduler may then treat N blocks as computed even though FullAttention KV covers only N - 1. It skips one complete block of target-model computation. All block IDs and memory accesses remain valid, so this does not necessarily crash; instead,
  the model continues from semantically inconsistent FullAttention and Mamba states, which can silently corrupt logits and produce garbled output.

  This PR:

  - prevents MambaSpec groups from receiving the EAGLE lookup margin in both Ascend hybrid lookup paths;
  - keeps the existing lookahead-and-drop behavior for non-Mamba EAGLE groups, including the DeepSeek-V4/SWA path; and
  - adds a regression test proving that a Mamba EAGLE lookup cannot expand the hit length established by FullAttention.

  The DeepSeek-V4/SWA behavior remains unchanged because SlidingWindow managers actually consume drop_eagle_block: they retain the additional contiguous KV needed for replay, remove the lookahead block from the returned hit, and never expand the
  incoming hybrid candidate.

  This is a focused release-branch backport of the Mamba guard introduced by vLLM upstream PR https://github.com/vllm-project/vllm/pull/46384. It is not a full backport of the partial-prefix-hit interface changes.

  ### Does this PR introduce any user-facing change?

  Yes. It fixes a silent correctness risk for hybrid Mamba models using prefix caching with MTP/EAGLE. There is no API or configuration change.

  ### How was this patch tested?

  - Added test_mamba_eagle_lookup_does_not_expand_hybrid_hit, covering a two-block FullAttention hit, a Mamba EAGLE group, and a global three-block lookup limit.
  - Main PR: https://github.com/vllm-project/vllm-ascend/pull/12091
  - vLLM version: v0.23.0
  - vLLM main commit: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389