### PR TITLE
[Refactor] Remove npu_sign_bits_pack ops

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -644,19 +644,6 @@ at::Tensor npu_reshape_and_cache_bnsd(const at::Tensor& hashq,
     return hashkCacheOut;
 }
 
-at::Tensor npu_sign_bits_pack(const at::Tensor& input,
-                                   const int64_t size) {
-    int64_t ySize = (input.size(0) + 7) / 8;
-    int64_t outDim = 0;
-    if (size != 0) {
-        outDim = ySize / size;
-    }
-
-    at::Tensor out = torch::empty({size, outDim}, torch::TensorOptions().dtype(torch::kUInt8).device(input.device()));
-    EXEC_NPU_CMD(aclnnSignBitsPack, input, size, out);
-    return out;
-}
-
 std::tuple<at::Tensor, at::Tensor> npu_gemma_rms_norm(
     const at::Tensor& x,
     const at::Tensor& gamma,
@@ -2505,9 +2492,6 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "npu_reshape_and_cache_bnsd(Tensor q, Tensor k_comp, Tensor slot_mapping, Tensor seq_len, Tensor k_out) -> Tensor"
     );
     ops.impl("npu_reshape_and_cache_bnsd", torch::kPrivateUse1, &vllm_ascend::npu_reshape_and_cache_bnsd);
-
-    ops.def("npu_sign_bits_pack(Tensor input, int size) -> Tensor");
-    ops.impl("npu_sign_bits_pack", torch::kPrivateUse1, &vllm_ascend::npu_sign_bits_pack);
 
     ops.def(
         "transpose_kv_cache_by_block(Tensor[] kCache, Tensor[] vCache, Tensor blockIDs, int blockSize, int headNum, int headDim, int splitNum, int layerNum) -> ()"

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -633,20 +633,6 @@ at::Tensor npu_hamming_dist_top_k_meta(const at::Tensor &hashq,
     return out;
 }
 
-at::Tensor npu_sign_bits_pack_meta(const at::Tensor& input,
-                                   const int64_t size) {
-    auto ySize = ceil_div(input.sym_size(0), 8);
-    c10::SymInt outDim(0);
-    if (size != 0) {
-        outDim = ySize / c10::SymInt(size);
-    }
-
-    at::Tensor out = at::empty_symint(
-        c10::SymDimVector{c10::SymInt(size), outDim},
-        torch::TensorOptions().dtype(torch::kUInt8).device(input.device()));
-    return out;
-}
-
 std::tuple<at::Tensor, at::Tensor> npu_gemma_rms_norm_meta(
     const at::Tensor& x,
     const at::Tensor& gamma,
@@ -1803,8 +1789,6 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_hamming_dist_top_k", &vllm_ascend::meta::npu_hamming_dist_top_k_meta);
     // reshape_and_cache_bnsd
     ops.impl("npu_reshape_and_cache_bnsd", &vllm_ascend::meta::npu_reshape_and_cache_bnsd_meta);
-    // npu_sign_bits_pack
-    ops.impl("npu_sign_bits_pack", &vllm_ascend::meta::npu_sign_bits_pack_meta);
     // CopyAndExpandEagleInputs
     ops.impl("npu_copy_and_expand_eagle_inputs", &vllm_ascend::meta::npu_copy_and_expand_eagle_inputs_meta);
     // causal_conv1d_fn

--- a/vllm_ascend/worker/kvcomp_utils.py
+++ b/vllm_ascend/worker/kvcomp_utils.py
@@ -444,12 +444,11 @@ class HashEncoder:
         if x_flat.dtype != self.dtype:
             x_flat = x_flat.to(self.dtype)
 
-        # [N, hash_bits]
-        xW = torch.matmul(x_flat, self.hash_weights)
-        # [N * hash_bits]
-        xW_flat = xW.view(-1)
-        # [N*hash_numbers], where hash_numbers = hash_bits // 8
-        packed_codes_flat = torch.ops._C_ascend.npu_sign_bits_pack(xW_flat, size=1)
+        # [N, hash_numbers, 8]
+        sign_bits = (torch.matmul(x_flat, self.hash_weights) > 0).to(torch.uint8).view(-1, self.hash_numbers, 8)
+        bit_weights = torch.tensor([1, 2, 4, 8, 16, 32, 64, 128], dtype=torch.uint8, device=self.device)
+        # [N, hash_numbers], where hash_numbers = hash_bits // 8
+        packed_codes_flat = (sign_bits * bit_weights).sum(dim=-1).to(torch.uint8).view(-1)
 
         # e.g., [s1, s2, s3, hash_numbers]
         out_shape = orig_shape + (self.hash_numbers,)


### PR DESCRIPTION
## What this PR does / why we need it?

Remove the custom _C_ascend.npu_sign_bits_pack op registration and meta implementation. HashEncoder.compute_hash now packs sign bits with standard PyTorch tensor operations, so KV compression no longer depends on this custom op.

## Does this PR introduce _any_ user-facing change?

No. This removes an internal custom op path.

## How was this patch tested?

- git diff --check
- python -m py_compile vllm_ascend/worker/kvcomp_utils.py
- git grep -n "npu_sign_bits_pack\|aclnnSignBitsPack\|sign_bits_pack" -- .
- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
