### PR TITLE
[cherry-pick][v0.23.0][Test] remove DeepSeek-V3.2-W8A8-DCP-replicated-indexer from nightly config

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -125,9 +125,6 @@ a3:
       - name: DeepSeek-V4-Flash-W8A8-A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
-      - name: deepseek-v3-2-dcp-replicated-indexer
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: DeepSeek-V3.2-W8A8-DCP.yaml
       - name: kimi-k2-thinking
         os: linux-aarch64-nightly-a3-16
         config_file_path: Kimi-K2-Thinking.yaml


### PR DESCRIPTION
### What this PR does / why we need it?

Cherry-pick #11874 to releases/v0.23.0. Removes the DeepSeek-V3.2-W8A8-DCP replicated-indexer nightly entry while C8 SFA adaptation is not ready.

Source PR: #11874
Source commit: c8cb918c4b2734e6d92cceabd18de891a1056bf6

### How was this patch tested?

- `git diff --check upstream/releases/v0.23.0..HEAD`
- Confirmed the target nightly config entry is absent from `.github/workflows/configs/nightly_config.yaml`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
