### PR TITLE
[BugFix][CI] Add E2E for kv sliding window; fix block size input bug

### DIFF
--- a/tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py
+++ b/tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py
@@ -427,3 +427,87 @@ def test_qwen3_vwn_eagle3_tp2():
         print(f"golden: {golden}")
 
     assert match
+
+
+def test_eagle3_sliding_window():
+    method = "eagle3"
+    num_speculative_tokens = 3
+    draft_window_size = 512
+
+    main_model_name = MODELS[method]["main"]
+    spec_model_name = MODELS[method]["spec"]
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        main_model_name,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=32,
+    )
+
+    # Build a prompt that exceeds draft_window_size (512) tokens so the
+    # sliding window actually crops the draft's attention.
+    filler = "This is a padding sentence for testing sliding window draft attention. " * 80
+    long_prompt = {
+        "role": "user",
+        "content": filler + " What is 2+2?",
+    }
+    prompt_text = tokenizer.apply_chat_template(
+        [long_prompt],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    prompt_tokens = tokenizer(prompt_text, return_tensors="pt")["input_ids"].shape[1]
+    assert prompt_tokens > draft_window_size, (
+        f"Prompt ({prompt_tokens} tokens) must exceed draft_window_size ({draft_window_size})"
+    )
+
+    speculative_config = {
+        "method": method,
+        "num_speculative_tokens": num_speculative_tokens,
+        "model": spec_model_name,
+    }
+    additional_config = {"draft_window_size": draft_window_size}
+
+    with VllmRunner(
+        main_model_name,
+        enforce_eager=True,
+        max_model_len=4096,
+        disable_log_stats=False,
+        tensor_parallel_size=2,
+        max_num_seqs=16,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.7,
+        speculative_config=speculative_config,
+        additional_config=additional_config,
+    ) as llm:
+        outputs = llm.model.generate([prompt_text], sampling_params)
+        metrics = llm.model.get_metrics()
+
+    # The model must not crash and must produce output.
+    assert len(outputs) == 1
+    assert len(outputs[0].outputs[0].token_ids) > 0
+    print(f"Generated: {outputs[0].outputs[0].text!r}")
+
+    # Sliding window should still give non-zero acceptance.
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * num_speculative_tokens
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [n / num_drafts for n in num_accepted_tokens_per_pos]
+    golden = [0.7, 0.4, 0.3]
+    match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
+    if not match:
+        print(f"acceptance_per_pos: {acceptance_per_pos}")
+        print(f"golden: {golden}")
+
+    assert match

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -275,30 +275,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_arange_np = np.arange(self.max_num_tokens + 1, dtype=np.int32)
         self.enable_enpu = self.runner.enable_enpu
         self.use_eagle = self.runner.use_eagle
-        # Sliding window attention for draft model
-        self.draft_window_size = getattr(self.speculative_config, "draft_window_size", None)
-        if self.draft_window_size is None and self.vllm_config.additional_config:
-            self.draft_window_size = self.vllm_config.additional_config.get("draft_window_size")
-        else:
-            self.draft_window_size = None
-
-        # Sliding-window draft attention adapter. Reuse ``self.draft_window_size``
-        # resolved above (speculative_config -> additional_config -> None, all
-        # None-guarded). Do NOT re-read additional_config here: it is None in the
-        # proposers used by unit tests, and the unguarded ``.get()`` would crash.
-        if self.draft_window_size is not None:
-            # EAGLE3: seq_lens at apply time is context-only, so the window end
-            # must cover the K draft positions beyond it -> future_offset = K.
-            # DFlash: set_inputs_first_pass already bakes the query stretch
-            # (bonus + mask) into seq_lens -> future_offset = 0.
-            future_offset = 0 if self.method == "dflash" else self.num_speculative_tokens
-            self.sliding_window = SlidingWindowAdapter(
-                self.draft_window_size,
-                self.runner.block_size,
-                self.runner.max_num_reqs,
-                future_offset,
-                self.device,
-            )
+        self.draft_window_size = None
+        self.sliding_window = None
 
     def _raise_if_padded_drafter_batch_disabled_and_full_graph_enabled(self):
         if (
@@ -362,6 +340,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.kernel_block_size = (
             draft_attn_layers_dict[self.attn_layer_names[0]].get_attn_backend().get_supported_kernel_block_sizes()[0]
         )
+
+        # Sliding-window draft attention adapter.
+        self.draft_window_size = (
+            self.vllm_config.additional_config.get("draft_window_size") if self.vllm_config.additional_config else None
+        )
+        if self.draft_window_size is not None:
+            # EAGLE3: seq_lens is context-only, K draft positions lie beyond it
+            #   -> future_offset = K.
+            # DFlash: set_inputs_first_pass bakes the query stretch into seq_lens
+            #   -> future_offset = 0.
+            future_offset = 0 if self.method == "dflash" else self.num_speculative_tokens
+            self.sliding_window = SlidingWindowAdapter(
+                self.draft_window_size,
+                self.kernel_block_size,
+                self.runner.max_num_reqs,
+                future_offset,
+                self.device,
+            )
 
         self.piece_all_attn_layer_name = []
         for _ in range(self.num_speculative_tokens):
@@ -894,8 +890,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
 
         if self.draft_window_size is not None:
-            # Save original seq_lens and apply sliding window before any CP adjustments.
-            # Guarded so the clone is skipped when the window is disabled.
             self.sliding_window.apply(common_attn_metadata)
 
         if self.supports_mm_inputs:


### PR DESCRIPTION
…for qwen3.6 when applying sliding window

### What this PR does / why we need it?

1. Fix KV sliding window's block size initialization error for Hybrid Attention Model like Qwen3.6;
2. Add a 2-card E2E test for kv sliding window draft

The testing results for Qwen3.6-35B-A3B and DFlash with sliding window are as following:
> dflash: num_spec_tokens=7

---
**Average Acceptance Length**

| case | 32K | 64K | 128K | LongBench |
|---|---|---|---|---|
| dflash baseline | 1.11 | 1.05 | 1.05 | 1.51 |
| **dflash win 2048** | **4.49** | **4.23** | **4.46** | **3.98** |
| **dflash win 4096** | **4.81** | **4.72** | **4.66** | **4.12** |

---

**Output Throughput Gain**

| case | 32K | 64K | 128K | LongBench |
|---|---|---|---|---|
| dflash baseline | 266.3 | 214.4 | 115.7 | 271.2 |
| **dflash win 2048** | **572.6 ( ×2.15)** | **407.2 ( ×1.90)** | **198.2 (×1.71)** | **482.2 (×1.78)** |
| **dflash win 4096** | **569.7 (×2.14)** | **441.1 (×2.06)** | **197.8 (×1.71)** | **503.3 (×1.86)** |

---
**The testing results show significant performance gain for dflash's acceptance rate under long-context scenario** 

### Does this PR introduce _any_ user-facing change?

Nope

### How was this patch tested?
VLLM-Ascend: Main@ 63a194ef73d821d1b4b024d341383537a5030998
VLLM: v0.24.0


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
