### PR TITLE
[Doc][Misc] Change max_completion_tokens to max_tokens in tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B.md
@@ -149,7 +149,7 @@ curl http://localhost:8000/v1/completions \
     -d '{
         "model": "qwen3.5",
         "prompt": "The future of AI is",
-        "max_completion_tokens": 50,
+        "max_tokens": 50,
         "temperature": 0
     }'
 ```


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the Qwen3.5-27B model tutorial documentation to correct the API parameter from `max_completion_tokens` to `max_tokens` in the curl example.

### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.

### How was this patch tested?
No testing is required for this documentation-only change.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
