### PR TITLE
[Test][Platform] Add A5 aclgraph capture-size and SFA-C8 platform guards

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -616,6 +616,7 @@
     - vllm_ascend/utils.py
     - setup.py
   tests:
+    - tests/ut/test_a5_platform_guards.py
     - tests/ut/test_ascend_config.py
     - tests/ut/test_ascend_forward_context.py
     - tests/ut/test_cpu_binding.py

--- a/tests/ut/test_a5_platform_guards.py
+++ b/tests/ut/test_a5_platform_guards.py
@@ -84,7 +84,11 @@ def test_a5_platform_safety_guards_present():
     either would silently enable an unsupported A5 path. This source-level
     assertion fails fast if the guards are refactored away.
     """
-    src = Path("vllm_ascend/platform.py").read_text(encoding="utf-8")
+    # Resolve via the module's __file__ so the test does not depend on the
+    # current working directory being the repository root.
+    import vllm_ascend.platform
+
+    src = Path(vllm_ascend.platform.__file__).read_text(encoding="utf-8")
     assert "prune_capture_sizes_for_950" in src
     assert "AscendDeviceType.A5" in src
     assert "not supported on A5" in src

--- a/tests/ut/test_a5_platform_guards.py
+++ b/tests/ut/test_a5_platform_guards.py
@@ -12,36 +12,33 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-"""Guards for A5 (Ascend 950) platform-level safety behavior.
+"""Unit tests for the A5 (Ascend 950) platform guards.
 
-A5 HDK has an ACL graph capture-size incompatibility (see the TODO in
-``vllm_ascend/platform.py``) and does not support SFA DCP with sparse C8 yet.
-Both guards live in ``vllm_ascend/platform.py`` and are A5-only; because there
-is no A5 CI runner yet, removing them during refactoring would let A5
-regressions slip through silently.
+This UT layer keeps only what is genuinely unit-testable on CPU:
 
-The capture-size guard (``prune_capture_sizes_for_950``) is a standalone
-function and is verified behaviorally here, including the empty / at-limit /
-over-limit boundaries. The SFA-DCP guard is an inline ``raise`` inside
-``NPUPlatform.check_and_update_config``; rather than grepping source text (which
-would pass even for dead code / comments), we drive the real code path with a
-mocked config so the ``NotImplementedError`` must actually fire on A5.
+* ``prune_capture_sizes_for_950`` -- a pure function with no A5-runtime
+  dependency inside; its pruning contract (empty / at-limit / over-limit) is
+  verified behaviorally here.
+* An AST structural drift guard for the inline SFA-DCP ``NotImplementedError``
+  that lives inside ``NPUPlatform.check_and_update_config``. That raise is an
+  A5-runtime behavior, so its *firing* is validated by the e2e single-card A5
+  suite, not mocked here. This UT only asserts the raise stays *wired to the
+  A5 branch* in source -- a text grep cannot prove that (it would pass for a
+  comment or dead code), but an AST walk can.
 """
 
+import ast
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-import pytest
-
 from vllm_ascend.platform import (
     MAX_CAPTURE_SIZES_FOR_950,
-    NPUPlatform,
     prune_capture_sizes_for_950,
 )
-from vllm_ascend.utils import AscendDeviceType
 
 # ---------------------------------------------------------------------------
-# prune_capture_sizes_for_950 — behavior + boundary coverage
+# prune_capture_sizes_for_950 -- pure-function behavior + boundaries
 # ---------------------------------------------------------------------------
 
 
@@ -68,7 +65,6 @@ def test_prune_is_noop_at_exact_limit():
     with mock.patch("vllm_ascend.platform.update_cudagraph_capture_sizes") as mocked_update:
         prune_capture_sizes_for_950(cfg)
     mocked_update.assert_not_called()
-    # The original list is left untouched.
     assert cfg.compilation_config.cudagraph_capture_sizes == sizes
 
 
@@ -97,103 +93,67 @@ def test_prune_samples_down_to_limit_preserving_endpoints():
 
     mocked_update.assert_called_once()
     pruned = captured["sizes"]
-    # Cardinality contract.
     assert len(pruned) == MAX_CAPTURE_SIZES_FOR_950
-    # Endpoints preserved so the smallest / largest batch sizes stay captured.
     assert pruned[0] == sizes[0]
     assert pruned[-1] == sizes[-1]
