### PR TITLE
[Feat][KV Pool] Support DeepSeek V4 layerwise transfer

### DIFF
--- a/docs/source/developer_guide/Design_Documents/deepseek_v4_layerwise_kv_pool.md
+++ b/docs/source/developer_guide/Design_Documents/deepseek_v4_layerwise_kv_pool.md
@@ -1,0 +1,278 @@
+# DeepSeek V4 Layerwise KV Pool 设计
+
+## 背景
+
+AscendStore 原有的 layerwise 路径按以下假设实现：
+
+- 只有一个 KV cache group；
+- 模型执行层序号等于缓存中的物理层序号；
+- 所有层共享相同的 block size 和 token 粒度；
+- layerwise 请求可以通过一个全局递增的 `current_layer` 识别当前层。
+
+DeepSeek V4 不满足这些假设。它会按 cache spec 和压缩比例把缓存拆成多个 group，典型形态包含
+c4、c128 和 sliding-window cache。MTP 层也可能出现在注册的 KV cache 中。因此，同一个模型层同时具有：
+
+- 模型执行顺序中的位置；
+- KV cache group id；
+- group 内的局部层序号；
+- group 对应的压缩比例、block table 和物理地址布局。
+
+如果仅删除原有的多 group `NotImplementedError`，put/get 会使用 group 0 的 block table 和地址，lookup
+也会为每个 group 查询模型全部层，最终造成错误命中、地址越界或 KV 数据写入错误层。
+
+## 目标与边界
+
+本设计实现以下能力：
+
+1. DeepSeek V4 的每个已注册 KV cache 层可以独立 put 和 get。
+2. c4、c128、sliding-window 等多个 group 使用各自的 key 粒度、block table 和物理地址。
+3. lookup 只有在每个 group 的全部层都命中时才返回公共前缀命中。
+4. 保留一层 look-ahead get，使下一层传输与当前层计算重叠。
+5. MTP 重复执行基础层时，不重复提交同一层的 put。
+6. 单 group 模型保持原有 key 和调用行为。
+
+本次 layerwise put 的范围是 prefill 节点：只有 `kv_producer` 和 `kv_both` 创建逐层发送线程。
+`kv_consumer` 仍可逐层 get，但即使配置了 `consumer_is_to_put=true` 也不会逐层 put。该配置继续只控制
+非 layerwise 的 decode 节点回灌能力，不属于本次适配范围。
+
+本次不改变后端协议，不新增环境变量，也不修改 DeepSeek V4 模型文件和 attention kernel。唯一功能开关是
+`kv_connector_extra_config.use_layerwise=true`。
+
+## 核心数据模型
+
+### 层映射
+
+`register_kv_caches` 根据 `KVCacheConfig.kv_cache_groups` 建立两种独立视图：
+
+| 视图 | 示例 | 用途 |
+|------|------|------|
+| 执行顺序 | layer 0、layer 1、...、MTP | 决定 get 预取和“最后一个唯一层” |
+| 物理位置 | `(group_id, group_layer_id)` | 决定 key、block table 和地址 |
+
+DeepSeek V4 的执行顺序使用 `extract_dsv4_layer_index` 排序，避免 cache group 的注册顺序被误认为模型
+forward 顺序。物理位置始终保留 group 内原始顺序，以便和注册的地址数组一致。
+
+### Layerwise key
+
+每个 key 由以下字段共同确定：
+
+```text
+model + parallel ranks + group_id + cache_family + group_layer_id + chunk_hash
+```
+
+`group_layer_id` 是组内序号，而不是全局模型层序号。因为 key 已包含 `group_id`，不同 group 的局部层 0
+不会冲突。该方案也避免为稀疏分组构造大量不存在的层 key。
+
+### Layerwise 传输任务
+
+单层任务增加以下信息：
+
+- `kv_cache_group_id`：选择当前层所属 group；
+- `layer_id`：当前 group 内的局部层序号；
+- `key_block_ids`：每个 key 对应的真实物理 block id；
+- `layer_name`：用于校验 attention hook 传入的真实层；
+- `is_last_layer`：与 group 内局部序号解耦的全局完成标记；
+- `completion_event` 和 `load_failed`：单层 get 的完成与失败状态。
+
+显式携带 `key_block_ids` 是 sliding-window 正确性的必要条件。滑窗 group 可能只保留逻辑序列尾部的
+block table，不能再用 `start // block_size` 直接索引这个截断后的列表。
+
+## Lookup 设计
+
+lookup 对每个 group 独立执行：
+
+1. 按该 group 的 `block_size * compress_ratio` 对原始 block hash 重新分组。
+2. 每个 chunk 只展开该 group 的层数，而不是模型总层数。
+3. 对同一 chunk 的全部组内层执行 AND；任一层缺失则该 chunk 未命中。
+4. 对 TP/PP 副本继续执行 AND。
+5. 将压缩缓存位置乘以 `compress_ratio`，恢复为原始 token 坐标。
+6. 在所有 group 的命中位置中取最大公共位置。
+
+第 5 步是 DeepSeek V4 多压缩组可以求交集的关键。c4 group 的物理位置 512 和 c128 group 的物理
+位置 16 都可能代表原始 token 位置 2048；不能直接比较两个物理位置。
+
+## Put 时序
+
+1. attention hook 调用 `save_kv_layer(layer_name, ...)`。
+2. connector 把真实 `layer_name` 传给 worker。
+3. worker 查出 `(group_id, group_layer_id)`，使用该 group 的 block table 生成单层任务。
+4. 当前层记录独立的 NPU event，发送线程在访问该层 KV 前同步该 event。
+5. 发送线程按 group 和真实 block id 计算地址并调用 backend `put`。
+6. 当本轮所有唯一层都已提交时，最后一个任务携带 `is_last_layer=True`。
+7. MTP 再次执行基础层时，已提交的 `layer_name` 被跳过；独立的 MTP cache 层仍正常提交。
+
+每个调度 chunk 在其最后一层完成时都会减少一次 in-flight 计数；只有最后一个 prompt chunk 才把请求
+标记为整体 put 完成。这样 chunked prefill 不会残留无法归零的发送计数。
+
+## Get 时序
+
+1. `start_load_kv` 收集需要 load 的请求，并预取执行顺序中的第一层。
+2. attention hook 在计算当前层前调用 `wait_for_layer_load(layer_name)`。
+3. worker 等待当前层所有请求的 `completion_event`。
+4. 当前层成功后立即提交下一层，实现一层 look-ahead。
+5. 若实际 hook 顺序与预取顺序不同，则按真实 `layer_name` 补交当前层任务，避免把错误层数据当成已加载。
+6. backend 返回失败或传输线程抛异常时设置 `load_failed`，当前请求在进入 attention 计算前失败。
+
+多 group load 失败时不把裸 block id 注入单 group 的 fallback 集合，因为不同 group 可以复用相同的
+数字 block id。当前实现选择 fail-fast，防止用部分恢复的 KV 继续推理而产生静默精度错误。
+
+## 地址计算
+
+`prepare_value_layer` 接收 `kv_cache_group_id`、组内 `layer_id` 和可选的显式 `block_id`：
+
+```text
+addr = group_layer_base_addr + block_id * group_layer_block_stride
+size = group_layer_block_len / group_block_size * transferred_tokens
+```
+
+地址数组、block length、stride 和层数都从指定 group 读取。默认参数仍指向 group 0，以兼容已有单
+group 调用和测试。
+
+## 代码修改及原因
+
+| 文件 | 修改 | 原因 |
+|------|------|------|
+| `attention/sfa_v1.py` | DSA-CP full-weight o_proj 提前返回前触发当前层 save callback | `kv_both` 的 DeepSeek V4 prefill 会走该提前返回分支；原逻辑跳过 callback，导致 metadata 可保存但没有 put |
+| `ascend_store_connector.py` | 透传 `layer_name`；consumer 的 layerwise save callback 直接跳过 | DSV4 不能依赖全局层计数；本次逐层 put 只覆盖 prefill 角色 |
+| `pool_scheduler.py` | 允许 layerwise 使用多个 KV group；consumer 不生成逐层 save metadata | 原有保护直接阻止 DSV4 启动，同时不能让 decode 回灌配置误入逐层 put |
+| `config_data.py` | 扩展按组地址接口和单层任务元数据 | 同时表达 group、局部层、尾块和完成状态 |
+| `pool_worker.py` | 建立层映射，重写单层任务、预取和 lookup；只为 producer/both 创建逐层 sender | 保证 key、block table、地址和命中坐标都按 group 处理，并明确 prefill put 边界 |
+| `kv_transfer.py` | 发送/接收线程按 group 取地址并处理显式最后层 | 局部层 0 也可能是模型最后层，不能再和全局层数比较 |
+| `tests/ut/distributed/ascend_store/` | 增加 DSV4 多组回归 | 覆盖 c4/c128 lookup、组内层、尾块及 hook 透传 |
+
+## 配置示例
+
+在已有 AscendStore 配置中启用 layerwise：
+
+```json
+{
+  "kv_connector": "AscendStoreConnector",
+  "kv_role": "kv_producer",
+  "kv_connector_extra_config": {
+    "backend": "mooncake",
+    "use_layerwise": true
+  }
+}
+```
+
+layerwise 模式需要 piecewise graph；connector 的 `requires_piecewise_for_cudagraph` 会根据
+`use_layerwise` 返回对应要求。
+
+以上是分离式部署中 prefill 节点的 put 配置。若在同一实例连续验证 put 和 get，可使用 `kv_both`；
+decode consumer 保持 `kv_consumer`，并且不会因为 `consumer_is_to_put=true` 产生 layerwise put。
+
+## 验证
+
+CPU 单元测试覆盖：
+
+- 单 group 原有行为；
+- c4 两层与 c128 一层的多 group lookup；
+- 压缩位置恢复为原始 token 坐标后的公共命中；
+- group 内层序号和 cache family key；
+- sliding-window 截断 block table 的显式 block id；
+- 单层 get 完成事件与失败标记；
+- connector 的真实层名透传；
+- MTP 场景所需的显式最后层判定。
+
+代码合入前仍需在 Ascend 环境使用真实 DeepSeek V4 权重完成以下门禁：
+
+1. 第一次请求产生逐层 put，第二次相同请求产生逐层 get。
+2. 第二次请求输出与关闭 KV pool 的 greedy 输出一致。
+3. 日志中的 key 同时出现预期的 group、cache family 和局部 layer id。
+4. Mooncake、TP/EP、MTP 和 piecewise ACLGraph 组合无超时或传输失败。
+5. 至少验证 128K 上下文、`max_num_seqs=16`；若硬件不足需记录实际可运行上限。
+
+### Mooncake 日志验证
+
+验证时设置已有的 vLLM 日志级别，不新增 AscendStore 环境变量：
+
+```bash
+export VLLM_LOGGING_LEVEL=INFO
+```
+
+启动日志必须依次包含：
+
+```text
+[AscendStore][layerwise] connector enabled ... backend=mooncake
+[AscendStore][layerwise] cache layout registered ... transfer_granularity=<N> ...
+[AscendStore][layerwise] transfer threads ready ... sender=True receiver=True
+```
+
+测试 prompt 的 token 数必须不小于启动日志中的 `transfer_granularity`。短 prompt 没有完整可传输 chunk，
+会在 enqueue 阶段得到 `keys=0`，不会调用 Mooncake put。使用一个未写入过池的长 prompt 连续请求两次。
+
+第一次请求应出现：
+
+```text
+[AscendStore][layerwise][put] enqueue ... keys=<大于 0>
+[AscendStore][layerwise][put] backend call backend=MooncakeBackend ...
+[AscendStore][Mooncake][put] completed ... failed=0
+[AscendStore][layerwise][put] chunk complete ... processed_layers=<总层数>/<总层数> ...
+```
+
+第二次相同请求应出现 scheduler 的 `KV pool load spec created`，以及：
+
+```text
+[AscendStore][layerwise][get] enqueue ... keys=<大于 0>
+[AscendStore][layerwise][get] backend call backend=MooncakeBackend ...
+[AscendStore][Mooncake][get] completed ... failed=0
+[AscendStore][layerwise][get] chunk complete ... status=success
+```
+
+可用以下命令过滤关键日志：
+
+```bash
+rg "\[AscendStore\].*(layerwise|Mooncake)|KV pool load spec created" <server.log>
+```
+
+关键诊断字段含义：
+
+| 日志 | 结论 |
+|------|------|
+| `sender=False` | 当前节点不是 prefill put 角色；layerwise sender 只为 `kv_producer`/`kv_both` 创建 |
+| `saveable=0` | scheduler 本轮没有下发可保存请求 |
+| 只有 `forward metadata ... saveable=1`，没有 `save callback` | attention 执行路径跳过了逐层 hook；重点检查 SFA DSA-CP early-return 分支 |
+| `reason=request_not_registered` | 请求在发送线程中已被清理，需检查请求完成/抢占时序 |
+| enqueue 阶段 `keys=0` | prompt 太短，或 store mask 过滤了所有完整 chunk |
+| `total_keys>0 owned_keys=0` | 当前 TP rank 不负责该 chunk；结合 `tp_rank/put_step` 跨 rank 检查，属于正常分片 |
+| `backend_call_layers=0 all_exist_layers>0` | key 已存在，跳过重复 put，属于正常行为 |
+| `processed_layers` 小于总层数 | attention hook 没有覆盖所有唯一 KV 层 |
+| Mooncake `failed>0` | put/get 已执行，但 Mooncake 返回失败，检查容量、metadata server 和网络 |
+
+功能通过标准为：每个 rank 的 `processed_layers` 等于本 PP rank 的总层数；跨 TP rank 汇总后首次请求的
+每一层都有 owner 执行 put；第二次请求完成全部层 get；Mooncake 的 `failed=0`；第二次请求的 greedy
+输出与关闭 KV pool 时一致。仅看到 `backend call` 不能证明写入成功，必须同时检查 Mooncake
+`completed` 和最终 chunk 汇总。
+
+空 metadata 通常来自 decode 或没有 connector 任务的 forward step，不代表 put 失败。为避免 INFO 验证日志刷屏，
+`requests=0` 的 metadata 汇总不再打印；判断 put 是否触发应从 `saveable=1` 后的 `save callback` 开始追踪。
+
+### 性能收益验证
+
+layerwise 的预期收益不是减少传输总字节数，而是把已经完成计算的层尽早交给 Mooncake，使逐层 put 与后续
+层的 NPU 计算重叠，从而缩短 prefill forward 结束后的集中保存尾延迟。代价是每层增加一次 event、队列调度、
+exists 和 backend 调用；当单层数据量过小或 Mooncake 更依赖大批量传输时，layerwise 可能没有收益，甚至降低
+吞吐。因此不能仅凭功能日志判断性能。
+
+在同一套 DeepSeek V4 权重、并行配置、Mooncake 节点和网络条件下做以下 A/B：
+
+| 对照组 | 实验组 | 其余变量 |
+|--------|--------|----------|
+| `use_layerwise=false` | `use_layerwise=true` | 模型、并行度、block size、batch、prompt、Mooncake 配置完全一致 |
+
+分别覆盖 2K、8K、32K、128K prompt 和并发 1、4、16；硬件不足时记录实际可运行矩阵。每组先 warmup，
+再至少采集 20 轮，并分别测量：
+
+1. 使用不同 prompt 的 cold put，防止 `all_keys_exist` 把写入跳过。
+2. 使用相同 prompt 的 warm get，确认逐层预取没有增加 TTFT。
+3. `kv_producer` prefill 节点只评估 put；若需在单实例同时测 put/get，使用 `kv_both`。
+
+记录 p50/p90/p99 TTFT、prefill latency、input token throughput、请求完成到最后一次 Mooncake put 完成的
+尾延迟、Mooncake 有效带宽和调用次数、CPU/NPU 利用率。建议以“cold put 尾延迟或端到端 prefill latency
+至少改善 5%，且 input throughput 与 p99 TTFT 回退不超过 3%”作为初始收益门槛；最终门槛应由真实业务
+流量确认。
+
+当前验证阶段将逐层诊断日志临时提升为 `INFO`，功能验证无需开启 DEBUG。正式性能 A/B 前必须删除这些日志或
+降回 `DEBUG`，并使用相同的 INFO 日志配置测试两组；否则逐层日志会放大 Python I/O 和调度开销，不能用于判断
+layerwise 是否有收益。当前实现不在逐层热路径新增同步计时或 `tensor.item()`，避免为了测量引入 NPU 同步和
+额外性能扰动。

