### PR TITLE
[v0.23.0][CI][Misc] Update MiniMax-M2.5 test config: set environment variables and parameters, and adjust baselines

### DIFF
--- a/tests/e2e/weekly/single_node/configs/MiniMax-M2.5-w8a8-QuaRot-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/MiniMax-M2.5-w8a8-QuaRot-A3.yaml
@@ -9,12 +9,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -40,7 +36,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -53,7 +49,7 @@ test_cases:
         max_out_len: 1024
         batch_size: 30
         request_rate: 0
-        baseline: 548.06
+        baseline: 586.15
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in16k-16-4"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -61,13 +57,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM-ASCEND_ENABLE_NZ: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -93,7 +84,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -106,7 +97,7 @@ test_cases:
         max_out_len: 1024
         batch_size: 4
         request_rate: 0
-        baseline: 191.58
+        baseline: 202.68
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in32k-36-9"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -114,12 +105,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -145,7 +132,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -158,7 +145,7 @@ test_cases:
         max_out_len: 512
         batch_size: 9
         request_rate: 0
-        baseline: 146.06
+        baseline: 162.16
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in32k-80-20"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -166,12 +153,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -197,7 +180,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -210,7 +193,7 @@ test_cases:
         max_out_len: 512
         batch_size: 20
         request_rate: 0
-        baseline: 428.36
+        baseline: 444.84
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in32k-4-1"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -218,12 +201,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -249,7 +228,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -262,7 +241,7 @@ test_cases:
         max_out_len: 512
         batch_size: 1
         request_rate: 0
-        baseline: 35.17
+        baseline: 35.57
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in32k-4-1-90"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -270,12 +249,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -301,7 +276,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -322,12 +297,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -353,7 +324,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -366,7 +337,7 @@ test_cases:
         max_out_len: 1024
         batch_size: 18
         request_rate: 0
-        baseline: 321.37
+        baseline: 325.65
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in64k-4-1"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -374,12 +345,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -405,7 +372,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"method":"eagle3","model":"vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens":3}'
     benchmarks:
@@ -426,12 +393,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -461,7 +424,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"enforce_eager": true, "method": "eagle3", "model": "vllm-ascend/MiniMax-M2.5-eagle-model-0318", "num_speculative_tokens": 1}'
     benchmarks:
@@ -474,7 +437,7 @@ test_cases:
         max_out_len: 1024
         batch_size: 8
         request_rate: 0
-        baseline: 132.5
+        baseline: 172.94
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in128k-4-1"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -482,12 +445,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -517,7 +476,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true,"weight_nz_mode":1}'
       - "--speculative_config"
       - '{"enforce_eager": true, "method": "eagle3", "model": "vllm-ascend/MiniMax-M2.5-eagle-model-0318", "num_speculative_tokens": 1}'
     benchmarks:
@@ -530,7 +489,7 @@ test_cases:
         max_out_len: 1024
         batch_size: 1
         request_rate: 0
-        baseline: 24.66
+        baseline: 38.31
         threshold: 0.97
   - name: "MiniMax-M2.5-w8a8-in128k-64-16"
     model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
@@ -538,11 +497,8 @@ test_cases:
       HCCL_OP_EXPANSION_MODE: "AIV"
       HCCL_BUFFSIZE: "512"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-      VLLM_ASCEND_ENABLE__FUSED_MC2: "1"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM-ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_USE_MODELSCOPE: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -568,7 +524,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":1,"enable_flashcomm1":true,"enable_balance_scheduling":true}'
       - "--speculative_config"
       - '{"enforce_eager": true, "method": "eagle3", "model": "vllm-ascend/MiniMax-M2.5-eagle-model-0318", "num_speculative_tokens": 1}'
     benchmarks:
@@ -581,5 +537,5 @@ test_cases:
         max_out_len: 1024
         batch_size: 16
         request_rate: 0
-        baseline: 296.08
+        baseline: 259.45
         threshold: 0.97


### PR DESCRIPTION
### What this PR does / why we need it?
cherry-pick https://github.com/vllm-project/vllm-ascend/pull/11972

This PR updates the test configuration for `MiniMax-M2.5` in `tests/e2e/weekly/single_node/configs/MiniMax-M2.5-w8a8-QuaRot-A3.yaml`. It removes several environment variables (such as `VLLM_ASCEND_ENABLE__FUSED_MC2`, `VLLM_ASCEND_ENABLE_FLASHCOMM1`, `VLLM-ASCEND_BALANCE_SCHEDULING`, and `VLLM_ASCEND_ENABLE_NZ`) and instead passes them as parameters inside `--additional-config` (e.g., `enable_fused_mc2`, `enable_flashcomm1`, `enable_balance_scheduling`, and `weight_nz_mode`) and adjust baseline values for all test cases based on actual test results.

### Does this PR introduce _any_ user-facing change?

No, this PR only updates internal CI test configurations and does not introduce any user-facing changes.

### How was this patch tested?

Tested via CI with the updated weekly single-node E2E test configurations.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
