### PR TITLE
[BugFix][Worker] Patch CpuGpuBuffer with double-buffer rotation to fix async H2D race

### DIFF
--- a/tests/ut/worker/test_utils.py
+++ b/tests/ut/worker/test_utils.py
@@ -4,10 +4,13 @@ The patch (vllm_ascend.patch.worker.patch_cpu_gpu_buffer) replaces
 ``copy_to_gpu`` with a version that copies through two rotating pinned
 CPU shadow buffers, preventing async-scheduling races where the next
 iteration's CPU writes corrupt an in-flight H2D transfer.
+
+Each shadow is guarded by an NPU event: before reusing a shadow (two
+iterations later), ``synchronize()`` ensures its prior H2D completed.
 """
 
 import torch
-import torch_npu  # noqa: F401  -- required for NPU device
+import torch_npu  # noqa: F401  -- required for NPU device and Event
 
 import vllm_ascend.patch.worker  # noqa: F401  -- triggers patch registration
 from vllm.v1.utils import CpuGpuBuffer
@@ -26,6 +29,13 @@ class TestCpuGpuBufferDoubleBuffer:
             assert shadow.shape == buf.cpu.shape
             assert shadow.dtype == buf.cpu.dtype
         assert buf._shadow_idx == 0
+
+    def test_init_creates_two_events(self):
+        buf = _make_buffer(8, torch.int32, torch.device("npu:0"))
+        assert hasattr(buf, "_shadow_events")
+        assert len(buf._shadow_events) == 2
+        for evt in buf._shadow_events:
+            assert isinstance(evt, torch.npu.Event)
 
     def test_cpu_gpu_np_addresses_stay_fixed(self):
         """The patch must not change cpu/gpu/np addresses (graph + ref safety)."""
@@ -83,6 +93,27 @@ class TestCpuGpuBufferDoubleBuffer:
         assert buf._shadow_buffers[0].tolist() == [10, 10, 10, 10]
         # shadow[1] should hold 20 (iteration 1's snapshot).
         assert buf._shadow_buffers[1].tolist() == [20, 20, 20, 20]
+
+    def test_reuse_shadow_waits_for_prior_h2d(self):
+        """Third call reuses shadow[0]; its data must reflect iteration 2, not 0.
+
+        This verifies the event guard: ``synchronize()`` before reusing
+        shadow[0] ensures iteration 0's H2D has completed, so writing
+        iteration 2's data into shadow[0] is safe.
+        """
+        buf = _make_buffer(4, torch.int32, torch.device("npu:0"))
+        # Iteration 0 -> shadow[0]
+        buf.cpu.fill_(10)
+        buf.copy_to_gpu()
+        # Iteration 1 -> shadow[1]
+        buf.cpu.fill_(20)
+        buf.copy_to_gpu()
+        # Iteration 2 -> shadow[0] (reused)
+        buf.cpu.fill_(30)
+        buf.copy_to_gpu()
+        buf.gpu.npu.stream_synchronize()
+        assert buf.gpu.tolist() == [30, 30, 30, 30]
+        assert buf._shadow_buffers[0].tolist() == [30, 30, 30, 30]
 
     def test_partial_copy_to_gpu(self):
         buf = _make_buffer(8, torch.int32, torch.device("npu:0"))

--- a/tests/ut/worker/test_utils.py
+++ b/tests/ut/worker/test_utils.py
@@ -1,41 +1,92 @@
-import unittest
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+"""Tests for the double-buffer rotation patch on CpuGpuBuffer.
+
+The patch (vllm_ascend.patch.worker.patch_cpu_gpu_buffer) replaces
+``copy_to_gpu`` with a version that copies through two rotating pinned
+CPU shadow buffers, preventing async-scheduling races where the next
+iteration's CPU writes corrupt an in-flight H2D transfer.
+"""
 
 import torch
+import torch_npu  # noqa: F401  -- required for NPU device
 
-from vllm_ascend.worker.utils import copy_snapshot_to_gpu
+import vllm_ascend.patch.worker  # noqa: F401  -- triggers patch registration
+from vllm.v1.utils import CpuGpuBuffer
 
 
-class TestQueryStartLocCopy(unittest.TestCase):
-    def test_copy_uses_stable_cpu_snapshot(self):
-        class DeferredCopy:
-            def copy_(self, source, non_blocking=False):
-                self.source = source
-                self.non_blocking = non_blocking
-                return self
+def _make_buffer(size, dtype, device):
+    return CpuGpuBuffer(size, dtype=dtype, device=device, pin_memory=False)
 
-        cpu = torch.tensor([0, 2, 5], dtype=torch.int32)
-        gpu = DeferredCopy()
-        query_start_loc = SimpleNamespace(cpu=cpu, gpu=gpu)
 
-        with patch.object(torch.Tensor, "pin_memory", lambda tensor: tensor):
-            copy_snapshot_to_gpu(query_start_loc)
-        cpu.fill_(99)
+class TestCpuGpuBufferDoubleBuffer:
+    def test_init_creates_two_shadow_buffers(self):
+        buf = _make_buffer(8, torch.int32, torch.device("npu:0"))
+        assert hasattr(buf, "_shadow_buffers")
+        assert len(buf._shadow_buffers) == 2
+        for shadow in buf._shadow_buffers:
+            assert shadow.shape == buf.cpu.shape
+            assert shadow.dtype == buf.cpu.dtype
+        assert buf._shadow_idx == 0
 
-        self.assertEqual(gpu.source.tolist(), [0, 2, 5])
-        self.assertNotEqual(gpu.source.data_ptr(), cpu.data_ptr())
-        self.assertTrue(gpu.non_blocking)
+    def test_cpu_gpu_np_addresses_stay_fixed(self):
+        """The patch must not change cpu/gpu/np addresses (graph + ref safety)."""
+        buf = _make_buffer(8, torch.int32, torch.device("npu:0"))
+        cpu_ptr = buf.cpu.data_ptr()
+        gpu_ptr = buf.gpu.data_ptr()
+        np_ptr = buf.np.__array_interface__["data"][0]
+        buf.copy_to_gpu()
+        buf.copy_to_gpu()
+        assert buf.cpu.data_ptr() == cpu_ptr
+        assert buf.gpu.data_ptr() == gpu_ptr
+        assert buf.np.__array_interface__["data"][0] == np_ptr
 
-    def test_copy_pins_snapshot(self):
-        cpu = MagicMock()
-        snapshot = MagicMock()
-        pinned_snapshot = MagicMock()
-        cpu.clone.return_value = snapshot
-        snapshot.pin_memory.return_value = pinned_snapshot
-        gpu = MagicMock()
+    def test_shadow_idx_rotates(self):
+        buf = _make_buffer(8, torch.int32, torch.device("npu:0"))
+        assert buf._shadow_idx == 0
+        buf.copy_to_gpu()
+        assert buf._shadow_idx == 1
+        buf.copy_to_gpu()
+        assert buf._shadow_idx == 0
 
-        copy_snapshot_to_gpu(SimpleNamespace(cpu=cpu, gpu=gpu))
+    def test_copy_to_gpu_uses_shadow_not_cpu_directly(self):
+        """Verify H2D source is the shadow buffer, not buffer.cpu.
 
