### PR TITLE
[Doc][310P][v0.23.0] 310P includes a new Qwen 3.5-Dense support documentation

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -714,7 +714,7 @@ After about several minutes, you can get the performance evaluation result.
 >
 > **Parallelism Strategy**: `Qwen3.5-27B-w8a8` and `Qwen3.6-27B-w8a8` are only ~30 GB and easily fit in a single NPU (64 GB HBM per NPU). Following the **DP-first** principle, **TP=2 is the recommended default** for most scenarios, and the remaining NPUs should be allocated to DP for parallel request batches. **TP=8 is only recommended for ultra-long context (256K+) scenarios**, where it shards the KV cache across 8 NPUs to maximize the available context window per rank. For `Qwen3.6-27B-w8a8`, you can also raise `--max-model-len` up to 262144 in the same TP/DP layout.
 >
-> **Atlas inference products**: Currently only the TP scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. Configure `--max-model-len` and `--max-num-seqs` based on the actual workload; setting them too high may cause OOM.
+> **Atlas inference products**: Currently only the TP scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. With **TP=4**, `--max-model-len` can support **128K** and **256K** long-sequence scenarios; configure `--max-num-seqs` as needed—setting it too high may cause OOM.
 
 #### Table 1: Scenario Overview
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -147,12 +147,12 @@ docker run --rm \
     --device /dev/devmm_svm \
     --device /dev/hisi_hdc \
     -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /root/.cache:/root/.cache \
+    -p 8080:8080 \
     -it $IMAGE bash
 ```
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -134,7 +134,6 @@ export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
 docker run --rm \
     --name vllm-ascend \
     --shm-size=1g \
-    --net=host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \
@@ -306,7 +305,7 @@ Key Parameter Descriptions:
 
 ::::::{tab-item} Atlas inference products
 
-Currently only the **TP** scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. With **TP=4**, `--max-model-len` can support **128K** and **256K** long-sequence scenarios; configure `--max-num-seqs` as needed—setting it too high may cause OOM. Replace `MODEL_PATH` with a ModelScope model id or a local directory path.
+Currently only the **TP** scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. Replace `MODEL_PATH` with a ModelScope model id or a local directory path. The quantized versions need to start with the `--quantization ascend` parameter.
 
 :::::{tab-set}
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -174,13 +174,13 @@ If you don't want to use the docker image as above, you can also build all from 
 
     For the complete installation steps, refer to [installation](../../installation.md).
 
-````{note}
-On Atlas inference products, you may need to uninstall `triton-ascend` and `triton` to avoid dependency conflicts:
+    ````{note}
+    On Atlas inference products, you may need to uninstall `triton-ascend` and `triton` to avoid dependency conflicts:
 
-```bash
-pip uninstall -y triton-ascend triton
-```
-````
+    ```bash
+    pip uninstall -y triton-ascend triton
+    ```
+    ````
 
 2. If you want to deploy a multi-node environment, you need to set up the environment on each node.
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -20,13 +20,13 @@ Please refer to the [Feature Guide](../../user_guide/feature_guide/index.md) for
 
 **Qwen3.5-27B**
 
-- `Qwen3.5-27B` (BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.5-27B)
-- `Qwen3.5-27B-w8a8` (Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)
+- `Qwen3.5-27B` (BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node or Atlas inference products. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.5-27B)
+- `Qwen3.5-27B-w8a8` (Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)
 
 **Qwen3.6-27B**
 
-- `Qwen3.6-27B` (BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-27B)
-- `Qwen3.6-27B-w8a8` (Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8)
+- `Qwen3.6-27B` (BF16 version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node or Atlas inference products. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-27B)
+- `Qwen3.6-27B-w8a8` (Quantized version): requires 1 Atlas 800 A3 (64G × 16) node or 1 Atlas 800 A2 (64G × 8) node or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 
@@ -175,6 +175,14 @@ If you don't want to use the docker image as above, you can also build all from 
 
     For the complete installation steps, refer to [installation](../../installation.md).
 
+````{note}
+On Atlas inference products, you may need to uninstall `triton-ascend` and `triton` to avoid dependency conflicts:
+
+```bash
+pip uninstall -y triton-ascend triton
+```
+````
+
 2. If you want to deploy a multi-node environment, you need to set up the environment on each node.
 
 To verify the source code installation, run the following command and confirm the displayed version matches the one you installed:
@@ -193,7 +201,15 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 
 Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwen3_5_mtp` speculative decoding method can be used for both.
 
-**Qwen3.5-27B-w8a8**
+:::::::{tab-set}
+
+::::::{tab-item} Atlas 800 A3 / Atlas 800 A2
+
+The following examples are for Atlas 800 A3 / Atlas 800 A2. Quantized versions need `--quantization ascend`.
+
+:::::{tab-set}
+
+::::{tab-item} Qwen3.5-27B-w8a8
 
 Startup Command:
 
@@ -228,7 +244,9 @@ vllm serve Eco-Tech/Qwen3.5-27B-w8a8-mtp \
 --async-scheduling
 ```
 
-**Qwen3.6-27B-w8a8**
+::::
+
+::::{tab-item} Qwen3.6-27B-w8a8
 
 Startup Command (supports up to 262144 context length):
 
@@ -263,7 +281,66 @@ vllm serve Eco-Tech/Qwen3.6-27B-w8a8 \
 --async-scheduling
 ```
 
