### PR TITLE
support dsv4 mxfp eplb

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1027,11 +1027,14 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
         # W4A8 mxfp
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
+            # weight/scale may be a per-expert list (EPLB 单多单) or a single packed tensor (单单单).
+            weight_arg = weight if isinstance(weight, list) else [weight]
+            scale_arg = weight_scale if isinstance(weight_scale, list) else [weight_scale]
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[x],
-                weight=[weight],
+                weight=weight_arg,
                 scale=None,
-                antiquant_scale=[weight_scale],
+                antiquant_scale=scale_arg,
                 scale_dtype=None,
                 per_token_scale=[x_scale],
                 per_token_scale_dtype=torch.float8_e8m0fnu,
@@ -1170,10 +1173,13 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
         output_dtype = gmm2_kwargs.pop("output_dtype")
 
-        if isinstance(weight, list) and len(weight) != 1:
-            raise ValueError(f"w2 must have a single tensor in MXFP path, but got {len(weight)}.")
-        if isinstance(weight_scale, list) and len(weight_scale) != 1:
-            raise ValueError(f"w2_scale must have a single tensor in MXFP path, but got {len(weight_scale)}.")
+        # W4A8MXFP supports a per-expert weight list (EPLB 单多单); other MXFP paths require a
+        # single tensor.
+        if mxfp_quant_dtype != QuantType.W4A8MXFP:
+            if isinstance(weight, list) and len(weight) != 1:
+                raise ValueError(f"w2 must have a single tensor in MXFP path, but got {len(weight)}.")
+            if isinstance(weight_scale, list) and len(weight_scale) != 1:
+                raise ValueError(f"w2_scale must have a single tensor in MXFP path, but got {len(weight_scale)}.")
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
@@ -1192,7 +1198,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
             gmm2_scale = None  # type: ignore[assignment]
-            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
+            gmm2_kwargs.update({"antiquant_scale": weight_scale if isinstance(weight_scale, list) else [weight_scale]})
 
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1027,7 +1027,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
         # W4A8 mxfp
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            # weight/scale may be a per-expert list (EPLB 单多单) or a single packed tensor (单单单).
+            # weight/scale may be a per-expert list or a single packed tensor .
             weight_arg = weight if isinstance(weight, list) else [weight]
             scale_arg = weight_scale if isinstance(weight_scale, list) else [weight_scale]
             hidden_states = torch_npu.npu_grouped_matmul(
@@ -1173,7 +1173,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
         output_dtype = gmm2_kwargs.pop("output_dtype")
 
-        # W4A8MXFP supports a per-expert weight list (EPLB 单多单); other MXFP paths require a
+        # W4A8MXFP supports a per-expert weight list; other MXFP paths require a
         # single tensor.
         if mxfp_quant_dtype != QuantType.W4A8MXFP:
             if isinstance(weight, list) and len(weight) != 1:

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+import torch_npu
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -54,7 +55,30 @@ EPLB_EXPERT_WEIGHT_NAMES = {
     (QuantType.MXFP4, True): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
     (QuantType.MXFP8, False): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
     (QuantType.MXFP8, True): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
+    (QuantType.W4A8MXFP, False): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_list",
+        "w2_weight_scale_list",
+    ),
+    (QuantType.W4A8MXFP, True): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_list",
+        "w2_weight_scale_list",
+    ),
 }
+
+# W4A8MXFP expert weights are FRACTAL_NZ (mxfp C0_16). batch_isend_irecv carries the standalone
+# offset-0 NZ block directly, so their receive buffer must be a matching NZ tensor built with this
+# (customize_dtype, input_dtype) pair (torch.empty_like on NZ falls back to ND). Only the weight
+# lists are NZ; the scale lists stay ND.
+ACL_FORMAT_FRACTAL_NZ = 29
+_W4A8MXFP_NZ_CAST_KWARGS = {
+    "customize_dtype": torch.float8_e4m3fn,
+    "input_dtype": torch_npu.float4_e2m1fn_x2,
+}
+_W4A8MXFP_NZ_WEIGHT_NAMES = {"w13_weight_list", "w2_weight_list"}
 
 
 class VllmEplbAdaptor:
@@ -118,9 +142,15 @@ class VllmEplbAdaptor:
                 continue
             buffer_tensor_shapes[expert_weight_key] = expert_tensor_shapes
             self.buffer_tensor_list[expert_weight_key] = [[] for _ in range(num_buffer_tensor)]
+            quant_type = expert_weight_key[0]
             for buffer_id in range(num_buffer_tensor):
