### PR TITLE
[CI] add 310P weekly test dispatch from PR /weekly command

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -124,7 +124,7 @@ a3:
   single_node:
     test_config:
       # pytest-driven tests
-      - name: engine-func-tests
+      - name: engine-func-tests-310p
         os: linux-aarch64-310p-4
         tests: tests/e2e/weekly/single_node/engine_func_test_robot
       - name: Qwen3-8B-w8a8sc-310p

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -43,6 +43,7 @@ jobs:
       is_authorized: ${{ steps.auth.outputs.is_authorized }}
       dispatch_a2: ${{ steps.resolve.outputs.dispatch_a2 }}
       dispatch_a3: ${{ steps.resolve.outputs.dispatch_a3 }}
+      dispatch_310p: ${{ steps.resolve.outputs.dispatch_310p }}
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
       aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
       command: ${{ steps.resolve.outputs.command }}
@@ -168,6 +169,7 @@ jobs:
             {
               echo "dispatch_a2=true"
               echo "dispatch_a3=true"
+              echo "dispatch_310p=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -355,9 +357,49 @@ jobs:
           echo "weekly_a3_run_id=$A3_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "Dispatched Weekly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
 
+  dispatch-weekly-310p:
+    name: Trigger Weekly-310P
+    needs: [authorize]
+    if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.command == 'weekly' && needs.authorize.outputs.dispatch_310p == 'true'
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
+    outputs:
+      weekly_310p_run_id: ${{ steps.dispatch_weekly_310p.outputs.weekly_310p_run_id }}
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo mkdir -p -m 755 /etc/apt/keyrings
+          curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install gh -y
+
+      - name: Dispatch weekly-310p workflow
+        id: dispatch_weekly_310p
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          REPO='${{ github.event.client_payload.github.payload.repository.full_name }}'
+          REQUEST_ID='${{ github.run_id }}'
+          gh workflow run schedule_weekly_test_310p.yaml \
+            --repo "$REPO" \
+            --ref main \
+            -f test_cases='${{ needs.authorize.outputs.test_cases }}' \
+            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
+            -f request_id="$REQUEST_ID" \
+            -f skip_build_image=true \
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}'
+          sleep 8
+          _310P_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_weekly_test_310p.yaml/runs?per_page=1" \
+            --jq '.workflow_runs[0].id')
+          echo "weekly_310p_run_id=$_310P_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Dispatched Weekly-310P with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+
   post-links:
     name: Post workflow links
-    needs: [authorize, dispatch-a2, dispatch-a3, dispatch-weekly-a2, dispatch-weekly-a3]
+    needs: [authorize, dispatch-a2, dispatch-a3, dispatch-weekly-a2, dispatch-weekly-a3, dispatch-weekly-310p]
     if: always() && needs.authorize.outputs.is_authorized == 'true'
     runs-on: linux-amd64-cpu-2-hk
     steps:
@@ -380,6 +422,10 @@ jobs:
           if [[ "${{ needs.dispatch-weekly-a3.result }}" == "success" ]]; then
             BODY="$BODY
           - Weekly-A3: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-weekly-a3.outputs.weekly_a3_run_id }})"
+          fi
+          if [[ "${{ needs.dispatch-weekly-310p.result }}" == "success" ]]; then
+            BODY="$BODY
+          - Weekly-310P: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-weekly-310p.outputs.weekly_310p_run_id }})"
           fi
           {
             echo "body<<EOF"

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -53,6 +53,11 @@ on:
         required: false
         default: ''
         type: string
+      aop_enabled:
+        description: 'Enable AOP hooks (capture / classify / skip-or-process)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read

--- a/.github/workflows/scripts/resolve_nightly_tests.py
+++ b/.github/workflows/scripts/resolve_nightly_tests.py
@@ -64,11 +64,12 @@ def cmd_dispatch(_args):
     matrix_b64 = os.environ.get("NIGHTLY_MATRIX", "") or os.environ.get("WEEKLY_MATRIX", "")
     a2_names = parse_nightly_matrix(matrix_b64, "a2")
     a3_names = parse_nightly_matrix(matrix_b64, "a3")
+    _310p_names = parse_nightly_matrix(matrix_b64, "310p")
 
     raw = os.environ.get("TEST_CASES", "")
     test_cases = [tc.strip() for tc in raw.split(",") if tc.strip()]
 
-    da2, da3 = False, False
+    da2, da3, d310p = False, False, False
     transformed = None
     for tc in test_cases:
         if "/" in tc:
@@ -84,12 +85,15 @@ def cmd_dispatch(_args):
                 da2 = True
             if tc in a3_names:
                 da3 = True
+            if tc in _310p_names:
+                d310p = True
 
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         if transformed:
             f.write(f"test_cases={transformed}\n")
         f.write(f"dispatch_a2={str(da2).lower()}\n")
         f.write(f"dispatch_a3={str(da3).lower()}\n")
+        f.write(f"dispatch_310p={str(d310p).lower()}\n")
 
 
 def cmd_matrix(_args):


### PR DESCRIPTION
### What this PR does / why we need it?
Add dispatch-weekly-310p job to pr_nightly_command.yml so that the /weekly slash command can trigger 310P weekly tests via PR comment. Previously only A2 and A3 weekly workflows could be dispatched from PRs; 310P was only reachable via cron schedule or manual workflow_dispatch.

Also add 310P test name resolution in resolve_nightly_tests.py to correctly parse 310p.single_node.test_config entries from weekly_config.yaml and set the dispatch_310p output flag.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
