### PR TITLE
[Doc][Misc] Change max_completion_tokens to max_tokens in tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -539,7 +539,7 @@ curl http://localhost:8000/v1/completions \
     -d '{
         "model": "qwen3.5",
         "prompt": "The future of AI is",
-        "max_completion_tokens": 50,
+        "max_tokens": 50,
         "temperature": 0
     }'
 ```


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects the parameter name in the `/v1/completions` API example within the Qwen3.5/3.6 tutorial. It changes `max_completion_tokens` (which is only valid for `/v1/chat/completions`) to `max_tokens` (which is the correct parameter for `/v1/completions`).

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only change, no testing required.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