-    # Sampling without replacement, preserving ascending order.
     assert pruned == sorted(pruned)
     assert len(set(pruned)) == len(pruned)
     assert set(pruned).issubset(set(sizes))
 
 
 # ---------------------------------------------------------------------------
-# SFA-DCP sparse-C8 guard — behavior-level (replaces source string grep)
+# SFA-DCP A5 raise -- AST structural drift guard
 # ---------------------------------------------------------------------------
 
 
-def _sfa_dcp_vllm_config():
-    """A config that routes ``check_and_update_config`` to the SFA-DCP block.
+def _raised_exception_name(exc) -> str | None:
+    """Return the exception class name raised by an ``ast.Raise`` exc node."""
+    node = exc
+    # raise X(...) -> exc is a Call; unwrap to the callable
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
 
-    Concrete integers are used wherever the platform code does arithmetic or
-    comparisons on the parallel config (``> 1``, ``*``, ``!=``), so the heavy
-    branches are skipped deterministically and execution reaches the A5 raise.
+
+def _references_a5(node) -> bool:
+    """True if an AST node's text references ``AscendDeviceType.A5``."""
+    return any(isinstance(n, ast.Attribute) and n.attr == "A5" for n in ast.walk(node))
+
+
+def test_sfa_dcp_a5_raise_guard_is_wired_in_check_and_update_config():
+    """AST guard: the SFA-DCP ``NotImplementedError`` must stay wired to the
+    A5 branch of ``NPUPlatform.check_and_update_config``.
+
+    The raise firing on real A5 is validated by the e2e single-card A5 suite.
+    Here we only assert, via AST (not text grep), that the raise still exists
+    *inside* an A5-gated ``if``. Removing the guard or unwiring it from the A5
+    condition fails this test; a comment/dead-code string would not satisfy it.
     """
-    vllm_config = mock.MagicMock()
-    # Skip the device-type early return.
-    vllm_config.device_config = None
-    vllm_config.model_config = mock.MagicMock()
-    vllm_config.model_config.enforce_eager = True
-    vllm_config.model_config.is_encoder_decoder = False
-    vllm_config.model_config.enable_sleep_mode = True
-    vllm_config.model_config.hf_text_config = SimpleNamespace()  # no index_topk
-    vllm_config.kv_transfer_config = None
-    vllm_config.speculative_config = None
-    vllm_config.additional_config = {"enable_sparse_c8": True}
+    import vllm_ascend.platform as platform_mod
 
-    pc = vllm_config.parallel_config
-    pc.tensor_parallel_size = 1
-    pc.decode_context_parallel_size = 1
-    pc.prefill_context_parallel_size = 1
-    pc.worker_cls = "NPUWorker"
+    tree = ast.parse(Path(platform_mod.__file__).read_text(encoding="utf-8"))
 
-    from vllm.config.compilation import CUDAGraphMode
+    method = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "check_and_update_config"),
+        None,
+    )
+    assert method is not None, "check_and_update_config not found in platform.py"
 
-    cc = vllm_config.compilation_config
-    cc.cudagraph_mode = CUDAGraphMode.NONE
-    return vllm_config
+    found = False
+    for node in ast.walk(method):
+        if not (isinstance(node, ast.If) and _references_a5(node.test)):
+            continue
+        # Is there a `raise NotImplementedError` within this A5-gated branch?
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Raise) and _raised_exception_name(sub.exc) == "NotImplementedError":
+                found = True
+                break
+        if found:
+            break
 