-**Atlas inference products**
+::::
+
+:::::
+
+Key Parameter Descriptions:
+
+- `--data-parallel-size 1` and `--tensor-parallel-size 2` are common settings for data parallelism (DP) and tensor parallelism (TP) sizes.
+- `--max-model-len` represents the context length, which is the maximum value of the input plus output for a single request. The Qwen3.6-27B model supports up to 262144.
+- `--max-num-seqs` indicates the maximum number of requests that each DP group is allowed to process. If the number of requests sent to the service exceeds this limit, the excess requests will remain in a waiting state and will not be scheduled. Note that the time spent in the waiting state is also counted in metrics such as TTFT and TPOT. Therefore, when testing performance, it is generally recommended that `--max-num-seqs` * `--data-parallel-size` >= the actual total concurrency.
+- `--max-num-batched-tokens` represents the maximum number of tokens that the model can process in a single step. Currently, vLLM v1 scheduling enables ChunkPrefill/SplitFuse by default, which means:
+    - (1) If the input length of a request is greater than `--max-num-batched-tokens`, it will be divided into multiple rounds of computation according to `--max-num-batched-tokens`;
+    - (2) Decode requests are prioritized for scheduling, and prefill requests are scheduled only if there is available capacity.
+    - Generally, if `--max-num-batched-tokens` is set to a larger value, the overall latency will be lower, but the pressure on HBM memory (activation value usage) will be greater.
+- `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Its essential function is to calculate the available kv_cache size. During the warm-up phase (referred to as profile run in vLLM), vLLM records the peak HBM memory usage during an inference process with an input size of `--max-num-batched-tokens`. The available kv_cache size is then calculated as: `--gpu-memory-utilization` * HBM size - peak HBM memory usage. Therefore, the larger the value of `--gpu-memory-utilization`, the more kv_cache can be used. However, since the HBM memory usage during the warm-up phase may differ from that during actual inference (e.g., due to uneven EP load), setting `--gpu-memory-utilization` too high may lead to OOM (Out of Memory) issues during actual inference. The default value is `0.9`.
+- `--no-enable-prefix-caching` indicates that prefix caching is disabled. The current implementation of hybrid kv cache for Qwen3.5-27B / Qwen3.6-27B may result in a very large effective `block_size` when prefix caching is enabled (e.g., 2048), which means any prefix shorter than `block_size` will never be cached. If your workload has many short repeated prefixes, consider keeping prefix caching disabled. For related issues, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html).
+- `--quantization ascend` indicates that quantization is used. To disable quantization, remove this option.
+- `--speculative-config` uses `qwen3_5_mtp` for both `Qwen3.5-27B` and `Qwen3.6-27B` because they share the same MTP head design.
+- `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are `"cudagraph_mode"` and `"cudagraph_capture_sizes"`, which have the following meanings:
+    - `"cudagraph_mode"`: represents the specific graph mode. Currently, `"PIECEWISE"` and `"FULL_DECODE_ONLY"` are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, `"FULL_DECODE_ONLY"` is recommended.
+    - `"cudagraph_capture_sizes"`: represents different levels of graph modes. The default value is `[1, 2, 4, 8, 16, 24, 32, 40,..., --max-num-seqs]`. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance.
+
+::::::
+
+::::::{tab-item} Atlas inference products
+
+Currently only the **TP** scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. With **TP=4**, `--max-model-len` can support **128K** and **256K** long-sequence scenarios; configure `--max-num-seqs` as needed—setting it too high may cause OOM. Replace `MODEL_PATH` with a ModelScope model id or a local directory path.
+
+:::::{tab-set}
+
+::::{tab-item} Qwen3.5-27B-w8a8
+
+Startup Command:
+
+```bash
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+
+# Model weight path; can be a ModelScope model id or a local directory path
+export MODEL_PATH=/home/data/Qwen3.5-27B-W8A8/
+
+vllm serve $MODEL_PATH \
+--host 127.0.0.1 \
+--port 1025 \
+--tensor-parallel-size 4 \
+--served-model-name qwen3.5 \
+--max-num-seqs 128 \
+--max-model-len 16384 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--mamba-ssm-cache-dtype float16 \
+--dtype float16 \
+--speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
+```
+
+::::
+
+::::{tab-item} Qwen3.6-27B-w8a8
 
 Startup Command:
 
