### PR TITLE
[Refactor][Scheduler] Nest scheduler configuration

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -16,7 +16,7 @@ Starting from [PR #9064](https://github.com/vllm-project/vllm-ascend/pull/9064),
 
 | Environment Variable | Config Key | Type Conversion |
 |---------------------|------------|-----------------|
-| `VLLM_ASCEND_BALANCE_SCHEDULING` | `enable_balance_scheduling` | `"1"` → `true`, `"0"` → `false` |
+| `VLLM_ASCEND_BALANCE_SCHEDULING` | `scheduler_config.enable_balance_scheduling` | `"1"` → `true`, `"0"` → `false` |
 | `VLLM_ASCEND_ENABLE_FLASHCOMM1` | `enable_flashcomm1` | `"1"` → `true`, `"0"` → `false` |
 | `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE` | `enable_matmul_allreduce` | `"1"` → `true`, `"0"` → `false` |
 | `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE` | `enable_flashcomm2_parallel_size` | Integer (unchanged) |
@@ -70,13 +70,13 @@ The following table lists additional configuration options available in vLLM Asc
 | `finegrained_tp_config`             | dict | `{}`    | Configuration options for module tensor parallelism                                                       |
 | `ascend_compilation_config`         | dict | `{}`    | Configuration options for ascend compilation                                                              |
 | `eplb_config`                       | dict | `{}`    | Configuration options for eplb |
+| `scheduler_config`                  | dict | `{}`    | Configuration options for Ascend scheduler extensions, including balance scheduling, recompute scheduling, ShortRequestFirst, and dynamic chunked pipeline parallel. |
 | `refresh`                           | bool | `false` | Whether to refresh global Ascend configuration content. This is usually used by rlhf or ut/e2e test case. |
 | `dump_config`                       | dict | `None`  | Inline msprobe dump configuration. vLLM-Ascend will materialize it to a temporary JSON file and pass that file to the debugger. |
 | `dump_config_path`                  | str  | `None`  | Configuration file path for msprobe dump (compatible legacy option).                                      |
 | `enable_async_exponential`          | bool | `False` | Whether to enable asynchronous exponential overlap. To enable asynchronous exponential, set this config to True.        |
 | `enable_shared_expert_dp`           | bool | `False` | When the expert is shared in DP, it delivers better performance but consumes more memory. Currently only DeepSeek series models are supported. |
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
-| `recompute_scheduler_enable`        | bool | `False` | Whether to enable the recompute scheduler. **Only valid on PD-disaggregated D nodes** (`kv_role` is `kv_consumer`). **Do not enable on P nodes or in PD-mixed mode** (no `kv_transfer_config`, `kv_role` is `kv_producer`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
 | `enable_sleep_mode_extra_cleanup`   | bool | `False` | Enables extra sleep-mode cleanup for RL workloads, including HCCL process-group release and ACL graph workspace cleanup. Disabled by default because wakeup may need to restore HCCL and recapture ACL graphs. |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |
@@ -86,8 +86,6 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_mc2_hierarchy_comm`         | bool | `False` | Enable dispatch/combine op inter-node communication by ROCE. |
 | `enable_prefill_mc2`                | bool | `False` | Whether to reserve mc2_token_capacity for prefill batches. When enabled, `max_num_batched_tokens` is used to calculate the mc2_token_capacity instead of the decode-only capacity. In this scenario, the recommended maximum value of `max_num_batched_tokens` is `tp_size * 512`. This is a temporary switch; once MC2 operators are complete for all scenarios, this switch will be removed and MC2 will be enabled by default. |
 | `mega_moe_max_tokens`               | int  | `65536` | Per-rank token capacity after dispatch in the mega moe (dispatch_ffn_combine) fused operator. When load imbalance causes a rank to receive more tokens than this limit, the excess tokens are dropped and skipped from computation, degrading accuracy. Do not set this too large: workspace memory scales linearly with this value. |
-| `profiling_chunk_config`            | dict | `{}`    | Configuration options for dynamic chunked pipeline parallel. See [Dynamic Chunked Pipeline Parallel](../feature_guide/dynamic_chunk_pipeline_parallel.md) for details. |
-| `enable_balance_scheduling`         | bool | `False` | Whether to enable balance scheduling. Can also be configured via the `VLLM_ASCEND_BALANCE_SCHEDULING` environment variable during the migration period. |
 | `enable_flashcomm1`                 | bool | `False` | Whether to enable FlashComm1 optimization. Can also be configured via the `VLLM_ASCEND_ENABLE_FLASHCOMM1` environment variable during the migration period. |
 | `enable_matmul_allreduce`           | bool | `False` | Whether to enable matmul allreduce optimization. Can also be configured via the `VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE` environment variable during the migration period. |
 | `flashcomm2_parallel_size`          | int  | `0`     | FlashComm2 parallel size. Can also be configured via the `VLLM_ASCEND_FLASHCOMM2_PARALLEL_SIZE` environment variable during the migration period. |
@@ -100,7 +98,6 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature depends on FLASHCOMM1. Please ensure that FLASHCOMM1 is enabled before enabling this feature.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
 | `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
-| `short_request_first_config`       | dict | `{}`    | Configuration options for ShortRequestFirst prefill scheduling on the PD prefill (P) node. Used with `recompute_scheduler_enable=true`. |
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. |
 
 The details of each configuration option are as follows:
@@ -145,7 +142,18 @@ The details of each configuration option are as follows:
 | `eplb_policy_type`               | int | `1`    | EPLB balancing policy: `0`=Random, `1`=DefaultEplb (open-source algorithm), `2`=SwiftBalanceEplb (optimized for low-bandwidth), `3`=FlashLB (statistical method with sliding windows). |
 | `eplb_heat_collection_stage`      | str | `"all"`| Stage to collect EPLB heat: `"prefill"` collects only during prefill, `"decode"` collects only during decode, `"all"` collects during both stages. In PD colocation scenarios, prefill and decode requests may produce different expert workloads. Selectively collecting heat on one stage can reduce expert imbalance more effectively. |
 
-**profiling_chunk_config**
+**scheduler_config**
+
+The legacy top-level `enable_balance_scheduling`, `recompute_scheduler_enable`, `short_request_first_config`, and `profiling_chunk_config` keys remain supported during the migration period, but are deprecated. If both formats provide the same field, the value in `scheduler_config` takes precedence.
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enable_balance_scheduling` | bool | `False` | Whether to enable balance scheduling. Can also be configured via the `VLLM_ASCEND_BALANCE_SCHEDULING` environment variable during the migration period. |
+| `recompute_scheduler_enable` | bool | `False` | Whether to enable the recompute scheduler. **Only valid on PD-disaggregated D nodes** (`kv_role` is `kv_consumer`). **Do not enable on P nodes or in PD-mixed mode** (no `kv_transfer_config`, `kv_role` is `kv_producer`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
+| `profiling_chunk_config` | dict | `{}` | Configuration options for dynamic chunked pipeline parallel. See [Dynamic Chunked Pipeline Parallel](../feature_guide/dynamic_chunk_pipeline_parallel.md) for details. |
+| `short_request_first_config` | dict | `{}` | Configuration options for ShortRequestFirst prefill scheduling on the PD prefill (P) node. Used with `recompute_scheduler_enable=true`. |
+
+**scheduler_config.profiling_chunk_config**
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
@@ -166,9 +174,9 @@ The details of each configuration option are as follows:
 | `posterior_threshold`   | float | `0.95`  | Upper bound for the entropy-adjusted acceptance threshold. Must be in (0, 1]. The effective threshold is `min(exp(-entropy * posterior_alpha), posterior_threshold)`. |
 | `posterior_alpha`       | float | `0.4`   | Scaling factor for entropy in the threshold computation. Must be >= 0. Higher values make the threshold more sensitive to entropy — high-entropy tokens become much easier to accept, improving performance but reducing precision. |
 
-**short_request_first_config**
+**scheduler_config.short_request_first_config**
 
-ShortRequestFirst prefill scheduling for the PD prefill (P) node. It applies when the recompute scheduler is enabled and the scheduler policy is FCFS.
+ShortRequestFirst is a waiting-queue policy wired through the recompute scheduler. See [ShortRequestFirst Prefill Scheduling](../feature_guide/short_request_first.md) for usage, behavior, and tuning guidance.
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -66,7 +66,7 @@ vllm serve Qwen/Qwen3-30B-A3B \
     --max-num-batched-tokens 32768 \
     --enable-prefix-caching \
     --no-async-scheduling \
-    --additional-config '{"profiling_chunk_config": {"enabled": true}}' \
+    --additional-config '{"scheduler_config": {"profiling_chunk_config": {"enabled": true}}}' \
     --kv-transfer-config \
     '{
         "kv_connector": "MooncakeConnectorV1",

--- a/docs/source/user_guide/feature_guide/recompute_cpu_offload.md
+++ b/docs/source/user_guide/feature_guide/recompute_cpu_offload.md
@@ -60,15 +60,15 @@ Decode DP size. For example, when starting a DP2TP8 Decode service, setting
 offload space. To avoid ambiguity, use `cpu_bytes_to_use_per_rank` for new
 deployments.
 
-`recompute_scheduler_enable` must also be enabled in `additional-config` on
+`scheduler_config.recompute_scheduler_enable` must also be enabled in `additional-config` on
 P/D-disaggregated Decode nodes:
 
 ```bash
---additional-config '{"recompute_scheduler_enable":true}'
+--additional-config '{"scheduler_config":{"recompute_scheduler_enable":true}}'
 ```
 
 ```{note}
-`recompute_scheduler_enable` is only valid in P/D-disaggregated mode
+`scheduler_config.recompute_scheduler_enable` is only valid in P/D-disaggregated mode
 (`kv_role` is `kv_producer` or `kv_consumer`). Do not enable it in PD-mixed
 mode (`kv_role` is `kv_both`).
 ```
@@ -141,7 +141,7 @@ python3 -m vllm.entrypoints.openai.api_server \
     --max-model-len 32768 \
     --block-size 128 \
     --max-num-batched-tokens 4096 \
-    --additional-config '{"recompute_scheduler_enable":true}' \
+    --additional-config '{"scheduler_config":{"recompute_scheduler_enable":true}}' \
     --kv-transfer-config \
     '{
       "kv_connector": "MultiConnector",
@@ -212,7 +212,7 @@ For online serving:
 
 ```bash
 vllm serve /path/to/model \
-    --additional-config '{"recompute_scheduler_enable":true}' \
+    --additional-config '{"scheduler_config":{"recompute_scheduler_enable":true}}' \
     --kv-transfer-config '{
         "kv_connector": "RecomputeCPUOffloadConnector",
         "kv_role": "kv_consumer",
@@ -259,7 +259,7 @@ allocated for the resumed request.
   scheduler.
 * The feature is only intended for Decode nodes in P/D disaggregation. It is not
   supported in PD-mixed or normal non-P/D deployments.
-* Do not enable `recompute_scheduler_enable` in PD-mixed deployments. Without
+* Do not enable `scheduler_config.recompute_scheduler_enable` in PD-mixed deployments. Without
   P/D-disaggregated Decode-side `RecomputeScheduler`, recompute CPU offload is
   not active and vLLM follows the normal recompute path.
 * When running in Docker with a large per-rank offload budget, reserve enough

--- a/docs/source/user_guide/feature_guide/short_request_first.md
+++ b/docs/source/user_guide/feature_guide/short_request_first.md
@@ -14,15 +14,17 @@ Keep it disabled if the workload is mostly uniform, or if FCFS ordering is more 
 
 ## Configuration
 
-Add `short_request_first_config` to the prefill (P) node's `additional_config` in a PD-disaggregated deployment. Because ShortRequestFirst is wired through the recompute scheduler, keep `recompute_scheduler_enable=true` in the same P-node config:
+Add `short_request_first_config` to the prefill (P) node's `scheduler_config` in a PD-disaggregated deployment. Because ShortRequestFirst is wired through the recompute scheduler, keep `recompute_scheduler_enable=true` in the same P-node configuration:
 
 ```json
 {
-  "recompute_scheduler_enable": true,
-  "short_request_first_config": {
-    "enabled": true,
-    "threshold": 256,
-    "long_max_wait_ms": 2000
+  "scheduler_config": {
+    "recompute_scheduler_enable": true,
+    "short_request_first_config": {
+      "enabled": true,
+      "threshold": 256,
+      "long_max_wait_ms": 2000
+    }
   }
 }
 ```
@@ -105,22 +107,9 @@ ShortRequestFirst only changes the waiting-queue policy and is wired into the re
 
 ## Minimal examples
 
-P-node `additional_config` example:
-
-```json
-{
-  "recompute_scheduler_enable": true,
-  "short_request_first_config": {
-    "enabled": true,
-    "threshold": 256,
-    "long_max_wait_ms": 2000
-  }
-}
-```
-
 Disable it explicitly:
 
 ```bash
 vllm serve <model> \
-  --additional-config '{"short_request_first_config": {"enabled": false}}'
+  --additional-config '{"scheduler_config": {"short_request_first_config": {"enabled": false}}}'
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,7 +251,6 @@ nav:
         - user_guide/feature_guide/netloader.md
         - user_guide/feature_guide/rfork.md
         - user_guide/feature_guide/epd_disaggregation.md
-        - user_guide/feature_guide/short_request_first.md
         - user_guide/feature_guide/kv_pool.md
         - user_guide/feature_guide/kv_cache_cpu_offload.md
         - user_guide/feature_guide/recompute_cpu_offload.md
@@ -265,6 +264,7 @@ nav:
         - user_guide/feature_guide/batch_invariance.md
         - user_guide/feature_guide/lmcache_ascend_deployment.md
         - user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+        - user_guide/feature_guide/short_request_first.md
         - user_guide/feature_guide/flash_attention.md
     - Deployment Guide:
         - user_guide/deployment_guide/index.md

--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -97,7 +97,7 @@ class TestProfilingChunkConfig(TestBase):
         vllm_config = VllmConfig()
         vllm_config.model_config = MagicMock()
         vllm_config.additional_config = {
-            "profiling_chunk_config": {"enabled": True},
+            "scheduler_config": {"profiling_chunk_config": {"enabled": True}},
             "refresh": True,
         }
         vllm_config.parallel_config.pipeline_parallel_size = 1
@@ -114,12 +114,12 @@ class TestProfilingChunkConfig(TestBase):
         vllm_config = VllmConfig()
         vllm_config.model_config = MagicMock()
         vllm_config.additional_config = {
-            "profiling_chunk_config": {"enabled": True},
+            "scheduler_config": {"profiling_chunk_config": {"enabled": True}},
             "refresh": True,
         }
         vllm_config.parallel_config.pipeline_parallel_size = 2
         ascend_config = init_ascend_config(vllm_config)
-        self.assertTrue(ascend_config.profiling_chunk_config.enabled)
+        self.assertTrue(ascend_config.scheduler_config.profiling_chunk_config.enabled)
         clear_ascend_config()
 
     @patch("vllm.config.VllmConfig.__post_init__", MagicMock())
@@ -131,7 +131,7 @@ class TestProfilingChunkConfig(TestBase):
         vllm_config.model_config = MagicMock()
         vllm_config.additional_config = {"refresh": True}
         ascend_config = init_ascend_config(vllm_config)
-        self.assertFalse(ascend_config.profiling_chunk_config.enabled)
+        self.assertFalse(ascend_config.scheduler_config.profiling_chunk_config.enabled)
         clear_ascend_config()
 
 
@@ -255,7 +255,7 @@ class TestProfilingChunkScheduler(TestBase):
         profiling_cfg.enabled = True
         profiling_cfg.smooth_factor = 0.8
         profiling_cfg.min_chunk = 256
-        mock_get_ascend_config.return_value = MagicMock(profiling_chunk_config=profiling_cfg)
+        mock_get_ascend_config.return_value.scheduler_config.profiling_chunk_config = profiling_cfg
 
         mock_hf_config = MagicMock()
         mock_hf_config.model_type = "qwen3"

--- a/tests/ut/core/test_recompute_scheduler_short_request_first.py
+++ b/tests/ut/core/test_recompute_scheduler_short_request_first.py
@@ -52,7 +52,7 @@ class FakeClock:
 def _fake_ascend_config(**overrides) -> SimpleNamespace:
     config = {"enabled": True, "threshold": THRESHOLD}
     config.update(overrides)
-    return SimpleNamespace(short_request_first_config=ShortRequestFirstConfig(config))
+    return SimpleNamespace(scheduler_config=SimpleNamespace(short_request_first_config=ShortRequestFirstConfig(config)))
 
 
 def create_requests(num_tokens_list, max_tokens: int = 16):

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -97,7 +97,7 @@ class TestAscendRowParallelLinear(BaseLinearTest):
     )
     def test_mlp_optimize(self, mock_enable_sp, mock_get_current_vllm_config):
         ascend_config._ASCEND_CONFIG = MagicMock()
-        ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
+        ascend_config._ASCEND_CONFIG.scheduler_config.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.mlp_tensor_parallel_size = 2
         ascend_config._ASCEND_CONFIG.ascend_scheduler_config.enabled = False
 
@@ -119,7 +119,7 @@ class TestAscendRowParallelLinear(BaseLinearTest):
     )
     def test_oproj_tp(self, mock_enable_sp, mock_get_current_vllm_config):
         ascend_config._ASCEND_CONFIG = MagicMock()
-        ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
+        ascend_config._ASCEND_CONFIG.scheduler_config.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.oproj_tensor_parallel_size = 2
         ascend_config._ASCEND_CONFIG.ascend_scheduler_config.enabled = False
 
@@ -137,7 +137,7 @@ class TestAscendRowParallelLinear(BaseLinearTest):
 class TestAscendMergedColumnParallelLinear(BaseLinearTest):
     def test_merged_mlp_tp_init(self):
         ascend_config._ASCEND_CONFIG = MagicMock()
-        ascend_config._ASCEND_CONFIG.recompute_scheduler_enable = False
+        ascend_config._ASCEND_CONFIG.scheduler_config.recompute_scheduler_enable = False
         ascend_config._ASCEND_CONFIG.finegrained_tp_config.mlp_tensor_parallel_size = 2
         ascend_config._ASCEND_CONFIG.ascend_scheduler_config.enabled = False
 

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -42,6 +42,8 @@ import inspect
 import subprocess
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -74,8 +76,53 @@ _UPSTREAM_SCHED_FILE = _upstream_sched_mod.__file__
 from vllm_ascend.patch.platform.patch_balance_schedule import (  # noqa: E402
     BalanceScheduler,
     _balance_run_engine_core,
+    _balance_scheduling_enabled,
     _OriginalRunEngineCore,
 )
+
+# ---------------------------------------------------------------------------
+# Scheduler config compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_balance_config_uses_initialized_scheduler_config():
+    ascend_config = SimpleNamespace(scheduler_config=SimpleNamespace(enable_balance_scheduling=True))
+    vllm_config = SimpleNamespace(additional_config={"scheduler_config": {"enable_balance_scheduling": False}})
+
+    with patch("vllm_ascend.ascend_config.get_ascend_config", return_value=ascend_config):
+        assert _balance_scheduling_enabled(vllm_config) is True
+
+
+def test_balance_config_fallback_prefers_nested_config():
+    vllm_config = SimpleNamespace(
+        additional_config={
+            "scheduler_config": {"enable_balance_scheduling": False},
+            "enable_balance_scheduling": True,
+        }
+    )
+
+    with patch("vllm_ascend.ascend_config.get_ascend_config", side_effect=RuntimeError):
+        assert _balance_scheduling_enabled(vllm_config) is False
+
+
+def test_balance_config_fallback_ignores_non_dict_nested_config():
+    vllm_config = SimpleNamespace(
+        additional_config={
+            "scheduler_config": None,
+            "enable_balance_scheduling": True,
+        }
+    )
+
+    with patch("vllm_ascend.ascend_config.get_ascend_config", side_effect=RuntimeError):
+        assert _balance_scheduling_enabled(vllm_config) is True
+
+
+def test_balance_config_fallback_accepts_legacy_top_level_config():
+    vllm_config = SimpleNamespace(additional_config={"enable_balance_scheduling": True})
+
+    with patch("vllm_ascend.ascend_config.get_ascend_config", side_effect=RuntimeError):
+        assert _balance_scheduling_enabled(vllm_config) is True
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -22,6 +22,7 @@ from vllm.config import KVTransferConfig, VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
+    SchedulerConfig,
     ShortRequestFirstConfig,
     clear_ascend_config,
     get_ascend_config,
@@ -101,6 +102,27 @@ class TestAscendConfig(TestBase):
 
         ascend_fusion_config = ascend_config.ascend_fusion_config
         self.assertFalse(ascend_fusion_config.fusion_ops_gmmswigluquant)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_init_ascend_config_with_nested_scheduler_config(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "scheduler_config": {
+                "enable_balance_scheduling": True,
+                "recompute_scheduler_enable": True,
+                "short_request_first_config": {"enabled": True, "threshold": 512},
+                "profiling_chunk_config": {"enabled": False},
+            }
+        }
+
+        scheduler_config = init_ascend_config(test_vllm_config).scheduler_config
+
+        self.assertTrue(scheduler_config.enable_balance_scheduling)
+        self.assertTrue(scheduler_config.recompute_scheduler_enable)
+        self.assertTrue(scheduler_config.short_request_first_config.enabled)
+        self.assertEqual(scheduler_config.short_request_first_config.threshold, 512)
+        self.assertFalse(scheduler_config.profiling_chunk_config.enabled)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -462,3 +484,101 @@ class TestShortRequestFirstConfig(TestBase):
         self.assertFalse(cfg.enabled)
         self.assertEqual(cfg.threshold, 256)
         self.assertEqual(cfg.long_max_wait_ms, 0.0)
+
+
+class TestSchedulerConfig(TestBase):
+    def test_defaults(self):
+        config = SchedulerConfig({}, balance_env_value=False)
+
+        self.assertFalse(config.enable_balance_scheduling)
+        self.assertFalse(config.recompute_scheduler_enable)
+        self.assertFalse(config.short_request_first_config.enabled)
+        self.assertFalse(config.profiling_chunk_config.enabled)
+
+    @patch("vllm_ascend.ascend_config.logger.warning_once")
+    def test_none_config_uses_defaults_and_legacy_fallback(self, mock_warning_once):
+        config = SchedulerConfig(
+            {
+                "scheduler_config": None,
+                "recompute_scheduler_enable": True,
+            },
+            balance_env_value=False,
+        )
+
+        self.assertTrue(config.recompute_scheduler_enable)
+        self.assertEqual(mock_warning_once.call_count, 1)
+
+    def test_non_dict_config_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "scheduler_config must be a dict, got list"):
+            SchedulerConfig({"scheduler_config": []}, balance_env_value=False)
+
+    def test_nested_config_overrides_all_scheduler_settings(self):
+        config = SchedulerConfig(
+            {
+                "scheduler_config": {
+                    "enable_balance_scheduling": True,
+                    "recompute_scheduler_enable": True,
+                    "short_request_first_config": {
+                        "enabled": True,
+                        "threshold": 512,
+                        "long_max_wait_ms": 2000,
+                    },
+                    "profiling_chunk_config": {"enabled": True, "need_timing": False},
+                }
+            },
+            balance_env_value=False,
+        )
+
+        self.assertTrue(config.enable_balance_scheduling)
+        self.assertTrue(config.recompute_scheduler_enable)
+        self.assertTrue(config.short_request_first_config.enabled)
+        self.assertEqual(config.short_request_first_config.threshold, 512)
+        self.assertEqual(config.short_request_first_config.long_max_wait_ms, 2000.0)
+        self.assertTrue(config.profiling_chunk_config.enabled)
+        self.assertFalse(config.profiling_chunk_config.need_timing)
+
+    @patch("vllm_ascend.ascend_config.logger.warning_once")
+    def test_legacy_top_level_config_warns_and_remains_supported(self, mock_warning_once):
+        config = SchedulerConfig(
+            {
+                "enable_balance_scheduling": True,
+                "recompute_scheduler_enable": True,
+                "short_request_first_config": {"enabled": True},
+                "profiling_chunk_config": {"enabled": True},
+            },
+            balance_env_value=False,
+        )
+
+        self.assertTrue(config.enable_balance_scheduling)
+        self.assertTrue(config.recompute_scheduler_enable)
+        self.assertTrue(config.short_request_first_config.enabled)
+        self.assertTrue(config.profiling_chunk_config.enabled)
+        self.assertEqual(mock_warning_once.call_count, 4)
+
+    @patch("vllm_ascend.ascend_config.logger.warning_once")
+    def test_nested_config_wins_and_legacy_fields_fill_missing_values(self, mock_warning_once):
+        config = SchedulerConfig(
+            {
+                "scheduler_config": {
+                    "recompute_scheduler_enable": True,
+                    "short_request_first_config": {"enabled": True},
+                },
+                "recompute_scheduler_enable": False,
+                "enable_balance_scheduling": True,
+                "short_request_first_config": {"enabled": False},
+            },
+            balance_env_value=False,
+        )
+
+        self.assertTrue(config.recompute_scheduler_enable)
+        self.assertTrue(config.short_request_first_config.enabled)
+        self.assertTrue(config.enable_balance_scheduling)
+        self.assertEqual(mock_warning_once.call_count, 3)
+
+    @patch("vllm_ascend.ascend_config.logger.info_once")
+    def test_balance_falls_back_to_environment_default(self, mock_info_once):
+        with patch.dict(os.environ, {"VLLM_ASCEND_BALANCE_SCHEDULING": "1"}):
+            config = SchedulerConfig({}, balance_env_value=True)
+
+        self.assertTrue(config.enable_balance_scheduling)
+        mock_info_once.assert_called_once()

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -51,13 +51,14 @@ class TestNPUPlatform(TestBase):
         mock_ascend_config.xlite_graph_config.full_mode = False
         mock_ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         mock_ascend_config.ascend_fusion_config = None
-        mock_ascend_config.recompute_scheduler_enable = False
-        mock_ascend_config.enable_balance_scheduling = False
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
+        mock_ascend_config.scheduler_config.enable_balance_scheduling = False
         mock_ascend_config.enable_mc2_hierarchy_comm = False
         mock_ascend_config.enable_fused_mc2 = False
         mock_ascend_config.enable_flashcomm1 = False
         mock_ascend_config.enable_shared_expert_dp = False
-        mock_ascend_config.short_request_first_config.enabled = False
+        mock_ascend_config.scheduler_config.short_request_first_config.enabled = False
+        mock_ascend_config.scheduler_config.profiling_chunk_config.enabled = False
         mock_ascend_config.update_compile_ranges_split_points = MagicMock()
         return mock_ascend_config
 
@@ -501,7 +502,7 @@ class TestNPUPlatform(TestBase):
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        mock_ascend_config.recompute_scheduler_enable = True
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -533,7 +534,7 @@ class TestNPUPlatform(TestBase):
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        mock_ascend_config.recompute_scheduler_enable = True
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -566,8 +567,8 @@ class TestNPUPlatform(TestBase):
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        mock_ascend_config.recompute_scheduler_enable = True
-        mock_ascend_config.profiling_chunk_config.enabled = False
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
+        mock_ascend_config.scheduler_config.profiling_chunk_config.enabled = False
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -592,7 +593,7 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(vllm_config)
 
         mock_init_recompute.assert_not_called()
-        self.assertFalse(mock_ascend_config.recompute_scheduler_enable)
+        self.assertFalse(mock_ascend_config.scheduler_config.recompute_scheduler_enable)
         self.assertIs(vllm_config.scheduler_config, scheduler_config)
         mock_warning.assert_called_once()
         self.assertIn(
@@ -608,8 +609,8 @@ class TestNPUPlatform(TestBase):
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        mock_ascend_config.recompute_scheduler_enable = True
-        mock_ascend_config.profiling_chunk_config.enabled = False
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
+        mock_ascend_config.scheduler_config.profiling_chunk_config.enabled = False
         mock_init_ascend.return_value = mock_ascend_config
 
         recompute_scheduler_config = MagicMock()
@@ -654,8 +655,8 @@ class TestNPUPlatform(TestBase):
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        mock_ascend_config.recompute_scheduler_enable = False
-        mock_ascend_config.enable_balance_scheduling = True
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
+        mock_ascend_config.scheduler_config.enable_balance_scheduling = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()
@@ -686,8 +687,8 @@ class TestNPUPlatform(TestBase):
         self, mock_init_recompute, mock_init_ascend, mock_soc_version, mock_auto_detect
     ):
         mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
-        mock_ascend_config.recompute_scheduler_enable = False
-        mock_ascend_config.enable_balance_scheduling = True
+        mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
+        mock_ascend_config.scheduler_config.enable_balance_scheduling = True
         mock_init_ascend.return_value = mock_ascend_config
 
         vllm_config = TestNPUPlatform.mock_vllm_config()

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -397,7 +397,7 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer():
     vllm_config.kv_transfer_config.is_kv_consumer = True
     vllm_config.kv_transfer_config.is_kv_producer = False
     ascend_config = mock.MagicMock()
-    ascend_config.recompute_scheduler_enable = True
+    ascend_config.scheduler_config.recompute_scheduler_enable = True
     with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
         assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is True
 
@@ -443,6 +443,6 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer_disabled():
     vllm_config.kv_transfer_config.is_kv_consumer = True
     vllm_config.kv_transfer_config.is_kv_producer = False
     ascend_config = mock.MagicMock()
-    ascend_config.recompute_scheduler_enable = False
+    ascend_config.scheduler_config.recompute_scheduler_enable = False
     with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
         assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is False

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -581,7 +581,9 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner = self._build_runner(MagicMock(spec=["start", "stop", "step"]))
         runner.vllm_config = MagicMock()
         runner.vllm_config.model_config.enable_return_routed_experts = False
-        runner.ascend_config = SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+        runner.ascend_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+        )
         runner.execute_model_state = None
         runner.speculative_config = None
         runner.use_async_scheduling = False
@@ -617,7 +619,9 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner = self._build_runner(MagicMock(spec=["start", "stop", "step"]))
         runner.vllm_config = MagicMock()
         runner.vllm_config.model_config.enable_return_routed_experts = False
-        runner.ascend_config = SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+        runner.ascend_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+        )
         runner.execute_model_state = None
         runner.speculative_config = None
         runner.use_async_scheduling = False

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -49,42 +49,41 @@ class AscendConfig:
         eplb_config = additional_config.get("eplb_config", {})
         self.eplb_config = EplbConfig(eplb_config)
 
-        profiling_chunk_config = additional_config.get("profiling_chunk_config", {})
-        self.profiling_chunk_config = ProfilingChunkConfig(profiling_chunk_config)
-        if self.profiling_chunk_config.enabled:
+        from vllm_ascend import envs as ascend_envs
+
+        self.scheduler_config = SchedulerConfig(
+            additional_config,
+            balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING,
+        )
+        if self.scheduler_config.profiling_chunk_config.enabled:
             max_batched = vllm_config.scheduler_config.max_num_batched_tokens
-            if max_batched < self.profiling_chunk_config.min_chunk:
+            if max_batched < self.scheduler_config.profiling_chunk_config.min_chunk:
                 logger.warning(
                     "max_num_batched_tokens is smaller than profiling_chunk_config.min_chunk. "
                     "max_num_batched_tokens=%d, min_chunk=%d. "
                     "Clamping min_chunk to %d to avoid it being silently ignored.",
                     max_batched,
-                    self.profiling_chunk_config.min_chunk,
+                    self.scheduler_config.profiling_chunk_config.min_chunk,
                     max_batched,
                 )
-                self.profiling_chunk_config.min_chunk = max_batched
-        if self.profiling_chunk_config.enabled and vllm_config.parallel_config.pipeline_parallel_size <= 1:
+                self.scheduler_config.profiling_chunk_config.min_chunk = max_batched
+        if (
+            self.scheduler_config.profiling_chunk_config.enabled
+            and vllm_config.parallel_config.pipeline_parallel_size <= 1
+        ):
             raise ValueError(
                 "profiling_chunk_config requires pipeline parallelism (pp > 1). "
                 "Please set --pipeline-parallel-size to a value greater than 1, "
                 "or disable profiling_chunk_config."
             )
 
-        from vllm_ascend import envs as ascend_envs
-
-        self.enable_balance_scheduling = self._get_config_value(
-            additional_config,
-            "enable_balance_scheduling",
-            "VLLM_ASCEND_BALANCE_SCHEDULING",
-            ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING,
-        )
         self.enable_flashcomm1 = self._get_config_value(
             additional_config,
             "enable_flashcomm1",
             "VLLM_ASCEND_ENABLE_FLASHCOMM1",
             ascend_envs.VLLM_ASCEND_ENABLE_FLASHCOMM1,
         )
-        if self.profiling_chunk_config.enabled and self.enable_balance_scheduling:
+        if self.scheduler_config.profiling_chunk_config.enabled and self.scheduler_config.enable_balance_scheduling:
             raise ValueError(
                 "profiling_chunk_config and balance scheduling (enable_balance_scheduling) "
                 "cannot be enabled at the same time. Please disable one of them."
@@ -126,7 +125,6 @@ class AscendConfig:
                 )
         self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
         # PD-disaggregated D node only (kv_consumer); invalid on P nodes and in PD-mixed mode.
-        self.recompute_scheduler_enable = additional_config.get("recompute_scheduler_enable", False)
         # DSV4 oproj / embedding fine-grained TP (oproj_tensor_parallel_size /
         # embedding_tensor_parallel_size) use static, graph-stable exchange
         # buffers and run cross-DP HCCL collectives (all_to_all / all_gather /
@@ -139,16 +137,13 @@ class AscendConfig:
         if (
             self.finegrained_tp_config.oproj_tensor_parallel_size > 0
             or self.finegrained_tp_config.embedding_tensor_parallel_size > 0
-        ) and not self.recompute_scheduler_enable:
+        ) and not self.scheduler_config.recompute_scheduler_enable:
             raise AssertionError(
                 "oproj_tensor_parallel_size / embedding_tensor_parallel_size "
                 "require recompute_scheduler_enable=true: their cross-DP HCCL "
                 "collectives need uniform num_tokens across DP ranks, which is "
                 "only guaranteed when the recompute scheduler is enabled."
             )
-        self.short_request_first_config = ShortRequestFirstConfig(
-            additional_config.get("short_request_first_config", {})
-        )
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
         self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
@@ -653,11 +648,11 @@ class ProfilingChunkConfig:
 
     Usage (online)::
 
-        vllm serve <model> --additional-config '{"profiling_chunk_config": {"enabled": true}}'
+        vllm serve <model> --additional-config '{"scheduler_config": {"profiling_chunk_config": {"enabled": true}}}'
 
     Usage (offline)::
 
-        llm = LLM(model, additional_config={"profiling_chunk_config": {"enabled": true}})
+        llm = LLM(model, additional_config={"scheduler_config": {"profiling_chunk_config": {"enabled": true}}})
     """
 
     def __init__(self, config: dict | None = None):
@@ -820,7 +815,7 @@ class EplbConfig:
 
 
 class ShortRequestFirstConfig:
-    """Configuration object for ``additional_config["short_request_first_config"]``."""
+    """Configuration object for ``additional_config["scheduler_config"]["short_request_first_config"]``."""
 
     _defaults = {
         "enabled": False,
@@ -846,6 +841,77 @@ class ShortRequestFirstConfig:
             raise ValueError(f"short_request_first_config.threshold must be a non-negative int; got {self.threshold}")
         if self.long_max_wait_ms < 0:
             raise ValueError(f"short_request_first_config.long_max_wait_ms must be >= 0; got {self.long_max_wait_ms}")
+
+
+class SchedulerConfig:
+    """Configuration object for ``additional_config[\"scheduler_config\"]``."""
+
+    def __init__(self, additional_config: dict[str, Any], balance_env_value: Any):
+        scheduler_config = additional_config.get("scheduler_config")
+        if scheduler_config is None:
+            scheduler_config = {}
+        elif not isinstance(scheduler_config, dict):
+            raise ValueError(
+                f"additional_config.scheduler_config must be a dict, got {type(scheduler_config).__name__}."
+            )
+        self.enable_balance_scheduling = self._get_config_value(
+            scheduler_config,
+            additional_config,
+            "enable_balance_scheduling",
+            balance_env_value,
+            "VLLM_ASCEND_BALANCE_SCHEDULING",
+        )
+        self.recompute_scheduler_enable = self._get_config_value(
+            scheduler_config,
+            additional_config,
+            "recompute_scheduler_enable",
+            False,
+        )
+        self.short_request_first_config = ShortRequestFirstConfig(
+            self._get_config_value(scheduler_config, additional_config, "short_request_first_config", {})
+        )
+        self.profiling_chunk_config = ProfilingChunkConfig(
+            self._get_config_value(scheduler_config, additional_config, "profiling_chunk_config", {})
+        )
+
+    @staticmethod
+    def _get_config_value(
+        scheduler_config: dict[str, Any],
+        additional_config: dict[str, Any],
+        config_key: str,
+        default: Any,
+        env_key: str | None = None,
+    ) -> Any:
+        if config_key in scheduler_config:
+            if config_key in additional_config:
+                logger.warning_once(
+                    "additional_config.%s is deprecated and ignored because "
+                    "additional_config.scheduler_config.%s is set.",
+                    config_key,
+                    config_key,
+                )
+            return scheduler_config[config_key]
+
+        if config_key in additional_config:
+            logger.warning_once(
+                "additional_config.%s is deprecated; use additional_config.scheduler_config.%s instead.",
+                config_key,
+                config_key,
+            )
+            return additional_config[config_key]
+
+        if env_key is not None and env_key in os.environ:
+            logger.info_once(
+                "AscendConfig.scheduler_config.%s falls back to environment variable %s with value %s. "
+                "Please use additional_config.scheduler_config.%s instead, because %s will be removed in the "
+                "next release.",
+                config_key,
+                env_key,
+                default,
+                config_key,
+                env_key,
+            )
+        return default
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -109,7 +109,7 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
             and self.vllm_config.kv_transfer_config.is_kv_consumer
         )
         self.is_kv_producer = self.vllm_config.kv_transfer_config and self.vllm_config.kv_transfer_config.is_kv_producer
-        if get_ascend_config().short_request_first_config.enabled:
+        if get_ascend_config().scheduler_config.short_request_first_config.enabled:
             self._init_short_request_first_waiting_queue()
 
     def _pop_waiting_request(

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -80,7 +80,7 @@ class ProfilingChunkScheduler(Scheduler):
         from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
         init_ascend_config(vllm_config)
-        profiling_cfg = get_ascend_config().profiling_chunk_config
+        profiling_cfg = get_ascend_config().scheduler_config.profiling_chunk_config
         self.profiling_chunk_config = profiling_cfg
         base_chunk = self.max_num_scheduled_tokens
 

--- a/vllm_ascend/core/short_request_first_scheduler.py
+++ b/vllm_ascend/core/short_request_first_scheduler.py
@@ -398,7 +398,7 @@ class ShortRequestFirstSchedulerMixin:
 
         if immediate_predicate is None:
             immediate_predicate = self._is_recovery_request
-        short_request_first_config = get_ascend_config().short_request_first_config
+        short_request_first_config = get_ascend_config().scheduler_config.short_request_first_config
         self.waiting = ShortRequestFirstRequestQueue(
             policy=self.policy,
             threshold=short_request_first_config.threshold,

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -87,10 +87,13 @@ def _balance_scheduling_enabled(vllm_config) -> bool:
     try:
         from vllm_ascend.ascend_config import get_ascend_config
 
-        return bool(get_ascend_config().enable_balance_scheduling)
+        return bool(get_ascend_config().scheduler_config.enable_balance_scheduling)
     except Exception:
         pass
     additional_config = getattr(vllm_config, "additional_config", None) or {}
+    scheduler_config = additional_config.get("scheduler_config")
+    if isinstance(scheduler_config, dict) and "enable_balance_scheduling" in scheduler_config:
+        return bool(scheduler_config["enable_balance_scheduling"])
     if "enable_balance_scheduling" in additional_config:
         return bool(additional_config["enable_balance_scheduling"])
     return False

--- a/vllm_ascend/patch/platform/patch_profiling_chunk.py
+++ b/vllm_ascend/patch/platform/patch_profiling_chunk.py
@@ -62,7 +62,7 @@ def _record_execution_timing(scheduler, scheduler_output, model_output):
         try:
             from vllm_ascend.ascend_config import get_ascend_config
 
-            get_ascend_config().profiling_chunk_config.need_timing = False
+            get_ascend_config().scheduler_config.profiling_chunk_config.need_timing = False
         except RuntimeError:
             pass
         # Mark the scheduler so that the next scheduler_output carries

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -623,7 +623,8 @@ class NPUPlatform(Platform):
         if get_ascend_device_type() != AscendDeviceType._310P:
             compilation_config.custom_ops = ["all"]
 
-        if ascend_config.enable_balance_scheduling:
+        scheduler_extension_config = ascend_config.scheduler_config
+        if scheduler_extension_config.enable_balance_scheduling:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_transfer_config is not None and kv_role != "kv_both":
@@ -635,7 +636,7 @@ class NPUPlatform(Platform):
 
         cls._validate_kv_load_failure_policy(vllm_config)
 
-        short_request_first_config = ascend_config.short_request_first_config
+        short_request_first_config = scheduler_extension_config.short_request_first_config
         enable_short_request_first = short_request_first_config.enabled
         short_request_first_supported_policy = vllm_config.scheduler_config.policy == "fcfs"
         if enable_short_request_first and not short_request_first_supported_policy:
@@ -645,7 +646,7 @@ class NPUPlatform(Platform):
                 vllm_config.scheduler_config.policy,
             )
 
-        if ascend_config.recompute_scheduler_enable:
+        if scheduler_extension_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
             if kv_role == "kv_producer":
@@ -655,7 +656,7 @@ class NPUPlatform(Platform):
                     "Please remove it from P-node configs and keep it only on PD-disaggregated D nodes "
                     "(kv_role='kv_consumer')."
                 )
-                ascend_config.recompute_scheduler_enable = False
+                scheduler_extension_config.recompute_scheduler_enable = False
             elif kv_transfer_config is None or kv_role != "kv_consumer":
                 raise ValueError(
                     "recompute_scheduler_enable can only be enabled on PD-disaggregated D nodes "
@@ -682,7 +683,7 @@ class NPUPlatform(Platform):
             )
 
         # Use ProfilingChunkScheduler when profiling-based chunk sizing is on.
-        if ascend_config.profiling_chunk_config.enabled:
+        if scheduler_extension_config.profiling_chunk_config.enabled:
             vllm_config.scheduler_config.scheduler_cls = (
                 "vllm_ascend.core.scheduler_profiling_chunk.ProfilingChunkScheduler"
             )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1108,7 +1108,7 @@ def is_pd_decode_recompute_scheduler_enabled(vllm_config: VllmConfig | None = No
         kv_cfg = vllm_config.kv_transfer_config
         if kv_cfg is None or not kv_cfg.is_kv_consumer or kv_cfg.is_kv_producer:
             return False
-        return get_ascend_config().recompute_scheduler_enable
+        return get_ascend_config().scheduler_config.recompute_scheduler_enable
     except (RuntimeError, AttributeError):
         return False
 
@@ -1176,7 +1176,7 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
     Skipping is applicable for all dense models and for moe models only on ranks
     that act as KV consumers. We skip the DP all-reduce when either:
     - Both the prefill and decode communication methods are MC2 (or FUSED_MC2), or
-    - Decode requires MC2 and ascend_config.recompute_scheduler_enable is True.
+    - Decode requires MC2 and ascend_config.scheduler_config.recompute_scheduler_enable is True.
 
     Skipping means each rank may have a different number of tokens, so MC2 needs
     a non-zero global_bs and must NOT receive mc2_mask.
@@ -1215,7 +1215,9 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
     prefill_must_use_mc2 = needs_mc2(scheduler_config.max_num_batched_tokens)
     # Skip all-reduce if decode requires MC2 and either prefill also
     # requires MC2 or recompute-based scheduler is enabled.
-    return decode_must_use_mc2 and (prefill_must_use_mc2 or get_ascend_config().recompute_scheduler_enable)
+    return decode_must_use_mc2 and (
+        prefill_must_use_mc2 or get_ascend_config().scheduler_config.recompute_scheduler_enable
+    )
 
 
 def has_layer_idx(model_instance: torch.nn.Module) -> bool:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1996,13 +1996,13 @@ class NPUModelRunner(GPUModelRunner):
             if self.routed_experts_initialized:
                 self.routed_experts_capturer.clear_buffer()
 
-        if self.ascend_config.profiling_chunk_config.need_timing:
+        if self.ascend_config.scheduler_config.profiling_chunk_config.need_timing:
             # Check if the scheduler signaled that calibration is complete.
             # This flag is set cross-process via scheduler_output because
             # modifying the config singleton in the scheduler process does
             # not affect this worker process.
             if getattr(scheduler_output, "disable_profiling_timing", False):
-                self.ascend_config.profiling_chunk_config.need_timing = False
+                self.ascend_config.scheduler_config.profiling_chunk_config.need_timing = False
             else:
                 self._sync_device()
                 self._execution_start_time = time.perf_counter()
@@ -2605,7 +2605,9 @@ class NPUModelRunner(GPUModelRunner):
             cudagraph_stats=cudagraph_stats,
             routed_experts=None,
         )
-        if self.ascend_config.profiling_chunk_config.need_timing and hasattr(self, '_execution_start_time'):
+        if self.ascend_config.scheduler_config.profiling_chunk_config.need_timing and hasattr(
+            self, "_execution_start_time"
+        ):
             self._sync_device()
             model_runner_output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0
 


### PR DESCRIPTION
### What this PR does / why we need it?

Move Ascend scheduler-extension settings under `additional_config["scheduler_config"]`.

Keep the existing top-level keys compatible during migration, with deprecation warnings. Update runtime consumers, tests, and documentation to use the nested configuration.

### Does this PR introduce *any* user-facing change?

Yes.

Scheduler-related `additional_config` entries now use the recommended nested `scheduler_config` format. Existing top-level keys remain supported temporarily with deprecation warnings.

### How was this patch tested?

Added and updated unit tests for nested parsing, legacy compatibility, precedence, platform selection, and Balance fallback.

Ruff, formatting, compile checks, and Markdown lint passed.

Targeted pytest could not run locally because the environment is missing `torch`.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
