### PR TITLE
[v0.23.0][BugFix][Attention] Fix SFA C8 StoreKVBlock metadata handling

### DIFF
--- a/csrc/attention/store_kv_block/store_kv_block_torch_adpt.h
+++ b/csrc/attention/store_kv_block/store_kv_block_torch_adpt.h
@@ -17,21 +17,24 @@
 
 #ifndef STORE_KV_BLOCK_TORCH_ADPT_H
 #define STORE_KV_BLOCK_TORCH_ADPT_H
-#include <climits>  
+#include <climits>
 namespace vllm_ascend {
 
 void store_kv_block(
     const at::Tensor &key_in,
-    const at::Tensor &key_cache_in,
+    at::Tensor &key_cache_in,
     const at::Tensor &group_len,
     const at::Tensor &group_key_idx,
     const at::Tensor &group_key_cache_idx,
     int64_t block_size)
 {
+    TORCH_CHECK(group_len.dim() == 1 && group_key_idx.dim() == 1 && group_key_cache_idx.dim() == 1,
+                "StoreKVBlock group buffers must be 1-D.");
+    TORCH_CHECK(group_len.numel() == group_key_idx.numel() && group_len.numel() == group_key_cache_idx.numel(),
+                "StoreKVBlock group buffers must have the same length.");
 
-    EXEC_NPU_CMD(aclnnStoreKVBlock, key_in, key_cache_in,group_len, group_key_idx, group_key_cache_idx, block_size);
-    
-} 
-
+    EXEC_NPU_CMD(aclnnStoreKVBlock, key_in, key_cache_in, group_len, group_key_idx, group_key_cache_idx, block_size);
 }
-#endif
+
+}  // namespace vllm_ascend
+#endif  // STORE_KV_BLOCK_TORCH_ADPT_H

--- a/csrc/attention/store_kv_block_metadata/op_kernel_aicpu/store_kv_block_metadata_aicpu.cpp
+++ b/csrc/attention/store_kv_block_metadata/op_kernel_aicpu/store_kv_block_metadata_aicpu.cpp
@@ -72,11 +72,30 @@ bool StoreKvBlockMetadataCpuKernel::GenMetaData()
     int32_t *groupKeyIdxData = static_cast<int32_t *>(groupKeyIdx_->GetData());
     int32_t *groupKeyCacheIdxData = static_cast<int32_t *>(groupKeyCacheIdx_->GetData());
 
-    // total elements in slot_mapping (1-D tensor)
-    int64_t slotMappingLen = slotMapping_->GetTensorShape()->GetDimSize(0);
+    auto slotMappingShape = slotMapping_->GetTensorShape();
+    auto groupLenShape = groupLen_->GetTensorShape();
+    auto groupKeyIdxShape = groupKeyIdx_->GetTensorShape();
+    auto groupKeyCacheIdxShape = groupKeyCacheIdx_->GetTensorShape();
+    if (slotMappingShape == nullptr || groupLenShape == nullptr || groupKeyIdxShape == nullptr ||
+        groupKeyCacheIdxShape == nullptr) {
+        KERNEL_LOG_ERROR("input tensor shape is null");
+        return false;
+    }
 
-    // total capacity of output tensors (1-D, same shape as input)
-    int64_t outCapacity = groupLen_->GetTensorShape()->GetDimSize(0);
+    // The number of groups is at most the number of slot_mapping entries.
+    int64_t slotMappingLen = slotMappingShape->GetDimSize(0);
+    int64_t outCapacity = groupLenShape->GetDimSize(0);
+    int64_t groupKeyIdxCapacity = groupKeyIdxShape->GetDimSize(0);
+    int64_t groupKeyCacheIdxCapacity = groupKeyCacheIdxShape->GetDimSize(0);
+    if (outCapacity != groupKeyIdxCapacity || outCapacity != groupKeyCacheIdxCapacity ||
+        outCapacity < slotMappingLen) {
+        KERNEL_LOG_ERROR("invalid group buffer capacities: slot_mapping=%lld, group_len=%lld, "
+                         "group_key_idx=%lld, group_key_cache_idx=%lld",
+                         static_cast<long long>(slotMappingLen), static_cast<long long>(outCapacity),
+                         static_cast<long long>(groupKeyIdxCapacity),
+                         static_cast<long long>(groupKeyCacheIdxCapacity));
+        return false;
+    }
 
     int32_t idxSlotmap = 0;
     int32_t idxGroups = 0;
