### PR TITLE
[v0.23.0][Feature][KVCache] Add multi-group layerwise KV cache support for DSV4 with MemCache backend

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -13,10 +13,17 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    maybe_save_kv_layer_to_connector,
+    notify_kv_cache_written,
+    split_decodes_and_prefills,
+    wait_for_kv_layer_from_connector,
+)
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
+from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
@@ -1190,6 +1197,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             return output.fill_(0)
         if not isinstance(attn_metadata, list):
             attn_metadata = [attn_metadata]
+        wait_for_kv_layer_from_connector(layer_name)
         full_gather_wo_a_enabled = (
             self.tp_size > 1
             and self.enable_dsa_cp_with_o_proj_tp
@@ -1259,6 +1267,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
         finally:
             if full_gather_wo_a_enabled:
                 self._switch_o_proj_to_tp_weight()
+
+        maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output
 
@@ -1424,6 +1434,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 compressed_kv = None
             DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
 
+        notify_kv_cache_written(layer_name)
+        record_attention_compute_start()
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
         if has_prefill:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -18,10 +18,17 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.abstract import DSAAttentionImpl
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    maybe_save_kv_layer_to_connector,
+    notify_kv_cache_written,
+    split_decodes_and_prefills,
+    wait_for_kv_layer_from_connector,
+)
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_otp_group
+from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
@@ -1692,6 +1699,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
+        wait_for_kv_layer_from_connector(layer_name)
         if has_prefill:
             assert attn_metadata[0].prefill is not None
             output_prefill = self._forward_prefill(
@@ -1724,6 +1732,8 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         # o
         self._forward_o_proj(o_proj_input, output)
+
+        maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output_padded
 
@@ -1937,6 +1947,8 @@ class AscendDSAImpl(DSAAttentionImpl):
         DeviceOperator.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
 
         if self.compress_ratio <= 1:
+            notify_kv_cache_written(layer_name)
+            record_attention_compute_start()
             return attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -2073,6 +2085,9 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
+
+            notify_kv_cache_written(layer_name)
+            record_attention_compute_start()
 
             if self.compress_ratio == 4:
                 DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
@@ -2365,6 +2380,8 @@ class AscendDSAImpl(DSAAttentionImpl):
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
 
+        notify_kv_cache_written(layer_name)
+        record_attention_compute_start()
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -603,6 +603,7 @@ class RequestTracker:
     # Full prompt length before chunk truncation, used by sparse retention masks.
     num_prompt_tokens: int | None = None
     block_gvas: list[int] = field(default_factory=list)
+    block_gvas_by_group: list[list[int]] = field(default_factory=list)
     gva_block_offset: int = 0
     last_block_gva: int | None = None
 
@@ -632,6 +633,7 @@ class RequestTracker:
         token_ids: list[int] | None = None,
         num_prompt_tokens: int | None = None,
         block_gvas: list[int] | None = None,
+        block_gvas_by_group: list[list[int]] | None = None,
         gva_block_offset: int = 0,
         last_block_gva: int | None = None,
         block_keys: list[str] | None = None,
@@ -655,6 +657,7 @@ class RequestTracker:
         self.token_ids = token_ids
         self.num_prompt_tokens = num_prompt_tokens
         self.block_gvas = [] if block_gvas is None else block_gvas
+        self.block_gvas_by_group = block_gvas_by_group if block_gvas_by_group is not None else []
         self.gva_block_offset = gva_block_offset
         self.last_block_gva = last_block_gva
         self.block_keys = [] if block_keys is None else block_keys
@@ -795,9 +798,12 @@ class ReqMeta:
         ends: list[int] | None = None,
         sizes_per_chunk: list[list[int]] | None = None,
         block_ids_np: np.ndarray | None = None,
+        block_ids_by_group_np: list[np.ndarray] | None = None,
         block_gvas_np: np.ndarray | None = None,
+        block_gvas_by_group_np: list[np.ndarray] | None = None,
         gva_block_offset: int = 0,
         load_block_gvas_np: np.ndarray | None = None,
+        load_block_gvas_by_group_np: list[np.ndarray] | None = None,
         load_gva_block_offset: int = 0,
     ) -> None:
         if token_len_chunk is None:
@@ -829,9 +835,12 @@ class ReqMeta:
         self.ends = ends
         self.sizes_per_chunk = sizes_per_chunk
         self.block_ids_np = block_ids_np
+        self.block_ids_by_group_np = block_ids_by_group_np
         self.block_gvas_np = block_gvas_np
+        self.block_gvas_by_group_np = block_gvas_by_group_np
         self.gva_block_offset = gva_block_offset
         self.load_block_gvas_np = load_block_gvas_np
+        self.load_block_gvas_by_group_np = load_block_gvas_by_group_np
         self.load_gva_block_offset = load_gva_block_offset
 
     @property
@@ -852,8 +861,11 @@ class ReqMeta:
     sizes_per_chunk: list[list[int]] | None = None
 
     block_ids_np: np.ndarray | None = None
+    block_ids_by_group_np: list[np.ndarray] | None = None
     block_gvas_np: np.ndarray | None = None
+    block_gvas_by_group_np: list[np.ndarray] | None = None
     gva_block_offset: int = 0
+    load_block_gvas_by_group_np: list[np.ndarray] | None = None
 
     @staticmethod
     def from_request_tracker(
@@ -943,7 +955,13 @@ class ReqMeta:
             last_block_gva=tracker.last_block_gva,
             partial_block_index=partial_block_index,
             block_ids_np=np.asarray(tracker.allocated_block_ids, dtype=np.int64),
+            block_ids_by_group_np=[np.asarray(ids, dtype=np.int64) for ids in tracker.allocated_block_ids_by_group]
+            if tracker.allocated_block_ids_by_group
+            else None,
             block_gvas_np=np.asarray(tracker.block_gvas, dtype=np.int64),
+            block_gvas_by_group_np=[np.asarray(gvas, dtype=np.int64) for gvas in tracker.block_gvas_by_group]
+            if hasattr(tracker, "block_gvas_by_group") and tracker.block_gvas_by_group
+            else None,
             gva_block_offset=tracker.gva_block_offset,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
             kv_cache_families_by_group=kv_cache_group_families,
@@ -1004,6 +1022,8 @@ class LayerTransferTask:
     layer_id: int
     block_ranges: list[LayerBlockRange]
     shared_block_data: SharedBlockData | None = None
+    group_id: int = 0
+    layer_idx_in_group: int = 0
     # Cache for KVCacheStoreKeyLayerSendingThread:
     # maps block_range index -> list of (start, end, key_all_layers)
     cached_process_tokens: dict[int, list[tuple[int, int, list]]] | None = None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -558,6 +558,10 @@ def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHa
     return BlockHash(hasher.digest())
 
 
+def block_hash_to_str(block_hash: BlockHash | str) -> str:
+    return block_hash if isinstance(block_hash, str) else block_hash.hex()
+
+
 def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
         if len(block_hash) == 64:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -145,17 +145,33 @@ class LayerBatchBuilder:
     ) -> tuple[np.ndarray, np.ndarray]:
         request = block_range.request
         group_id = self.group_id
+        block_ids_np: np.ndarray | None
+        block_gvas_np: np.ndarray | None
         if is_save:
-            if request.block_gvas_by_group_np is not None and group_id < len(request.block_gvas_by_group_np):
-                block_ids_np = request.block_ids_by_group_np[group_id]
-                block_gvas_np = request.block_gvas_by_group_np[group_id]
+            group_block_ids = request.block_ids_by_group_np
+            group_block_gvas = request.block_gvas_by_group_np
+            if (
+                group_block_ids is not None
+                and group_block_gvas is not None
+                and group_id < len(group_block_ids)
+                and group_id < len(group_block_gvas)
+            ):
+                block_ids_np = group_block_ids[group_id]
+                block_gvas_np = group_block_gvas[group_id]
             else:
                 block_ids_np = request.block_ids_np
                 block_gvas_np = request.block_gvas_np
         else:
-            if request.load_block_gvas_by_group_np is not None and group_id < len(request.load_block_gvas_by_group_np):
-                block_ids_np = request.block_ids_by_group_np[group_id]
-                block_gvas_np = request.load_block_gvas_by_group_np[group_id]
+            group_block_ids = request.block_ids_by_group_np
+            group_block_gvas = request.load_block_gvas_by_group_np
+            if (
+                group_block_ids is not None
+                and group_block_gvas is not None
+                and group_id < len(group_block_ids)
+                and group_id < len(group_block_gvas)
+            ):
+                block_ids_np = group_block_ids[group_id]
+                block_gvas_np = group_block_gvas[group_id]
             else:
                 block_ids_np = request.block_ids_np
                 block_gvas_np = request.load_block_gvas_np
@@ -1225,11 +1241,10 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.sync_save_events = sync_save_events
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
+        self.group_builders: list[LayerBatchBuilder] | None = group_builders
         if group_builders is not None:
-            self.group_builders = group_builders
             self.layer_batch_builder = group_builders[0]
         else:
-            self.group_builders = None
             self.layer_batch_builder = LayerBatchBuilder(
                 token_database,
                 my_key_index,
@@ -1372,11 +1387,10 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         self.h2d_stagger_us = h2d_stagger_us
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
+        self.group_builders: list[LayerBatchBuilder] | None = group_builders
         if group_builders is not None:
-            self.group_builders = group_builders
             self.layer_batch_builder = group_builders[0]
         else:
-            self.group_builders = None
             self.layer_batch_builder = LayerBatchBuilder(
                 token_database,
                 my_key_index,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -44,19 +44,21 @@ class LayerBatchBuilder:
         num_ranks_per_layer: int,
         page_size_bytes: int,
         num_layers: int,
+        group_id: int = 0,
     ) -> None:
         self.my_key_index = my_key_index
         self.num_ranks_per_layer = num_ranks_per_layer
         self.page_size_bytes = page_size_bytes
         self.num_layers = num_layers
-        self._block_len_np = np.asarray(token_database.group_block_len[0], dtype=np.int64)
+        self.group_id = group_id
+        self._block_len_np = np.asarray(token_database.group_block_len[group_id], dtype=np.int64)
         self._kv_caches_base_addr_np = np.asarray(
-            token_database.group_kv_caches_base_addr[0],
+            token_database.group_kv_caches_base_addr[group_id],
             dtype=np.int64,
         )
-        group_block_stride = token_database.group_block_stride.get(0, token_database.group_block_len[0])
+        group_block_stride = token_database.group_block_stride.get(group_id, token_database.group_block_len[group_id])
         self._block_stride_np = np.asarray(group_block_stride, dtype=np.int64)
-        # group_block_len[0] / kv_caches_base_addr[0] are laid out flat as
+        # group_block_len[group_id] / kv_caches_base_addr[group_id] are laid out flat as
         # [layer0_caches..., layer1_caches..., ...]; the per-layer stride is the
         # total length divided by the number of layers (mirrors
         # ChunkedTokenDatabase caches_per_layer computation).
@@ -136,20 +138,33 @@ class LayerBatchBuilder:
             gvas_arr.ravel(),
         )
 
-    @staticmethod
     def _require_request_arrays(
+        self,
         block_range: LayerBlockRange,
         is_save: bool = True,
     ) -> tuple[np.ndarray, np.ndarray]:
         request = block_range.request
-        if request.block_ids_np is None:
-            raise RuntimeError("ReqMeta numpy block metadata is not initialized")
-        gvas_np = request.block_gvas_np if is_save else request.load_block_gvas_np
-        if gvas_np is None:
+        group_id = self.group_id
+        if is_save:
+            if request.block_gvas_by_group_np is not None and group_id < len(request.block_gvas_by_group_np):
+                block_ids_np = request.block_ids_by_group_np[group_id]
+                block_gvas_np = request.block_gvas_by_group_np[group_id]
+            else:
+                block_ids_np = request.block_ids_np
+                block_gvas_np = request.block_gvas_np
+        else:
+            if request.load_block_gvas_by_group_np is not None and group_id < len(request.load_block_gvas_by_group_np):
+                block_ids_np = request.block_ids_by_group_np[group_id]
+                block_gvas_np = request.load_block_gvas_by_group_np[group_id]
+            else:
+                block_ids_np = request.block_ids_np
+                block_gvas_np = request.load_block_gvas_np
+        if block_ids_np is None or block_gvas_np is None:
             raise RuntimeError(
-                f"ReqMeta {'save' if is_save else 'load'} block_gvas_np is not initialized for request {request.req_id}"
+                f"ReqMeta {'save' if is_save else 'load'} block metadata"
+                f" is not initialized for request {request.req_id}"
             )
-        return request.block_ids_np, gvas_np
+        return block_ids_np, block_gvas_np
 
     def build_shared(self, task: LayerTransferTask, is_save: bool = True) -> SharedBlockData | None:
         """Pre-compute shared block data that is identical across all layers."""
@@ -239,7 +254,7 @@ class LayerBatchBuilder:
         shared = self.build_shared(task, is_save)
         if shared is None:
             return None
-        return self.build_addrs(shared, task.layer_id)
+        return self.build_addrs(shared, task.layer_idx_in_group)
 
 
 class KVTransferThread(threading.Thread):
@@ -1190,6 +1205,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         sync_save_events: list[torch.npu.Event],
         max_transfer_blocks: int = 0,
         max_transfer_bytes: int = 0,