--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -13,16 +13,18 @@
 # This file is a part of the vllm-ascend project.
 #
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
 from tests.ut.base import TestBase
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
 
 if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
 from vllm_ascend.attention.sfa_v1 import AscendSFAImpl
+from vllm_ascend.utils import AscendDeviceType
 
 
 class TestAscendSFAOProjTPParams(TestBase):
@@ -101,3 +103,70 @@ class TestAscendSFAOProjTPParams(TestBase):
         self.assertEqual(impl.o_proj.weight_scale_second.data_ptr(), original_scale_ptr)
         self.assertFalse(require_o_proj_forward)
         self.assertTrue(torch.equal(output, torch.ones(2, 4)))
+
+    @patch("vllm_ascend.attention.sfa_v1.maybe_save_kv_layer_to_connector")
+    @patch("vllm_ascend.attention.sfa_v1.wait_for_kv_layer_from_connector")
+    @patch("vllm_ascend.attention.sfa_v1.get_weight_prefetch_method")
+    @patch(
+        "vllm_ascend.attention.sfa_v1.get_ascend_device_type",
+        return_value=AscendDeviceType.A5,
+    )
+    def test_dsa_cp_full_o_proj_notifies_layerwise_connector_before_early_return(
+        self,
+        _mock_device_type,
+        mock_weight_prefetch,
+        _mock_wait_for_layer,
+        mock_save_layer,
+    ):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.enable_dsa_cp = False
+        impl.enable_dsa_cp_with_o_proj_tp = True
+        impl.enable_sfa_prolog_v3 = False
+        impl.enable_mlapo = True
+        impl.enable_sp = False
+        impl.has_indexer = False
+        impl.is_kv_producer = False
+        impl.skip_topk = True
+        impl.o_proj = MagicMock()
+        impl._sfa_preprocess_with_mlapo = MagicMock(
+            return_value=(
+                torch.zeros(1, 4),
+                torch.zeros(1, 1, 4),
+                torch.zeros(1, 1, 4),
+                torch.zeros(1, 4),
+            )
+        )
+        impl._get_indexcache_topk_indices = MagicMock(return_value=torch.zeros(1, 1, dtype=torch.int32))
+        impl._execute_sparse_flash_attention_process = MagicMock(return_value=torch.zeros(1, 1, 4))
+        impl._v_up_proj = MagicMock(return_value=torch.zeros(1, 4))
+
+        output = torch.empty(1, 4)
+        impl._handle_o_proj_weight_switch_and_forward = MagicMock(return_value=(output, False))
+        mock_weight_prefetch.return_value = MagicMock()
+        metadata = MagicMock()
+        metadata.cos = torch.zeros(1, 4)
+        metadata.sin = torch.zeros(1, 4)
+        metadata.slot_mapping = torch.zeros(1, dtype=torch.int32)
+        metadata.dcp_context = None
+        metadata.cum_query_lens = torch.tensor([0, 1], dtype=torch.int32)
+        metadata.seq_lens = torch.tensor([1], dtype=torch.int32)
+        metadata.num_input_tokens = 1
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        kv_cache = (torch.empty(1), torch.empty(1))
+
+        with patch.object(
+            torch.ops.vllm,
+            "maybe_all_gather_and_maybe_unpad",
+            side_effect=lambda tensor, _need_gather: tensor,
+            create=True,
+        ):
+            result = impl.forward(
+                "model.layers.0.self_attn.attn",
+                torch.zeros(1, 4),
+                kv_cache,
+                metadata,
+                output=output,
+            )
+
+        self.assertIs(result, output)
+        mock_save_layer.assert_called_once_with("model.layers.0.self_attn.attn", list(kv_cache))

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -280,6 +280,28 @@ class TestAscendStoreConnector(unittest.TestCase):
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
+    def test_layerwise_hooks_forward_layer_name(self, mock_worker_cls, mock_lookup_cls):
+        config = self._make_vllm_config(extra_config={"use_layerwise": True})
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        connector = AscendStoreConnector(
+            vllm_config=config,
+            role=KVConnectorRole.WORKER,
+            kv_cache_config=None,
+        )
+        connector._get_connector_metadata = MagicMock(return_value=MagicMock())
+
+        connector.wait_for_layer_load("model.layers.7.self_attn.attn")
+        connector.save_kv_layer("model.layers.7.self_attn.attn", MagicMock(), MagicMock())
+
+        worker = mock_worker_cls.return_value
+        worker.wait_for_layer_load.assert_called_once_with("model.layers.7.self_attn.attn")
+        worker.save_kv_layer.assert_called_once_with(
+            "model.layers.7.self_attn.attn", connector._get_connector_metadata.return_value
+        )
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
     def test_save_kv_layer_not_layerwise(self, mock_worker_cls, mock_lookup_cls):
         config = self._make_vllm_config(extra_config={"use_layerwise": False})
         from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
@@ -304,7 +326,25 @@ class TestAscendStoreConnector(unittest.TestCase):
             kv_cache_config=None,
         )
         connector.save_kv_layer("layer_0", MagicMock(), MagicMock())
-        # Consumer should not save
+        mock_worker_cls.return_value.save_kv_layer.assert_not_called()
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
+    def test_save_kv_layer_consumer_is_to_put_still_skips_layerwise(self, mock_worker_cls, mock_lookup_cls):
+        config = self._make_vllm_config(
+            kv_role="kv_consumer",
+            extra_config={"use_layerwise": True, "consumer_is_to_put": True},
+        )
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        connector = AscendStoreConnector(
+            vllm_config=config,
+            role=KVConnectorRole.WORKER,
+            kv_cache_config=None,
+        )
+        connector.save_kv_layer("layer_0", MagicMock(), MagicMock())
+
+        mock_worker_cls.return_value.save_kv_layer.assert_not_called()
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -364,8 +364,10 @@ class TestMooncakeBackendMethods(unittest.TestCase):
     def test_put(self):
         b = self._make_backend()
         b.store.batch_put_from_multi_buffers.return_value = [0, 0]
-        b.put(["k1"], [[100]], [[10]])
+        with self.assertLogs("vllm", level="INFO") as captured:
+            b.put(["k1"], [[100]], [[10]])
         b.store.batch_put_from_multi_buffers.assert_called_once()
+        self.assertIn("[AscendStore][Mooncake][put] completed", "\n".join(captured.output))
 
     def test_put_error(self):
         b = self._make_backend()
@@ -380,8 +382,10 @@ class TestMooncakeBackendMethods(unittest.TestCase):
     def test_get(self):
         b = self._make_backend()
         b.store.batch_get_into_multi_buffers.return_value = [0]
-        b.get(["k1"], [[100]], [[10]])
+        with self.assertLogs("vllm", level="INFO") as captured:
+            b.get(["k1"], [[100]], [[10]])
         b.store.batch_get_into_multi_buffers.assert_called_once()
