### PR TITLE
[BugFix][Worker] Snapshot query start locations before async H2D copies

### DIFF
--- a/tests/ut/worker/test_pcp_manager.py
+++ b/tests/ut/worker/test_pcp_manager.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -476,8 +476,9 @@ def test_generate_pcp_mtp_input(
         input_batch.num_computed_tokens_cpu,
         input_batch.num_prompt_tokens,
     )
-    pcp_manager.generate_pcp_mtp_input(total_num_scheduled_tokens, num_scheduled_tokens, False,
-                                       input_batch, arange_np)
+    with patch.object(torch.Tensor, "pin_memory", lambda tensor: tensor):
+        pcp_manager.generate_pcp_mtp_input(total_num_scheduled_tokens, num_scheduled_tokens, False,
+                                           input_batch, arange_np)
     assert torch.equal(
         pcp_manager.input_ids_pcp_full.cpu[:total_num_scheduled_tokens],
         target_input_ids_pcp_full)

--- a/tests/ut/worker/test_utils.py
+++ b/tests/ut/worker/test_utils.py
@@ -1,0 +1,41 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
+
+
+class TestQueryStartLocCopy(unittest.TestCase):
+    def test_copy_uses_stable_cpu_snapshot(self):
+        class DeferredCopy:
+            def copy_(self, source, non_blocking=False):
+                self.source = source
+                self.non_blocking = non_blocking
+                return self
+
+        cpu = torch.tensor([0, 2, 5], dtype=torch.int32)
+        gpu = DeferredCopy()
+        query_start_loc = SimpleNamespace(cpu=cpu, gpu=gpu)
+
+        with patch.object(torch.Tensor, "pin_memory", lambda tensor: tensor):
+            copy_snapshot_to_gpu(query_start_loc)
+        cpu.fill_(99)
+
+        self.assertEqual(gpu.source.tolist(), [0, 2, 5])
+        self.assertNotEqual(gpu.source.data_ptr(), cpu.data_ptr())
+        self.assertTrue(gpu.non_blocking)
+
+    def test_copy_pins_snapshot(self):
+        cpu = MagicMock()
+        snapshot = MagicMock()
+        pinned_snapshot = MagicMock()
+        cpu.clone.return_value = snapshot
+        snapshot.pin_memory.return_value = pinned_snapshot
+        gpu = MagicMock()
+
+        copy_snapshot_to_gpu(SimpleNamespace(cpu=cpu, gpu=gpu))
+
+        snapshot.pin_memory.assert_called_once_with()
+        gpu.copy_.assert_called_once_with(pinned_snapshot, non_blocking=True)

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -57,6 +57,7 @@ from vllm_ascend.spec_decode.utils import (
 )
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, is_rc_device, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN = 1
 _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
@@ -229,7 +230,7 @@ class NPUModelRunner310(NPUModelRunner):
             query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
             num_reqs_padded = num_reqs_padded + 1
 
-        query_start_loc.copy_to_gpu()
+        copy_snapshot_to_gpu(query_start_loc)
         return num_reqs_padded
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
@@ -400,13 +401,13 @@ class NPUModelRunner310(NPUModelRunner):
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
         if is_rc_device():
             self.query_start_loc.np[num_reqs + 1 :].fill(-1)
-        self.query_start_loc.copy_to_gpu()
+        copy_snapshot_to_gpu(self.query_start_loc)
 
         if self._has_gdn:
             self.gdn_query_start_loc.np[0] = 0
             self.gdn_query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
             self.gdn_query_start_loc.np[num_reqs + 1 :].fill(cu_num_tokens[-1])
