### PR TITLE
[BugFix] Fix GDN graph padding state indices with PCP

### DIFF
--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -573,10 +573,10 @@ def test_full_graph_spec_actual_seq_lengths_use_padded_builder_buffer():
     )
 
 
-def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
+def test_full_graph_non_spec_metadata_nulls_padded_state_indices():
     batch_spec = BatchSpec(
-        seq_lens=[1, 1],
-        query_lens=[1, 1],
+        seq_lens=[1, 1, 0, 0],
+        query_lens=[1, 1, 0, 0],
         name="full_graph_padded_non_spec_actual_seq_lengths",
     )
     common_attn_metadata = create_common_attn_metadata(
@@ -584,7 +584,9 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
         block_size=16,
         device=torch.device("cpu"),
     )
-    common_attn_metadata.num_actual_tokens = 4
+    # PCP leaves padded block-table rows untouched. Model the stale valid
+    # state slots that can remain there after the preceding decode batch.
+    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor([10, 11, 98, 99])
     builder = _make_builder(
         device=torch.device("cpu"),
         num_heads=32,
@@ -597,6 +599,10 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
     assert torch.equal(
         attn_metadata.non_spec_query_start_loc,
         torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),
+    )
+    assert torch.equal(
+        attn_metadata.non_spec_state_indices_tensor,
+        torch.tensor([10, 11, 0, 0], dtype=torch.int32),
     )
     assert (
         attn_metadata.non_spec_decode_metadata.actual_seq_lengths.data_ptr()

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -705,22 +705,28 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
-                non_spec_state_indices_tensor,
+            # ``num_decodes`` includes CUDA-graph padding requests, while
+            # ``batch_size`` is the number of real one-token decode requests.
+            # Do not copy padded block-table rows into the graph input buffer:
+            # under PCP those rows are intentionally left uninitialized and
+            # can contain a valid state slot from a previous batch.
+            graph_batch_size = m.num_reqs
+            actual_num_decodes = min(batch_size, num_decodes)
+            self.non_spec_state_indices_tensor[actual_num_decodes:].fill_(NULL_BLOCK_ID)
+            self.non_spec_state_indices_tensor[:actual_num_decodes].copy_(
+                non_spec_state_indices_tensor[:actual_num_decodes],
                 non_blocking=True,
             )
-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:graph_batch_size]
             non_spec_conv1d_cache_indices = non_spec_state_indices_tensor
 
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
-                non_spec_query_start_loc,
+            self.non_spec_query_start_loc[: actual_num_decodes + 1].copy_(
+                non_spec_query_start_loc[: actual_num_decodes + 1],
                 non_blocking=True,
             )
-            non_spec_num_query_tokens = non_spec_query_start_loc[-1]
-            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
-            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+            non_spec_num_query_tokens = non_spec_query_start_loc[actual_num_decodes]
+            non_spec_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
+            non_spec_query_start_loc[actual_num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,


### PR DESCRIPTION
## What this PR does

Fixes corrupted Qwen3.5/Qwen3.6 GDN decode output when PCP is combined with `FULL_DECODE_ONLY` graph execution and the active request count is smaller than the captured graph batch size.

The GDN metadata builder now:

- keeps non-spec decode metadata at the padded graph request batch size;
- copies state indices and query offsets only for real one-token decode requests;
- fills padded state-index rows with `NULL_BLOCK_ID` and repeats the final query offset.

No host metadata updater, event, or device-wide synchronization is added.

## Root cause

In full graph decode, `num_decodes`/`num_reqs` include graph padding requests, while `num_actual_tokens` is the number of real one-token decode requests.

The previous builder cleared the tail of its stable state-index buffer using `num_actual_tokens`, but then copied `num_decodes` rows from the block table. Under PCP, padded block-table rows are intentionally not initialized by the common model runner and can retain a valid state slot from an earlier batch. The copy therefore overwrote the cleared tail. The Python metadata view was then shortened to the real-token count, but the captured GDN conv1d kernel still consumed the fixed graph-sized buffer and could update a real request's conv state through the padded lane. That state corruption propagated through subsequent GDN decode steps and produced garbled output.

SFA/DSA are unaffected because their PCP paths consume explicitly padded slot-mapping/request metadata rather than constructing GDN conv/SSM state indices from padded block-table rows.

## Validation

- `pytest -q tests/ut/ops/test_gdn_attn_builder.py`: 16 passed.
- Added a regression test with two real decode requests and two padded rows containing stale valid state slots; the resulting fixed graph input is `[10, 11, 0, 0]` with query offsets `[0, 1, 2, 2, 2]`.
- Qwen3.6-35B-A3B W8A8 (Qwen3.5 GDN architecture), vLLM 0.23.0, latest vLLM Ascend main, TP2 + PCP2 + expert parallel + `FULL_DECODE_ONLY`:
  - focused 16-request GPQA run at 4096 max output tokens: 16/16 complete, 0 garbled responses;
  - full 198-request GPQA run at concurrency 16: 198/198 valid JSON responses, 0 responses with the baseline corruption signature (random control/script characters or hundreds-to-thousands of repeated spaces).

The exact Qwen3.5 checkpoint was not present on the validation host, so end-to-end validation used the available Qwen3.6-35B-A3B W8A8 checkpoint, which resolves to the same `Qwen3_5MoeForConditionalGeneration` GDN implementation.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/e5588e49bc2642670116664a7fc4096e27adb179
