### PR TITLE
[v0.23.0][BugFix][KV Transfer] Fix non-contiguous Mooncake PA cache inputs

### DIFF
--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -1,9 +1,78 @@
+import ast
+from pathlib import Path
 from unittest import mock
 
 import pytest
 import torch
 
 from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+
+
+def _get_function_call_names(relative_path: str, function_name: str) -> set[str]:
+    repo_root = Path(__file__).parents[3]
+    tree = ast.parse((repo_root / relative_path).read_text())
+    functions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
+    ]
+    assert functions
+
+    def get_name(node: ast.expr) -> str:
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            parent = get_name(node.value)
+            return f"{parent}.{node.attr}" if parent else node.attr
+        return ""
+
+    return {get_name(node.func) for function in functions for node in ast.walk(function) if isinstance(node, ast.Call)}
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "function_name", "expected_call", "forbidden_call"),
+    [
+        (
+            "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+            "reformat_kv_cache",
+            "DeviceOperator.kv_cache_load",
+            "torch_npu.npu_gather_pa_kv_cache",
+        ),
+        (
+            "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+            "_cat_kv_cache",
+            "DeviceOperator.reshape_and_cache",
+            "torch_npu.npu_scatter_pa_kv_cache",
+        ),
+        (
+            "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+            "reformat_kv_cache",
+            "DeviceOperator.kv_cache_load",
+            "torch_npu.npu_gather_pa_kv_cache",
+        ),
+        (
+            "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+            "_cat_kv_cache",
+            "DeviceOperator.reshape_and_cache",
+            "torch_npu.npu_scatter_pa_kv_cache",
+        ),
+        (
+            "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+            "save_kv_layer",
+            "DeviceOperator.kv_cache_load",
+            "torch_npu.npu_gather_pa_kv_cache",
+        ),
+    ],
+)
+def test_mooncake_pa_cache_calls_use_device_operator(
+    relative_path: str,
+    function_name: str,
+    expected_call: str,
+    forbidden_call: str,
+):
+    call_names = _get_function_call_names(relative_path, function_name)
+    assert expected_call in call_names
+    assert forbidden_call not in call_names
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -57,6 +57,7 @@ from vllm.v1.request import RequestStatus
 
 from vllm_ascend import envs as ascend_envs
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
     RegisterRegions,
@@ -1214,14 +1215,14 @@ class KVCacheRecvingThread(threading.Thread):
         # Process each layer in the KV cache
         for _, (k_cache_layer, v_cache_layer) in kv_caches.items():
             # Load cache data into buffers