+        self.assertIn("[AscendStore][Mooncake][get] completed", "\n".join(captured.output))
 
     def test_get_error(self):
         b = self._make_backend()

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -106,10 +106,11 @@ class TestLayerPoolKey(unittest.TestCase):
         self.assertNotEqual(hash(k1), hash(k2))
 
     def test_to_string_contains_layer_id(self):
-        meta = KeyMetadata("model", 0, 0, 0, 0)
+        meta = KeyMetadata("model", 0, 0, 0, 3)
         k = LayerPoolKey(meta, "h1", 5)
         s = k.to_string()
         self.assertIn("@layer_id:5", s)
+        self.assertIn("@pp_rank:3", s)
         self.assertIn("model", s)
         self.assertTrue(s.endswith("@h1"))
 
@@ -234,6 +235,37 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         # layer_id=0, entries_per_layers=2 => group_addrs[0] and group_addrs[1]
         self.assertEqual(addr[0], 1000 + 5 * 160)
         self.assertEqual(addr[1], 2000 + 5 * 320)
+
+    def test_prepare_value_layer_uses_group_local_layer_and_explicit_block(self):
+        metadata = [
+            KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=0),
+            KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=1),
+        ]
+        db = ChunkedTokenDatabase(metadata, block_size=[16, 16], partitions=None)
+        db.set_group_buffers(
+            {
+                0: [1000],
+                1: [2000, 3000],
+            },
+            {
+                0: [160],
+                1: [160, 320],
+            },
+            group_num_layers={0: 1, 1: 2},
+        )
+
+        addr, size, block_id = db.prepare_value_layer(
+            0,
+            16,
+            [11],
+            layer_id=1,
+            kv_cache_group_id=1,
+            block_id=77,
+        )
+
+        self.assertEqual(block_id, 77)
+        self.assertEqual(addr, [3000 + 77 * 320])
+        self.assertEqual(size, [320])
 
     def test_decode_adaptor_prefill_pp_no_partitions(self):
         key, addr, size = self.db.decode_adaptor_prefill_pp(["k1"], [[1, 2]], [[10, 20]])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -470,6 +470,24 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
 
+    def test_final_layer_logs_put_summary(self):
+        t, store = self._make_thread([0], num_layers=2)
+        req = self._make_layer_req(layer_id=0, is_last_chunk=True, num_keys=1)
+        req.layer_name = "model.layers.1.self_attn.attn"
+        req.is_last_layer = True
+        t.add_stored_request(req.req_id)
+        t.request_queue.put(req)
+
+        with self.assertLogs("vllm", level="INFO") as captured:
+            t._handle_request(req)
+
+        self.assertEqual(len(store.put_calls), 1)
+        summary = "\n".join(captured.output)
+        self.assertIn("[AscendStore][layerwise][put] chunk complete", summary)
+        self.assertIn("processed_layers=1/2", summary)
+        self.assertIn("backend_call_layers=1", summary)
+        self.assertIn("backend_keys=1", summary)
+
     def test_handle_request_all_exist_not_last(self):
         t, store = self._make_thread([1, 1])
         req = self._make_layer_req(layer_id=0, is_last_chunk=False)
@@ -532,6 +550,17 @@ class TestKVCacheStoreLayerSendingThread(unittest.TestCase):
         t._handle_request(req)
         finished = t.get_and_clear_finished_requests()
         self.assertIn("r1", finished)
+
+    def test_group_local_layer_can_mark_global_final_layer(self):
+        t, store = self._make_thread([0], num_layers=3)
+        req = self._make_layer_req(layer_id=0, is_last_chunk=True, num_keys=1)
+        req.is_last_layer = True
+        t.add_stored_request(req.req_id)
+        t.request_queue.put(req)
+
+        t._handle_request(req)
+
+        self.assertIn("r1", t.get_and_clear_finished_requests())
 
     def test_layerwise_kv_event_published_on_final_layer(self):
         t, store = self._make_thread([0], num_layers=2, enable_kv_event=True)
@@ -597,6 +626,64 @@ class TestKVCacheStoreLayerRecvingThread(unittest.TestCase):
         t._handle_request(req)
         self.assertEqual(len(store.get_calls), 1)
         self.assertTrue(get_event.is_set())
+
+    def test_handle_request_uses_cache_group_and_explicit_tail_block(self):
+        class GroupAwareTokenDatabase(FakeTokenDatabase):
+            def __init__(self):
+                super().__init__()
+                self.prepare_calls = []
+
+            def prepare_value_layer(
+                self,
+                start,
+                end,
+                block_ids,
+                layer_id,
+                kv_cache_group_id=0,
+                block_id=None,
+            ):
+                self.prepare_calls.append((kv_cache_group_id, layer_id, block_ids, block_id))
+                return [3000 + kv_cache_group_id * 100 + block_id], [end - start], block_id
+
+        class SuccessfulStore(FakeStore):
+            def get(self, keys, addrs, sizes):
+                super().get(keys, addrs, sizes)
+                return [0] * len(keys)
+
+        store = SuccessfulStore()
+        db = GroupAwareTokenDatabase()
+        get_event = threading.Event()
+        completion_event = threading.Event()
+        t = KVCacheStoreLayerRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=[16, 16],
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            get_event=get_event,
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+        )
+        meta = KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=1, cache_family="c128")
+        req = LayerMultiBlockReqMeta(
+            req_id="r1",
+            keys=[LayerPoolKey(meta, "h0", 0)],
+            starts=[128],
+            ends=[144],
+            block_ids_by_group=[[1, 2], [77]],
+            layer_id=0,
+            kv_cache_group_id=1,
+            key_block_ids=[77],
+            completion_event=completion_event,
+        )
+        t.request_queue.put(req)
+
+        t._handle_request(req)
+
+        self.assertEqual(db.prepare_calls, [(1, 0, [77], 77)])
+        self.assertTrue(completion_event.is_set())
+        self.assertFalse(req.load_failed)
 
 
 class TestKVTransferTpMismatchDispatch(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -16,14 +16,24 @@
 #
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+# isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
     KVPoolScheduler,
     LookupKeyClient,
     get_zmq_rpc_path_lookup,
 )
+# isort: on
 
 
 class TestGetZmqRpcPathLookup(unittest.TestCase):
@@ -62,6 +72,44 @@ class TestKVPoolScheduler(unittest.TestCase):
         config.parallel_config.decode_context_parallel_size = 1
         config.cache_config.block_size = block_size
         return config
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_layerwise_accepts_dsv4_multi_group_cache(self, mock_client_cls):
+        config = self._make_config(block_size=16)
+        hf_config = SimpleNamespace(
+            model_type="deepseek_v4",
+            compress_ratios=[4, 128],
+            num_hidden_layers=2,
+        )
+        config.model_config.hf_text_config = hf_config
+        config.model_config.hf_config = hf_config
+        config.scheduler_config.disable_hybrid_kv_cache_manager = False
+        config.speculative_config = None
+        config.parallel_config.world_size = 1
+        config.cache_config.hash_block_size = 16
+        c4_spec = FullAttentionSpec(block_size=16, compress_ratio=4)
+        c128_spec = SlidingWindowSpec(block_size=16, sliding_window=2048, compress_ratio=128)
+        kv_cache_config = KVCacheConfig(
+            num_blocks=8,
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=["model.layers.0.self_attn.attn"],
+                    kv_cache_spec=UniformTypeKVCacheSpecs(
+                        block_size=16,
+                        kv_cache_specs={"model.layers.0.self_attn.attn": c4_spec},
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    layer_names=["model.layers.1.self_attn.attn"],
+                    kv_cache_spec=c128_spec,
+                ),
+            ],
+        )
+
+        scheduler = KVPoolScheduler(config, use_layerwise=True, kv_cache_config=kv_cache_config)
+
+        self.assertEqual(scheduler.kv_cache_group_ids, [0, 1])
+        self.assertEqual(scheduler.kv_cache_group_families, ["c4", "c128"])
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_consumer_no_load(self, mock_client_cls):
@@ -248,10 +296,10 @@ class TestKVPoolScheduler(unittest.TestCase):
 
 
 class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
-    def _make_config(self, kv_role="kv_producer", block_size=16):
+    def _make_config(self, kv_role="kv_producer", block_size=16, extra_config=None):
         config = MagicMock()
         config.kv_transfer_config.kv_role = kv_role
-        config.kv_transfer_config.kv_connector_extra_config = {}
+        config.kv_transfer_config.kv_connector_extra_config = extra_config or {}
         config.kv_transfer_config.get_from_extra_config.return_value = True
         config.parallel_config.data_parallel_rank = 0
         config.parallel_config.prefill_context_parallel_size = 1
@@ -345,8 +393,40 @@ class TestKVPoolSchedulerBuildMeta(unittest.TestCase):
         sched_output.scheduled_cached_reqs = MagicMock()
         sched_output.scheduled_cached_reqs.req_ids = []
 
-        _meta = scheduler.build_connector_meta(sched_output)
-        # Consumer with no consumer_is_to_put => force_skip_save
+        meta = scheduler.build_connector_meta(sched_output)
+        self.assertEqual(meta.requests, [])
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_build_connector_meta_layerwise_consumer_never_saves(self, mock_client_cls):
+        config = self._make_config(
+            kv_role="kv_consumer",
+            extra_config={"consumer_is_to_put": True},
+        )
+        scheduler = KVPoolScheduler(config, use_layerwise=True)
+
+        request = MagicMock()
+        request.request_id = "r1"
+        request.prompt_token_ids = list(range(32))
+        scheduler.update_state_after_alloc(request, MagicMock(), 0)
+
+        new_req_data = MagicMock()
+        new_req_data.req_id = "r1"
+        new_req_data.num_computed_tokens = 0
+        new_req_data.block_ids = [0, 1]
+        new_req_data.prompt_token_ids = list(range(32))
+
+        sched_output = MagicMock()
+        sched_output.finished_req_ids = set()
+        sched_output.preempted_req_ids = set()
+        sched_output.scheduled_new_reqs = [new_req_data]
+        sched_output.num_scheduled_tokens = {"r1": 32}
+        sched_output.scheduled_cached_reqs = MagicMock()
+        sched_output.scheduled_cached_reqs.req_ids = []
+
+        meta = scheduler.build_connector_meta(sched_output)
+
+        self.assertEqual(meta.requests, [])
+        self.assertEqual(scheduler.request_finished(request, [0, 1]), (False, None))
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_build_connector_meta_preempted(self, mock_client_cls):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock, patch
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
+    ChunkedTokenDatabase,
+    KeyMetadata,
     LoadSpec,
     ReqMeta,
 )
@@ -534,12 +536,12 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         config.kv_events_config = None
         return config
 
-    def _make_worker(self, kv_role="kv_producer", extra_config=None):
+    def _make_worker(self, kv_role="kv_producer", extra_config=None, use_layerwise=False):
         self._patch_all()
         config = self._make_config(kv_role=kv_role, extra_config=extra_config)
         from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import KVPoolWorker
 
-        worker = KVPoolWorker(config, use_layerwize=False)
+        worker = KVPoolWorker(config, use_layerwize=use_layerwise)
         return worker
 
     def setUp(self):
