### PR TITLE
[Performance][Ops][Feature]optimize slot mapping kernel:

### DIFF
--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -172,6 +172,69 @@ class TestBlockTableComputeSlotMapping(TestBase):
                     f"dcp_rank={dcp_rank}, pcp_rank={pcp_rank}",
                 )
 
+    def _run_slot_mapping_kernel_launch_case(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+        max_num_batched_tokens: int,
+        expected_pad_blocks: int,
+    ):
+        old_max_num_batched_tokens = self.max_num_batched_tokens
+        self.max_num_batched_tokens = max_num_batched_tokens
+        try:
+            block_table = self.create_block_table(
+                dcp_world_size=1,
+                dcp_rank=0,
+                pcp_world_size=1,
+                pcp_rank=0,
+                cp_kv_cache_interleave_size=1,
+            )
+        finally:
+            self.max_num_batched_tokens = old_max_num_batched_tokens
+
+        self.setup_block_table_data(block_table, num_reqs=num_reqs)
+        counts = np.full(num_reqs, num_tokens // num_reqs, dtype=np.int32)
+        counts[: num_tokens % num_reqs] += 1
+        query_start_loc = torch.from_numpy(np.concatenate([[0], np.cumsum(counts)]).astype(np.int32))
+        positions = torch.arange(num_tokens, dtype=torch.int64)
+
+        from vllm_ascend.worker import block_table as block_table_module
+
+        kernel_mock = MagicMock()
+        launcher_mock = MagicMock()
+        kernel_mock.__getitem__.return_value = launcher_mock
+        with patch.object(block_table_module, "_compute_slot_mapping_kernel", kernel_mock):
+            block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
+
+        kernel_mock.__getitem__.assert_called_once_with((num_reqs + expected_pad_blocks,))
+        launcher_mock.assert_called_once()
+        args, kwargs = launcher_mock.call_args
+        self.assertEqual(args[0], num_tokens)
+        self.assertEqual(args[1], max_num_batched_tokens)
+        self.assertEqual(args[2], num_reqs)
+        self.assertEqual(kwargs["BLOCK_SIZE"], 1024)
+        self.assertEqual(kwargs["BLOCK_TABLE_WINDOW_SIZE"], 16)
+        self.assertEqual(kwargs["KV_CACHE_BLOCK_SIZE"], self.block_size)
+        self.assertEqual(kwargs["BLOCKS_PER_KV_BLOCK"], 1)
+
+    def test_compute_slot_mapping_small_num_tokens_large_max_num_batched_tokens_launch_grid(self):
+        """Small active token count should split padding across programs."""
+        self._run_slot_mapping_kernel_launch_case(
+            num_reqs=2,
+            num_tokens=3,
+            max_num_batched_tokens=4096,
+            expected_pad_blocks=4,
+        )
+
+    def test_compute_slot_mapping_normal_num_tokens_normal_max_num_batched_tokens_launch_grid(self):
+        """No padding programs are needed when active tokens fill the graph size."""
+        self._run_slot_mapping_kernel_launch_case(
+            num_reqs=2,
+            num_tokens=512,
+            max_num_batched_tokens=512,
+            expected_pad_blocks=0,
+        )
+
     def test_compute_slot_mapping_dcp1_pcp1_interleave1(self):
         """Test compute_slot_mapping with DCP=1, PCP=1, interleave_size=1
 

--- a/vllm_ascend/ops/triton/compute_slot_mapping.py
+++ b/vllm_ascend/ops/triton/compute_slot_mapping.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from vllm.triton_utils import tl, triton
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+@triton.jit(do_not_specialize=["num_tokens", "max_num_tokens"])
+def _compute_slot_mapping_kernel(
+    num_tokens,
+    max_num_tokens,
+    num_reqs,
+    query_start_loc_ptr,  # [num_reqs + 1], int32
+    positions_ptr,  # [num_tokens], int64
+    block_table_ptr,  # [max_num_reqs, max_num_blocks_per_req], int32
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,  # [max_num_tokens], int32
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx >= num_reqs:
+        # Pad remaining slots for CUDA graph compatibility. Use one program per
+        # BLOCK_SIZE tile instead of making a single program sweep the tail.
+        pad_block_idx = req_idx - num_reqs
+        offsets = num_tokens + pad_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        tl.store(slot_mapping_ptr + offsets, PAD_ID, mask=offsets < max_num_tokens)
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1)
+    row_offset = req_idx * block_table_stride
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+    virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        positions = tl.load(positions_ptr + offsets, mask=mask, other=0).to(tl.int32)
+
+        virtual_block_indices = positions // virtual_block_size
+        virtual_block_offsets = positions - virtual_block_size * virtual_block_indices
+
+        if TOTAL_CP_WORLD_SIZE == 1:
+            is_local = mask
+            local_block_offsets = virtual_block_offsets
+        else:
+            interleave_chunks = virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+            rank_in_chunk = interleave_chunks - TOTAL_CP_WORLD_SIZE * (interleave_chunks // TOTAL_CP_WORLD_SIZE)
+            is_local = rank_in_chunk == TOTAL_CP_RANK
+            rounds = virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+            remainder_base = virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+            remainder = virtual_block_offsets - CP_KV_CACHE_INTERLEAVE_SIZE * remainder_base
+            local_block_offsets = rounds * CP_KV_CACHE_INTERLEAVE_SIZE + remainder
+
+        local_block_indices = local_block_offsets // block_size
+        block_indices = virtual_block_indices * BLOCKS_PER_KV_BLOCK + local_block_indices
+
+        # Non-contiguous block_table loads degrade to scalar on Ascend. Positions
+        # are grouped by request, so a token tile only spans a small block window.
+        valid_block_indices = tl.where(mask, block_indices, 2147483647)
+        block_idx_base = tl.min(valid_block_indices, axis=0)
+        block_table_window_offsets = block_idx_base + block_table_offsets
+        block_table_window = tl.load(
+            block_table_ptr + row_offset + block_table_window_offsets,
+            mask=block_table_window_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
+        relative_block_indices = tl.where(mask & is_local, block_indices - block_idx_base, 0)
+        block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
+
+        slot_offsets = local_block_offsets - block_size * local_block_indices
+        slot_ids = block_numbers * block_size + slot_offsets
+        slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -5,10 +5,12 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec, MambaSpec, UniformTypeKVCacheSpecs
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.block_table import _compute_slot_mapping_kernel
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
-from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.ops.triton.compute_slot_mapping import (
+    _compute_slot_mapping_kernel,
+    _next_power_of_2,
+)
 
 
 class BlockTable:
@@ -161,23 +163,22 @@ class BlockTable:
             self._compute_pcp_dcp_slot_mapping(req_indices, positions)
         else:
             kernel_kwargs = {
+                "KV_CACHE_BLOCK_SIZE": self.physical_block_size,
+                "BLOCKS_PER_KV_BLOCK": self.blocks_per_phys_block,
                 "TOTAL_CP_WORLD_SIZE": total_cp_world_size,
                 "TOTAL_CP_RANK": total_cp_rank,
                 "CP_KV_CACHE_INTERLEAVE_SIZE": self.cp_kv_cache_interleave_size,
                 "PAD_ID": PAD_SLOT_ID,
                 "BLOCK_SIZE": 1024,
+                "BLOCK_TABLE_WINDOW_SIZE": _next_power_of_2(cdiv(1024, self.block_size) + 1),
             }
-            if not vllm_version_is("0.25.1"):
-                # vLLM #40996 split physical KV blocks into kernel blocks in
-                # the slot-mapping kernel. These are required constexprs on
-                # main; the v0.25.1 kernel does not accept them.
-                kernel_kwargs.update(
-                    KV_CACHE_BLOCK_SIZE=self.physical_block_size,
-                    BLOCKS_PER_KV_BLOCK=self.blocks_per_phys_block,
-                )
-            _compute_slot_mapping_kernel[(num_reqs + 1,)](
+
+            num_pad_tokens = max(self.max_num_batched_tokens - num_tokens, 0)
+            num_pad_blocks = cdiv(num_pad_tokens, 1024)
+            _compute_slot_mapping_kernel[(num_reqs + num_pad_blocks,)](
                 num_tokens,
                 self.max_num_batched_tokens,
+                num_reqs,
                 query_start_loc,
                 positions,
                 self.block_table.gpu,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR optimizes the Ascend slot mapping Triton kernel in the v1 block table path.

The previous path reused the generic upstream vLLM `_compute_slot_mapping_kernel`, which can generate excessive scalar computation on Ascend NPUs due to int64 arithmetic, modulo operations, and non-contiguous block table loads. It also used one final program to serially fill the padded slot mapping range, which is inefficient when `num_tokens` is much smaller than `max_num_tokens`.

This PR adds a local Ascend-optimized `_compute_slot_mapping_kernel` with the following improvements:

- use int32 arithmetic in the hot path;
- rewrite modulo operations with div/mul/sub expressions;
- replace non-contiguous block table loads with bounded contiguous window loads plus `tl.gather`;
- bound the block table window by the current token tile instead of the full block table row;
- preserve physical KV block to kernel block mapping with `KV_CACHE_BLOCK_SIZE` and `BLOCKS_PER_KV_BLOCK`;
- parallelize padding by launching one padding program per `BLOCK_SIZE` tile instead of using a single trailing program.

This reduces scalar computation and avoids a single-core padding bottleneck for cases where `num_tokens << max_num_tokens`.

Performacne
|cases | shape | time before opt  | time after opt| gains|
| ------ | ------ | ------ |--------| -------- |
| case1 | num_tokens=4,num_reqs=2,CP=1,max_num_batched_tokens=8192 | 173.19us | 3.071us | 5639.5% |
| case2 | num_tokens=32\*256,num_reqs=256,CP=1,max_num_batched_tokens=32\*256 | 1056.497us | 21.155us | 4994.1% |

### Does this PR introduce _any_ user-facing change?
No. This is an internal performance optimization for Ascend slot mapping.

### How was this patch tested?
Tested with new unit tests in `tests/ut/worker/a2/test_block_table.py` verifying the kernel launch grid with different numbers of tokens and requests.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
