### PR TITLE
[BugFix][RFork] Synchronize NPU before quantized weight transfer

### DIFF
--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -268,6 +268,9 @@ class RForkModelLoader(BaseModelLoader):
                 if processed_layout_transfer:
                     logger.info("RFork uses post-load tensor layout transfer for quantized model.")
                     process_weights_after_loading(model, model_config, target_device)
+                    # Layout conversion can enqueue asynchronous NPU operations.
+                    # Complete them before RFork exposes the converted buffers.
+                    torch.npu.synchronize()
 
                 weight_load_start_time = time.perf_counter()
                 if not rfork_worker.pre_transfer(model):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR synchronizes the NPU after post-load tensor layout conversion and before RFork starts transferring quantized model weights.

Qwen3-32B-W8A8 can reproduce this issue: `process_weights_after_loading()` may enqueue asynchronous NPU layout-conversion operations, while RFork immediately proceeds to `pre_transfer()` and exposes the converted buffers for transfer. Without an explicit synchronization boundary, RFork may transfer weights before the layout conversion has completed, resulting in corrupted model output that appears as garbled responses.

Calling `torch.npu.synchronize()` at this boundary ensures that RFork transfers fully converted weights.

### Does this PR introduce _any_ user-facing change?

Yes. RFork loading for quantized models such as Qwen3-32B-W8A8 no longer risks producing garbled responses due to incomplete asynchronous weight layout conversion.

### How was this patch tested?

- `python -m py_compile vllm_ascend/model_loader/rfork/rfork_loader.py`
- `git diff --check`

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