@@ -558,6 +560,26 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.register_kv_caches(kv_caches)
         self.assertEqual(len(worker.group_kv_caches_base_addr[0]), 2)
         worker.m_store.register_buffer.assert_called_once()
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.threading.Event")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreLayerSendingThread")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreLayerRecvingThread")
+    def test_layerwise_consumer_does_not_create_put_thread(self, mock_recv_cls, mock_send_cls, mock_event_cls):
+        worker = self._make_worker(
+            kv_role="kv_consumer",
+            extra_config={"backend": "mooncake", "consumer_is_to_put": True},
+            use_layerwise=True,
+        )
+        fake_cache = MagicMock()
+        fake_cache.shape = [100, 16, 8, 64]
+        fake_cache.element_size.return_value = 2
+        fake_cache.data_ptr.return_value = 10000
+
+        worker.register_kv_caches({"layer.0": (fake_cache, fake_cache)})
+
+        mock_send_cls.assert_not_called()
+        mock_recv_cls.assert_called_once()
+        self.assertIsNone(worker.kv_send_thread)
 
     def test_start_load_kv_sync(self):
         worker = self._make_worker()
@@ -614,6 +636,13 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.start_load_kv(meta)
         # No get called since no load_spec
 
+    def test_layerwise_empty_forward_does_not_log_metadata_summary(self):
+        worker = self._make_worker(use_layerwise=True)
+        meta = AscendConnectorMetadata(set(), set())
+
+        with self.assertNoLogs("vllm", level="INFO"):
+            worker.start_load_kv(meta)
+
     def test_wait_for_save(self):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()
@@ -668,6 +697,20 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         done_s, done_r = worker.get_finished(set(), meta)
         self.assertEqual(done_s, set())
 
+    def test_get_finished_layerwise_consumer_does_not_use_put_thread(self):
+        worker = self._make_worker(
+            kv_role="kv_consumer",
+            extra_config={"backend": "mooncake", "consumer_is_to_put": True},
+            use_layerwise=True,
+        )
+        worker.kv_send_thread = None
+        meta = AscendConnectorMetadata(set(), set())
+
+        done_s, done_r = worker.get_finished(set(), meta)
+
+        self.assertEqual(done_s, set())
+        self.assertEqual(done_r, set())
+
     def test_lookup_scheduler_all_cached(self):
         worker = self._make_worker()
         worker.m_store.exists.return_value = [1, 1]
@@ -698,6 +741,88 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.m_store.exists.return_value = [1, 1, 1, 1]
         result = worker.lookup_scheduler(32, ["h0", "h1"], use_layerwise=True)
         self.assertEqual(result, 32)
+
+    def test_dsv4_layerwise_lookup_checks_each_group_in_raw_token_coordinates(self):
+        worker = self._make_worker()
+        metadata = [
+            KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=0),
+            KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=1),
+        ]
+        worker.token_database = ChunkedTokenDatabase(
+            metadata,
+            block_size=[16, 16],
+            partitions=None,
+            hash_block_size=16,
+        )
+        worker.token_database.group_cache_families["kv"] = {0: "c4", 1: "c128"}
+        worker.grouped_block_size = [16, 16]
+        worker.kv_cache_group_families = ["c4", "c128"]
+        worker.group_num_layers = {0: 2, 1: 1}
+        worker.group_uses_align_state = [False, False]
+        worker.num_kv_cache_groups = 2
+        worker.cache_coordinator = None
+        worker.cache_transfer_granularity = 2048
+        worker.max_model_len = 4096
+        worker.m_store.exists.side_effect = lambda keys: [1] * len(keys)
+        block_hashes = [bytes([index]) * 32 for index in range(128)]
+
+        result = worker.lookup_scheduler(
+            2048,
+            block_hashes,
+            kv_cache_group_ids=[0, 1],
+            use_layerwise=True,
+        )
+
+        self.assertEqual(result, 2048)
+        first_group_keys = worker.m_store.exists.call_args_list[0].args[0]
+        second_group_keys = worker.m_store.exists.call_args_list[1].args[0]
+        self.assertEqual(len(first_group_keys), 64)  # 32 chunks * 2 c4 layers
+        self.assertEqual(len(second_group_keys), 1)  # 1 chunk * 1 c128 layer
+        self.assertIn("@group:1", second_group_keys[0])
+        self.assertIn("@layer_id:0", second_group_keys[0])
+
+    def test_dsv4_layerwise_task_uses_group_local_layer_and_block_table(self):
+        worker = self._make_worker()
+        metadata = [
+            KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=0),
+            KeyMetadata("dsv4", 0, 0, 0, 0, kv_cache_group_id=1),
+        ]
+        worker.token_database = ChunkedTokenDatabase(
+            metadata,
+            block_size=[16, 16],
+            partitions=None,
+            hash_block_size=16,
+        )
+        worker.token_database.group_cache_families["kv"] = {0: "c4", 1: "c128"}
+        worker.grouped_block_size = [16, 16]
+        worker.hash_block_size = 16
+        worker.kv_cache_group_families = ["c4", "c128"]
+        worker.group_uses_align_state = [False, False]
+        worker.layer_to_group = {
+            "model.layers.0.self_attn.attn": (0, 0),
+            "model.layers.1.self_attn.attn": (1, 0),
+        }
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=2048,
+            block_ids_by_group=[list(range(32)), [77]],
+            block_hashes=[bytes([index]) * 32 for index in range(128)],
+            can_save=True,
+        )
+
+        task = worker._build_layerwise_task(
+            request,
+            "model.layers.1.self_attn.attn",
+            is_load=False,
+            is_last_layer=True,
+        )
+
+        self.assertEqual(task.kv_cache_group_id, 1)
+        self.assertEqual(task.layer_id, 0)
+        self.assertEqual(task.key_block_ids, [77])
+        self.assertTrue(task.is_last_layer)
+        self.assertEqual(len(task.keys), 1)
+        self.assertIn("@cache_family:c128", task.keys[0].to_string())
 
     def test_lookup_scheduler_multi_tp(self):
         self._stop_all()

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1820,6 +1820,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                 should_shard_weight=full_gather_o_proj_enabled,
             )
             if not require_o_proj_forward:
+                # The full-weight DSA-CP prefill path completes o_proj here and
+                # returns early, so it must notify layerwise KV connectors first.
+                maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
                 return result
             attn_output = result
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -87,6 +87,14 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.consumer_is_to_put = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "consumer_is_to_put", False
         )
+        backend = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
+        if self.use_layerwise:
+            logger.info(
+                "[AscendStore][layerwise] connector enabled role=%s backend=%s prefill_put=%s",
+                self.kv_role,
+                backend,
+                self.kv_role in ["kv_producer", "kv_both"],
+            )
 
         connector_name = vllm_config.kv_transfer_config.kv_connector
         if connector_name == "MooncakeConnectorStoreV1":
@@ -214,7 +222,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_layer_load(self, layer_name: str) -> None:
         if not self.use_layerwise:
             return
-        self.connector_worker.wait_for_layer_load()
+        self.connector_worker.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
         self, layer_name: str, kv_layer: torch.Tensor, attn_metadata: "AttentionMetadata", **kwargs
@@ -223,12 +231,15 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
             return
 
         if self.kv_role == "kv_consumer":
-            # Don't do save if the role is kv_consumer
+            logger.info(
+                "[AscendStore][layerwise][put] skip save callback layer=%s reason=consumer_role",
+                layer_name,
+            )
             return
-        self.connector_worker.save_kv_layer(self._get_connector_metadata())
+        self.connector_worker.save_kv_layer(layer_name, self._get_connector_metadata())
 
     def wait_for_save(self):
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+        if self.kv_role == "kv_consumer" and (self.use_layerwise or not self.consumer_is_to_put):
             # Don't do save if the role is kv_consumer
             return
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -181,14 +181,22 @@ class MooncakeBackend(Backend):
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         self.ensure_initialized()
         assert self.store is not None
+        logger.info("[AscendStore][Mooncake][put] start keys=%d", len(keys))
         try:
             config = ReplicateConfig()
             if self.config.preferred_segment:
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            failed_codes = [int(value) for value in res if value < 0]
+            res_list = list(res)
+            failed_codes = [int(value) for value in res_list if value < 0]
             failed_count = len(failed_codes)
+            logger.info(
+                "[AscendStore][Mooncake][put] completed keys=%d returned=%d failed=%d",
+                len(keys),
+                len(res_list),
+                failed_count,
+            )
             if failed_count:
                 error_codes = sorted(set(failed_codes))
                 logger.error(
@@ -197,7 +205,7 @@ class MooncakeBackend(Backend):
                     len(keys),
                     error_codes,
                 )
-                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
+                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res_list)
                 if self._lazy_init:
                     logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
@@ -226,16 +234,18 @@ class MooncakeBackend(Backend):
             logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
-        logger.debug(
-            "MooncakeBackend.get enter keys=%d sample_keys=%s",
-            len(keys),
-            keys[:3],
-        )
+        logger.info("[AscendStore][Mooncake][get] start keys=%d", len(keys))
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
             res_list = list(res)
             failed_codes = [int(value) for value in res_list if value < 0]
             failed_count = len(failed_codes)
+            logger.info(
+                "[AscendStore][Mooncake][get] completed keys=%d returned=%d failed=%d",
+                len(keys),
+                len(res_list),
+                failed_count,
+            )
             error_codes = sorted(set(failed_codes))
             if failed_count:
                 logger.error(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import threading
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -151,6 +152,7 @@ class LayerPoolKey(PoolKey):
                 self.key_metadata.head_or_tp_rank,
                 self.key_metadata.pcp_rank,
                 self.key_metadata.dcp_rank,
+                self.key_metadata.pp_rank,
                 self.key_metadata.kv_cache_group_id,
                 self.key_metadata.cache_role,
                 self.key_metadata.cache_family,
@@ -164,6 +166,7 @@ class LayerPoolKey(PoolKey):
             f"{self.key_metadata.model_name}"
             f"@pcp{self.key_metadata.pcp_rank}@dcp{self.key_metadata.dcp_rank}"
             f"@head_or_tp_rank:{self.key_metadata.head_or_tp_rank}"
+            f"@pp_rank:{self.key_metadata.pp_rank}"
             f"@group:{self.key_metadata.kv_cache_group_id}"
             f"@cache_role:{self.key_metadata.cache_role}"
             f"@cache_family:{self.key_metadata.cache_family}"
@@ -407,16 +410,34 @@ class ChunkedTokenDatabase:
             size_list.append(size)
         return addr_list, size_list, block_id
 
-    def prepare_value_layer(self, start: int, end: int, block_ids: list[int], layer_id: int):
-        group_block_size = self.get_block_size(0)
-        block_idx = start // group_block_size
-        if block_idx >= len(block_ids):
-            return [], [], 0
-        block_id = block_ids[block_idx]
+    def prepare_value_layer(
+        self,
+        start: int,
+        end: int,
+        block_ids: list[int],
+        layer_id: int,
+        kv_cache_group_id: int = 0,
+        block_id: int | None = None,
+    ):
+        """Return the physical regions for one layer in one cache group.
+
+        ``layer_id`` is local to ``kv_cache_group_id``.  Keeping both values
+        explicit is required by packed/hybrid layouts such as DeepSeek V4,
+        where model execution order and physical group order are different.
+        ``block_id`` may be supplied by ``process_tokens_with_block_ids`` so a
+        clipped sliding-window block table does not get indexed as if it were
+        the full logical block table.
+        """
+        group_block_size = self.get_block_size(kv_cache_group_id)
+        if block_id is None:
+            block_idx = start // group_block_size
+            if block_idx >= len(block_ids):
+                return [], [], 0
+            block_id = block_ids[block_idx]
         addr_list: list[int] = []
         size_list: list[int] = []
-        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(0)
-        num_layers = self.group_num_layers.get("kv", {}).get(0, 1)
+        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id)
+        num_layers = self.group_num_layers.get("kv", {}).get(kv_cache_group_id, 1)
         entries_per_layer = len(group_addrs) // num_layers if num_layers else 0
         if layer_id >= num_layers or entries_per_layer == 0:
             return [], [], 0
@@ -914,6 +935,11 @@ class LayerMultiBlockReqMeta:
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
     kv_cache_group_id: int = 0
