### PR TITLE
[CI]Supplement the logic of accurate test coverage or missing test case coverage, retrieve and supplement the data from historical records.

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -322,7 +322,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: selected-test-coverage-vllm-${{ inputs.vllm }}-${{ matrix.group.npu_type }}-${{ matrix.group.num_npus }}card-${{ matrix.group.partition }}
-          path: tests/outputs/**/covdata/**
+          path: |
+            tests/outputs/**/EXPECTED
+            tests/outputs/**/covdata/**
           if-no-files-found: ignore
           retention-days: 14
           compression-level: 0
@@ -358,6 +360,57 @@ jobs:
             path: all-coverage
             pattern: selected-test-coverage-*
             merge-multiple: true
+
+        - name: Check full coverage data completeness
+          id: coverage-completeness
+          env:
+            SELECTED_TEST_GROUPS: ${{ inputs.test_groups }}
+          run: |
+            python3 .github/workflows/scripts/assemble_coverage.py check \
+              --test-groups-json "${SELECTED_TEST_GROUPS}" \
+              --current-root all-coverage
+
+        - name: Download previous coverage data from OBS
+          if: steps.coverage-completeness.outputs.has_missing == 'true'
+          run: |
+            pip install esdk-obs-python --quiet
+            mkdir -p previous-coverage
+            # The OBS SDK calls os.makedirs(dirname(downloadPath)); a bare
+            # filename yields dirname='' and crashes with FileNotFoundError,
+            # so always hand it an absolute path with a real directory.
+            python3 - <<'EOF'
+            import os
+            from obs import ObsClient
+
+            client = ObsClient(
+                access_key_id=os.environ['OBS_ACCESS_KEY'],
+                secret_access_key=os.environ['OBS_SECRET_KEY'],
+                server='https://obs.cn-north-4.myhuaweicloud.com'
+            )
+            download_path = os.path.abspath('previous-coverage.tar')
+            response = client.getObject(
+                'vllm-ascend',
+                'ci/precision-test/coverage.tar',
+                downloadPath=download_path,
+            )
+            if response.status >= 300:
+                raise RuntimeError(
+                    f'Failed to download previous coverage: '
+                    f'{response.status} {response.errorMessage}'
+                )
+            print(f'Downloaded previous coverage data from OBS -> {download_path}')
+            EOF
+            tar xf previous-coverage.tar -C previous-coverage
+
+        - name: Backfill missing coverage data
+          if: steps.coverage-completeness.outputs.has_missing == 'true'
+          env:
+            SELECTED_TEST_GROUPS: ${{ inputs.test_groups }}
+          run: |
+            python3 .github/workflows/scripts/assemble_coverage.py backfill \
+              --test-groups-json "${SELECTED_TEST_GROUPS}" \
+              --current-root all-coverage \
+              --previous-root previous-coverage
 
         - name: Debug - List downloaded coverage files
           run: |
@@ -429,6 +482,16 @@ jobs:
               echo "TASK_DATE=${TASK_DATE}"
               echo "TASK_NAME=${TASK_NAME}"
             } >> "${GITHUB_ENV}"
+
+        - name: Upload coverage package artifact
+          uses: actions/upload-artifact@v7
+          with:
+            name: coverage-package-${{ env.TASK_NAME }}
+            path: |
+              coverage.tar
+              coverage_version.txt
+            retention-days: 7
+            compression-level: 0
 
         - name: Upload coverage to OBS
           run: |

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -467,16 +467,6 @@ jobs:
               echo "TASK_NAME=${TASK_NAME}"
             } >> "${GITHUB_ENV}"
 
-        - name: Upload coverage package artifact
-          uses: actions/upload-artifact@v7
-          with:
-            name: coverage-package-${{ env.TASK_NAME }}
-            path: |
-              coverage.tar
-              coverage_version.txt
-            retention-days: 7
-            compression-level: 0
-
         - name: Upload coverage to OBS
           run: |
             pip install esdk-obs-python --quiet

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -373,34 +373,18 @@ jobs:
         - name: Download previous coverage data from OBS
           if: steps.coverage-completeness.outputs.has_missing == 'true'
           run: |
-            pip install esdk-obs-python --quiet
             mkdir -p previous-coverage
-            # The OBS SDK calls os.makedirs(dirname(downloadPath)); a bare
-            # filename yields dirname='' and crashes with FileNotFoundError,
-            # so always hand it an absolute path with a real directory.
-            python3 - <<'EOF'
-            import os
-            from obs import ObsClient
-
-            client = ObsClient(
-                access_key_id=os.environ['OBS_ACCESS_KEY'],
-                secret_access_key=os.environ['OBS_SECRET_KEY'],
-                server='https://obs.cn-north-4.myhuaweicloud.com'
-            )
-            download_path = os.path.abspath('previous-coverage.tar')
-            response = client.getObject(
-                'vllm-ascend',
-                'ci/precision-test/coverage.tar',
-                downloadPath=download_path,
-            )
-            if response.status >= 300:
-                raise RuntimeError(
-                    f'Failed to download previous coverage: '
-                    f'{response.status} {response.errorMessage}'
-                )
-            print(f'Downloaded previous coverage data from OBS -> {download_path}')
-            EOF
-            tar xf previous-coverage.tar -C previous-coverage
+            # The historical coverage package is exposed as a public-read
+            # object in OBS, so download it directly via its public URL with
+            # curl (no SDK or credentials needed). On the very first run there
+            # is no history yet (HTTP 404); tolerate that so the downstream
+            # backfill/assemble steps still proceed with the current data.
+            if curl -fSL --retry 3 -o previous-coverage.tar \
+              "https://vllm-ascend.obs.cn-north-4.myhuaweicloud.com/ci/precision-test/coverage.tar"; then
+              tar xf previous-coverage.tar -C previous-coverage
+            else
+              echo "::warning::No previous coverage data found on OBS (first run?). Backfill will be skipped."
+            fi
 
         - name: Backfill missing coverage data
           if: steps.coverage-completeness.outputs.has_missing == 'true'

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -18,6 +18,16 @@
 name: Schedule Test Coverage
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    branches:
+      - 'main'
+      - '*-dev'
+      - 'releases/v*'
   schedule:
     - cron: "0 18 * * *"
   workflow_dispatch:
@@ -41,7 +51,7 @@ concurrency:
 
 jobs:
   select-full-tests:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: linux-amd64-cpu-8-hk
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -19,7 +19,7 @@ name: Schedule Test Coverage
 
 on:
   schedule:
-    - cron: "0 18 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       vllm_ascend_ref:

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.select-full-tests.outputs.release_tag }}
+          - ${{ needs.select-full-tests.outputs.main_commit }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -100,10 +100,8 @@ jobs:
           pip install regex pyyaml
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           python3 .github/workflows/scripts/select_tests.py \
-            --explicit-e2e-tests \
-            tests/e2e/pull_request/one_card/test_sampler.py \
-            tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py \
-            tests/e2e/pull_request/one_card/_310p/test_vl_model_310p.py
+            --changed-files vllm_ascend/dummy.py \
+            --run-all-modules
 
   ensure-csrc-cache:
     needs: select-full-tests

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.vllm_ascend_ref || 'main' }}
+          ref: ${{ github.event.pull_request.head.sha || inputs.vllm_ascend_ref || github.ref }}
           fetch-depth: 0
 
       - name: Resolve refs

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -100,8 +100,10 @@ jobs:
           pip install regex pyyaml
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           python3 .github/workflows/scripts/select_tests.py \
-            --changed-files vllm_ascend/dummy.py \
-            --run-all-modules
+            --explicit-e2e-tests \
+            tests/e2e/pull_request/one_card/test_sampler.py \
+            tests/e2e/pull_request/one_card/_310p/test_spec_decode_mtp_310p.py \
+            tests/e2e/pull_request/one_card/_310p/test_vl_model_310p.py
 
   ensure-csrc-cache:
     needs: select-full-tests

--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -18,16 +18,6 @@
 name: Schedule Test Coverage
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-    branches:
-      - 'main'
-      - '*-dev'
-      - 'releases/v*'
   schedule:
     - cron: "0 18 * * *"
   workflow_dispatch:
@@ -51,7 +41,7 @@ concurrency:
 
 jobs:
   select-full-tests:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: linux-amd64-cpu-8-hk
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
@@ -68,7 +58,7 @@ jobs:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || inputs.vllm_ascend_ref || github.ref }}
+          ref: ${{ inputs.vllm_ascend_ref || 'main' }}
           fetch-depth: 0
 
       - name: Resolve refs
@@ -120,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.select-full-tests.outputs.main_commit }}
+          - ${{ needs.select-full-tests.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}

--- a/.github/workflows/scripts/assemble_coverage.py
+++ b/.github/workflows/scripts/assemble_coverage.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Check and backfill per-test coverage data for full coverage runs.
+
+A test target is considered "available" only when its ``covdata/`` directory
+exists, contains files, and does NOT carry a ``FAILED`` sentinel. The runner
+(``run_selected_tests.sh``) writes that sentinel when a target fails, so a
+failed run's partial coverage is treated as unusable and replaced with the
+OBS historical coverage during backfill (rather than shipped as-is).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+FAILED_SENTINEL = "FAILED"
+EXPECTED_SENTINEL = "EXPECTED"
+
+
+def coverage_key(target: str) -> str:
+    """Return the output directory name used by run_selected_tests.sh."""
+    basename = target[:-3] if target.endswith(".py") else target
+    return basename.replace("\\", "/").replace("/", "__").replace("::", "--")
+
+
+def expected_coverage_keys(
+    test_groups: list[dict[str, Any]],
+    coverage_root: Path | None = None,
+) -> set[str]:
+    """Collect the expected coverage keys.
+
+    Case-level coverage runners write an ``EXPECTED`` sentinel before running
+    each collected pytest nodeid. Prefer those keys when present. Falling back
+    to test groups keeps existing file-level coverage packages compatible.
+    """
+    if coverage_root is not None and coverage_root.exists():
+        case_keys = {
+            path.parent.name
+            for path in coverage_root.rglob(EXPECTED_SENTINEL)
+            if path.is_file()
+        }
+        if case_keys:
+            return case_keys
+
+    keys: set[str] = set()
+    for group in test_groups:
+        if group.get("npu_type") == "cpu":
+            if group.get("tests", "").split():
+                keys.add("cpu-ut")
+            continue
+        keys.update(coverage_key(target) for target in group.get("tests", "").split())
+    return keys
+
+
+def _scan_coverage(root: Path) -> tuple[dict[str, list[Path]], set[str]]:
+    """Return ``(dirs_by_key, failed_keys)`` found under *root*.
+
+    ``dirs_by_key`` maps each coverage key to its ``covdata`` directories that
+    contain at least one file. ``failed_keys`` holds keys whose ``covdata``
+    directory contains a ``FAILED`` sentinel.
+    """
+    dirs_by_key: dict[str, list[Path]] = {}
+    failed: set[str] = set()
+    if not root.exists():
+        return dirs_by_key, failed
+    for covdata_dir in root.rglob("covdata"):
+        if not covdata_dir.is_dir():
+            continue
+        files = [path for path in covdata_dir.rglob("*") if path.is_file()]
+        if not files:
+            continue
+        key = covdata_dir.parent.name
+        dirs_by_key.setdefault(key, []).append(covdata_dir)
+        if any(path.name == FAILED_SENTINEL for path in files):
+            failed.add(key)
+    return dirs_by_key, failed
+
+
+def missing_coverage_keys(test_groups: list[dict[str, Any]], coverage_root: Path) -> list[str]:
+    """Return expected test keys that have no usable coverage files.
+
+    A key is unusable when it has no ``covdata`` directory at all OR when its
+    ``covdata`` directory carries a ``FAILED`` sentinel (the run failed, so its
+    partial coverage must be replaced from history).
+    """
+    dirs_by_key, failed = _scan_coverage(coverage_root)
+    usable = set(dirs_by_key) - failed
+    return sorted(expected_coverage_keys(test_groups, coverage_root) - usable)
+
+
+def backfill_missing_coverage(
+    test_groups: list[dict[str, Any]],
+    current_root: Path,
+    previous_root: Path,
+) -> list[str]:
+    """Replace missing/failed per-test coverage from a previous package.
+
+    For each missing key (absent or ``FAILED``), any existing ``covdata``
+    directory under *current_root* is wiped first so the failed run's partial
+    coverage (and its sentinel) is discarded, then the historical files are
+    copied in from *previous_root*.
+    """
+    missing = missing_coverage_keys(test_groups, current_root)
+    previous_dirs, _ = _scan_coverage(previous_root)
+
+    for key in missing:
+        sources = previous_dirs.get(key)
+        if not sources:
+            continue
+        destination = current_root / key / "covdata"
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.mkdir(parents=True, exist_ok=True)
+        for source in sources:
+            for path in source.rglob("*"):
+                if not path.is_file():
+                    continue
+                relative_path = path.relative_to(source)
+                target = destination / relative_path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(path, target)
+
+    return missing_coverage_keys(test_groups, current_root)
+
+
+def _load_test_groups(raw_json: str) -> list[dict[str, Any]]:
+    value = json.loads(raw_json)
+    if not isinstance(value, list) or not all(isinstance(group, dict) for group in value):
+        raise ValueError("test groups must be a JSON array of objects")
+    return value
+
+
+def _write_github_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as output:
+            output.write(f"{name}={value}\n")
+
+
+def _write_missing_file(path: Path, missing: list[str]) -> None:
+    path.write_text("\n".join(missing) + ("\n" if missing else ""), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("check", "backfill"))
+    parser.add_argument("--test-groups-json", required=True)
+    parser.add_argument("--current-root", type=Path, required=True)
+    parser.add_argument("--previous-root", type=Path)
+    parser.add_argument("--missing-file", type=Path, default=Path("missing-coverage-tests.txt"))
+    args = parser.parse_args()
+
+    test_groups = _load_test_groups(args.test_groups_json)
+    if args.command == "backfill":
+        if args.previous_root is None:
+            parser.error("--previous-root is required for backfill")
+        missing = backfill_missing_coverage(test_groups, args.current_root, args.previous_root)
+    else:
+        missing = missing_coverage_keys(test_groups, args.current_root)
+
+    _write_missing_file(args.missing_file, missing)
+    _write_github_output("has_missing", str(bool(missing)).lower())
+    _write_github_output("missing_count", str(len(missing)))
+
+    if missing:
+        print(f"Missing coverage data for {len(missing)} test target(s):")
+        for key in missing:
+            print(f"  - {key}")
+        if args.command == "backfill":
+            print(
+                f"::warning::Coverage data is still missing for {len(missing)} "
+                "test target(s) after OBS backfill; uploading the available data."
+            )
+    else:
+        print("Coverage data is complete for all selected test targets.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/assemble_coverage.py
+++ b/.github/workflows/scripts/assemble_coverage.py
@@ -38,11 +38,7 @@ def expected_coverage_keys(
     to test groups keeps existing file-level coverage packages compatible.
     """
     if coverage_root is not None and coverage_root.exists():
-        case_keys = {
-            path.parent.name
-            for path in coverage_root.rglob(EXPECTED_SENTINEL)
-            if path.is_file()
-        }
+        case_keys = {path.parent.name for path in coverage_root.rglob(EXPECTED_SENTINEL) if path.is_file()}
         if case_keys:
             return case_keys
 

--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -127,6 +127,12 @@ run_pytest_target() {
   fi
   local status=${PIPESTATUS[0]}
   set -e
+  # When a target fails, mark its covdata dir so the downstream coverage
+  # assembler treats it as unusable and backfills from the OBS history
+  # instead of shipping the failed run's partial coverage.
+  if [ "${status}" -ne 0 ] && [ "${enable_coverage}" = "true" ]; then
+    echo "1" > "$(dirname "${COVERAGE_FILE}")/FAILED"
+  fi
   if [ "${record_timing}" = true ]; then
     local elapsed_ns=$(( $(date +%s%N) - start_time ))
     local elapsed=$(( elapsed_ns / 1000000000 )).$(( (elapsed_ns % 1000000000) / 100000000 ))
@@ -169,6 +175,9 @@ run_pytest_batch() {
   fi
   local status=${PIPESTATUS[0]}
   set -e
+  if [ "${status}" -ne 0 ] && [ "${enable_coverage}" = "true" ]; then
+    echo "1" > "$(dirname "${COVERAGE_FILE}")/FAILED"
+  fi
   if [ "${record_timing}" = true ]; then
     local elapsed_ns=$(( $(date +%s%N) - start_time ))
     local elapsed=$(( elapsed_ns / 1000000000 )).$(( (elapsed_ns % 1000000000) / 100000000 ))

--- a/tests/e2e/pull_request/one_card/test_sampler.py
+++ b/tests/e2e/pull_request/one_card/test_sampler.py
@@ -61,6 +61,7 @@ def test_qwen3_topk(vllm_runner) -> None:
     compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 32, 64]},
 )
 def test_qwen3_prompt_logprobs(vllm_runner) -> None:
+    # assert False, "手动标记该用例强制失败"
     example_prompts = [
         "Hello, my name is",
     ]

--- a/tests/e2e/pull_request/one_card/test_sampler.py
+++ b/tests/e2e/pull_request/one_card/test_sampler.py
@@ -61,7 +61,6 @@ def test_qwen3_topk(vllm_runner) -> None:
     compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 32, 64]},
 )
 def test_qwen3_prompt_logprobs(vllm_runner) -> None:
-    assert False, "手动标记该用例强制失败"
     example_prompts = [
         "Hello, my name is",
     ]

--- a/tests/e2e/pull_request/one_card/test_sampler.py
+++ b/tests/e2e/pull_request/one_card/test_sampler.py
@@ -61,7 +61,7 @@ def test_qwen3_topk(vllm_runner) -> None:
     compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1, 32, 64]},
 )
 def test_qwen3_prompt_logprobs(vllm_runner) -> None:
-    # assert False, "手动标记该用例强制失败"
+    assert False, "手动标记该用例强制失败"
     example_prompts = [
         "Hello, my name is",
     ]


### PR DESCRIPTION
### What this PR does / why we need it?
If some test cases fail to run during the coverage data running, the coverage data of some cases that are not executed will be missing. To ensure the accuracy of the test, you are advised to supplement the historical coverage data.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
Some test cases are failed to run to collect coverage data. The coverage data of the failed and not run test cases is obtained from the historical coverage data and added to the new coverage data.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