-        snapshot.pin_memory.assert_called_once_with()
-        gpu.copy_.assert_called_once_with(pinned_snapshot, non_blocking=True)
+        After copy_to_gpu, mutate buffer.cpu. If GPU got the snapshot via
+        the shadow (pre-copy), gpu should reflect the value at copy time,
+        not the mutation. (On NPU the copy is async, so synchronize first.)
+        """
+        buf = _make_buffer(4, torch.int32, torch.device("npu:0"))
+        buf.cpu.fill_(42)
+        buf.copy_to_gpu()
+        # Mutate CPU after the snapshot was taken.
+        buf.cpu.fill_(99)
+        buf.gpu.npu.stream_synchronize()
+        assert buf.gpu.tolist() == [42, 42, 42, 42]
+
+    def test_alternating_shadows_isolate_iterations(self):
+        """Simulate async race: iteration N+1 must not overwrite N's H2D.
+
+        With double-buffer, copy_to_gpu(N) uses shadow[0], then copy_to_gpu(N+1)
+        uses shadow[1]. Mutating buffer.cpu before N's H2D completes is safe
+        because shadow[0] already holds N's snapshot.
+        """
+        buf = _make_buffer(4, torch.int32, torch.device("npu:0"))
+        # Iteration 0
+        buf.cpu.fill_(10)
+        buf.copy_to_gpu()  # shadow[0] <- 10, H2D shadow[0] -> gpu
+        # Iteration 1 (before gpu sync, simulating async overlap)
+        buf.cpu.fill_(20)
+        buf.copy_to_gpu()  # shadow[1] <- 20, H2D shadow[1] -> gpu
+        # GPU now should have iteration 1's data (20).
+        buf.gpu.npu.stream_synchronize()
+        assert buf.gpu.tolist() == [20, 20, 20, 20]
+        # shadow[0] should still hold 10 (iteration 0's snapshot).
+        assert buf._shadow_buffers[0].tolist() == [10, 10, 10, 10]
+        # shadow[1] should hold 20 (iteration 1's snapshot).
+        assert buf._shadow_buffers[1].tolist() == [20, 20, 20, 20]
+
+    def test_partial_copy_to_gpu(self):
+        buf = _make_buffer(8, torch.int32, torch.device("npu:0"))
+        buf.cpu.fill_(7)
+        buf.copy_to_gpu(n=3)
+        buf.gpu.npu.stream_synchronize()
+        assert buf.gpu[:3].tolist() == [7, 7, 7]

--- a/tests/ut/worker/test_utils.py
+++ b/tests/ut/worker/test_utils.py
@@ -10,10 +10,10 @@ iterations later), ``synchronize()`` ensures its prior H2D completed.
 """
 
 import torch
