### PR TITLE
[Doc][Misc] Change max_completion_tokens to max_tokens in tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -515,7 +515,7 @@ curl http://localhost:8000/v1/completions \
     -d '{
         "model": "qwen3.5",
         "prompt": "The future of AI is",
-        "max_completion_tokens": 50,
+        "max_tokens": 50,
         "temperature": 0
     }'
 ```


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the curl example in the Qwen3.5/3.6 model tutorial documentation to use `max_tokens` instead of `max_completion_tokens` for the `/v1/completions` endpoint.

### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.

### How was this patch tested?
No testing is required as this is a documentation change.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
