### PR TITLE
[v0.23.0][Performance][Attention] Optimize SFA DSA-CP output merge with All2All

### DIFF
--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -32,7 +32,7 @@ from vllm_ascend.attention.context_parallel.sfa_cp import (
     AscendSFACPMetadataBuilder,
     AscendSFADCPImpl,
 )
-from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, DCPContext
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata, DCPContext, DSACPContext
 
 
 def _make_indexer_mock():
@@ -1488,6 +1488,149 @@ class TestAscendSFACPImpl(TestBase):
 
 
 class TestAscendSFADCPImpl(TestBase):
+    @staticmethod
+    def _make_dsa_cp_context(
+        *,
+        num_tokens: int = 4,
+        num_tokens_pad: int = 4,
+        local_start: int = 0,
+        local_end_with_pad: int = 2,
+    ) -> DSACPContext:
+        return DSACPContext(
+            num_tokens=num_tokens,
+            num_tokens_pad=num_tokens_pad,
+            local_start=local_start,
+            local_end=min(local_end_with_pad, num_tokens),
+            local_end_with_pad=local_end_with_pad,
+            slot_mapping_cp=torch.empty(0, dtype=torch.int32),
+            actual_seq_lengths_query=torch.empty(0, dtype=torch.int32),
+            actual_seq_lengths_key=torch.empty(0, dtype=torch.int32),
+        )
+
+    def test_all_to_all_dcp_tensor_supports_head_and_token_scatter(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_size = 2
+        impl.dcp_group = MagicMock()
+        tensor = torch.arange(4 * 6 * 2).view(4, 6, 2)
+
+        def copy_all_to_all(recv, send, *, group):
+            self.assertIs(group, impl.dcp_group.device_group)
+            recv.copy_(send)
+
+        with patch(
+            "vllm_ascend.attention.context_parallel.sfa_cp.dist.all_to_all_single",
+            side_effect=copy_all_to_all,
+        ):
+            for scatter_dim in (0, 1):
+                with self.subTest(scatter_dim=scatter_dim):
+                    result = impl._all_to_all_dcp_tensor(tensor, scatter_dim)
+                    send = tensor.movedim(scatter_dim, 0).contiguous()
+                    expected = send.view(impl.dcp_size, send.shape[0] // impl.dcp_size, *send.shape[1:])
+                    torch.testing.assert_close(result, expected)
+
+    def test_all_to_all_dcp_tensor_rejects_nondivisible_scatter_size(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_size = 2
+        impl.dcp_group = MagicMock()
+
+        with self.assertRaisesRegex(RuntimeError, "scatter dimension to be divisible"):
+            impl._all_to_all_dcp_tensor(torch.empty(3, 4, 2), scatter_dim=0)
+
+    def test_merge_dcp_outputs_with_torch_matches_head_and_token_layouts(self):
+        output_by_head = torch.arange(2 * 2 * 3 * 2, dtype=torch.float16).view(2, 2, 3, 2)
+        lse_by_head = torch.tensor(
+            [
+                [[0.0, 1.0, -1.0], [2.0, 0.0, 1.0]],
+                [[1.0, 0.0, -2.0], [0.0, 2.0, 1.0]],
+            ],
+            dtype=torch.float32,
+        )
+        weights = torch.softmax(lse_by_head, dim=0)
+        expected = (output_by_head.float() * weights.unsqueeze(-1)).sum(dim=0).movedim(1, 0).contiguous()
+
+        native_output = AscendSFADCPImpl._merge_dcp_outputs_with_torch(
+            output_by_head,
+            lse_by_head,
+            token_dim=2,
+        )
+        dsa_output = AscendSFADCPImpl._merge_dcp_outputs_with_torch(
+            output_by_head.movedim(1, 2),
+            lse_by_head.movedim(1, 2),
+            token_dim=1,
+        )
+
+        torch.testing.assert_close(native_output, expected)
+        torch.testing.assert_close(dsa_output, expected)
+
+    def test_merge_dcp_outputs_selects_native_head_scatter(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_size = 2
+        impl.dcp_rank = 0
+        impl.dcp_group = MagicMock()
+        sfa_output = torch.randn(4, 4, 8)
+        softmax_lse = torch.randn(4, 4, 1)
+        output_recv = torch.randn(2, 2, 4, 8)
+        lse_recv = torch.randn(2, 2, 4, 1)
+        expected = torch.randn(4, 2, 8)
+        impl._all_to_all_dcp_tensor = MagicMock(side_effect=(output_recv, lse_recv))
+        impl._merge_dcp_outputs_with_torch = MagicMock(return_value=expected)
+
+        result = impl._merge_dcp_outputs(sfa_output, softmax_lse)
+
+        self.assertIs(result, expected)
+        all_to_all_calls = impl._all_to_all_dcp_tensor.call_args_list
+        self.assertEqual(len(all_to_all_calls), 2)
+        self.assertIs(all_to_all_calls[0].args[0], sfa_output)
+        self.assertEqual(all_to_all_calls[0].args[1], 1)
+        self.assertIs(all_to_all_calls[1].args[0], softmax_lse)
+        self.assertEqual(all_to_all_calls[1].args[1], 1)
+        merge_args = impl._merge_dcp_outputs_with_torch.call_args.args
+        self.assertIs(merge_args[0], output_recv)
+        torch.testing.assert_close(merge_args[1], lse_recv.squeeze(-1))
+        self.assertEqual(merge_args[2], 2)
+
+    def test_merge_dcp_outputs_selects_dsa_token_scatter(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_size = 2
+        impl.dcp_rank = 0
+        impl.dcp_group = MagicMock()
+        sfa_output = torch.randn(4, 4, 8)
+        softmax_lse = torch.randn(4, 4, 1)
+        output_recv = torch.randn(2, 2, 4, 8)
+        lse_recv = torch.randn(2, 2, 4, 1)
+        expected = torch.randn(2, 4, 8)
+        dsa_cp_context = self._make_dsa_cp_context()
+        impl._all_to_all_dcp_tensor = MagicMock(side_effect=(output_recv, lse_recv))
+        impl._merge_dcp_outputs_with_torch = MagicMock(return_value=expected)
+
+        result = impl._merge_dcp_outputs(sfa_output, softmax_lse, dsa_cp_context)
+
+        self.assertIs(result, expected)
+        all_to_all_calls = impl._all_to_all_dcp_tensor.call_args_list
+        self.assertEqual(len(all_to_all_calls), 2)
+        self.assertIs(all_to_all_calls[0].args[0], sfa_output)
+        self.assertEqual(all_to_all_calls[0].args[1], 0)
+        self.assertIs(all_to_all_calls[1].args[0], softmax_lse)
+        self.assertEqual(all_to_all_calls[1].args[1], 0)
+        merge_args = impl._merge_dcp_outputs_with_torch.call_args.args
+        self.assertIs(merge_args[0], output_recv)
+        torch.testing.assert_close(merge_args[1], lse_recv.squeeze(-1))
+        self.assertEqual(merge_args[2], 1)
+
+    def test_merge_dcp_outputs_rejects_misaligned_dsa_token_shard(self):
+        impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+        impl.dcp_size = 2
+        impl.dcp_rank = 0
+        impl.dcp_group = MagicMock()
+        dsa_cp_context = self._make_dsa_cp_context(local_start=1, local_end_with_pad=3)
+
+        with self.assertRaisesRegex(RuntimeError, "token shards must follow DCP rank order"):
+            impl._merge_dcp_outputs(
+                torch.randn(4, 4, 8),
+                torch.randn(4, 4, 1),
+                dsa_cp_context,
+            )
+
     def test_record_dcp_kv_gather_context_c8_only_gathers_packed_kv(self):
         impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
         impl.dcp_group = MagicMock()
@@ -1544,6 +1687,7 @@ class TestAscendSFADCPImpl(TestBase):
 
         attn_metadata = MagicMock()
         attn_metadata.num_prefills = 0
+        attn_metadata.dsa_cp_context = None
         attn_metadata.dcp_context = DCPContext(
             slot_mapping=torch.tensor([0, 1], dtype=torch.int32),
             block_table=dcp_block_table,
@@ -1577,4 +1721,4 @@ class TestAscendSFADCPImpl(TestBase):
         self.assertIs(call_kwargs["block_table"], dcp_block_table)
         self.assertEqual(call_kwargs["sparse_mode"], 0)
         self.assertTrue(call_kwargs["return_lse"])
-        impl._merge_dcp_outputs.assert_called_once_with(sfa_output, softmax_lse)
+        impl._merge_dcp_outputs.assert_called_once_with(sfa_output, softmax_lse, None)

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -19,6 +19,7 @@ from vllm_ascend.attention.sfa_v1 import (
     AscendSFAMetadataBuilder,
     DCPContext,
     DCPGatherContext,
+    DSACPContext,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enabling_mlapo, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
@@ -1115,79 +1116,84 @@ class AscendSFADCPImpl(AscendSFAImpl):
         _, pack_order = torch.sort(pack_keys, dim=-1)
         return torch.gather(remapped_indices, dim=-1, index=pack_order.to(torch.int32))
 
-    def _merge_dsa_cp_dcp_outputs(
+    def _all_to_all_dcp_tensor(
         self,
-        sfa_output: torch.Tensor,
-        softmax_lse: torch.Tensor,
+        tensor: torch.Tensor,
+        scatter_dim: int,
     ) -> torch.Tensor:
-        # DSA-CP keeps the head dimension replicated/full.  Only DCP shards KV,
-        # so merge the per-DCP partial outputs explicitly instead of using the
-        # common CP helper, which assumes DCP also shards heads.
-        num_tokens, num_heads, head_size = sfa_output.shape
-        assert self.dcp_group is not None
-        out_flat = self.dcp_group.all_gather(sfa_output.contiguous(), dim=0)
-        lse_flat = self.dcp_group.all_gather(softmax_lse.contiguous(), dim=0)
-        out_flat = out_flat.view(
-            self.dcp_size,
-            num_tokens,
-            num_heads,
-            head_size,
-        )
-        lse_flat = lse_flat.view(
-            self.dcp_size,
-            num_tokens,
-            num_heads,
-            1,
-        )
-        out_flat = out_flat.to(torch.float32).flatten(1, 2)
-        lse_flat = lse_flat.to(torch.float32).flatten(1, -1)
-        output, _ = torch_npu.npu_attention_update(lse_flat.unbind(0), out_flat.unbind(0), 0)
-        return output.view(num_tokens, num_heads, head_size)
+        assert self.dcp_group is not None, "DCP output All2All requires dcp_group when dcp_size > 1."
+        scatter_size = tensor.shape[scatter_dim]
+        if scatter_size % self.dcp_size != 0:
+            raise RuntimeError(
+                "DCP output All2All requires the scatter dimension to be divisible "
+                f"by dcp_size, got shape={tuple(tensor.shape)}, scatter_dim={scatter_dim}, "
+                f"and dcp_size={self.dcp_size}."
+            )
+
+        local_scatter_size = scatter_size // self.dcp_size
+        send = tensor.movedim(scatter_dim, 0).contiguous()
+        recv = torch.empty_like(send)
+        dist.all_to_all_single(recv, send, group=self.dcp_group.device_group)
+        recv = recv.view(self.dcp_size, local_scatter_size, *send.shape[1:])
+        return recv
 
     @staticmethod
     def _merge_dcp_outputs_with_torch(
         output_recv: torch.Tensor,
         lse_recv: torch.Tensor,
+        token_dim: int,
     ) -> torch.Tensor:
-        lse_recv = lse_recv.masked_fill(torch.isnan(lse_recv) | torch.isinf(lse_recv), float("-inf"))
-        lse_max = torch.amax(lse_recv, dim=0)
-        lse_max = lse_max.masked_fill(lse_max == float("-inf"), 0.0)
-        weights = torch.exp(lse_recv - lse_max.unsqueeze(0))
-        weights = weights.masked_fill(torch.isnan(weights), 0.0)
-        weights = weights / weights.sum(dim=0, keepdim=True).clamp_min(1e-10)
+        if output_recv.ndim != 4 or lse_recv.ndim != 3 or output_recv.shape[:3] != lse_recv.shape:
+            raise RuntimeError(
+                "DCP output merge expects matching rank/token/head dimensions, "
+                f"got {tuple(output_recv.shape)} and {tuple(lse_recv.shape)}."
+            )
+        if token_dim not in (1, 2):
+            raise RuntimeError(f"DCP output merge token_dim must be 1 or 2, got {token_dim}.")
+        lse_recv = lse_recv.masked_fill(~torch.isfinite(lse_recv), float("-inf"))
+        weights = torch.softmax(lse_recv, dim=0)
+        weights = torch.nan_to_num(weights, nan=0.0)
 
-        output = (output_recv.to(torch.float32) * weights.unsqueeze(-1)).sum(dim=0)
-        return output.permute(1, 0, 2).contiguous()
+        output = (output_recv.to(lse_recv.dtype) * weights.unsqueeze(-1)).sum(dim=0)
+        return output.movedim(token_dim - 1, 0).contiguous()
 
     def _merge_dcp_outputs(
         self,
         sfa_output: torch.Tensor,
         softmax_lse: torch.Tensor,
+        dsa_cp_context: DSACPContext | None = None,
     ) -> torch.Tensor:
-        assert self.dcp_group is not None, "DCP output merge requires dcp_group when dcp_size > 1."
-        num_tokens, num_heads, head_size = sfa_output.shape
-        assert num_heads % self.dcp_size == 0
-        local_num_heads = num_heads // self.dcp_size
+        scatter_dim = 1
+        token_dim = 2
+        if dsa_cp_context is not None:
+            # DSA-CP keeps heads replicated and shards tokens. The All2All
+            # destination must match the token range assigned to this rank.
+            num_tokens = sfa_output.shape[0]
+            if num_tokens != dsa_cp_context.num_tokens_pad:
+                raise RuntimeError(
+                    "DSA-CP DCP All2All expects the SFA token count to match "
+                    f"num_tokens_pad, got {num_tokens} and {dsa_cp_context.num_tokens_pad}."
+                )
+            if num_tokens % self.dcp_size != 0:
+                raise RuntimeError(
+                    f"DSA-CP DCP All2All requires {num_tokens} tokens to be divisible by dcp_size={self.dcp_size}."
+                )
+            local_num_tokens = num_tokens // self.dcp_size
+            expected_local_start = self.dcp_rank * local_num_tokens
+            actual_local_num_tokens = dsa_cp_context.local_end_with_pad - dsa_cp_context.local_start
+            if dsa_cp_context.local_start != expected_local_start or actual_local_num_tokens != local_num_tokens:
+                raise RuntimeError(
+                    "DSA-CP token shards must follow DCP rank order for the output All2All, "
+                    f"but rank {self.dcp_rank} expects [{expected_local_start}, "
+                    f"{expected_local_start + local_num_tokens}) and metadata provides "
+                    f"[{dsa_cp_context.local_start}, {dsa_cp_context.local_end_with_pad})."
+                )
+            scatter_dim = 0
+            token_dim = 1
 
-        output_send = sfa_output.permute(1, 0, 2).contiguous()
-        output_recv = torch.empty_like(output_send)
-        dist.all_to_all_single(
-            output_recv,
-            output_send,
-            group=self.dcp_group.device_group,
-        )
-        output_recv = output_recv.view(self.dcp_size, local_num_heads, num_tokens, head_size)
-
-        lse_send = softmax_lse.to(torch.float32).permute(1, 0, 2).contiguous()
-        lse_recv = torch.empty_like(lse_send)
-        dist.all_to_all_single(
-            lse_recv,
-            lse_send,
-            group=self.dcp_group.device_group,
-        )
-        lse_recv = lse_recv.view(self.dcp_size, local_num_heads, num_tokens)
-
-        return self._merge_dcp_outputs_with_torch(output_recv, lse_recv)
+        output_recv = self._all_to_all_dcp_tensor(sfa_output, scatter_dim)
+        lse_recv = self._all_to_all_dcp_tensor(softmax_lse, scatter_dim).squeeze(-1)
+        return self._merge_dcp_outputs_with_torch(output_recv, lse_recv, token_dim)
 
     def _start_dcp_query_gather(
         self,
@@ -1306,11 +1312,5 @@ class AscendSFADCPImpl(AscendSFAImpl):
             return_lse=True,
         )
         output_dtype = sfa_output.dtype
-        if self.enable_dsa_cp:
-            output = self._merge_dsa_cp_dcp_outputs(sfa_output, softmax_lse)
-            assert attn_metadata.dsa_cp_context is not None, "DSA-CP DCP output selection requires dsa_cp_context."
-            dsa_cp_context = attn_metadata.dsa_cp_context
-            output = output[dsa_cp_context.local_start : dsa_cp_context.local_end_with_pad]
-            return output.to(output_dtype)
-        output = self._merge_dcp_outputs(sfa_output, softmax_lse)
+        output = self._merge_dcp_outputs(sfa_output, softmax_lse, attn_metadata.dsa_cp_context)
         return output.to(output_dtype)


### PR DESCRIPTION
## What changed
cherry-pick from #11980
- Replace the DSA-CP + DCP full output/LSE AllGather followed by local slicing with token-sharded All2All.
- Share one All2All helper between native DCP head sharding and DSA-CP token sharding.
- Merge partial outputs in FP32 with a stable softmax over source DCP ranks.
- Preserve the native receive layout so DSA-CP does not perform a full output/LSE transpose.
- Validate that DSA-CP token shards follow DCP rank order before communication.

## Why

The previous DSA-CP path gathered every rank's complete partial output and LSE on every device, then retained only the local token range. This replicated communication and temporary tensors by the DCP world size and could lead to excessive HBM usage or OOM.

The All2All path sends each destination only its required token shard. Every device still receives all partial contributions needed for the numerically equivalent cross-rank merge, without materializing all tokens from all ranks.

## Impact

- Reduces DSA-CP output-merge communication and peak receive-buffer usage compared with full AllGather.
- Keeps native DCP behavior by scattering heads, while DSA-CP scatters tokens.
- Does not add communication collectives; output and LSE each use one All2All.
- Avoids an additional full-tensor transpose on the DSA-CP receive path.

## Validation

- `python -m py_compile vllm_ascend/attention/context_parallel/sfa_cp.py`
- `git diff --cached --check`
- Verified tensor layouts for native DCP (`[rank, head, token, dim]`) and DSA-CP (`[rank, token, head, dim]`) through the shared rank-wise merge.

NPU runtime tests were not run locally because this workspace does not provide `torch_npu` execution.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