-
-def _sfa_dcp_ascend_config():
-    """A mock AscendConfig whose optional branches all stay disabled."""
-    ascend_config = mock.MagicMock()
-    # Skip the additional_config setdefault/update branches.
-    ascend_config.ascend_fusion_config = None
-    # xlite_graph_config.enabled must be falsy to avoid overwriting cudagraph_mode.
-    ascend_config.xlite_graph_config.enabled = False
-    ascend_config.enable_balance_scheduling = False
-    ascend_config.short_request_first_config.enabled = False
-    ascend_config.recompute_scheduler_enable = False
-    ascend_config.SLO_limits_for_dynamic_batch = -1  # concrete int (compared != -1)
-    ascend_config.profiling_chunk_config.enabled = False
-    return ascend_config
-
-
-def test_sfa_dcp_sparse_c8_raises_not_implemented_on_a5():
-    """A5 + SFA-DCP replicated indexer + sparse C8 must raise NotImplementedError.
-
-    This drives the real ``NPUPlatform.check_and_update_config`` path (heavy
-    dependencies mocked) so the guard must actually fire on A5. Deleting or
-    bypassing the inline ``raise`` makes this test fail (no NotImplementedError),
-    which is the regression signal a bare string-grep could not give.
-    """
-    vllm_config = _sfa_dcp_vllm_config()
-
-    with (
-        mock.patch(
-            "vllm_ascend.platform.init_ascend_config",
-            return_value=_sfa_dcp_ascend_config(),
-        ),
-        mock.patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization"),
-        mock.patch.object(NPUPlatform, "_validate_layer_sharding_config"),
-        mock.patch.object(NPUPlatform, "_validate_draft_decode_context_parallel_config"),
-        mock.patch.object(NPUPlatform, "_validate_parallel_config"),
-        mock.patch.object(NPUPlatform, "_fix_incompatible_config"),
-        mock.patch.object(NPUPlatform, "_validate_kv_load_failure_policy"),
-        mock.patch("vllm_ascend.logger.configure_ascend_file_logging"),
-        mock.patch("vllm_ascend.logger.configure_ascend_logging"),
-        mock.patch("vllm_ascend.platform.refresh_block_size"),
-        mock.patch("vllm_ascend.platform.model_uses_sfa_sparse", return_value=True),
-        mock.patch(
-            "vllm_ascend.platform.enable_sfa_dcp_replicated_indexer",
-            return_value=True,
-        ),
-        mock.patch(
-            "vllm_ascend.platform.get_ascend_device_type",
-            return_value=AscendDeviceType.A5,
-        ),
-        mock.patch("vllm_ascend.platform.enable_sp", return_value=False),
-        pytest.raises(NotImplementedError, match="not supported on A5"),
-    ):
-        NPUPlatform.check_and_update_config(vllm_config)
+    assert found, (
+        "SFA-DCP NotImplementedError guard is missing or no longer wired to the "
+        "A5 branch in NPUPlatform.check_and_update_config"
+    )

--- a/tests/ut/test_a5_platform_guards.py
+++ b/tests/ut/test_a5_platform_guards.py
@@ -18,41 +18,72 @@ A5 HDK has an ACL graph capture-size incompatibility (see the TODO in
 ``vllm_ascend/platform.py``) and does not support SFA DCP with sparse C8 yet.
 Both guards live in ``vllm_ascend/platform.py`` and are A5-only; because there
 is no A5 CI runner yet, removing them during refactoring would let A5
-regressions slip through silently. These CPU tests pin both behaviors.
+regressions slip through silently.
 
