### PR TITLE
[Doc] update MiniMax M2 serving parameters

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -387,10 +387,10 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --max-num-batched-tokens 16384 \
     --max-num-seqs 64 \
     --trust-remote-code \
-    --gpu-memory-utilization 0.85 \
+    --gpu-memory-utilization 0.75 \
     --quantization ascend \
     --enforce-eager \
-    --speculative_config '{"method": "eagle3", "model": "/path/to/weight/Eagle3/", "num_speculative_tokens": 3}' \
+    --speculative_config '{"method": "eagle3", "model": "/path/to/weight/Eagle3/", "num_speculative_tokens": 1}' \
     --additional-config '{"enable_cpu_binding":true}' \
     --kv-transfer-config \
         '{"kv_connector": "MooncakeConnectorV1",
@@ -450,7 +450,7 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --max-num-seqs 16 \
     --trust-remote-code \
     --no-enable-prefix-caching \
-    --gpu-memory-utilization 0.85 \
+    --gpu-memory-utilization 0.75 \
     --quantization ascend \
     --async-scheduling \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \


### PR DESCRIPTION
### What this PR does / why we need it?

Updates the recommended serving parameters in the MiniMax M2.7 W8A8 QuaRot deployment guide:

- Lowers --gpu-memory-utilization from 0.85 to 0.75 in the single-node and PD-disaggregation examples.
- Lowers Eagle3 num_speculative_tokens from 3 to 1 in the PD-disaggregation example.

These values provide more conservative, stable configuration recommendations for the documented deployment scenarios.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

No code changes were made, so no automated tests were added. The command examples were reviewed to confirm that only the intended parameter values changed.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