+        group_builders: list[LayerBatchBuilder] | None = None,
     ):
         super().__init__(
             m_store,
@@ -1209,13 +1225,19 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.sync_save_events = sync_save_events
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
-        self.layer_batch_builder = LayerBatchBuilder(
-            token_database,
-            my_key_index,
-            num_ranks_per_layer,
-            page_size_bytes,
-            num_layers,
-        )
+        if group_builders is not None:
+            self.group_builders = group_builders
+            self.layer_batch_builder = group_builders[0]
+        else:
+            self.group_builders = None
+            self.layer_batch_builder = LayerBatchBuilder(
+                token_database,
+                my_key_index,
+                num_ranks_per_layer,
+                page_size_bytes,
+                num_layers,
+                group_id=0,
+            )
 
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -1233,7 +1255,11 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
 
     def build_shared_data(self, task: LayerTransferTask) -> SharedBlockData | None:
         """Pre-compute shared block data for all layers (GVA path)."""
-        return self.layer_batch_builder.build_shared(task, is_save=True)
+        if self.group_builders is not None:
+            builder = self.group_builders[task.group_id]
+        else:
+            builder = self.layer_batch_builder
+        return builder.build_shared(task, is_save=True)
 
     def add_request(  # type: ignore[override]
         self, req_meta: list[LayerTransferTask]
@@ -1246,52 +1272,63 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         if len(transfer_tasks) == 0:
             self.request_queue.task_done()
             return
-        if len(transfer_tasks) > 1:
-            raise ValueError(f"Expected at most one layer transfer task, got {len(transfer_tasks)}")
-        task = transfer_tasks[0]
-        shared = task.shared_block_data
-        if shared is None:
-            layer_id = task.layer_id
-            assert not self.layer_save_finished_events[layer_id].is_set(), f"thread: {layer_id} save failed "
-            logger.debug("Layer save event set: layer %d", layer_id)
-            self.layer_save_finished_events[layer_id].set()
+        physical_layer = transfer_tasks[0].layer_id
+        has_any_save = False
+        all_gvas = []
+        all_addrs = []
+        all_sizes = []
+        all_req_ids = []
+        for task in transfer_tasks:
+            shared = task.shared_block_data
+            if shared is None:
+                continue
+            has_any_save = True
+            builder = self.group_builders[task.group_id] if self.group_builders else self.layer_batch_builder
+            req_meta = builder.build_addrs(shared, task.layer_idx_in_group)
+            for req_id in req_meta.req_ids:
+                self.dec_stored_request(req_id)
+                all_req_ids.append(req_id)
+            all_gvas.append(req_meta.gvas_array)
+            all_addrs.append(req_meta.addr_array)
+            all_sizes.append(req_meta.size_array)
+        if has_any_save:
+            self.sync_save_events[physical_layer].synchronize()
+            gvas_array = np.concatenate(all_gvas) if len(all_gvas) > 1 else all_gvas[0]
+            addr_array = np.concatenate(all_addrs) if len(all_addrs) > 1 else all_addrs[0]
+            size_array = np.concatenate(all_sizes) if len(all_sizes) > 1 else all_sizes[0]
+            res = self._batch_copy_with_limits(
+                gvas_array,
+                addr_array,
+                size_array,
+                0,
+                self.max_transfer_blocks,
+                self.max_transfer_bytes,
+            )
+            if physical_layer <= 2 or res != 0:
+                logger.info(
+                    "save_thread: layer=%d groups=%d blocks=%d res=%d",
+                    physical_layer,
+                    len(all_gvas),
+                    len(gvas_array),
+                    res,
+                )
+            if res != 0:
+                logger.error("Layerwise %d save batch_copy failed with return code %d", physical_layer, res)
+            for req_id in all_req_ids:
+                if self.try_finish_and_delete_stored_request(req_id):
+                    self.set_finished_request(req_id)
+        if not has_any_save:
+            assert not self.layer_save_finished_events[physical_layer].is_set(), (
+                f"thread: {physical_layer} save failed "
+            )
+            logger.debug("Layer save event set: layer %d", physical_layer)
+            self.layer_save_finished_events[physical_layer].set()
+            transfer_tasks.clear()
             self.request_queue.task_done()
             return
-        req_meta = self.layer_batch_builder.build_addrs(shared, task.layer_id)
-        layer_id = req_meta.layer_id
-        # Only tp_rank % put_step == 0 saves (checked in
-        # _process_save_for_layer_batch).  The saving rank writes the full
-        # k+v for each block so that its blob is completely filled.
-        addr_array = req_meta.addr_array
-        size_array = req_meta.size_array
-        gvas_array = req_meta.gvas_array
-        logger.debug(
-            "[KVPOOL] save_thread layer=%d tp_rank=%d put_step=%d gvas_array=%s size_array=%s",
-            layer_id,
-            self.tp_rank,
-            self.put_step,
-            gvas_array.tolist(),
-            size_array.tolist(),
-        )
-        for req_id in req_meta.req_ids:
-            self.dec_stored_request(req_id)
-        self.sync_save_events[layer_id].synchronize()
-        res = self._batch_copy_with_limits(
-            gvas_array,
-            addr_array,
-            size_array,
-            0,
-            self.max_transfer_blocks,
-            self.max_transfer_bytes,
-        )
-        if res != 0:
-            logger.error("Layerwise %d save batch_copy failed with return code %d", layer_id, res)
-        for req_id in req_meta.req_ids:
-            if self.try_finish_and_delete_stored_request(req_id):
-                self.set_finished_request(req_id)
-        assert not self.layer_save_finished_events[layer_id].is_set(), f"thread: {layer_id} save failed "
-        logger.debug("Layer save event set: layer %d", layer_id)
-        self.layer_save_finished_events[layer_id].set()
+        assert not self.layer_save_finished_events[physical_layer].is_set(), f"thread: {physical_layer} save failed "
+        logger.debug("Layer save event set: layer %d", physical_layer)
+        self.layer_save_finished_events[physical_layer].set()
         transfer_tasks.clear()
         self.request_queue.task_done()
 
@@ -1316,6 +1353,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         h2d_stagger_us: int = 0,
         max_transfer_blocks: int = 0,
         max_transfer_bytes: int = 0,
+        group_builders: list[LayerBatchBuilder] | None = None,
     ):
         super().__init__(
             m_store,
@@ -1334,17 +1372,27 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         self.h2d_stagger_us = h2d_stagger_us
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
-        self.layer_batch_builder = LayerBatchBuilder(
-            token_database,
-            my_key_index,
-            num_ranks_per_layer,
-            page_size_bytes,
-            num_layers,
-        )
+        if group_builders is not None:
+            self.group_builders = group_builders
+            self.layer_batch_builder = group_builders[0]
+        else:
+            self.group_builders = None
+            self.layer_batch_builder = LayerBatchBuilder(
+                token_database,
+                my_key_index,
+                num_ranks_per_layer,
+                page_size_bytes,
+                num_layers,
+                group_id=0,
+            )
 
     def build_shared_data(self, task: LayerTransferTask) -> SharedBlockData | None:
         """Pre-compute shared block data for all layers (GVA path)."""
-        return self.layer_batch_builder.build_shared(task, is_save=False)
+        if self.group_builders is not None:
+            builder = self.group_builders[task.group_id]
+        else:
+            builder = self.layer_batch_builder
+        return builder.build_shared(task, is_save=False)
 
     def add_request(  # type: ignore[override]
         self, req_meta: LayerLoadTask
@@ -1385,21 +1433,25 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             self.request_queue.task_done()
             return
 
-        if len(transfer_tasks) > 1:
-            raise ValueError(f"Expected at most one layer transfer task, got {len(transfer_tasks)}")
-        task = transfer_tasks[0]
-        shared = task.shared_block_data
-        if shared is not None:
-            req_meta: LayerBatchReqMeta | None = self.layer_batch_builder.build_addrs(shared, task.layer_id)
-        else:
-            req_meta = self.layer_batch_builder.build(task, is_save=False)
-        if req_meta is None:
+        # Build req_meta for all tasks first; if all are None, early return
+        # before wait_for_save (matches original single-task behavior).
+        task_metas: list[tuple[LayerTransferTask, LayerBatchReqMeta]] = []
+        for task in transfer_tasks:
+            shared = task.shared_block_data
+            builder = self.group_builders[task.group_id] if self.group_builders else self.layer_batch_builder
+            if shared is not None:
+                req_meta: LayerBatchReqMeta | None = builder.build_addrs(shared, task.layer_idx_in_group)
+            else:
+                req_meta = builder.build(task, is_save=False)
+            if req_meta is not None:
+                task_metas.append((task, req_meta))
+
+        if not task_metas:
             assert not self.layer_load_finished_events[layer_id].is_set()
             logger.debug("Layer load event set: layer %d", layer_id)
             self.layer_load_finished_events[layer_id].set()
             self.request_queue.task_done()
             return
-        layer_id = req_meta.layer_id
 
         if wait_for_save is not None:
             while not self.layer_save_finished_events[wait_for_save].wait(timeout=10):
@@ -1411,13 +1463,27 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             while not attention_start_gate.wait(timeout=10):
                 logger.info("Layerwise %d load waits for attention compute start", layer_id)
 
-        # Every rank reads the full k+v (no slicing).  The saving
-        # rank (tp_rank % put_step == 0) wrote the complete blob; all ranks
-        # read from it via per-process add_lease + batch_copy G2L.
-        gvas_array = req_meta.gvas_array
-        addr_array = req_meta.addr_array
-        size_array = req_meta.size_array
+        all_load_keys: list[str] = []
+        all_req_ids: set[str] = set()
+        last_chunk_req_ids: set[str] = set()
+        all_gvas = []
+        all_addrs = []
+        all_sizes = []
+        for task, req_meta in task_metas:
+            if req_meta.load_keys:
+                all_load_keys.extend(req_meta.load_keys)
+            for req_id, is_last_chunk in zip(req_meta.req_ids, req_meta.is_last_chunks):
+                all_req_ids.add(req_id)
+                if is_last_chunk:
+                    last_chunk_req_ids.add(req_id)
+            all_gvas.append(req_meta.gvas_array)
+            all_addrs.append(req_meta.addr_array)
+            all_sizes.append(req_meta.size_array)
+
         self._stagger_h2d_submit(layer_id)
+        gvas_array = np.concatenate(all_gvas) if len(all_gvas) > 1 else all_gvas[0]
+        addr_array = np.concatenate(all_addrs) if len(all_addrs) > 1 else all_addrs[0]
+        size_array = np.concatenate(all_sizes) if len(all_sizes) > 1 else all_sizes[0]
         res = self._batch_copy_with_limits(
             gvas_array,
             addr_array,
@@ -1426,21 +1492,27 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             self.max_transfer_blocks,
             self.max_transfer_bytes,
         )
+        if layer_id <= 2 or res != 0:
+            logger.info(
+                "load_thread: layer=%d groups=%d blocks=%d res=%d",
+                layer_id,
+                len(all_gvas),
+                len(gvas_array),
+                res,
+            )
         if res != 0:
             logger.error("Layerwise %d load batch_copy failed with return code %d", layer_id, res)
-        # Release read leases immediately after the last layer's batch_copy
-        # completes. The lease was needed to protect the blob during all 27
-        # layers of batch_copy G2L; once reading is done, release right away.
-        if layer_id == self.final_layer_id and req_meta.load_keys:
-            self.m_store.batch_remove_lease(req_meta.load_keys)
+
+        if layer_id == self.final_layer_id and all_load_keys:
+            self.m_store.batch_remove_lease(all_load_keys)
             logger.info(
                 "[KVPOOL] load_thread released %d leases after final layer %d",
-                len(req_meta.load_keys),
+                len(all_load_keys),
                 layer_id,
             )
         if layer_id == self.final_layer_id:
-            for req_id, is_last_chunk in zip(req_meta.req_ids, req_meta.is_last_chunks):
-                if is_last_chunk:
+            for req_id in all_req_ids:
+                if req_id in last_chunk_req_ids:
                     self.set_finished_request(req_id)
         assert not self.layer_load_finished_events[layer_id].is_set(), f"thread: {layer_id} load failed "
         logger.debug("Layer load event set: layer %d", layer_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -35,7 +35,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
+    get_block_hashes,
     get_cache_family_granularity,
+    infer_cache_family_ratio,
     infer_group_cache_families,
     normalize_block_ids_by_group,
 )
@@ -80,8 +82,6 @@ class KVPoolScheduler:
                     raise NotImplementedError(
                         "AscendStore hybrid linear-attention support currently requires mamba_cache_mode='align'."
                     )
-        if self.use_layerwise and len(self.kv_cache_group_ids) > 1:
-            raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.consumer_is_to_load = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "consumer_is_to_load", False
@@ -125,7 +125,7 @@ class KVPoolScheduler:
         )
         if self.use_layerwise:
             self._discard_partial_chunks = vllm_config.kv_transfer_config.get_from_extra_config(
-                "discard_partial_chunks", False
+                "discard_partial_chunks", True
             )
         self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._unfinished_request_ids: set[str] = set()
@@ -177,6 +177,7 @@ class KVPoolScheduler:
         num_layer_keys = self.num_layers if self.use_gva_layerwise else 1
         keys_per_block_hash = self.pcp_size * self.dcp_size * (self.tp_size // self.put_step) * num_layer_keys
         self.keys_per_block_hash = keys_per_block_hash
+
         self.client: LookupKeyClient | None = None
 
     def _get_or_create_request_tracker(self, req_id: str) -> RequestTracker:
@@ -283,67 +284,82 @@ class KVPoolScheduler:
         num_hit_blocks = query_start_block + num_queried_hit_blocks
         return num_hit_blocks * self._block_size
 
+    def _make_layerwise_gva_keys_for_hit_check(self, group_id: int, block_hash_hex: str) -> list[str]:
+        """Generate all-rank GVA keys for scheduler-side hit check.
+
+        Single-group uses PR #11585 format; multi-group includes group_id.
+        Returns one key per head_or_tp_rank (ranks in the same put_step
+        group share one key for MLA).
+        """
+        head_or_tp_ranks = self.tp_size // self.put_step
+        if len(self.kv_cache_group_ids) > 1:
+            return [f"{self.model_name}@{group_id}@{block_hash_hex}@{h}" for h in range(head_or_tp_ranks)]
+        else:
+            return [f"{self.model_name}@{block_hash_hex}@{h}" for h in range(head_or_tp_ranks)]
+
     def _get_layerwise_gva_hit_tokens(
         self,
         request: "Request",
         token_len: int,
         num_computed_tokens: int,
     ) -> int:
-        num_blocks = token_len // self._block_size
-        block_hashes_to_check = request.block_hashes[:num_blocks]
         # In layerwise mode, always query from block 0 because the remote
         # pool stores per-layer data that may not match local prefix cache.
-        query_start_block = 0 if self.use_layerwise else min(num_computed_tokens // self._block_size, num_blocks)
-        block_hashes_to_query = block_hashes_to_check[query_start_block:]
-        if not block_hashes_to_query:
-            return 0
-        # Keys use head_or_tp_rank (= tp_rank // put_step).  Ranks in
-        # the same put_step group share one key (same KV cache for MLA latent).
-        # Only tp_size // put_step keys per block, not tp_size.
-        head_or_tp_ranks = self.tp_size // self.put_step
-        keys_by_block = [
-            [f"{self.model_name}@{bh.hex()}@{h}" for h in range(head_or_tp_ranks)] for bh in block_hashes_to_query
-        ]
-        all_keys = [key for block_keys in keys_by_block for key in block_keys]
-        logger.debug(
-            "[KVPOOL] hit_check req=%s query_blocks=%d head_or_tp_ranks=%d total_keys=%d",
-            request.request_id,
-            len(keys_by_block),
-            head_or_tp_ranks,
-            len(all_keys),
-        )
-        # Use batch_get_key_info instead of batch_is_exist: a key that has
-        # been alloc'd but not yet fully saved will not return a valid GVA.
-        # This prevents false hits where hit_check sees an alloc'd key before
-        # the 27-layer save has completed.
-        key_infos = self.store_scheduler.batch_get_key_info(all_keys)
-        if len(key_infos) != len(all_keys):
-            raise RuntimeError(
-                "KV pool batch_get_key_info returned unexpected number of results for "
-                f"request {request.request_id}: expected={len(all_keys)}, "
-                f"actual={len(key_infos)}"
-            )
-        num_queried_hit_blocks = 0
-        offset = 0
-        for block_keys in keys_by_block:
-            block_infos = key_infos[offset : offset + len(block_keys)]
-            offset += len(block_keys)
-            # A block is considered hit only when every rank's key returns a
-            # valid GVA (i.e., save is complete).
-            if all(ki.size() and ki.size() > 0 for ki in block_infos):
-                num_queried_hit_blocks += 1
+        num_hash_blocks = token_len // self.hash_block_size
+        block_hashes_to_check = request.block_hashes[:num_hash_blocks]
+        hits_per_group: list[int] = []
+        self._get_or_create_request_tracker(request.request_id)
+
+        for group_id in range(len(self.grouped_block_size)):
+            effective_block_size = self._get_effective_group_block_size(group_id)
+            group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
+            # Generate all-rank keys for each block hash
+            keys_by_block = [
+                self._make_layerwise_gva_keys_for_hit_check(group_id, bh.hex()) for bh in group_block_hashes
+            ]
+            all_keys = [key for block_keys in keys_by_block for key in block_keys]
+            if not all_keys:
                 continue
-            break
-        num_hit_blocks = query_start_block + num_queried_hit_blocks
-        hit_sample = [1 if (ki.size() and ki.size() > 0) else 0 for ki in key_infos[: min(8, len(key_infos))]]
+
+            key_infos = self.store_scheduler.batch_get_key_info(all_keys)
+            if len(key_infos) != len(all_keys):
+                logger.error(
+                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
+                    len(all_keys),
+                    len(key_infos),
+                )
+                hits_per_group.append(0)
+                continue
+
+            # A block is hit only when ALL ranks' keys return valid GVA
+            num_hit_blocks = 0
+            offset = 0
+            for block_keys in keys_by_block:
+                block_infos = key_infos[offset : offset + len(block_keys)]
+                offset += len(block_keys)
+                if all(ki.size() and ki.size() > 0 for ki in block_infos):
+                    num_hit_blocks += 1
+                else:
+                    break
+
+            hits_per_group.append(num_hit_blocks * effective_block_size)
+
+        if not hits_per_group:
+            logger.info(
+                "hit_check: req=%s token_len=%d no participating groups (all skipped)",
+                request.request_id,
+                token_len,
+            )
+            return 0
+        hit_tokens = min(hits_per_group)
         logger.info(
-            "[KVPOOL] hit_check req=%s hit_blocks=%d/%d gva_states_sample=%s",
+            "hit_check: req=%s token_len=%d hits_per_group=%s hit_tokens=%d",
             request.request_id,
-            num_queried_hit_blocks,
-            len(keys_by_block),
-            hit_sample,
+            token_len,
+            hits_per_group,
+            hit_tokens,
         )
-        return num_hit_blocks * self._block_size
+        return hit_tokens
 
     def _infer_group_families(self) -> list[str]:
         kv_cache_groups = self.kv_cache_config.kv_cache_groups if self.kv_cache_config is not None else None
@@ -374,6 +390,10 @@ class KVPoolScheduler:
         if group_id >= len(families):
             return "default"
         return families[group_id]
+
+    def _get_effective_group_block_size(self, group_id: int) -> int:
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        return self._get_group_block_size(group_id) * max(infer_cache_family_ratio(cache_family), 1)
 
     def _infer_cache_transfer_granularity(self) -> int:
         granularities = [self.lcm_block_size]
@@ -469,28 +489,30 @@ class KVPoolScheduler:
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_load:
             return 0, False
 
-        if self._discard_partial_chunks:
-            token_len = self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
-        else:
-            token_len = len(request.prompt_token_ids)
-
-        if token_len < self.cache_transfer_granularity:
-            return 0, False
-
         if self.use_gva_layerwise:
+            token_len = len(request.prompt_token_ids)
             num_external_hit_tokens = self._get_layerwise_gva_hit_tokens(request, token_len, num_computed_tokens)
-        elif self.use_layerwise:
-            num_external_hit_tokens = self._get_store_lookup_hit_tokens(
-                request, token_len, num_computed_tokens, include_layers=True
-            )
         else:
-            if self.client is None:
-                self.client = LookupKeyClient(self.vllm_config)
-            num_external_hit_tokens = self.client.lookup(
-                token_len,
-                request.block_hashes,
-                self.kv_cache_group_ids,
-            )
+            if self._discard_partial_chunks:
+                token_len = self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
+            else:
+                token_len = len(request.prompt_token_ids)
+
+            if token_len < self.cache_transfer_granularity:
+                return 0, False
+
+            if self.use_layerwise:
+                num_external_hit_tokens = self._get_store_lookup_hit_tokens(
+                    request, token_len, num_computed_tokens, include_layers=True
+                )
+            else:
+                if self.client is None:
+                    self.client = LookupKeyClient(self.vllm_config)
+                num_external_hit_tokens = self.client.lookup(
+                    token_len,
+                    request.block_hashes,
+                    self.kv_cache_group_ids,
+                )
 
         if num_external_hit_tokens == 0:
             return 0, False
@@ -684,7 +706,7 @@ class KVPoolScheduler:
             block_sizes=self.grouped_block_size,
         )
         self._request_trackers[request.req_id] = request_tracker
-        num_blocks = num_tokens_to_compute // self._block_size
+        num_blocks = num_tokens_to_compute // self.hash_block_size
         has_last_block = num_tokens_to_compute % self._block_size != 0
         self._allocate_gva_if_needed(
             request_tracker,
@@ -735,7 +757,7 @@ class KVPoolScheduler:
             block_sizes=self.grouped_block_size,
         )
         self._request_trackers[req_id] = request_tracker
-        num_blocks = len(new_block_ids_by_group[0])
+        num_blocks = num_tokens_to_compute // self.hash_block_size
         has_last_block = num_tokens_to_compute % self._block_size != 0
         self._allocate_gva_if_needed(
             request_tracker,
@@ -780,8 +802,8 @@ class KVPoolScheduler:
         else:
             raise ValueError(f"Request {req_id} is not in _unfinished_requests, but it is scheduled to be cached")
         prev_token_count = request_tracker.token_len - num_new_tokens
-        prev_hash_count = prev_token_count // self._block_size
-        current_hash_count = request_tracker.token_len // self._block_size
+        prev_hash_count = prev_token_count // self.hash_block_size
+        current_hash_count = request_tracker.token_len // self.hash_block_size
         new_hash_count = current_hash_count - prev_hash_count
         has_last_block = request_tracker.token_len % self._block_size != 0 or current_hash_count > len(
             request.block_hashes
@@ -837,7 +859,7 @@ class KVPoolScheduler:
             block_sizes=self.grouped_block_size,
         )
         self._request_trackers[request_id] = request_tracker
-        num_blocks = num_tokens_to_compute // self._block_size
+        num_blocks = num_tokens_to_compute // self.hash_block_size
         has_last_block = num_tokens_to_compute % self._block_size != 0
         self._allocate_gva_if_needed(
             request_tracker,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -314,6 +314,10 @@ class KVPoolScheduler:
         for group_id in range(len(self.grouped_block_size)):
             effective_block_size = self._get_effective_group_block_size(group_id)
             group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
+            query_start_block = (
+                0 if self.use_layerwise else min(num_computed_tokens // effective_block_size, len(group_block_hashes))
+            )
+            group_block_hashes = group_block_hashes[query_start_block:]
             # Generate all-rank keys for each block hash
             keys_by_block = [
                 self._make_layerwise_gva_keys_for_hit_check(group_id, block_hash_to_str(bh))
@@ -344,7 +348,7 @@ class KVPoolScheduler:
                 else:
                     break
 
-            hits_per_group.append(num_hit_blocks * effective_block_size)
+            hits_per_group.append((query_start_block + num_hit_blocks) * effective_block_size)
 
         if not hits_per_group:
             logger.info(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -35,6 +35,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     PoolKey,
     ReqMeta,
     RequestTracker,
+    block_hash_to_str,
     get_block_hashes,
     get_cache_family_granularity,
     infer_cache_family_ratio,
@@ -315,7 +316,8 @@ class KVPoolScheduler:
             group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
             # Generate all-rank keys for each block hash
             keys_by_block = [
-                self._make_layerwise_gva_keys_for_hit_check(group_id, bh.hex()) for bh in group_block_hashes
+                self._make_layerwise_gva_keys_for_hit_check(group_id, block_hash_to_str(bh))
+                for bh in group_block_hashes
             ]
             all_keys = [key for block_keys in keys_by_block for key in block_keys]
             if not all_keys:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -40,6 +40,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     get_block_hashes,
     get_cache_family_granularity,
+    infer_cache_family_ratio,
     infer_group_cache_families,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
@@ -54,6 +55,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     KVCacheStoreRecvingThread,
     KVCacheStoreSendingThread,
     KVTransferThread,
+    LayerBatchBuilder,
     _circular_shift,
     record_failed_blocks,
 )
@@ -153,8 +155,6 @@ class KVPoolWorker:
         self.kv_cache_group_families = self._infer_group_families()
         self.group_uses_align_state = self._infer_group_uses_align_state()
         self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
-        if self.use_layerwise and self.num_kv_cache_groups > 1:
-            raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
         self.h2d_stagger_us = int(extra_config.get("h2d_stagger_us", 0))
         self.layerwise_max_transfer_blocks = int(extra_config.get("layerwise_max_transfer_blocks", 0))
         self.layerwise_max_transfer_bytes = int(extra_config.get("layerwise_max_transfer_bytes", 0))
@@ -276,14 +276,91 @@ class KVPoolWorker:
         self._allocated_gvas: dict[str, int] = {}
 
     def _init_layerwise_config(self) -> None:
-        self.layer_load_tasks: list[list[LayerTransferTask]] = [[] for i in range(self.num_layers)]
-        self.layer_save_tasks: list[list[LayerTransferTask]] = [[] for i in range(self.num_layers)]
+        # Build mapping: physical_layer -> [(group_id, layer_idx_in_group), ...]
+        # layer_idx_in_group is the index of the physical layer within the
+        # group (not the index in layer_names). Multiple layer_names at the
+        # same physical layer (e.g. indexer.k_cache + attn) are treated as
+        # multiple cache tensors of ONE layer (caches_per_layer > 1).
+        self.physical_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
+
+        if self.kv_cache_config is not None and self.num_kv_cache_groups > 1:
+            for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
+                # Map each unique physical layer to a sequential layer_idx_in_group
+                phys_to_layer_idx: dict[int, int] = {}
+                for layer_name in group_spec.layer_names:
+                    physical_layer = self._extract_physical_layer_index(layer_name)
+                    if physical_layer >= self.num_layers:
+                        continue
+                    if physical_layer not in phys_to_layer_idx:
+                        phys_to_layer_idx[physical_layer] = len(phys_to_layer_idx)
+
+                # Add one entry per unique physical layer (no duplicates)
+                for physical_layer, layer_idx_in_group in phys_to_layer_idx.items():
+                    existing = self.physical_layer_to_group_layers.setdefault(physical_layer, [])
+                    entry = (group_id, layer_idx_in_group)
+                    if entry not in existing:
+                        existing.append(entry)
+
+                logger.info(
+                    "layerwise group %d: %d layer_names, %d unique physical layers, caches_per_layer=%d",
+                    group_id,
+                    len(group_spec.layer_names),
+                    len(phys_to_layer_idx),
+                    len(group_spec.layer_names) // max(1, len(phys_to_layer_idx)),
+                )
+
+        self.layer_load_tasks: list[list[LayerTransferTask]] = [[] for _ in range(self.num_layers)]
+        self.layer_save_tasks: list[list[LayerTransferTask]] = [[] for _ in range(self.num_layers)]
         self.layer_load_finished_events: list[threading.Event] | None = None
         self.layer_save_finished_events: list[threading.Event] | None = None
 
         self.next_layer_to_submit = 0
         self.num_prefetch_layers = int(self._extra_config.get("layerwise_prefetch_layers", 1))
         self.sync_save_events: list[torch.npu.Event] | None = None
+
+        logger.info(
+            "layerwise config: num_layers=%d num_groups=%d physical_layer_to_group_layers_sample=%s",
+            self.num_layers,
+            self.num_kv_cache_groups,
+            {k: v for k, v in list(self.physical_layer_to_group_layers.items())[:3]},
+        )
+
+    def _extract_physical_layer_index(self, layer_name: str) -> int:
+        import regex as re
+
+        m = re.search(r"layers\.(\d+)", layer_name)
+        if m:
+            return int(m.group(1))
+        # MTP layers have names like "mtp.0.self_attn.xxx" without "layers."
+        # prefix. Map them after the main model layers.
+        if ".mtp." in f".{layer_name}.":
+            m = re.search(r"mtp\.(\d+)", layer_name)
+            if m:
+                num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
+                return num_hidden_layers + int(m.group(1))
+        m = re.search(r"(\d+)", layer_name)
+        return int(m.group(1)) if m else 0
+
+    def _build_group_layer_builders(self) -> list[LayerBatchBuilder]:
+        builders = []
+        for group_id in range(self.num_kv_cache_groups):
+            group_num_layers = self.group_num_layers.get(group_id, self.num_layers)
+            group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
+            if group_block_len and group_num_layers > 0:
+                group_page_size = sum(group_block_len) // group_num_layers
+            else:
+                group_page_size = self.page_size_bytes
+            builders.append(
+                LayerBatchBuilder(
+                    self.token_database,
+                    self.my_key_index,
+                    self.num_ranks_per_layer,
+                    group_page_size,
+                    group_num_layers,
+                    group_id=group_id,
+                )
+            )
+        return builders
 
     def _start_kv_transfer_threads(self) -> None:
         if self._transfer_threads_started:
@@ -313,6 +390,7 @@ class KVPoolWorker:
                     self.sync_save_events,
                     self.layerwise_max_transfer_blocks,
                     self.layerwise_max_transfer_bytes,
+                    group_builders=self._build_group_layer_builders(),
                 )
                 self.kv_send_thread.start()
                 ready_event_sending.wait()
@@ -353,6 +431,7 @@ class KVPoolWorker:
                     self.h2d_stagger_us,
                     self.layerwise_max_transfer_blocks,
                     self.layerwise_max_transfer_bytes,
+                    group_builders=self._build_group_layer_builders(),
                 )
             else:
                 self.kv_recv_thread = KVCacheStoreKeyLayerRecvingThread(
@@ -464,6 +543,10 @@ class KVPoolWorker:
         if group_id >= len(self.grouped_block_size):
             return self.grouped_block_size[0]
         return self.grouped_block_size[group_id]
+
+    def _get_effective_group_block_size(self, group_id: int) -> int:
+        cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+        return self._get_group_block_size(group_id) * max(infer_cache_family_ratio(cache_family), 1)
 
     @staticmethod
     def _get_group_family(families: list[str], group_id: int) -> str:
@@ -643,11 +726,15 @@ class KVPoolWorker:
             self._infer_cache_group_metadata(0, list(kv_caches.keys()))
 
         # group_num_layers is computed from the actual kv_caches dict which
-        # includes ALL attention layers (main + MTP), so it is the authoritative
-        # layer count for this worker.
+        # includes ALL attention layers (main + MTP). For single-group models,
+        # sum(group_num_layers.values()) equals the physical layer count
+        # (including MTP). For multi-group models, it counts (group, layer)
+        # pairs which is NOT the physical layer count — keep the original
+        # num_layers (physical layers) in that case.
         original_num_layers = self.num_layers
-        self.num_layers = sum(self.group_num_layers.values())
-        if self.num_layers != original_num_layers:
+        new_num_layers = sum(self.group_num_layers.values())
+        if self.num_kv_cache_groups == 1 and new_num_layers != original_num_layers:
+            self.num_layers = new_num_layers
             logger.info(
                 "KVPoolWorker: updated num_layers %d -> %d (includes MTP/spec-decode draft layers).",
                 original_num_layers,
@@ -808,24 +895,41 @@ class KVPoolWorker:
         self,
         requests: list[ReqMeta],
         layer_id: int,
+        group_id: int = 0,
+        layer_idx_in_group: int = 0,
     ) -> None:
         # Only the first rank in each put_step group saves to the
         # pool.  Other ranks in the same group share the same KV cache
         # (e.g. MLA latent), so they skip save to avoid redundant writes.
         if self.tp_rank % self.put_step != 0:
             return
+        block_size = self._get_effective_group_block_size(group_id)
         request_block_ranges = []
         for request in requests:
             if request.can_save is None or not request.can_save:
                 continue
-            save_start_block = request.save_start_token // self.block_size
-            save_end_block = request.save_end_token // self.block_size
+            save_start_block = request.save_start_token // block_size
+            save_end_block = request.save_end_token // block_size
             # Skip blocks that are hit in the KV pool — their KV is already
             # in the pool (loaded via load_prepare), so re-saving would write
             # to a READABLE blob and fail with MMC_UNMATCHED_KEY.
             if request.load_spec is not None and request.load_spec.can_load:
-                hit_full_blocks = request.load_spec.kvpool_cached_tokens // self.block_size
+                hit_full_blocks = request.load_spec.kvpool_cached_tokens // block_size
                 save_start_block = max(save_start_block, hit_full_blocks)
+            # Skip blocks already saved in previous requests (GVA cached
+            # locally). The overall hit_tokens is min(hits_per_group), so
+            # individual groups may have more saved blocks than the overall
+            # hit suggests. Without this skip, batch_copy would re-write to
+            # already-written blobs, causing -3107 which corrupts the blob
+            # state and cascades to load failures (-3101/-3102).
+            if self.use_gva_layerwise and save_start_block < save_end_block:
+                group_block_hashes = get_block_hashes(request.block_hashes, block_size, self.hash_block_size)
+                while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
+                    key = self._make_layerwise_gva_key(group_id, group_block_hashes[save_start_block].hex())
+                    if key in self._allocated_gvas:
+                        save_start_block += 1
+                    else:
+                        break
             if save_start_block >= save_end_block and request.partial_block_index is None:
                 continue
             partial_block_index = request.partial_block_index
@@ -842,6 +946,8 @@ class KVPoolWorker:
                 LayerTransferTask(
                     layer_id=layer_id,
                     block_ranges=request_block_ranges,
+                    group_id=group_id,
+                    layer_idx_in_group=layer_idx_in_group,
                 )
             )
 
@@ -849,24 +955,23 @@ class KVPoolWorker:
         self,
         requests: list[ReqMeta],
         layer_id: int,
+        group_id: int = 0,
+        layer_idx_in_group: int = 0,
     ) -> None:
+        block_size = self._get_effective_group_block_size(group_id)
         request_block_ranges = []
         for request in requests:
             if request.load_spec is None or not request.load_spec.can_load:
                 continue
             cached_tokens = request.load_spec.kvpool_cached_tokens
-            load_start_block = request.load_spec.vllm_cached_tokens // self.block_size
-            cached_full_blocks = cached_tokens // self.block_size
+            load_start_block = request.load_spec.vllm_cached_tokens // block_size
+            cached_full_blocks = cached_tokens // block_size
             full_blocks = min(cached_full_blocks, len(request.block_hashes))
             needs_last_block_at_boundary = (
-                cached_tokens > 0 and cached_tokens % self.block_size == 0 and full_blocks < cached_full_blocks
+                cached_tokens > 0 and cached_tokens % block_size == 0 and full_blocks < cached_full_blocks
             )
-            if request.last_block_gva is not None and (
-                cached_tokens % self.block_size != 0 or needs_last_block_at_boundary
-            ):
-                partial_block_index = (
-                    cached_full_blocks if cached_tokens % self.block_size != 0 else cached_full_blocks - 1
-                )
+            if request.last_block_gva is not None and (cached_tokens % block_size != 0 or needs_last_block_at_boundary):
+                partial_block_index = cached_full_blocks if cached_tokens % block_size != 0 else cached_full_blocks - 1
             else:
                 partial_block_index = None
             if partial_block_index is not None and partial_block_index < load_start_block:
@@ -886,115 +991,136 @@ class KVPoolWorker:
                 LayerTransferTask(
                     layer_id=layer_id,
                     block_ranges=request_block_ranges,
+                    group_id=group_id,
+                    layer_idx_in_group=layer_idx_in_group,
                 )
             )
 
-    def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
-        """Allocate per-rank GVA on the worker side right before batch_copy.
+    def _make_layerwise_gva_key(self, group_id: int, block_hash_hex: str) -> str:
+        """Generate GVA key for layerwise transfer.
 
-        memcache requires batch_alloc and batch_copy to run in the same
-        process because the gvaBlobTracker that batch_copy consults is
-        per-process. The scheduler no longer allocates GVA; each worker
-        allocates its own per-rank GVA here using a per-rank store key.
-        batch_alloc is non-idempotent, so already-allocated keys are reused
-        from ``self._allocated_gvas`` instead of being re-allocated.
+        Single-group models use the PR #11585 format (model@hash@rank) for
+        backward compatibility. Multi-group models include group_id
+        (model@group_id@hash@rank) to distinguish groups.
+        """
+        if self.num_kv_cache_groups > 1:
+            return f"{self.model_name}@{group_id}@{block_hash_hex}@{self.head_or_tp_rank}"
+        else:
+            return f"{self.model_name}@{block_hash_hex}@{self.head_or_tp_rank}"
+
+    def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
+        """Allocate per-group GVA on the worker side right before batch_copy.
+
+        For multi-group models, iterates all KV cache groups and allocates
+        per-group GVAs. Key format: model@group_id@hash@head_or_tp_rank
+        (multi-group) or model@hash@head_or_tp_rank (single-group, backward
+        compat with PR #11585).
         """
         if not self.use_gva_layerwise:
             return
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
             return
-        # Only the first rank in each put_step group allocates.
         if self.tp_rank % self.put_step != 0:
             return
-        alloc_size = self.page_size_bytes * self.num_layers
-        logger.info(
-            "[KVPOOL] save_alloc enter tp_rank=%d head_or_tp_rank=%d reqs=%d alloc_size=%d",
-            self.tp_rank,
-            self.head_or_tp_rank,
-            len(requests),
-            alloc_size,
-        )
         for request in requests:
             if request.can_save is None or not request.can_save:
                 continue
-            save_start_block = request.save_start_token // self.block_size
-            save_end_block = request.save_end_token // self.block_size
             block_hashes = request.block_hashes
-            # Skip blocks that are hit in the KV pool (already loaded, no re-save).
-            if request.load_spec is not None and request.load_spec.can_load:
-                hit_full_blocks = request.load_spec.kvpool_cached_tokens // self.block_size
-                save_start_block = max(save_start_block, hit_full_blocks)
-            if save_start_block >= save_end_block and request.partial_block_index is None:
+            if not block_hashes:
                 continue
 
-            block_gvas: list[int] = []
-            new_block_keys: list[str] = []
-            new_key_positions: list[int] = []
-            for blk_idx in range(save_start_block, save_end_block):
-                if blk_idx >= len(block_hashes):
-                    break
-                key = f"{self.model_name}@{block_hashes[blk_idx].hex()}@{self.head_or_tp_rank}"
-                cached = self._allocated_gvas.get(key)
-                if cached is not None:
-                    block_gvas.append(cached)
+            all_group_gvas: list[np.ndarray] = []
+            all_group_block_ids: list[np.ndarray] = []
+            for group_id in range(self.num_kv_cache_groups):
+                group_block_size = self.grouped_block_size[group_id]
+                cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+                ratio = max(infer_cache_family_ratio(cache_family), 1)
+                effective_block_size = group_block_size * ratio
+                group_num_layers = self.group_num_layers.get(group_id, self.num_layers)
+                group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
+                if group_block_len and group_num_layers > 0:
+                    group_page_size = sum(group_block_len) // group_num_layers
                 else:
-                    new_block_keys.append(key)
-                    new_key_positions.append(len(block_gvas))
-                    block_gvas.append(0)
+                    group_page_size = self.page_size_bytes
+                alloc_size = group_page_size * group_num_layers
 
-            last_block_key: str | None = None
-            last_block_gva: int | None = None
-            last_block_is_new = False
-            if request.partial_block_index is not None:
-                last_block_key = f"{self.model_name}@{request.req_id}_lastblock@{self.head_or_tp_rank}"
-                last_block_gva = self._allocated_gvas.get(last_block_key)
-                if last_block_gva is None:
-                    last_block_is_new = True
+                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+                block_ids_by_group = (
+                    request.block_ids_by_group_np[group_id]
+                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
+                    else request.block_ids_np
+                )
 
-            alloc_keys = list(new_block_keys)
-            if last_block_is_new:
-                assert last_block_key is not None
-                alloc_keys.append(last_block_key)
-            if alloc_keys:
-                logger.debug(
-                    "[KVPOOL] save_alloc req=%s tp_rank=%d batch_alloc keys=%d "
-                    "save_blocks=[%d,%d) new_keys=%d last_block_new=%s",
+                save_start_block = request.save_start_token // effective_block_size
+                save_end_block = request.save_end_token // effective_block_size
+                if request.load_spec is not None and request.load_spec.can_load:
+                    hit_full_blocks = request.load_spec.kvpool_cached_tokens // effective_block_size
+                    save_start_block = max(save_start_block, hit_full_blocks)
+                # Skip blocks already saved (GVA cached locally from previous
+                # request). See _process_save_for_layer_batch for rationale.
+                while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
+                    key = self._make_layerwise_gva_key(group_id, group_block_hashes[save_start_block].hex())
+                    if key in self._allocated_gvas:
+                        save_start_block += 1
+                    else:
+                        break
+
+                block_gvas: list[int] = []
+                new_keys: list[str] = []
+                new_positions: list[int] = []
+                for blk_idx in range(save_start_block, min(save_end_block, len(group_block_hashes))):
+                    key = self._make_layerwise_gva_key(group_id, group_block_hashes[blk_idx].hex())
+                    cached = self._allocated_gvas.get(key)
+                    if cached is not None:
+                        block_gvas.append(cached)
+                    else:
+                        new_keys.append(key)
+                        new_positions.append(len(block_gvas))
+                        block_gvas.append(0)
+
+                if new_keys:
+                    new_gvas = self.m_store.batch_alloc(new_keys, [alloc_size] * len(new_keys))
+                    if any(gva <= 0 for gva in new_gvas):
+                        logger.error(
+                            "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
+                            request.req_id,
+                            group_id,
+                            alloc_size,
+                            len(new_keys),
+                            new_gvas[:5],
+                            sum(1 for g in new_gvas if g <= 0),
+                        )
+                    for pos, key, gva in zip(new_positions, new_keys, new_gvas):
+                        block_gvas[pos] = gva
+                        self._allocated_gvas[key] = gva
+
+                logger.info(
+                    "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
+                    "new_keys=%d cached_keys=%d alloc_size=%d",
                     request.req_id,
-                    self.tp_rank,
-                    len(alloc_keys),
+                    group_id,
+                    effective_block_size,
                     save_start_block,
                     save_end_block,
-                    len(new_block_keys),
-                    last_block_is_new,
+                    len(new_keys),
+                    len(block_gvas) - len(new_keys),
+                    alloc_size,
                 )
-                new_gvas = self.m_store.batch_alloc(alloc_keys, [alloc_size] * len(alloc_keys))
-                if any(gva <= 0 for gva in new_gvas):
-                    logger.error(
-                        "Request %s: batch_alloc failed for some keys, gvas=%s. "
-                        "Save will likely fail; continuing without crash.",
-                        request.req_id,
-                        new_gvas,
-                    )
-                logger.debug(
-                    "[KVPOOL] save_alloc req=%s tp_rank=%d batch_alloc done gvas=%s",
-                    request.req_id,
-                    self.tp_rank,
-                    new_gvas,
-                )
-                num_block = len(new_block_keys)
-                for pos, key, gva in zip(new_key_positions, new_block_keys, new_gvas[:num_block]):
-                    block_gvas[pos] = gva
-                    self._allocated_gvas[key] = gva
-                if last_block_is_new:
-                    assert last_block_key is not None
-                    new_last_gva = new_gvas[num_block]
-                    last_block_gva = new_last_gva
-                    self._allocated_gvas[last_block_key] = new_last_gva
 
-            request.block_gvas_np = np.asarray(block_gvas, dtype=np.int64)
-            request.gva_block_offset = save_start_block
-            if last_block_gva is not None:
-                request.last_block_gva = last_block_gva
+                # Pad block_gvas to match block_ids length (fill 0 for blocks before save_start)
+                full_gvas = [0] * len(block_ids_by_group)
+                for i, gva in enumerate(block_gvas):
+                    if save_start_block + i < len(full_gvas):
+                        full_gvas[save_start_block + i] = gva
+
+                all_group_gvas.append(np.asarray(full_gvas, dtype=np.int64))
+                all_group_block_ids.append(np.asarray(block_ids_by_group, dtype=np.int64))
+
+            if all_group_gvas:
+                request.block_gvas_by_group_np = all_group_gvas
+                request.block_ids_by_group_np = all_group_block_ids
+                request.block_gvas_np = all_group_gvas[0]
+                request.gva_block_offset = 0
 
     def _prepare_load_gvas(self, requests: list[ReqMeta]) -> None:
         """Fetch per-rank GVA and acquire read lease for the load path.
@@ -1008,89 +1134,76 @@ class KVPoolWorker:
         """
         if not self.use_gva_layerwise:
             return
-        logger.debug("[KVPOOL] load_prepare enter tp_rank=%d reqs=%d", self.tp_rank, len(requests))
         for request in requests:
             if request.load_spec is None or not request.load_spec.can_load:
                 continue
             cached_tokens = request.load_spec.kvpool_cached_tokens
-            load_start_block = request.load_spec.vllm_cached_tokens // self.block_size
-            cached_full_blocks = cached_tokens // self.block_size
-            full_blocks = min(cached_full_blocks, len(request.block_hashes))
-            if load_start_block >= full_blocks and cached_tokens % self.block_size == 0:
-                continue
-
             block_hashes = request.block_hashes
-            keys = [
-                f"{self.model_name}@{block_hashes[i].hex()}@{self.head_or_tp_rank}"
-                for i in range(load_start_block, full_blocks)
-            ]
 
-            needs_last_block_at_boundary = (
-                cached_tokens > 0 and cached_tokens % self.block_size == 0 and full_blocks < cached_full_blocks
-            )
-            last_block_key: str | None = None
-            if cached_tokens % self.block_size != 0 or needs_last_block_at_boundary:
-                last_block_key = f"{self.model_name}@{request.req_id}_lastblock@{self.head_or_tp_rank}"
-                keys.append(last_block_key)
-            if not keys:
-                continue
+            all_group_load_gvas: list[np.ndarray] = []
+            all_group_load_keys: list[str] = []
+            for group_id in range(self.num_kv_cache_groups):
+                group_block_size = self.grouped_block_size[group_id]
+                cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
+                ratio = max(infer_cache_family_ratio(cache_family), 1)
+                effective_block_size = group_block_size * ratio
 
-            logger.info(
-                "[KVPOOL] load_prepare req=%s tp_rank=%d keys=%d load_blocks=[%d,%d) cached_tokens=%d last_block=%s",
-                request.req_id,
-                self.tp_rank,
-                len(keys),
-                load_start_block,
-                full_blocks,
-                cached_tokens,
-                last_block_key is not None,
-            )
-            # 1. Fetch per-rank GVA via batch_get_key_info.
-            key_infos = self.m_store.batch_get_key_info(keys)
-            gvas: list[int] = []
-            for ki in key_infos:
-                sizes = ki.size()
-                if sizes and sizes > 0:
-                    gvas.append(ki.gva_list()[0])
-                else:
-                    logger.error(
-                        "Request %s: batch_get_key_info returned no gva for a "
-                        "key expected to be in the pool. Load will likely fail; "
-                        "continuing without crash.",
-                        request.req_id,
-                    )
-                    gvas.append(0)
-            logger.info(
-                "[KVPOOL] load_prepare req=%s tp_rank=%d get_key_info done gvas=%s",
-                request.req_id,
-                self.tp_rank,
-                gvas,
-            )
+                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+                load_start_block = request.load_spec.vllm_cached_tokens // effective_block_size
+                cached_full_blocks = cached_tokens // effective_block_size
+                full_blocks = min(cached_full_blocks, len(group_block_hashes))
 
-            # 2. Acquire read lease (registers blob in per-process gvaBlobTracker).
-            lease_results = self.m_store.batch_add_lease(keys, LAYERWISE_READ_LEASE_TTL_MS)
-            if any(r != 0 for r in lease_results):
-                logger.error(
-                    "Request %s: batch_add_lease failed, results=%s. Load will likely fail; continuing without crash.",
-                    request.req_id,
-                    lease_results,
+                block_ids_by_group = (
+                    request.block_ids_by_group_np[group_id]
+                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
+                    else request.block_ids_np
                 )
-            logger.info(
-                "[KVPOOL] load_prepare req=%s tp_rank=%d add_lease done results=%s ttl_ms=%d",
-                request.req_id,
-                self.tp_rank,
-                lease_results,
-                LAYERWISE_READ_LEASE_TTL_MS,
-            )
-            # Store keys on the request so the load thread can release the
-            # lease immediately after batch_copy G2L completes.
-            request.load_keys = keys
+                full_len = len(block_ids_by_group) if block_ids_by_group is not None else 0
 
-            num_block_keys = full_blocks - load_start_block
-            request.load_block_gvas_np = np.asarray(gvas[:num_block_keys], dtype=np.int64)
-            request.load_gva_block_offset = load_start_block
-            if last_block_key is not None:
-                request.last_block_gva = gvas[-1]
+                if load_start_block >= full_blocks:
+                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
+                    continue
+
+                keys = [
+                    self._make_layerwise_gva_key(group_id, group_block_hashes[i].hex())
+                    for i in range(load_start_block, full_blocks)
+                ]
+                if not keys:
+                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
+                    continue
+
+                key_infos = self.m_store.batch_get_key_info(keys)
+                lease_results = self.m_store.batch_add_lease(keys, LAYERWISE_READ_LEASE_TTL_MS)
+                gvas = []
+                for ki in key_infos:
+                    sizes = ki.size()
+                    gvas.append(ki.gva_list()[0] if sizes and sizes > 0 else 0)
+                all_group_load_keys.extend(keys)
+
+                logger.info(
+                    "load_gvas: req=%s group=%d eff_bs=%d load_blocks=[%d,%d) keys=%d valid_gvas=%d lease_fail=%d",
+                    request.req_id,
+                    group_id,
+                    effective_block_size,
+                    load_start_block,
+                    full_blocks,
+                    len(keys),
+                    sum(1 for g in gvas if g > 0),
+                    sum(1 for r in lease_results if r != 0),
+                )
+
+                # Pad to match block_ids_by_group length, with 0s before load_start_block
+                full_gvas = [0] * full_len
+                for i, gva in enumerate(gvas):
+                    if load_start_block + i < len(full_gvas):
+                        full_gvas[load_start_block + i] = gva
+                all_group_load_gvas.append(np.asarray(full_gvas, dtype=np.int64))
+
+            if all_group_load_gvas:
+                request.load_keys = all_group_load_keys
+                request.load_block_gvas_by_group_np = all_group_load_gvas
+                request.load_block_gvas_np = all_group_load_gvas[0]
+                request.load_gva_block_offset = 0
 
     def _build_shared_save_data(self) -> None:
         """Build shared block data once and attach to all layer save tasks.
@@ -1100,23 +1213,36 @@ class KVPoolWorker:
 
         For Key path (KVCacheStoreKeyLayerSendingThread): pre-computes
         cached process_tokens via build_cached_process_tokens().
-        """
-        # Find the first non-empty layer task (all have identical block_ranges)
-        first_task = None
-        for layer_id in range(self.num_layers):
-            if self.layer_save_tasks[layer_id]:
-                first_task = self.layer_save_tasks[layer_id][0]
-                break
-        if first_task is None:
-            return
 
+        In multi-group mode, shared data is built per-group because each
+        group has different block_ranges (different effective_block_size).
+        """
         if isinstance(self.kv_send_thread, KVCacheStoreLayerSendingThread):
-            shared = self.kv_send_thread.build_shared_data(first_task)
-            if shared is not None:
+            for group_id in range(self.num_kv_cache_groups):
+                first_task = None
                 for layer_id in range(self.num_layers):
                     for task in self.layer_save_tasks[layer_id]:
-                        task.shared_block_data = shared
+                        if task.group_id == group_id:
+                            first_task = task
+                            break
+                    if first_task:
+                        break
+                if first_task is None:
+                    continue
+                shared = self.kv_send_thread.build_shared_data(first_task)
+                if shared is not None:
+                    for layer_id in range(self.num_layers):
+                        for task in self.layer_save_tasks[layer_id]:
+                            if task.group_id == group_id:
+                                task.shared_block_data = shared
         elif isinstance(self.kv_send_thread, KVCacheStoreKeyLayerSendingThread):
+            first_task = None
+            for layer_id in range(self.num_layers):
+                if self.layer_save_tasks[layer_id]:
+                    first_task = self.layer_save_tasks[layer_id][0]
+                    break
+            if first_task is None:
+                return
             cached = self.kv_send_thread.build_cached_process_tokens(first_task)
             if cached is not None:
                 for layer_id in range(self.num_layers):
@@ -1124,38 +1250,45 @@ class KVPoolWorker:
                         task.cached_process_tokens = cached
 
     def _build_shared_load_data(self) -> None:
-        """Build shared block data once and attach to all layer load tasks."""
+        """Build shared block data once and attach to all layer load tasks.
+
+        In multi-group mode, shared data is built per-group because each
+        group has different block_ranges (different effective_block_size).
+        """
         if not isinstance(self.kv_recv_thread, KVCacheStoreLayerRecvingThread):
             return
-        first_task = None
-        for layer_id in range(self.num_layers):
-            if self.layer_load_tasks[layer_id]:
-                first_task = self.layer_load_tasks[layer_id][0]
-                break
-        if first_task is None:
-            return
-        shared = self.kv_recv_thread.build_shared_data(first_task)
-        if shared is not None:
+        for group_id in range(self.num_kv_cache_groups):
+            first_task = None
             for layer_id in range(self.num_layers):
                 for task in self.layer_load_tasks[layer_id]:
-                    task.shared_block_data = shared
+                    if task.group_id == group_id:
+                        first_task = task
+                        break
+                if first_task:
+                    break
+            if first_task is None:
+                continue
+            shared = self.kv_recv_thread.build_shared_data(first_task)
+            if shared is not None:
+                for layer_id in range(self.num_layers):
+                    for task in self.layer_load_tasks[layer_id]:
+                        if task.group_id == group_id:
+                            task.shared_block_data = shared
 
     def process_layer_data(self, requests: list[ReqMeta]) -> None:
         if not requests:
             return
-        logger.debug(
-            "[KVPOOL] process_layer_data tp_rank=%d reqs=%d req_ids=%s",
-            self.tp_rank,
-            len(requests),
-            [r.req_id for r in requests],
-        )
-        for layer_id in range(self.num_layers):
-            self._process_save_for_layer_batch(requests, layer_id)
+        for physical_layer in range(self.num_layers):
+            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
+            for group_id, layer_idx_in_group in group_layers:
+                self._process_save_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
         self._alloc_gvas_for_save(requests)
         self._build_shared_save_data()
         self._prepare_load_gvas(requests)
-        for layer_id in range(self.num_layers):
-            self._process_load_for_layer_batch(requests, layer_id)
+        for physical_layer in range(self.num_layers):
+            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
+            for group_id, layer_idx_in_group in group_layers:
+                self._process_load_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
         self._build_shared_load_data()
 
     def _submit_ready_layer_loads(self) -> None:
@@ -1210,10 +1343,6 @@ class KVPoolWorker:
         return invalid_blocks
 
     def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
-        # MTP speculative decoding re-runs the base model's attention layers
-        # during draft execution (_run_merged_draft), causing extra
-        # save_kv_layer calls beyond num_layers. These extra calls would
-        # exhaust the store_layer generators and raise StopIteration.
         if self.current_layer >= self.num_layers:
             return
         assert self.sync_save_events is not None
@@ -1222,8 +1351,9 @@ class KVPoolWorker:
         send_thread = self.kv_send_thread
         self.sync_save_events[self.current_layer].record()
         if self.layer_save_tasks[self.current_layer]:
-            for block_range in self.layer_save_tasks[self.current_layer][0].block_ranges:
-                send_thread.add_stored_request(block_range.request.req_id)
+            for task in self.layer_save_tasks[self.current_layer]:
+                for block_range in task.block_ranges:
+                    send_thread.add_stored_request(block_range.request.req_id)
             send_thread.add_request(self.layer_save_tasks[self.current_layer])  # type: ignore[arg-type]
         else:
             self.layer_save_finished_events[self.current_layer].set()
@@ -1233,7 +1363,6 @@ class KVPoolWorker:
                 logger.info("Layerwise %d save wait timed out", self.current_layer)
             for layer_id in range(self.num_layers):
                 if self.layer_save_finished_events[layer_id].is_set():
-                    logger.debug(">>>>>>>>>>>>>>>>>>>> clear save layer %d", layer_id)
                     self.layer_save_finished_events[layer_id].clear()
 
         self.current_layer = self.current_layer + 1

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -38,6 +38,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
+    block_hash_to_str,
     get_block_hashes,
     get_cache_family_granularity,
     infer_cache_family_ratio,
@@ -324,22 +325,6 @@ class KVPoolWorker:
             self.num_kv_cache_groups,
             {k: v for k, v in list(self.physical_layer_to_group_layers.items())[:3]},
         )
-
-    def _extract_physical_layer_index(self, layer_name: str) -> int:
-        import regex as re
-
-        m = re.search(r"layers\.(\d+)", layer_name)
-        if m:
-            return int(m.group(1))
-        # MTP layers have names like "mtp.0.self_attn.xxx" without "layers."
-        # prefix. Map them after the main model layers.
-        if ".mtp." in f".{layer_name}.":
-            m = re.search(r"mtp\.(\d+)", layer_name)
-            if m:
-                num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
-                return num_hidden_layers + int(m.group(1))
-        m = re.search(r"(\d+)", layer_name)
-        return int(m.group(1)) if m else 0
 
     def _build_group_layer_builders(self) -> list[LayerBatchBuilder]:
         builders = []
@@ -925,7 +910,9 @@ class KVPoolWorker:
             if self.use_gva_layerwise and save_start_block < save_end_block:
                 group_block_hashes = get_block_hashes(request.block_hashes, block_size, self.hash_block_size)
                 while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
-                    key = self._make_layerwise_gva_key(group_id, group_block_hashes[save_start_block].hex())
+                    key = self._make_layerwise_gva_key(
+                        group_id, block_hash_to_str(group_block_hashes[save_start_block])
+                    )
                     if key in self._allocated_gvas:
                         save_start_block += 1
                     else:
@@ -1050,6 +1037,8 @@ class KVPoolWorker:
                     if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
                     else request.block_ids_np
                 )
+                if block_ids_by_group is None:
+                    raise RuntimeError(f"Block IDs are not initialized for request {request.req_id}")
 
                 save_start_block = request.save_start_token // effective_block_size
                 save_end_block = request.save_end_token // effective_block_size
@@ -1059,7 +1048,9 @@ class KVPoolWorker:
                 # Skip blocks already saved (GVA cached locally from previous
                 # request). See _process_save_for_layer_batch for rationale.
                 while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
-                    key = self._make_layerwise_gva_key(group_id, group_block_hashes[save_start_block].hex())
+                    key = self._make_layerwise_gva_key(
+                        group_id, block_hash_to_str(group_block_hashes[save_start_block])
+                    )
                     if key in self._allocated_gvas:
                         save_start_block += 1
                     else:
@@ -1069,7 +1060,7 @@ class KVPoolWorker:
                 new_keys: list[str] = []
                 new_positions: list[int] = []
                 for blk_idx in range(save_start_block, min(save_end_block, len(group_block_hashes))):
-                    key = self._make_layerwise_gva_key(group_id, group_block_hashes[blk_idx].hex())
+                    key = self._make_layerwise_gva_key(group_id, block_hash_to_str(group_block_hashes[blk_idx]))
                     cached = self._allocated_gvas.get(key)
                     if cached is not None:
                         block_gvas.append(cached)
@@ -1165,7 +1156,7 @@ class KVPoolWorker:
                     continue
 
                 keys = [
-                    self._make_layerwise_gva_key(group_id, group_block_hashes[i].hex())
+                    self._make_layerwise_gva_key(group_id, block_hash_to_str(group_block_hashes[i]))
                     for i in range(load_start_block, full_blocks)
                 ]
                 if not keys:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR recreates #11773 from a clean `releases/v0.23.0` worktree and adds multi-group layerwise KV cache support for DeepSeek V4 Flash (6 KV cache groups with different block sizes and compression ratios) using the MemCache backend.

The implementation is based on the original work by @tyy0829, who is credited as a co-author in the commit.

Key changes:

1. Add multi-group layerwise callbacks for the DSA CP and DSA V1 attention backends.
2. Add per-group GVA allocation, lookup, load, and save handling.
3. Exclude MTP layers from group sizing and guard MTP layerwise callbacks.
4. Combine per-group batch copies by physical layer and fix layerwise request completion handling.
5. Default `discard_partial_chunks` to `true` for layerwise KV pool.
6. Apply repository formatting and use `regex as re` to satisfy CI import policy.

### Does this PR introduce _any_ user-facing change?

No. Multi-group layerwise KV cache continues to use the existing `kv-transfer-config` options `use_layerwise: true` and `use_gva_layerwise: true`. Single-group models remain backward compatible.

### How was this patch tested?

- Commit-time pre-commit hooks passed, including ruff check, ruff format, forbidden imports, boolean context manager checks, and long-function checks.
- Python syntax compilation passed for all six changed files.
- The resulting tree was compared against the GitHub merge ref for #11773; differences are limited to ruff formatting and the CI-required `regex as re` import.
- Hardware validation inherited from #11773:
  - DeepSeek V4 Flash: 8 sequential identical requests (~1.7k tokens), identical outputs, zero errors, `hit_tokens=1664`.
  - GLM-4.7-Flash: tested for single-group backward compatibility with correct cache hits.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
