### PR TITLE
[v0.23.0][Bugfix] Bind Mooncake receiver threads to KV cache device

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -618,6 +618,69 @@ class TestKVCacheRecvingThreadBasic(unittest.TestCase):
         result = self.thread.get_and_clear_finished_requests()
         self.assertEqual(result, {"req1", "req2"})
 
+    def test_executor_workers_bind_kv_cache_device_before_handling_requests(self):
+        expected_device = torch.device("npu:5")
+        kv_cache = MagicMock(device=expected_device)
+        worker_events: defaultdict[int, list[tuple[str, int | str]]] = defaultdict(list)
+        events_lock = threading.Lock()
+        both_workers_started = threading.Event()
+        release_workers = threading.Event()
+
+        def record_set_device(device):
+            device_index = device if isinstance(device, int) else torch.device(device).index
+            with events_lock:
+                worker_events[threading.get_ident()].append(("set_device", cast(int, device_index)))
+
+        with patch("torch.npu.set_device", side_effect=record_set_device):
+            thread = KVCacheRecvingThread(
+                tp_rank=1,
+                tp_size=4,
+                _prefill_pp_size=1,
+                engine=self.engine,
+                local_engine_id="local_engine",
+                local_handshake_port=5555,
+                side_channel_port=30000,
+                local_kv_caches_base_addr=[[0x1000]],
+                block_len_per_addr=[[1024]],
+                block_stride_per_addr=[[1024]],
+                ready_event=self.ready_event,
+                vllm_config=self.vllm_config,
+                kv_caches={"layer.0": (kv_cache, kv_cache)},
+                prefill_pp_layer_partition=None,
+            )
+
+            def handle_request(req_meta: dict[str, Any]):
+                with events_lock:
+                    worker_events[threading.get_ident()].append(("handle", req_meta["request_id"]))
+                    handled_worker_count = sum(
+                        any(event == "handle" for event, _ in events) for events in worker_events.values()
+                    )
+                    if handled_worker_count == 2:
+                        both_workers_started.set()
+                release_workers.wait()
+
+            thread._handle_request = handle_request  # type: ignore[method-assign]
+            try:
+                for index in range(2):
+                    thread._submit_request(
+                        {
+                            "request_id": f"req-{index}",
+                            "remote_host": f"host-{index}",
+                            "remote_handshake_port": 6000 + index,
+                            "all_task_done": True,
+                        }
+                    )
+                self.assertTrue(both_workers_started.wait(timeout=5.0), "executor did not start two workers")
+            finally:
+                release_workers.set()
+                thread.executor.shutdown(wait=True, cancel_futures=True)
+
+        handled_worker_events = [events for events in worker_events.values() if any(e == "handle" for e, _ in events)]
+        self.assertEqual(len(handled_worker_events), 2)
+        for events in handled_worker_events:
+            self.assertEqual(events[0], ("set_device", expected_device.index))
+            self.assertEqual(events[1][0], "handle")
+
     def test_submit_request_serializes_same_peer_fifo(self):
         release_first_request = threading.Event()
         first_request_started = threading.Event()

--- a/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
@@ -6,7 +6,9 @@ import unittest
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import torch
 
 fake_engine = types.ModuleType("mooncake.engine")
 fake_engine.TransferEngine = MagicMock()  # type: ignore[attr-defined]
@@ -51,6 +53,90 @@ class TestHybridKVCacheRecvingThreadDispatch(unittest.TestCase):
         thread.finished_request_markers = set()
         thread.request_task_counts_lock = threading.Lock()
         return thread