@@ -90,6 +109,12 @@ bool StoreKvBlockMetadataCpuKernel::GenMetaData()
         }
 
         int32_t blockId = cacheSlot / blockSize_;
+
+        if (idxGroups >= outCapacity) {
+            KERNEL_LOG_ERROR("group metadata capacity exceeded: index=%d, capacity=%lld",
+                             idxGroups, static_cast<long long>(outCapacity));
+            return false;
+        }
 
         // Record group start: source index and destination cache index
         groupKeyIdxData[idxGroups] = idxSlotmap;

--- a/csrc/attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp
+++ b/csrc/attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp
@@ -28,13 +28,26 @@ namespace vllm_ascend {
 // by scanning for the first zero group_len entry.
 void store_kv_block_metadata(
     const at::Tensor &slot_mapping_npu,
-    const at::Tensor &group_len,
-    const at::Tensor &group_key_idx,
-    const at::Tensor &group_key_cache_idx,
+    at::Tensor &group_len,
+    at::Tensor &group_key_idx,
+    at::Tensor &group_key_cache_idx,
     int64_t block_size)
 {
     TORCH_CHECK(slot_mapping_npu.numel() > 0, "Tensor slot_mapping_npu is empty.");
     TORCH_CHECK(block_size > 0, "block_size must be positive, but got ", block_size);
+    TORCH_CHECK(slot_mapping_npu.dim() == 1, "slot_mapping_npu must be 1-D.");
+    TORCH_CHECK(group_len.dim() == 1 && group_key_idx.dim() == 1 && group_key_cache_idx.dim() == 1,
+                "StoreKvBlockMetadata group buffers must be 1-D.");
+    TORCH_CHECK(group_len.scalar_type() == at::kInt && group_key_idx.scalar_type() == at::kInt &&
+                    group_key_cache_idx.scalar_type() == at::kInt,
+                "StoreKvBlockMetadata group buffers must use int32 dtype.");
+    TORCH_CHECK(group_len.is_contiguous() && group_key_idx.is_contiguous() && group_key_cache_idx.is_contiguous(),
+                "StoreKvBlockMetadata group buffers must be contiguous.");
+    TORCH_CHECK(group_len.numel() == group_key_idx.numel() && group_len.numel() == group_key_cache_idx.numel(),
+                "StoreKvBlockMetadata group buffers must have the same capacity.");
+    TORCH_CHECK(group_len.numel() >= slot_mapping_npu.numel(),
+                "StoreKvBlockMetadata group buffer capacity must be at least slot_mapping size, but got capacity ",
+                group_len.numel(), " and slot_mapping size ", slot_mapping_npu.numel(), ".");
 
     EXEC_NPU_CMD(aclnnStoreKvBlockMetadata,
                  slot_mapping_npu,

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2939,18 +2939,19 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     );
     ops.impl("chunk_fwd_o", torch::kPrivateUse1, &vllm_ascend::chunk_fwd_o);
 
-    //store_kv_block
-     ops.def(
-        "store_kv_block_metadata(Tensor slot_mapping_npu, Tensor group_len, Tensor group_key_idx, Tensor group_key_cache_idx, int block_size=0)"
-         "-> ()"
-     );
+    // store_kv_block
+    ops.def(
+        "store_kv_block_metadata(Tensor slot_mapping_npu, Tensor(a!) group_len, Tensor(b!) group_key_idx, "
+        "Tensor(c!) group_key_cache_idx, int block_size=0) -> ()"
+    );
     ops.impl("store_kv_block_metadata", torch::kPrivateUse1, &vllm_ascend::store_kv_block_metadata);
 
     ops.def(
-        "store_kv_block(Tensor key_in, Tensor key_cache_in, Tensor group_len, Tensor group_key_idx,Tensor group_key_cache_idx, int block_size=0) -> ()"
+        "store_kv_block(Tensor key_in, Tensor(a!) key_cache_in, Tensor group_len, Tensor group_key_idx, "
+        "Tensor group_key_cache_idx, int block_size=0) -> ()"
     );
     ops.impl("store_kv_block", torch::kPrivateUse1, &vllm_ascend::store_kv_block);
-    
+
     // Fused GDN gating.
     ops.def(
         "npu_fused_gdn_gating(Tensor A_log, "

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1742,25 +1742,24 @@ at::Tensor chunk_fwd_o_meta(
 
 void store_kv_block_metadata(
     const at::Tensor &slot_mapping_npu,
-    const at::Tensor &group_len,
-    const at::Tensor &group_key_idx,
-    const at::Tensor &group_key_cache_idx,
+    at::Tensor &group_len,
+    at::Tensor &group_key_idx,
+    at::Tensor &group_key_cache_idx,
     int64_t block_size)
- {
+{
     return;
- }
+}
 
 void store_kv_block(
     const at::Tensor &key_in,
-    const at::Tensor &key_cache_in,
+    at::Tensor &key_cache_in,
     const at::Tensor &group_len,
     const at::Tensor &group_key_idx,
     const at::Tensor &group_key_cache_idx,
     int64_t block_size)
 {
     return;
-
-} 
+}
 
 } // namespace meta
 } // namespace vllm_ascend
@@ -1877,8 +1876,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("chunk_gated_delta_rule_fwd_h", &vllm_ascend::meta::chunk_gated_delta_rule_fwd_h_meta);
     // chunk_fwd_o
     ops.impl("chunk_fwd_o", &vllm_ascend::meta::chunk_fwd_o_meta);
-     // store_kv_block
-    ops.impl("store_kv_block_pre", &vllm_ascend::meta::store_kv_block_metadata);
+    // store_kv_block
+    ops.impl("store_kv_block_metadata", &vllm_ascend::meta::store_kv_block_metadata);
     ops.impl("store_kv_block", &vllm_ascend::meta::store_kv_block);
     // npu_fused_gdn_gating
     ops.impl("npu_fused_gdn_gating", &vllm_ascend::meta::npu_fused_gdn_gating_meta);

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
@@ -64,19 +64,18 @@ def test_scatter(num_tokens, num_head, block_size, num_blocks, count):
     torch.testing.assert_close(key_expect, key_cache, atol=0.001, rtol=0.1)
 
 
-@pytest.mark.parametrize("num_tokens", [52])  # 6398
+@pytest.mark.parametrize("num_tokens", [4])
 @pytest.mark.parametrize("num_head", [1])  # 512
-@pytest.mark.parametrize("block_size", [1])  # 128
-@pytest.mark.parametrize("num_blocks", [1773])  # 1599
+@pytest.mark.parametrize("block_size", [128])
+@pytest.mark.parametrize("num_blocks", [4])
 @pytest.mark.parametrize("count", [1])
-def test_myops(num_tokens, num_head, block_size, num_blocks, count):
+def test_store_kv_block_crosses_cache_block_boundary(num_tokens, num_head, block_size, num_blocks, count):
     head_size_k = 2
     key_cache = torch.randint(low=0, high=128, size=(num_blocks, block_size, num_head, head_size_k), dtype=torch.int8)
     key_cache_npu = key_cache.npu()
 
-    slot_list = []
-    for i in range(0, num_tokens):
-        slot_list.append(2 + i)
+    slot_list = [126, 127, 128, 129]
+    assert len(slot_list) == num_tokens
 
     slot_list_np = np.array(slot_list)
     slot_mapping_npu = torch.from_numpy(slot_list_np).to(torch.int32).npu()
@@ -97,8 +96,24 @@ def test_myops(num_tokens, num_head, block_size, num_blocks, count):
         key_npu, key_cache_npu, group_len, group_key_idx, group_key_cache_idx, block_size
     )
 
