### PR TITLE
[Doc][Misc] Change max_completion_tokens to max_tokens in tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -198,7 +198,7 @@ curl http://localhost:8000/v1/completions \
     -d '{
         "model": "qwen3.5",
         "prompt": "The future of AI is",
-        "max_completion_tokens": 50,
+        "max_tokens": 50,
         "temperature": 0
     }'
 ```


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects the parameter name in the `/v1/completions` curl example within the Qwen tutorial. It changes `max_completion_tokens` to `max_tokens`, as `max_completion_tokens` is only supported in the `/v1/chat/completions` endpoint, whereas `/v1/completions` uses `max_tokens`.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation change only, no functional testing required.
- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
