### PR TITLE
[CI] fix _manual-hitest.yaml avoid E2E break

### DIFF
--- a/.github/workflows/_manual-hitest.yaml
+++ b/.github/workflows/_manual-hitest.yaml
@@ -51,6 +51,7 @@ jobs:
         run: git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
 
       - name: Execute hitest entry
+        continue-on-error: true
         env:
           AUROGON_API_PREFIX: https://174e1b821a8446f38998a67186ba766e.apic.cn-southwest-2.huaweicloudapis.com/aurogon_service
           HITEST_APIG_APPCODE: ${{ secrets.HITEST_APIG_APPCODE }}
@@ -58,6 +59,11 @@ jobs:
           HITEST_SECRET: ${{ secrets.HITEST_SECRET }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          echo "===== DEBUG GITHUB WORKFLOW ENV LENGTH ===="
+          echo "HITEST_APIG_APPCODE len: ${#HITEST_APIG_APPCODE}"
+          echo "HITEST_KEY len: ${#HITEST_KEY}"
+          echo "HITEST_SECRET len: ${#HITEST_SECRET}"
+          echo "==========================================="
           python3 .github/workflows/scripts/run_hitest.py
 
       - name: Upload recommended pytest paths artifact


### PR DESCRIPTION
### What this PR does / why we need it?
avoid E2E break from hitest

### Does this PR introduce _any_ user-facing change?
avoid E2E break from hitest

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