-    torch.testing.assert_close(key_expect, key_cache_npu, atol=0.001, rtol=0.1)
+    torch.testing.assert_close(key_expect, key_cache_npu, atol=0, rtol=0)
 
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+def test_store_kv_block_metadata_rejects_insufficient_capacity():
+    slot_mapping = torch.tensor([126, 127, 128], dtype=torch.int32).npu()
+    group_len = torch.empty(1, dtype=torch.int32).npu()
+    group_key_idx = torch.empty(1, dtype=torch.int32).npu()
+    group_key_cache_idx = torch.empty(1, dtype=torch.int32).npu()
+
+    with pytest.raises(RuntimeError, match="group buffer capacity must be at least slot_mapping size"):
+        torch.ops._C_ascend.store_kv_block_metadata(
+            slot_mapping,
+            group_len,
+            group_key_idx,
+            group_key_cache_idx,
+            128,
+        )

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -606,21 +606,26 @@ class TestAscendSFAMetadataBuilder(TestBase):
         )
 
         common_attn_metadata = MagicMock()
-        common_attn_metadata.num_reqs = 10
-        common_attn_metadata.num_actual_tokens = 100
-        common_attn_metadata.query_start_loc = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
-        common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 10, 20, 30, 40, 50, 60, 70, 80, 90])
-        common_attn_metadata.slot_mapping = torch.randn(100, 4, 1024)
-        common_attn_metadata.seq_lens_cpu = torch.tensor([2] * 10)
-        common_attn_metadata.positions = torch.randn(100)
+        common_attn_metadata.num_reqs = 1
+        common_attn_metadata.num_actual_tokens = 3
+        common_attn_metadata.query_start_loc = torch.tensor([0, 3])
+        common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 3])
+        common_attn_metadata.slot_mapping = torch.tensor([126, 127, 128], dtype=torch.int32)
+        common_attn_metadata.seq_lens = torch.tensor([3], dtype=torch.int32)
+        common_attn_metadata.seq_lens_cpu = torch.tensor([3], dtype=torch.int32)
+        common_attn_metadata._seq_lens_cpu = None
+        common_attn_metadata.positions = torch.arange(3)
         common_attn_metadata.attn_mask = None
         common_attn_metadata.attn_state = AscendAttentionState.ChunkedPrefill