@@ -291,25 +368,27 @@ vllm serve $MODEL_PATH \
 --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
 ```
 
+::::
+
+:::::
+
 Key Parameter Descriptions:
 
-- `--data-parallel-size 1` and `--tensor-parallel-size 2` are common settings for data parallelism (DP) and tensor parallelism (TP) sizes.
-- `--max-model-len` represents the context length, which is the maximum value of the input plus output for a single request. The Qwen3.6-27B model supports up to 262144.
-- `--max-num-seqs` indicates the maximum number of requests that each DP group is allowed to process. If the number of requests sent to the service exceeds this limit, the excess requests will remain in a waiting state and will not be scheduled. Note that the time spent in the waiting state is also counted in metrics such as TTFT and TPOT. Therefore, when testing performance, it is generally recommended that `--max-num-seqs` * `--data-parallel-size` >= the actual total concurrency.
-- `--max-num-batched-tokens` represents the maximum number of tokens that the model can process in a single step. Currently, vLLM v1 scheduling enables ChunkPrefill/SplitFuse by default, which means:
-    - (1) If the input length of a request is greater than `--max-num-batched-tokens`, it will be divided into multiple rounds of computation according to `--max-num-batched-tokens`;
-    - (2) Decode requests are prioritized for scheduling, and prefill requests are scheduled only if there is available capacity.
-    - Generally, if `--max-num-batched-tokens` is set to a larger value, the overall latency will be lower, but the pressure on HBM memory (activation value usage) will be greater.
-- `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Its essential function is to calculate the available kv_cache size. During the warm-up phase (referred to as profile run in vLLM), vLLM records the peak HBM memory usage during an inference process with an input size of `--max-num-batched-tokens`. The available kv_cache size is then calculated as: `--gpu-memory-utilization` * HBM size - peak HBM memory usage. Therefore, the larger the value of `--gpu-memory-utilization`, the more kv_cache can be used. However, since the HBM memory usage during the warm-up phase may differ from that during actual inference (e.g., due to uneven EP load), setting `--gpu-memory-utilization` too high may lead to OOM (Out of Memory) issues during actual inference. The default value is `0.9`.
-- `--no-enable-prefix-caching` indicates that prefix caching is disabled. The current implementation of hybrid kv cache for Qwen3.5-27B / Qwen3.6-27B may result in a very large effective `block_size` when prefix caching is enabled (e.g., 2048), which means any prefix shorter than `block_size` will never be cached. If your workload has many short repeated prefixes, consider keeping prefix caching disabled. For related issues, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html).
-- `--quantization ascend` indicates that quantization is used. To disable quantization, remove this option.
-- `--speculative-config` uses `qwen3_5_mtp` for both `Qwen3.5-27B` and `Qwen3.6-27B` because they share the same MTP head design.
+- `--tensor-parallel-size` sets the tensor parallel size. Choose **TP=2** or **TP=4** according to the available devices.
+- `--max-model-len` represents the context length, which is the maximum value of the input plus output for a single request. Configure it based on the actual workload and available memory; with **TP=4**, the Qwen3.6-27B model supports up to 262144.
+- `--max-num-seqs` indicates the maximum number of concurrent requests. Configure it as needed—setting it too high may cause OOM.
+- `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Configure this value according to the actual device memory; setting it too high may cause OOM. The default value is `0.9`.
 - `--mamba-ssm-cache-dtype` sets the data type of the Mamba SSM cache. On Atlas inference products, only `float16` is supported.
 - `--dtype float16` must be set on Atlas inference products. These devices only support the FP16 data type.
+- `--speculative-config` uses `qwen3_5_mtp` for both `Qwen3.5-27B` and `Qwen3.6-27B` because they share the same MTP head design. On Atlas inference products, it is recommended to set `num_speculative_tokens` to `1`.
 - `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are `"cudagraph_mode"` and `"cudagraph_capture_sizes"`, which have the following meanings:
     - `"cudagraph_mode"`: represents the specific graph mode. Currently, `"PIECEWISE"` and `"FULL_DECODE_ONLY"` are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, `"FULL_DECODE_ONLY"` is recommended.
-    - `"cudagraph_capture_sizes"`: represents different levels of graph modes. The default value is `[1, 2, 4, 8, 16, 24, 32, 40,..., --max-num-seqs]`. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance. On Atlas inference products, when tensor parallelism (TP) is enabled, hardware event-id constraints allow at most two capture sizes (for example, `[1, 8]`).
+    - `"cudagraph_capture_sizes"`: represents different levels of graph modes. When tensor parallelism (TP) is enabled, hardware event-id constraints allow at most two capture sizes (for example, `[1, 8]`).
 - `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required on Atlas inference products because `enable_npugraph_ex` is not supported on this platform.
+
+::::::
+
+:::::::
 
 Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -6,7 +6,7 @@ Qwen3.5-27B and Qwen3.6-27B are dense hybrid Mamba-Transformer language models i
 
 This document will demonstrate the main validation steps for the models, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, as well as accuracy and performance evaluation.
 
-It is **strongly recommended to use the latest release candidate (rc) version or the latest official version** of `vllm-ascend`. As a minimum-version requirement, `Qwen3.5-27B` is first supported in `vllm-ascend:v0.17.0rc1`, and `Qwen3.6-27B` is first supported in `vllm-ascend:v0.18.0rc1`.
+It is **strongly recommended to use the latest release candidate (rc) version or the latest official version** of `vllm-ascend`. As a minimum-version requirement, `Qwen3.5-27B` is first supported in `vllm-ascend:v0.17.0rc1`, and `Qwen3.6-27B` is first supported in `vllm-ascend:v0.18.0rc1`. Support for Atlas inference products starts from `vllm-ascend:v0.23.0rc1`.
 
 ## 2 Supported Features
 
@@ -40,7 +40,7 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 
-It is **recommended to use the latest release candidate (rc) version or the latest official version** of the `vllm-ascend` image to ensure the best compatibility and access to the latest features. As a minimum-version requirement, use `vllm-ascend:v0.17.0rc1` (or a later version) for `Qwen3.5-27B`, and `vllm-ascend:v0.18.0rc1` (or a later version) for `Qwen3.6-27B`. For `Qwen3.6-27B` on Atlas 800 A3, please use the matching `v0.18.0rc1-a3` (or a later `-a3`) image.
+It is **recommended to use the latest release candidate (rc) version or the latest official version** of the `vllm-ascend` image to ensure the best compatibility and access to the latest features. As a minimum-version requirement, use `vllm-ascend:v0.17.0rc1` (or a later version) for `Qwen3.5-27B`, and `vllm-ascend:v0.18.0rc1` (or a later version) for `Qwen3.6-27B`. For `Qwen3.6-27B` on Atlas 800 A3, please use the matching `v0.18.0rc1-a3` (or a later `-a3`) image. For Atlas inference products, use `vllm-ascend:v0.23.0rc1-310p` (or a later `-310p`) image.
 
 :::::{tab-set}
 :sync-group: install
@@ -122,6 +122,41 @@ docker run --rm \
 ```
 
 ::::
+
+::::{tab-item} Atlas inference products
+:sync: atlas
+
+Start the docker image on your each node.
+
+```{code-block} bash
+  :substitutions:
+export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
+docker run --rm \
+    --name vllm-ascend \
+    --shm-size=1g \
+    --net=host \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -it $IMAGE bash
+```
+
+::::
 :::::
 
 After a successful docker run, you can verify the running container service by executing the `docker ps` command. The expected result is that the container `vllm-ascend` is listed with status `Up`, confirming the docker installation is successful.
