### PR TITLE
[Feature] Support hybrid partial prefix cache hits

### DIFF
--- a/tests/ut/core/test_partial_prefix_cache_hybrid.py
+++ b/tests/ut/core/test_partial_prefix_cache_hybrid.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlockCopy,
+    get_block_hash,
+    get_group_id,
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+from vllm.v1.request import Request
+
+from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
+    AscendHybridKVCacheCoordinator,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+HASH_BLOCK_SIZE = 2
+MAMBA_BLOCK_SIZE = 2 * HASH_BLOCK_SIZE
+
+
+@pytest.fixture(autouse=True)
+def _init_hash_seed() -> None:
+    init_none_hash(sha256)
+
+
+def _make_request(request_id: str, token_ids: list[int]) -> Request:
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=token_ids,
+        sampling_params=SamplingParams(max_tokens=8),
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(HASH_BLOCK_SIZE, sha256),
+    )
+
+
+def _make_manager(
+    *,
+    full_block_size: int = HASH_BLOCK_SIZE,
+    num_blocks: int = 24,
+) -> KVCacheManager:
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=full_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=MAMBA_BLOCK_SIZE,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = KVCacheManager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        max_in_flight_tokens=8192,
+        scheduler_block_size=MAMBA_BLOCK_SIZE,
+        hash_block_size=HASH_BLOCK_SIZE,
+        enable_caching=True,
+    )
+    assert isinstance(manager.coordinator, AscendHybridKVCacheCoordinator)
+    return manager
+
+
+def test_ascend_hybrid_mamba_partial_hit_uses_cow() -> None:
+    manager = _make_manager()
+    owner = _make_request("owner", [0, 0, 1, 1, 2, 2])
+
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    assert num_computed == 0
+    assert manager.allocate_slots(owner, 6, num_computed, computed) is not None
+    manager.free(owner)
+    manager.new_step_starts()
+
+    partial_hash = owner.block_hashes[2]
+    partial_mamba_block = manager.block_pool.get_cached_block(
+        partial_hash,
+        kv_cache_group_ids=[1],
+    )
+    assert partial_mamba_block is not None
+    assert partial_mamba_block[0].block_hash_num_tokens == 6
+
+    consumer = _make_request("consumer", [0, 0, 1, 1, 2, 2, 3, 3])
+    computed, num_computed, _ = manager.get_computed_blocks(consumer)
+    assert num_computed == 6
+    assert [len(group) for group in computed.blocks] == [3, 2]
+
+    new_blocks = manager.allocate_slots(consumer, 2, num_computed, computed)
+    assert new_blocks is not None
+    new_mamba_ids = new_blocks.get_block_ids()[1]
+    assert len(new_mamba_ids) == 1
+    assert (
+        KVCacheBlockCopy(
+            src_block_id=partial_mamba_block[0].block_id,
+            dst_block_id=new_mamba_ids[0],
+        )
+        in manager.take_kv_cache_block_copies()[0]
+    )
+
+
+def test_ascend_hybrid_partial_tail_owner_continuation_preserves_cache() -> None:
+    manager = _make_manager(num_blocks=32)
+    owner = _make_request("owner", [0, 0, 1, 1, 2, 2])
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    assert manager.allocate_slots(owner, 6, num_computed, computed) is not None
+
+    partial_hash = owner.block_hashes[2]
+    cached = manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[1])
+    assert cached is not None
+    original_block_id = cached[0].block_id
+
+    owner.num_computed_tokens = 6
+    owner.append_output_token_ids([3])
+    new_blocks = manager.allocate_slots(owner, 1)
+    assert new_blocks is not None
+    assert new_blocks.get_block_ids()[1] == []
+
+    copies, _ = manager.take_kv_cache_block_copies()
+    cow_copy = next(copy for copy in copies if copy.src_block_id == original_block_id)
+    assert cow_copy.dst_block_id != original_block_id
+    assert cached[0].block_hash is None
+
+    moved = manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[1])
+    assert moved is not None
+    assert moved[0].block_id == cow_copy.dst_block_id
+    assert get_block_hash(moved[0].block_hash) == partial_hash
+    assert get_group_id(moved[0].block_hash) == 1
+    assert moved[0].block_hash_num_tokens == 6
+
+
+def test_ascend_hybrid_full_attention_partial_hit_uses_cow() -> None:
+    manager = _make_manager(full_block_size=MAMBA_BLOCK_SIZE)
+    owner = _make_request("owner", [0, 0, 1, 1, 2, 2])
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    assert manager.allocate_slots(owner, 6, num_computed, computed) is not None
+    manager.free(owner)
+    manager.new_step_starts()
+
+    partial_hash = owner.block_hashes[2]
+    partial_full_block = manager.block_pool.get_cached_block(
+        partial_hash,
+        kv_cache_group_ids=[0],
+    )
+    assert partial_full_block is not None
+
+    consumer = _make_request("consumer", [0, 0, 1, 1, 2, 2, 3, 3])
+    computed, num_computed, _ = manager.get_computed_blocks(consumer)
+    assert num_computed == 6
+
+    new_blocks = manager.allocate_slots(consumer, 2, num_computed, computed)
+    assert new_blocks is not None
+    new_full_ids = new_blocks.get_block_ids()[0]
+    assert len(new_full_ids) == 1
+
+    copies, retained = manager.take_kv_cache_block_copies()
+    assert (
+        KVCacheBlockCopy(
+            src_block_id=partial_full_block[0].block_id,
+            dst_block_id=new_full_ids[0],
+        )
+        in copies
+    )
+    assert partial_full_block[0].ref_cnt == 1
+    manager.block_pool.free_blocks(retained)
+    assert partial_full_block[0].ref_cnt == 0