-        common_attn_metadata.block_table_tensor = torch.randn(100, 4)
+        common_attn_metadata.block_table_tensor = torch.zeros((1, 1), dtype=torch.int32)
         common_attn_metadata.cos = None
         common_attn_metadata.sin = None
-        common_attn_metadata.num_input_tokens = 100
+        common_attn_metadata.num_input_tokens = 3
+        common_attn_metadata.group_len = torch.empty(3, dtype=torch.int32)
+        common_attn_metadata.group_key_idx = torch.empty(3, dtype=torch.int32)
+        common_attn_metadata.group_key_cache_idx = torch.empty(3, dtype=torch.int32)
 
-        mock_get_cos_and_sin_mla.return_value = (torch.randn(100), torch.randn(100))
+        mock_get_cos_and_sin_mla.return_value = (torch.randn(3), torch.randn(3))
 
         with patch("vllm_ascend.attention.sfa_v1.get_ascend_config") as mock_get_ascend_config:
             mock_ascend_config = MagicMock()
@@ -634,14 +639,37 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
         assert isinstance(metadata, AscendSFAMetadata)
         assert metadata.num_actual_tokens == common_attn_metadata.num_actual_tokens
-        assert metadata.slot_mapping.shape == (100, 4, 1024)
+        assert metadata.slot_mapping.tolist() == [126, 127, 128]
 
         store_kv_block_metadata.assert_called_once()
         actual_args, _ = store_kv_block_metadata.call_args
         assert torch.equal(actual_args[0], common_attn_metadata.slot_mapping)
+        assert actual_args[1].numel() == common_attn_metadata.slot_mapping.numel()
+        assert actual_args[2].numel() == common_attn_metadata.slot_mapping.numel()
+        assert actual_args[3].numel() == common_attn_metadata.slot_mapping.numel()
         assert actual_args[4] == 128
 
         assert metadata.block_size == 128
         assert metadata.group_len is actual_args[1]
         assert metadata.group_key_idx is actual_args[2]
         assert metadata.group_key_cache_idx is actual_args[3]
