### PR TITLE
[Doc][Misc] Change max_completion_tokens to max_tokens in tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B.md
@@ -149,7 +149,7 @@ curl http://localhost:8000/v1/completions \
     -d '{
         "model": "qwen3.5",
         "prompt": "The future of AI is",
-        "max_completion_tokens": 50,
+        "max_tokens": 50,
         "temperature": 0
     }'
 ```


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the tutorial for Qwen3.5-27B by changing the parameter `max_completion_tokens` to `max_tokens` in the `/v1/completions` curl example. This is needed because the legacy `/v1/completions` endpoint uses `max_tokens` rather than `max_completion_tokens`.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

No testing is required as this is a documentation-only change.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