--- a/tests/ut/core/test_partial_prefix_cache_schedulers.py
+++ b/tests/ut/core/test_partial_prefix_cache_schedulers.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
+
+from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
+from vllm_ascend.core.scheduler_profiling_chunk import ProfilingChunkScheduler
+from vllm_ascend.core.scheduler_utils import take_pending_kv_cache_block_copies
+from vllm_ascend.patch.platform.patch_balance_schedule import BalanceScheduler
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_take_pending_kv_cache_block_copies_defers_retained_blocks() -> None:
+    copies = [KVCacheBlockCopy(src_block_id=3, dst_block_id=7)]
+    retained_blocks = [object()]
+    scheduler = SimpleNamespace(
+        kv_cache_manager=MagicMock(),
+        sched_step_seq=11,
+        _free_cow_retained_blocks=MagicMock(),
+    )
+    scheduler.kv_cache_manager.take_kv_cache_block_copies.return_value = (
+        copies,
+        retained_blocks,
+    )
+
+    assert take_pending_kv_cache_block_copies(scheduler) == copies
+    scheduler._free_cow_retained_blocks.assert_called_once_with(
+        retained_blocks,
+        12,
+    )
+
+
+def test_take_pending_kv_cache_block_copies_ignores_empty_queue() -> None:
+    scheduler = SimpleNamespace(
+        kv_cache_manager=MagicMock(),
+        sched_step_seq=2,
+        _free_cow_retained_blocks=MagicMock(),
+    )
+    scheduler.kv_cache_manager.take_kv_cache_block_copies.return_value = ([], [])
+
+    assert take_pending_kv_cache_block_copies(scheduler) is None
+    scheduler._free_cow_retained_blocks.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "scheduler_cls",
+    [RecomputeScheduler, ProfilingChunkScheduler, BalanceScheduler],
+)
+def test_custom_scheduler_preserves_cow_handoff_contract(scheduler_cls) -> None:
+    source = inspect.getsource(scheduler_cls.schedule)
+
+    assert "take_pending_kv_cache_block_copies(self)" in source
+    assert "kv_cache_block_copies=kv_cache_block_copies" in source

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -285,7 +285,8 @@ class _FakeSingleTypeKVCacheManager:
         if drop_eagle_block and computed and computed[0]:
             for blocks in computed:
                 blocks.pop()
-        return computed
+        hit_length = len(computed[0]) * kv_cache_spec.block_size
+        return computed, hit_length
 
 
 class _FakeSlidingWindowManager(_FakeSingleTypeKVCacheManager):

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -415,6 +415,40 @@ def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> N
     assert manager.block_size == mamba_spec.block_size
 
 
