### PR TITLE
[Doc] Clarify CPU-only build verification

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -601,6 +601,18 @@
   tests:
     - tests/ut/
 # Single File
+- name: dependency_documentation
+  optional: true
+  cpu_only: true
+  source_file_dependencies:
+    - docs/source/community/versioning_policy.md
+    - docs/source/installation.md
+    - mkdocs.yml
+    - pyproject.toml
+    - requirements.txt
+  tests:
+    - tests/ut/test_dependency_documentation.py
+
 - name: misc
   optional: false
   source_file_dependencies:

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -68,6 +68,18 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 |-------------|--------------|------------------|-------------|--------------------|---------------|
 |     main    | {{main_vllm_commit}}, {{main_vllm_tag}} | {{main_python_version}}   | {{main_cann_version}} | {{main_pytorch_torch_npu_version}} | {{main_triton_ascend_version}} |
 
+The release rows and the main row are different installation targets. For a
+release installation, use the vLLM and vLLM Ascend versions from the same
+release row. For main-branch development, check out the exact vLLM commit from
+`.github/vllm-main-verified.commit`. Do not assume that an arbitrary vLLM tag
+or PyPI release has the same transitive dependencies as that verified commit.
+
+The matrix describes the complete NPU runtime stack. A successful CPU-only
+editable build verifies package construction only; it does not prove that the
+resulting environment is resolver-compatible or that NPU runtime tests pass.
+Using `--no-build-isolation` can bypass build-environment resolution, so run
+`python -m pip check` before using such an environment for runtime testing.
+
 ## Release cadence
 
 ### Release window

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -22,6 +22,15 @@ This document describes how to install vllm-ascend manually.
 
     Atlas inference products require CANN 9.1.0 beta. The Atlas A2/A3 requirements in the table above remain unchanged.
 