-import torch_npu  # noqa: F401  -- required for NPU device and Event
+import torch_npu  # noqa: F401
+from vllm.v1.utils import CpuGpuBuffer
 
 import vllm_ascend.patch.worker  # noqa: F401  -- triggers patch registration
-from vllm.v1.utils import CpuGpuBuffer
 
 
 def _make_buffer(size, dtype, device):

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -57,7 +57,6 @@ from vllm_ascend.spec_decode.utils import (
 )
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, is_rc_device, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
-from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN = 1
 _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
@@ -228,7 +227,7 @@ class NPUModelRunner310(NPUModelRunner):
             query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
             num_reqs_padded = num_reqs_padded + 1
 
-        copy_snapshot_to_gpu(query_start_loc)
+        query_start_loc.copy_to_gpu()
         return num_reqs_padded
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
@@ -452,13 +451,13 @@ class NPUModelRunner310(NPUModelRunner):
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
         if is_rc_device():
             self.query_start_loc.np[num_reqs + 1 :].fill(-1)
-        copy_snapshot_to_gpu(self.query_start_loc)
+        self.query_start_loc.copy_to_gpu()
 
         if self._has_gdn:
             self.gdn_query_start_loc.np[0] = 0
             self.gdn_query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
             self.gdn_query_start_loc.np[num_reqs + 1 :].fill(cu_num_tokens[-1])
