### PR TITLE
[Doc][Misc] Update num_speculative_tokens to 1 in model tutorials

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -536,7 +536,7 @@ Before you start, please
             --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' \
             --profiler-config \
             '{"profiler": "torch",
             "torch_profiler_dir": "./vllm_profile",
@@ -610,7 +610,7 @@ Before you start, please
             --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' \
             --profiler-config \
             '{"profiler": "torch",
             "torch_profiler_dir": "./vllm_profile",

--- a/docs/source/tutorials/models/GLM4.x.md
+++ b/docs/source/tutorials/models/GLM4.x.md
@@ -417,7 +417,7 @@ Before you start, please
             --gpu-memory-utilization 0.9 \
             --quantization ascend \
             --enforce-eager \
-            --speculative-config '{"num_speculative_tokens": 3, "method":"mtp", "enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"mtp", "enforce_eager": true}' \
             --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": false}' \
             --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}' \
             --kv-transfer-config \
@@ -479,7 +479,7 @@ Before you start, please
             --gpu-memory-utilization 0.9 \
             --quantization ascend \
             --enforce-eager \
-            --speculative-config '{"num_speculative_tokens": 3, "method":"mtp", "enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"mtp", "enforce_eager": true}' \
             --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": false}' \
             --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}' \
             --kv-transfer-config \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -673,7 +673,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-52 \
             --max-model-len 135000 \
-            --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp", "enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
             --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
@@ -743,7 +743,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-52 \
             --max-model-len 135000 \
-            --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp", "enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
             --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1053,7 +1053,7 @@ vllm serve <MODEL_PATH> \
     "multistream_overlap_shared_expert": true,
     "enable_dsa_cp": true
   }' \
-  --speculative-config '{"num_speculative_tokens": 3, "method":"deepseek_mtp", "enforce_eager": true}'
+  --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}'
 ```
 
 `run_dp_template.sh` for the decode nodes:

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -811,7 +811,7 @@ Before you start, please
             --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 3, "method":"deepseek_mtp", "enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
             --profiler-config \
             '{"profiler": "torch",
             "torch_profiler_dir": "./vllm_profile",
@@ -891,7 +891,7 @@ Before you start, please
             --data-parallel-rpc-port $6 \
             --tensor-parallel-size $7 \
             --enable-expert-parallel \
-            --speculative-config '{"num_speculative_tokens": 3, "method":"deepseek_mtp", "enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
             --profiler-config \
             '{"profiler": "torch",
             "torch_profiler_dir": "./vllm_profile",

--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -521,7 +521,7 @@ vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
     --no-enable-prefix-caching \
     --gpu-memory-utilization 0.8 \
     --enforce-eager \
-    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
+    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 1}' \
     --mm-encoder-tp-mode data \
     --kv-transfer-config \
     '{"kv_connector": "MooncakeConnectorV1",
@@ -601,7 +601,7 @@ vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
     --no-enable-prefix-caching \
     --gpu-memory-utilization 0.8 \
     --enforce-eager \
-    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
+    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 1}' \
     --mm-encoder-tp-mode data \
     --kv-transfer-config \
     '{"kv_connector": "MooncakeConnectorV1",

--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -357,7 +357,7 @@ vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
     --no-enable-prefix-caching \
     --gpu-memory-utilization 0.95 \
     --enforce-eager \
-    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 3}' \
+    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 1}' \
     --mm-encoder-tp-mode data \
     --kv-transfer-config \
     '{"kv_connector": "MooncakeConnectorV1",
@@ -437,7 +437,7 @@ vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
     --no-enable-prefix-caching \
     --gpu-memory-utilization 0.95 \
     --enforce-eager \
-    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 3}' \
+    --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 1}' \
     --mm-encoder-tp-mode data \
     --kv-transfer-config \
     '{"kv_connector": "MooncakeConnectorV1",


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the speculative decoding configuration in several model tutorial markdown files (DeepSeek-V3.2, GLM5.2, GLM5, Kimi-K2.5, and Kimi-K2.6). Specifically, it changes the `num_speculative_tokens` parameter from various values (2, 3, or 5) to `1` across these documentation files.

### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.

### How was this patch tested?
No testing is required as these are documentation changes.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
