### PR TITLE
[BugFix] Fix block_table overwrite during CPU-to-NPU transfer

### DIFF
--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -285,7 +285,10 @@ class BlockTable:
             self.slot_mapping.cpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
 
     def commit_block_table(self, num_reqs: int) -> None:
-        self.block_table.copy_to_gpu(num_reqs)
+        self.block_table.gpu[:num_reqs].copy_(
+            self.block_table.cpu[:num_reqs].clone().pin_memory(),
+            non_blocking=True,
+        )
 
     def clear(self) -> None:
         self.block_table.fill_(0)


### PR DESCRIPTION

### What this PR does / why we need it?

In the PD disaggregated inference scenario, `block_table` may be overwritten during the asynchronous CPU-to-device transfer, resulting in incorrect data being copied to the device and causing inference accuracy issues.

This PR fixes the issue by creating a cloned copy of `block_table` before the device transfer. The cloned tensor is then used as the source of the asynchronous `copy_()` operation, ensuring that the transferred data remains unchanged even if the original `block_table` is updated concurrently.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified in the PD disaggregated inference scenario.

- Reproduced the inference accuracy issue before the fix.
- Applied this patch and reran the same workload.
- Confirmed that `block_table` is no longer overwritten during CPU-to-device transfer and the inference accuracy issue is resolved.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