-            copy_snapshot_to_gpu(self.gdn_query_start_loc)
+            self.gdn_query_start_loc.copy_to_gpu()
 
         torch.add(
             self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -60,6 +60,7 @@ import vllm_ascend.patch.worker.patch_kimi_k25  # noqa
 import vllm_ascend.patch.worker.patch_draft_quarot  # noqa
 import vllm_ascend.patch.worker.patch_eagle3_init  # noqa
 import vllm_ascend.patch.worker.patch_cudagraph  # noqa
+import vllm_ascend.patch.worker.patch_cpu_gpu_buffer  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_mtp  # noqa
 import vllm_ascend.patch.worker.patch_deepseek_v2  # noqa
 import vllm_ascend.patch.worker.patch_gqa_c8  # noqa

--- a/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
+++ b/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 """Patch CpuGpuBuffer with double-buffer rotation for async H2D safety.
 
 Under async scheduling, the next iteration's CPU writes to ``buffer.cpu``
@@ -5,14 +21,17 @@ can race with the previous iteration's in-flight ``non_blocking=True``
 H2D copy, corrupting the data seen by GPU consumers (e.g. query_start_loc).
 
 This patch keeps ``self.cpu`` / ``self.gpu`` / ``self.np`` addresses fixed
-(important for long-term references and graph capture/replay), but routes
-``copy_to_gpu`` through two pre-allocated pinned CPU shadow buffers that
-rotate each call. With ``max_concurrent_batches=1`` the double-buffer is
-naturally safe: by the time buffer[0] is reused (two iterations later),
-its previous H2D has certainly completed.
+(graph-compatible, long-term-ref safe), but routes ``copy_to_gpu`` through
+two pre-allocated pinned CPU shadow buffers that rotate each call. Each
+shadow is guarded by an NPU event: before reusing a shadow (two iterations
+after its previous use), ``synchronize()`` ensures the prior H2D has
+completed before the CPU writes to it. In the common case where one
+iteration's CPU preparation outlasts the H2D, ``synchronize()`` returns
+immediately with zero overhead.
 """
 
 import torch
+import torch_npu
 from vllm.v1.utils import CpuGpuBuffer
 
 _orig_init = CpuGpuBuffer.__init__
@@ -25,10 +44,14 @@ def _patched_init(self, *args, **kwargs):
     self._shadow_buffers = [
         torch.empty_like(self.cpu, pin_memory=pin_memory) for _ in range(2)
     ]
+    self._shadow_events = [torch.npu.Event() for _ in range(2)]
     self._shadow_idx = 0
 
 
 def _patched_copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
+    # Ensure this shadow's previous H2D has completed before CPU writes to it.
+    self._shadow_events[self._shadow_idx].synchronize()
+
     shadow = self._shadow_buffers[self._shadow_idx]
     if n is None:
         shadow.copy_(self.cpu)
@@ -36,6 +59,8 @@ def _patched_copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
     else:
         shadow[:n].copy_(self.cpu[:n])
         result = self.gpu[:n].copy_(shadow[:n], non_blocking=True)
+
+    self._shadow_events[self._shadow_idx].record()
     self._shadow_idx = (self._shadow_idx + 1) % 2
     return result
 

--- a/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
+++ b/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
@@ -41,9 +41,7 @@ _orig_copy_to_gpu = CpuGpuBuffer.copy_to_gpu
 def _patched_init(self, *args, **kwargs):
     _orig_init(self, *args, **kwargs)
     pin_memory = self.cpu.is_pinned()
-    self._shadow_buffers = [
-        torch.empty_like(self.cpu, pin_memory=pin_memory) for _ in range(2)
-    ]
+    self._shadow_buffers = [torch.empty_like(self.cpu, pin_memory=pin_memory) for _ in range(2)]
     self._shadow_events = [torch.npu.Event() for _ in range(2)]
     self._shadow_idx = 0
 

--- a/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
+++ b/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
@@ -31,7 +31,7 @@ immediately with zero overhead.
 """
 
 import torch
-import torch_npu
+import torch_npu  # noqa: F401
 from vllm.v1.utils import CpuGpuBuffer
 
 _orig_init = CpuGpuBuffer.__init__

--- a/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
+++ b/vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py
@@ -1,0 +1,44 @@
+"""Patch CpuGpuBuffer with double-buffer rotation for async H2D safety.
+
+Under async scheduling, the next iteration's CPU writes to ``buffer.cpu``
+can race with the previous iteration's in-flight ``non_blocking=True``
+H2D copy, corrupting the data seen by GPU consumers (e.g. query_start_loc).
+
+This patch keeps ``self.cpu`` / ``self.gpu`` / ``self.np`` addresses fixed
+(important for long-term references and graph capture/replay), but routes
+``copy_to_gpu`` through two pre-allocated pinned CPU shadow buffers that
+rotate each call. With ``max_concurrent_batches=1`` the double-buffer is
+naturally safe: by the time buffer[0] is reused (two iterations later),
+its previous H2D has certainly completed.
+"""
+
+import torch
+from vllm.v1.utils import CpuGpuBuffer
+
+_orig_init = CpuGpuBuffer.__init__
+_orig_copy_to_gpu = CpuGpuBuffer.copy_to_gpu
+
+
+def _patched_init(self, *args, **kwargs):
+    _orig_init(self, *args, **kwargs)
+    pin_memory = self.cpu.is_pinned()
+    self._shadow_buffers = [
+        torch.empty_like(self.cpu, pin_memory=pin_memory) for _ in range(2)
+    ]
+    self._shadow_idx = 0
+
+
+def _patched_copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
+    shadow = self._shadow_buffers[self._shadow_idx]
+    if n is None:
+        shadow.copy_(self.cpu)
+        result = self.gpu.copy_(shadow, non_blocking=True)
+    else:
+        shadow[:n].copy_(self.cpu[:n])
+        result = self.gpu[:n].copy_(shadow[:n], non_blocking=True)
+    self._shadow_idx = (self._shadow_idx + 1) % 2
+    return result
+
+
+CpuGpuBuffer.__init__ = _patched_init
+CpuGpuBuffer.copy_to_gpu = _patched_copy_to_gpu

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -52,8 +52,7 @@ from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
-from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
-from vllm_ascend.worker.utils import copy_snapshot_to_gpu
+from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
 
 if not vllm_version_is("0.24.0"):
     from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
@@ -608,7 +607,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             # num_reqs is already the padded version
             self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
-            copy_snapshot_to_gpu(self.query_start_loc)
+            self.query_start_loc.copy_to_gpu()
 
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -52,7 +52,7 @@ from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
-from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
+from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shared_expert_dp_enabled, vllm_version_is
 
 if not vllm_version_is("0.24.0"):
     from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -25,7 +25,6 @@ from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.utils import lmhead_tp_enable
-from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 
 class AscendStep3p5MTPProposer(AscendEagleProposer):
@@ -255,7 +254,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             num_computed_tokens_cpu = self.runner.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
 
             self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
-            copy_snapshot_to_gpu(self.query_start_loc)
+            self.query_start_loc.copy_to_gpu()
 
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -167,7 +167,7 @@ from vllm_ascend.utils import (
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.pcp_utils import PCPAsyncSpecDecodeRebuildResult, PCPManager
-from vllm_ascend.worker.utils import AscendKVBlockZeroer, copy_snapshot_to_gpu
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
 
 from vllm_ascend.ascend_forward_context import (  # isort: skip
     MoECommType,
@@ -846,7 +846,7 @@ class NPUModelRunner(GPUModelRunner):
                 query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
                 num_reqs_padded = num_reqs_padded + 1
 
-        copy_snapshot_to_gpu(query_start_loc)
+        query_start_loc.copy_to_gpu()
 
         return num_reqs_padded
 
@@ -1056,7 +1056,7 @@ class NPUModelRunner(GPUModelRunner):
 
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
-        copy_snapshot_to_gpu(self.query_start_loc)
+        self.query_start_loc.copy_to_gpu()
 
         # Now, query_start_loc is padded.
         # But gdn needs an unpadded one.
@@ -1066,7 +1066,7 @@ class NPUModelRunner(GPUModelRunner):
             self.gdn_query_start_loc.np[0] = 0
             self.gdn_query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
             self.gdn_query_start_loc.np[num_reqs + 1 :].fill(cu_num_tokens[-1])
-            copy_snapshot_to_gpu(self.gdn_query_start_loc)
+            self.gdn_query_start_loc.copy_to_gpu()
 
 
         # Compute optimistic seq_lens (assumes all draft tokens from previous
@@ -3525,10 +3525,10 @@ class NPUModelRunner(GPUModelRunner):
             cum_num_tokens = self._get_cumsum_and_arange(
             num_scheduled_tokens, self.query_pos.np)
             self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-            copy_snapshot_to_gpu(self.query_start_loc)
+            self.query_start_loc.copy_to_gpu()
             if self._has_gdn:
                 self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-                copy_snapshot_to_gpu(self.gdn_query_start_loc)
+                self.gdn_query_start_loc.copy_to_gpu()
 
             if not profile_cpp:
                 num_reqs_padded = self._pad_query_start_loc_for_fia(

--- a/vllm_ascend/worker/pcp_utils.py
+++ b/vllm_ascend/worker/pcp_utils.py
@@ -36,7 +36,6 @@ from vllm.v1.utils import CpuGpuBuffer
 from vllm_ascend.spec_decode.utils import correct_optimistic_seq_lens_cpu
 from vllm_ascend.utils import is_pd_decode_recompute_scheduler_enabled
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
-from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -1684,7 +1683,7 @@ class PCPManager:
             out=self.input_ids_pcp_full.cpu[:total_num_scheduled_tokens_pcp_full],
         )
         self.input_ids_pcp_full.copy_to_gpu(total_num_scheduled_tokens_pcp_full)
-        copy_snapshot_to_gpu(self.query_start_loc_pcp_full)
+        self.query_start_loc_pcp_full.copy_to_gpu()
         if self.use_async_scheduling:
             self._update_input_ids_pcp_full_ids(
                 input_batch,

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -6,16 +6,9 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import largest_power_of_2_divisor
 from vllm.v1.kv_cache_interface import FullAttentionSpec
-from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-
-
-def copy_snapshot_to_gpu(buffer: CpuGpuBuffer) -> torch.Tensor:
-    """Copy a pinned snapshot of a CPU buffer to its GPU buffer."""
-    cpu_snapshot = buffer.cpu.clone().pin_memory()
-    return buffer.gpu.copy_(cpu_snapshot, non_blocking=True)
 
 
 @triton.jit


### PR DESCRIPTION
### What this PR does / why we need it?
The CPU side of CpuGpuBuffer can be updated for the next iteration before a non-blocking H2D copy actually executes on the stream. Under async scheduling, this races with the device copy and exposes overwritten data to GPU consumers (e.g. query_start_loc out-of-bounds in logits_indices , torn attention metadata).

#12079 fixed this by cloning the CPU buffer into a fresh pinned snapshot before each H2D copy. While correct, it allocates and frees a pinned tensor on every iteration.

This PR takes a lower-overhead approach: monkey-patch CpuGpuBuffer with event-guarded double-buffer rotation .

- Adds vllm_ascend/patch/worker/patch_cpu_gpu_buffer.py : patches __init__ to pre-allocate two pinned CPU shadow buffers + two NPU events; patches copy_to_gpu to rotate through them.
- Keeps self.cpu / self.gpu / self.np addresses fixed (graph-compatible, long-term-ref safe) — only the H2D source switches between shadows.
- Before reusing a shadow, synchronize() its event to ensure the prior H2D completed. In the common case (CPU prep ≥ H2D time) this returns immediately with zero overhead ; the wait only happens for large buffers when CPU is faster than H2D — exactly the scenario where a race would otherwise occur.
- Reverts #12079's copy_snapshot_to_gpu helper and 11 call-site replacements, restoring original copy_to_gpu() calls (patch applies transparently at import time).
- All CpuGpuBuffer instances benefit automatically (query_start_loc, gdn, block_table, drafter, Step3.5 MTP, PCP, 310P) without per-call-site changes.

### Does this PR introduce _any_ user-facing change?
No.This is an internal correctness fix for asynchronous CPU-to-NPU buffer copies.
### How was this patch tested?
- Local unit tests: 8 passed (shadow rotation, address stability, event-guarded reuse, partial copy, alternating shadows isolation).
- No model weights were required.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
