### PR TITLE
[CI][BugFix][MRV2] Fix logprobs signature for MRV2

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -41,7 +41,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.skipif(True, reason="Fix me, it's broken after CANN and trition-ascend are upgraded.")
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [True])
@@ -61,6 +60,9 @@ def test_qwen3_dense_eager_mode(
     sampling_params = SamplingParams(
         max_tokens=max_tokens,
         temperature=0.5,
+        top_p=0.95,
+        top_k=10,
+        repetition_penalty=1.03,
         logprobs=2,
         prompt_logprobs=2,
         logit_bias={0: -1.0, 1: 0.5},
@@ -73,7 +75,7 @@ def test_qwen3_dense_eager_mode(
         enforce_eager=enforce_eager,
         async_scheduling=True,
     ) as runner:
-        runner.model.generate(prompts, sampling_params)
+        runner.generate(prompts, sampling_params)
 
 
 @pytest.mark.parametrize("model", MAIN_MODELS)

--- a/vllm_ascend/worker/v2/sample/logprob.py
+++ b/vllm_ascend/worker/v2/sample/logprob.py
@@ -18,6 +18,7 @@
 # This file is a part of the vllm-ascend project.
 
 import torch
+from vllm.logger import logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
 
@@ -120,18 +121,22 @@ def compute_topk_logprobs(
     num_logprobs: int,
     sampled_token_ids: torch.Tensor,
     cu_num_logits: list[int] | None = None,
+    logprob_token_ids_state=None,
+    expanded_idx_mapping: torch.Tensor | None = None,
+    max_per_req_token_ids: int = 0,
 ) -> LogprobsTensors:
     assert num_logprobs >= 0
     batch_size, vocab_size = logits.shape
+
+    if max_per_req_token_ids != 0:
+        logger.warning_once("Custom logprob_token_ids is not supported yet. Falling back to default logprob_token_ids.")
+
     logprob_token_ids = sampled_token_ids.unsqueeze(-1)
     if num_logprobs > 0:
         topk_indices = torch.topk(logits, num_logprobs, dim=-1).indices
-        logprob_token_ids = torch.cat((sampled_token_ids.unsqueeze(-1), topk_indices), dim=1)
-
-    # NOTE(woosuk): Here, to save GPU memory, we do not materialize the full
-    # logprobs tensor. Instead, we only compute and return the logprobs of
-    # the topk + 1 tokens.
+        logprob_token_ids = torch.cat((logprob_token_ids, topk_indices), dim=1)
     logprobs = compute_token_logprobs(logits, logprob_token_ids)
+
     token_ranks = torch.empty(
         batch_size,
         dtype=torch.int64,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes the `compute_topk_logprobs` signature in the Ascend MRV2 (Model Runner V2) implementation to match the updated vLLM v1 interface.  Additionally, it re-enables the end-to-end test for Qwen3 dense eager mode.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Tested via the re-enabled end-to-end test `test_qwen3_dense_eager_mode` in `tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py`.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
