### PR TITLE
[Feature][v0.23] Support hybrid load failure recompute

### DIFF
--- a/tests/ut/distributed/kv_transfer/test_kv_transfer_failures.py
+++ b/tests/ut/distributed/kv_transfer/test_kv_transfer_failures.py
@@ -181,6 +181,17 @@ class TestRecordFailedBlocks(unittest.TestCase):
         self.assertEqual(result, {11})
         mock_logger.error.assert_called_once()
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer.logger")
+    def test_hybrid_peer_blocks_fail_together(self, mock_logger: MagicMock):
+        """Test hybrid peer block sets are marked invalid together."""
+        block_ids: list[int | set[int]] = [{10, 20}, {11, 21}, {12, 22}]
+        ret_codes: list[int] = [0, 1, 0]
+
+        result = record_failed_blocks(block_ids, ret_codes)
+
+        self.assertEqual(result, {11, 21})
+        mock_logger.error.assert_called_once()
+
 
 class TestRecordFailedBlocksEdgeCases(unittest.TestCase):
     """Additional edge case tests for record_failed_blocks."""

--- a/tests/ut/patch/platform/test_patch_scheduler.py
+++ b/tests/ut/patch/platform/test_patch_scheduler.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from vllm_ascend.patch.platform import patch_scheduler
+
+
+class _KVCacheManager:
+    def __init__(self, block_ids_by_req):
+        self.block_ids_by_req = block_ids_by_req
+
+    def get_block_ids(self, req_id):
+        return self.block_ids_by_req[req_id]
+
+
+def test_update_requests_with_invalid_blocks_handles_hybrid_groups() -> None:
+    request = SimpleNamespace(request_id="req", num_computed_tokens=256)
+    scheduler = SimpleNamespace(
+        block_size=128,
+        kv_cache_config=SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=256)),
+                SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=128)),
+            ],
+        ),
+        kv_cache_manager=_KVCacheManager({"req": ([10], [20, 21])}),
+    )
+
+    affected_req_ids, total_affected_tokens, blocks_to_evict = patch_scheduler._update_requests_with_invalid_blocks(
+        scheduler,
+        [request],
+        {10, 21},
+        {},
+    )
+
+    assert affected_req_ids == {"req"}
+    assert request.num_computed_tokens == 0
+    assert total_affected_tokens == 256
+    assert blocks_to_evict == {10, 20, 21}

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -637,14 +637,6 @@ class TestNPUPlatform(TestBase):
         mock_init_recompute.assert_called_once_with(vllm_config)
         self.assertIs(vllm_config.scheduler_config, recompute_scheduler_config)
 
-    def test_validate_kv_load_failure_policy_rejects_hybrid_recompute(self):
-        vllm_config = TestNPUPlatform.mock_vllm_config()
-        vllm_config.model_config.is_hybrid = True
-        vllm_config.kv_transfer_config = MagicMock(kv_load_failure_policy="recompute")
-
-        with pytest.raises(AssertionError, match="Hybrid models do not support recompute mode kv load failure policy"):
-            self.platform._validate_kv_load_failure_policy(vllm_config)
-
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
     @patch("vllm_ascend.ascend_config.init_ascend_config")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -5,6 +5,7 @@ import queue
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -574,6 +575,32 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.prepare_value(start, end, block_ids)
 
+    def _collect_peer_block_ids(
+        self,
+        start: int,
+        block_ids_by_group: list[list[int]],
+        group_ids: list[int],
+        skip_null_blocks_by_group: list[bool] | None = None,
+    ) -> set[int]:
+        peer_block_ids: set[int] = set()
+        for group_id in group_ids:
+            if group_id >= len(block_ids_by_group):
+                continue
+            group_block_ids = block_ids_by_group[group_id]
+            block_idx = start // self._get_block_size(group_id)
+            if block_idx >= len(group_block_ids):
+                continue
+            block_id = group_block_ids[block_idx]
+            skip_null = (
+                skip_null_blocks_by_group is not None
+                and group_id < len(skip_null_blocks_by_group)
+                and skip_null_blocks_by_group[group_id]
+            )
+            if skip_null and block_id <= 0:
+                continue
+            peer_block_ids.add(block_id)
+        return peer_block_ids
+
     def _decode_adaptor_prefill_pp(
         self,
         keys: list[str],
@@ -842,7 +869,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         addr_list = []
         size_list = []
         key_list = []
-        block_id_list: list[int] = []
+        block_id_list: list[set[int]] = []
         group_ids = req_meta.kv_cache_group_ids or [0]
         load_masks = self._load_mask(req_meta, token_len)
         for group_id in group_ids:
@@ -873,7 +900,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 key_list.append(key.to_string())
                 addr_list.append(addr)
                 size_list.append(size)
-                block_id_list.append(block_id)
+                block_id_list.append(
+                    self._collect_peer_block_ids(
+                        start,
+                        req_meta.block_ids_by_group,
+                        group_ids,
+                        req_meta.skip_null_blocks_by_group,
+                    )
+                    or {block_id}
+                )
         if not key_list:
             self.set_finished_request(req_id)
             self.request_queue.task_done()
@@ -898,33 +933,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 block_id_list_c,
                 ret,
             )
