### PR TITLE
[Doc](GLM5.2, DCP): update GLM5.2 docs with 1M Context Configuration

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1181,7 +1181,8 @@ This section provides a usable starting configuration for serving `GLM-5.2` with
 | Mode | Hardware | Parallelism | Context | Notes |
 | ---- | -------- | ----------- | ------- | ----- |
 | Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` | Prefill and decode run in one service. This is the simplest 1M context validation mode. |
-| 2P2D PD disaggregation | 2 prefiller A3 nodes + 2 decoder A3 nodes | Prefill `DP4 PP1 TP4 PCP1 DCP4`, Decode `DP4 PP1 TP4 PCP1 DCP4` | `1024000` | Prefill and decode are separated through Mooncake KV transfer and a proxy. Each node starts 2 local DP ranks. |
+| Dual-node co-located | 2 Atlas 800 A3 (64G x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` | Prefill and decode run in one service across two nodes. Each node starts 2 local DP ranks. |
+| 2P2D PD disaggregation | 2 prefiller A3 nodes + 2 decoder A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` | Prefill and decode are separated through Mooncake KV transfer and a proxy. P and D nodes use the same DP/TP/DCP shape. |
 
 #### Single-Node 1M Deployment
 
@@ -1230,9 +1231,67 @@ vllm serve <MODEL_PATH> \
   --safetensors-load-strategy prefetch
 ```
 
+#### Dual-Node Co-Located 1M Deployment
+
+Run the following script on both co-located nodes. For node 0, set `local_ip="<NODE0_IP>"`, `node_0_ip="<NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For node 1, set `local_ip="<NODE1_IP>"`, `node_0_ip="<NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
+
+```shell
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_NODE_IP>"
+node_0_ip="<NODE0_IP>"
+data_parallel_start_rank=0
+server_role_args="--api-server-count 1"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+
+export VLLM_ASCEND_ENABLE_NZ=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=20
+export HCCL_BUFFSIZE=768
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export ASCEND_ENABLE_USE_FABRIC_MEM=1
+export TASK_QUEUE_ENABLE=1
+export CPU_AFFINITY_CONF=1
+# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9000 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.80 \
+  ${server_role_args} \
+  --max-num-seqs 32 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
+  --data-parallel-start-rank $data_parallel_start_rank \
+  --data-parallel-address $node_0_ip \
+  --data-parallel-rpc-port 16591 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 8 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 8 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch
+```
+
 #### PD Disaggregation 1M Deployment
 
-For PD disaggregation, start two prefiller nodes and two decoder nodes, then start the request forwarding proxy. The following example uses global `DP4 TP4 DCP4` on both the prefill and decode sides. Each node runs two local DP ranks (`--data-parallel-size-local 2`) with `TP4`, and the second node on each side joins with `--headless` and `--data-parallel-start-rank 2`.
+For PD disaggregation, start two prefiller nodes and two decoder nodes, then start the request forwarding proxy. The following example uses global `DP4 TP8 DCP8` on both the prefill and decode sides. Each P/D node uses the same shape: two local DP ranks (`--data-parallel-size-local 2`) with `TP8`. The second node on each side joins with `--headless` and `--data-parallel-start-rank 2`.
 
 Run the prefiller on both prefiller nodes. For prefiller node 0, set `local_ip="<PREFILL_NODE0_IP>"`, `node_p0_ip="<PREFILL_NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For prefiller node 1, set `local_ip="<PREFILL_NODE1_IP>"`, `node_p0_ip="<PREFILL_NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
 
@@ -1260,8 +1319,8 @@ export ASCEND_ENABLE_USE_FABRIC_MEM=1
 export TASK_QUEUE_ENABLE=1
 export CPU_AFFINITY_CONF=1
 export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-# Each node uses 2 local DP ranks x TP4 = 8 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 
 vllm serve <MODEL_PATH> \
   --seed 1024 \
@@ -1279,9 +1338,9 @@ vllm serve <MODEL_PATH> \
   --data-parallel-address $node_p0_ip \
   --data-parallel-rpc-port 16591 \
   --pipeline-parallel-size 1 \