-            torch_npu.npu_gather_pa_kv_cache(
+            DeviceOperator.kv_cache_load(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_offset=seq_start_tensor,
-                key=k_buffer,
-                value=v_buffer,
+                seq_start_tensor,
+                k_buffer,
+                v_buffer,
             )
             if need_cat_cache:
                 self._cat_kv_cache(
@@ -1271,13 +1272,12 @@ class KVCacheRecvingThread(threading.Thread):
         v_buffer = _transpose_kv_cache_between_head(v_buffer)
 
         # Reshape and cache the processed buffers
-        torch_npu.npu_scatter_pa_kv_cache(
+        DeviceOperator.reshape_and_cache(
             key=k_buffer,
             value=v_buffer,
             key_cache=k_cache_layer,
             value_cache=v_cache_layer,
             slot_mapping=slot_mapping,
-            cache_mode="Norm",
         )
 
     def _nz_kv_cache(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -52,6 +52,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import RequestStatus
 
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value
 from vllm_ascend.utils import enable_custom_op, is_vl_model
@@ -889,14 +890,14 @@ class KVCacheRecvingThread(threading.Thread):
         # Process each layer in the KV cache
         for _, (k_cache_layer, v_cache_layer) in self.kv_caches.items():
             # Load cache data into buffers
-            torch_npu.npu_gather_pa_kv_cache(
+            DeviceOperator.kv_cache_load(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_offset=seq_start_tensor,
-                key=k_buffer,
-                value=v_buffer,
+                seq_start_tensor,
+                k_buffer,
+                v_buffer,
             )
             if need_cat_cache:
                 self._cat_kv_cache(
@@ -927,13 +928,12 @@ class KVCacheRecvingThread(threading.Thread):
         v_buffer = _transpose_kv_cache_between_head(v_buffer)
 
         # Reshape and cache the processed buffers
-        torch_npu.npu_scatter_pa_kv_cache(
+        DeviceOperator.reshape_and_cache(
             key=k_buffer,
             value=v_buffer,
             key_cache=k_cache_layer,
             value_cache=v_cache_layer,
             slot_mapping=slot_mapping,
-            cache_mode="Norm",
         )
 
     def _nz_kv_cache(self, k_cache_layer, v_cache_layer, k_buffer, v_buffer, slot_mapping):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -21,7 +21,6 @@ import msgspec
 import numpy as np
 import numpy.typing as npt
 import torch
-import torch_npu
 import zmq
 from mooncake.engine import TransferEngine  # type: ignore
 from vllm.config import VllmConfig
@@ -54,6 +53,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.worker.utils import extract_layer_index
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import GET_META_MSG
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
@@ -1750,14 +1750,14 @@ class MooncakeLayerwiseConnectorWorker:
                     )
 
                     # Load cache data into buffers
-                    torch_npu.npu_gather_pa_kv_cache(
+                    DeviceOperator.kv_cache_load(
                         kv_layer[0],
                         kv_layer[1],
                         send_task.group_block_table[layer_group_idx],
                         send_task.group_block_len_tensor[layer_group_idx],
-                        seq_offset=send_task.group_seq_start_tensor[layer_group_idx],
-                        key=keys,
-                        value=values,
+                        send_task.group_seq_start_tensor[layer_group_idx],
+                        keys,
+                        values,
                     )
                     if self.pd_head_ratio != 1:
                         # sort kv caches for each block


### PR DESCRIPTION
### What this PR does / why we need it?

Fix a DeepSeek-V3.1 P/D disaggregation segmentation fault introduced by the
PA KV cache operator replacement in #11867.

The standard, hybrid, and layerwise Mooncake connectors called
`torch_npu.npu_gather_pa_kv_cache` and `torch_npu.npu_scatter_pa_kv_cache`
directly. Those call sites bypassed the input-layout normalization in
`DeviceOperator`, allowing non-contiguous sequence-length, key, value, or slot
mapping tensors to reach the NPU operators.

This patch routes all five affected Mooncake call sites through:

- `DeviceOperator.kv_cache_load`, which makes the sequence-length tensor
  contiguous before calling the gather operator.
- `DeviceOperator.reshape_and_cache`, which makes key, value, and slot mapping
  tensors contiguous before calling the scatter operator.

Using `DeviceOperator` also preserves device-specific behavior such as the
Ascend 310P reshape-and-cache implementation. The existing NZ-specific paths
are unchanged.

This PR is based directly on the latest `releases/v0.23.0` and does not include
the separate revert in #12172; it keeps the PA scatter/gather operator
replacement from #11867 and fixes its missing layout normalization.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-V3.1 P/D disaggregation no longer passes non-contiguous Mooncake
KV transfer tensors directly to the PA cache operators, avoiding the observed
segmentation fault. There is no public API change.

### How was this patch tested?

- Added regression coverage for all five Mooncake PA cache call sites to ensure
  they use `DeviceOperator` and do not regress to direct torch_npu calls.
- Executed the same five routing checks directly with Python: all passed.
- `python3 -m py_compile` on all four modified Python files.
- `uvx ruff check` on all four modified Python files.
- `uvx ruff format --check` on all four modified Python files.
- `git -c core.whitespace=cr-at-eol diff --check origin/releases/v0.23.0...HEAD`.
- `bash format.sh ci`: all relevant hooks passed. The release branch still
  reports the unrelated baseline shellcheck `SC2328` at `csrc/build.sh:524`,
  which is outside this PR.

The targeted pytest run was unavailable because the local macOS system Python
does not provide pytest or the NPU runtime stack. PR CI should run the unit
tests; the DeepSeek-V3.1 P/D reproduction requires target NPU hardware.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
