### PR TITLE
[v0.23.0][Doc] Update KV Pool backend installation guidance

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -14,7 +14,7 @@
     * CANN >= 8.5.0
     * vLLM：main branch
     * vLLM-Ascend：main branch
-    * mooncake：>= 0.3.9
+    * mooncake：>= 0.3.11.post1
 
 ### KV Pool Parameter Description
 
@@ -63,51 +63,16 @@ export PYTHONHASHSEED=0
     * Install Mooncake
 
         Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI.
-        Installation and Compilation Guide: <https://github.com/kvcache-ai/Mooncake?tab=readme-ov-file#build-and-use-binaries>.
-        First, we need to obtain the Mooncake project. Refer to the following command:
+        The Mooncake wheel requires glibc 2.35 or later. Check the installed glibc version before installation:
 
         ```shell
-        git clone -b v0.3.9 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+        ldd --version
         ```
 
-        (Optional) Replace go install url if the network is poor
+        Install Mooncake with pip:
 
         ```shell
-        cd Mooncake
-        sed -i 's|https://go.dev/dl/|https://golang.google.cn/dl/|g' dependencies.sh
-        ```
-
-        Install mpi
-
-        ```shell
-        apt-get install mpich libmpich-dev -y
-        ```
-
-        Install the relevant dependencies. The installation of Go is not required.
-
-        ```shell
-        bash dependencies.sh -y
-        ```
-
-        Compile and install
-
-        ```shell
-        mkdir build
-        cd build
-        cmake .. -DUSE_ASCEND_DIRECT=ON
-        make -j
-        make install
-        ```
-
-        Set environment variables
-
-        **Note:**
-
-        * Adjust the Python path according to your specific Python installation
-        * Ensure `/usr/local/lib` and `/usr/local/lib64` are in your `LD_LIBRARY_PATH`
-
-        ```shell
-        export LD_LIBRARY_PATH=/usr/local/lib64/python3.12/site-packages/mooncake:$LD_LIBRARY_PATH
+        python3 -m pip install mooncake-transfer-engine-npu==0.3.11.post1 --extra-index-url https://mirrors.aliyun.com/pypi/web/simple
         ```
 
 ### Environment Variables Description
@@ -536,8 +501,14 @@ ock.mmc.local_service.dram.size = 1GB
 
 Starting the MetaService service.
 
+Run `pip show memcache_hybrid` and find the `Location` value in the output. Use that value as `{INSTALL_PATH}` below.
+
 ```shell
-export MMC_META_CONFIG_PATH=/usr/local/memcache_hybrid/latest/config/mmc-meta.conf
+pip show memcache_hybrid
+```
+
+```shell
+export MMC_META_CONFIG_PATH={INSTALL_PATH}/memcache_hybrid/config/mmc-meta.conf
 
 python -c "from memcache_hybrid import MetaService; MetaService.main()"
 ```


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #12108 to `releases/v0.23.0`.

- Replaces the Mooncake source-build instructions in the KV Pool guide with the pip installation used by `Dockerfile` and `Dockerfile.openEuler`.
- Documents the glibc >= 2.35 requirement and installs Mooncake `0.3.11.post1` while preserving the existing feature-specific version requirements.
- Explains how to obtain the Memcache pip installation location and uses `{INSTALL_PATH}` for the MetaService configuration path.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

- `pre-commit run --files docs/source/user_guide/feature_guide/kv_pool.md`
- `bash format.sh ci` (all documentation-related checks pass; the full run hits the existing ShellCheck `SC2328` in `csrc/build.sh:524` on the release branch)

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