-  --tensor-parallel-size 4 \
+  --tensor-parallel-size 8 \
   --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 4 \
+  --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
   --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
@@ -1298,11 +1357,11 @@ vllm serve <MODEL_PATH> \
       "use_ascend_direct": true,
       "prefill": {
         "dp_size": 4,
-        "tp_size": 4
+        "tp_size": 8
       },
       "decode": {
         "dp_size": 4,
-        "tp_size": 4
+        "tp_size": 8
       }
     }
   }'
@@ -1333,8 +1392,8 @@ export VLLM_WORKER_MULTIPROC_METHOD=spawn
 export ASCEND_ENABLE_USE_FABRIC_MEM=1
 export TASK_QUEUE_ENABLE=1
 export CPU_AFFINITY_CONF=1
-# Each node uses 2 local DP ranks x TP4 = 8 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 
 vllm serve <MODEL_PATH> \
   --seed 1024 \
@@ -1352,9 +1411,9 @@ vllm serve <MODEL_PATH> \
   --data-parallel-address $node_d0_ip \
   --data-parallel-rpc-port 16600 \
   --pipeline-parallel-size 1 \
-  --tensor-parallel-size 4 \
+  --tensor-parallel-size 8 \
   --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 4 \
+  --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
   --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
@@ -1371,11 +1430,11 @@ vllm serve <MODEL_PATH> \
       "use_ascend_direct": true,
       "prefill": {
         "dp_size": 4,
-        "tp_size": 4
+        "tp_size": 8
       },
       "decode": {
         "dp_size": 4,
-        "tp_size": 4
+        "tp_size": 8
       }
     }
   }'
