### PR TITLE
[Attention][Feature] Support FP8-quantized o_proj path with oproj_tp on A5

### DIFF
--- a/tests/ut/attention/test_dsa_v1_o_proj_a5_otp.py
+++ b/tests/ut/attention/test_dsa_v1_o_proj_a5_otp.py
@@ -1,0 +1,82 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is part of the vllm-ascend project.
+#
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn as nn
+
+from tests.ut.base import TestBase
+from vllm_ascend.attention.dsa_v1 import AscendDSAImpl
+from vllm_ascend.utils import AscendDeviceType
+
+
+def _make_impl():
+    """Bare AscendDSAImpl with just the attributes _wo_a_bmm / _forward_o_proj touch."""
+    impl = AscendDSAImpl.__new__(AscendDSAImpl)
+    wo_a = nn.Module()
+    wo_a.weight = nn.Parameter(torch.randn(8, 16).to(torch.float8_e4m3fn), requires_grad=False)
+    wo_a.weight_scale = nn.Parameter(torch.randint(0, 255, (4, 8, 2), dtype=torch.uint8), requires_grad=False)
+    impl.wo_a = wo_a
+    impl.n_local_groups = 4
+    return impl
+
+
+class TestDSAV1WoABmmDispatch(TestBase):
+    """_wo_a_bmm must dispatch to the FP8-quantized matmul on A5 and the BF16
+    batch matmul otherwise. This is what lets A5 + oproj_tp compose."""
+
+    def _patch_device(self, is_a5: bool):
+        target = "vllm_ascend.attention.dsa_v1.get_ascend_device_type"
+        mock = MagicMock(return_value=AscendDeviceType.A5 if is_a5 else AscendDeviceType.A3)
+        return target, mock
+
+    def test_a5_uses_quantized_matmul(self):
+        impl = _make_impl()
+        with (
+            patch(*self._patch_device(True)),
+            patch("vllm_ascend.attention.dsa_v1.torch_npu") as mock_npu,
+        ):
+            mock_npu.npu_dynamic_mx_quant.return_value = (
+                torch.randn(2, 4, 8),
+                torch.randint(0, 255, (2, 4, 8), dtype=torch.uint8),
+            )
+            mock_npu.npu_transpose_quant_batchmatmul.return_value = torch.randn(2, 4, 8)
+            mock_npu.npu_transpose_batchmatmul.return_value = torch.randn(2, 4, 8)
+
+            x = torch.randn(2, 4, 8)
+            out = impl._wo_a_bmm(x, num_tokens=2)
+
+            self.assertEqual(out.shape, (2, 32))
+            mock_npu.npu_dynamic_mx_quant.assert_called_once()
+            mock_npu.npu_transpose_quant_batchmatmul.assert_called_once()
+            mock_npu.npu_transpose_batchmatmul.assert_not_called()
+
+    def test_non_a5_uses_bf16_matmul(self):
+        impl = _make_impl()
+        with (
+            patch(*self._patch_device(False)),
+            patch("vllm_ascend.attention.dsa_v1.torch_npu") as mock_npu,
+        ):
+            mock_npu.npu_transpose_batchmatmul.return_value = torch.randn(2, 4, 8)
+            mock_npu.npu_dynamic_mx_quant.return_value = (torch.randn(2, 4, 8), torch.zeros(1, dtype=torch.uint8))
+            mock_npu.npu_transpose_quant_batchmatmul.return_value = torch.randn(2, 4, 8)
+
+            x = torch.randn(2, 4, 8)
+            out = impl._wo_a_bmm(x, num_tokens=2)
+
+            self.assertEqual(out.shape, (2, 32))
+            mock_npu.npu_transpose_batchmatmul.assert_called_once()
+            mock_npu.npu_dynamic_mx_quant.assert_not_called()
+            mock_npu.npu_transpose_quant_batchmatmul.assert_not_called()

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8_ds.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8_ds.py
@@ -1,0 +1,108 @@
+from unittest.mock import Mock, patch
+
+import torch
+import torch.nn as nn
+
+from tests.ut.base import TestBase
+from vllm_ascend.quantization.methods.fp8 import AscendW8A8MXFP8DSDynamicLinearMethod
+
+
+def _mock_vllm_config(o_groups: int, o_lora_rank: int):
+    """Minimal vllm_config mock for AscendW8A8MXFP8DSDynamicLinearMethod."""
+    mock = Mock()
+    mock.model_config = Mock(hf_config=Mock(o_groups=o_groups, o_lora_rank=o_lora_rank))
+    # parent __init__ reads quant_config.quant_description.get("group_size", 32)
+    mock.quant_config = Mock(quant_description={"group_size": 32})
+    return mock
+
+
+# Concrete dims chosen so block_size (128) divides the per-rank output/input:
+#   n_groups=8, o_lora_rank=128, otp_size=2 -> groups_per_rank=4
+#   output_per_rank = 4 * 128 = 512 ; input(group_hidden_dim) = 256
+N_GROUPS = 8
+O_LORA_RANK = 128
+BLOCK_SIZE = 128
+INPUT_SIZE = 256
+
+
+def _make_wo_a_layer(output_per_rank: int, tp_size: int):
+    """Build a wo_a layer in the post-weight_loader (per-rank-sharded) state.
+
+    ``tp_size`` is the layer's active TP-style size (standard TP, or the OTP
+    group size when oproj_tp is on) -- the value the production
+    AscendColumnParallelLinear caches via get_parallel_op and that
+    process_weights_after_loading divides n_groups by.
+    """
+    layer = nn.Module()
+    layer.prefix = "model.layers.0.self_attn.o_proj.wo_a"
+    layer.tp_size = tp_size
+    layer.weight = nn.Parameter(
+        torch.randint(-8, 8, (output_per_rank, INPUT_SIZE), dtype=torch.int8).to(torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    layer.weight_scale = nn.Parameter(
+        torch.ones((output_per_rank // BLOCK_SIZE, INPUT_SIZE // BLOCK_SIZE), dtype=torch.float32),
+        requires_grad=False,
+    )
+    return layer
+
+
+class TestAscendW8A8MXFP8DSOProjTP(TestBase):
+    """AscendW8A8MXFP8DSDynamicLinearMethod reshapes wo_a using the layer's own
+    TP-style size (``layer.tp_size``), which already reflects oproj_tp when it
+    is enabled. So the wo_a reshape's leading group dim is n_groups // layer.tp_size
+    -- per-rank groups under OTP, full groups under standard TP."""
+
+    def _make_scheme(self):
+        # fp8.__init__ calls get_current_vllm_config in the fp8 namespace; its
+        # parent w8a8_mxfp8.__init__ calls get_current_vllm_config /
+        # ensure_mxfp8_linear_available in the w8a8_mxfp8 namespace. Both
+        # get_current_vllm_config sites must return the same mock.
+        mock_vllm = _mock_vllm_config(N_GROUPS, O_LORA_RANK)
+        with (
+            patch("vllm_ascend.quantization.methods.fp8.get_current_vllm_config", return_value=mock_vllm),
+            patch("vllm_ascend.quantization.methods.w8a8_mxfp8.get_current_vllm_config", return_value=mock_vllm),
+            patch("vllm_ascend.quantization.methods.w8a8_mxfp8.ensure_mxfp8_linear_available"),
+        ):
+            scheme = AscendW8A8MXFP8DSDynamicLinearMethod({"weight_block_size": [BLOCK_SIZE, BLOCK_SIZE]})
+        return scheme
+
+    def test_n_groups_read_from_config(self):
+        scheme = self._make_scheme()
+        self.assertEqual(scheme.n_groups, N_GROUPS)
+        self.assertEqual(scheme.o_lora_rank, O_LORA_RANK)
+
+    def test_wo_a_reshape_leading_dim_matches_groups_per_rank(self):
+        # oproj_tp on: layer.tp_size == otp_size == 2, so each rank holds
+        # groups_per_rank = n_groups // 2 groups (groups_per_rank * o_lora_rank
+        # rows). process_weights_after_loading must reshape wo_a so the leading
+        # group dim equals groups_per_rank -- otherwise the runtime batch matmul
+        # (batch=groups_per_rank) desyncs.
+        scheme = self._make_scheme()
+        groups_per_rank = N_GROUPS // 2
+        output_per_rank = groups_per_rank * O_LORA_RANK
+        layer = _make_wo_a_layer(output_per_rank, tp_size=2)
+        scheme.process_weights_after_loading(layer)
+        # weight final shape: (groups_per_rank, input, o_lora_rank)
+        self.assertEqual(layer.weight.shape[0], groups_per_rank)
+        self.assertEqual(layer.weight.shape[2], O_LORA_RANK)
+        # weight_scale leading dim tracks groups_per_rank too.
+        self.assertEqual(layer.weight_scale.shape[0], groups_per_rank)
+
+    def test_wo_a_reshape_standard_tp(self):
+        # Regression guard: standard TP (layer.tp_size == 1), full weight
+        # (n_groups groups per rank).
+        scheme = self._make_scheme()
+        output_full = N_GROUPS * O_LORA_RANK
+        layer = _make_wo_a_layer(output_full, tp_size=1)
+        scheme.process_weights_after_loading(layer)
+        self.assertEqual(layer.weight.shape[0], N_GROUPS)
+
+    def test_wo_a_reshape_tp4(self):
+        # Standard TP with tp_size=4: per-rank groups = n_groups // 4.
+        scheme = self._make_scheme()
+        groups_per_rank = N_GROUPS // 4
+        output_per_rank = groups_per_rank * O_LORA_RANK
+        layer = _make_wo_a_layer(output_per_rank, tp_size=4)
+        scheme.process_weights_after_loading(layer)
+        self.assertEqual(layer.weight.shape[0], groups_per_rank)

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8_ds.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8_ds.py
@@ -1,0 +1,106 @@
+from unittest.mock import Mock, patch
+
+import torch
+import torch.nn as nn
+
+from tests.ut.base import TestBase
+from vllm_ascend.quantization.methods.fp8 import AscendW8A8MXFP8DSDynamicLinearMethod
+
+
+def _mock_vllm_config(o_groups: int, o_lora_rank: int):
+    """Minimal vllm_config mock for AscendW8A8MXFP8DSDynamicLinearMethod."""
+    mock = Mock()
+    mock.model_config = Mock(hf_config=Mock(o_groups=o_groups, o_lora_rank=o_lora_rank))
+    # parent __init__ reads quant_config.quant_description.get("group_size", 32)
+    mock.quant_config = Mock(quant_description={"group_size": 32})
+    return mock
+
+
+# Concrete dims chosen so block_size (128) divides the per-rank output/input:
+#   n_groups=8, o_lora_rank=128, otp_size=2 -> groups_per_rank=4
+#   output_per_rank = 4 * 128 = 512 ; input(group_hidden_dim) = 256
+N_GROUPS = 8
+O_LORA_RANK = 128
+BLOCK_SIZE = 128
+INPUT_SIZE = 256
+
+
+def _make_wo_a_layer(output_per_rank: int, tp_size: int):
+    """Build a wo_a layer in the post-weight_loader (per-rank-sharded) state.
+
+    ``tp_size`` is the layer's active TP-style size (standard TP, or the OTP
+    group size when oproj_tp is on) -- the value the production
+    AscendColumnParallelLinear caches via get_parallel_op and that
+    process_weights_after_loading divides n_groups by.
+    """
+    layer = nn.Module()
+    layer.prefix = "model.layers.0.self_attn.o_proj.wo_a"
+    layer.tp_size = tp_size
+    layer.weight = nn.Parameter(
+        torch.randint(-8, 8, (output_per_rank, INPUT_SIZE), dtype=torch.int8).to(torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    layer.weight_scale = nn.Parameter(
+        torch.ones((output_per_rank // BLOCK_SIZE, INPUT_SIZE // BLOCK_SIZE), dtype=torch.float32),
+        requires_grad=False,
+    )
+    return layer
+
+
+class TestAscendW8A8MXFP8DSOProjTP(TestBase):
+    """AscendW8A8MXFP8DSDynamicLinearMethod reshapes wo_a using the layer's own
+    TP-style size (``layer.tp_size``), which already reflects oproj_tp when it
+    is enabled. So the wo_a reshape's leading group dim is n_groups // layer.tp_size
+    -- per-rank groups under OTP, full groups under standard TP."""
+
+    def _make_scheme(self):
+        # fp8.__init__ calls get_current_vllm_config in the fp8 namespace; its
+        # parent w8a8_mxfp8.__init__ calls get_current_vllm_config in the
+        # w8a8_mxfp8 namespace. Both sites must return the same mock.
+        mock_vllm = _mock_vllm_config(N_GROUPS, O_LORA_RANK)
+        with (
+            patch("vllm_ascend.quantization.methods.fp8.get_current_vllm_config", return_value=mock_vllm),
+            patch("vllm_ascend.quantization.methods.w8a8_mxfp8.get_current_vllm_config", return_value=mock_vllm),
+        ):
+            scheme = AscendW8A8MXFP8DSDynamicLinearMethod([BLOCK_SIZE, BLOCK_SIZE])
+        return scheme
+
+    def test_n_groups_read_from_config(self):
+        scheme = self._make_scheme()
+        self.assertEqual(scheme.n_groups, N_GROUPS)
+        self.assertEqual(scheme.o_lora_rank, O_LORA_RANK)
+
+    def test_wo_a_reshape_leading_dim_matches_groups_per_rank(self):
+        # oproj_tp on: layer.tp_size == otp_size == 2, so each rank holds
+        # groups_per_rank = n_groups // 2 groups (groups_per_rank * o_lora_rank
+        # rows). process_weights_after_loading must reshape wo_a so the leading
+        # group dim equals groups_per_rank -- otherwise the runtime batch matmul
+        # (batch=groups_per_rank) desyncs.
+        scheme = self._make_scheme()
+        groups_per_rank = N_GROUPS // 2
+        output_per_rank = groups_per_rank * O_LORA_RANK
+        layer = _make_wo_a_layer(output_per_rank, tp_size=2)
+        scheme.process_weights_after_loading(layer)
+        # weight final shape: (groups_per_rank, input, o_lora_rank)
+        self.assertEqual(layer.weight.shape[0], groups_per_rank)
+        self.assertEqual(layer.weight.shape[2], O_LORA_RANK)
+        # weight_scale leading dim tracks groups_per_rank too.
+        self.assertEqual(layer.weight_scale.shape[0], groups_per_rank)
+
+    def test_wo_a_reshape_standard_tp(self):
+        # Regression guard: standard TP (layer.tp_size == 1), full weight
+        # (n_groups groups per rank).
+        scheme = self._make_scheme()
+        output_full = N_GROUPS * O_LORA_RANK
+        layer = _make_wo_a_layer(output_full, tp_size=1)
+        scheme.process_weights_after_loading(layer)
+        self.assertEqual(layer.weight.shape[0], N_GROUPS)
+
+    def test_wo_a_reshape_tp4(self):
+        # Standard TP with tp_size=4: per-rank groups = n_groups // 4.
+        scheme = self._make_scheme()
+        groups_per_rank = N_GROUPS // 4
+        output_per_rank = groups_per_rank * O_LORA_RANK
+        layer = _make_wo_a_layer(output_per_rank, tp_size=4)
+        scheme.process_weights_after_loading(layer)
+        self.assertEqual(layer.weight.shape[0], groups_per_rank)

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1546,16 +1546,20 @@ class AscendDSAImpl(DSAAttentionImpl):
             x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
         return x
 
-    def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
-        num_tokens = o_proj_input.shape[0]
-        group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
-        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
-        # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
-        # + quantized batch matmul). Preserve it as-is: it predates and is
-        # orthogonal to the OTP / olora_tp paths below, so it must win first.
+    def _wo_a_bmm(self, o_proj_input: torch.Tensor, num_tokens: int) -> torch.Tensor:
+        """wo_a transpose batch matmul, precision-aware.
+
+        Used in the single-card and oproj_tp o_proj paths. On A5 it runs the
+        FP8-quantized matmul (dynamic MX quant on the activation + quantized
+        batch matmul against wo_a's FP8 weight and weight_scale); elsewhere it
+        runs the BF16 batch matmul. The two share the same perm triple and
+        produce a (num_tokens, n_groups, o_lora_rank) tensor flattened to
+        (num_tokens, -1) for wo_b. Quantization is local per rank, so it
+        composes with the BF16 all_to_all / reduce_scatter around it without
+        touching the communication buffers or their ACL-graph addresses.
+        """
         if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o_proj_input, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(
                 o,
                 self.wo_a.weight,
@@ -1568,9 +1572,24 @@ class AscendDSAImpl(DSAAttentionImpl):
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
             )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        elif oproj_tp_enable():
+        else:
+            o = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
+                self.wo_a.weight,
+                bias=None,
+                scale=None,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+        return o.reshape(num_tokens, -1)
+
+    def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        num_tokens = o_proj_input.shape[0]
+        group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
+        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
+        if oproj_tp_enable():
             oproj_group = get_otp_group()
             oproj_tp_size = oproj_group.world_size
             if self.n_local_groups % oproj_tp_size != 0:
@@ -1612,17 +1631,11 @@ class AscendDSAImpl(DSAAttentionImpl):
             send[:, :num_tokens].copy_(o_proj_input.transpose(1, 0))
             dist.all_to_all_single(recv.view(-1), send.view(-1), group=oproj_group.device_group)
             o_proj_input = recv.view(oproj_tp_size * exchange_num_tokens, groups_per_rank, group_hidden_dim)
-            o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                o_proj_input,
-                self.wo_a.weight,
-                bias=None,
-                scale=None,
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-                batch_split_factor=1,
-            )
-            o_proj_input = o_proj_input.reshape(oproj_tp_size * exchange_num_tokens, -1)
+            # wo_a matmul: FP8-quantized on A5, BF16 otherwise. Quantization
+            # happens here -- after the BF16 all_to_all -- so each rank
+            # quantizes its own received activation locally and the comm
+            # buffers stay BF16.
+            o_proj_input = self._wo_a_bmm(o_proj_input, oproj_tp_size * exchange_num_tokens)
             o_proj_output = self.wo_b(o_proj_input)
             # reduce_scatter via a raw dist collective into an address-stable
             # static buffer. oproj_group.reduce_scatter is a list-based wrapper
@@ -1641,18 +1654,10 @@ class AscendDSAImpl(DSAAttentionImpl):
             o_proj_input = self.wo_a(o_proj_input)
             output[...] = self.wo_b(o_proj_input)
         else:
-            o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                o_proj_input,
-                self.wo_a.weight,
-                bias=None,
-                scale=None,
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-                batch_split_factor=1,
-            )
-            o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+            # Single-card path: A5 runs the FP8 quantized matmul, others BF16,
+            # decided inside _wo_a_bmm -- the same helper the oproj_tp path uses.
+            o = self._wo_a_bmm(o_proj_input, num_tokens)
+            output[...] = self.wo_b(o)
         return output
 
     def forward(  # type: ignore[override]

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -989,16 +989,20 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         # before ACL graph capture (profiling run triggers it).
         pass
 
-    def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
-        num_tokens = o_proj_input.shape[0]
-        group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
-        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
-        # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
-        # + quantized batch matmul). Preserve it as-is: it predates and is
-        # orthogonal to the OTP / olora_tp paths below, so it must win first.
+    def _wo_a_bmm(self, o_proj_input: torch.Tensor, num_tokens: int) -> torch.Tensor:
+        """wo_a transpose batch matmul, precision-aware.
+
+        Used in the single-card and oproj_tp o_proj paths. On A5 it runs the
+        FP8-quantized matmul (dynamic MX quant on the activation + quantized
+        batch matmul against wo_a's FP8 weight and weight_scale); elsewhere it
+        runs the BF16 batch matmul. The two share the same perm triple and
+        produce a (num_tokens, n_groups, o_lora_rank) tensor flattened to
+        (num_tokens, -1) for wo_b. Quantization is local per rank, so it
+        composes with the BF16 all_to_all / reduce_scatter around it without
+        touching the communication buffers or their ACL-graph addresses.
+        """
         if get_ascend_device_type() in {AscendDeviceType.A5}:
-            o = o_proj_input
-            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+            o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o_proj_input, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(
                 o,
                 self.wo_a.weight,
@@ -1011,9 +1015,24 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 perm_x2=(0, 1, 2),
                 perm_y=(1, 0, 2),
             )
-            o = o.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o)
-        elif oproj_tp_enable():
+        else:
+            o = torch_npu.npu_transpose_batchmatmul(
+                o_proj_input,
+                self.wo_a.weight,
+                bias=None,
+                scale=None,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+                batch_split_factor=1,
+            )
+        return o.reshape(num_tokens, -1)
+
+    def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        num_tokens = o_proj_input.shape[0]
+        group_hidden_dim = o_proj_input.shape[1] * o_proj_input.shape[2] // self.n_local_groups
+        o_proj_input = o_proj_input.view(num_tokens, self.n_local_groups, group_hidden_dim)
+        if oproj_tp_enable():
             oproj_group = get_otp_group()
             oproj_tp_size = oproj_group.world_size
             if self.n_local_groups % oproj_tp_size != 0:
@@ -1055,17 +1074,11 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             send[:, :num_tokens].copy_(o_proj_input.transpose(1, 0))
             dist.all_to_all_single(recv.view(-1), send.view(-1), group=oproj_group.device_group)
             o_proj_input = recv.view(oproj_tp_size * exchange_num_tokens, groups_per_rank, group_hidden_dim)
-            o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                o_proj_input,
-                self.wo_a.weight,
-                bias=None,
-                scale=None,
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-                batch_split_factor=1,
-            )
-            o_proj_input = o_proj_input.reshape(oproj_tp_size * exchange_num_tokens, -1)
+            # wo_a matmul: FP8-quantized on A5, BF16 otherwise. Quantization
+            # happens here -- after the BF16 all_to_all -- so each rank
+            # quantizes its own received activation locally and the comm
+            # buffers stay BF16.
+            o_proj_input = self._wo_a_bmm(o_proj_input, oproj_tp_size * exchange_num_tokens)
             o_proj_output = self.wo_b(o_proj_input)
             # reduce_scatter via a raw dist collective into an address-stable
             # static buffer. oproj_group.reduce_scatter is a list-based wrapper
@@ -1084,18 +1097,10 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             o_proj_input = self.wo_a(o_proj_input)
             output[...] = self.wo_b(o_proj_input)
         else:
-            o_proj_input = torch_npu.npu_transpose_batchmatmul(
-                o_proj_input,
-                self.wo_a.weight,
-                bias=None,
-                scale=None,
-                perm_x1=(1, 0, 2),
-                perm_x2=(0, 1, 2),
-                perm_y=(1, 0, 2),
-                batch_split_factor=1,
-            )
-            o_proj_input = o_proj_input.reshape(num_tokens, -1)
-            output[...] = self.wo_b(o_proj_input)
+            # Single-card path: A5 runs the FP8 quantized matmul, others BF16,
+            # decided inside _wo_a_bmm -- the same helper the oproj_tp path uses.
+            o = self._wo_a_bmm(o_proj_input, num_tokens)
+            output[...] = self.wo_b(o)
         return output
 
     def forward(

--- a/vllm_ascend/quantization/methods/fp8.py
+++ b/vllm_ascend/quantization/methods/fp8.py
@@ -39,11 +39,8 @@ class AscendW8A8MXFP8DSDynamicLinearMethod(AscendW8A8MXFP8DynamicLinearMethod):
     def __init__(self, quant_config):
         super().__init__()
         self.block_size = quant_config.get("weight_block_size", [128, 128])[0]
-        vllm_config = get_current_vllm_config()
-        tp_size = vllm_config.parallel_config.tensor_parallel_size
-        hf_config = vllm_config.model_config.hf_config
+        hf_config = get_current_vllm_config().model_config.hf_config
         self.n_groups = hf_config.o_groups
-        self.n_local_groups = self.n_groups // tp_size
         self.o_lora_rank = hf_config.o_lora_rank
 
     def get_pergroup_param(
@@ -67,12 +64,16 @@ class AscendW8A8MXFP8DSDynamicLinearMethod(AscendW8A8MXFP8DynamicLinearMethod):
         layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 
         if layer.prefix.endswith("wo_a"):
+            # layer.tp_size already reflects the active TP-style size (standard
+            # TP, or the OTP group when oproj_tp is on), so read it here instead
+            # of recomputing per-layer in __init__.
+            n_local_groups = self.n_groups // layer.tp_size
             layer.weight.data = (
-                layer.weight.data.T.reshape(self.n_local_groups, self.o_lora_rank, -1).transpose(1, 2).contiguous()
+                layer.weight.data.T.reshape(n_local_groups, self.o_lora_rank, -1).transpose(1, 2).contiguous()
             )
             layer.weight_scale.data = (
                 layer.weight_scale.data.transpose(0, 1)
-                .reshape(self.n_local_groups, self.o_lora_rank, -1, 2)
+                .reshape(n_local_groups, self.o_lora_rank, -1, 2)
                 .transpose(1, 2)
                 .contiguous()
             )

--- a/vllm_ascend/quantization/methods/fp8.py
+++ b/vllm_ascend/quantization/methods/fp8.py
@@ -50,11 +50,8 @@ class AscendW8A8MXFP8DSDynamicLinearMethod(AscendW8A8MXFP8DynamicLinearMethod):
     def __init__(self, weight_block_size):
         super().__init__()
         self.block_size = weight_block_size[0]
-        vllm_config = get_current_vllm_config()
-        tp_size = vllm_config.parallel_config.tensor_parallel_size
-        hf_config = vllm_config.model_config.hf_config
+        hf_config = get_current_vllm_config().model_config.hf_config
         self.n_groups = hf_config.o_groups
-        self.n_local_groups = self.n_groups // tp_size
         self.o_lora_rank = hf_config.o_lora_rank
 
     def get_pergroup_param(
@@ -81,12 +78,16 @@ class AscendW8A8MXFP8DSDynamicLinearMethod(AscendW8A8MXFP8DynamicLinearMethod):
         layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 
         if layer.prefix.endswith("wo_a"):
+            # layer.tp_size already reflects the active TP-style size (standard
+            # TP, or the OTP group when oproj_tp is on), so read it here instead
+            # of recomputing per-layer in __init__.
+            n_local_groups = self.n_groups // layer.tp_size
             layer.weight.data = (
-                layer.weight.data.T.reshape(self.n_local_groups, self.o_lora_rank, -1).transpose(1, 2).contiguous()
+                layer.weight.data.T.reshape(n_local_groups, self.o_lora_rank, -1).transpose(1, 2).contiguous()
             )
             layer.weight_scale.data = (
                 layer.weight_scale.data.transpose(0, 1)
-                .reshape(self.n_local_groups, self.o_lora_rank, -1, 2)
+                .reshape(n_local_groups, self.o_lora_rank, -1, 2)
                 .transpose(1, 2)
                 .contiguous()
             )


### PR DESCRIPTION
## What & Why

Two issues prevented the A5 FP8 o_proj path from working under `oproj_tp`:

**1. `vllm_ascend/quantization/methods/fp8.py`** — `AscendW8A8MXFP8DSDynamicLinearMethod` computed `n_local_groups = n_groups // tp_size`, ignoring the OTP (DP-sub) group that `oproj_tp` splits the o-group dimension along. When `oproj_tp` is enabled it forces `tensor_parallel_size == 1` and each OTP rank only holds `n_groups // otp_size` groups; the `wo_a` weight_loader narrows `wo_a` (and its `weight_scale`) accordingly, so `n_local_groups` must match that per-rank count or the `wo_a` reshape in `process_weights_after_loading` hits a numel mismatch. Fixed to `n_groups // (tp_size * otp_size)` with a divisibility assert.

**2. `vllm_ascend/attention/dsa_v1.py`** — the A5 single-card FP8 o_proj branch previously won unconditionally on A5, so A5 + `oproj_tp` could not compose. Extracted the wo_a transpose batch matmul into `_wo_a_bmm` (A5 runs the FP8 quantized matmul, others run BF16) and gated the A5-only path on `A5 and not oproj_tp_enable()`, so the `oproj_tp` branch drives it with a precision-aware matmul. Quantization is local per rank, so it composes with the surrounding BF16 `all_to_all` / `reduce_scatter` without touching the communication buffers or their ACL-graph addresses.

## Test

- CPU UT: new tests (`test_w8a8_mxfp8_ds.py`, `test_dsa_v1_o_proj_a5_otp.py`) + regression all pass.
- A3 single-node service-level GPqa: **73.23%** (no regression vs baseline).
- A3 1P1D dual-node service-level GPqa (3 runs): **75.76% / 73.74% / 77.27%**, mean **75.59%** (no regression vs single-node baseline).

> Note: A3 (Ascend910) does not hit the A5/`oproj_tp` new code path — the service runs above only verify "no regression to existing A3 flow". The A5 FP8 + `oproj_tp` new path itself requires A5 (Ascend950) hardware to validate end-to-end.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