-Recent A5 regressions (e.g. prefix-cache perf fluctuation #11113) show exactly
-the class of issues these guards exist to prevent.
+The capture-size guard (``prune_capture_sizes_for_950``) is a standalone
+function and is verified behaviorally here, including the empty / at-limit /
+over-limit boundaries. The SFA-DCP guard is an inline ``raise`` inside
+``NPUPlatform.check_and_update_config``; rather than grepping source text (which
+would pass even for dead code / comments), we drive the real code path with a
+mocked config so the ``NotImplementedError`` must actually fire on A5.
 """
 
-from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 
-from vllm_ascend.platform import MAX_CAPTURE_SIZES_FOR_950, prune_capture_sizes_for_950
-
-
-@pytest.mark.parametrize(
-    "capture_sizes, should_prune",
-    [
-        # Already within the A5 limit -> no-op.
-        ([1, 2, 4], False),
-        # Over the limit -> sampled down to MAX_CAPTURE_SIZES_FOR_950.
-        ([1, 2, 4, 8, 16, 32, 64, 128], True),
-    ],
+from vllm_ascend.platform import (
+    MAX_CAPTURE_SIZES_FOR_950,
+    NPUPlatform,
+    prune_capture_sizes_for_950,
 )
-def test_prune_capture_sizes_for_950_behavior(capture_sizes, should_prune):
-    """On A5, capture sizes are pruned to MAX_CAPTURE_SIZES_FOR_950.
+from vllm_ascend.utils import AscendDeviceType
 
-    The pruned list must keep the first and last capture sizes (so the
-    smallest and largest batch sizes are still captured) and stay within the
-    A5 HDK limit. When already within the limit, the function must be a
-    no-op and must not touch the config.
+# ---------------------------------------------------------------------------
+# prune_capture_sizes_for_950 — behavior + boundary coverage
+# ---------------------------------------------------------------------------
+
+
+def _cfg(capture_sizes):
+    """Build a minimal config object accepted by ``prune_capture_sizes_for_950``."""
+    return SimpleNamespace(compilation_config=SimpleNamespace(cudagraph_capture_sizes=list(capture_sizes)))
+
+
+def test_prune_is_noop_when_capture_sizes_empty():
+    """An empty capture-size list must short-circuit without touching config."""
+    cfg = _cfg([])
+    with mock.patch("vllm_ascend.platform.update_cudagraph_capture_sizes") as mocked_update:
+        prune_capture_sizes_for_950(cfg)
+    mocked_update.assert_not_called()
+
+
+def test_prune_is_noop_at_exact_limit():
+    """``len == MAX_CAPTURE_SIZES_FOR_950`` hits the ``<=`` boundary -> no-op.
+
+    This is the most fragile off-by-one edge: one element more would prune.
     """
-    cfg = SimpleNamespace(
-        compilation_config=SimpleNamespace(cudagraph_capture_sizes=list(capture_sizes))
-    )
+    sizes = list(range(1, MAX_CAPTURE_SIZES_FOR_950 + 1))  # len == limit
+    cfg = _cfg(sizes)
+    with mock.patch("vllm_ascend.platform.update_cudagraph_capture_sizes") as mocked_update:
+        prune_capture_sizes_for_950(cfg)
+    mocked_update.assert_not_called()
+    # The original list is left untouched.
+    assert cfg.compilation_config.cudagraph_capture_sizes == sizes
+
+
+def test_prune_is_noop_below_limit():
+    """``len < limit`` is a no-op."""
+    cfg = _cfg([1, 2, 4])  # len 3 < 4
+    with mock.patch("vllm_ascend.platform.update_cudagraph_capture_sizes") as mocked_update:
+        prune_capture_sizes_for_950(cfg)
+    mocked_update.assert_not_called()
+
+
+def test_prune_samples_down_to_limit_preserving_endpoints():
+    """Over the limit, output keeps endpoints, stays ascending, all from source."""
+    sizes = [1, 2, 4, 8, 16, 32, 64, 128]  # len 8 > 4
+    cfg = _cfg(sizes)
     captured = {}
 
     def fake_update(vllm_config, new_sizes):
@@ -64,31 +95,105 @@ def test_prune_capture_sizes_for_950_behavior(capture_sizes, should_prune):
     ) as mocked_update:
         prune_capture_sizes_for_950(cfg)
 
