### PR TITLE
[Performance][KVCache] Optimize AscendStore key construction and miss path

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -49,6 +49,19 @@ To guarantee uniform hash generation, it is required to synchronize the PYTHONHA
 export PYTHONHASHSEED=0
 ```
 
+AscendStore also provides the following performance switches. Except for the
+direct key-string path, they are disabled by default so deployments can opt in
+after validating their cache-visibility and retention requirements.
+
+| Environment variable | Default | Description |
+| :--- | :--- | :--- |
+| `VLLM_ASCEND_PUT_KEY_STRING_FAST_PATH` | `1` | Builds backend key strings without allocating intermediate `PoolKey` objects. Layerwise mode keeps using `PoolKey` because it needs per-layer keys. |
+| `VLLM_ASCEND_PUT_SPARSE_STORE_MASK` | `0` | Builds keys only for chunks selected by the hybrid-cache store mask. The implementation falls back automatically when mask and key granularities do not match. |
+| `VLLM_ASCEND_PUT_PRE_SHARD_KEY_BUILD` | `0` | With sparse store-mask key building enabled, builds only the keys owned by the local put shard. |
+| `VLLM_ASCEND_LOOKUP_REACHABLE_MASK` | `0` | Skips hybrid-cache chunks that cannot contribute to an aligned external-cache hit. |
+| `VLLM_ASCEND_PER_REQUEST_SAVE_WAIT` | `0` | Waits only for save jobs belonging to the current request instead of the complete global save queue. |
+| `VLLM_ASCEND_ASYNC_SAVE` | `0` | Returns after enqueueing save jobs. This removes backend save time from the request critical path, but a following identical request can perform lookup before the save becomes visible. Per-request waiting takes precedence when both switches are enabled. |
+
 ## Example of using Mooncake as a KV Pool backend
 
 * Software:

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -193,6 +193,12 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         result = list(self.db.process_token_key_strings(40, hashes))
         self.assertEqual(result, expected)
 
+    def test_process_tokens_does_not_round_trip_through_key_strings(self):
+        self.db.process_token_key_strings = MagicMock(side_effect=AssertionError("string path must not be used"))
+        result = list(self.db.process_tokens(32, ["aaa", "bbb"]))
+        self.assertEqual(len(result), 2)
+        self.db.process_token_key_strings.assert_not_called()
+
     def test_process_token_key_strings_with_block_ids_matches_process_tokens(self):
         db = ChunkedTokenDatabase([self.meta], block_size=[16], partitions=None, hash_block_size=8)
         hashes = ["a", "b", "c", "d"]
@@ -236,6 +242,29 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         layer_key = pool_key_result[0][2].split_layers(2)[1]
         self.assertEqual(layer_key.chunk_hash_bytes, direct_key_result[0][3])
         self.assertIn("@group:1@cache_role:kv@cache_family:c2@layer_id:1", layer_key.to_string())
+
+    def test_sparse_store_mask_pre_shards_before_hash_construction(self):
+        hashes = ["a", "b", "c", "d"]
+        result = list(
+            self.db.process_token_key_strings_with_block_ids_sparse_store_mask(
+                64,
+                hashes,
+                [10, 11, 12, 13],
+                [True, False, True, True],
+                shard_rank=1,
+                shard_size=2,
+            )
+        )
+        self.assertEqual([(start, end, block_id) for start, end, _, _, block_id in result], [(32, 48, 12)])
+
+    def test_sparse_store_mask_rejects_short_mask(self):
+        self.assertFalse(
+            self.db.can_use_sparse_store_mask_key_build(
+                64,
+                ["a", "b", "c", "d"],
+                [True, False],
+            )
+        )
 
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -184,6 +184,59 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
         self.assertEqual(len(result[0][2].chunk_hash), 64)
 
+    def test_process_token_key_strings_matches_process_tokens(self):
+        hashes = ["aaa", "bbb", "ccc"]
+        expected = [
+            (start, end, key.to_string(), key.chunk_hash_bytes)
+            for start, end, key in self.db.process_tokens(40, hashes)
+        ]
+        result = list(self.db.process_token_key_strings(40, hashes))
+        self.assertEqual(result, expected)
+
+    def test_process_token_key_strings_with_block_ids_matches_process_tokens(self):
+        db = ChunkedTokenDatabase([self.meta], block_size=[16], partitions=None, hash_block_size=8)
+        hashes = ["a", "b", "c", "d"]
+        block_ids = [5, 6]
+        expected = [
+            (start, end, key.to_string(), key.chunk_hash_bytes, block_id)
+            for start, end, key, block_id in db.process_tokens_with_block_ids(32, hashes, block_ids)
+        ]
+        result = list(db.process_token_key_strings_with_block_ids(32, hashes, block_ids))
+        self.assertEqual(result, expected)
+
+    def test_direct_keys_preserve_multigroup_layerwise_key_semantics(self):
+        group_metadata = [
+            KeyMetadata("llama", 0, 0, 0, 0),
+            KeyMetadata("llama", 1, 0, 0, 0),
+        ]
+        db = ChunkedTokenDatabase(group_metadata, block_size=[16, 32], partitions=None, hash_block_size=16)
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [160], 1: [320]},
+            group_cache_families={0: "c1", 1: "c2"},
+            group_num_layers={0: 2, 1: 2},
+        )
+        hashes = ["a", "b", "c", "d"]
+
+        pool_key_result = list(db.process_tokens(64, hashes, kv_cache_group_id=1))
+        direct_key_result = list(db.process_token_key_strings(64, hashes, kv_cache_group_id=1))
+
+        self.assertEqual(len(pool_key_result), 1)
+        self.assertEqual(
+            direct_key_result,
+            [
+                (
+                    pool_key_result[0][0],
+                    pool_key_result[0][1],
+                    pool_key_result[0][2].to_string(),
+                    pool_key_result[0][2].chunk_hash_bytes,
+                )
+            ],
+        )
+        layer_key = pool_key_result[0][2].split_layers(2)[1]
+        self.assertEqual(layer_key.chunk_hash_bytes, direct_key_result[0][3])
+        self.assertIn("@group:1@cache_role:kv@cache_family:c2@layer_id:1", layer_key.to_string())
+
     def test_get_block_hashes_rehashes_grouped_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
         self.assertEqual(

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -173,6 +173,24 @@ class TestAscendStoreCoordinator(unittest.TestCase):
 
         self.assertEqual(masks, ([False, False, False, True],))
 
+    def test_lookup_mask_uses_reachability_without_retention(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _sliding_spec(block_size=128, sliding_window=256))],
+            scheduler_block_size=512,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c1"],
+            retention_interval=256,
+        )
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+            return_value=[False, False, False, True],
+        ) as reachable:
+            masks = coord.lookup_mask(512)
+
+        self.assertEqual(masks, ([False, False, False, True],))
+        self.assertIsNone(reachable.call_args.kwargs["retention_interval"])
+
     def test_store_mask_propagates_eagle_to_same_spec_siblings(self):
         calls = []
 

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -373,6 +373,64 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
 
+    def test_handle_request_skips_known_kvpool_hit_prefix(self):
+        t, store = self._make_thread([0, 0])
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[0, 1, 2, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=31,
+                kvpool_store_skip_tokens=32,
+                can_load=True,
+            ),
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        keys, _, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 2)
+        self.assertTrue(keys[0].endswith("@k2"))
+        self.assertTrue(keys[1].endswith("@k3"))
+
+    def test_per_request_save_event_completes_on_success(self):
+        t, _ = self._make_thread([1])
+        t._per_request_save_wait = True
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+        t.add_stored_request("r1")
+        done = t.prepare_stored_request_done_event("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertIsNotNone(done)
+        self.assertTrue(done.is_set())  # type: ignore[union-attr]
+        self.assertEqual(t.request_queue.unfinished_tasks, 0)
+
+    def test_save_exception_completes_event_and_queue_lifecycle(self):
+        t, store = self._make_thread([0])
+        t._per_request_save_wait = True
+        store.put = MagicMock(side_effect=RuntimeError("put failed"))
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+        t.add_stored_request("r1")
+        done = t.prepare_stored_request_done_event("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertIsNotNone(done)
+        self.assertTrue(done.is_set())  # type: ignore[union-attr]
+        self.assertEqual(t.request_queue.unfinished_tasks, 0)
+        self.assertNotIn("r1", t.stored_requests)
+
 
 class TestKVCacheStoreRecvingThread(unittest.TestCase):
     def test_handle_request(self):

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -128,6 +128,12 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(need, 32)  # 48 - 16
         self.assertFalse(is_async)
         self.assertIn("r1", scheduler.load_specs)
+        mock_client_cls.return_value.lookup.assert_called_once_with(
+            64,
+            request.block_hashes,
+            [0],
+            hbm_hit_tokens=16,
+        )
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_all_hit(self, mock_client_cls):
@@ -144,6 +150,20 @@ class TestKVPoolScheduler(unittest.TestCase):
 
         need, _ = scheduler.get_num_new_matched_tokens(request, 0)
         self.assertEqual(need, 63)
+        self.assertEqual(scheduler.load_specs["r1"].kvpool_cached_tokens, 63)
+        self.assertEqual(scheduler.load_specs["r1"].kvpool_store_skip_tokens, 64)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_get_num_new_matched_tokens_full_hbm_hit_skips_external_lookup(self, mock_client_cls):
+        scheduler = KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
+        request = MagicMock()
+        request.prompt_token_ids = list(range(64))
+        request.num_tokens = 64
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 4
+
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 64), (0, False))
+        mock_client_cls.return_value.lookup.assert_not_called()
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_less_than_computed(self, mock_client_cls):
@@ -424,9 +444,12 @@ class TestLookupKeyClient(unittest.TestCase):
         mock_socket.recv.return_value = (32).to_bytes(4, "big")
 
         client = LookupKeyClient(config)
-        result = client.lookup(64, [b"\xaa\xbb"])
+        client.encoder.encode.side_effect = [[b"hashes"], [b"groups"]]
+        result = client.lookup(64, [b"\xaa\xbb"], hbm_hit_tokens=16)
         self.assertEqual(result, 32)
         mock_socket.send_multipart.assert_called_once()
+        frames = mock_socket.send_multipart.call_args.args[0]
+        self.assertEqual(int.from_bytes(frames[2], "big"), 16)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.make_zmq_socket")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.zmq")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -110,16 +111,16 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
         worker.num_kv_cache_groups = 1
+        worker.lookup_reachable_mask = False
         worker.cache_coordinator = MagicMock()
         worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
         worker.m_store = MagicMock()
         worker.m_store.exists.return_value = [1]
 
-        key = MagicMock()
-        key.chunk_hash = "ab" * 32
-        key.to_string.return_value = "key"
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens.return_value = [(0, 128, key)]
+        worker.token_database.get_block_size.return_value = 128
+        worker.token_database.group_cache_families = {"kv": {0: "default"}}
+        worker.token_database.process_token_key_strings.return_value = [(0, 128, "key", "ab" * 32)]
 
         hit = worker._lookup_with_coordinator(
             128,
@@ -132,6 +133,7 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         self.assertEqual(hit, 128)
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
+        worker.token_database.process_tokens.assert_not_called()
 
 
 class TestKVPoolWorkerInit(unittest.TestCase):
@@ -580,6 +582,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
     def test_wait_for_save(self):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread._per_request_save_wait = False
+        worker.kv_send_thread._async_save = False
 
         req = ReqMeta(
             req_id="r1",
@@ -593,6 +597,45 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.wait_for_save(meta)
         worker.kv_send_thread.add_stored_request.assert_called_with("r1")
         worker.kv_send_thread.add_request.assert_called_once()
+        worker.kv_send_thread.request_queue.join.assert_called_once()
+
+    def test_wait_for_save_async_does_not_join_global_queue(self):
+        worker = self._make_worker()
+        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread._per_request_save_wait = False
+        worker.kv_send_thread._async_save = True
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=["h0"],
+            can_save=True,
+        )
+        meta = AscendConnectorMetadata(set(), set())
+        meta.add_request(req)
+        worker.wait_for_save(meta)
+        worker.kv_send_thread.request_queue.join.assert_not_called()
+
+    def test_wait_for_save_per_request_takes_precedence(self):
+        worker = self._make_worker()
+        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread._per_request_save_wait = True
+        worker.kv_send_thread._async_save = True
+        done = threading.Event()
+        done.set()
+        worker.kv_send_thread.prepare_stored_request_done_event.return_value = done
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=["h0"],
+            can_save=True,
+        )
+        meta = AscendConnectorMetadata(set(), set())
+        meta.add_request(req)
+        worker.wait_for_save(meta)
+        worker.kv_send_thread.prepare_stored_request_done_event.assert_called_once_with("r1")
+        worker.kv_send_thread.request_queue.join.assert_not_called()
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -304,13 +304,19 @@ class LookupKeyServer:
                 all_frames = self.socket.recv_multipart(copy=False)
                 token_len = int.from_bytes(all_frames[0], byteorder="big")
                 kv_group_ids = self.decoder.decode([all_frames[1]])
-                hash_frames = all_frames[2:]
+                if len(all_frames) > 3:
+                    hbm_hit_tokens = int.from_bytes(all_frames[2], byteorder="big")
+                    hash_frames = all_frames[3:]
+                else:
+                    hbm_hit_tokens = 0
+                    hash_frames = all_frames[2:]
                 hashes_str = self.decoder.decode(hash_frames)
                 result = self.pool_worker.lookup_scheduler(
                     token_len,
                     hashes_str,
                     kv_group_ids,
                     use_layerwise=False,
+                    hbm_hit_tokens=hbm_hit_tokens,
                 )
                 logger.debug(
                     "KV pool lookup response token_len=%d groups=%s hit_tokens=%d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -138,6 +138,14 @@ def infer_cache_family_ratio(cache_family: str | None) -> int:
     return int(ratio) if ratio.isdigit() else 1
 
 
+def _shard_allows(
+    candidate_index: int,
+    shard_rank: int | None,
+    shard_size: int | None,
+) -> bool:
+    return shard_rank is None or shard_size is None or shard_size <= 1 or candidate_index % shard_size == shard_rank
+
+
 def get_cache_family_granularity(block_size: int, cache_family: str | None) -> int:
     return block_size * infer_cache_family_ratio(cache_family)
 
@@ -430,15 +438,29 @@ class ChunkedTokenDatabase:
         chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
-        for start_idx, end_idx, _key_string, hash_val in self.process_token_key_strings(
-            token_len,
-            block_hashes,
-            mask_num=mask_num,
-            kv_cache_group_id=kv_cache_group_id,
-            cache_role=cache_role,
-            cache_family=cache_family,
-            chunk_filter=chunk_filter,
-        ):
+        if not block_hashes:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        if not grouped_hashes:
+            return
+        for chunk_id, hash_val in enumerate(grouped_hashes):
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
             yield (
                 start_idx,
                 end_idx,
@@ -507,17 +529,42 @@ class ChunkedTokenDatabase:
         cache_family: str | None = None,
         chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey, int]]:
-        for start_idx, end_idx, _key_string, hash_val, block_id in self.process_token_key_strings_with_block_ids(
-            token_len,
-            block_hashes,
-            block_ids,
-            mask_num=mask_num,
-            kv_cache_group_id=kv_cache_group_id,
-            skip_null_blocks=skip_null_blocks,
-            cache_role=cache_role,
-            cache_family=cache_family,
-            chunk_filter=chunk_filter,
-        ):
+        if not block_hashes:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        if not grouped_hashes:
+            return
+
+        num_by_hashes = len(grouped_hashes)
+        num_by_token_len = cdiv(token_len, effective_block_size) if token_len > 0 else 0
+        num_logical_blocks = min(num_by_hashes, num_by_token_len)
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+
+        for chunk_id in range(num_logical_blocks):
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            block_idx = start_idx // base_block_size - block_id_offset
+            if block_idx < 0 or block_idx >= len(block_ids):
+                continue
+            block_id = block_ids[block_idx]
+            if skip_null_blocks and block_id <= 0:
+                continue
+            hash_val = grouped_hashes[chunk_id]
             yield (
                 start_idx,
                 end_idx,
@@ -588,6 +635,114 @@ class ChunkedTokenDatabase:
             chunk_hash = block_hash_to_str(hash_val)
             yield start_idx, end_idx, prefix + chunk_hash, hash_val, block_id
 
+    def can_use_sparse_store_mask_key_build(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        store_mask: Sequence[bool],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+    ) -> bool:
+        if not block_hashes or not store_mask:
+            return False
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        effective_block_size = base_block_size * max(infer_cache_family_ratio(cache_family), 1)
+        coordinator_sizes = getattr(getattr(self, "cache_coordinator", None), "group_effective_block_sizes", None)
+        coordinator_size = (
+            coordinator_sizes[kv_cache_group_id]
+            if coordinator_sizes is not None and kv_cache_group_id < len(coordinator_sizes)
+            else None
+        )
+        num_logical_blocks = min(
+            get_num_block_hashes(block_hashes, effective_block_size, self.hash_block_size),
+            cdiv(token_len, effective_block_size) if token_len > 0 else 0,
+        )
+        if coordinator_size is not None and coordinator_size != effective_block_size:
+            logger.warning(
+                "KV pool sparse key build fallback: effective block size mismatch group=%d key_build=%d coordinator=%d",
+                kv_cache_group_id,
+                effective_block_size,
+                coordinator_size,
+            )
+            return False
+        if len(store_mask) < num_logical_blocks:
+            logger.warning(
+                "KV pool sparse key build fallback: mask too short group=%d mask=%d chunks=%d",
+                kv_cache_group_id,
+                len(store_mask),
+                num_logical_blocks,
+            )
+            return False
+        return True
+
+    def process_token_key_strings_with_block_ids_sparse_store_mask(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        block_ids: list[int],
+        store_mask: Sequence[bool],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        shard_rank: int | None = None,
+        shard_size: int | None = None,
+    ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
+        """Build only store-mask and local-shard keys."""
+        if not self.can_use_sparse_store_mask_key_build(
+            token_len,
+            block_hashes,
+            store_mask,
+            kv_cache_group_id=kv_cache_group_id,
+            cache_role=cache_role,
+            cache_family=cache_family,
+        ):
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+        num_logical_blocks = min(
+            get_num_block_hashes(block_hashes, effective_block_size, self.hash_block_size),
+            cdiv(token_len, effective_block_size) if token_len > 0 else 0,
+        )
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+        prefix = self._get_key_prefix(kv_cache_group_id, cache_role, cache_family)
+        candidate_index = 0
+
+        for chunk_id in range(num_logical_blocks):
+            if not store_mask[chunk_id]:
+                continue
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            block_idx = start_idx // base_block_size - block_id_offset
+            if block_idx < 0 or block_idx >= len(block_ids):
+                continue
+            block_id = block_ids[block_idx]
+            if skip_null_blocks and block_id <= 0:
+                continue
+            if not _shard_allows(candidate_index, shard_rank, shard_size):
+                candidate_index += 1
+                continue
+            candidate_index += 1
+            hash_val = get_block_hash_at(block_hashes, chunk_id, effective_block_size, self.hash_block_size)
+            if hash_val is None:
+                continue
+            yield start_idx, end_idx, prefix + block_hash_to_str(hash_val), hash_val, block_id
+
     def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
         if self.partitions is None or len(self.partitions) == 1:
             return key, addr, size
@@ -636,6 +791,34 @@ def get_block_hashes(
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
     return _LazyGroupedBlockHashList(block_hashes, group_block_size // hash_block_size)
+
+
+def get_num_block_hashes(
+    block_hashes: Sequence[BlockHash | str],
+    group_block_size: int,
+    hash_block_size: int,
+) -> int:
+    if group_block_size == hash_block_size:
+        return len(block_hashes)
+    assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+    return len(block_hashes) // (group_block_size // hash_block_size)
+
+
+def get_block_hash_at(
+    block_hashes: Sequence[BlockHash | str],
+    chunk_id: int,
+    group_block_size: int,
+    hash_block_size: int,
+) -> BlockHash | str | None:
+    if group_block_size == hash_block_size:
+        return block_hashes[chunk_id] if chunk_id < len(block_hashes) else None
+    assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+    scale_factor = group_block_size // hash_block_size
+    start = chunk_id * scale_factor
+    end = start + scale_factor
+    if end > len(block_hashes):
+        return None
+    return _rehash_block_hash_group(block_hashes[start:end])
 
 
 class _LazyGroupedBlockHashList(Sequence[BlockHash]):
@@ -708,6 +891,8 @@ class LoadSpec:
     kvpool_cached_tokens: int
     # Whether the scheduler allow us to load the tokens
     can_load: bool
+    # Raw KVPool hit length used to avoid storing an already pooled prefix.
+    kvpool_store_skip_tokens: int | None = None
 
     token_len: int = 0
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1175,7 +1175,7 @@ class LayerMultiBlockReqMeta:
     ends: list[int]
     block_ids_by_group: list[list[int]]
     layer_id: int
-    block_hashes: list[Any] = field(default_factory=list)
+    block_hashes: Sequence[Any] = field(default_factory=list)
     is_last_chunk: bool | None = True
     current_event: torch.npu.Event | None = None
     token_ids: list[int] | None = None
@@ -1195,7 +1195,7 @@ class LayerMultiBlockReqMeta:
         block_ids: list[int] | list[list[int]] | None = None,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
-        block_hashes: list[Any] | None = None,
+        block_hashes: Sequence[Any] | None = None,
         kv_cache_group_id: int = 0,
     ) -> None:
         self.req_id = req_id

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -45,6 +45,7 @@ class KeyMetadata:
 class PoolKey:
     key_metadata: KeyMetadata
     chunk_hash: str
+    chunk_hash_bytes: BlockHash | str | None = field(default=None, compare=False, kw_only=True)
 
     def __hash__(self):
         return hash(
@@ -82,6 +83,7 @@ class PoolKey:
                     self.key_metadata,
                     self.chunk_hash,
                     layer_id,
+                    chunk_hash_bytes=self.chunk_hash_bytes,
                 )
             )
         return keys
@@ -227,7 +229,32 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self._key_prefix_cache: dict[tuple[int, str, str], str] = {}
         self.cache_coordinator: Any | None = None
+
+    def _get_key_prefix(
+        self,
+        kv_cache_group_id: int,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+    ) -> str:
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_key = (kv_cache_group_id, cache_role, cache_family)
+        prefix = self._key_prefix_cache.get(cache_key)
+        if prefix is None:
+            group_metadata = self.metadata[kv_cache_group_id]
+            prefix = (
+                f"{group_metadata.model_name}"
+                f"@pcp{group_metadata.pcp_rank}@dcp{group_metadata.dcp_rank}"
+                f"@head_or_tp_rank:{group_metadata.head_or_tp_rank}"
+                f"@pp_rank:{group_metadata.pp_rank}"
+                f"@group:{kv_cache_group_id}"
+                f"@cache_role:{cache_role}"
+                f"@cache_family:{cache_family}@"
+            )
+            self._key_prefix_cache[cache_key] = prefix
+        return prefix
 
     def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:
         self.cache_coordinator = cache_coordinator
@@ -268,6 +295,7 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_hash_bytes: BlockHash | str | None = None,
         layer_id: int | None = None,
     ):
         assert self.metadata is not None
@@ -286,6 +314,7 @@ class ChunkedTokenDatabase:
                 cache_family=cache_family,
             ),
             chunk_hash,
+            chunk_hash_bytes=chunk_hash_bytes,
         )
 
     def get_block_size(self, kv_cache_group_id: int) -> int:
@@ -312,6 +341,7 @@ class ChunkedTokenDatabase:
             self.group_block_stride = group_block_stride or {}
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
+            self._key_prefix_cache.clear()
         if group_num_layers is not None:
             self.group_num_layers[cache_role] = group_num_layers.copy()
 
@@ -397,50 +427,73 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
+        for start_idx, end_idx, _key_string, hash_val in self.process_token_key_strings(
+            token_len,
+            block_hashes,
+            mask_num=mask_num,
+            kv_cache_group_id=kv_cache_group_id,
+            cache_role=cache_role,
+            cache_family=cache_family,
+            chunk_filter=chunk_filter,
+        ):
+            yield (
+                start_idx,
+                end_idx,
+                self._make_key_by_hash(
+                    block_hash_to_str(hash_val),
+                    kv_cache_group_id=kv_cache_group_id,
+                    cache_role=cache_role,
+                    cache_family=cache_family,
+                    chunk_hash_bytes=hash_val,
+                ),
+            )
+
+    def process_token_key_strings(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        max_num: int | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
+    ) -> Iterable[tuple[int, int, str, BlockHash | str]]:
+        """Yield cache key strings directly without materializing PoolKey objects."""
         if not block_hashes:
             return
-        group_block_size = self.get_block_size(kv_cache_group_id)
+        base_block_size = self.get_block_size(kv_cache_group_id)
         if cache_family is None:
             cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
         cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
-        group_block_size *= cache_family_ratio
-        block_hashes = get_block_hashes(
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(
             block_hashes,
-            group_block_size,
+            effective_block_size,
             self.hash_block_size,
         )
-        if not block_hashes:
+        if not grouped_hashes:
             return
-        if not isinstance(block_hashes[0], str):
-            block_hashes = [
-                h.hex() if not isinstance(h, str) else h  # type: ignore[union-attr]
-                for h in block_hashes
-            ]
-        start_idx = 0
-        for chunk_id, hash_val in enumerate(block_hashes):
-            start_idx = chunk_id * group_block_size
-            if start_idx >= token_len:
+        prefix = self._get_key_prefix(kv_cache_group_id, cache_role, cache_family)
+        lookup_end = token_len if max_num is None else min(token_len, max_num)
+        for chunk_id, hash_val in enumerate(grouped_hashes):
+            start_token = chunk_id * effective_block_size
+            if start_token >= lookup_end:
                 break
-            end_idx = min(start_idx + group_block_size, token_len)
-            if start_idx < mask_num:
+            end_token = min(start_token + effective_block_size, lookup_end)
+            if start_token < mask_num:
                 continue
-            else:
-                start_idx //= cache_family_ratio
-                end_idx //= cache_family_ratio
-                if end_idx <= start_idx:
-                    continue
-                yield (
-                    start_idx,
-                    end_idx,
-                    self._make_key_by_hash(
-                        hash_val,
-                        kv_cache_group_id=kv_cache_group_id,
-                        cache_role=cache_role,
-                        cache_family=cache_family,
-                    ),
-                )
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            chunk_hash = block_hash_to_str(hash_val)
+            yield start_idx, end_idx, prefix + chunk_hash, hash_val
 
     def process_tokens_with_block_ids(
         self,
@@ -452,46 +505,88 @@ class ChunkedTokenDatabase:
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
     ) -> Iterable[tuple[int, int, PoolKey, int]]:
-        all_chunks = list(
-            self.process_tokens(
-                token_len,
-                block_hashes,
-                0,
-                kv_cache_group_id=kv_cache_group_id,
-                cache_role=cache_role,
-                cache_family=cache_family,
-            )
-        )
-        if not all_chunks:
-            return
-
-        group_block_size = self.get_block_size(kv_cache_group_id)
-        # Sliding-window groups can expose only live tail block ids while keys
-        # still use logical chunk positions from the full prefix.
-        num_logical_blocks = all_chunks[-1][0] // group_block_size + 1
-        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
-        chunks = all_chunks
-        if mask_num:
-            chunks = list(
-                self.process_tokens(
-                    token_len,
-                    block_hashes,
-                    mask_num,
+        for start_idx, end_idx, _key_string, hash_val, block_id in self.process_token_key_strings_with_block_ids(
+            token_len,
+            block_hashes,
+            block_ids,
+            mask_num=mask_num,
+            kv_cache_group_id=kv_cache_group_id,
+            skip_null_blocks=skip_null_blocks,
+            cache_role=cache_role,
+            cache_family=cache_family,
+            chunk_filter=chunk_filter,
+        ):
+            yield (
+                start_idx,
+                end_idx,
+                self._make_key_by_hash(
+                    block_hash_to_str(hash_val),
                     kv_cache_group_id=kv_cache_group_id,
                     cache_role=cache_role,
                     cache_family=cache_family,
-                )
+                    chunk_hash_bytes=hash_val,
+                ),
+                block_id,
             )
 
-        for start_idx, end_idx, key in chunks:
-            block_idx = start_idx // group_block_size - block_id_offset
+    def process_token_key_strings_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        chunk_filter: Callable[[int], bool] | None = None,
+    ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
+        """Yield cache key strings and resolved block ids without PoolKey allocation."""
+        if not block_hashes:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(
+            block_hashes,
+            effective_block_size,
+            self.hash_block_size,
+        )
+        if not grouped_hashes:
+            return
+
+        num_by_hashes = len(grouped_hashes)
+        num_by_token_len = cdiv(token_len, effective_block_size) if token_len > 0 else 0
+        num_logical_blocks = min(num_by_hashes, num_by_token_len)
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+        prefix = self._get_key_prefix(kv_cache_group_id, cache_role, cache_family)
+
+        for chunk_id in range(num_logical_blocks):
+            start_token = chunk_id * effective_block_size
+            if start_token >= token_len:
+                break
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            block_idx = start_idx // base_block_size - block_id_offset
             if block_idx < 0 or block_idx >= len(block_ids):
                 continue
             block_id = block_ids[block_idx]
             if skip_null_blocks and block_id <= 0:
                 continue
-            yield start_idx, end_idx, key, block_id
+            hash_val = grouped_hashes[chunk_id]
+            chunk_hash = block_hash_to_str(hash_val)
+            yield start_idx, end_idx, prefix + chunk_hash, hash_val, block_id
 
     def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
         if self.partitions is None or len(self.partitions) == 1:
@@ -536,15 +631,46 @@ def get_block_hashes(
     block_hashes: BlockHashList | list[str],
     group_block_size: int,
     hash_block_size: int,
-) -> BlockHashList | list[str]:
+) -> Sequence[BlockHash | str]:
     if group_block_size == hash_block_size:
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
-    scale_factor = group_block_size // hash_block_size
-    return [
-        _rehash_block_hash_group(block_hashes[idx : idx + scale_factor])
-        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
-    ]
+    return _LazyGroupedBlockHashList(block_hashes, group_block_size // hash_block_size)
+
+
+class _LazyGroupedBlockHashList(Sequence[BlockHash]):
+    def __init__(self, block_hashes: Sequence[BlockHash | str], scale_factor: int) -> None:
+        self._block_hashes = block_hashes
+        self._scale_factor = scale_factor
+        self._length = len(block_hashes) // scale_factor
+        self._cache: dict[int, BlockHash] = {}
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __iter__(self):
+        for idx in range(self._length):
+            yield self[idx]
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return [self[idx] for idx in range(*index.indices(self._length))]
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        cached = self._cache.get(index)
+        if cached is None:
+            start = index * self._scale_factor
+            end = start + self._scale_factor
+            cached = _rehash_block_hash_group(self._block_hashes[start:end])
+            self._cache[index] = cached
+        return cached
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Sequence):
+            return list(self) == list(other)
+        return False
 
 
 def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -199,6 +199,40 @@ class AscendStoreCoordinator:
             masks.append([True] * num_chunks if mask is None else mask)
         return tuple(masks)
 
+    def lookup_mask(
+        self,
+        aligned_token_len: int,
+    ) -> tuple[list[bool] | None, ...]:
+        """Return chunks that can contribute to an aligned external hit.
+
+        ``None`` means that every chunk in the group is a lookup candidate.
+        The final hit length is still decided by ``find_longest_cache_hit``.
+        """
+        assert aligned_token_len % self.lcm_block_size == 0, (
+            f"aligned_token_len ({aligned_token_len}) must be a multiple of lcm_block_size ({self.lcm_block_size})"
+        )
+        masks: list[list[bool] | None] = []
+        for group_id, spec in enumerate(self.group_effective_specs):
+            num_chunks = aligned_token_len // self.group_effective_block_sizes[group_id]
+            if not _uses_reachable_mask(self.group_cache_families[group_id]):
+                masks.append(None)
+                continue
+            manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
+            mask = _reachable_block_mask(
+                manager_cls,
+                start_block=0,
+                end_block=num_chunks,
+                alignment_tokens=self.lcm_block_size,
+                kv_cache_spec=spec,
+                use_eagle=group_id in self.eagle_reachable_group_ids,
+                retention_interval=None,
+                num_prompt_tokens=None,
+            )
+            if mask is not None:
+                assert len(mask) == num_chunks
+            masks.append(None if mask is None or all(mask) else mask)
+        return tuple(masks)
+
     def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: KVCacheSpec) -> BlockHashList:
         if spec.block_size == self.hash_block_size:
             return block_hashes

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import os
 import queue
 import threading
 import time
@@ -347,6 +348,8 @@ class KVTransferThread(threading.Thread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 self.stored_requests[req_id] -= 1
+                return self.stored_requests[req_id]
+            return None
 
     def try_finish_and_delete_stored_request(self, req_id: str) -> bool:
         with self.done_task_lock:
@@ -456,6 +459,7 @@ class KVTransferThread(threading.Thread):
         self.m_store.set_device()
         self.ready_event.set()
         while True:
+            request_data = None
             try:
                 request_data = self.request_queue.get()
                 if request_data is None:
@@ -464,6 +468,8 @@ class KVTransferThread(threading.Thread):
                     continue
                 self._handle_request(request_data)
             except Exception as e:
+                if request_data is not None:
+                    self._handle_request_exception(request_data)
                 logger.error(
                     "Error in KVCacheTransferThread(%s). type=%s, error=%s. Check thread state and request processing.",
                     self.name,
@@ -472,6 +478,10 @@ class KVTransferThread(threading.Thread):
                 )
 
     def _handle_request(self, req_meta: Any):
+        pass
+
+    def _handle_request_exception(self, request_data: Any):
+        """Allow subclasses to complete queue/request bookkeeping on errors."""
         pass
 
     def lookup(
@@ -522,6 +532,7 @@ class KVTransferThread(threading.Thread):
         kv_cache_group_id: int = 0,
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
+        chunk_filter=None,
     ):
         process_with_block_ids = getattr(self.token_database, "process_tokens_with_block_ids", None)
         if process_with_block_ids is not None:
@@ -533,6 +544,7 @@ class KVTransferThread(threading.Thread):
                 kv_cache_group_id=kv_cache_group_id,
                 skip_null_blocks=skip_null_blocks,
                 cache_role=cache_role,
+                chunk_filter=chunk_filter,
             )
 
         def iter_with_legacy_process_tokens():
@@ -548,6 +560,8 @@ class KVTransferThread(threading.Thread):
                 block_id = block_ids[block_idx]
                 if skip_null_blocks and cache_role == "kv" and block_id <= 0:
                     continue
+                if chunk_filter is not None and not chunk_filter(start):
+                    continue
                 yield start, end, key, block_id
 
         return iter_with_legacy_process_tokens()
@@ -561,6 +575,7 @@ class KVTransferThread(threading.Thread):
         kv_cache_group_id: int = 0,
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
+        chunk_filter=None,
     ):
         process_key_strings = getattr(self.token_database, "process_token_key_strings_with_block_ids", None)
         if process_key_strings is not None:
@@ -572,6 +587,7 @@ class KVTransferThread(threading.Thread):
                 kv_cache_group_id=kv_cache_group_id,
                 skip_null_blocks=skip_null_blocks,
                 cache_role=cache_role,
+                chunk_filter=chunk_filter,
             )
 
         def iter_with_pool_keys():
@@ -583,6 +599,7 @@ class KVTransferThread(threading.Thread):
                 kv_cache_group_id=kv_cache_group_id,
                 skip_null_blocks=skip_null_blocks,
                 cache_role=cache_role,
+                chunk_filter=chunk_filter,
             ):
                 yield start, end, key.to_string(), getattr(key, "chunk_hash_bytes", key.chunk_hash), block_id
 
@@ -646,7 +663,7 @@ class KVTransferThread(threading.Thread):
 
     def _mask_allows_chunk(
         self,
-        masks: tuple[list[bool], ...] | None,
+        masks: tuple[list[bool], ...] | list[list[bool]] | None,
         group_id: int,
         start: int,
     ) -> bool:
@@ -654,6 +671,75 @@ class KVTransferThread(threading.Thread):
         if mask_allows_chunk is None:
             return True
         return mask_allows_chunk(masks, group_id, start)
+
+    def _get_store_granularity(self, group_id: int) -> int:
+        get_store_granularity = getattr(self.token_database, "_get_store_granularity", None)
+        if get_store_granularity is not None:
+            return get_store_granularity(group_id)
+        return self._get_block_size(group_id)
+
+    @staticmethod
+    def _kvpool_hit_skip_range(req_meta: ReqMeta) -> tuple[int, int] | None:
+        load_spec = req_meta.load_spec
+        if load_spec is None:
+            return None
+        skip_end = (
+            load_spec.kvpool_store_skip_tokens
+            if load_spec.kvpool_store_skip_tokens is not None
+            else load_spec.kvpool_cached_tokens
+        )
+        if skip_end <= load_spec.vllm_cached_tokens:
+            return None
+        return load_spec.vllm_cached_tokens, skip_end
+
+    @staticmethod
+    def _should_skip_kvpool_hit_chunk(
+        start: int,
+        end: int,
+        skip_range: tuple[int, int] | None,
+    ) -> bool:
+        if skip_range is None:
+            return False
+        skip_start, skip_end = skip_range
+        return start >= skip_start and end <= skip_end
+
+    def _apply_kvpool_hit_skip_to_store_mask(
+        self,
+        store_mask: list[bool] | None,
+        group_id: int,
+        skip_range: tuple[int, int] | None,
+    ) -> tuple[list[bool] | None, int]:
+        if store_mask is None or skip_range is None:
+            return store_mask, 0
+        granularity = self._get_store_granularity(group_id)
+        adjusted_mask = list(store_mask)
+        skipped = 0
+        for chunk_idx, allowed in enumerate(adjusted_mask):
+            if not allowed:
+                continue
+            start = chunk_idx * granularity
+            if self._should_skip_kvpool_hit_chunk(start, start + granularity, skip_range):
+                adjusted_mask[chunk_idx] = False
+                skipped += 1
+        return adjusted_mask, skipped
+
+    def _chunk_filter_allows_put(
+        self,
+        masks: tuple[list[bool], ...] | list[list[bool]] | None,
+        group_id: int,
+        start: int,
+        skip_range: tuple[int, int] | None,
+    ) -> bool:
+        if not self._mask_allows_chunk(masks, group_id, start):
+            return False
+        base_block_size = self._get_block_size(group_id)
+        granularity = self._get_store_granularity(group_id)
+        chunk_start = start // base_block_size * granularity
+        return not self._should_skip_kvpool_hit_chunk(
+            chunk_start,
+            chunk_start + granularity,
+            skip_range,
+        )
 
 
 class KVCacheStoreSendingThread(KVTransferThread):
@@ -681,11 +767,38 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.enable_kv_event = enable_kv_event
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
+        self._put_key_string_fast_path = os.getenv("VLLM_ASCEND_PUT_KEY_STRING_FAST_PATH", "1") != "0"
+        self._put_sparse_store_mask = os.getenv("VLLM_ASCEND_PUT_SPARSE_STORE_MASK", "0") == "1"
+        self._put_pre_shard_key_build = os.getenv("VLLM_ASCEND_PUT_PRE_SHARD_KEY_BUILD", "0") == "1"
+        self._async_save = os.getenv("VLLM_ASCEND_ASYNC_SAVE", "0") == "1"
+        self._per_request_save_wait = os.getenv("VLLM_ASCEND_PER_REQUEST_SAVE_WAIT", "0") == "1"
+        self._stored_request_done_events: dict[str, threading.Event] = {}
+
+    def prepare_stored_request_done_event(self, req_id: str) -> threading.Event | None:
+        if not self._per_request_save_wait:
+            return None
+        with self.done_task_lock:
+            event = self._stored_request_done_events.get(req_id)
+            if event is None:
+                event = threading.Event()
+                self._stored_request_done_events[req_id] = event
+            return event
+
+    def _notify_stored_request_done(self, req_id: str, remaining: int | None) -> None:
+        if not self._per_request_save_wait or (remaining is not None and remaining > 0):
+            return
+        with self.done_task_lock:
+            event = self._stored_request_done_events.pop(req_id, None)
+        if event is not None:
+            event.set()
 
     def delete_finished_stored_request(self, req_id: str):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
+            event = self._stored_request_done_events.pop(req_id, None)
+        if event is not None:
+            event.set()
 
     def mark_completed_events(self, event_id: int | None) -> None:
         if event_id is not None:
@@ -700,144 +813,237 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.completed_events.clear()
         return completed_events
 
+    def _handle_request_exception(self, request_data: Any):
+        req_id = getattr(request_data, "req_id", None)
+        remaining = None
+        if req_id is not None:
+            with self.done_task_lock:
+                tracked_request = req_id in self.stored_requests
+            if tracked_request:
+                remaining = self.dec_stored_request(req_id)
+                self._notify_stored_request_done(req_id, remaining)
+        self.request_queue.task_done()
+
     def _handle_request(self, req_meta: ReqMeta):
+        req_id = req_meta.req_id
+        tracked_request = False
+        try:
+            with self.done_task_lock:
+                tracked_request = req_id in self.stored_requests
+            if not tracked_request:
+                return
+            self._handle_stored_request(req_meta)
+        except Exception:
+            logger.exception("Failed to store KV cache for request %s", req_id)
+        finally:
+            remaining = self.dec_stored_request(req_id) if tracked_request else None
+            self._notify_stored_request_done(req_id, remaining)
+            if tracked_request and remaining == 0:
+                self.delete_finished_stored_request(req_id)
+                self.set_finished_request(req_id)
+            self.mark_completed_events(req_meta.event_id)
+            self.request_queue.task_done()
+
+    def _handle_stored_request(self, req_meta: ReqMeta):
         token_len = req_meta.token_len_chunk
         req_id = req_meta.req_id
         current_event = req_meta.current_event
-        try:
-            if req_id not in self.stored_requests:
-                self.request_queue.task_done()
-                return
+        store_masks = self._store_mask(req_meta)
+        mutable_store_masks = [list(mask) for mask in store_masks] if store_masks is not None else None
+        skip_range = self._kvpool_hit_skip_range(req_meta)
 
-            store_masks = self._store_mask(req_meta)
-            for group_id in req_meta.kv_cache_group_ids or [0]:
-                starts = []
-                ends = []
-                keys = []
-                block_hashes = []
-                key_block_ids = []
-                block_ids = req_meta.block_ids_by_group[group_id]
-                group_block_size = self._get_block_size(group_id)
+        for group_id in req_meta.kv_cache_group_ids or [0]:
+            group_store_mask = None
+            if mutable_store_masks is not None and group_id < len(mutable_store_masks):
+                group_store_mask = mutable_store_masks[group_id]
+                group_store_mask, skipped_chunks = self._apply_kvpool_hit_skip_to_store_mask(
+                    group_store_mask,
+                    group_id,
+                    skip_range,
+                )
+                if group_store_mask is not None:
+                    mutable_store_masks[group_id] = group_store_mask
+                if skipped_chunks:
+                    logger.debug(
+                        "KV pool put skipped %d pooled chunks for request %s group %d",
+                        skipped_chunks,
+                        req_id,
+                        group_id,
+                    )
+                if not group_store_mask or not any(group_store_mask):
+                    continue
 
-                for start, end, key, block_hash, block_id in self._process_token_key_strings_with_block_ids(
-                    token_len,
-                    req_meta.block_hashes,
-                    block_ids,
-                    kv_cache_group_id=group_id,
-                    skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+            starts: list[int] = []
+            ends: list[int] = []
+            keys: list[str] = []
+            block_hashes = []
+            key_block_ids: list[int] = []
+            block_ids = req_meta.block_ids_by_group[group_id]
+            group_block_size = self._get_block_size(group_id)
+            skip_null_blocks = self._skip_null_blocks(req_meta, group_id)
+            align_state_group = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
+
+            def chunk_filter(start: int, group_id=group_id) -> bool:
+                return self._chunk_filter_allows_put(
+                    mutable_store_masks,
+                    group_id,
+                    start,
+                    skip_range,
+                )
+
+            sparse_mask = False
+            pre_sharded = False
+            can_use_sparse_key_build = getattr(
+                self.token_database,
+                "can_use_sparse_store_mask_key_build",
+                None,
+            )
+            if self._put_key_string_fast_path:
+                if (
+                    self._put_sparse_store_mask
+                    and group_store_mask is not None
+                    and can_use_sparse_key_build is not None
+                    and can_use_sparse_key_build(
+                        token_len,
+                        req_meta.block_hashes,
+                        group_store_mask,
+                        kv_cache_group_id=group_id,
+                    )
                 ):
-                    if not self._mask_allows_chunk(store_masks, group_id, start):
+                    sparse_mask = True
+                    pre_sharded = (
+                        self._put_pre_shard_key_build
+                        and self.dcp_size <= 1
+                        and not req_meta.disable_tp_key_sharding
+                        and not align_state_group
+                    )
+                    iterator = self.token_database.process_token_key_strings_with_block_ids_sparse_store_mask(
+                        token_len,
+                        req_meta.block_hashes,
+                        block_ids,
+                        group_store_mask,
+                        kv_cache_group_id=group_id,
+                        skip_null_blocks=skip_null_blocks,
+                        shard_rank=self.tp_rank % self.put_step if pre_sharded else None,
+                        shard_size=self.put_step if pre_sharded else None,
+                    )
+                else:
+                    iterator = self._process_token_key_strings_with_block_ids(
+                        token_len,
+                        req_meta.block_hashes,
+                        block_ids,
+                        kv_cache_group_id=group_id,
+                        skip_null_blocks=skip_null_blocks,
+                        chunk_filter=chunk_filter,
+                    )
+                for start, end, key, block_hash, block_id in iterator:
+                    if not sparse_mask and not chunk_filter(start):
                         continue
                     starts.append(start)
                     ends.append(end)
                     keys.append(key)
-                    block_hashes.append(block_hash)
+                    if self.enable_kv_event:
+                        block_hashes.append(block_hash)
+                    key_block_ids.append(block_id)
+            else:
+                for start, end, pool_key, block_id in self._process_tokens_with_block_ids(
+                    token_len,
+                    req_meta.block_hashes,
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                    skip_null_blocks=skip_null_blocks,
+                    chunk_filter=chunk_filter,
+                ):
+                    if not chunk_filter(start):
+                        continue
+                    starts.append(start)
+                    ends.append(end)
+                    keys.append(pool_key.to_string())
+                    if self.enable_kv_event:
+                        block_hashes.append(pool_key.chunk_hash_bytes or pool_key.chunk_hash)
                     key_block_ids.append(block_id)
 
-                if (
-                    not self.dcp_size > 1
-                    and not req_meta.disable_tp_key_sharding
-                    and not self.group_uses_align_state[group_id]
-                ):
-                    starts = starts[self.tp_rank % self.put_step :: self.put_step]
-                    ends = ends[self.tp_rank % self.put_step :: self.put_step]
-                    keys = keys[self.tp_rank % self.put_step :: self.put_step]
-                    block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
-                    key_block_ids = key_block_ids[self.tp_rank % self.put_step :: self.put_step]
+            if (
+                not pre_sharded
+                and self.dcp_size <= 1
+                and not req_meta.disable_tp_key_sharding
+                and not align_state_group
+            ):
+                shard_start = self.tp_rank % self.put_step
+                starts = starts[shard_start :: self.put_step]
+                ends = ends[shard_start :: self.put_step]
+                keys = keys[shard_start :: self.put_step]
+                if self.enable_kv_event:
+                    block_hashes = block_hashes[shard_start :: self.put_step]
+                key_block_ids = key_block_ids[shard_start :: self.put_step]
 
-                if not keys:
-                    continue
-
-                exists_states = self.lookup(keys)
-                missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
-
-                if not missing_indices:
-                    continue
-
-                starts = [starts[index] for index in missing_indices]
-                ends = [ends[index] for index in missing_indices]
-                keys = [keys[index] for index in missing_indices]
+            if not keys:
+                continue
+            exists_states = self.lookup(keys)
+            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+            if not missing_indices:
+                continue
+            starts = [starts[index] for index in missing_indices]
+            ends = [ends[index] for index in missing_indices]
+            keys = [keys[index] for index in missing_indices]
+            if self.enable_kv_event:
                 block_hashes = [block_hashes[index] for index in missing_indices]
-                key_block_ids = [key_block_ids[index] for index in missing_indices]
+            key_block_ids = [key_block_ids[index] for index in missing_indices]
 
-                logger.debug(
-                    "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
-                    len(keys),
-                    token_len // group_block_size,
-                    len(missing_indices),
-                    req_id,
-                    group_id,
+            logger.debug(
+                "Storing KV cache for %d out of %d blocks for request %s in group %d",
+                len(keys),
+                token_len // group_block_size,
+                req_id,
+                group_id,
+            )
+            addrs = []
+            sizes = []
+            stored_events: list[BlockStored] = []
+            prev_key = None
+            new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
+            for index, start in enumerate(starts):
+                addr, size, _ = self._prepare_value(
+                    start,
+                    ends[index],
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                    block_id=key_block_ids[index],
                 )
-                logger.debug(
-                    "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
-                    req_id,
-                    group_id,
-                    token_len,
-                    len(keys),
-                    keys[:3],
-                )
-
-                addrs = []
-                sizes = []
-                stored_events: list[BlockStored] = []
-                prev_key = None
-                new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
-                for index, start in enumerate(starts):
-                    addr, size, _ = self._prepare_value(
-                        start,
-                        ends[index],
-                        block_ids,
-                        kv_cache_group_id=group_id,
-                        block_id=key_block_ids[index],
+                addrs.append(addr)
+                sizes.append(size)
+                if self.enable_kv_event:
+                    token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
+                    block_size = (
+                        req_meta.original_block_size[group_id]
+                        if isinstance(req_meta.original_block_size, list)
+                        else req_meta.original_block_size
                     )
-                    addrs.append(addr)
-                    sizes.append(size)
-
-                    # Create KV event
-                    if self.enable_kv_event:
-                        token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
-                        block_size = (
-                            req_meta.original_block_size[group_id]
-                            if isinstance(req_meta.original_block_size, list)
-                            else req_meta.original_block_size
+                    if block_size is not None:
+                        stored_event = BlockStored(
+                            block_hashes=[new_block_hashes[index]],
+                            parent_block_hash=prev_key,
+                            token_ids=token_ids,
+                            block_size=block_size,
+                            lora_id=None,
+                            medium="cpu",
+                            lora_name=None,
                         )
-                        if block_size is not None:
-                            stored_event = BlockStored(
-                                block_hashes=[new_block_hashes[index]],
-                                parent_block_hash=prev_key,
-                                token_ids=token_ids,
-                                block_size=block_size,
-                                lora_id=None,
-                                medium="cpu",
-                                lora_name=None,
-                            )
-                            stored_events.append(stored_event)
-                            prev_key = new_block_hashes[index]
-                            logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+                        stored_events.append(stored_event)
+                        prev_key = new_block_hashes[index]
 
-                if self.kv_role == "kv_consumer":
-                    keys, addrs, sizes = self._decode_adaptor_prefill_pp(
-                        keys,
-                        addrs,
-                        sizes,
-                        kv_cache_group_id=group_id,
-                    )
-
-                if current_event is not None:
-                    current_event.synchronize()
-                self.m_store.put(keys, addrs, sizes)
-
-                # TODO Query specific replica info to update the event
-                if self.enable_kv_event and stored_events is not None:
-                    self.update_kv_event(stored_events)
-        finally:
-            # always free blocks
-            self.mark_completed_events(req_meta.event_id)
-        self.dec_stored_request(req_id)
-        if self.stored_requests.get(req_id, -1) == 0:
-            self.delete_finished_stored_request(req_id)
-            self.set_finished_request(req_id)
-        self.request_queue.task_done()
+            if self.kv_role == "kv_consumer":
+                keys, addrs, sizes = self._decode_adaptor_prefill_pp(
+                    keys,
+                    addrs,
+                    sizes,
+                    kv_cache_group_id=group_id,
+                )
+            if current_event is not None:
+                current_event.synchronize()
+            self.m_store.put(keys, addrs, sizes)
+            if self.enable_kv_event and stored_events:
+                self.update_kv_event(stored_events)
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):
@@ -883,6 +1089,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 // group_block_size
                 * group_block_size
             )
+
+            def chunk_filter(start: int, group_id=group_id) -> bool:
+                return self._mask_allows_chunk(load_masks, group_id, start)
+
             for start, end, key, _block_hash, block_id in self._process_token_key_strings_with_block_ids(
                 token_len,
                 req_meta.block_hashes,
@@ -890,9 +1100,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 mask_num,
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                chunk_filter=chunk_filter,
             ):
-                if not self._mask_allows_chunk(load_masks, group_id, start):
-                    continue
                 addr, size, block_id = self._prepare_value(
                     start,
                     end,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -25,7 +25,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerTransferTask,
     ReqMeta,
     SharedBlockData,
-    get_block_hashes,
 )
 # isort: on
 
@@ -553,6 +552,42 @@ class KVTransferThread(threading.Thread):
 
         return iter_with_legacy_process_tokens()
 
+    def _process_token_key_strings_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes,
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+    ):
+        process_key_strings = getattr(self.token_database, "process_token_key_strings_with_block_ids", None)
+        if process_key_strings is not None:
+            return process_key_strings(
+                token_len,
+                block_hashes,
+                block_ids,
+                mask_num=mask_num,
+                kv_cache_group_id=kv_cache_group_id,
+                skip_null_blocks=skip_null_blocks,
+                cache_role=cache_role,
+            )
+
+        def iter_with_pool_keys():
+            for start, end, key, block_id in self._process_tokens_with_block_ids(
+                token_len,
+                block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=kv_cache_group_id,
+                skip_null_blocks=skip_null_blocks,
+                cache_role=cache_role,
+            ):
+                yield start, end, key.to_string(), getattr(key, "chunk_hash_bytes", key.chunk_hash), block_id
+
+        return iter_with_pool_keys()
+
     def _prepare_value(
         self,
         start: int,
@@ -683,13 +718,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 key_block_ids = []
                 block_ids = req_meta.block_ids_by_group[group_id]
                 group_block_size = self._get_block_size(group_id)
-                group_block_hashes = get_block_hashes(
-                    req_meta.block_hashes,
-                    group_block_size,
-                    getattr(self.token_database, "hash_block_size", group_block_size),
-                )
 
-                for start, end, key, block_id in self._process_tokens_with_block_ids(
+                for start, end, key, block_hash, block_id in self._process_token_key_strings_with_block_ids(
                     token_len,
                     req_meta.block_hashes,
                     block_ids,
@@ -700,8 +730,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         continue
                     starts.append(start)
                     ends.append(end)
-                    keys.append(key.to_string())
-                    block_hashes.append(group_block_hashes[start // group_block_size])
+                    keys.append(key)
+                    block_hashes.append(block_hash)
                     key_block_ids.append(block_id)
 
                 if (
@@ -853,7 +883,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 // group_block_size
                 * group_block_size
             )
-            for start, end, key, block_id in self._process_tokens_with_block_ids(
+            for start, end, key, _block_hash, block_id in self._process_token_key_strings_with_block_ids(
                 token_len,
                 req_meta.block_hashes,
                 block_ids,
@@ -870,7 +900,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     kv_cache_group_id=group_id,
                     block_id=block_id,
                 )
-                key_list.append(key.to_string())
+                key_list.append(key)
                 addr_list.append(addr)
                 size_list.append(size)
                 block_id_list.append(block_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -91,6 +91,8 @@ class KVPoolScheduler:
             "consumer_is_to_put", False
         )
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        retention_interval = getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None)
+        self.retention_interval = retention_interval if isinstance(retention_interval, int) else None
         self.save_decode_cache = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "save_decode_cache", False
         )
@@ -495,14 +497,22 @@ class KVPoolScheduler:
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_load:
             return 0, False
 
+        prompt_token_len = len(request.prompt_token_ids)
+        if (
+            self.retention_interval is not None
+            and not self.use_layerwise
+            and prompt_token_len < 2 * self.retention_interval
+        ):
+            return 0, False
+
         if self.use_gva_layerwise:
-            token_len = len(request.prompt_token_ids)
+            token_len = prompt_token_len
             num_external_hit_tokens = self._get_layerwise_gva_hit_tokens(request, token_len, num_computed_tokens)
         else:
             if self._discard_partial_chunks:
-                token_len = self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
+                token_len = self._floor_to_cache_transfer_granularity(prompt_token_len)
             else:
-                token_len = len(request.prompt_token_ids)
+                token_len = prompt_token_len
 
             if token_len < self.cache_transfer_granularity:
                 return 0, False
@@ -512,17 +522,21 @@ class KVPoolScheduler:
                     request, token_len, num_computed_tokens, include_layers=True
                 )
             else:
+                if num_computed_tokens >= token_len:
+                    return 0, False
                 if self.client is None:
                     self.client = LookupKeyClient(self.vllm_config)
                 num_external_hit_tokens = self.client.lookup(
                     token_len,
                     request.block_hashes,
                     self.kv_cache_group_ids,
+                    hbm_hit_tokens=num_computed_tokens,
                 )
 
         if num_external_hit_tokens == 0:
             return 0, False
 
+        store_skip_tokens = num_external_hit_tokens
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 
@@ -550,6 +564,7 @@ class KVPoolScheduler:
             vllm_cached_tokens=num_computed_tokens,
             kvpool_cached_tokens=num_external_hit_tokens,
             can_load=force_layerwise_load,
+            kvpool_store_skip_tokens=store_skip_tokens,
         )
         logger.info(
             "KV pool load spec created req=%s vllm_cached=%d kvpool_cached=%d "
@@ -1096,13 +1111,15 @@ class LookupKeyClient:
         token_len: int,
         block_hashes: list[BlockHash],
         kv_cache_group_ids: list[int] | None = None,
+        hbm_hit_tokens: int = 0,
     ) -> int:
         kv_cache_group_ids = kv_cache_group_ids or [0]
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
         kv_group_frames = self.encoder.encode(kv_cache_group_ids)
         token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [token_len_bytes] + list(kv_group_frames) + list(hash_frames)
+        hbm_hit_bytes = hbm_hit_tokens.to_bytes(4, byteorder="big")
+        all_frames = [token_len_bytes] + list(kv_group_frames) + [hbm_hit_bytes] + list(hash_frames)
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -802,7 +802,13 @@ class KVPoolWorker:
                 group_block_size = self.grouped_block_size[group_id]
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
                 skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
-                for start, end, key, block_id in self.token_database.process_tokens_with_block_ids(
+                for (
+                    start,
+                    end,
+                    key,
+                    _block_hash,
+                    block_id,
+                ) in self.token_database.process_token_key_strings_with_block_ids(
                     token_len,
                     request.block_hashes,
                     block_ids,
@@ -819,7 +825,7 @@ class KVPoolWorker:
                         kv_cache_group_id=group_id,
                         block_id=block_id,
                     )
-                    key_list.append(key.to_string())
+                    key_list.append(key)
                     addr_list.append(addr)
                     size_list.append(size)
                     block_id_list.append(block_id)
@@ -1593,19 +1599,27 @@ class KVPoolWorker:
                 keys = []
                 starts = []
                 ends = []
-                for start, end, key in self.token_database.process_tokens(
-                    token_len,
-                    block_hashes,
-                    kv_cache_group_id=group_id,
-                ):
-                    if use_layerwise:
+                if use_layerwise:
+                    token_iter = self.token_database.process_tokens(
+                        token_len,
+                        block_hashes,
+                        kv_cache_group_id=group_id,
+                    )
+                    for start, end, key in token_iter:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:
                             keys.append(item.to_string())
-                    else:
-                        keys.append(key.to_string())
-                    starts.append(start)
-                    ends.append(end)
+                        starts.append(start)
+                        ends.append(end)
+                else:
+                    for start, end, key, _ in self.token_database.process_token_key_strings(
+                        token_len,
+                        block_hashes,
+                        kv_cache_group_id=group_id,
+                    ):
+                        keys.append(key)
+                        starts.append(start)
+                        ends.append(end)
 
                 if not keys:
                     hits.append(0)
@@ -1780,19 +1794,27 @@ class KVPoolWorker:
                 keys = []
                 starts = []
                 ends = []
-                for start, end, key in self.token_database.process_tokens(
-                    token_len,
-                    block_hashes,
-                    kv_cache_group_id=group_id,
-                ):
-                    if use_layerwise:
+                if use_layerwise:
+                    token_iter = self.token_database.process_tokens(
+                        token_len,
+                        block_hashes,
+                        kv_cache_group_id=group_id,
+                    )
+                    for start, end, key in token_iter:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:
                             keys.append(item.to_string())
-                    else:
-                        keys.append(key.to_string())
-                    starts.append(start)
-                    ends.append(end)
+                        starts.append(start)
+                        ends.append(end)
+                else:
+                    for start, end, key, _ in self.token_database.process_token_key_strings(
+                        token_len,
+                        block_hashes,
+                        kv_cache_group_id=group_id,
+                    ):
+                        keys.append(key)
+                        starts.append(start)
+                        ends.append(end)
 
                 if not keys:
                     return 0

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import math
+import os
 import threading
 from collections.abc import Generator
 from typing import Any
@@ -159,6 +160,7 @@ class KVPoolWorker:
         self.h2d_stagger_us = int(extra_config.get("h2d_stagger_us", 0))
         self.layerwise_max_transfer_blocks = int(extra_config.get("layerwise_max_transfer_blocks", 0))
         self.layerwise_max_transfer_bytes = int(extra_config.get("layerwise_max_transfer_bytes", 0))
+        self.lookup_reachable_mask = os.getenv("VLLM_ASCEND_LOOKUP_REACHABLE_MASK", "0") == "1"
 
         logger.info(
             "use_hybrid: %s, use_mamba: %s, num_kv_cache_groups: %s, hash_block_size: %s, lcm_block_size: %s",
@@ -802,6 +804,10 @@ class KVPoolWorker:
                 group_block_size = self.grouped_block_size[group_id]
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
                 skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
+
+                def chunk_filter(start: int, group_id=group_id, load_masks=load_masks) -> bool:
+                    return self.token_database.mask_allows_chunk(load_masks, group_id, start)
+
                 for (
                     start,
                     end,
@@ -815,9 +821,8 @@ class KVPoolWorker:
                     mask_num,
                     kv_cache_group_id=group_id,
                     skip_null_blocks=skip_null,
+                    chunk_filter=chunk_filter,
                 ):
-                    if not self.token_database.mask_allows_chunk(load_masks, group_id, start):
-                        continue
                     addr, size, block_id = self.token_database.prepare_value(
                         start,
                         end,
@@ -1367,6 +1372,11 @@ class KVPoolWorker:
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
         current_event = None
         has_save_request = False
+        save_done_events: list[threading.Event] = []
+        assert self.kv_send_thread is not None
+        send_thread = self.kv_send_thread
+        per_request_save_wait = getattr(send_thread, "_per_request_save_wait", False)
+        async_save = getattr(send_thread, "_async_save", False)
         for request in connector_metadata.requests:
             can_save = request.can_save
             if can_save is None or not can_save:
@@ -1382,19 +1392,23 @@ class KVPoolWorker:
 
             request.skip_null_blocks_by_group = self.group_uses_align_state
             request.current_event = current_event
-            self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                request.req_id
-            )
-            self.kv_send_thread.add_request(  # type: ignore[union-attr]
-                request,
-            )
+            send_thread.add_stored_request(request.req_id)
+            if per_request_save_wait:
+                event = send_thread.prepare_stored_request_done_event(request.req_id)  # type: ignore[attr-defined]
+                if event is not None:
+                    save_done_events.append(event)
+            send_thread.add_request(request)
             has_save_request = True
 
         if has_save_request:
-            # vLLM expects wait_for_save() to make stores visible before the
-            # request is reported as finished. Without this barrier a following
-            # identical prompt can lookup before Mooncake put() has completed.
-            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
+            if per_request_save_wait:
+                for event in save_done_events:
+                    if not event.wait(timeout=300):
+                        logger.warning("Timed out waiting for an AscendStore request save")
+            elif not async_save:
+                # Default consistency barrier: make stores visible before the
+                # request is reported as finished.
+                send_thread.request_queue.join()
 
     def retrieve_layer(
         self,
@@ -1684,13 +1698,15 @@ class KVPoolWorker:
         return f"{key[:value_start]}{value}{key[value_end:]}"
 
     @staticmethod
-    def _chunk_hash_to_bytes(chunk_hash: str) -> bytes:
-        if len(chunk_hash) == 64:
-            try:
-                return bytes.fromhex(chunk_hash)
-            except ValueError:
-                pass
-        return chunk_hash.encode("utf-8")
+    def _chunk_hash_to_bytes(chunk_hash: BlockHash | str) -> bytes:
+        if isinstance(chunk_hash, str):
+            if len(chunk_hash) == 64:
+                try:
+                    return bytes.fromhex(chunk_hash)
+                except ValueError:
+                    pass
+            return chunk_hash.encode("utf-8")
+        return bytes(chunk_hash)
 
     def _expand_lookup_key_variants(self, key: str, group_id: int, include_all_ranks: bool) -> list[str]:
         if not include_all_ranks:
@@ -1710,6 +1726,7 @@ class KVPoolWorker:
         kv_cache_group_ids: list[int],
         use_layerwise: bool,
         include_all_ranks: bool,
+        hbm_hit_tokens: int = 0,
     ) -> int | None:
         if self.cache_coordinator is None or use_layerwise:
             return None
@@ -1717,18 +1734,63 @@ class KVPoolWorker:
             return None
 
         exists: set[tuple[int, bytes]] = set()
+        if hbm_hit_tokens > 0:
+            for group_id in kv_cache_group_ids:
+                base_block_size = self.token_database.get_block_size(group_id)
+                cache_family = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+                effective_block_size = get_cache_family_granularity(base_block_size, cache_family)
+                grouped_hashes = get_block_hashes(
+                    block_hashes,
+                    effective_block_size,
+                    self.token_database.hash_block_size,
+                )
+                num_hbm_chunks = hbm_hit_tokens // effective_block_size
+                for chunk_id in range(min(num_hbm_chunks, len(grouped_hashes))):
+                    exists.add((group_id, self._chunk_hash_to_bytes(grouped_hashes[chunk_id])))
+
+        lookup_masks = None
+        store_masks = None
+        if self.lookup_reachable_mask:
+            aligned_len = (
+                (token_len + self.cache_coordinator.lcm_block_size - 1)
+                // self.cache_coordinator.lcm_block_size
+                * self.cache_coordinator.lcm_block_size
+            )
+            lookup_masks = self.cache_coordinator.lookup_mask(aligned_len)
+            store_masks = self.cache_coordinator.store_mask(aligned_len, None)
+
         for group_id in kv_cache_group_ids:
             keys: list[str] = []
-            chunk_hashes: list[str] = []
+            chunk_hashes: list[BlockHash | str] = []
             variant_counts: list[int] = []
-            for _, _, key in self.token_database.process_tokens(
+            base_block_size = self.token_database.get_block_size(group_id)
+            cache_family = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+            effective_block_size = get_cache_family_granularity(base_block_size, cache_family)
+            lookup_start = hbm_hit_tokens // effective_block_size * effective_block_size
+            lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
+            store_mask = store_masks[group_id] if store_masks is not None and group_id < len(store_masks) else None
+
+            def chunk_filter(
+                start: int,
+                base_block_size=base_block_size,
+                lookup_mask=lookup_mask,
+                store_mask=store_mask,
+            ) -> bool:
+                chunk_idx = start // base_block_size
+                if lookup_mask is not None and (chunk_idx >= len(lookup_mask) or not lookup_mask[chunk_idx]):
+                    return False
+                return store_mask is None or (chunk_idx < len(store_mask) and store_mask[chunk_idx])
+
+            for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
                 token_len,
                 block_hashes,
+                mask_num=lookup_start,
                 kv_cache_group_id=group_id,
+                chunk_filter=chunk_filter,
             ):
-                variants = self._expand_lookup_key_variants(key.to_string(), group_id, include_all_ranks)
+                variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
                 keys.extend(variants)
-                chunk_hashes.append(key.chunk_hash)
+                chunk_hashes.append(chunk_hash)
                 variant_counts.append(len(variants))
 
             if not keys:
@@ -1771,6 +1833,7 @@ class KVPoolWorker:
         block_hashes: list[BlockHash],
         kv_cache_group_ids: list[int] | None = None,
         use_layerwise: bool = False,
+        hbm_hit_tokens: int = 0,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
@@ -1787,6 +1850,7 @@ class KVPoolWorker:
                 kv_cache_group_ids,
                 use_layerwise,
                 include_all_ranks=True,
+                hbm_hit_tokens=hbm_hit_tokens,
             )
             if coordinator_hit is not None:
                 return coordinator_hit

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1612,12 +1612,12 @@ class KVPoolWorker:
                         starts.append(start)
                         ends.append(end)
                 else:
-                    for start, end, key, _ in self.token_database.process_token_key_strings(
+                    for start, end, key_string, _ in self.token_database.process_token_key_strings(
                         token_len,
                         block_hashes,
                         kv_cache_group_id=group_id,
                     ):
-                        keys.append(key)
+                        keys.append(key_string)
                         starts.append(start)
                         ends.append(end)
 
@@ -1807,12 +1807,12 @@ class KVPoolWorker:
                         starts.append(start)
                         ends.append(end)
                 else:
-                    for start, end, key, _ in self.token_database.process_token_key_strings(
+                    for start, end, key_string, _ in self.token_database.process_token_key_strings(
                         token_len,
                         block_hashes,
                         kv_cache_group_id=group_id,
                     ):
-                        keys.append(key)
+                        keys.append(key_string)
                         starts.append(start)
                         ends.append(end)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This adapts the AscendStore key-construction and KVPool miss-path optimizations to `releases/v0.23.0` while preserving the hybrid/layerwise architecture introduced on the release branch.

Key construction and lookup:

- Keeps `process_tokens()` as a direct lazy-hash-to-`PoolKey` path for layerwise `split_layers()` operations.
- Generates serialized non-layerwise keys directly, caches immutable prefixes, and computes grouped hashes lazily.
- Propagates HBM hit tokens through the lookup RPC, skips external lookup on a full HBM hit, and avoids querying the HBM-resident prefix again.
- Optionally applies hybrid-cache reachable masks before key construction.

Put and save path:

- Applies store/load masks before key construction.
- Adds validated sparse store-mask key construction and optional pre-shard key construction.
- Preserves the raw KVPool hit length so an already pooled prefix is not queried or stored again.
- Adds global-queue, per-request, and asynchronous save modes with exception-safe queue/request lifecycle handling.
- Skips external lookup for retention-enabled prompts that are too short to produce a reusable retained prefix.

Scope boundaries:

- This PR intentionally does **not** add C128-first lookup, a C128 miss gate, or `LOOKUP_FULL_GUARD` behavior.
- Layerwise mode continues to use `PoolKey` and per-layer keys. The non-layerwise string fast path and asynchronous save controls do not replace the layerwise transfer path.

### Does this PR introduce _any_ user-facing change?

The default key format and cache behavior remain unchanged. The direct string path is enabled by default. More aggressive sparse/pre-shard lookup and save behavior remains opt-in through documented environment variables, including `VLLM_ASCEND_ASYNC_SAVE`; asynchronous save can allow a following identical lookup to race with save visibility.

### How was this patch tested?

- 137 targeted AscendStore unit tests passed with repository mock dependencies; 10 existing deprecated layerwise tests were skipped.
- `ruff check` and `ruff format --check` passed for all changed Python files.
- Targeted mypy checks passed with missing external imports ignored locally; CI provides the full vLLM/PyTorch environment.
- Python compile checks, repository custom Python checks, and `git diff --check` passed.
- Local key-build microbenchmarks show about 4x speedup for direct 512-key construction, 6.9x for a 50%-masked 512-block path, and effectively unchanged layerwise key generation.
- NPU hardware testing was not available locally; CI/NPU validation is required.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