@@ -154,7 +189,7 @@ Expected result: The version information of `vllm-ascend` is displayed, confirmi
 
 ### 5.1 Single-Node Online Deployment
 
-Single-node deployment completes both Prefill and Decode within the same node, suitable for development, testing, and medium-scale inference scenarios. The `Qwen3.5-27B`, `Qwen3.5-27B-w8a8`, `Qwen3.6-27B`, and `Qwen3.6-27B-w8a8` models can all be deployed on 1 Atlas 800 A3 (64G × 16) or 1 Atlas 800 A2 (64G × 8). The quantized versions need to start with the `--quantization ascend` parameter.
+Single-node deployment completes both Prefill and Decode within the same node, suitable for development, testing, and medium-scale inference scenarios. The `Qwen3.5-27B`, `Qwen3.5-27B-w8a8`, `Qwen3.6-27B`, and `Qwen3.6-27B-w8a8` models can all be deployed on 1 Atlas 800 A3 (64G × 16) or 1 Atlas 800 A2 (64G × 8). On Atlas inference products, at least 2 devices are required. The quantized versions need to start with the `--quantization ascend` parameter.
 
 Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwen3_5_mtp` speculative decoding method can be used for both.
 
@@ -228,6 +263,34 @@ vllm serve Eco-Tech/Qwen3.6-27B-w8a8 \
 --async-scheduling
 ```
 
+**Atlas inference products**
+
+Startup Command:
+
+```bash
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+
+# Model weight path; can be a ModelScope model id or a local directory path
+export MODEL_PATH=/home/data/Qwen3.6-27B-W8A8/
+
+vllm serve $MODEL_PATH \
+--host 127.0.0.1 \
+--port 1025 \
+--tensor-parallel-size 4 \
+--served-model-name qwen3.6 \
+--max-num-seqs 128 \
+--max-model-len 16384 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--mamba-ssm-cache-dtype float16 \
+--dtype float16 \
+--speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
+```
+
 Key Parameter Descriptions:
 
 - `--data-parallel-size 1` and `--tensor-parallel-size 2` are common settings for data parallelism (DP) and tensor parallelism (TP) sizes.
@@ -241,9 +304,12 @@ Key Parameter Descriptions:
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. The current implementation of hybrid kv cache for Qwen3.5-27B / Qwen3.6-27B may result in a very large effective `block_size` when prefix caching is enabled (e.g., 2048), which means any prefix shorter than `block_size` will never be cached. If your workload has many short repeated prefixes, consider keeping prefix caching disabled. For related issues, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html).
 - `--quantization ascend` indicates that quantization is used. To disable quantization, remove this option.
 - `--speculative-config` uses `qwen3_5_mtp` for both `Qwen3.5-27B` and `Qwen3.6-27B` because they share the same MTP head design.
+- `--mamba-ssm-cache-dtype` sets the data type of the Mamba SSM cache. On Atlas inference products, only `float16` is supported.
+- `--dtype float16` must be set on Atlas inference products. These devices only support the FP16 data type.
 - `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are `"cudagraph_mode"` and `"cudagraph_capture_sizes"`, which have the following meanings:
     - `"cudagraph_mode"`: represents the specific graph mode. Currently, `"PIECEWISE"` and `"FULL_DECODE_ONLY"` are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, `"FULL_DECODE_ONLY"` is recommended.
-    - `"cudagraph_capture_sizes"`: represents different levels of graph modes. The default value is `[1, 2, 4, 8, 16, 24, 32, 40,..., --max-num-seqs]`. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance.
+    - `"cudagraph_capture_sizes"`: represents different levels of graph modes. The default value is `[1, 2, 4, 8, 16, 24, 32, 40,..., --max-num-seqs]`. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance. On Atlas inference products, when tensor parallelism (TP) is enabled, hardware event-id constraints allow at most two capture sizes (for example, `[1, 8]`).
+- `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required on Atlas inference products because `enable_npugraph_ex` is not supported on this platform.
 
 Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 