+@pytest.mark.parametrize(
+    ("total_computed_tokens", "num_local_computed_tokens", "expected_blocks"),
+    [
+        pytest.param(24, 16, 5, id="partial-local-hit-with-external-tokens"),
+        pytest.param(16, 16, 4, id="no-external-tokens"),
+    ],
+)
+def test_ascend_mamba_allocation_uses_exact_local_hit_length(
+    monkeypatch,
+    total_computed_tokens: int,
+    num_local_computed_tokens: int,
+    expected_blocks: int,
+) -> None:
+    manager = AscendMambaManager.__new__(AscendMambaManager)
+    manager.block_size = 16
+    base_manager = AscendMambaManager.__bases__[0]
+    monkeypatch.setattr(
+        base_manager,
+        "get_num_blocks_to_allocate",
+        lambda *args, **kwargs: 4,
+    )
+
+    actual = manager.get_num_blocks_to_allocate(
+        request_id="request",
+        num_tokens=32,
+        new_computed_blocks=[MagicMock()],
+        total_computed_tokens=total_computed_tokens,
+        num_local_computed_tokens=num_local_computed_tokens,
+        num_tokens_main_model=32,
+    )
+
+    assert actual == expected_blocks
+
+
 def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:
     """Regression: when ``scheduler_block_size`` is aligned to ``lcm_block_size``
     (instead of the raw-block-size LCM), ``SlidingWindowManager.reachable_block_mask``

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -98,7 +98,7 @@ def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
     )[0]
     assert cached_hash == expected_hash
 
-    hit_result = CompressAttentionManager.find_longest_cache_hit(
+    hit_blocks, hit_length = CompressAttentionManager.find_longest_cache_hit(
         block_hashes=request_b.block_hashes,
         max_length=logical_block_size,
         kv_cache_group_ids=[0],
@@ -107,9 +107,8 @@ def test_compressed_prefix_cache_uses_logical_block_hash() -> None:
         drop_eagle_block=False,
         alignment_tokens=logical_block_size,
     )
-    hit_blocks = hit_result[0][0]
-
-    assert hit_blocks == []
+    assert hit_blocks == ([],)
+    assert hit_length == 0
 
 
 def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
@@ -126,7 +125,7 @@ def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
     )
     manager.cache_blocks(request, num_tokens=logical_block_size)
 
-    hit_result = CompressAttentionManager.find_longest_cache_hit(
+    hit_blocks, hit_length = CompressAttentionManager.find_longest_cache_hit(
         block_hashes=request.block_hashes,
         max_length=logical_block_size,
         kv_cache_group_ids=[0],
@@ -135,9 +134,8 @@ def test_compressed_prefix_cache_hits_identical_logical_block() -> None:
         drop_eagle_block=False,
         alignment_tokens=logical_block_size,
     )
-    hit_blocks = hit_result[0][0]
-
-    assert hit_blocks == manager.req_to_blocks[request.request_id]
+    assert hit_blocks == (manager.req_to_blocks[request.request_id],)
+    assert hit_length == logical_block_size
 
 
 def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -50,6 +50,8 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
+from vllm_ascend.core.scheduler_utils import take_pending_kv_cache_block_copies
+
 
 @dataclass
 class RecomputeSchedulerConfig(SchedulerConfig):
@@ -884,6 +886,8 @@ class RecomputeScheduler(Scheduler):
         if self.dynamic_sd_lookup is not None and num_scheduled_tokens:
             num_spec_tokens_to_schedule = self.dynamic_sd_lookup[len(num_scheduled_tokens)]
 
+        kv_cache_block_copies = take_pending_kv_cache_block_copies(self)
+
         scheduler_output = RecomputeSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -901,6 +905,7 @@ class RecomputeScheduler(Scheduler):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            kv_cache_block_copies=kv_cache_block_copies,
             preempted_reqs=preempted_req_data,
             recomputed_reqs=recomputed_reqs,
         )

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -42,6 +42,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_ascend.core.profiling_chunk_predictor import ProfilingChunkManager
+from vllm_ascend.core.scheduler_utils import take_pending_kv_cache_block_copies
 
 
 class ProfilingChunkScheduler(Scheduler):
@@ -732,6 +733,7 @@ class ProfilingChunkScheduler(Scheduler):
         new_block_ids_to_zero = (
             (self.kv_cache_manager.take_new_block_ids() or None) if self.needs_kv_cache_zeroing else None
         )
+        kv_cache_block_copies = take_pending_kv_cache_block_copies(self)
 
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
@@ -745,6 +747,7 @@ class ProfilingChunkScheduler(Scheduler):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            kv_cache_block_copies=kv_cache_block_copies,
         )
 
         if self.connector is not None:

--- a/vllm_ascend/core/scheduler_utils.py
+++ b/vllm_ascend/core/scheduler_utils.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
+
+
+def take_pending_kv_cache_block_copies(scheduler: Any) -> list[KVCacheBlockCopy] | None:
+    """Drain pending CoW copies and defer retained-block release.
+
+    Ascend schedulers that override the upstream scheduling loop must preserve
+    its copy-on-write handoff contract explicitly.
+    """
+    copies, retained_blocks = scheduler.kv_cache_manager.take_kv_cache_block_copies()
+    if not copies:
+        return None
+
+    scheduler._free_cow_retained_blocks(
+        retained_blocks,
+        scheduler.sched_step_seq + 1,
+    )
+    return copies

--- a/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
-    BlockHashListWithBlockSize,
     KVCacheBlock,
+    resolve_block_hashes,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
@@ -28,6 +28,10 @@ if TYPE_CHECKING:
 
 
 class CompressAttentionManager(FullAttentionManager):
+    # A compressed state covers one complete logical block. It cannot be
+    # copied or resumed from a hash boundary inside that logical block.
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
+
     def __init__(self, kv_cache_spec: "AscendMLAAttentionSpec", block_pool: BlockPool, **kwargs) -> None:
         super().__init__(kv_cache_spec, block_pool, **kwargs)
         self.compress_ratio = kv_cache_spec.compress_ratio
@@ -228,7 +232,7 @@ class CompressAttentionManager(FullAttentionManager):
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
         drop_eagle_block: bool = False,
-    ) -> tuple[list[KVCacheBlock], ...] | tuple[tuple[list[KVCacheBlock], ...], int]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         # Keep pcp_world_size in this override's signature for compatibility
         # with the upstream manager interface. PCP is rejected by the platform.
         del pcp_world_size
@@ -243,8 +247,13 @@ class CompressAttentionManager(FullAttentionManager):
         if dcp_world_size > 1:
             block_size *= dcp_world_size
         logical_block_size = block_size * kv_cache_spec.compress_ratio
-        hash_block_size = block_pool.hash_block_size
-        logical_block_hashes = BlockHashListWithBlockSize(block_hashes, hash_block_size, logical_block_size)
+        logical_block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            logical_block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
         max_num_blocks = max_length // logical_block_size
         for block_hash in itertools.islice(logical_block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -79,6 +79,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.core.scheduler_utils import take_pending_kv_cache_block_copies
 
 
 def _balance_scheduling_enabled(vllm_config) -> bool:
@@ -788,6 +789,8 @@ class BalanceScheduler(Scheduler):
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
             num_spec_tokens_to_schedule = self.dynamic_sd_lookup[len(num_scheduled_tokens)]
 
+        kv_cache_block_copies = take_pending_kv_cache_block_copies(self)
+
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -805,6 +808,7 @@ class BalanceScheduler(Scheduler):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            kv_cache_block_copies=kv_cache_block_copies,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -8,10 +8,8 @@ from collections.abc import Sequence
 
 import vllm.v1.core.single_type_kv_cache_manager as single_type_kv_cache_manager
 from vllm.v1.core.single_type_kv_cache_manager import (
-    BlockHashList,
     BlockPool,
     KVCacheBlock,
-    KVCacheSpec,
     MambaManager,
     MambaSpec,
 )
@@ -22,45 +20,16 @@ class AscendMambaManager(MambaManager):
         super().__init__(kv_cache_spec, block_pool, **kwargs)
         self.block_size = kv_cache_spec.block_size
 
-    @classmethod
-    def find_longest_cache_hit(
-        cls,
-        block_hashes: BlockHashList,
-        max_length: int,
-        kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
-        kv_cache_spec: KVCacheSpec,
-        alignment_tokens: int,
-        dcp_world_size: int = 1,
-        pcp_world_size: int = 1,
-        drop_eagle_block: bool = False,
-    ) -> tuple[list[KVCacheBlock], ...] | tuple[tuple[list[KVCacheBlock], ...], int]:
-        return super().find_longest_cache_hit(
-            block_hashes=block_hashes,
-            max_length=max_length,
-            kv_cache_group_ids=kv_cache_group_ids,
-            block_pool=block_pool,
-            kv_cache_spec=kv_cache_spec,
-            alignment_tokens=alignment_tokens,
-            dcp_world_size=dcp_world_size,
-            pcp_world_size=pcp_world_size,
-            drop_eagle_block=drop_eagle_block,
-        )
-
     def get_num_blocks_to_allocate(
         self,
         request_id: str,
         num_tokens: int,
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
-        num_local_computed_tokens: int | None = None,
-        num_tokens_main_model: int | None = None,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
         apply_admission_cap: bool = False,
     ) -> int:
-        if num_tokens_main_model is None:
-            assert num_local_computed_tokens is not None
-            num_tokens_main_model = num_local_computed_tokens
-        local_hit_tokens = len(new_computed_blocks) * self.block_size
         num_new_blocks = super().get_num_blocks_to_allocate(
             request_id,
             num_tokens,
@@ -77,7 +46,7 @@ class AscendMambaManager(MambaManager):
         # (External tokens exist when total_computed_tokens exceeds
         # what local prefix-cache hits cover; sync loading when
         # num_tokens_main_model exceeds total_computed_tokens.)
-        has_external_tokens = total_computed_tokens > local_hit_tokens
+        has_external_tokens = total_computed_tokens > num_local_computed_tokens
         has_new_scheduled_tokens = num_tokens_main_model > total_computed_tokens
         if has_external_tokens and has_new_scheduled_tokens:
             # one more block for external computed tokens


### PR DESCRIPTION
Support fine-grained prefix-cache hits for aligned full-attention + Mamba hybrid models.
Refer to https://github.com/vllm-project/vllm/pull/46384.
Need to wait for a version beyond 0.25.0.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
