### PR TITLE
[Doc][BugFix]: fix broken docker run command in ray tutorial

### DIFF
--- a/docs/source/tutorials/features/ray.md
+++ b/docs/source/tutorials/features/ray.md
@@ -64,6 +64,7 @@ export NAME=vllm-ascend
 
 # Run the container using the defined variables
 # Note if you are running bridge network with docker, please expose available ports for multiple nodes communication in advance.
+# IMPORTANT: The cache directory mounted at /root/.cache must be a shared directory accessible by all nodes.
 docker run --rm \
 --name $NAME \
 --net=host \
@@ -85,8 +86,7 @@ docker run --rm \
 -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
 -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
 -v /etc/ascend_install.info:/etc/ascend_install.info \
-# IMPORTANT: This must be a shared directory accessible by all nodes
--v /path/to/shared/cache:/root/.cache \ 
+-v /path/to/shared/cache:/root/.cache \
 -it $IMAGE bash
 ```
 


### PR DESCRIPTION
### What this PR does / why we need it?
Fix broken docker run command in ray tutorial

Move a # comment that was embedded inside a \ -continued docker run command to before the command block, and remove trailing whitespace after a line-continuation backslash.

Both issues caused the command to be split into separate shell statements, resulting in "invalid reference format"
and "command not found" errors.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
