### PR TITLE
[BugFix] [load_balance_proxy] Forward decode backend errors to client instead of empty 200

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -875,7 +875,13 @@ async def stream_service_response(
         first_chunk_sent = False
         try:
             async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
-                response.raise_for_status()
+                if response.status_code >= 400:
+                    # Buffer the upstream error body so callers can forward the real
+                    # cause (e.g. vLLM's "maximum context length" message) instead of
+                    # dropping it into an empty 200. The body is unreadable once this
+                    # streaming context exits, so read it before raising.
+                    await response.aread()
+                    response.raise_for_status()
                 async for chunk in response.aiter_bytes():
                     first_chunk_sent = True
                     yield chunk
@@ -993,6 +999,20 @@ async def reassign_instances(
     return await assign_instances(api, req_data, request_length, is_initial_request=False)
 
 
+async def _replay_first_chunk(first_chunk: bytes, gen: Any):
+    """Replay a pre-read first chunk, then stream the rest of ``gen``.
+
+    ``handle_completions_impl`` pre-reads the first chunk of the decode stream
+    before committing the ASGI response head so an initial decode error can be
+    returned with the real HTTP status; this replays that chunk so the client
+    still receives the full stream.
+    """
+    if first_chunk:
+        yield first_chunk
+    async for chunk in gen:
+        yield chunk
+
+
 async def handle_completions_impl(api: str, request: Request):
     runtime = get_runtime()
     args = get_global_args()
@@ -1014,9 +1034,53 @@ async def handle_completions_impl(api: str, request: Request):
             origin_prompt = ""
         origin_max_tokens = req_data.get("max_tokens", 16)
 
+        # Pre-open the decode response BEFORE committing the ASGI 200 head so an
+        # initial decode 4xx/5xx/connection failure can be returned with the real
+        # HTTP status code instead of an empty 200. On success the opened stream
+        # (first chunk already read) is handed to generate_stream via these vars.
+        preopened_gen = None
+        preopened_first = b""
+        decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+        preopened_gen = stream_service_response(
+            decoder_client,
+            api,
+            req_data,
+            request_id=instance_info.request_id,
+            max_retries=args.max_retries,
+            base_delay=args.retry_delay,
+        )
+        try:
+            preopened_first = await preopened_gen.__anext__()
+        except asyncio.CancelledError:
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            raise
+        except StopAsyncIteration:
+            preopened_first = b""
+        except httpx.HTTPStatusError as exc:
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            return Response(
+                content=exc.response.content, status_code=exc.response.status_code, media_type="application/json"
+            )
+        except httpx.RequestError as exc:
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "error": {
+                        "message": f"Decode backend request to {api} failed: {exc}",
+                        "type": "upstream_error",
+                        "code": "decode_backend_unavailable",
+                    }
+                },
+            )
+
         async def generate_stream():
             nonlocal instance_info
             nonlocal request_released
+            nonlocal preopened_gen, preopened_first
             generated_token = ""
             released_kv = False
             retry_count = 0
@@ -1035,15 +1099,22 @@ async def handle_completions_impl(api: str, request: Request):
             try:
                 while retry:
                     retry = False
-                    decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response(
-                        decoder_client,
-                        api,
-                        req_data,
-                        request_id=instance_info.request_id,
-                        max_retries=args.max_retries,
-                        base_delay=args.retry_delay,
-                    ):
+                    if preopened_gen is not None:
+                        # First iteration: consume the decode stream pre-opened by the
+                        # caller so initial 4xx/5xx could be returned with the real status.
+                        gen = _replay_first_chunk(preopened_first, preopened_gen)
+                        preopened_gen = None
+                    else:
+                        decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+                        gen = stream_service_response(
+                            decoder_client,
+                            api,
+                            req_data,
+                            request_id=instance_info.request_id,
+                            max_retries=args.max_retries,
+                            base_delay=args.retry_delay,
+                        )
+                    async for chunk in gen:
                         if not released_kv and chunk:
                             await release_prefill_kv_once()
                         try:


### PR DESCRIPTION
## Description

Fixes #12166.

When the decode backend returns an error (e.g. 4xx because `prompt_tokens + max_tokens > max_model_len`, or 5xx/OOM/connection), the load-balance proxy currently swallows the exception inside `generate_stream()` and ends the `StreamingResponse` generator without yielding any body. Because `StreamingResponse` had already sent the HTTP 200 head, the client received a `200` with an **empty body** and no way to learn the cause.

This PR makes the decode-phase error visible to the client.

## Changes (`examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py`)

