### PR TITLE
[BugFix][CI] Add partition distinction to CI output log files to prevent overwriting

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -315,7 +315,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
-          name: selected-test-logs-vllm-${{ inputs.vllm }}-${{ matrix.group.npu_type }}-${{ matrix.group.num_npus }}card
+          name: selected-test-logs-vllm-${{ inputs.vllm }}-${{ matrix.group.npu_type }}-${{ matrix.group.num_npus }}card-${{ matrix.group.partition }}
           path: ${{ runner.temp }}/selected-tests-*
           if-no-files-found: ignore
           retention-days: 14


### PR DESCRIPTION
### What this PR does / why we need it?
Add partition distinction to CI output log files to prevent overwriting

### Does this PR introduce _any_ user-facing change?
NA
### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