+!!! important "Install a matched software stack"
+
+    Treat vLLM Ascend, vLLM, PyTorch, torch-npu, CANN, and Triton Ascend as
+    one compatibility set. For a release installation, select one complete
+    row from the [release compatibility matrix](community/versioning_policy.md#release-compatibility-matrix).
+    For main-branch development, use the exact vLLM commit recorded in
+    `.github/vllm-main-verified.commit`; an arbitrary vLLM tag or PyPI release
+    can have different transitive dependencies.
+
 There are two installation methods:
 
 - **Using pip**: first prepare the environment manually or via a CANN image, then install `vllm-ascend` using pip.
@@ -94,6 +103,7 @@ Refer to [CANN Installation](https://www.hiascend.com/cann/download?versionId=73
         chmod +x ./Ascend-cann-toolkit_9.0.1_linux-"$(uname -i)".run
         ./Ascend-cann-toolkit_9.0.1_linux-"$(uname -i)".run --full
         source /usr/local/Ascend/ascend-toolkit/set_env.sh
+        export ASCEND_TOOLKIT_HOME="${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/ascend-toolkit/latest}"
 
         wget --header="Referer: https://www.hiascend.com/" https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%209.0.1/Ascend-cann-910b-ops_9.0.1_linux-"$(uname -i)".run
         chmod +x ./Ascend-cann-910b-ops_9.0.1_linux-"$(uname -i)".run
@@ -119,9 +129,9 @@ First, install system dependencies and configure the pip mirror:
 ```bash
 # Using apt-get with mirror
 sed -i 's|ports.ubuntu.com|mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list
-apt-get update -y && apt-get install -y gcc g++ cmake libnuma-dev wget git curl jq
+apt-get update -y && apt-get install -y gcc g++ cmake ninja-build libnuma-dev wget git curl jq
 # Or using yum
-# yum update -y && yum install -y gcc g++ cmake numactl-devel wget git curl jq
+# yum update -y && yum install -y gcc g++ cmake ninja-build numactl-devel wget git curl jq
 # Config pip mirror, only versions 0.11.0 and earlier are supported, if using a version later than 0.11.0, do not execute this command
 pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 ```
@@ -215,6 +225,67 @@ Then you can install `vllm` and `vllm-ascend` from a **pre-built wheel** using o
         ```bash
         pip uninstall -y triton-ascend triton
         ```
+
+### CPU-only build verification
+
+CPU-only verification checks that the Python package can be built when no
+Ascend device is visible. It does **not** validate NPU runtime loading,
+inference examples, custom kernels, or NPU-specific tests. A CANN toolkit is
+still required because the build reads its headers and libraries.
+
+Install the Python build backend and native build tools first. The editable
+build uses setuptools-scm directly, and `arctic-inference` requires CMake and
+Ninja when a compatible wheel is not available:
+
+```bash
+python -m pip install --upgrade \
+    pip "setuptools>=64" "setuptools-scm>=8" wheel \
+    attrs googleapis-common-protos \
+    "cmake>=3.26" ninja
+```
+
+This build-only procedure intentionally does not install vLLM. If you continue
+with combined vLLM and vLLM Ascend testing on the main branch, use the exact
+vLLM commit recorded in `.github/vllm-main-verified.commit` and verify the
+combined environment as described below.
+
+On x86, install the CPU variants of the PyTorch packages from the PyTorch CPU
+index before installing the remaining Ascend dependencies:
+
+```bash
+python -m pip install \
+    --index-url https://download.pytorch.org/whl/cpu/ \
+    torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
+python -m pip install \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    torch-npu==2.10.0 triton-ascend==3.2.1
+python -m pip install \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    -r requirements.txt
+```
+
+Set the build target explicitly and disable device backend auto-loading before
+building vLLM Ascend:
+
+```bash
+export ASCEND_TOOLKIT_HOME="${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/ascend-toolkit/latest}"
+export TORCH_DEVICE_BACKEND_AUTOLOAD=0
+export COMPILE_CUSTOM_KERNELS=0
+export SOC_VERSION=ascend910b1  # Atlas A2; use the matching value below for other products
+python -m pip install \
+    --no-build-isolation \
+    --no-deps \
+    --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
+    -e .
+```
+
+Together, the explicit build dependencies above and `requirements.txt` supply
+the complete build-system requirements before the non-isolated editable
+build. `--no-build-isolation` only reuses packages from the current build
+environment; it does not make incompatible vLLM, PyTorch, and torch-npu
+versions compatible. Before treating an environment as runtime-capable, run
+`python -m pip check` and resolve every reported conflict. Skip inference
+examples and NPU-specific tests when no device is available.
 
 !!! note
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -258,7 +258,7 @@ python -m pip install \
     torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
 python -m pip install \
     --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
-    torch-npu==2.10.0 triton-ascend==3.2.1
+    torch-npu==2.10.0.post2 triton-ascend==3.2.1
 python -m pip install \
     --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
     -r requirements.txt

--- a/tests/ut/test_dependency_documentation.py
+++ b/tests/ut/test_dependency_documentation.py
@@ -107,7 +107,9 @@ class DependencyDocumentationTest(unittest.TestCase):
         manual_install_end = installation.index('=== "Before using docker"', manual_install_start)
         manual_install = installation[manual_install_start:manual_install_end]
         export_position = manual_install.index("export ASCEND_TOOLKIT_HOME=")
-        nnal_install_position = manual_install.index('./Ascend-cann-nnal_9.0.0_linux-"$(uname -i)".run --install')
+        nnal_install = re.search(r'^\s*\./Ascend-cann-nnal_[^\n]+\.run --install$', manual_install, flags=re.MULTILINE)
+        self.assertIsNotNone(nnal_install)
+        nnal_install_position = nnal_install.start()
         self.assertLess(export_position, nnal_install_position)
 
 

--- a/tests/ut/test_dependency_documentation.py
+++ b/tests/ut/test_dependency_documentation.py
@@ -107,7 +107,7 @@ class DependencyDocumentationTest(unittest.TestCase):
         manual_install_end = installation.index('=== "Before using docker"', manual_install_start)
         manual_install = installation[manual_install_start:manual_install_end]
         export_position = manual_install.index("export ASCEND_TOOLKIT_HOME=")
-        nnal_install = re.search(r'^\s*\./Ascend-cann-nnal_[^\n]+\.run --install$', manual_install, flags=re.MULTILINE)
+        nnal_install = re.search(r"^\s*\./Ascend-cann-nnal_[^\n]+\.run --install$", manual_install, flags=re.MULTILINE)
         self.assertIsNotNone(nnal_install)
         nnal_install_position = nnal_install.start()
         self.assertLess(export_position, nnal_install_position)

--- a/tests/ut/test_dependency_documentation.py
+++ b/tests/ut/test_dependency_documentation.py
@@ -108,7 +108,7 @@ class DependencyDocumentationTest(unittest.TestCase):
         manual_install = installation[manual_install_start:manual_install_end]
         export_position = manual_install.index("export ASCEND_TOOLKIT_HOME=")
         nnal_install = re.search(r"^\s*\./Ascend-cann-nnal_[^\n]+\.run --install$", manual_install, flags=re.MULTILINE)
-        self.assertIsNotNone(nnal_install)
+        assert nnal_install is not None
         nnal_install_position = nnal_install.start()
         self.assertLess(export_position, nnal_install_position)
 

--- a/tests/ut/test_dependency_documentation.py
+++ b/tests/ut/test_dependency_documentation.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORE_DEPENDENCIES = ("torch", "torch-npu", "triton-ascend")
+CPU_BUILD_DEPENDENCIES = (
+    "torch",
+    "torch-npu",
+    "torchvision",
+    "torchaudio",
+    "triton-ascend",
+)
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _requirements_versions() -> dict[str, str]:
+    versions = {}
+    for name, version in re.findall(
+        r"^(torch|torch-npu|torchvision|torchaudio|triton-ascend)==([^\s;]+)$",
+        _read("requirements.txt"),
+        flags=re.MULTILINE,
+    ):
+        versions[name] = version
+    return versions
+
+
+def _pyproject_versions() -> dict[str, str]:
+    versions = {}
+    for name, version in re.findall(
+        r'"(torch|torch-npu|triton-ascend)==([^";]+)"',
+        _read("pyproject.toml"),
+    ):
+        versions[name] = version
+    return versions
+
+
+def _mkdocs_main_versions() -> dict[str, str]:
+    mkdocs = _read("mkdocs.yml")
+    torch_pair = re.search(
+        r'^\s*main_pytorch_torch_npu_version:\s*["\']?([^"\'\n]+)',
+        mkdocs,
+        flags=re.MULTILINE,
+    )
+    triton = re.search(
+        r'^\s*main_triton_ascend_version:\s*["\']?([^"\'\s#]+)',
+        mkdocs,
+        flags=re.MULTILINE,
+    )
+    if torch_pair is None or triton is None:
+        return {}
+    torch_version, torch_npu_version = (
+        value.strip() for value in torch_pair.group(1).split("/")
+    )
+    return {
+        "torch": torch_version,
+        "torch-npu": torch_npu_version,
+        "triton-ascend": triton.group(1),
+    }
+
+
+class DependencyDocumentationTest(unittest.TestCase):
+    def test_main_dependency_versions_match_repository_metadata(self):
+        requirements = _requirements_versions()
+        core_requirements = {
+            package: requirements[package] for package in CORE_DEPENDENCIES
+        }
+        self.assertEqual(set(requirements), set(CPU_BUILD_DEPENDENCIES))
+        self.assertEqual(_pyproject_versions(), core_requirements)
+        self.assertEqual(_mkdocs_main_versions(), core_requirements)
+
+    def test_cpu_only_build_contract_is_documented(self):
+        installation = _read("docs/source/installation.md")
+        section_start = installation.index("### CPU-only build verification")
+        section_end = installation.index("\n!!! note", section_start)
+        cpu_section = installation[section_start:section_end]
+        required_text = (
+            "### CPU-only build verification",
+            ".github/vllm-main-verified.commit",
+            "COMPILE_CUSTOM_KERNELS=0",
+            "TORCH_DEVICE_BACKEND_AUTOLOAD=0",
+            "SOC_VERSION=",
+            "--no-build-isolation",
+            "https://download.pytorch.org/whl/cpu/",
+            '"setuptools>=64"',
+            '"setuptools-scm>=8"',
+            "attrs",
+            "googleapis-common-protos",
+            "wheel",
+            "ninja",
+            "python -m pip check",
+        )
+        for text in required_text:
+            with self.subTest(text=text):
+                self.assertIn(text, cpu_section)
+
+        requirements = _requirements_versions()
+        for package in CPU_BUILD_DEPENDENCIES:
+            with self.subTest(package=package):
+                self.assertIn(
+                    f"{package}=={requirements[package]}", cpu_section
+                )
+
+    def test_ascend_toolkit_home_is_set_before_nnal_installation(self):
+        installation = _read("docs/source/installation.md")
+        manual_install_start = installation.index(
+            "??? \"Click here to see 'Install CANN manually'\""
+        )
+        manual_install_end = installation.index(
+            '=== "Before using docker"', manual_install_start
+        )
+        manual_install = installation[manual_install_start:manual_install_end]
+        export_position = manual_install.index("export ASCEND_TOOLKIT_HOME=")
+        nnal_install_position = manual_install.index(
+            './Ascend-cann-nnal_9.0.0_linux-"$(uname -i)".run --install'
+        )
+        self.assertLess(export_position, nnal_install_position)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/test_dependency_documentation.py
+++ b/tests/ut/test_dependency_documentation.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import re
 import unittest
 from pathlib import Path
 
+import regex as re
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CORE_DEPENDENCIES = ("torch", "torch-npu", "triton-ascend")
@@ -55,9 +55,7 @@ def _mkdocs_main_versions() -> dict[str, str]:
     )
     if torch_pair is None or triton is None:
         return {}
-    torch_version, torch_npu_version = (
-        value.strip() for value in torch_pair.group(1).split("/")
-    )
+    torch_version, torch_npu_version = (value.strip() for value in torch_pair.group(1).split("/"))
     return {
         "torch": torch_version,
         "torch-npu": torch_npu_version,
@@ -68,9 +66,7 @@ def _mkdocs_main_versions() -> dict[str, str]:
 class DependencyDocumentationTest(unittest.TestCase):
     def test_main_dependency_versions_match_repository_metadata(self):
         requirements = _requirements_versions()
-        core_requirements = {
-            package: requirements[package] for package in CORE_DEPENDENCIES
-        }
+        core_requirements = {package: requirements[package] for package in CORE_DEPENDENCIES}
         self.assertEqual(set(requirements), set(CPU_BUILD_DEPENDENCIES))
         self.assertEqual(_pyproject_versions(), core_requirements)
         self.assertEqual(_mkdocs_main_versions(), core_requirements)
@@ -103,23 +99,15 @@ class DependencyDocumentationTest(unittest.TestCase):
         requirements = _requirements_versions()
         for package in CPU_BUILD_DEPENDENCIES:
             with self.subTest(package=package):
-                self.assertIn(
-                    f"{package}=={requirements[package]}", cpu_section
-                )
+                self.assertIn(f"{package}=={requirements[package]}", cpu_section)
 
     def test_ascend_toolkit_home_is_set_before_nnal_installation(self):
         installation = _read("docs/source/installation.md")
-        manual_install_start = installation.index(
-            "??? \"Click here to see 'Install CANN manually'\""
-        )
-        manual_install_end = installation.index(
-            '=== "Before using docker"', manual_install_start
-        )
+        manual_install_start = installation.index("??? \"Click here to see 'Install CANN manually'\"")
+        manual_install_end = installation.index('=== "Before using docker"', manual_install_start)
         manual_install = installation[manual_install_start:manual_install_end]
         export_position = manual_install.index("export ASCEND_TOOLKIT_HOME=")
-        nnal_install_position = manual_install.index(
-            './Ascend-cann-nnal_9.0.0_linux-"$(uname -i)".run --install'
-        )
+        nnal_install_position = manual_install.index('./Ascend-cann-nnal_9.0.0_linux-"$(uname -i)".run --install')
         self.assertLess(export_position, nnal_install_position)
 
 


### PR DESCRIPTION
## What this PR does

This PR clarifies the CPU-only build verification workflow for
vLLM Ascend environments without Ascend NPU hardware.

The documentation now explains:

- how to disable custom kernel compilation with
  `COMPILE_CUSTOM_KERNELS=0`;
- which parts of the build can be verified in a CPU-only environment;
- which tests or examples still require Ascend NPU hardware;
- the limitations of CPU-only verification.

## Why this change is needed

During TTFHW verification in a WSL CPU-only environment, the repository
could be built successfully, but the existing documentation did not
clearly distinguish between:

- build and import verification that can run without an NPU;
- runtime and end-to-end tests that require Ascend hardware.

This could cause contributors to interpret hardware-related test
limitations as build failures.

## Verification

The following checks were performed in a CPU-only WSL environment:

- `pip install -e .` with `COMPILE_CUSTOM_KERNELS=0`
- Python package import checks
- `pip check`
- verification of hardware-dependent test limitations

No Ascend NPU runtime or end-to-end inference tests were executed.

## Related issue

Fixes #11928

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