@@ -260,6 +326,10 @@ If the service starts successfully, the following startup log will be displayed:
 For functional testing (e.g., `completions` and `chat.completions` curl examples with expected responses), please refer to [Section 6](#6-functional-verification).
 
 ### 5.2 Multi-Node PD Separation Deployment
+
+```{note}
+Multi-node PD separation deployment is **not supported** on Atlas inference products.
+```
 
 For high-concurrency production scenarios, multi-node PD (Prefill-Decode) separation can be used to scale the service. The recommended approach is to use Mooncake for deployment: [Mooncake Multi-Node PD Disaggregation Guide](../features/pd_disaggregation_mooncake_multi_node.md).
 
@@ -643,6 +713,8 @@ After about several minutes, you can get the performance evaluation result.
 > **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on factors such as maximum input/output length, prefix cache hit rate, precision requirements, and deployment machine ratios. It is recommended to refer to [Section 9.2](#92-tuning-guidelines) for tuning based on actual conditions.
 >
 > **Parallelism Strategy**: `Qwen3.5-27B-w8a8` and `Qwen3.6-27B-w8a8` are only ~30 GB and easily fit in a single NPU (64 GB HBM per NPU). Following the **DP-first** principle, **TP=2 is the recommended default** for most scenarios, and the remaining NPUs should be allocated to DP for parallel request batches. **TP=8 is only recommended for ultra-long context (256K+) scenarios**, where it shards the KV cache across 8 NPUs to maximize the available context window per rank. For `Qwen3.6-27B-w8a8`, you can also raise `--max-model-len` up to 262144 in the same TP/DP layout.
+>
+> **Atlas inference products**: Currently only the TP scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. Configure `--max-model-len` and `--max-num-seqs` based on the actual workload; setting them too high may cause OOM.
 
 #### Table 1: Scenario Overview
 

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -319,8 +319,8 @@ Startup Command:
 # Load model from ModelScope to speed up download
 export VLLM_USE_MODELSCOPE=True
 
-# Model weight path; can be a ModelScope model id or a local directory path
-export MODEL_PATH=/home/data/Qwen3.5-27B-W8A8/
+# Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.5-27B-w8a8-mtp) or a local directory path
+export MODEL_PATH=Eco-Tech/Qwen3.5-27B-w8a8-mtp
 
 vllm serve $MODEL_PATH \
 --host 127.0.0.1 \
@@ -349,8 +349,8 @@ Startup Command:
 # Load model from ModelScope to speed up download
 export VLLM_USE_MODELSCOPE=True
 
-# Model weight path; can be a ModelScope model id or a local directory path
-export MODEL_PATH=/home/data/Qwen3.6-27B-W8A8/
+# Model weight path; can be a ModelScope model id (e.g., Eco-Tech/Qwen3.6-27B-w8a8) or a local directory path
+export MODEL_PATH=Eco-Tech/Qwen3.6-27B-w8a8
 
 vllm serve $MODEL_PATH \
 --host 127.0.0.1 \

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -46,7 +46,6 @@ export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
 docker run --rm \
     --name vllm-ascend \
     --shm-size=1g \
-    --net=host \
     --device /dev/davinci0 \
     --device /dev/davinci1 \
     --device /dev/davinci2 \

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -1,0 +1,419 @@
+# Qwen3.5-Dense (Qwen3.5-2B/4B/9B)
+
+## 1 Introduction
+
+Qwen3.5-2B, Qwen3.5-4B, and Qwen3.5-9B are dense hybrid Mamba-Transformer language models in the Qwen3.5 family. They share the same hybrid attention design (GDN + full attention) and are suitable for general-purpose text generation tasks such as dialogue, content creation, and code generation.
+
+This document describes deployment and verification of these models on **Atlas inference products** and **Atlas 200I Pro**, including environment preparation, Docker installation, single-node online deployment, functional verification, and tuning notes.
+
+It is **strongly recommended to use the latest release candidate (rc) version or the latest official version** of `vllm-ascend`. Support for Qwen3.5-2B/4B/9B on Atlas inference products and Atlas 200I Pro starts from `vllm-ascend:v0.23.0rc1`.
+
+## 2 Supported Features
+
+Please refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) for the model support matrix.
+
+Please refer to the [Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration information.
+
+## 3 Prerequisites
+
+### 3.1 Model Weight
+
+| Model | Version | Hardware Requirement | Download |
+|-------|---------|----------------------|----------|
+| Qwen3.5-2B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://modelscope.cn/models/Qwen/Qwen3.5-2B) |
+| Qwen3.5-4B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://modelscope.cn/models/Qwen/Qwen3.5-4B) |
+| Qwen3.5-9B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://modelscope.cn/models/Qwen/Qwen3.5-9B) |
+
+It is recommended to download the model weight to a local directory such as `/root/.cache/` or `/home/data/`.
+
+## 4 Installation
+
+### 4.1 Docker Image Installation
+
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+
+It is **recommended to use the latest release candidate (rc) version or the latest official version** of the `vllm-ascend` image. As a minimum-version requirement, use `vllm-ascend:v0.23.0rc1-310p` (or a later `-310p`) image. For Atlas 200I Pro on openEuler, use the matching `-310p-openeuler` image.
+
+:::::::{tab-set}
+
+::::::{tab-item} Atlas inference products
+
+Start the docker image on your each node.
+
+```{code-block} bash
+  :substitutions:
+export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
+docker run --rm \
+    --name vllm-ascend \
+    --shm-size=1g \
+    --net=host \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -it $IMAGE bash
+```
+
+::::::
+
+::::::{tab-item} Atlas 200I Pro
+
+Start the docker image on your each node. Adjust `--device=/dev/davinci0` according to the NPU ID you want to use.
+
+:::::{tab-set}
+
+::::{tab-item} Ubuntu 24.04
+:selected:
+
+```{code-block} bash
+  :substitutions:
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
+
+docker run --rm \
+--privileged \
+--name vllm-ascend \
+--shm-size=10g \
+--device=/dev/davinci0:/dev/davinci0 \
+--device=/dev/davinci_manager \
+--device=/dev/ascend_manager \
+--device=/dev/user_config \
+-v /etc/sys_version.conf:/etc/sys_version.conf \
+-v /etc/ld.so.conf.d/mind_so.conf:/etc/ld.so.conf.d/mind_so.conf \
+-v /etc/hdcBasic.cfg:/etc/hdcBasic.cfg \
+-v /var/dmp_daemon:/var/dmp_daemon \
+-v /usr/lib64/libmmpa.so:/usr/lib64/libmmpa.so \
+-v /usr/lib64/libcrypto.so.1.1:/usr/lib64/libcrypto.so.1.1 \
+-v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+-v /usr/lib64/libstackcore.so:/usr/lib64/libstackcore.so \
+-v /usr/lib/aarch64-linux-gnu/libyaml-0.so.2:/usr/lib64/libyaml-0.so.2 \
+-v /etc/slog.conf:/etc/slog.conf \
+-v /var/slogd:/var/slogd \
+-v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+-v /usr/lib64/libtensorflow.so:/usr/lib64/libtensorflow.so \
+-v /root/.cache:/root/.cache \
+-p 8080:8080 \
+-it $IMAGE bash
+```
+
+::::
+
+::::{tab-item} openEuler 24.03
+
+```{code-block} bash
+  :substitutions:
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p-openeuler
+
+docker run --rm \
+--privileged \
+--name vllm-ascend \
+--shm-size=10g \
+--device=/dev/davinci0:/dev/davinci0 \
+--device=/dev/davinci_manager \
+--device=/dev/ascend_manager \
+--device=/dev/user_config \
+-v /etc/sys_version.conf:/etc/sys_version.conf \
+-v /etc/ld.so.conf.d/mind_so.conf:/etc/ld.so.conf.d/mind_so.conf \
+-v /etc/hdcBasic.cfg:/etc/hdcBasic.cfg \
+-v /var/dmp_daemon:/var/dmp_daemon \
+-v /usr/lib64/libsemanage.so.2:/usr/lib64/libsemanage.so.2 \
+-v /usr/lib64/libmmpa.so:/usr/lib64/libmmpa.so \
+-v /usr/lib64/libcrypto.so.1.1:/usr/lib64/libcrypto.so.1.1 \
+-v /usr/lib64/libyaml-0.so.2.0.9:/usr/lib64/libyaml-0.so.2 \
+-v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+-v /usr/lib64/libstackcore.so:/usr/lib64/libstackcore.so \
+-v /etc/slog.conf:/etc/slog.conf \
+-v /var/slogd:/var/slogd \
+-v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+-v /usr/lib64/libtensorflow.so:/usr/lib64/libtensorflow.so \
+-v /root/.cache:/root/.cache \
+-p 8080:8080 \
+-it $IMAGE bash
+```
+
+::::
+:::::
+
+::::::
+:::::::
+
+After a successful docker run, you can verify the running container service by executing the `docker ps` command. The expected result is that the container `vllm-ascend` is listed with status `Up`, confirming the docker installation is successful.
+
+### 4.2 Source Code Installation
+
+If you don't want to use the docker image as above, you can also build all from source:
+
+1. Clone the repository and install `vllm-ascend` from source:
+
+    ```bash
+    git clone https://github.com/vllm-project/vllm-ascend.git
+    cd vllm-ascend
+    pip install -e .
+    ```
+
+    For the complete installation steps, refer to [installation](../../installation.md).
+
+````{note}
+On Atlas inference products and Atlas 200I Pro, you may need to uninstall `triton-ascend` and `triton` to avoid dependency conflicts:
+
+```bash
+pip uninstall -y triton-ascend triton
+```
+````
+
+To verify the source code installation, run the following command and confirm the displayed version matches the one you installed:
+
+```bash
+pip show vllm-ascend
+```
+
+Expected result: The version information of `vllm-ascend` is displayed, confirming a successful installation.
+
+## 5 Online Service Deployment
+
+### 5.1 Single-Node Online Deployment
+
+Single-node deployment completes both Prefill and Decode within the same node. `Qwen3.5-2B`, `Qwen3.5-4B`, and `Qwen3.5-9B` can be deployed on Atlas inference products or Atlas 200I Pro.
+
+> **Parallelism note**: These platforms currently support the **TP** scenario. Choose **TP=1** or **TP=2** according to the model size and available devices. On Atlas 200I Pro with a single visible NPU, use **TP=1**.
+
+The following examples use FP16 weights from ModelScope. Replace `MODEL_PATH` with your local directory if needed.
+
+:::::{tab-set}
+
+::::{tab-item} Qwen3.5-2B
+
+Startup Command:
+
+```bash
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+
+# Model weight path; can be a ModelScope model id or a local directory path
+export MODEL_PATH=Qwen/Qwen3.5-2B
+
+vllm serve $MODEL_PATH \
+--host 127.0.0.1 \
+--port 1025 \
+--tensor-parallel-size 1 \
+--served-model-name qwen3.5 \
+--max-num-seqs 32 \
+--max-model-len 16384 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--mamba-ssm-cache-dtype float16 \
+--dtype float16 \
+--speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
+```
+
+::::
+
+::::{tab-item} Qwen3.5-4B
+
+Startup Command:
+
+```bash
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+
+# Model weight path; can be a ModelScope model id or a local directory path
+export MODEL_PATH=Qwen/Qwen3.5-4B
+
+vllm serve $MODEL_PATH \
+--host 127.0.0.1 \
+--port 1025 \
+--tensor-parallel-size 1 \
+--served-model-name qwen3.5 \
+--max-num-seqs 32 \
+--max-model-len 16384 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--mamba-ssm-cache-dtype float16 \
+--dtype float16 \
+--speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
+```
+
+::::
+
+::::{tab-item} Qwen3.5-9B
+
+Startup Command:
+
+```bash
+#!/bin/sh
+# Load model from ModelScope to speed up download
+export VLLM_USE_MODELSCOPE=True
+
+# Model weight path; can be a ModelScope model id or a local directory path
+export MODEL_PATH=Qwen/Qwen3.5-9B
+
+vllm serve $MODEL_PATH \
+--host 127.0.0.1 \
+--port 1025 \
+--tensor-parallel-size 2 \
+--served-model-name qwen3.5 \
+--max-num-seqs 32 \
+--max-model-len 16384 \
+--trust-remote-code \
+--gpu-memory-utilization 0.90 \
+--mamba-ssm-cache-dtype float16 \
+--dtype float16 \
+--speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
+```
+
+::::
+:::::
+
+Key Parameter Descriptions:
+
+- `--tensor-parallel-size` sets the tensor parallel size. Prefer **TP=1** on Atlas 200I Pro. On Atlas inference products, use **TP=1** for 2B/4B and **TP=2** for 9B as a starting point; adjust according to available devices.
+- `--max-model-len` represents the context length (input plus output for a single request). On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM.
+- `--max-num-seqs` indicates the maximum number of requests that can be processed concurrently. On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM.
+- `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM. The default value is `0.9`.
+- `--dtype float16` must be set on Atlas inference products and Atlas 200I Pro. These devices only support the FP16 data type.
+- `--mamba-ssm-cache-dtype` sets the data type of the Mamba SSM cache. On Atlas inference products and Atlas 200I Pro, only `float16` is supported.
+- `--speculative-config` uses `qwen3_5_mtp` for Qwen3.5 Dense models that include an MTP head.
+- `--compilation-config` contains configurations related to the aclgraph graph mode:
+    - `"cudagraph_mode"`: `"FULL_DECODE_ONLY"` is recommended.
+    - `"cudagraph_capture_sizes"`: when tensor parallelism (TP) is enabled, hardware event-id constraints allow at most two capture sizes (for example, `[1, 8]`).
+- `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required because `enable_npugraph_ex` is not supported on these platforms.
+
+Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
+
+Service Verification:
+
+If the service starts successfully, the following startup log will be displayed:
+
+```text
+(APIServer pid=<pid>) INFO:     Started server process [<pid>]
+(APIServer pid=<pid>) INFO:     Waiting for application startup.
+(APIServer pid=<pid>) INFO:     Application startup complete.
+```
+
+## 6 Functional Verification
+
+After the service is started, the model can be invoked by sending a prompt. Two API interfaces are supported: `completions` and `chat.completions`. Use the `--served-model-name` you configured (for example, `qwen3.5`). If you used `--port 1025` or `-p 8080:8080`, adjust the URL accordingly.
+
+**Completions API:**
+
+```bash
+curl http://127.0.0.1:1025/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.5",
+        "prompt": "The future of AI is",
+        "max_completion_tokens": 50,
+        "temperature": 0
+    }'
+```
+
+**Chat Completions API:**
+
+```bash
+curl http://127.0.0.1:1025/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.5",
+        "messages": [
+            {"role": "user", "content": "The future of AI is"}
+        ],
+        "max_completion_tokens": 1024,
+        "temperature": 0.7,
+        "top_p": 0.95
+    }'
+```
+
+Expected Result: The service returns HTTP 200 OK. The JSON response contains the `choices` field with generated text.
+
+## 7 Accuracy Evaluation
+
+### Using AISBench
+
+1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
+
+2. After execution, you can get the result. Here are the accuracy results of `Qwen3.5-2B`, `Qwen3.5-4B`, and `Qwen3.5-9B` on Atlas inference products for reference only.
+
+**Accuracy Evaluation Config File:**
+
+```python
+# Example configuration: benchmarks/ais_bench/benchmark/configs/models/vllm_api/vllm_api_general_chat.py
+from ais_bench.benchmark.models import VLLMCustomAPIChat
+from ais_bench.benchmark.utils.model_postprocessors import extract_non_reasoning_content
+
+models = [
+    dict(
+        attr="service",
+        type=VLLMCustomAPIChat,
+        abbr="vllm-api-general-chat",
+        path="your_model_path",
+        model="qwen3.5",
+        request_rate=0,
+        retry=2,
+        host_ip="127.0.0.1",
+        host_port=1025,
+        max_out_len=4096,
+        batch_size=16,
+        trust_remote_code=False,
+        generation_kwargs=dict(
+            temperature=0.0,
+            ignore_eos=False,
+            chat_template_kwargs = {"enable_thinking": False},
+        ),
+        pred_postprocessor=dict(type=extract_non_reasoning_content)
+    )
+]
+```
+
+| Model | dataset | version | metric | mode | vllm-api-general-chat |
+|-------|---------|---------|--------|------|------------------------|
+| Qwen3.5-2B | gsm8k | - | accuracy | gen | 77.71 |
+| Qwen3.5-2B | textvqa | - | accuracy | gen | 76.09 |
+| Qwen3.5-4B | gsm8k | - | accuracy | gen | 93.18 |
+| Qwen3.5-4B | textvqa | - | accuracy | gen | 79.08 |
+| Qwen3.5-9B | gsm8k | - | accuracy | gen | 95.30 |
+| Qwen3.5-9B | textvqa | - | accuracy | gen | 82.33 |
+
+## 8 Performance Evaluation
+
+### Using AISBench
+
+Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
+
+## 9 Performance Tuning
+
+### 9.1 Recommended Configurations
+
+> **Note**: The following configurations are for reference only. The optimal configuration depends on model size, maximum input/output length, and actual device memory.
+>
+> **Atlas inference products / Atlas 200I Pro**: Currently only the TP scenario is supported. Prefer **TP=1** for Qwen3.5-2B/4B and on Atlas 200I Pro. For Qwen3.5-9B on Atlas inference products, **TP=2** is a reasonable starting point. Configure `--max-model-len`, `--max-num-seqs`, and `--gpu-memory-utilization` based on the actual device memory; setting them too high may cause OOM.
+
+### 9.2 Tuning Guidelines
+
+Please refer to the [Public Performance Tuning Documentation](../../developer_guide/performance_and_debug/optimization_and_tuning.md) for tuning methods.
+
+Please refer to the [Feature Guide](../../user_guide/support_matrix/feature_matrix.md) for detailed feature descriptions.
+
+## 10 FAQ
+
+For common environment, installation, and general parameter issues, please refer to the [vLLM-Ascend Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html).

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -59,12 +59,12 @@ docker run --rm \
     --device /dev/devmm_svm \
     --device /dev/hisi_hdc \
     -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
     -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /root/.cache:/root/.cache \
+    -p 8080:8080 \
     -it $IMAGE bash
 ```
 

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -293,7 +293,7 @@ Key Parameter Descriptions:
 - `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM. The default value is `0.9`.
 - `--dtype float16` must be set on Atlas inference products and Atlas 200I Pro. These devices only support the FP16 data type.
 - `--mamba-ssm-cache-dtype` sets the data type of the Mamba SSM cache. On Atlas inference products and Atlas 200I Pro, only `float16` is supported.
-- `--speculative-config` uses `qwen3_5_mtp` for Qwen3.5 Dense models that include an MTP head.
+- `--speculative-config` uses `qwen3_5_mtp` for Qwen3.5 Dense models that include an MTP head. It is recommended to set `num_speculative_tokens` to `1`.
 - `--compilation-config` contains configurations related to the aclgraph graph mode:
     - `"cudagraph_mode"`: `"FULL_DECODE_ONLY"` is recommended.
     - `"cudagraph_capture_sizes"`: when tensor parallelism (TP) is enabled, hardware event-id constraints allow at most two capture sizes (for example, `[1, 8]`).

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -165,13 +165,13 @@ If you don't want to use the docker image as above, you can also build all from 
 
     For the complete installation steps, refer to [installation](../../installation.md).
 
-````{note}
-On Atlas inference products and Atlas 200I Pro, you may need to uninstall `triton-ascend` and `triton` to avoid dependency conflicts:
+    ````{note}
+    On Atlas inference products and Atlas 200I Pro, you may need to uninstall `triton-ascend` and `triton` to avoid dependency conflicts:
 
-```bash
-pip uninstall -y triton-ascend triton
-```
-````
+    ```bash
+    pip uninstall -y triton-ascend triton
+    ```
+    ````
 
 To verify the source code installation, run the following command and confirm the displayed version matches the one you installed:
 

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -248,7 +248,7 @@ vllm serve $MODEL_PATH \
 --mamba-ssm-cache-dtype float16 \
 --dtype float16 \
 --speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
 --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
 ```
 
@@ -269,7 +269,7 @@ export MODEL_PATH=Qwen/Qwen3.5-9B
 vllm serve $MODEL_PATH \
 --host 127.0.0.1 \
 --port 1025 \
---tensor-parallel-size 2 \
+--tensor-parallel-size 1 \
 --served-model-name qwen3.5 \
 --max-num-seqs 32 \
 --max-model-len 16384 \
@@ -278,7 +278,7 @@ vllm serve $MODEL_PATH \
 --mamba-ssm-cache-dtype float16 \
 --dtype float16 \
 --speculative-config '{"method": "qwen3_5_mtp","num_speculative_tokens":1}' \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
 --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}'
 ```
 

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -188,7 +188,7 @@ Expected result: The version information of `vllm-ascend` is displayed, confirmi
 
 Single-node deployment completes both Prefill and Decode within the same node. `Qwen3.5-2B`, `Qwen3.5-4B`, and `Qwen3.5-9B` can be deployed on Atlas inference products or Atlas 200I Pro.
 
-> **Parallelism note**: These platforms currently support the **TP** scenario. Choose **TP=1** or **TP=2** according to the model size and available devices. On Atlas 200I Pro with a single visible NPU, use **TP=1**.
+> **Parallelism note**: These platforms currently support the **TP** scenario. Choose **TP=1** or **TP=2** according to the available devices. On Atlas 200I Pro with a single visible NPU, use **TP=1**.
 
 The following examples use FP16 weights from ModelScope. Replace `MODEL_PATH` with your local directory if needed.
 
@@ -287,7 +287,7 @@ vllm serve $MODEL_PATH \
 
 Key Parameter Descriptions:
 
-- `--tensor-parallel-size` sets the tensor parallel size. Prefer **TP=1** on Atlas 200I Pro. On Atlas inference products, use **TP=1** for 2B/4B and **TP=2** for 9B as a starting point; adjust according to available devices.
+- `--tensor-parallel-size` sets the tensor parallel size. Prefer **TP=1** on Atlas 200I Pro. On Atlas inference products, **TP=1** and **TP=2** are both supported; choose according to the available devices.
 - `--max-model-len` represents the context length (input plus output for a single request). On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM.
 - `--max-num-seqs` indicates the maximum number of requests that can be processed concurrently. On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM.
 - `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. On Atlas inference products and Atlas 200I Pro, configure this value according to the actual device memory; setting it too high may cause OOM. The default value is `0.9`.
@@ -406,7 +406,7 @@ Refer to [Using AISBench for performance evaluation](../../developer_guide/evalu
 
 > **Note**: The following configurations are for reference only. The optimal configuration depends on model size, maximum input/output length, and actual device memory.
 >
-> **Atlas inference products / Atlas 200I Pro**: Currently only the TP scenario is supported. Prefer **TP=1** for Qwen3.5-2B/4B and on Atlas 200I Pro. For Qwen3.5-9B on Atlas inference products, **TP=2** is a reasonable starting point. Configure `--max-model-len`, `--max-num-seqs`, and `--gpu-memory-utilization` based on the actual device memory; setting them too high may cause OOM.
+> **Atlas inference products / Atlas 200I Pro**: Currently only the TP scenario is supported. Prefer **TP=1** on Atlas 200I Pro. On Atlas inference products, **TP=1** and **TP=2** are both supported; choose according to the available devices. Configure `--max-model-len`, `--max-num-seqs`, and `--gpu-memory-utilization` based on the actual device memory; setting them too high may cause OOM.
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -19,6 +19,7 @@ Qwen3-VL-Reranker.md
 Qwen3-Next.md
 Qwen3-Omni-30B-A3B-Thinking.md
 Qwen3.5-27B-Qwen3.6-27B.md
+Qwen3.5-Dense.md
 Qwen3.5-397B-A17B.md
 Qwen3.6-35B-A3B.md
 DeepSeek-V3.1.md


### PR DESCRIPTION

### What this PR does / why we need it?
Documentation Update: Added comprehensive documentation for Qwen3.5-Dense models (2B/4B/9B) on Atlas inference products and Atlas 200I Pro.
Atlas Inference Support: Updated existing Qwen3.5/3.6-27B documentation to include support details and configuration guidelines for Atlas inference products.
Navigation Update: Updated the models tutorial index to include the new Qwen3.5-Dense documentation.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