+
+    def test_executor_workers_bind_kv_cache_device_before_handling_requests(self):
+        expected_device = torch.device("npu:5")
+        kv_cache = MagicMock(device=expected_device)
+        model_config = types.SimpleNamespace(
+            is_deepseek_mla=False,
+            hf_config=types.SimpleNamespace(compress_ratios=[1]),
+            hf_text_config=types.SimpleNamespace(num_hidden_layers=1),
+        )
+        vllm_config = types.SimpleNamespace(
+            model_config=model_config,
+            cache_config=types.SimpleNamespace(block_size=16),
+        )
+        kv_cache_config = types.SimpleNamespace(kv_cache_groups=[])
+        worker_events: defaultdict[int, list[tuple[str, int | str]]] = defaultdict(list)
+        events_lock = threading.Lock()
+        both_workers_started = threading.Event()
+        release_workers = threading.Event()
+
+        def record_set_device(device):
+            device_index = device if isinstance(device, int) else torch.device(device).index
+            with events_lock:
+                worker_events[threading.get_ident()].append(("set_device", device_index))
+
+        with (
+            patch("torch.npu.set_device", side_effect=record_set_device),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector.is_vl_model",
+                return_value=False,
+            ),
+        ):
+            thread = KVCacheRecvingThread(
+                tp_rank=1,
+                tp_size=2,
+                _prefill_pp_size=1,
+                engine=MagicMock(),
+                local_engine_id="local_engine",
+                local_handshake_port=5555,
+                side_channel_port=30000,
+                local_kv_caches_base_addr=[0x1000],
+                block_len_per_addr=[1024],
+                block_stride_per_addr=[1024],
+                addr_group_idx=[0],
+                mamba_ssm_size=(0, 0),
+                use_hybrid=False,
+                has_mamba=False,
+                hma_group_size=1,
+                ready_event=threading.Event(),
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+                kv_caches={"layer.0": (kv_cache, kv_cache)},
+            )
+
+            def handle_request(req_meta: dict[str, Any]):
+                with events_lock:
+                    worker_events[threading.get_ident()].append(("handle", req_meta["request_id"]))
+                    handled_worker_count = sum(
+                        any(event == "handle" for event, _ in events) for events in worker_events.values()
+                    )
+                    if handled_worker_count == 2:
+                        both_workers_started.set()
+                release_workers.wait()
+
+            thread._handle_request = handle_request  # type: ignore[method-assign]
+            try:
+                for index in range(2):
+                    thread._submit_request(
+                        {
+                            "request_id": f"req-{index}",
+                            "remote_host": f"host-{index}",
+                            "remote_handshake_port": 6000 + index,
+                            "all_task_done": True,
+                        }
+                    )
+                self.assertTrue(both_workers_started.wait(timeout=5.0), "executor did not start two workers")
+            finally:
+                release_workers.set()
+                thread.executor.shutdown(wait=True, cancel_futures=True)
+
+        handled_worker_events = [events for events in worker_events.values() if any(e == "handle" for e, _ in events)]
+        self.assertEqual(len(handled_worker_events), 2)
+        for events in handled_worker_events:
+            self.assertEqual(events[0], ("set_device", expected_device.index))
+            self.assertEqual(events[1][0], "handle")
 
     def test_submit_request_serializes_same_peer_fifo(self):
         thread = self._make_thread()

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -466,7 +466,19 @@ class KVCacheRecvingThread(threading.Thread):
         self.remote_metadata_lock = threading.Lock()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
-        self.executor = ThreadPoolExecutor(max_workers=32)
+        first_kv_cache = next(iter(self.kv_caches.values()), None)
+        if first_kv_cache is None:
+            self.executor = ThreadPoolExecutor(max_workers=32)
+        else:
+            # NPU device selection is thread-local. Executor workers do not
+            # inherit the device selected by the model worker thread and would
+            # otherwise use device 0 on their first NPU operation.
+            kv_cache_device = first_kv_cache[0].device
+            self.executor = ThreadPoolExecutor(
+                max_workers=32,
+                initializer=torch.npu.set_device,
+                initargs=(kv_cache_device,),
+            )
         self.peer_request_queues: defaultdict[tuple[str, int], deque[dict[str, Any]]] = defaultdict(deque)
         self.active_peer_request_handlers: set[tuple[str, int]] = set()
         self.peer_request_queues_lock = threading.Lock()

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -408,7 +408,19 @@ class KVCacheRecvingThread(threading.Thread):
         self.remote_metadata_lock = threading.Lock()
 
         self.request_queue: queue.Queue[Any] = queue.Queue()
-        self.executor = ThreadPoolExecutor(max_workers=32)
+        first_kv_cache = next(iter(self.kv_caches.values()), None)
+        if first_kv_cache is None:
+            self.executor = ThreadPoolExecutor(max_workers=32)
+        else:
+            # NPU device selection is thread-local. Executor workers do not
+            # inherit the device selected by the model worker thread and would
+            # otherwise use device 0 on their first NPU operation.
+            kv_cache_device = first_kv_cache[0].device
+            self.executor = ThreadPoolExecutor(
+                max_workers=32,
+                initializer=torch.npu.set_device,
+                initargs=(kv_cache_device,),
+            )
         self.peer_request_queues: defaultdict[tuple[str, int], deque[dict[str, Any]]] = defaultdict(deque)
         self.active_peer_request_handlers: set[tuple[str, int]] = set()
         self.peer_request_queues_lock = threading.Lock()


### PR DESCRIPTION
## What this PR does

Backport of #12126 to `releases/v0.23.0`.

- Bind every Mooncake receiver `ThreadPoolExecutor` worker to the NPU device of the registered KV cache.
- Apply the fix to both the standard and hybrid Mooncake connectors.
- Add regression tests that force two executor workers and verify each worker calls `torch.npu.set_device` before handling a request.

## Why this is needed

NPU current-device state is thread-local. Mooncake receiver executor workers do not inherit the device selected by the decode model worker thread and start with logical device 0.

During TP-mismatch KV cache reformatting, current-device-dependent NPU calls can therefore create an unintended context on device 0. This makes the same non-zero-rank worker PID appear on both its assigned NPU and device 0.

The registered KV cache tensor is used as the authoritative device source instead of `tp_rank`, which is not reliable with DP/PP/PCP layouts or `ASCEND_RT_VISIBLE_DEVICES` remapping.

## User impact

This prevents an extra NPU context from leaking onto device 0 in Mooncake PD-disaggregated deployments. There is no API change.

## Validation

- Cherry-picked cleanly onto `origin/releases/v0.23.0@c83bf9bd`.
- Both related release unit-test files: `110 passed, 18 warnings`.
- `git diff --check` and `py_compile` pass.
- The equivalent main change was validated on Ascend A3 with Qwen3-4B and a P TP4 / D TP2 topology; after the fix, four KV transfers and generation completed successfully while every decode PID remained on one chip.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