-                for expert_tensor in expert_tensors:
-                    buffer_tensor = torch.empty_like(expert_tensor)
+                for name, expert_tensor in zip(expert_weight_names, expert_tensors):
+                    if quant_type == QuantType.W4A8MXFP and name in _W4A8MXFP_NZ_WEIGHT_NAMES:
+                        # NZ weight is transferred as-is; build a matching C0_16 NZ receive buffer.
+                        nd = torch.empty(expert_tensor.shape, dtype=expert_tensor.dtype, device=expert_tensor.device)
+                        buffer_tensor = torch_npu.npu_format_cast(nd, ACL_FORMAT_FRACTAL_NZ, **_W4A8MXFP_NZ_CAST_KWARGS)
+                    else:
+                        buffer_tensor = torch.empty_like(expert_tensor)
                     self.buffer_tensor_list[expert_weight_key][buffer_id].append(buffer_tensor)
 
     def init_expert_param_per_layer(self):

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -164,12 +164,19 @@ def quant_apply_mlp(
                 swiglu_limit=swiglu_limit,
             )
         elif use_gmm_swiglu_quant_fusion:
+            # With EPLB, mxfp weights are a per-expert list fed to the 单多单 matmul; otherwise a
+            # single packed tensor is required.
+            mxfp_expert_list = use_mxfp_quant and dynamic_eplb
+            w1_arg = w1 if mxfp_expert_list else _require_single_tensor_for_swiglu_quant(w1, name="w1")
+            w1_scale_arg = (
+                w1_scale if mxfp_expert_list else _require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale")
+            )
             # gmm1: gate_up_proj & act_fn: swiglu
             hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
-                weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
+                weight=w1_arg,
                 group_list=cumsum_group_list(group_list, group_list_type, 0),
-                weight_scale=_require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale"),
+                weight_scale=w1_scale_arg,
                 x_scale=pertoken_scale,
                 bias=None,
                 use_mxfp_quant=use_mxfp_quant,
@@ -293,11 +300,18 @@ def quant_apply_mlp(
                 swiglu_limit=swiglu_limit,
             )
         elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP:
+            # With EPLB, mxfp weights are a per-expert list fed to the 单多单 matmul; otherwise a
+            # single packed tensor is required.
+            mxfp_expert_list = use_mxfp_quant and dynamic_eplb
+            w1_arg = w1 if mxfp_expert_list else _require_single_tensor_for_swiglu_quant(w1, name="w1")
+            w1_scale_arg = (
+                w1_scale if mxfp_expert_list else _require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale")
+            )
             hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
                 x=hidden_states,
-                weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
+                weight=w1_arg,
                 group_list=cumsum_group_list(group_list, group_list_type, 0),
-                weight_scale=_require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale"),
+                weight_scale=w1_scale_arg,
                 x_scale=pertoken_scale,
                 bias=bias1,
                 use_mxfp_quant=use_mxfp_quant,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -164,7 +164,7 @@ def quant_apply_mlp(
                 swiglu_limit=swiglu_limit,
             )
         elif use_gmm_swiglu_quant_fusion:
-            # With EPLB, mxfp weights are a per-expert list fed to the 单多单 matmul; otherwise a
+            # With EPLB, mxfp weights are a per-expert list fed to the single-multi-single matmul; otherwise a
             # single packed tensor is required.
             mxfp_expert_list = use_mxfp_quant and dynamic_eplb
             w1_arg = w1 if mxfp_expert_list else _require_single_tensor_for_swiglu_quant(w1, name="w1")
@@ -300,7 +300,7 @@ def quant_apply_mlp(
                 swiglu_limit=swiglu_limit,
             )
         elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP:
-            # With EPLB, mxfp weights are a per-expert list fed to the 单多单 matmul; otherwise a
+            # With EPLB, mxfp weights are a per-expert list fed to the single-multi-single matmul; otherwise a
             # single packed tensor is required.
             mxfp_expert_list = use_mxfp_quant and dynamic_eplb
             w1_arg = w1 if mxfp_expert_list else _require_single_tensor_for_swiglu_quant(w1, name="w1")

--- a/vllm_ascend/quantization/methods/fp8.py
+++ b/vllm_ascend/quantization/methods/fp8.py
@@ -105,7 +105,44 @@ class AscendW4A8MXFPDSDynamicFusedMoEMethod(AscendW4A8MXFPDynamicFusedMoEMethod)
         )
         return param_dict
 
