### PR TITLE
[Ops][BugFix] Adapt triton 3.6.0 api

### DIFF
--- a/vllm_ascend/ops/triton/fla/chunk_o.py
+++ b/vllm_ascend/ops/triton/fla/chunk_o.py
@@ -90,7 +90,7 @@ def chunk_fwd_kernel_o(
             offs_t = i_t * BT + tl.arange(0, BT)
             mask_t = offs_t < T
             g_ptr = g + bos + i_h * T_max
-            b_g = tl.load(g_ptr + offs_t, mask=mask_t, other=0.0)
+            b_g = tl.load(g_ptr + offs_t, mask=mask_t, other=0.0).to(tl.float32)
 
             b_o = b_o * tl.exp(b_g)[:, None]
             b_A = b_A * safe_exp(b_g[:, None] - b_g[None, :])


### PR DESCRIPTION
### What this PR does / why we need it?

Since triton 3.6.0, the `tl.exp` API only supports `fp32`/`fp64` inputs. This PR casts the input tensor `b_g` to `tl.float32` before passing it to `tl.exp` and `safe_exp` in the chunk forward kernel to prevent runtime errors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