1. **`open_stream_service_response_with_retry`** (renamed from the streaming wrapper): open the decode response with `client.send(..., stream=True)` and return `(response, chunk_iterator, first_chunk)` instead of consuming it as a generator. On a non-2xx response it buffers the upstream error body (`await response.aread()`), retries 5xx, and **returns the 4xx/last-5xx immediately without raising** so the caller can forward the real upstream status. 4xx is not retried (deterministic). The first chunk is pre-read on success so connection-level failures surface within the retry budget.

2. **`_open_decoder_stream_or_early_response`**: open the decode response *before* creating `StreamingResponse`. If the decode backend failed up front, return a verbatim `Response(status_code=upstream.status_code, content=upstream.content)` (or a `502` for connection failures) — i.e. the real upstream HTTP status reaches the client before the ASGI response head is committed. Only on success is a `StreamingResponse` created (carrying the upstream 200).

3. **`_DecodeStreamSession`** (replaces the nested `generate_stream` closure): per-request state for chunk forwarding, recompute retry, and error forwarding. Its `except Exception` forwards a proxy-side/late fault to the client as an SSE `error` event + `data: [DONE]` (streaming) or a JSON `{"error": {...}}` body (non-streaming), instead of dropping it. A mid-stream late decode error (only reachable on a recompute retry after the head is committed) is forwarded the same way.

4. Helpers: `DecodeUpstreamError`, `build_error_payload` (returns the standard `{"error":{...}}` shape verbatim, with a flat-`{"message":}` wrap and a raw-body-truncation fallback), `_encode_error_body`, `_parse_stream_chunk`, `_upstream_error_response`, `_decode_unavailable_response`, `_late_decode_error_body`.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Streaming + initial decode 4xx/5xx | `200` + 0 bytes | **real `4xx`/`5xx`** + upstream body verbatim |
| Non-streaming + initial decode 4xx/5xx | `200` + 0 bytes | **real `4xx`/`5xx`** + upstream body verbatim |
| Decode backend unreachable (retries exhausted) | `200` + 0 bytes | **`502`** + `{"error":{...,"code":"decode_backend_unavailable"}}` |
| Mid-stream late decode error (recompute retry) | `200` + 0 bytes (or truncated) | `200` head already sent + SSE/JSON `{"error":{...}}` body |
| Normal request | unchanged | unchanged |

Note on the streaming status code: the original draft only did body-level forwarding because `StreamingResponse` commits the 200 head before the generator runs. The merged implementation goes further — by pre-opening the decode response before `StreamingResponse` is constructed, **initial** decode 4xx/5xx are returned with the real upstream status code. Only errors that occur *after* the head is committed (a recompute retry failing mid-stream) fall back to body-level forwarding, since the status can no longer be changed.

## Follow-up fixes in this PR

- `max_retries=0` boundary: `open_stream_service_response_with_retry` now uses `max(1, max_retries)` so `max_retries=0` still makes one attempt (previously `range(1, 0+1)` was empty and raised `RuntimeError` without sending any request). Matches the prefill path's existing convention.
- Non-streaming late-error corruption: once a non-streaming body chunk has been forwarded, a subsequent late decode error body is dropped instead of appended (appending would concatenate with the already-sent single JSON into invalid JSON). Streaming is unaffected (SSE errors are independent events).

## Verification

Unit-checked locally with a mocked decode backend (`max_retries=3`):
- 4xx → returned immediately, not retried; real status + body forwarded.
- 5xx → retried, then last 5xx returned on exhaustion; 5xx-then-200 succeeds.
- `RequestError` → retried, then `502 decode_backend_unavailable`.
- `build_error_payload` extracts vLLM's `{"error":{"message":...,"type":"BadRequestError"}}` verbatim; flat `{"message":}` wrapped; non-JSON body truncated to 1000B; non-upstream exceptions fall back to `502`.
- `max_retries=0` now makes one attempt (no `RuntimeError`).
- 54 mock unit cases pass (0 failures): covers all branches of `open_stream_service_response_with_retry`, `_open_decoder_stream_or_early_response`, `_DecodeStreamSession` (incl. recompute loop, mid-stream late error, raw/skip chunk parsing, cancellation), and `handle_completions_impl` (incl. `/v1/completions` prompt path and outer `HTTPStatusError` handling).

Reproduction from the issue against a deployed 1P1D instance (Qwen2.5-7B-Instruct on Atlas 800T A2):
- Non-streaming over-limit (`max_tokens` > `max_model_len`): previously `200` + 0 bytes → now returns the real upstream `400` + `{"error":{"message":"max_tokens=... cannot be greater than max_model_len..."}}`.
- Streaming over-limit: previously `200` + 0 bytes → now returns the real upstream `400` + the same error body.
- Decode backend down: previously `200` + 0 bytes → now `502` + `decode_backend_unavailable`.
- Normal requests: unchanged.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
