### PR TITLE
add record_stream&support fused_matmul on A5

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1749,6 +1749,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         e_q_quant_done = main_stream.record_event()
 
+        hidden_states.record_stream(aux_stream)
         with npu_stream_switch(aux_stream, enabled=True):
             torch.npu.current_stream().wait_event(e_q_quant_done)
             kv_quant, kv_pertoken_scale = self.cv_wkv.quantize(hidden_states)
@@ -2031,6 +2032,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 with npu_stream_switch(aux_stream, enabled=True):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
+                    weights_proj_output.record_stream(main_stream)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
                 q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
 
@@ -2322,6 +2324,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 with npu_stream_switch(aux_stream, enabled=True):
                     torch.npu.current_stream().wait_event(e_compressed_kv_done)
                     weights_proj_output = self.weights_proj(hidden_states)
+                    weights_proj_output.record_stream(main_stream)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
                 q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
 
@@ -2757,6 +2760,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         # Aux: kv_quant + scatter_k_cache (parallel with main matmul + rope)
         if kv is not None:
+            kv.record_stream(aux_stream)
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_kv_ready)
                 kv, kv_scale = DeviceOperator.indexer_quant_scatter_part1(

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -44,6 +44,17 @@ else:
 
 
 class BaseDeviceAdaptor:
+
+    @staticmethod
+    def compute_gate_logits(
+        hidden_states: torch.Tensor,
+        weight: torch.Tensor,
+        weight_fp32: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if weight_fp32 is not None:
+            return F.linear(hidden_states.float(), weight_fp32)
+        return F.linear(hidden_states.float(), weight)
+
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
         torch_npu._npu_reshape_and_cache(
@@ -857,6 +868,17 @@ class BaseDeviceAdaptor:
 
 
 class A5DeviceAdaptor(BaseDeviceAdaptor):
+
+    @staticmethod
+    def compute_gate_logits(
+        hidden_states: torch.Tensor,
+        weight: torch.Tensor,
+        weight_fp32: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return torch_npu.npu_fused_matmul(
+            hidden_states, weight.t(), fused_op_type="16cast32"
+        )
+
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
         torch_npu.npu_scatter_pa_kv_cache(

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -77,6 +77,7 @@ from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_dsa_cp,
@@ -473,7 +474,7 @@ class DeepseekV4MoE(nn.Module):
             fused_moe_out = self.experts(hidden_states=hidden_states, router_logits=hidden_states)
         else:
             # router_logits: (num_tokens, n_experts)
-            router_logits = F.linear(hidden_states.float(), self.gate.weight)
+            router_logits = DeviceOperator.compute_gate_logits(hidden_states, self.gate.weight)
             fused_moe_out = self.experts(hidden_states=hidden_states, router_logits=router_logits)
 
         fused_moe_out_is_tuple = isinstance(fused_moe_out, tuple)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -562,6 +562,9 @@ else:
                 assert fc3_context is not None
                 assert AscendMoERunner.gate_stream is not None
                 AscendMoERunner.gate_stream.wait_stream(torch.npu.current_stream())
+                main_stream = torch.npu.current_stream()
+                hidden_states.record_stream(AscendMoERunner.gate_stream)
+                router_logits.record_stream(AscendMoERunner.gate_stream)
                 with npu_stream_switch(AscendMoERunner.gate_stream, enabled=self.multistream_overlap_gate):
                     # share_expert
                     assert fc3_context.shared_experts is not None
@@ -574,6 +577,7 @@ else:
                     ):
                         shared_out = tensor_model_parallel_all_reduce(shared_out)
                     set_flash_common3_context(shared_out=shared_out)
+                    shared_out.record_stream(main_stream)
                     input_ids = getattr(get_forward_context(), "input_ids", None)
 
                     topk_weights, topk_ids = select_experts(
@@ -691,6 +695,8 @@ else:
                 if evt is not None:
                     torch.npu.current_stream().wait_event(evt)
 
+            main_stream = torch.npu.current_stream()
+            hidden_states.record_stream(shared_experts_calculation_stream())
             with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
                 # Only used for int quantization
                 has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
@@ -712,9 +718,6 @@ else:
                         bias=None,
                         output_dtype=torch.int32,
                     )
-                    # Execute activation concurrently with gmm2.
-
-                    maybe_wait_event(fused_moe_evts.before_gmm2)
                     quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                         x=hidden_states,
                         weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
@@ -750,8 +753,6 @@ else:
                     # dispatch communication.
                     maybe_wait_event(fused_moe_evts.before_dispatch)
                     hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
-                    # Execute activation concurrently with gmm2.
-                    maybe_wait_event(fused_moe_evts.before_gmm2)
                     quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
                         hidden_states,
                         topk_weight=None,
@@ -775,6 +776,8 @@ else:
                     # communication.
                     maybe_wait_event(fused_moe_evts.before_combine)
                     shared_out = self._shared_experts_part2(hidden_states, part1_out)
+
+                shared_out.record_stream(main_stream)
 
             # Make sure the default stream waits for the shared experts stream to
             # finish.

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -43,6 +43,7 @@ from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedEx
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
 from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_NZ,
     maybe_trans_nz,
@@ -803,13 +804,10 @@ else:
             if self.is_internal_router:
                 gate = self.gate
                 assert gate is not None
-                # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
-                # increase with extra hidden states. We also assume that all gate
-                # linear is unquantized so that we the weight is pre-casted in
-                # process_weights_after_loading of AscendUnquantizedLinearMethod.
-                hidden_states_fp32 = hidden_states.float()
                 before_routed_experts = torch.npu.current_stream().record_event()
-                router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
+                router_logits = DeviceOperator.compute_gate_logits(
+                    hidden_states, gate.weight, gate.weight_fp32
+                )
                 after_routed_experts = torch.npu.current_stream().record_event()
             else:
                 before_routed_experts = torch.npu.current_stream().record_event()

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -437,6 +437,9 @@ class AscendFusedMoE(FusedMoE):
             fc3_context = get_flash_common3_context()
             assert fc3_context is not None
             AscendFusedMoE.gate_stream.wait_stream(torch.npu.current_stream())
+            main_stream = torch.npu.current_stream()
+            hidden_states.record_stream(AscendFusedMoE.gate_stream)
+            router_logits.record_stream(AscendFusedMoE.gate_stream)
             with npu_stream_switch(AscendFusedMoE.gate_stream, enabled=self.multistream_overlap_gate):
                 # share_expert
                 assert fc3_context.shared_experts is not None
@@ -449,6 +452,7 @@ class AscendFusedMoE(FusedMoE):
                 ):
                     shared_out = tensor_model_parallel_all_reduce(shared_out)
                 set_flash_common3_context(shared_out=shared_out)
+                shared_out.record_stream(main_stream)
                 input_ids = getattr(get_forward_context(), "input_ids", None)
                 topk_weights, topk_ids = select_experts(
                     hidden_states=hidden_states,
@@ -561,6 +565,8 @@ class AscendFusedMoE(FusedMoE):
             if evt is not None:
                 torch.npu.current_stream().wait_event(evt)
 
+        main_stream = torch.npu.current_stream()
+        hidden_states.record_stream(shared_experts_calculation_stream())
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
             # Only used for int quantization
             has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
@@ -582,9 +588,6 @@ class AscendFusedMoE(FusedMoE):
                     bias=None,
                     output_dtype=torch.int32,
                 )
-                # Execute activation concurrently with gmm2.
-
-                maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                     x=hidden_states,
                     weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
@@ -620,8 +623,6 @@ class AscendFusedMoE(FusedMoE):
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
                 hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
-                # Execute activation concurrently with gmm2.
-                maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
                     hidden_states,
                     topk_weight=None,
@@ -645,6 +646,8 @@ class AscendFusedMoE(FusedMoE):
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = self._shared_experts_part2(hidden_states, part1_out)
+
+            shared_out.record_stream(main_stream)
 
         # Make sure the default stream waits for the shared experts stream to
         # finish.

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -58,6 +58,7 @@ from vllm_ascend.ops.fused_moe.fused_moe import (
     torch_npu,
     wraps,
 )
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.utils import enable_sp
 
 
@@ -673,13 +674,10 @@ class AscendFusedMoE(FusedMoE):
         if self.is_internal_router:
             gate = self.gate
             assert gate is not None
-            # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
-            # increase with extra hidden states. We also assume that all gate
-            # linear is unquantized so that we the weight is pre-casted in
-            # process_weights_after_loading of AscendUnquantizedLinearMethod.
-            hidden_states_fp32 = hidden_states.float()
             before_routed_experts = torch.npu.current_stream().record_event()
-            router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
+            router_logits = DeviceOperator.compute_gate_logits(
+                hidden_states, gate.weight, gate.weight_fp32
+            )
             after_routed_experts = torch.npu.current_stream().record_event()
         else:
             before_routed_experts = torch.npu.current_stream().record_event()

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -381,8 +381,11 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         if self.multistream_overlap_gate:
             assert PrepareAndFinalize.quant_stream is not None
             PrepareAndFinalize.quant_stream.wait_stream(torch.npu.current_stream())
+            main_stream = torch.npu.current_stream()
+            hidden_states.record_stream(PrepareAndFinalize.quant_stream)
             with npu_stream_switch(PrepareAndFinalize.quant_stream, enabled=self.multistream_overlap_gate):
                 hidden_states = fc3_all_gather_and_maybe_unpad_impl(hidden_states)
+                hidden_states.record_stream(main_stream)
         else:
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, True, True)
             router_logits = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(router_logits, True, True)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces several stream-safety and performance improvements for Ascend NPU:
1. **Stream Safety (`record_stream`)**: Adds `record_stream` calls to various tensors (e.g., `hidden_states`, `weights_proj_output`, `shared_out`, `kv`) that are allocated on one stream but consumed on another (such as `aux_stream`, `gate_stream`, `quant_stream`, or `shared_experts_calculation_stream`). This prevents PyTorch's caching allocator from prematurely reusing their memory, avoiding potential memory corruption.
2. **A5 Fused Matmul Support**: Replaces `F.linear` with `torch_npu.npu_fused_matmul` (using `fused_op_type="16cast32"`) for the gate/router projection when running on A5 (950) devices, improving performance.
3. **Concurrency Optimization**: Removes unnecessary stream synchronization points (`maybe_wait_event(fused_moe_evts.before_gmm2)`) in MoE implementations, allowing activation functions to run concurrently with the main stream.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested on Ascend NPU devices (A5/950 and others) to ensure correct execution and stream safety.

- vLLM version: v0.23.0
