### PR TITLE
[Doc][v0.23.0] Add constraints of num_speculative_tokens for PD separation

### DIFF
--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
@@ -247,6 +247,11 @@ Use `launch_online_dp.py` to launch external dp vllm servers.
 Modify `run_dp_template.sh` on each node.
 [run_dp_template.sh](https://github.com/vllm-project/vllm-ascend/blob/main/examples/external_online_dp/run_dp_template.sh)
 
+> **Note**: If speculative decoding is enabled, `num_speculative_tokens` should be subject to one of the following conditions:
+>
+> 1. Hybrid Mamba models (e.g., Qwen-Next and Qwen3.5 series): `num_speculative_tokens` should be equal on P nodes and D nodes.
+> 2. Other models: `num_speculative_tokens` on P nodes should be 1, and `num_speculative_tokens` on D nodes should be greater or equal to 1.
+
 #### Layerwise
 
 :::::{tab-set}

--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -29,6 +29,10 @@ All speculative decoding methods are configured through the `speculative_config`
 
 - **`method`** (str, required): The speculative decoding method. Must be one of the supported method names listed in the table above.
 - **`num_speculative_tokens`** (int, required): Number of speculative tokens to generate per forward pass. Auto-filled from the draft model's `n_predict` config (e.g., MTP) or `suffix_decoding_max_tree_depth` (suffix method) when available.
+    > **Note**: For PD Separation deployment, `num_speculative_tokens` should be subject to one of the following conditions:
+    >
+    > 1. Hybrid Mamba models (e.g., Qwen-Next and Qwen3.5 series): `num_speculative_tokens` should be equal on P nodes and D nodes.
+    > 2. Other models: `num_speculative_tokens` on P nodes should be 1, and `num_speculative_tokens` on D nodes should be greater or equal to 1.
 - **`model`** (str, optional): Path or HF repo ID for the draft model. Required for `eagle`, `eagle3`, `dflash`, `medusa`, and `draft_model`. Automatically resolved for `mtp` (reuses target model), `ngram`, `suffix`, and `extract_hidden_states`.
 - **`draft_tensor_parallel_size`** (int, optional): Tensor parallelism size for the draft model. Can only be `1` or the same as the target model's tensor parallel size.
 - **`disable_padded_drafter_batch`** (bool, default: `False`): Disable input padding for speculative decoding. If set to `True`, speculative input batches can contain sequences of different lengths, which may only be supported by certain attention backends. **Note:** Only effective with `eagle`, `eagle3`, `mtp`, `dflash`, `draft_model`, and `extract_hidden_states` methods.


### PR DESCRIPTION
Cherry-picked from https://github.com/vllm-project/vllm-ascend/pull/12104
### What this PR does / why we need it?
Add constraints for num_speculative_tokens when using PD Separation deployment.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