+
+    @patch("torch.ops._C_ascend.store_kv_block_metadata", create=True)
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_store_kv_block_metadata_rejects_request_sized_buffers(
+        self,
+        mock_get_ascend_config,
+        store_kv_block_metadata,
+    ):
+        mock_get_ascend_config.return_value.c8_enable_reshape_optim = True
+        builder = AscendSFAMetadataBuilder.__new__(AscendSFAMetadataBuilder)
+        common_attn_metadata = MagicMock()
+        common_attn_metadata.group_len = torch.empty(1, dtype=torch.int32)
+        common_attn_metadata.group_key_idx = torch.empty(1, dtype=torch.int32)
+        common_attn_metadata.group_key_cache_idx = torch.empty(1, dtype=torch.int32)
+        slot_mapping = torch.tensor([126, 127, 128], dtype=torch.int32)
+
+        with self.assertRaisesRegex(RuntimeError, "capacity=1, num_slots=3"):
+            builder._build_store_kv_block_metadata(slot_mapping, common_attn_metadata, block_size=128)
+
+        store_kv_block_metadata.assert_not_called()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -212,6 +212,85 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         )
 
 
+class TestNPUModelRunnerAttentionMetadata(unittest.TestCase):
+    def test_store_kv_block_group_buffers_use_token_capacity(self):
+        num_tokens = 3
+        num_tokens_padded = 4
+        num_reqs = num_reqs_padded = 1
+
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.max_model_len = 1024
+        runner.pcp_size = 1
+        runner.use_cp = False
+        runner.use_async_spec_decode = False
+        runner.use_compress = False
+        runner.model_config = SimpleNamespace(enable_return_routed_experts=False)
+
+        slot_mapping = torch.tensor([126, 127, 128, 999], dtype=torch.int32)
+        block_table = SimpleNamespace(
+            slot_mapping=SimpleNamespace(gpu=slot_mapping),
+            get_device_tensor=lambda: torch.tensor([[0, 1]], dtype=torch.int32),
+        )
+        runner.kv_cache_config = SimpleNamespace(kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())])
+        runner.input_batch = SimpleNamespace(
+            block_table=[block_table],
+            num_computed_tokens_cpu_tensor=torch.tensor([126], dtype=torch.int32),
+            num_prompt_tokens_cpu_tensor=torch.tensor([129], dtype=torch.int32),
+        )
+        query_start_loc = torch.tensor([0, num_tokens], dtype=torch.int32)
+        runner.query_start_loc = SimpleNamespace(
+            gpu=query_start_loc,
+            cpu=query_start_loc.clone(),
+        )
+        runner.seq_lens = torch.tensor([129], dtype=torch.int32)
+        runner.optimistic_seq_lens_cpu = torch.tensor([129], dtype=torch.int32)
+        runner.actual_seq_lengths_q = [num_tokens]
+        runner.positions = torch.arange(num_tokens_padded, dtype=torch.int32)
+        runner.attn_state = None
+        runner.decode_token_per_req = 1
+
+        backing_size = 8
+        runner.group_len = SimpleNamespace(gpu=torch.empty(backing_size, dtype=torch.int32))
+        runner.group_key_idx = SimpleNamespace(gpu=torch.empty(backing_size, dtype=torch.int32))
+        runner.group_key_cache_idx = SimpleNamespace(gpu=torch.empty(backing_size, dtype=torch.int32))
+
+        captured = {}
+
+        class MetadataCaptured(Exception):
+            pass
+
+        def capture_metadata(**kwargs):
+            captured.update(kwargs)
+            raise MetadataCaptured
+
+        with (
+            patch(
+                "vllm_ascend.worker.model_runner_v1.AscendCommonAttentionMetadata",
+                side_effect=capture_metadata,
+            ),
+            self.assertRaises(MetadataCaptured),
+        ):
+            runner._build_attention_metadata(
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                max_query_len=num_tokens,
+                num_tokens_padded=num_tokens_padded,
+                num_reqs_padded=num_reqs_padded,
+                for_cudagraph_capture=True,
+            )
+
+        self.assertEqual(captured["num_reqs"], num_reqs_padded)
+        self.assertEqual(captured["num_actual_tokens"], num_tokens)
+        self.assertEqual(captured["num_input_tokens"], num_tokens_padded)
+        self.assertEqual(captured["slot_mapping"].tolist(), [126, 127, 128, -1])
+
+        for name in ("group_len", "group_key_idx", "group_key_cache_idx"):
+            group_view = captured[name]
+            backing = getattr(runner, name).gpu
+            self.assertEqual(group_view.shape, (num_tokens_padded,))
+            self.assertEqual(group_view.data_ptr(), backing.data_ptr())
+
+
 class TestNPUModelRunnerOutputTokenIds(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -335,6 +335,44 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
     ) -> AscendSFAMetadata:
         return self._build(common_attn_metadata, draft_index=draft_index)
 
