### PR TITLE
[BugFix][EPLB] Propagate heat status to MTP draft dummy run (v0.23)

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -496,6 +496,8 @@ class TestEagleProposerDummyRun(TestBase):
         self.runner.dcp_size = 1
         self.runner.pcp_manager = None
         self.runner.pin_memory = False
+        self.runner.dynamic_eplb = True
+        self.runner.eplb_heat_collection_status = True
         self.runner._sync_metadata_across_dp.return_value = (8, torch.tensor([8]), CUDAGraphMode.NONE)
 
         self.vllm_config.cache_config.block_size = 16
@@ -597,6 +599,7 @@ class TestEagleProposerDummyRun(TestBase):
             self.proposer.dummy_run(num_tokens=num_tokens, with_prefill=with_prefill)
 
             self.assertTrue(self.proposer._runnable.call_count == 1)
+            self.assertTrue(mock_context.call_args.kwargs["eplb_heat_collection_status"])
 
     # cpu does not support parallel-group, let alone `sp`
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -689,6 +689,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
             draft_attn_metadatas=multi_steps_attn_metadata,
+            eplb_heat_collection_status=(
+                self.runner.eplb_heat_collection_status if self.runner.dynamic_eplb else False
+            ),
         ):
             # Reset MOE layer index before first model call
             forward_context = get_forward_context()


### PR DESCRIPTION
### What this PR does / why we need it?

This backports #12154 to `releases/v0.23.0`.

When MTP and dynamic EPLB are enabled, the regular draft forward path propagates the current EPLB heat-collection status through the Ascend forward context, but the draft dummy-run path did not. During DP dummy execution, this mismatch can leave the draft MoE layer with zero recorded load while heat collection is active, producing `NaN` hotness metrics and potentially invalid expert-placement decisions.

This change propagates the runner's EPLB heat-collection status to the draft dummy-run context. A focused unit test verifies that the status reaches the context.

### Does this PR introduce _any_ user-facing change?

Yes. DP + EP + MTP workloads with dynamic EPLB no longer collect incomplete draft-layer heat data from the affected dummy-run path.

### How was this patch tested?

- CI `lint-and-select-tests`: passed.
- Real Ascend NPU focused unit test: `tests/ut/spec_decode/a2/test_eagle_proposer.py::TestEagleProposerDummyRun` — 4 passed.
- Real Ascend NPU model smoke test with DP=4, EP, MTP, dynamic EPLB, four redundant experts, and EPLB policy types 1 and 2: 12 requests completed successfully; all eight hotness updates remained finite, with no divide-by-zero warning or invalid replicated-expert placement error.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