-    if should_prune:
-        mocked_update.assert_called_once()
-        pruned = captured["sizes"]
-        assert len(pruned) == MAX_CAPTURE_SIZES_FOR_950
-        assert pruned[0] == capture_sizes[0]
-        assert pruned[-1] == capture_sizes[-1]
-        # Every sampled size must come from the original list.
-        assert all(size in capture_sizes for size in pruned)
-    else:
-        mocked_update.assert_not_called()
+    mocked_update.assert_called_once()
+    pruned = captured["sizes"]
+    # Cardinality contract.
+    assert len(pruned) == MAX_CAPTURE_SIZES_FOR_950
+    # Endpoints preserved so the smallest / largest batch sizes stay captured.
+    assert pruned[0] == sizes[0]
+    assert pruned[-1] == sizes[-1]
+    # Sampling without replacement, preserving ascending order.
+    assert pruned == sorted(pruned)
+    assert len(set(pruned)) == len(pruned)
+    assert set(pruned).issubset(set(sizes))
 
 
-def test_a5_platform_safety_guards_present():
-    """Drift guard: the A5-only platform safety checks must stay in place.
+# ---------------------------------------------------------------------------
+# SFA-DCP sparse-C8 guard — behavior-level (replaces source string grep)
+# ---------------------------------------------------------------------------
 
-    ``prune_capture_sizes_for_950`` is called only on the A5 branch, and the
-    SFA-DCP sparse-C8 path raises ``NotImplementedError`` on A5. Removing
-    either would silently enable an unsupported A5 path. This source-level
-    assertion fails fast if the guards are refactored away.
+
+def _sfa_dcp_vllm_config():
+    """A config that routes ``check_and_update_config`` to the SFA-DCP block.
+
+    Concrete integers are used wherever the platform code does arithmetic or
+    comparisons on the parallel config (``> 1``, ``*``, ``!=``), so the heavy
+    branches are skipped deterministically and execution reaches the A5 raise.
     """
-    # Resolve via the module's __file__ so the test does not depend on the
-    # current working directory being the repository root.
-    import vllm_ascend.platform
+    vllm_config = mock.MagicMock()
+    # Skip the device-type early return.
+    vllm_config.device_config = None
+    vllm_config.model_config = mock.MagicMock()
+    vllm_config.model_config.enforce_eager = True
+    vllm_config.model_config.is_encoder_decoder = False
+    vllm_config.model_config.enable_sleep_mode = True
+    vllm_config.model_config.hf_text_config = SimpleNamespace()  # no index_topk
+    vllm_config.kv_transfer_config = None
+    vllm_config.speculative_config = None
+    vllm_config.additional_config = {"enable_sparse_c8": True}
 
-    src = Path(vllm_ascend.platform.__file__).read_text(encoding="utf-8")
-    assert "prune_capture_sizes_for_950" in src
-    assert "AscendDeviceType.A5" in src
-    assert "not supported on A5" in src
+    pc = vllm_config.parallel_config
+    pc.tensor_parallel_size = 1
+    pc.decode_context_parallel_size = 1
+    pc.prefill_context_parallel_size = 1
+    pc.worker_cls = "NPUWorker"
+
+    from vllm.config.compilation import CUDAGraphMode
+
+    cc = vllm_config.compilation_config
+    cc.cudagraph_mode = CUDAGraphMode.NONE
+    return vllm_config
+
+
+def _sfa_dcp_ascend_config():
+    """A mock AscendConfig whose optional branches all stay disabled."""
+    ascend_config = mock.MagicMock()
+    # Skip the additional_config setdefault/update branches.
+    ascend_config.ascend_fusion_config = None
+    # xlite_graph_config.enabled must be falsy to avoid overwriting cudagraph_mode.
+    ascend_config.xlite_graph_config.enabled = False
+    ascend_config.enable_balance_scheduling = False
+    ascend_config.short_request_first_config.enabled = False
+    ascend_config.recompute_scheduler_enable = False
+    ascend_config.SLO_limits_for_dynamic_batch = -1  # concrete int (compared != -1)
+    ascend_config.profiling_chunk_config.enabled = False
+    return ascend_config
+
+
+def test_sfa_dcp_sparse_c8_raises_not_implemented_on_a5():
+    """A5 + SFA-DCP replicated indexer + sparse C8 must raise NotImplementedError.
+
+    This drives the real ``NPUPlatform.check_and_update_config`` path (heavy
+    dependencies mocked) so the guard must actually fire on A5. Deleting or
+    bypassing the inline ``raise`` makes this test fail (no NotImplementedError),
+    which is the regression signal a bare string-grep could not give.
+    """
+    vllm_config = _sfa_dcp_vllm_config()
+
+    with (
+        mock.patch(
+            "vllm_ascend.platform.init_ascend_config",
+            return_value=_sfa_dcp_ascend_config(),
+        ),
+        mock.patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization"),
+        mock.patch.object(NPUPlatform, "_validate_layer_sharding_config"),
+        mock.patch.object(NPUPlatform, "_validate_draft_decode_context_parallel_config"),
+        mock.patch.object(NPUPlatform, "_validate_parallel_config"),
+        mock.patch.object(NPUPlatform, "_fix_incompatible_config"),
+        mock.patch.object(NPUPlatform, "_validate_kv_load_failure_policy"),
+        mock.patch("vllm_ascend.logger.configure_ascend_file_logging"),
+        mock.patch("vllm_ascend.logger.configure_ascend_logging"),
+        mock.patch("vllm_ascend.platform.refresh_block_size"),
+        mock.patch("vllm_ascend.platform.model_uses_sfa_sparse", return_value=True),
+        mock.patch(
+            "vllm_ascend.platform.enable_sfa_dcp_replicated_indexer",
+            return_value=True,
+        ),
+        mock.patch(
+            "vllm_ascend.platform.get_ascend_device_type",
+            return_value=AscendDeviceType.A5,
+        ),
+        mock.patch("vllm_ascend.platform.enable_sp", return_value=False),
+        pytest.raises(NotImplementedError, match="not supported on A5"),
+    ):
+        NPUPlatform.check_and_update_config(vllm_config)

--- a/tests/ut/test_a5_platform_guards.py
+++ b/tests/ut/test_a5_platform_guards.py
@@ -1,0 +1,90 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Guards for A5 (Ascend 950) platform-level safety behavior.
+
+A5 HDK has an ACL graph capture-size incompatibility (see the TODO in
+``vllm_ascend/platform.py``) and does not support SFA DCP with sparse C8 yet.
+Both guards live in ``vllm_ascend/platform.py`` and are A5-only; because there
+is no A5 CI runner yet, removing them during refactoring would let A5
+regressions slip through silently. These CPU tests pin both behaviors.
+
+Recent A5 regressions (e.g. prefix-cache perf fluctuation #11113) show exactly
+the class of issues these guards exist to prevent.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from vllm_ascend.platform import MAX_CAPTURE_SIZES_FOR_950, prune_capture_sizes_for_950
+
+
+@pytest.mark.parametrize(
+    "capture_sizes, should_prune",
+    [
+        # Already within the A5 limit -> no-op.
+        ([1, 2, 4], False),
+        # Over the limit -> sampled down to MAX_CAPTURE_SIZES_FOR_950.
+        ([1, 2, 4, 8, 16, 32, 64, 128], True),
+    ],
+)
+def test_prune_capture_sizes_for_950_behavior(capture_sizes, should_prune):
+    """On A5, capture sizes are pruned to MAX_CAPTURE_SIZES_FOR_950.
+
+    The pruned list must keep the first and last capture sizes (so the
+    smallest and largest batch sizes are still captured) and stay within the
+    A5 HDK limit. When already within the limit, the function must be a
+    no-op and must not touch the config.
+    """
+    cfg = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_capture_sizes=list(capture_sizes))
+    )
+    captured = {}
+
+    def fake_update(vllm_config, new_sizes):
+        captured["sizes"] = list(new_sizes)
+
+    with mock.patch(
+        "vllm_ascend.platform.update_cudagraph_capture_sizes",
+        side_effect=fake_update,
+    ) as mocked_update:
+        prune_capture_sizes_for_950(cfg)
+
+    if should_prune:
+        mocked_update.assert_called_once()
+        pruned = captured["sizes"]
+        assert len(pruned) == MAX_CAPTURE_SIZES_FOR_950
+        assert pruned[0] == capture_sizes[0]
+        assert pruned[-1] == capture_sizes[-1]
+        # Every sampled size must come from the original list.
+        assert all(size in capture_sizes for size in pruned)
+    else:
+        mocked_update.assert_not_called()
+
+
+def test_a5_platform_safety_guards_present():
+    """Drift guard: the A5-only platform safety checks must stay in place.
+
+    ``prune_capture_sizes_for_950`` is called only on the A5 branch, and the
+    SFA-DCP sparse-C8 path raises ``NotImplementedError`` on A5. Removing
+    either would silently enable an unsupported A5 path. This source-level
+    assertion fails fast if the guards are refactored away.
+    """
+    src = Path("vllm_ascend/platform.py").read_text(encoding="utf-8")
+    assert "prune_capture_sizes_for_950" in src
+    assert "AscendDeviceType.A5" in src
+    assert "not supported on A5" in src


### PR DESCRIPTION
## What this PR does / why we need it?

Two A5-only platform safety guards live in `vllm_ascend/platform.py`, but because there is **no A5 CI runner yet**, removing them during refactoring would let A5 regressions slip through silently:

- `prune_capture_sizes_for_950` — A5 HDK has an ACL graph capture-size incompatibility; capture sizes are pruned to `MAX_CAPTURE_SIZES_FOR_950 = 4` (see the TODO in `platform.py`).
- The SFA-DCP sparse-C8 path raises `NotImplementedError` on A5 (A5 uses a fused CKV quant sparse attention path that needs a separate DCP LSE merge).

Recent A5 regressions (e.g. prefix-cache performance fluctuation #11113) are exactly the class of issues these guards exist to prevent.

This PR adds two CPU tests (run on every PR via `default_cpu_ut`):

1. `test_prune_capture_sizes_for_950_behavior` — verifies pruning samples down to `MAX_CAPTURE_SIZES_FOR_950`, **preserves the first/last capture sizes**, and is a **no-op** when already within the limit.
2. `test_a5_platform_safety_guards_present` — source-level drift guard asserting the A5 pruning call-site and the SFA-DCP `not supported on A5` raise remain in place.

## Does this PR introduce _any_ user-facing change?

No. Test-only change.

## How was this patch tested?

- New CPU UT: `pytest -sv tests/ut/test_a5_platform_guards.py`.
- Auto-collected by the always-on `default_cpu_ut` module — no `test_config.yaml` change needed.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