-            self.gdn_query_start_loc.copy_to_gpu()
+            copy_snapshot_to_gpu(self.gdn_query_start_loc)
 
         torch.add(
             self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -52,6 +52,7 @@ from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 
 @contextmanager
@@ -577,7 +578,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             # num_reqs is already the padded version
             self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
-            self.query_start_loc.copy_to_gpu()
+            copy_snapshot_to_gpu(self.query_start_loc)
 
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -25,6 +25,7 @@ from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.utils import lmhead_tp_enable
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 
 class AscendStep3p5MTPProposer(AscendEagleProposer):
@@ -254,7 +255,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             num_computed_tokens_cpu = self.runner.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
 
             self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
-            self.query_start_loc.copy_to_gpu()
+            copy_snapshot_to_gpu(self.query_start_loc)
 
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -168,7 +168,7 @@ from vllm_ascend.utils import (
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.pcp_utils import PCPAsyncSpecDecodeRebuildResult, PCPManager
-from vllm_ascend.worker.utils import AscendKVBlockZeroer
+from vllm_ascend.worker.utils import AscendKVBlockZeroer, copy_snapshot_to_gpu
 
 from vllm_ascend.ascend_forward_context import (  # isort: skip
     MoECommType,
@@ -792,7 +792,7 @@ class NPUModelRunner(GPUModelRunner):
                 query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
                 num_reqs_padded = num_reqs_padded + 1
 
-        query_start_loc.copy_to_gpu()
+        copy_snapshot_to_gpu(query_start_loc)
 
         return num_reqs_padded
 
@@ -1002,7 +1002,7 @@ class NPUModelRunner(GPUModelRunner):
 
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
-        self.query_start_loc.copy_to_gpu()
+        copy_snapshot_to_gpu(self.query_start_loc)
 
         # Now, query_start_loc is padded.
         # But gdn needs an unpadded one.
@@ -1012,7 +1012,7 @@ class NPUModelRunner(GPUModelRunner):
             self.gdn_query_start_loc.np[0] = 0
             self.gdn_query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
             self.gdn_query_start_loc.np[num_reqs + 1 :].fill(cu_num_tokens[-1])
-            self.gdn_query_start_loc.copy_to_gpu()
+            copy_snapshot_to_gpu(self.gdn_query_start_loc)
 
 
         # Compute optimistic seq_lens (assumes all draft tokens from previous
@@ -3450,10 +3450,10 @@ class NPUModelRunner(GPUModelRunner):
             cum_num_tokens = self._get_cumsum_and_arange(
             num_scheduled_tokens, self.query_pos.np)
             self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-            self.query_start_loc.copy_to_gpu()
+            copy_snapshot_to_gpu(self.query_start_loc)
             if self._has_gdn:
                 self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-                self.gdn_query_start_loc.copy_to_gpu()
+                copy_snapshot_to_gpu(self.gdn_query_start_loc)
 
             if not profile_cpp:
                 num_reqs_padded = self._pad_query_start_loc_for_fia(

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -36,6 +36,7 @@ from vllm.v1.utils import CpuGpuBuffer
 from vllm_ascend.spec_decode.utils import correct_optimistic_seq_lens_cpu
 from vllm_ascend.utils import is_pd_decode_recompute_scheduler_enabled
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -1683,7 +1684,7 @@ class PCPManager:
             out=self.input_ids_pcp_full.cpu[:total_num_scheduled_tokens_pcp_full],
         )
         self.input_ids_pcp_full.copy_to_gpu(total_num_scheduled_tokens_pcp_full)
-        self.query_start_loc_pcp_full.copy_to_gpu()
+        copy_snapshot_to_gpu(self.query_start_loc_pcp_full)
         if self.use_async_scheduling:
             self._update_input_ids_pcp_full_ids(
                 input_batch,

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -6,9 +6,16 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import largest_power_of_2_divisor
 from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+def copy_snapshot_to_gpu(buffer: CpuGpuBuffer) -> torch.Tensor:
+    """Copy a pinned snapshot of a CPU buffer to its GPU buffer."""
+    cpu_snapshot = buffer.cpu.clone().pin_memory()
+    return buffer.gpu.copy_(cpu_snapshot, non_blocking=True)
 
 
 @triton.jit


### PR DESCRIPTION
### What this PR does / why we need it?

`query_start_loc` buffers reuse their CPU storage across scheduling iterations while `copy_to_gpu()` issues a non-blocking H2D transfer. A later CPU update can therefore overwrite the transfer source before the queued copy has consumed it, producing incorrect device-side query start locations and derived indices.

This PR:

- adds the public `copy_snapshot_to_gpu()` helper, which clones and pins the CPU buffer before copying it asynchronously into the existing GPU buffer;
- routes the v1, 310P, GDN, speculative proposer, Step3.5, and PCP query-start-location copies through that helper;
- preserves existing GPU buffer objects and addresses, so their consumers and ACL Graph paths do not need to change; and
- adds focused coverage for snapshot ownership, pinning, and non-blocking copy behavior.

### Does this PR introduce _any_ user-facing change?

No. This only prevents an internal asynchronous H2D source-buffer race.

### How was this patch tested?

- CPU-only stubbed unit test:
  - `run_stubbed_ut.py tests/ut/worker/test_utils.py`
  - Result: `2 passed`
- Targeted mypy for `vllm_ascend/worker/utils.py` with Python 3.10, 3.11, and 3.12: passed.
- NPU unit test:
  - `python -m pytest -q tests/ut/worker/test_utils.py`
  - Result: `2 passed, 16 warnings`
- Real NPU pinned H2D stress test:
  - reused one pinned `CpuGpuBuffer` for 1,000 snapshot copies;
  - overwrote the original CPU buffer immediately after every non-blocking copy;
  - synchronized and verified that the device buffer retained the final snapshot;
  - Result: passed, with `buffer.cpu.is_pinned() == True`.

No model weights were required.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
