### PR TITLE
[Doc][BugFix]Update versioning_policy.md to add the release date information for version v0.18.0

### DIFF
--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -79,6 +79,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 | 2026.06.03 | Release candidates, v0.20.2rc1            |
 | 2026.04.30 | Release candidates, v0.19.1rc1            |
 | 2026.04.24 | Release candidates, v0.13.0rc3            |
+| 2026.04.22 | v0.18.0 Final release, v0.18.0            |
 | 2026.04.01 | Release candidates, v0.18.0rc1            |
 | 2026.03.15 | Release candidates, v0.17.0rc1            |
 | 2026.03.10 | Release candidates, v0.16.0rc1            |


### PR DESCRIPTION
Added the release date information for version v0.18.0.

### What this PR does / why we need it?
Added the release date information for version v0.18.0.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
review

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
