### PR TITLE
[v0.23.0][BugFix] Use local Memcache config path

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -16,9 +16,9 @@ MEMCACHE_THREAD_START_WAIT_S = 0.1
 
 
 def _is_device_sdma() -> bool:
-    config_path = os.getenv("MMC_META_CONFIG_PATH")
+    config_path = os.getenv("MMC_LOCAL_CONFIG_PATH")
     if not config_path:
-        raise ValueError("The environment variable 'MMC_META_CONFIG_PATH' is not set.")
+        raise ValueError("The environment variable 'MMC_LOCAL_CONFIG_PATH' is not set.")
     with open(config_path, encoding="utf-8") as config_file:
         for line in config_file:
             line = line.strip()


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up fix for #12066.

The Memcache local-service protocol is stored in the local configuration file, so `MemcacheBackend` must read it from `MMC_LOCAL_CONFIG_PATH` rather than `MMC_META_CONFIG_PATH`.

This PR updates both the environment-variable lookup and the missing-variable error message.

### Does this PR introduce _any_ user-facing change?

Yes. `MMC_LOCAL_CONFIG_PATH` must point to the Memcache local configuration file when lazy initialization is requested.

### How was this patch tested?

- All repository pre-commit hooks passed.
- Python syntax compilation passed.
- Targeted smoke checks passed for protocol parsing, missing environment/file errors, and deferred buffer registration.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