+    @staticmethod
+    def _cast_weight_nz(nd_2d):
+        # nd_2d: an offset-0, contiguous ND uint8 expert weight (N, K). Cast to FRACTAL_NZ (mxfp
+        # C0_16) and keep the contiguous (N, K) layout -- apply() transposes it to (K, N) for the
+        # matmul, and EPLB transfers the contiguous block directly. Cloning to offset 0 is
+        # required because npu_format_cast mishandles a sliced (storage_offset != 0) input.
+        return torch_npu.npu_format_cast(
+            nd_2d, 29, customize_dtype=torch.float8_e4m3fn, input_dtype=torch_npu.float4_e2m1fn_x2
+        )
+
+    @staticmethod
+    def _process_scale_2d(scale_2d):
+        # scale_2d: (N, K_scale) e8m0 -> (K_scale/2, N, 2) uint8, matching the packed processing.
+        n, k = scale_2d.shape
+        return scale_2d.reshape(n, k // 2, 2).view(torch.uint8).transpose(-3, -2)
+
+    def _build_expert_lists(self, layer):
+        # EPLB List[Tensor] path: each expert is an INDEPENDENT tensor. The matmul accepts a
+        # per-expert NZ weight list only when each element is a standalone 4D-NZ tensor (a slice
+        # of the packed 3D-NZ keeps the packed 5D descriptor and is rejected), so build each
+        # expert from an offset-0 ND clone (see _cast_weight_nz).
+        num_experts = layer.w13_weight.shape[0]
+        w13_nd = layer.w13_weight.data.view(torch.uint8)
+        w2_nd = layer.w2_weight.data.view(torch.uint8)
+        layer.w13_weight_list = [self._cast_weight_nz(w13_nd[e].clone()) for e in range(num_experts)]
+        layer.w2_weight_list = [self._cast_weight_nz(w2_nd[e].clone()) for e in range(num_experts)]
+        layer.w13_weight_scale_list = [
+            self._process_scale_2d(layer.w13_weight_scale.data[e].clone()) for e in range(num_experts)
+        ]
+        layer.w2_weight_scale_list = [
+            self._process_scale_2d(layer.w2_weight_scale.data[e].clone()) for e in range(num_experts)
+        ]
+        del layer.w13_weight, layer.w2_weight, layer.w13_weight_scale, layer.w2_weight_scale
+
     def process_weights_after_loading(self, layer):
+        if self.dynamic_eplb:
+            self._build_expert_lists(layer)
+            return
         layer.w13_weight.data = torch_npu.npu_format_cast(
             layer.w13_weight.data.view(torch.uint8),
             29,

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -201,14 +201,25 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
 
         topk_weights = topk_weights.to(x.dtype)
 
+        if self.dynamic_eplb:
+            # EPLB stores each expert as an independent (N, K) NZ tensor; transpose to (K, N) for
+            # the 单多单 (single-x, multi-weight, single-out) matmul (fp8-fp4 needs a transposed
+            # weight). The transpose is a view, so the stored tensors stay contiguous for EPLB.
+            w1 = [w.transpose(0, 1) for w in layer.w13_weight_list]
+            w2 = [w.transpose(0, 1) for w in layer.w2_weight_list]
+            w1_scale, w2_scale = layer.w13_weight_scale_list, layer.w2_weight_scale_list
+        else:
+            w1, w2 = layer.w13_weight, layer.w2_weight
+            w1_scale, w2_scale = layer.w13_weight_scale, layer.w2_weight_scale
+
         moe_comm_method = get_forward_context().moe_comm_method
         return moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(
                 hidden_states=x,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
+                w1=w1,
+                w2=w2,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
                 expert_map=expert_map,
@@ -223,8 +234,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
                 mxfp_per_token_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
                 mxfp_use_bf16=(x.dtype == torch.bfloat16),
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
                 swiglu_limit=layer.swiglu_limit,
             )
         )

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -203,7 +203,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
 
         if self.dynamic_eplb:
             # EPLB stores each expert as an independent (N, K) NZ tensor; transpose to (K, N) for
-            # the 单多单 (single-x, multi-weight, single-out) matmul (fp8-fp4 needs a transposed
+            # the single-multi-single (single-x, multi-weight, single-out) matmul (fp8-fp4 needs a transposed
             # weight). The transpose is a view, so the stored tensors stay contiguous for EPLB.
             w1 = [w.transpose(0, 1) for w in layer.w13_weight_list]
             w2 = [w.transpose(0, 1) for w in layer.w2_weight_list]


### PR DESCRIPTION
### What this PR does / why we need it?

增加在A5上对Dsv4 mxfp4 MoE的EPLB负载均衡能力。

### Does this PR introduce _any_ user-facing change?

1. 需要修改npu_native_functions.yaml文件，配置copy_接口的internal_format_opai选项，编译PTA，使copy_接口支持NZ数据格式；
2. 确认使用ops-transformer主线，GMM支持Weight传入多Tensor的List。

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