@@ -1401,7 +1460,7 @@ For a scaled PD topology, keep `--max-model-len 1024000` and `--cp-kv-cache-inte
 Key parameter notes:
 
 - `--max-model-len 1024000` enables the 1M context window.
-- `--decode-context-parallel-size` must always be equal to `--tensor-parallel-size` in this model architecture. The single-node example uses `TP16 DCP16`, and the PD example uses `TP4 DCP4`.
+- `--decode-context-parallel-size` must always be equal to `--tensor-parallel-size` in this model architecture. The single-node example uses `TP16 DCP16`, and the dual-node co-located and PD examples use `TP8 DCP8`.
 
 ## Functional Verification
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1182,7 +1182,7 @@ Recommended configurations for serving `GLM-5.2` with a 1M context window on Atl
 | ---- | -------- | ----------- | ------- |
 | Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
 | Dual-node co-located | 2 Atlas 800 A3 (64G x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
-| 2P2D PD disaggregation | 1 prefiller with 2 A3 nodes + 1 decoder with 2 A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
+| 1P1D PD disaggregation | 1 prefiller with 2 A3 nodes + 1 decoder with 2 A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
 
 #### Single-Node 1M Deployment
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1403,8 +1403,6 @@ Key parameter notes:
 - `--max-model-len 1024000` enables the 1M context window.
 - `--decode-context-parallel-size` must always be equal to `--tensor-parallel-size` in this model architecture. The single-node example uses `TP16 DCP16`, and the PD example uses `TP4 DCP4`.
 
-
-
 ## Functional Verification
 
 Once your server is started, you can query the model with input prompts:

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1270,9 +1270,9 @@ vllm serve <MODEL_PATH> \
   --served-model-name glm-52 \
   --max-model-len 1024000 \
   --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.80 \
+  --gpu-memory-utilization 0.75 \
   ${server_role_args} \
-  --max-num-seqs 32 \
+  --max-num-seqs 8 \
   --data-parallel-size 4 \
   --data-parallel-size-local 2 \
   --data-parallel-start-rank $data_parallel_start_rank \
@@ -1283,7 +1283,7 @@ vllm serve <MODEL_PATH> \
   --prefill-context-parallel-size 1 \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
   --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
@@ -1331,9 +1331,9 @@ vllm serve <MODEL_PATH> \
   --served-model-name glm-52 \
   --max-model-len 1024000 \
   --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.80 \
+  --gpu-memory-utilization 0.75 \
   ${server_role_args} \
-  --max-num-seqs 32 \
+  --max-num-seqs 8 \
   --data-parallel-size 4 \
   --data-parallel-size-local 2 \
   --data-parallel-start-rank $data_parallel_start_rank \
@@ -1344,9 +1344,9 @@ vllm serve <MODEL_PATH> \
   --prefill-context-parallel-size 1 \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --enforce-eager \
   --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \
   --safetensors-load-strategy prefetch \
@@ -1407,7 +1407,7 @@ vllm serve <MODEL_PATH> \
   --served-model-name glm-52 \
   --max-model-len 1024000 \
   --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.80 \
+  --gpu-memory-utilization 0.75 \
   ${server_role_args} \
   --max-num-seqs 32 \
   --data-parallel-size 4 \
@@ -1420,7 +1420,7 @@ vllm serve <MODEL_PATH> \
   --prefill-context-parallel-size 1 \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
   --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1174,6 +1174,237 @@ Some configurations for optimization are shown below:
 
 Please refer to the following python file for further explanation and restrictions of the environment variables above: [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py)
 
+### 1M Context Configuration
+
+This section provides a usable starting configuration for serving `GLM-5.2` with a 1M context window, but it does not represent the best-performance configuration for all workloads. The examples target Atlas 800 A3 (64G x 16) and quantized GLM-5.2(W4A8C8) weights. Replace `<MODEL_PATH>`, IP addresses, ports, and NIC names with the actual values in your environment.
+
+| Mode | Hardware | Parallelism | Context | Notes |
+| ---- | -------- | ----------- | ------- | ----- |
+| Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` | Prefill and decode run in one service. This is the simplest 1M context validation mode. |
+| 2P2D PD disaggregation | 2 prefiller A3 nodes + 2 decoder A3 nodes | Prefill `DP4 PP1 TP4 PCP1 DCP4`, Decode `DP4 PP1 TP4 PCP1 DCP4` | `1024000` | Prefill and decode are separated through Mooncake KV transfer and a proxy. Each node starts 2 local DP ranks. |
+
+#### Single-Node 1M Deployment
+
+Run the following script on one Atlas 800 A3 node.
+
+```shell
+export VLLM_ASCEND_ENABLE_NZ=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=20
+export HCCL_BUFFSIZE=768
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+# Required only when the HDK version supports fabric memory.
+export ASCEND_ENABLE_USE_FABRIC_MEM=1
+
+export TASK_QUEUE_ENABLE=1
+export CPU_AFFINITY_CONF=1
+
+# Optional. Requires root permission in the container.
+echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9000 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.90 \
+  --api-server-count 1 \
+  --max-num-seqs 4 \
+  --data-parallel-size 1 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 16 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 16 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch
+```
+
+#### PD Disaggregation 1M Deployment
+
+For PD disaggregation, start two prefiller nodes and two decoder nodes, then start the request forwarding proxy. The following example uses global `DP4 TP4 DCP4` on both the prefill and decode sides. Each node runs two local DP ranks (`--data-parallel-size-local 2`) with `TP4`, and the second node on each side joins with `--headless` and `--data-parallel-start-rank 2`.
+
+Run the prefiller on both prefiller nodes. For prefiller node 0, set `local_ip="<PREFILL_NODE0_IP>"`, `node_p0_ip="<PREFILL_NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For prefiller node 1, set `local_ip="<PREFILL_NODE1_IP>"`, `node_p0_ip="<PREFILL_NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
+
+```shell
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_PREFILL_NODE_IP>"
+node_p0_ip="<PREFILL_NODE0_IP>"
+data_parallel_start_rank=0
+server_role_args="--api-server-count 1"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+
+export VLLM_ASCEND_ENABLE_NZ=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=20
+export HCCL_BUFFSIZE=768
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export ASCEND_ENABLE_USE_FABRIC_MEM=1
+export TASK_QUEUE_ENABLE=1
+export CPU_AFFINITY_CONF=1
+export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+# Each node uses 2 local DP ranks x TP4 = 8 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9081 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.90 \
+  ${server_role_args} \
+  --max-num-seqs 4 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
+  --data-parallel-start-rank $data_parallel_start_rank \
+  --data-parallel-address $node_p0_ip \
+  --data-parallel-rpc-port 16591 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 4 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 4 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch \
+  --kv-transfer-config \
+  '{"kv_connector": "MooncakeConnectorV1",
+    "kv_role": "kv_producer",
+    "kv_port": "30000",
+    "engine_id": "0",
+    "kv_connector_extra_config": {
+      "use_ascend_direct": true,
+      "prefill": {
+        "dp_size": 4,
+        "tp_size": 4
+      },
+      "decode": {
+        "dp_size": 4,
+        "tp_size": 4
+      }
+    }
+  }'
+```
+
+Run the decoder on both decoder nodes. For decoder node 0, set `local_ip="<DECODE_NODE0_IP>"`, `node_d0_ip="<DECODE_NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For decoder node 1, set `local_ip="<DECODE_NODE1_IP>"`, `node_d0_ip="<DECODE_NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
+
+```shell
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_DECODE_NODE_IP>"
+node_d0_ip="<DECODE_NODE0_IP>"
+data_parallel_start_rank=0
+server_role_args="--api-server-count 1"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+
+export VLLM_ASCEND_ENABLE_NZ=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=20
+export HCCL_BUFFSIZE=768
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export ASCEND_ENABLE_USE_FABRIC_MEM=1
+export TASK_QUEUE_ENABLE=1
+export CPU_AFFINITY_CONF=1
+# Each node uses 2 local DP ranks x TP4 = 8 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9900 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.90 \
+  ${server_role_args} \
+  --max-num-seqs 4 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
+  --data-parallel-start-rank $data_parallel_start_rank \
+  --data-parallel-address $node_d0_ip \
+  --data-parallel-rpc-port 16600 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 4 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 4 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
+  --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch \
+  --kv-transfer-config \
+  '{"kv_connector": "MooncakeConnectorV1",
+    "kv_role": "kv_consumer",
+    "kv_port": "30100",
+    "engine_id": "1",
+    "kv_connector_extra_config": {
+      "use_ascend_direct": true,
+      "prefill": {
+        "dp_size": 4,
+        "tp_size": 4
+      },
+      "decode": {
+        "dp_size": 4,
+        "tp_size": 4
+      }
+    }
+  }'
+```
+
+Start the proxy after both services are ready:
+
+```shell
+unset http_proxy
+unset https_proxy
+
+python load_balance_proxy_server_example.py \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --prefiller-hosts <PREFILL_NODE0_IP> \
+  --prefiller-ports 9081 \
+  --decoder-hosts <DECODE_NODE0_IP> \
+  --decoder-ports 9900
+```
+
+For a scaled PD topology, keep `--max-model-len 1024000` and `--cp-kv-cache-interleave-size 128` as the 1M context baseline, then update `--data-parallel-size`, `--data-parallel-size-local`, `--data-parallel-start-rank`, `--tensor-parallel-size`, `--decode-context-parallel-size`, `--data-parallel-address`, `--data-parallel-rpc-port`, and the `kv_connector_extra_config` `dp_size`/`tp_size` fields consistently across all P/D nodes. When changing TP, update DCP to the same value.
+
+Key parameter notes:
+
+- `--max-model-len 1024000` enables the 1M context window.
+- `--decode-context-parallel-size` must always be equal to `--tensor-parallel-size` in this model architecture. The single-node example uses `TP16 DCP16`, and the PD example uses `TP4 DCP4`.
+
+
+
 ## Functional Verification
 
 Once your server is started, you can query the model with input prompts:

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1182,7 +1182,7 @@ Recommended configurations for serving `GLM-5.2` with a 1M context window on Atl
 | ---- | -------- | ----------- | ------- |
 | Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
 | Dual-node co-located | 2 Atlas 800 A3 (64G x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
-| 2P2D PD disaggregation | 2 prefiller A3 nodes + 2 decoder A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
+| 2P2D PD disaggregation | 1 prefiller with 2 A3 nodes + 1 decoder with 2 A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
 
 #### Single-Node 1M Deployment
 
@@ -1195,17 +1195,9 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
 export HCCL_BUFFSIZE=768
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_SERVER_DEV_MODE=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 
-# Required only when the HDK version supports fabric memory.
-export ASCEND_ENABLE_USE_FABRIC_MEM=1
-
 export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
-
-# Optional. Requires root permission in the container.
-echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 
 vllm serve <MODEL_PATH> \
   --seed 1024 \
@@ -1255,13 +1247,8 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
 export HCCL_BUFFSIZE=768
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_SERVER_DEV_MODE=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export ASCEND_ENABLE_USE_FABRIC_MEM=1
 export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
-# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 
 vllm serve <MODEL_PATH> \
   --seed 1024 \
@@ -1315,14 +1302,9 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
 export HCCL_BUFFSIZE=768
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_SERVER_DEV_MODE=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export ASCEND_ENABLE_USE_FABRIC_MEM=1
 export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
 export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 
 vllm serve <MODEL_PATH> \
   --seed 1024 \
@@ -1391,14 +1373,9 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
 export HCCL_BUFFSIZE=768
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_SERVER_DEV_MODE=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export ASCEND_ENABLE_USE_FABRIC_MEM=1
 export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
 export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
 
 vllm serve <MODEL_PATH> \
   --seed 1024 \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1176,17 +1176,16 @@ Please refer to the following python file for further explanation and restrictio
 
 ### 1M Context Configuration
 
-This section provides a usable starting configuration for serving `GLM-5.2` with a 1M context window, but it does not represent the best-performance configuration for all workloads. The examples target Atlas 800 A3 (64G x 16) and quantized GLM-5.2(W4A8C8) weights. Replace `<MODEL_PATH>`, IP addresses, ports, and NIC names with the actual values in your environment.
+Recommended configurations for serving `GLM-5.2` with a 1M context window on Atlas 800 A3 (64G x 16) and quantized GLM-5.2(W4A8C8) weights:
 
-| Mode | Hardware | Parallelism | Context | Notes |
-| ---- | -------- | ----------- | ------- | ----- |
-| Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` | Prefill and decode run in one service. This is the simplest 1M context validation mode. |
-| Dual-node co-located | 2 Atlas 800 A3 (64G x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` | Prefill and decode run in one service across two nodes. Each node starts 2 local DP ranks. |
-| 2P2D PD disaggregation | 2 prefiller A3 nodes + 2 decoder A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` | Prefill and decode are separated through Mooncake KV transfer and a proxy. P and D nodes use the same DP/TP/DCP shape. |
+| Mode | Hardware | Parallelism | Context |
+| ---- | -------- | ----------- | ------- |
+| Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
+| Dual-node co-located | 2 Atlas 800 A3 (64G x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
 
 #### Single-Node 1M Deployment
 
-Run the following script on one Atlas 800 A3 node.
+Recommended command:
 
 ```shell
 export VLLM_ASCEND_ENABLE_NZ=1
@@ -1233,7 +1232,7 @@ vllm serve <MODEL_PATH> \
 
 #### Dual-Node Co-Located 1M Deployment
 
-Run the following script on both co-located nodes. For node 0, set `local_ip="<NODE0_IP>"`, `node_0_ip="<NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For node 1, set `local_ip="<NODE1_IP>"`, `node_0_ip="<NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
+Recommended command for both co-located nodes:
 
 ```shell
 nic_name="<NIC_NAME>"
@@ -1288,179 +1287,6 @@ vllm serve <MODEL_PATH> \
   --enable-expert-parallel \
   --safetensors-load-strategy prefetch
 ```
-
-#### PD Disaggregation 1M Deployment
-
-For PD disaggregation, start two prefiller nodes and two decoder nodes, then start the request forwarding proxy. The following example uses global `DP4 TP8 DCP8` on both the prefill and decode sides. Each P/D node uses the same shape: two local DP ranks (`--data-parallel-size-local 2`) with `TP8`. The second node on each side joins with `--headless` and `--data-parallel-start-rank 2`.
-
-Run the prefiller on both prefiller nodes. For prefiller node 0, set `local_ip="<PREFILL_NODE0_IP>"`, `node_p0_ip="<PREFILL_NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For prefiller node 1, set `local_ip="<PREFILL_NODE1_IP>"`, `node_p0_ip="<PREFILL_NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
-
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_PREFILL_NODE_IP>"
-node_p0_ip="<PREFILL_NODE0_IP>"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-
-export VLLM_ASCEND_ENABLE_NZ=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_SERVER_DEV_MODE=1
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export ASCEND_ENABLE_USE_FABRIC_MEM=1
-export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9081 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.90 \
-  ${server_role_args} \
-  --max-num-seqs 4 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_p0_ip \
-  --data-parallel-rpc-port 16591 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
-  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_role": "kv_producer",
-    "kv_port": "30000",
-    "engine_id": "0",
-    "kv_connector_extra_config": {
-      "use_ascend_direct": true,
-      "prefill": {
-        "dp_size": 4,
-        "tp_size": 8
-      },
-      "decode": {
-        "dp_size": 4,
-        "tp_size": 8
-      }
-    }
-  }'
-```
-
-Run the decoder on both decoder nodes. For decoder node 0, set `local_ip="<DECODE_NODE0_IP>"`, `node_d0_ip="<DECODE_NODE0_IP>"`, `data_parallel_start_rank=0`, and `server_role_args="--api-server-count 1"`. For decoder node 1, set `local_ip="<DECODE_NODE1_IP>"`, `node_d0_ip="<DECODE_NODE0_IP>"`, `data_parallel_start_rank=2`, and `server_role_args="--headless"`.
-
-```shell
-nic_name="<NIC_NAME>"
-local_ip="<CURRENT_DECODE_NODE_IP>"
-node_d0_ip="<DECODE_NODE0_IP>"
-data_parallel_start_rank=0
-server_role_args="--api-server-count 1"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-
-export VLLM_ASCEND_ENABLE_NZ=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=20
-export HCCL_BUFFSIZE=768
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_SERVER_DEV_MODE=1
-export VLLM_WORKER_MULTIPROC_METHOD=spawn
-export ASCEND_ENABLE_USE_FABRIC_MEM=1
-export TASK_QUEUE_ENABLE=1
-export CPU_AFFINITY_CONF=1
-# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-
-vllm serve <MODEL_PATH> \
-  --seed 1024 \
-  --host 0.0.0.0 \
-  --port 9900 \
-  --served-model-name glm-52 \
-  --max-model-len 1024000 \
-  --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.90 \
-  ${server_role_args} \
-  --max-num-seqs 4 \
-  --data-parallel-size 4 \
-  --data-parallel-size-local 2 \
-  --data-parallel-start-rank $data_parallel_start_rank \
-  --data-parallel-address $node_d0_ip \
-  --data-parallel-rpc-port 16600 \
-  --pipeline-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --prefill-context-parallel-size 1 \
-  --decode-context-parallel-size 8 \
-  --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
-  --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
-  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
-  --quantization ascend \
-  --enable-expert-parallel \
-  --safetensors-load-strategy prefetch \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_role": "kv_consumer",
-    "kv_port": "30100",
-    "engine_id": "1",
-    "kv_connector_extra_config": {
-      "use_ascend_direct": true,
-      "prefill": {
-        "dp_size": 4,
-        "tp_size": 8
-      },
-      "decode": {
-        "dp_size": 4,
-        "tp_size": 8
-      }
-    }
-  }'
-```
-
-Start the proxy after both services are ready:
-
-```shell
-unset http_proxy
-unset https_proxy
-
-python load_balance_proxy_server_example.py \
-  --host 0.0.0.0 \
-  --port 8000 \
-  --prefiller-hosts <PREFILL_NODE0_IP> \
-  --prefiller-ports 9081 \
-  --decoder-hosts <DECODE_NODE0_IP> \
-  --decoder-ports 9900
-```
-
-For a scaled PD topology, keep `--max-model-len 1024000` and `--cp-kv-cache-interleave-size 128` as the 1M context baseline, then update `--data-parallel-size`, `--data-parallel-size-local`, `--data-parallel-start-rank`, `--tensor-parallel-size`, `--decode-context-parallel-size`, `--data-parallel-address`, `--data-parallel-rpc-port`, and the `kv_connector_extra_config` `dp_size`/`tp_size` fields consistently across all P/D nodes. When changing TP, update DCP to the same value.
-
-Key parameter notes:
-
-- `--max-model-len 1024000` enables the 1M context window.
-- `--decode-context-parallel-size` must always be equal to `--tensor-parallel-size` in this model architecture. The single-node example uses `TP16 DCP16`, and the dual-node co-located and PD examples use `TP8 DCP8`.
 
 ## Functional Verification
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1345,7 +1345,7 @@ vllm serve <MODEL_PATH> \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --enforce-eager \
-  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
   --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \
@@ -1421,7 +1421,7 @@ vllm serve <MODEL_PATH> \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1182,6 +1182,7 @@ Recommended configurations for serving `GLM-5.2` with a 1M context window on Atl
 | ---- | -------- | ----------- | ------- |
 | Single-node co-located | 1 Atlas 800 A3 (64G x 16) | `DP1 PP1 TP16 PCP1 DCP16` | `1024000` |
 | Dual-node co-located | 2 Atlas 800 A3 (64G x 16) | `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