+    key_block_ids: list[int] = field(default_factory=list)
+    layer_name: str | None = None
+    is_last_layer: bool | None = None
+    completion_event: threading.Event | None = None
+    load_failed: bool = False
 
     def __init__(
         self,
@@ -930,6 +956,10 @@ class LayerMultiBlockReqMeta:
         original_block_size: list[int] | int | None = None,
         block_hashes: list[Any] | None = None,
         kv_cache_group_id: int = 0,
+        key_block_ids: list[int] | None = None,
+        layer_name: str | None = None,
+        is_last_layer: bool | None = None,
+        completion_event: threading.Event | None = None,
     ) -> None:
         self.req_id = req_id
         self.keys = keys
@@ -945,6 +975,11 @@ class LayerMultiBlockReqMeta:
         self.original_block_size = original_block_size
         self.block_hashes = [] if block_hashes is None else block_hashes
         self.kv_cache_group_id = kv_cache_group_id
+        self.key_block_ids = [] if key_block_ids is None else key_block_ids
+        self.layer_name = layer_name
+        self.is_last_layer = is_last_layer
+        self.completion_event = completion_event
+        self.load_failed = False
 
     @property
     def block_ids(self) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -197,6 +197,27 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.prepare_value(start, end, block_ids)
 
+    def _prepare_value_layer(
+        self,
+        start: int,
+        end: int,
+        block_ids: list[int],
+        layer_id: int,
+        kv_cache_group_id: int = 0,
+        block_id: int | None = None,
+    ):
+        try:
+            return self.token_database.prepare_value_layer(
+                start,
+                end,
+                block_ids,
+                layer_id,
+                kv_cache_group_id=kv_cache_group_id,
+                block_id=block_id,
+            )
+        except TypeError:
+            return self.token_database.prepare_value_layer(start, end, block_ids, layer_id)
+
     def _decode_adaptor_prefill_pp(
         self,
         keys: list[str],
@@ -616,6 +637,11 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.stored_requests: dict[str, int] = defaultdict(int)
         self.done_task_lock = threading.Lock()
         self.layerwise_event_lock = threading.Lock()
+        self._processed_layers: dict[str, set[str]] = defaultdict(set)
+        self._backend_call_layers: dict[str, set[str]] = defaultdict(set)
+        self._backend_key_counts: dict[str, int] = defaultdict(int)
+        self._all_exist_layer_counts: dict[str, int] = defaultdict(int)
+        self._empty_layer_counts: dict[str, int] = defaultdict(int)
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -632,14 +658,55 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 del self.stored_requests[req_id]
         with self.layerwise_event_lock:
             self.layerwise_event_starts.pop(req_id, None)
+        self._clear_put_stats(req_id)
+
+    @staticmethod
+    def _layer_label(req_meta: LayerMultiBlockReqMeta) -> str:
+        if req_meta.layer_name is not None:
+            return req_meta.layer_name
+        return f"group_{req_meta.kv_cache_group_id}.layer_{req_meta.layer_id}"
+
+    def _clear_put_stats(self, req_id: str) -> None:
+        self._processed_layers.pop(req_id, None)
+        self._backend_call_layers.pop(req_id, None)
+        self._backend_key_counts.pop(req_id, None)
+        self._all_exist_layer_counts.pop(req_id, None)
+        self._empty_layer_counts.pop(req_id, None)
+
+    def _log_put_summary(self, req_meta: LayerMultiBlockReqMeta) -> None:
+        if not self._is_final_layer(req_meta):
+            return
+        req_id = req_meta.req_id
+        logger.info(
+            "[AscendStore][layerwise][put] chunk complete backend=%s req=%s "
+            "processed_layers=%d/%d backend_call_layers=%d backend_keys=%d "
+            "all_exist_layers=%d empty_layers=%d tp_rank=%d put_step=%d is_last_chunk=%s",
+            type(self.m_store).__name__,
+            req_id,
+            len(self._processed_layers.get(req_id, set())),
+            self.final_layer_id + 1,
+            len(self._backend_call_layers.get(req_id, set())),
+            self._backend_key_counts.get(req_id, 0),
+            self._all_exist_layer_counts.get(req_id, 0),
+            self._empty_layer_counts.get(req_id, 0),
+            self.tp_rank,
+            self.put_step,
+            req_meta.is_last_chunk,
+        )
+        self._clear_put_stats(req_id)
 
     def _record_layerwise_event_starts(self, req_meta: LayerMultiBlockReqMeta, starts: list[int]) -> None:
         if self.enable_kv_event:
             with self.layerwise_event_lock:
                 self.layerwise_event_starts[req_meta.req_id].update(starts)
 
+    def _is_final_layer(self, req_meta: LayerMultiBlockReqMeta) -> bool:
+        if req_meta.is_last_layer is not None:
+            return req_meta.is_last_layer
+        return req_meta.layer_id == self.final_layer_id
+
     def _build_stored_events(self, req_meta: LayerMultiBlockReqMeta) -> list[BlockStored]:
-        if not self.enable_kv_event or req_meta.layer_id != self.final_layer_id:
+        if not self.enable_kv_event or not self._is_final_layer(req_meta):
             return []
         block_size = (
             req_meta.original_block_size[req_meta.kv_cache_group_id]
@@ -685,27 +752,59 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         starts = req_meta.starts
         ends = req_meta.ends
         keys = req_meta.keys
+        key_block_ids = req_meta.key_block_ids
         layer_id = req_meta.layer_id
         current_event = req_meta.current_event
         total_block = len(keys)
         is_last_chunk = req_meta.is_last_chunk
+        is_final_layer = self._is_final_layer(req_meta)
+        layer_label = self._layer_label(req_meta)
         with self.done_task_lock:
             if req_meta.req_id not in self.stored_requests:
+                logger.warning(
+                    "[AscendStore][layerwise][put] drop task req=%s layer=%s group=%d reason=request_not_registered",
+                    req_meta.req_id,
+                    layer_label,
+                    req_meta.kv_cache_group_id,
+                )
+                if is_final_layer:
+                    self._clear_put_stats(req_meta.req_id)
                 self.request_queue.task_done()
                 return
+        self._processed_layers[req_meta.req_id].add(layer_label)
         if not self.dcp_size > 1:
             starts = starts[self.tp_rank % self.put_step :: self.put_step]
             ends = ends[self.tp_rank % self.put_step :: self.put_step]
             keys = keys[self.tp_rank % self.put_step :: self.put_step]
+            key_block_ids = key_block_ids[self.tp_rank % self.put_step :: self.put_step]
+
+        logger.info(
+            "[AscendStore][layerwise][put] dequeue req=%s layer=%s group=%d group_layer=%d total_keys=%d owned_keys=%d",
+            req_meta.req_id,
+            layer_label,
+            req_meta.kv_cache_group_id,
+            layer_id,
+            total_block,
+            len(keys),
+        )
 
         if not keys:
-            if layer_id == self.final_layer_id:
+            self._empty_layer_counts[req_meta.req_id] += 1
+            logger.info(
+                "[AscendStore][layerwise][put] skip backend req=%s layer=%s group=%d reason=no_owned_keys",
+                req_meta.req_id,
+                layer_label,
+                req_meta.kv_cache_group_id,
+            )
+            if is_final_layer:
                 stored_events = self._build_stored_events(req_meta)
                 if stored_events:
                     self.update_kv_event(stored_events)
-            if is_last_chunk and layer_id == self.final_layer_id:
+            if is_final_layer:
                 self.dec_stored_request(req_meta.req_id)
-                self.set_finished_request(req_meta.req_id)
+                if is_last_chunk:
+                    self.set_finished_request(req_meta.req_id)
+            self._log_put_summary(req_meta)
             self.request_queue.task_done()
             return
 
@@ -717,45 +816,83 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
 
         if not missing_indices:
-            if layer_id == self.final_layer_id:
+            self._all_exist_layer_counts[req_meta.req_id] += 1
+            logger.info(
+                "[AscendStore][layerwise][put] skip backend req=%s layer=%s group=%d reason=all_keys_exist keys=%d",
+                req_meta.req_id,
+                layer_label,
+                req_meta.kv_cache_group_id,
+                len(key_list),
+            )
+            if is_final_layer:
                 stored_events = self._build_stored_events(req_meta)
                 if stored_events:
                     self.update_kv_event(stored_events)
-            if is_last_chunk and layer_id == self.final_layer_id:
+            if is_final_layer:
                 self.dec_stored_request(req_meta.req_id)
-                self.set_finished_request(req_meta.req_id)
+                if is_last_chunk:
+                    self.set_finished_request(req_meta.req_id)
+            self._log_put_summary(req_meta)
             self.request_queue.task_done()
             return
 
         starts = [starts[index] for index in missing_indices]
         ends = [ends[index] for index in missing_indices]
         key_list = [key_list[index] for index in missing_indices]
+        key_block_ids = [key_block_ids[index] for index in missing_indices] if key_block_ids else []
 
         addr_list = []
         size_list = []
         for index, key in enumerate(key_list):
-            addr, size, _ = self.token_database.prepare_value_layer(
-                starts[index], ends[index], req_meta.block_ids_by_group[0], layer_id
+            block_id = key_block_ids[index] if key_block_ids else None
+            addr, size, _ = self._prepare_value_layer(
+                starts[index],
+                ends[index],
+                req_meta.block_ids_by_group[req_meta.kv_cache_group_id],
+                layer_id,
+                kv_cache_group_id=req_meta.kv_cache_group_id,
+                block_id=block_id,
             )
             addr_list.append(addr)
             size_list.append(size)
 
         if current_event is not None:
             current_event.synchronize()
+        logger.info(
+            "[AscendStore][layerwise][put] backend call backend=%s req=%s layer=%s group=%d group_layer=%d keys=%d",
+            type(self.m_store).__name__,
+            req_meta.req_id,
+            layer_label,
+            req_meta.kv_cache_group_id,
+            layer_id,
+            len(key_list),
+        )
         self.m_store.put(key_list, addr_list, size_list)
+        self._backend_call_layers[req_meta.req_id].add(layer_label)
+        self._backend_key_counts[req_meta.req_id] += len(key_list)
+        logger.info(
+            "[AscendStore][layerwise][put] backend returned backend=%s req=%s layer=%s group=%d keys=%d",
+            type(self.m_store).__name__,
+            req_meta.req_id,
+            layer_label,
+            req_meta.kv_cache_group_id,
+            len(key_list),
+        )
         self._record_layerwise_event_starts(req_meta, starts)
         stored_events = self._build_stored_events(req_meta)
         if stored_events:
             self.update_kv_event(stored_events)
 
-        if layer_id == self.final_layer_id and is_last_chunk:
+        if is_final_layer:
             with self.layerwise_event_lock:
                 self.layerwise_event_starts.pop(req_meta.req_id, None)
             self.dec_stored_request(req_meta.req_id)
-            self.set_finished_request(req_meta.req_id)
+            if is_last_chunk:
+                self.set_finished_request(req_meta.req_id)
+        self._log_put_summary(req_meta)
         self.request_queue.task_done()
 
-        if layer_id == self.final_layer_id:
+        if is_final_layer:
             logger.info(
                 "Storing KV cache layerwise for %d out of %d blocks (missing_count=%d) for request %s, layer %d",
                 len(key_list),
@@ -803,39 +940,88 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
     def _handle_request(  # type: ignore[override]
         self, req_meta: LayerMultiBlockReqMeta
     ):
-        addr_list = []
-        size_list = []
-        key_list = []
-        block_id_list = []
-        for index, key in enumerate(req_meta.keys):
-            addr, size, block_id = self.token_database.prepare_value_layer(
-                req_meta.starts[index], req_meta.ends[index], req_meta.block_ids_by_group[0], req_meta.layer_id
+        try:
+            addr_list = []
+            size_list = []
+            key_list = []
+            block_id_list = []
+            group_id = req_meta.kv_cache_group_id
+            group_block_ids = req_meta.block_ids_by_group[group_id]
+            for index, key in enumerate(req_meta.keys):
+                requested_block_id = req_meta.key_block_ids[index] if req_meta.key_block_ids else None
+                addr, size, block_id = self._prepare_value_layer(
+                    req_meta.starts[index],
+                    req_meta.ends[index],
+                    group_block_ids,
+                    req_meta.layer_id,
+                    kv_cache_group_id=group_id,
+                    block_id=requested_block_id,
+                )
+                key_list.append(key.to_string())
+                addr_list.append(addr)
+                size_list.append(size)
+                block_id_list.append(block_id)
+
+            if not key_list:
+                logger.info(
+                    "[AscendStore][layerwise][get] skip backend req=%s layer=%s group=%d reason=no_keys",
+                    req_meta.req_id,
+                    req_meta.layer_name or req_meta.layer_id,
+                    group_id,
+                )
+                return
+
+            offset = self.tp_rank % len(key_list)
+            key_list_c = key_list[offset:] + key_list[:offset]
+            addr_list_c = addr_list[offset:] + addr_list[:offset]
+            size_list_c = size_list[offset:] + size_list[:offset]
+            block_id_list_c = block_id_list[offset:] + block_id_list[:offset]
+            logger.info(
+                "[AscendStore][layerwise][get] backend call backend=%s req=%s layer=%s group=%d group_layer=%d keys=%d",
+                type(self.m_store).__name__,
+                req_meta.req_id,
+                req_meta.layer_name or req_meta.layer_id,
+                group_id,
+                req_meta.layer_id,
+                len(key_list_c),
             )
-            key_list.append(key.to_string())
-            addr_list.append(addr)
-            size_list.append(size)
-            block_id_list.append(block_id)
+            ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
 
-        offset = self.tp_rank % len(key_list)
-        key_list_c = key_list[offset:] + key_list[:offset]
-        addr_list_c = addr_list[offset:] + addr_list[:offset]
-        size_list_c = size_list[offset:] + size_list[:offset]
-        block_id_list_c = block_id_list[offset:] + block_id_list[:offset]
-        ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
-
-        if ret is not None and any(r != 0 for r in ret):
-            missing_block_ids = record_failed_blocks(
-                block_id_list_c,
-                ret,
+            failed_count = 0
+            if ret is not None and any(r != 0 for r in ret):
+                missing_block_ids = record_failed_blocks(
+                    block_id_list_c,
+                    ret,
+                )
+                req_meta.load_failed = True
+                failed_count = sum(code != 0 for code in ret)
+                if len(req_meta.block_ids_by_group) == 1:
+                    with self._invalid_block_ids_lock:
+                        self._invalid_block_ids.update(missing_block_ids)
+            elif ret is None:
+                req_meta.load_failed = True
+                failed_count = len(key_list_c)
+                if len(req_meta.block_ids_by_group) == 1:
+                    with self._invalid_block_ids_lock:
+                        self._invalid_block_ids.update(block_id_list_c)
+            logger.info(
+                "[AscendStore][layerwise][get] backend returned backend=%s req=%s layer=%s group=%d "
+                "keys=%d failed_keys=%d",
+                type(self.m_store).__name__,
+                req_meta.req_id,
+                req_meta.layer_name or req_meta.layer_id,
+                group_id,
+                len(key_list_c),
+                failed_count,
             )
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(missing_block_ids)
-        elif ret is None:
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(block_id_list_c)
-
-        self.request_queue.task_done()
-        self.get_event.set()
+        except Exception:
+            req_meta.load_failed = True
+            raise
+        finally:
+            self.request_queue.task_done()
+            self.get_event.set()
+            if req_meta.completion_event is not None:
+                req_meta.completion_event.set()
 
 
 def record_failed_blocks(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -70,8 +70,6 @@ class KVPoolScheduler:
                     raise NotImplementedError(
                         "AscendStore hybrid linear-attention support currently requires mamba_cache_mode='align'."
                     )
-        if self.use_layerwise and len(self.kv_cache_group_ids) > 1:
-            raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.consumer_is_to_load = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "consumer_is_to_load", False
@@ -370,7 +368,7 @@ class KVPoolScheduler:
         Also, calling this function will reset the state of the connector.
         """
 
-        force_skip_save = self.kv_role == "kv_consumer" and not self.consumer_is_to_put
+        force_skip_save = self.kv_role == "kv_consumer" and (self.use_layerwise or not self.consumer_is_to_put)
 
         for finished_req_id in scheduler_output.finished_req_ids:
             self._request_trackers.pop(finished_req_id, None)
@@ -621,7 +619,7 @@ class KVPoolScheduler:
         Once a request is finished, determine whether request blocks
         should be freed now or will be sent asynchronously and freed later.
         """
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+        if self.kv_role == "kv_consumer" and (self.use_layerwise or not self.consumer_is_to_put):
             return False, None
         tracker = self._request_trackers.get(request.request_id)
         if tracker is not None and tracker.num_saved_tokens <= 0:
@@ -638,7 +636,7 @@ class KVPoolScheduler:
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         """HMA path for hybrid KV cache groups."""
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
+        if self.kv_role == "kv_consumer" and (self.use_layerwise or not self.consumer_is_to_put):
             return False, None
         tracker = self._request_trackers.get(request.request_id)
         if tracker is not None and tracker.num_saved_tokens <= 0:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import math
 import threading
-from collections.abc import Generator
 
 import torch
 import vllm.envs as envs
@@ -29,9 +28,11 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ChunkedTokenDatabase,
     KeyMetadata,
     LayerMultiBlockReqMeta,
+    LayerPoolKey,
     ReqMeta,
     get_block_hashes,
     get_cache_family_granularity,
+    infer_cache_family_ratio,
     infer_group_cache_families,
     infer_tp_mismatch_info,
 )
@@ -131,9 +132,6 @@ class KVPoolWorker:
         self.kv_cache_group_families = self._infer_group_families()
         self.group_uses_align_state = self._infer_group_uses_align_state()
         self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
-        if self.use_layerwise and self.num_kv_cache_groups > 1:
-            raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
-
         logger.info(
             "use_hybrid: %s, use_mamba: %s, num_kv_cache_groups: %s, hash_block_size: %s, lcm_block_size: %s",
             self.use_hybrid,
@@ -144,6 +142,15 @@ class KVPoolWorker:
         )
         self.current_layer = 0
         self.num_layers = model_config.get_num_layers(parallel_config)
+        self.group_layer_names: dict[int, list[str]] = {}
+        self.group_num_layers: dict[int, int] = {}
+        self.layer_to_group: dict[str, tuple[int, int]] = {}
+        self.layerwise_layer_names: list[str] = []
+        self._initialize_layerwise_layout()
+        self._layerwise_load_requests: list[ReqMeta] = []
+        self._layerwise_load_tasks: dict[str, list[LayerMultiBlockReqMeta]] = {}
+        self._layerwise_saved_layers: set[str] = set()
+        self._layerwise_store_initialized = False
 
         if self.use_mla:
             self.num_kv_head = 1
@@ -206,7 +213,7 @@ class KVPoolWorker:
             self.num_sub_keys = tp_mismatch_info.num_sub_keys
 
         partitions = None
-        if self.kv_role == "kv_consumer" and self.consumer_is_to_put:
+        if not self.use_layerwise and self.kv_role == "kv_consumer" and self.consumer_is_to_put:
             num_hidden_layers = model_config.hf_text_config.num_hidden_layers
             partition_list_str = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
                 "prefill_pp_layer_partition", None
@@ -346,6 +353,62 @@ class KVPoolWorker:
             return "default"
         return families[group_id]
 
+    def _initialize_layerwise_layout(self, kv_caches: dict[str, torch.Tensor] | None = None) -> None:
+        """Build the model-layer to physical cache-group mapping.
+
+        DeepSeek V4 groups layers by cache specification (for example c4,
+        c128 and sliding-window groups), while attention hooks run in model
+        layer order.  The mapping is therefore kept independently from the
+        execution-order list.
+        """
+        if self.kv_cache_config is None:
+            group_layer_names = {0: list(kv_caches or {})}
+        else:
+            registered_names = set(kv_caches) if kv_caches is not None else None
+            group_layer_names = {
+                group_id: [
+                    layer_name
+                    for layer_name in group.layer_names
+                    if registered_names is None or layer_name in registered_names
+                ]
+                for group_id, group in enumerate(self.kv_cache_config.kv_cache_groups)
+            }
+
+        layer_to_group: dict[str, tuple[int, int]] = {}
+        for group_id, layer_names in group_layer_names.items():
+            for group_layer_id, layer_name in enumerate(layer_names):
+                if layer_name in layer_to_group:
+                    if self.use_layerwise:
+                        raise ValueError(f"KV cache layer {layer_name!r} belongs to multiple groups.")
+                    continue
+                layer_to_group[layer_name] = (group_id, group_layer_id)
+
+        if kv_caches is not None:
+            missing_layers = set(kv_caches).difference(layer_to_group)
+            if missing_layers and self.use_layerwise:
+                raise ValueError(f"KV cache layers are missing from kv_cache_groups: {sorted(missing_layers)}")
+            execution_order = list(kv_caches)
+            if getattr(self.hf_config, "model_type", None) == "deepseek_v4":
+                from vllm_ascend.utils import extract_dsv4_layer_index
+
+                execution_order.sort(key=lambda name: (extract_dsv4_layer_index(self.hf_config, name), name))
+        else:
+            execution_order = [layer_name for layer_names in group_layer_names.values() for layer_name in layer_names]
+
+        self.group_layer_names = group_layer_names
+        self.group_num_layers = {group_id: len(layer_names) for group_id, layer_names in group_layer_names.items()}
+        self.layer_to_group = layer_to_group
+        self.layerwise_layer_names = execution_order
+
+    def _get_group_num_layers(self, group_id: int) -> int:
+        num_layers = self.group_num_layers.get(group_id, 0)
+        return num_layers if num_layers > 0 else self.num_layers
+
+    def _to_raw_token_positions(self, group_id: int, positions: list[int]) -> list[int]:
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        ratio = max(infer_cache_family_ratio(cache_family), 1)
+        return [position * ratio for position in positions]
+
     def _infer_cache_transfer_granularity(self) -> int:
         granularities = [self.lcm_block_size]
         for group_id in range(self.num_kv_cache_groups):
@@ -446,11 +509,11 @@ class KVPoolWorker:
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
         self.kv_caches = kv_caches
+        self._initialize_layerwise_layout(kv_caches)
         self.group_kv_cache_families: dict[int, str] = {
             group_id: self._get_group_family(self.kv_cache_group_families, group_id)
             for group_id in range(self.num_kv_cache_groups)
         }
-        self.group_num_layers: dict[int, int] = {}
 
         logger.info(
             "Registering KV_Caches. use_mla: %s, use_sparse: %s, shape %s",
@@ -479,11 +542,8 @@ class KVPoolWorker:
         ptrs = [start for start, _ in registered_regions.values()]
         lengths = [end - start for start, end in registered_regions.values()]
 
-        if self.kv_cache_config is not None and self.use_hybrid:
-            for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
-                self._infer_cache_group_metadata(group_id, group_spec.layer_names)
-        else:
-            self._infer_cache_group_metadata(0, list(kv_caches.keys()))
+        for group_id, layer_names in self.group_layer_names.items():
+            self._infer_cache_group_metadata(group_id, layer_names)
 
         # group_num_layers is computed from the actual kv_caches dict which
         # includes ALL attention layers (main + MTP), so it is the authoritative
@@ -495,6 +555,25 @@ class KVPoolWorker:
                 "KVPoolWorker: updated num_layers %d -> %d (includes MTP/spec-decode draft layers).",
                 original_num_layers,
                 self.num_layers,
+            )
+        if self.use_layerwise:
+            group_layout = [
+                (
+                    group_id,
+                    self._get_group_family(self.kv_cache_group_families, group_id),
+                    self.group_num_layers.get(group_id, 0),
+                    self._get_group_block_size(group_id),
+                )
+                for group_id in sorted(self.group_layer_names)
+            ]
+            logger.info(
+                "[AscendStore][layerwise] cache layout registered backend=%s total_layers=%d "
+                "transfer_granularity=%d "
+                "groups=(group_id,cache_family,num_layers,block_size)%s",
+                self.backend,
+                self.num_layers,
+                self.cache_transfer_granularity,
+                group_layout,
             )
 
         self.m_store.register_buffer(ptrs, lengths)
@@ -536,6 +615,7 @@ class KVPoolWorker:
                     self.enable_kv_events,
                 )
                 self.kv_send_thread.start()
+                ready_event_sending.wait()
             ready_event = threading.Event()
             self.kv_recv_thread = KVCacheStoreLayerRecvingThread(
                 self.m_store,
@@ -550,6 +630,12 @@ class KVPoolWorker:
             )
             self.kv_recv_thread.start()
             ready_event.wait()
+            logger.info(
+                "[AscendStore][layerwise] transfer threads ready backend=%s sender=%s receiver=%s",
+                type(self.m_store).__name__,
+                self.kv_send_thread is not None,
+                self.kv_recv_thread is not None,
+            )
         else:
             if self.kv_role in ["kv_producer", "kv_both"] or self.consumer_is_to_put:
                 ready_event_sending = threading.Event()
@@ -585,8 +671,18 @@ class KVPoolWorker:
 
     def start_load_kv(self, metadata: AscendConnectorMetadata):
         self.current_layer = 0
-        self.layerwise_retrievers = []
+        self._layerwise_load_requests = []
+        self._layerwise_load_tasks = {}
+        self._layerwise_saved_layers = set()
+        self._layerwise_store_initialized = False
         logger.debug("KV pool worker start_load_kv requests=%d", len(metadata.requests))
+        if self.use_layerwise and metadata.requests:
+            logger.info(
+                "[AscendStore][layerwise] forward metadata requests=%d saveable=%d loadable=%d",
+                len(metadata.requests),
+                sum(request.can_save is True for request in metadata.requests),
+                sum(request.load_spec is not None and request.load_spec.can_load for request in metadata.requests),
+            )
         for request in metadata.requests:
             load_spec = request.load_spec
             if load_spec is None or not load_spec.can_load:  # load =0
@@ -618,9 +714,7 @@ class KVPoolWorker:
                 self.load_async,
             )
             if self.use_layerwise:
-                layerwise_retriever = self.retrieve_layer(request)
-                next(layerwise_retriever)  # first layer load
-                self.layerwise_retrievers.append(layerwise_retriever)
+                self._layerwise_load_requests.append(request)
             elif self.tp_mismatch:
                 # tp_mismatch is restricted to non-hybrid -> single group.
                 group_block_size = self.grouped_block_size[0]
@@ -725,13 +819,143 @@ class KVPoolWorker:
                     len(key_list_c),
                 )
 
-    def wait_for_layer_load(self) -> None:
-        for layerwise_retriever in self.layerwise_retrievers:
-            ret_token_mask = next(layerwise_retriever)
-            if self.current_layer == self.num_layers - 1:
-                assert ret_token_mask is not None
-                num_retrieved_tokens = ret_token_mask.sum().item()
-                logger.debug("Retrieved %s tokens", num_retrieved_tokens)
+        # One-layer look-ahead preserves the original layerwise overlap while
+        # the actual callback layer name remains the source of truth.
+        if self.use_layerwise and self._layerwise_load_requests and self.layerwise_layer_names:
+            self._submit_layer_load(self.layerwise_layer_names[0])
+
+    def _build_layerwise_task(
+        self,
+        request: ReqMeta,
+        layer_name: str,
+        *,
+        is_load: bool,
+        current_event: torch.npu.Event | None = None,
+        is_last_layer: bool = False,
+    ) -> LayerMultiBlockReqMeta:
+        if layer_name not in self.layer_to_group:
+            raise ValueError(f"KV cache layer {layer_name!r} is not registered for layerwise transfer.")
+        group_id, group_layer_id = self.layer_to_group[layer_name]
+        if group_id >= len(request.block_ids_by_group):
+            raise ValueError(
+                f"Request {request.req_id!r} has no block table for KV cache group {group_id} "
+                f"used by layer {layer_name!r}."
+            )
+
+        block_ids = request.block_ids_by_group[group_id]
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        group_key_granularity = get_cache_family_granularity(self._get_group_block_size(group_id), cache_family)
+        token_len = (
+            request.load_spec.token_len if is_load and request.load_spec is not None else request.token_len_chunk
+        )
+        mask_num = 0
+        masks = None
+        if is_load and request.load_spec is not None:
+            mask_num = request.load_spec.vllm_cached_tokens // group_key_granularity * group_key_granularity
+            masks = self.token_database.load_mask(request.block_hashes, token_len)
+        elif not is_load:
+            try:
+                masks = self.token_database.store_mask(request.token_len_chunk, request.num_prompt_tokens)
+            except AssertionError as exc:
+                logger.info("Skip AscendStore layerwise store mask for request %s: %s", request.req_id, exc)
+
+        keys: list[LayerPoolKey] = []
+        starts: list[int] = []
+        ends: list[int] = []
+        key_block_ids: list[int] = []
+        skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
+        for start, end, key, block_id in self.token_database.process_tokens_with_block_ids(
+            token_len,
+            request.block_hashes,
+            block_ids,
+            mask_num,
+            kv_cache_group_id=group_id,
+            skip_null_blocks=skip_null,
+        ):
+            if not self.token_database.mask_allows_chunk(masks, group_id, start):
+                continue
+            starts.append(start)
+            ends.append(end)
+            keys.append(LayerPoolKey(key.key_metadata, key.chunk_hash, group_layer_id))
+            key_block_ids.append(block_id)
+
+        group_block_hashes = get_block_hashes(
+            request.block_hashes,
+            group_key_granularity,
+            self.hash_block_size,
+        )
+        completion_event = threading.Event() if is_load else None
+        return LayerMultiBlockReqMeta(
+            request.req_id,
+            keys,
+            starts,
+            ends,
+            request.block_ids_by_group,
+            group_layer_id,
+            request.is_last_chunk,
+            current_event,
+            token_ids=request.token_ids,
+            original_block_size=request.original_block_size,
+            block_hashes=group_block_hashes,
+            kv_cache_group_id=group_id,
+            key_block_ids=key_block_ids,
+            layer_name=layer_name,
+            is_last_layer=is_last_layer,
+            completion_event=completion_event,
+        )
+
+    def _submit_layer_load(self, layer_name: str) -> None:
+        if layer_name in self._layerwise_load_tasks:
+            return
+        tasks: list[LayerMultiBlockReqMeta] = []
+        is_last_layer = layer_name == self.layerwise_layer_names[-1]
+        for request in self._layerwise_load_requests:
+            task = self._build_layerwise_task(
+                request,
+                layer_name,
+                is_load=True,
+                is_last_layer=is_last_layer,
+            )
+            tasks.append(task)
+            logger.info(
+                "[AscendStore][layerwise][get] enqueue req=%s layer=%s group=%d group_layer=%d "
+                "keys=%d is_last_layer=%s",
+                task.req_id,
+                layer_name,
+                task.kv_cache_group_id,
+                task.layer_id,
+                len(task.keys),
+                is_last_layer,
+            )
+            self.kv_recv_thread.add_request(task)  # type: ignore[union-attr, arg-type]
+        self._layerwise_load_tasks[layer_name] = tasks
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        if layer_name not in self.layer_to_group:
+            raise ValueError(f"KV cache layer {layer_name!r} is not registered for layerwise transfer.")
+        self._submit_layer_load(layer_name)
+        for task in self._layerwise_load_tasks[layer_name]:
+            assert task.completion_event is not None
+            if not task.completion_event.wait(timeout=3):
+                raise TimeoutError(f"Layerwise get timed out for request {task.req_id!r}, layer {layer_name!r}.")
+            if task.load_failed:
+                raise RuntimeError(
+                    f"Layerwise get failed for request {task.req_id!r}, layer {layer_name!r}, "
+                    f"group {task.kv_cache_group_id}."
+                )
+
+        layer_index = self.layerwise_layer_names.index(layer_name)
+        if layer_index + 1 < len(self.layerwise_layer_names):
+            self._submit_layer_load(self.layerwise_layer_names[layer_index + 1])
+        else:
+            logger.info(
+                "[AscendStore][layerwise][get] chunk complete backend=%s final_layer=%s "
+                "requests=%d keys=%d status=success",
+                type(self.m_store).__name__,
+                layer_name,
+                len(self._layerwise_load_tasks[layer_name]),
+                sum(len(task.keys) for task in self._layerwise_load_tasks[layer_name]),
+            )
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         with self._invalid_block_ids_lock:
@@ -739,40 +963,64 @@ class KVPoolWorker:
             self._invalid_block_ids.clear()
         return invalid_blocks
 
-    def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
-        # MTP speculative decoding re-runs the base model's attention layers
-        # during draft execution (_run_merged_draft), causing extra
-        # save_kv_layer calls beyond num_layers. These extra calls would
-        # exhaust the store_layer generators and raise StopIteration.
-        if self.current_layer >= self.num_layers:
+    def save_kv_layer(self, layer_name: str, connector_metadata: AscendConnectorMetadata) -> None:
+        # MTP speculative decoding can re-run base-model layers. A layer name
+        # is saved at most once per forward, while the distinct MTP cache layer
+        # remains part of ``layerwise_layer_names``.
+        if layer_name not in self.layer_to_group:
+            raise ValueError(f"KV cache layer {layer_name!r} is not registered for layerwise transfer.")
+        if layer_name in self._layerwise_saved_layers:
+            logger.info(
+                "[AscendStore][layerwise][put] skip duplicate layer callback layer=%s",
+                layer_name,
+            )
             return
-        if self.current_layer == 0:
-            self.layerwise_storers = []
-            current_event = None
-            for request in connector_metadata.requests:
-                can_save = request.can_save
-                if can_save is None or not can_save:
-                    continue
-                current_event = torch.npu.Event()
-                current_event.record()
-                break
-            for request in connector_metadata.requests:
-                can_save = request.can_save
-                if can_save is None or not can_save:
-                    continue
 
-                request.current_event = current_event
-                self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                    request.req_id
-                )
-                layerwise_storer = self.store_layer(request, current_event)
-                self.layerwise_storers.append(layerwise_storer)
-        for layerwise_storer in self.layerwise_storers:
-            try:
-                next(layerwise_storer)
-            except Exception:
-                raise
-        self.current_layer = self.current_layer + 1
+        save_requests = [request for request in connector_metadata.requests if request.can_save]
+        logger.info(
+            "[AscendStore][layerwise][put] save callback layer=%s metadata_requests=%d saveable=%d",
+            layer_name,
+            len(connector_metadata.requests),
+            len(save_requests),
+        )
+        if self.kv_send_thread is None:
+            raise RuntimeError(
+                "AscendStore layerwise save callback was invoked without a sending thread. "
+                f"Layerwise put requires kv_role='kv_producer' or 'kv_both', got {self.kv_role!r}."
+            )
+        if not self._layerwise_store_initialized:
+            for request in connector_metadata.requests:
+                if request.can_save:
+                    request.skip_null_blocks_by_group = self.group_uses_align_state
+                    self.kv_send_thread.add_stored_request(request.req_id)
+            self._layerwise_store_initialized = True
+
+        current_event = None
+        if save_requests:
+            current_event = torch.npu.Event()
+            current_event.record()
+        is_last_layer = len(self._layerwise_saved_layers) + 1 == len(self.layerwise_layer_names)
+        for request in save_requests:
+            task = self._build_layerwise_task(
+                request,
+                layer_name,
+                is_load=False,
+                current_event=current_event,
+                is_last_layer=is_last_layer,
+            )
+            logger.info(
+                "[AscendStore][layerwise][put] enqueue req=%s layer=%s group=%d group_layer=%d "
+                "keys=%d is_last_layer=%s is_last_chunk=%s",
+                task.req_id,
+                layer_name,
+                task.kv_cache_group_id,
+                task.layer_id,
+                len(task.keys),
+                is_last_layer,
+                task.is_last_chunk,
+            )
+            self.kv_send_thread.add_request(task)  # type: ignore[arg-type]
+        self._layerwise_saved_layers.add(layer_name)
 
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
         current_event = None
@@ -805,144 +1053,6 @@ class KVPoolWorker:
             # request is reported as finished. Without this barrier a following
             # identical prompt can lookup before Mooncake put() has completed.
             self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
-
-    def retrieve_layer(
-        self,
-        request: ReqMeta,
-    ) -> Generator[torch.Tensor | None, None, None]:
-        """
-        Retrieve the KV cache in a layerwise manner.
-
-        :param torch.Tensor tokens: The tokens of the corresponding KV caches.
-
-        :param Optional[torch.Tensor] mask: The mask for the tokens. Should
-            have the same length as tokens. And the mask should ALWAYS be like
-            FFFFFTTTTTTT, where True means the tokens needs to be matched.
-
-        :param **kwargs: The additional arguments for the KV transfer which
-            will be passed into the npu_transfer.
-
-        return: A generator that yields Optional[torch.Tensor]. The tensor will
-            be the boolean mask indicating which tokens are retrieved and will
-            only be returned in the last iteration.
-        """
-        token_len = request.token_len_chunk
-        mask_num = (
-            request.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size
-            * self.block_size
-        )
-        num_required_tokens = token_len - mask_num
-
-        ret_mask = torch.zeros(token_len, dtype=torch.bool, device="cpu")
-
-        starts = []
-        ends = []
-        keys = []
-        first_flag = True
-        for start, end, key in self.token_database.process_tokens(token_len, request.block_hashes, mask_num):
-            keys_multi_layer = key.split_layers(self.num_layers)
-            starts.append(start)
-            ends.append(end)
-            keys.append(keys_multi_layer)
-            ret_mask[start:end] = True
-
-        if keys:
-            # Transpose the keys into layer major format
-            keys = [list(row) for row in zip(*keys)]  # [num_layer,block_num]
-            for layer_id, keys_multi_chunk in enumerate(keys):
-                if not first_flag:
-                    is_finish = self.get_event.wait(timeout=3)  # try---cache
-                    if not is_finish:
-                        logger.info(
-                            "Layerwise get failed. Timeout waiting for get_event. Check receiver thread status."
-                        )
-                self.get_event.clear()
-                req_meta = LayerMultiBlockReqMeta(
-                    request.req_id, keys_multi_chunk, starts, ends, request.block_ids_by_group, layer_id
-                )
-                self.kv_recv_thread.add_request(  # type: ignore[union-attr, call-arg]
-                    req_meta
-                )  # type: ignore[union-attr, call-arg, arg-type]
-                first_flag = False
-                yield None
-        else:
-            # If no cache are found, we still need to yield to avoid
-            # `StopIteration`
-            for layer_id in range(self.num_layers):
-                yield None
-
-        retrieved_tokens = torch.sum(ret_mask)
-        logger.debug(
-            "Retrieved %s out of %s out of total %s tokens",
-            retrieved_tokens,
-            num_required_tokens,
-            token_len,
-        )
-
-        yield ret_mask
-
-    def store_layer(
-        self,
-        request: ReqMeta,
-        current_event: torch.npu.Event | None,
-    ) -> Generator[None, None, None]:
-        """
-        Store the KV cache in a layerwise manner.
-
-        :param torch.Tensor tokens: The tokens of the corresponding KV caches.
-
-        :param Optional[torch.Tensor] mask: The mask for the tokens. Should
-            have the same length as tokens. And the mask should ALWAYS be like
-            FFFFFTTTTTTT, where True means the tokens needs to be matched.
-
-        :param **kwargs: The additional arguments for the storage backend which
-            will be passed into the gpu_connector.
-
-        return: A generator that yields None. In the first iteration, the
-            generator allocates the memory objects for all layers and moves
-            the KV cache of the first layer from GPU to CPU. In the next
-            iterations, it moves the KV cache of layer i from GPU to the memory
-            objects (on CPU) and puts the memory objects of layer i-1 to the
-            storage backends. In the last iteration, it puts the memory objects
-            of the last layer to the storage backends.
-        """
-        starts = []
-        ends = []
-        keys = []
-        group_id = 0
-        group_block_size = self.grouped_block_size[group_id]
-        group_block_hashes = get_block_hashes(request.block_hashes, group_block_size, self.hash_block_size)
-        for start, end, key in self.token_database.process_tokens(request.token_len_chunk, request.block_hashes):
-            keys_multi_layer = key.split_layers(self.num_layers)
-            starts.append(start)
-            ends.append(end)
-            keys.append(keys_multi_layer)  # [block_num,layer_num]
-
-        if keys:
-            keys = [list(row) for row in zip(*keys)]  # [layer_num,block_num]
-            for layer_id, keys_multi_chunk in enumerate(keys):
-                req_meta = LayerMultiBlockReqMeta(
-                    request.req_id,
-                    keys_multi_chunk,
-                    starts,
-                    ends,
-                    request.block_ids_by_group,
-                    layer_id,
-                    request.is_last_chunk,
-                    current_event,
-                    token_ids=request.token_ids,
-                    original_block_size=request.original_block_size,
-                    block_hashes=group_block_hashes,
-                    kv_cache_group_id=group_id,
-                )
-                self.kv_send_thread.add_request(  # type: ignore[union-attr, call-arg]
-                    req_meta
-                )  # type: ignore[union-attr, call-arg, arg-type]
-                yield
-        else:
-            for layer_id in range(self.num_layers):
-                yield
 
     def _make_sub_key_str(self, base_key, effective_rank: int) -> str:
         """Rewrite ``@head_or_tp_rank:<local>`` in base_key.to_string() to ``<effective_rank>``.
@@ -1117,7 +1227,7 @@ class KVPoolWorker:
                 finished_req_ids,
                 meta,  # type: ignore[union-attr]
             )
-            if self.kv_role in ["kv_producer", "kv_both"] or self.consumer_is_to_put
+            if self.kv_role in ["kv_producer", "kv_both"] or (not self.use_layerwise and self.consumer_is_to_put)
             else set()
         )
 
@@ -1201,6 +1311,7 @@ class KVPoolWorker:
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
+                group_num_layers = self._get_group_num_layers(group_id)
                 end = 0
                 keys: list[str] = []
                 starts = []
@@ -1211,9 +1322,9 @@ class KVPoolWorker:
                     kv_cache_group_id=group_id,
                 ):
                     if use_layerwise:
-                        keys_multi_layer = key.split_layers(self.num_layers)
-                        for layer_key in keys_multi_layer:
-                            keys.append(layer_key.to_string())
+                        keys_multi_layer = key.split_layers(group_num_layers)
+                        for item in keys_multi_layer:
+                            keys.append(item.to_string())
                     else:
                         keys.append(key.to_string())
                     starts.append(start)
@@ -1226,7 +1337,10 @@ class KVPoolWorker:
                 res = self.m_store.exists(keys)  # type: ignore[assignment]
 
                 if use_layerwise:
-                    res = self.check_all_layers_exists(res, self.num_layers)
+                    res = self.check_all_layers_exists(res, group_num_layers)
+                starts = self._to_raw_token_positions(group_id, starts)
+                ends = self._to_raw_token_positions(group_id, ends)
+                end = ends[-1]
                 if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
                     hit_end = 0
                     for index in range(len(ends) - 1, -1, -1):
@@ -1394,6 +1508,7 @@ class KVPoolWorker:
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
+                group_num_layers = self._get_group_num_layers(group_id)
                 keys: list[str] = []
                 starts = []
                 ends = []
@@ -1403,9 +1518,9 @@ class KVPoolWorker:
                     kv_cache_group_id=group_id,
                 ):
                     if use_layerwise:
-                        keys_multi_layer = key.split_layers(self.num_layers)
-                        for layer_key in keys_multi_layer:
-                            keys.append(layer_key.to_string())
+                        keys_multi_layer = key.split_layers(group_num_layers)
+                        for item in keys_multi_layer:
+                            keys.append(item.to_string())
                     else:
                         keys.append(key.to_string())
                     starts.append(start)
@@ -1419,8 +1534,9 @@ class KVPoolWorker:
                 res = self.m_store.exists(multi_tp_keys)  # type: ignore[assignment]
                 num_block = len(keys)
                 if use_layerwise:
-                    res = self.check_all_layers_exists(res, self.num_layers)
-                    num_block = len(keys) // self.num_layers
+                    res = self.check_all_layers_exists(res, group_num_layers)
+                    num_block = len(keys) // group_num_layers
+                ends = self._to_raw_token_positions(group_id, ends)
                 multi_tp_values = [
                     res[i * num_block : (i + 1) * num_block]  # type: ignore[index]
                     for i in range(num_ranks)


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 uses multiple compressed KV cache groups, so the original single-group layerwise path can select the wrong block table, layer index, key, or address. The SFA DSA-CP full-weight o_proj prefill path also returned before invoking the per-layer KV save callback, leaving requests marked saveable without any backend put.

This change:

- adds execution-order to cache-group/local-layer mapping for DeepSeek V4 hybrid KV layouts;
- performs lookup, put, get, and address calculation with group-specific compression ratios, block tables, and physical layouts;
- invokes the layerwise save callback before the SFA DSA-CP full-o-proj early return;
- preserves sliding-window physical block IDs and handles MTP duplicate base-layer callbacks;
- limits layerwise put to prefill roles (`kv_producer` and `kv_both`); `consumer_is_to_put` remains a non-layerwise decode-store option;
- adds structured AscendStore and Mooncake diagnostics plus a correctness and performance validation design.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStore can use `use_layerwise=true` with DeepSeek V4 multi-group KV caches. Layerwise consumer nodes continue to load KV, but do not store KV even when `consumer_is_to_put=true`.

### How was this patch tested?

- `pytest -q --confcutdir=tests/ut/distributed/ascend_store tests/ut/distributed/ascend_store/test_config_data.py tests/ut/distributed/ascend_store/test_kv_transfer.py tests/ut/distributed/ascend_store/test_pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_worker.py` (169 passed)
- AscendStore backend and connector unit tests with the repository dependency mocks (92 passed)
- Added a regression test for the SFA DSA-CP full-o-proj early-return path; local collection requires a regular PyTorch test environment, which is unavailable on the current host
- `python -m py_compile` for the SFA implementation and regression test
- `bash format.sh ci`

Real DeepSeek V4 inference on Ascend NPU with Mooncake is still required before this PR is marked ready. The design document includes the expected layerwise put/get logs, correctness gates, and an A/B performance matrix for `use_layerwise=false` versus `use_layerwise=true`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