-            if len(req_meta.block_ids_by_group) == 1:
-                with self._invalid_block_ids_lock:
-                    self._invalid_block_ids.update(missing_block_ids)
-            elif missing_block_ids:
-                logger.error(
-                    "KV load failed for hybrid request %s. "
-                    "Skip invalid-block fallback to avoid scheduler crash. "
-                    "failed_blocks=%s",
-                    req_id,
-                    missing_block_ids,
-                )
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(missing_block_ids)
         elif ret is None:
             missing_block_ids = record_failed_blocks(
                 block_id_list_c,
                 [1] * len(block_id_list_c),
             )
-            if len(req_meta.block_ids_by_group) == 1:
-                with self._invalid_block_ids_lock:
-                    self._invalid_block_ids.update(missing_block_ids)
-            elif missing_block_ids:
-                logger.error(
-                    "KV load failed for hybrid request %s. "
-                    "Skip invalid-block fallback to avoid scheduler crash. "
-                    "failed_blocks=%s",
-                    req_id,
-                    missing_block_ids,
-                )
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(missing_block_ids)
         logger.debug(
             "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
             req_id,
@@ -1537,13 +1554,17 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
 
 
 def record_failed_blocks(
-    block_ids: list[int],
-    ret_codes: list[int],
+    block_ids: Sequence[int | set[int]],
+    ret_codes: Sequence[int],
 ) -> set[int]:
     failed_blocks: set[int] = set()
-    for block_id, code in zip(block_ids, ret_codes):
-        if code != 0:
-            failed_blocks.add(block_id)
+    for block_id_or_group, code in zip(block_ids, ret_codes):
+        if code == 0:
+            continue
+        if isinstance(block_id_or_group, set):
+            failed_blocks.update(block_id_or_group)
+        else:
+            failed_blocks.add(block_id_or_group)
     if failed_blocks:
         logger.error(
             "Failed to load blocks. failed_count=%d, failed_blocks=%s. Check block availability and memory state.",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -793,7 +793,7 @@ class KVPoolWorker:
             addr_list = []
             size_list = []
             key_list = []
-            block_id_list: list[int] = []
+            block_id_list: list[set[int]] = []
             load_masks = self.token_database.load_mask(request.block_hashes, token_len)
             for group_id in load_group_ids:
                 if group_id >= len(request.block_ids_by_group):
@@ -822,7 +822,23 @@ class KVPoolWorker:
                     key_list.append(key.to_string())
                     addr_list.append(addr)
                     size_list.append(size)
-                    block_id_list.append(block_id)
+                    peer_block_ids: set[int] = set()
+                    for peer_group_id in load_group_ids:
+                        if peer_group_id >= len(request.block_ids_by_group):
+                            continue
+                        peer_block_ids_for_group = request.block_ids_by_group[peer_group_id]
+                        peer_block_idx = start // self.grouped_block_size[peer_group_id]
+                        if peer_block_idx >= len(peer_block_ids_for_group):
+                            continue
+                        peer_block_id = peer_block_ids_for_group[peer_block_idx]
+                        peer_skip_null = (
+                            peer_group_id < len(self.group_uses_align_state)
+                            and self.group_uses_align_state[peer_group_id]
+                        )
+                        if peer_skip_null and peer_block_id <= 0:
+                            continue
+                        peer_block_ids.add(peer_block_id)
+                    block_id_list.append(peer_block_ids or {block_id})
             if not key_list:
                 continue
             key_list_c = _circular_shift(key_list, self.tp_rank % len(key_list))
@@ -843,31 +859,13 @@ class KVPoolWorker:
                     block_id_list_c,
                     ret,
                 )
-                if len(request.block_ids_by_group) == 1:
-                    self._invalid_block_ids.update(missing_block_ids)
-                elif missing_block_ids:
-                    logger.error(
-                        "KV load failed for hybrid request %s. "
-                        "Skip invalid-block fallback to avoid scheduler crash. "
-                        "failed_blocks=%s",
-                        request.req_id,
-                        missing_block_ids,
-                    )
+                self._invalid_block_ids.update(missing_block_ids)
             elif ret is None:
                 missing_block_ids = record_failed_blocks(
                     block_id_list_c,
                     [1] * len(block_id_list_c),
                 )
-                if len(request.block_ids_by_group) == 1:
-                    self._invalid_block_ids.update(missing_block_ids)
-                elif missing_block_ids:
-                    logger.error(
-                        "KV load failed for hybrid request %s. "
-                        "Skip invalid-block fallback to avoid scheduler crash. "
-                        "failed_blocks=%s",
-                        request.req_id,
-                        missing_block_ids,
-                    )
+                self._invalid_block_ids.update(missing_block_ids)
             logger.debug(
                 "KV pool worker backend get returned request=%s token_len=%d groups=%s keys=%d",
                 request.req_id,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -379,6 +379,18 @@
 #       Remove this patch if upstream exposes a platform allocator capability hook
 #       for sleep mode validation.
 #
+# ** 14. File: platform/patch_scheduler.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.sched.scheduler.Scheduler._update_requests_with_invalid_blocks`
+#    Why:
+#       Upstream vLLM 0.23 assumes one KV cache group when handling invalid blocks from KV load failures.
+#    How:
+#       Scan all KV cache groups and rewind to the earliest invalid token boundary.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/48216
+#    Future Plan:
+#       Remove this patch once the supported upstream vLLM version includes hybrid invalid-block handling.
+#
 # ** 15. File: platform/patch_weight_transfer_engine.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["nccl"]`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -41,6 +41,7 @@ import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
+import vllm_ascend.patch.platform.patch_scheduler  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_scheduler.py
+++ b/vllm_ascend/patch/platform/patch_scheduler.py
@@ -1,0 +1,70 @@
+from collections.abc import Iterable
+
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.request import Request
+
+
+def _update_requests_with_invalid_blocks(
+    self,
+    requests: Iterable[Request],
+    invalid_block_ids: set[int],
+    num_scheduled_tokens: dict[str, int],
+    evict_blocks: bool = True,
+) -> tuple[set[str], int, set[int]]:
+    affected_req_ids: set[str] = set()
+    total_affected_tokens = 0
+    blocks_to_evict: set[int] = set()
+    marked_invalid_block_ids: set[int] = set()
+    kv_cache_groups = getattr(self.kv_cache_config, "kv_cache_groups", ())
+    coordinator = getattr(self.kv_cache_manager, "coordinator", None)
+    get_effective_block_size = getattr(coordinator, "_get_effective_block_size", None)
+
+    for request in requests:
+        is_affected = False
+        rewind_num_computed_tokens: int | None = None
+        req_id = request.request_id
+        req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
+        req_num_computed_tokens = request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+        group_block_sizes: list[int] = []
+
+        for group_id, req_block_ids in enumerate(req_block_ids_by_group):
+            block_size = self.block_size
+            if group_id < len(kv_cache_groups):
+                kv_cache_spec = kv_cache_groups[group_id].kv_cache_spec
+                block_size = (
+                    get_effective_block_size(kv_cache_spec)
+                    if get_effective_block_size is not None
+                    else getattr(kv_cache_spec, "block_size", block_size)
+                )
+            group_block_sizes.append(block_size)
+            req_num_computed_blocks = (req_num_computed_tokens + block_size - 1) // block_size
+
+            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
+                if block_id not in invalid_block_ids:
+                    continue
+
+                is_affected = True
+                if block_id in marked_invalid_block_ids:
+                    continue
+
+                marked_invalid_block_ids.add(block_id)
+                failed_token_pos = idx * block_size
+                if rewind_num_computed_tokens is None or failed_token_pos < rewind_num_computed_tokens:
+                    rewind_num_computed_tokens = failed_token_pos
+
+        if is_affected:
+            if rewind_num_computed_tokens is None:
+                total_affected_tokens += request.num_computed_tokens - req_num_computed_tokens
+                request.num_computed_tokens = req_num_computed_tokens
+            else:
+                request.num_computed_tokens = rewind_num_computed_tokens
+                total_affected_tokens += req_num_computed_tokens - request.num_computed_tokens
+                if evict_blocks:
+                    for block_ids, block_size in zip(req_block_ids_by_group, group_block_sizes):
+                        blocks_to_evict.update(block_ids[rewind_num_computed_tokens // block_size :])
+            affected_req_ids.add(request.request_id)
+
+    return affected_req_ids, total_affected_tokens, blocks_to_evict
+
+
+Scheduler._update_requests_with_invalid_blocks = _update_requests_with_invalid_blocks

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -674,8 +674,6 @@ class NPUPlatform(Platform):
                     "PD-disaggregated mode (kv_role='kv_producer'/'kv_consumer')."
                 )
 
-        cls._validate_kv_load_failure_policy(vllm_config)
-
         if ascend_config.recompute_scheduler_enable:
             kv_transfer_config = vllm_config.kv_transfer_config
             kv_role = getattr(kv_transfer_config, "kv_role", None)
@@ -887,16 +885,6 @@ class NPUPlatform(Platform):
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
         return True
-
-    @staticmethod
-    def _validate_kv_load_failure_policy(vllm_config: VllmConfig) -> None:
-        kv_transfer_config = vllm_config.kv_transfer_config
-        if kv_transfer_config is None:
-            return
-        if getattr(kv_transfer_config, "kv_load_failure_policy", "fail") == "recompute":
-            assert not getattr(vllm_config.model_config, "is_hybrid", False), (
-                "Hybrid models do not support recompute mode kv load failure policy now."
-            )
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:


### PR DESCRIPTION
## Summary
- Migrate hybrid KV load failure recompute support from #10882 to the v0.23.0 release branch.
- Mark peer blocks across KV groups as failed when one group fails to load.
- Patch scheduler invalid-block recovery to scan all KV groups, following the direction of vllm-project/vllm#48216.

## Validation
vLLM version: v0.23.0
vLLM main: vllm-project/vllm@ee0da84ab9e04ac7610e28580af62c365e898389

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