+    def _build_store_kv_block_metadata(
+        self,
+        slot_mapping: torch.Tensor,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        block_size: int,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        if not get_ascend_config().c8_enable_reshape_optim:
+            return None, None, None
+
+        if slot_mapping.ndim != 1:
+            raise ValueError(f"slot_mapping must be 1-D, but got shape {tuple(slot_mapping.shape)}")
+
+        num_slots = slot_mapping.shape[0]
+        group_buffers = (
+            common_attn_metadata.group_len,
+            common_attn_metadata.group_key_idx,
+            common_attn_metadata.group_key_cache_idx,
+        )
+        group_names = ("group_len", "group_key_idx", "group_key_cache_idx")
+        for name, group_buffer in zip(group_names, group_buffers, strict=True):
+            if group_buffer is None or group_buffer.numel() < num_slots:
+                capacity = 0 if group_buffer is None else group_buffer.numel()
+                raise RuntimeError(
+                    f"{name} capacity must cover every slot_mapping entry: capacity={capacity}, num_slots={num_slots}"
+                )
+
+        group_len = common_attn_metadata.group_len[:num_slots]
+        group_key_idx = common_attn_metadata.group_key_idx[:num_slots]
+        group_key_cache_idx = common_attn_metadata.group_key_cache_idx[:num_slots]
+        torch.ops._C_ascend.store_kv_block_metadata(
+            slot_mapping,
+            group_len,
+            group_key_idx,
+            group_key_cache_idx,
+            block_size,
+        )
+        return group_len, group_key_idx, group_key_cache_idx
+
     def _build(
         self,
         common_attn_metadata: AscendCommonAttentionMetadata,
@@ -452,14 +490,11 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 actual_seq_lengths_key=actual_seq_lengths_key,
             )
 
-        if get_ascend_config().c8_enable_reshape_optim:
-            torch.ops._C_ascend.store_kv_block_metadata(
-                slot_mapping,
-                common_attn_metadata.group_len,
-                common_attn_metadata.group_key_idx,
-                common_attn_metadata.group_key_cache_idx,
-                block_size,
-            )
+        group_len, group_key_idx, group_key_cache_idx = self._build_store_kv_block_metadata(
+            slot_mapping,
+            common_attn_metadata,
+            block_size,
+        )
 
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
@@ -476,9 +511,9 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             cos=cos[:num_input_tokens],
             dsa_cp_context=dsa_cp_context,
             block_size=block_size,
-            group_len=common_attn_metadata.group_len,
-            group_key_idx=common_attn_metadata.group_key_idx,
-            group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
+            group_len=group_len,
+            group_key_idx=group_key_idx,
+            group_key_cache_idx=group_key_cache_idx,
         )
 
     def build_for_graph_capture(
@@ -1767,6 +1802,13 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         if kv_cache is not None and self.has_indexer:
             assert k_li is not None
+            use_indexer_reshape_optim = (
+                self.is_kv_producer
+                and get_ascend_config().c8_enable_reshape_optim
+                and attn_metadata.group_len is not None
+                and attn_metadata.group_key_idx is not None
+                and attn_metadata.group_key_cache_idx is not None
+            )
             if self.use_sparse_c8_sfa:
                 dsa_k_cache_idx = 1
                 dsa_k_scale_cache_idx = 2
@@ -1774,7 +1816,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 dsa_k_cache_idx = 2
                 dsa_k_scale_cache_idx = 3
 
-            if get_ascend_config().c8_enable_reshape_optim:
+            if use_indexer_reshape_optim:
                 torch.ops._C_ascend.store_kv_block(
                     k_li,
                     kv_cache[dsa_k_cache_idx],
@@ -1792,7 +1834,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.use_sparse_c8_indexer:
                 assert len(kv_cache) == (3 if self.use_sparse_c8_sfa else 4)
                 if k_li_scale is not None:
-                    if get_ascend_config().c8_enable_reshape_optim:
+                    if use_indexer_reshape_optim:
                         torch.ops._C_ascend.store_kv_block(
                             k_li_scale,
                             kv_cache[dsa_k_scale_cache_idx],

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -603,9 +603,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 decode_token_per_req=self.runner.decode_token_per_req,
                 is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
                 max_seq_len=0,
-                group_len=self.runner.group_len.gpu[:num_reqs],
-                group_key_idx=self.runner.group_key_idx.gpu[:num_reqs],
-                group_key_cache_idx=self.runner.group_key_cache_idx.gpu[:num_reqs],
+                group_len=self.runner.group_len.gpu[:num_tokens],
+                group_key_idx=self.runner.group_key_idx.gpu[:num_tokens],
+                group_key_cache_idx=self.runner.group_key_cache_idx.gpu[:num_tokens],
             )
             if pcp_manager is not None:
                 # update long_seq related params and flatten block_table

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -306,13 +306,16 @@ class NPUModelRunner(GPUModelRunner):
             dtype=torch.int32,
         )
         self.group_len = self._make_buffer(
-            vllm_config.scheduler_config.max_num_batched_tokens , dtype=torch.int32
-        )        
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
+        )
         self.group_key_idx = self._make_buffer(
-           vllm_config.scheduler_config.max_num_batched_tokens , dtype=torch.int32
-        )        
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
+        )
         self.group_key_cache_idx = self._make_buffer(
-            vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.int32
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
         )
 
         # Now, query_start_loc is padded.
