### PR TITLE
[Bugfix] recover qwen3vt 310p patch

### DIFF
--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -39,9 +39,14 @@ QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get
 QwenGatedDeltaNetAttention.get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend
 
 if is_rc_device():
+    from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
     from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
 
     from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310
+    from vllm_ascend._310p.ops.qwen3vl_310 import rot_pos_emb_310
+
+    # 310P RC: use blocking H2D in rot_pos_emb to avoid race with subsequent indexing.
+    Qwen3_VisionTransformer.rot_pos_emb = rot_pos_emb_310  # type: ignore[method-assign]
 
     # Qwen3.5 on 310P RC uses upstream GDNAttentionBackend via MambaBase.get_attn_backend().
     GDNAttentionBackend.get_builder_cls = staticmethod(  # type: ignore[method-assign]


### PR DESCRIPTION
### What this PR does / why we need it?
Qwen3_VisionTransformer rotary embedding still needs to be patched by 310p specific impl. Fix it by patching it.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Local tested.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