+| 2P2D PD disaggregation | 2 prefiller A3 nodes + 2 decoder A3 nodes | Prefill `DP4 PP1 TP8 PCP1 DCP8`, Decode `DP4 PP1 TP8 PCP1 DCP8` | `1024000` |
 
 #### Single-Node 1M Deployment
 
@@ -1238,6 +1239,8 @@ Recommended command for both co-located nodes:
 nic_name="<NIC_NAME>"
 local_ip="<CURRENT_NODE_IP>"
 node_0_ip="<NODE0_IP>"
+# Node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
+# Node 1: data_parallel_start_rank=2, server_role_args="--headless"
 data_parallel_start_rank=0
 server_role_args="--api-server-count 1"
 
@@ -1286,6 +1289,175 @@ vllm serve <MODEL_PATH> \
   --quantization ascend \
   --enable-expert-parallel \
   --safetensors-load-strategy prefetch
+```
+
+#### PD Disaggregation 1M Deployment
+
+Recommended command for both prefiller nodes:
+
+```shell
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_PREFILL_NODE_IP>"
+node_p0_ip="<PREFILL_NODE0_IP>"
+# Prefiller node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
+# Prefiller node 1: data_parallel_start_rank=2, server_role_args="--headless"
+data_parallel_start_rank=0
+server_role_args="--api-server-count 1"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+
+export VLLM_ASCEND_ENABLE_NZ=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=20
+export HCCL_BUFFSIZE=768
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export ASCEND_ENABLE_USE_FABRIC_MEM=1
+export TASK_QUEUE_ENABLE=1
+export CPU_AFFINITY_CONF=1
+export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9081 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.80 \
+  ${server_role_args} \
+  --max-num-seqs 32 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
+  --data-parallel-start-rank $data_parallel_start_rank \
+  --data-parallel-address $node_p0_ip \
+  --data-parallel-rpc-port 16591 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 8 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 8 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch \
+  --kv-transfer-config \
+  '{"kv_connector": "MooncakeConnectorV1",
+    "kv_role": "kv_producer",
+    "kv_port": "30000",
+    "engine_id": "0",
+    "kv_connector_extra_config": {
+      "use_ascend_direct": true,
+      "prefill": {
+        "dp_size": 4,
+        "tp_size": 8
+      },
+      "decode": {
+        "dp_size": 4,
+        "tp_size": 8
+      }
+    }
+  }'
+```
+
+Recommended command for both decoder nodes:
+
+```shell
+nic_name="<NIC_NAME>"
+local_ip="<CURRENT_DECODE_NODE_IP>"
+node_d0_ip="<DECODE_NODE0_IP>"
+# Decoder node 0: data_parallel_start_rank=0, server_role_args="--api-server-count 1"
+# Decoder node 1: data_parallel_start_rank=2, server_role_args="--headless"
+data_parallel_start_rank=0
+server_role_args="--api-server-count 1"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+
+export VLLM_ASCEND_ENABLE_NZ=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=20
+export HCCL_BUFFSIZE=768
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_SERVER_DEV_MODE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export ASCEND_ENABLE_USE_FABRIC_MEM=1
+export TASK_QUEUE_ENABLE=1
+export CPU_AFFINITY_CONF=1
+export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+# Each node uses 2 local DP ranks x TP8 = 16 NPUs. Change the list if needed.
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+
+vllm serve <MODEL_PATH> \
+  --seed 1024 \
+  --host 0.0.0.0 \
+  --port 9900 \
+  --served-model-name glm-52 \
+  --max-model-len 1024000 \
+  --max-num-batched-tokens 16384 \
+  --gpu-memory-utilization 0.80 \
+  ${server_role_args} \
+  --max-num-seqs 32 \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 2 \
+  --data-parallel-start-rank $data_parallel_start_rank \
+  --data-parallel-address $node_d0_ip \
+  --data-parallel-rpc-port 16600 \
+  --pipeline-parallel-size 1 \
+  --tensor-parallel-size 8 \
+  --prefill-context-parallel-size 1 \
+  --decode-context-parallel-size 8 \
+  --cp-kv-cache-interleave-size 128 \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
+  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
+  --quantization ascend \
+  --enable-expert-parallel \
+  --safetensors-load-strategy prefetch \
+  --kv-transfer-config \
+  '{"kv_connector": "MooncakeConnectorV1",
+    "kv_role": "kv_consumer",
+    "kv_port": "30100",
+    "engine_id": "1",
+    "kv_connector_extra_config": {
+      "use_ascend_direct": true,
+      "prefill": {
+        "dp_size": 4,
+        "tp_size": 8
+      },
+      "decode": {
+        "dp_size": 4,
+        "tp_size": 8
+      }
+    }
+  }'
+```
+
+Recommended proxy command:
+
+```shell
+unset http_proxy
+unset https_proxy
+
+python load_balance_proxy_server_example.py \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --prefiller-hosts <PREFILL_NODE0_IP> \
+  --prefiller-ports 9081 \
+  --decoder-hosts <DECODE_NODE0_IP> \
+  --decoder-ports 9900
 ```
 
 ## Functional Verification

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1213,16 +1213,16 @@ vllm serve <MODEL_PATH> \
   --served-model-name glm-52 \
   --max-model-len 1024000 \
   --max-num-batched-tokens 16384 \
-  --gpu-memory-utilization 0.90 \
+  --gpu-memory-utilization 0.80 \
   --api-server-count 1 \
-  --max-num-seqs 4 \
+  --max-num-seqs 32 \
   --data-parallel-size 1 \
   --pipeline-parallel-size 1 \
   --tensor-parallel-size 16 \
   --prefill-context-parallel-size 1 \
   --decode-context-parallel-size 16 \
   --cp-kv-cache-interleave-size 128 \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16]}' \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
   --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "fuse_muls_add": true, "multistream_overlap_shared_expert": true, "enable_mc2_hierarchy_comm": false, "enable_sparse_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \


### PR DESCRIPTION
## Summary
- Updates the GLM5.2 tutorial docs with 1M context configuration guidance.
- Adds the DCP-related configuration and deployment notes for the GLM5.2 documentation.
- Cherry-picked from f080f60cdd7c3f737dac54a092091d3e0fb1251b.

## Validation
- Not run; docs-only change.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