@@ -3134,9 +3137,12 @@ class NPUModelRunner(GPUModelRunner):
             attn_state=self.attn_state,
             decode_token_per_req=self.decode_token_per_req,
             prefill_context_parallel_metadata=self.long_seq_metadata,
-            group_len = self.group_len.gpu[:num_reqs_padded],
-            group_key_idx = self.group_key_idx.gpu[:num_reqs_padded],
-            group_key_cache_idx = self.group_key_cache_idx.gpu[:num_reqs_padded],
+            # StoreKVBlockMetadata can emit one group per input token in the
+            # worst case, so these graph-stable views must use token capacity
+            # rather than request capacity.
+            group_len=self.group_len.gpu[:num_tokens_padded],
+            group_key_idx=self.group_key_idx.gpu[:num_tokens_padded],
+            group_key_cache_idx=self.group_key_cache_idx.gpu[:num_tokens_padded],
         )
 
         if logits_indices is not None and self.cache_config.kv_sharing_fast_prefill:


### PR DESCRIPTION
### What this PR does / why we need it?

When `c8_enable_reshape_optim` is enabled, `StoreKvBlockMetadata` may emit up to one group per input token. The production integration currently slices its persistent group buffers by padded request count instead of padded token count. For prefill or mixed batches where the number of physical cache-block runs exceeds the request count, the metadata kernel can write past the logical tensor view and `StoreKVBlock` consumes only the truncated prefix. This leaves indexer K/scale cache rows missing and can change sparse top-k selection even though the standalone store operator is numerically correct.

This PR:

- sizes graph-stable group metadata views by padded tokens in the model runner and draft graph path;
- validates the slot/group capacity invariant in the SFA builder and passes exact token-sized views to `StoreKVBlock`;
- restores the original P-node/producer-only optimization guard;
- adds Torch mutation annotations and fixes the missing `store_kv_block_metadata` Meta registration;
- rejects insufficient or mismatched group buffers at the Torch and AICPU boundaries instead of writing out of bounds;
- adds production-wiring, cross-cache-block, and insufficient-capacity regression coverage.

Related: #12057 contains the three-line model-runner token-slice correction. This PR includes that correction and extends it with the operator contract hardening and regression tests above. If #12057 lands first, this branch can be rebased to retain only the additional hardening.

Current validation scope is the documented P-node path with non-speculative execution and PCP size 1. Multi-draft metadata ownership and PCP post-remap metadata regeneration are separate lifecycle issues and are not claimed as fixed here.

### Does this PR introduce _any_ user-facing change?

No. It fixes internal SFA C8 cache-write correctness when `c8_enable_reshape_optim` is enabled.

### How was this patch tested?

- `python -m py_compile` for all changed Python files: passed.
- `pre-commit run --files <all changed files>`: passed.
- `git -c core.whitespace=cr-at-eol diff --check origin/releases/v0.23.0...HEAD`: passed.
- `bash format.sh ci`: all applicable checks passed except the existing out-of-scope ShellCheck `SC2328` at `csrc/build.sh:524` on the release branch.
- Added CPU unit coverage that executes `_build_attention_metadata()` and verifies padded-token group views retain graph-stable backing storage.
- Added an A2/A3 single-card StoreKVBlock case crossing slots `127 -> 128`, plus an insufficient-capacity error case.
- Targeted pytest could not run on the local macOS host because `torch`, `vllm`, and `torch_npu` are unavailable; C++ build and NPU execution are left to CI.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
