### PR TITLE
[v0.23.0][BugFix] Gate Memcache lazy init by protocol

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -1,4 +1,5 @@
 # Standard
+import os
 import threading
 import time
 from enum import Enum
@@ -10,9 +11,23 @@ from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 MEMCACHE_THREAD_START_WAIT_S = 0.1
+
+
+def _is_device_sdma() -> bool:
+    config_path = os.getenv("MMC_META_CONFIG_PATH")
+    if not config_path:
+        raise ValueError("The environment variable 'MMC_META_CONFIG_PATH' is not set.")
+    with open(config_path, encoding="utf-8") as config_file:
+        for line in config_file:
+            line = line.strip()
+            if not line or line.startswith(("#", ";")):
+                continue
+            key, separator, value = line.partition("=")
+            if separator and key.strip() == "ock.mmc.local_service.protocol":
+                return value.strip() == "device_sdma"
+    return False
 
 
 class MmcDirect(Enum):
@@ -32,14 +47,12 @@ class MemcacheBackend(Backend):
     ):
         self.local_rank = local_rank if local_rank is not None else get_world_group().local_rank
         self._init_bm = init_bm
-        self._is_a2 = get_ascend_device_type() in {AscendDeviceType.A2}
-        self._lazy_init = lazy_init and not self._is_a2
+        self._lazy_init = lazy_init and _is_device_sdma()
 
         self.store: Any | None = None
         self._store_initialized = False
         self._store_init_lock = threading.Lock()
-        self._registered_buffers: tuple[list[int], list[int]] | None = None
-        self._buffers_registered = False
+        self._pending_buffers: tuple[list[int], list[int]] | None = None
 
         if not self._lazy_init:
             self.store = self._setup_store()
@@ -67,11 +80,6 @@ class MemcacheBackend(Backend):
                 "https://gitee.com/ascend/memfabric_hybrid "  # noqa: E501
                 "to run vLLM with MemcacheConnector."
             ) from e
-
-        if self._init_bm and self._is_a2:
-            tmp_tensor = torch.zeros(1, device="npu")
-            output_tensor_list = [torch.empty_like(tmp_tensor) for _ in range(torch.distributed.get_world_size())]
-            torch.distributed.all_gather(output_tensor_list, tmp_tensor, group=get_world_group().device_group)
 
         store = DistributedObjectStore()
 
@@ -108,21 +116,17 @@ class MemcacheBackend(Backend):
         torch.npu.set_device(device)
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):
-        self._registered_buffers = (list(ptrs), list(sizes))
+        self._pending_buffers = (list(ptrs), list(sizes))
         self._register_buffers_if_needed()
 
     def _register_buffers_if_needed(self):
-        if not self._is_a2:
-            return
-        if self._registered_buffers is None or self._buffers_registered:
-            return
-        if not self._store_initialized:
+        if self._pending_buffers is None or not self._store_initialized:
             return
         assert self.store is not None
-        ptrs, sizes = self._registered_buffers
+        ptrs, sizes = self._pending_buffers
         for ptr, size in zip(ptrs, sizes):
             self.store.register_buffer(ptr, size)
-        self._buffers_registered = True
+        self._pending_buffers = None
 
     def exists(self, keys: list[str]) -> list[int]:
         if self._lazy_init and not self._store_initialized:


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #12064 to `releases/v0.23.0`.

- Removes the A2-specific `all_gather` before Memcache store initialization.
- Reads `ock.mmc.local_service.protocol` from `MMC_META_CONFIG_PATH` and enables lazy initialization only for `device_sdma`.
- Keeps buffer registrations pending until lazy store initialization completes, while delegating the decision to perform the real registration to `store.register_buffer`.
- Preserves the release branch's `init_bm`, scheduler client, and batch metadata behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Memcache lazy initialization is now selected by the configured protocol instead of the Ascend device type. `MMC_META_CONFIG_PATH` must be set when lazy initialization is requested; missing or unreadable configuration files raise their corresponding errors.

### How was this patch tested?

- All pre-commit hooks passed.
- Python syntax compilation passed.
- Targeted smoke checks covered whitespace and comment handling, `device_sdma` and non-`device_sdma` protocols, missing environment/file errors, and deferred buffer registration.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
