### PR TITLE
[Performance][DSA-CP] Optimize local token metadata computation with fused Triton kernel and caching

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_build_local_metadata_triton.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_build_local_metadata_triton.py
@@ -1,0 +1,155 @@
+import gc
+
+import pytest
+import torch
+from vllm.triton_utils import HAS_TRITON, triton
+
+from vllm_ascend.ops.triton.dsa_cp import build_local_metadata_triton
+
+MAX_NUM_SEQS = 1024
+NUM_REQS_LIST = [1, 7, 32, 1024]
+TP_SIZES = [1, 8]
+SEEDS = [0]
+DEVICES = [f"npu:{0}"]
+DEFAULT_ATOL = 0
+DEFAULT_RTOL = 0
+
+
+def _run_native(
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    local_start: int,
+    local_end: int,
+    num_reqs: int,
+    compute_start_pos: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    local_query_start = torch.clamp(query_start_loc[:-1], min=local_start, max=local_end)
+    local_query_end = torch.clamp(query_start_loc[1:], min=local_start, max=local_end)
+    local_query_lens = local_query_end - local_query_start
+
+    local_query_start_loc = torch.zeros(MAX_NUM_SEQS + 1, dtype=torch.int32, device=query_start_loc.device)
+    local_query_start_loc[1 : num_reqs + 1] = torch.cumsum(local_query_lens, dim=0)
+
+    offset = query_start_loc[1:] - local_query_end
+    local_seq_lens = torch.zeros(MAX_NUM_SEQS, dtype=torch.int32, device=query_start_loc.device)
+    local_seq_lens[:num_reqs] = (local_query_lens > 0) * (seq_lens - offset)
+
+    start_pos = None
+    if compute_start_pos:
+        seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
+        start_pos = torch.zeros(MAX_NUM_SEQS, dtype=torch.int32, device=query_start_loc.device)
+        start_pos[:num_reqs] = seq_lens[:num_reqs] - seq_lens_q
+
+    return local_query_start_loc, local_seq_lens, start_pos
+
+
+def _run_triton(
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    local_start: int,
+    local_end: int,
+    num_reqs: int,
+    compute_start_pos: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    local_query_start_loc = torch.zeros(MAX_NUM_SEQS + 1, dtype=torch.int32, device=query_start_loc.device)
+    local_seq_lens = torch.zeros(MAX_NUM_SEQS, dtype=torch.int32, device=query_start_loc.device)
+    zero_i32 = torch.tensor([0], device=query_start_loc.device, dtype=torch.int32)
+    start_pos_out = (
+        torch.zeros(MAX_NUM_SEQS, dtype=torch.int32, device=query_start_loc.device) if compute_start_pos else zero_i32
+    )
+
+    build_local_metadata_triton[(1,)](
+        query_start_loc,
+        seq_lens,
+        local_query_start_loc,
+        local_seq_lens,
+        local_start,
+        local_end,
+        num_reqs,
+        start_pos_out,
+        BLOCK_NUM_REQS=triton.next_power_of_2(num_reqs),
+        COMPUTE_START_POS=compute_start_pos,
+    )
+
+    return local_query_start_loc, local_seq_lens, start_pos_out if compute_start_pos else None
+
+
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton is not available")
+@pytest.mark.parametrize("num_reqs", NUM_REQS_LIST)
+@pytest.mark.parametrize("tp_size", TP_SIZES)
+@pytest.mark.parametrize("tp_rank", range(max(TP_SIZES)))
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_build_local_metadata_triton(
+    num_reqs: int,
+    tp_size: int,
+    tp_rank: int,
+    seed: int,
+    device: str,
+) -> None:
+    torch.manual_seed(seed)
+    torch.set_default_device(device)
+
+    # only test first rank and last rank
+    if tp_rank == 0 or tp_rank == tp_size - 1:
+        return
+
+    # Build random seq_lens and compute local_start/local_end as the builder does.
+    num_input_tokens = max(num_reqs * 4, 32)
+    max_tpr = num_input_tokens // max(num_reqs, 1) * 2
+    seq_lens_list = torch.randint(1, max_tpr + 1, (num_reqs,)).tolist()
+    query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
+    for i in range(num_reqs):
+        query_start_loc[i + 1] = query_start_loc[i] + seq_lens_list[i]
+    seq_lens = torch.tensor(seq_lens_list, dtype=torch.int32, device=device)
+
+    num_tokens_pad = ((num_input_tokens + tp_size - 1) // tp_size) * tp_size
+    tokens_per_rank = num_tokens_pad // tp_size
+    local_start = tp_rank * tokens_per_rank
+    local_end = local_start + tokens_per_rank
+
+    for compute_start_pos in [True, False]:
+        trt_qsl, trt_sl, trt_sp = _run_triton(
+            query_start_loc,
+            seq_lens,
+            local_start,
+            local_end,
+            num_reqs,
+            compute_start_pos=compute_start_pos,
+        )
+        ref_qsl, ref_sl, ref_sp = _run_native(
+            query_start_loc,
+            seq_lens,
+            local_start,
+            local_end,
+            num_reqs,
+            compute_start_pos=compute_start_pos,
+        )
+
+        torch.testing.assert_close(
+            trt_qsl[: num_reqs + 1],
+            ref_qsl[: num_reqs + 1],
+            atol=DEFAULT_ATOL,
+            rtol=DEFAULT_RTOL,
+        )
+        torch.testing.assert_close(
+            trt_sl[:num_reqs],
+            ref_sl[:num_reqs],
+            atol=DEFAULT_ATOL,
+            rtol=DEFAULT_RTOL,
+        )
+        if compute_start_pos:
+            assert trt_sp is not None and ref_sp is not None
+            torch.testing.assert_close(
+                trt_sp[:num_reqs],
+                ref_sp[:num_reqs],
+                atol=DEFAULT_ATOL,
+                rtol=DEFAULT_RTOL,
+            )
+        else:
+            assert trt_sp is None and ref_sp is None
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()

--- a/tests/ut/ops/test_rope_proxy.py
+++ b/tests/ut/ops/test_rope_proxy.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm_ascend.ops.rope_dsv4 import RopeDataProxy
+
+# ──────────────────────────────────────────────
+# Equivalence: pad_to + slice  vs  pad-positions + gather + slice
+# ──────────────────────────────────────────────
+
+
+def _gather_rope(
+    positions: torch.Tensor, rope_cos: torch.Tensor, rope_sin: torch.Tensor
+) -> tuple[RopeDataProxy, RopeDataProxy]:
+    """Index ``rope_cos`` / ``rope_sin`` by ``positions`` and wrap in ``RopeDataProxy``.
+
+    This mirrors what ``get_cos_and_sin_dsa`` does internally — lookup the
+    RoPE table at the given positions — without depending on the global
+    ``_ROPE_STATE`` singleton.
+    """
+    cos_t = rope_cos[positions]  # [N, 1, 1, D]
+    sin_t = rope_sin[positions]
+    data_map = {"_test": {"default": (cos_t, sin_t)}}
+    return RopeDataProxy(data_map, is_cos=True), RopeDataProxy(data_map, is_cos=False)
+
+
+def _extract_tensor(proxy: RopeDataProxy) -> torch.Tensor:
+    """Extract the raw tensor from a singled-group proxy for comparison."""
+    for groups in proxy._data.values():
+        for tensors in groups.values():
+            return tensors[proxy.idx]
+    raise AssertionError("empty proxy")
+
+
+def _tp_params(num_input_tokens: int, tp_size: int):
+    """Yield ``(tp_rank, local_start, local_end, num_tokens_pad)`` for each TP rank."""
+    num_tokens_pad = ((num_input_tokens + tp_size - 1) // tp_size) * tp_size
+    tokens_per_rank = num_tokens_pad // tp_size
+    for tp_rank in range(tp_size):
+        local_start = tp_rank * tokens_per_rank
+        local_end = local_start + tokens_per_rank
+        yield tp_rank, local_start, local_end, num_tokens_pad
+
+
+class TestEquivalenceWithGatherSemantics:
+    """Verify that ``proxy.pad_to(N)[s:e]`` is semantically equivalent to
+    the original ``get_cos_and_sin_dsa`` approach of padding positions first.
+    """
+
+    # (num_input_tokens, tp_size)
+    CASES = [
+        (32, 8),
+        (33, 8),
+        (39, 8),
+        (40, 8),
+        (45, 8),
+        (1, 2),
+        (2, 4),
+        (7, 8),
+        (100, 16),
+        (102, 16),
+    ]
+
+    def test_all_cases(self):
+        for num_input_tokens, tp_size in self.CASES:
+            self._run_equivalence(num_input_tokens, tp_size)
+
+    def _run_equivalence(self, num_input_tokens: int, tp_size: int):
+        """Run the equivalence check for one (N, tp_size) combination."""
+        max_pos = num_input_tokens + tp_size + 5  # rope table large enough
+        rotary_dim = 32
+        rng = torch.Generator().manual_seed(42)
+        rope_cos = torch.randn(max_pos, 1, 1, rotary_dim, generator=rng)
+        rope_sin = torch.randn(max_pos, 1, 1, rotary_dim, generator=rng)
+        input_positions = torch.randint(0, max_pos - 1, (num_input_tokens,), generator=rng)
+
+        # Gather from UNPADDED positions — this is what the optimised path does.
+        ref_cos_proxy, ref_sin_proxy = _gather_rope(input_positions, rope_cos, rope_sin)
+
+        for tp_rank, local_start, local_end, num_tokens_pad in _tp_params(num_input_tokens, tp_size):
+            # ── Original path: pad positions → gather → slice ──
+            padded_pos = torch.nn.functional.pad(input_positions, (0, num_tokens_pad - num_input_tokens), value=0)
+            orig_cos_p, orig_sin_p = _gather_rope(padded_pos, rope_cos, rope_sin)
+            orig_cos = _extract_tensor(orig_cos_p[local_start:local_end])
+            orig_sin = _extract_tensor(orig_sin_p[local_start:local_end])
+
+            # ── Optimised path: gather → pad_to → slice ──
+            opt_cos_p = ref_cos_proxy.pad_to(num_tokens_pad)
+            opt_sin_p = ref_sin_proxy.pad_to(num_tokens_pad)
+            opt_cos = _extract_tensor(opt_cos_p[local_start:local_end])
+            opt_sin = _extract_tensor(opt_sin_p[local_start:local_end])
+
+            # ── Compare ──
+            # Real-token region: exact match expected.
+            real_end = min(local_end, num_input_tokens) - local_start
+            if real_end > 0:
+                assert torch.equal(orig_cos[:real_end], opt_cos[:real_end]), (
+                    f"cos mismatch in real region, N={num_input_tokens}, tp_size={tp_size}, rank={tp_rank}"
+                )
+                assert torch.equal(orig_sin[:real_end], opt_sin[:real_end]), (
+                    f"sin mismatch in real region, N={num_input_tokens}, tp_size={tp_size}, rank={tp_rank}"
+                )

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tp_group
+from vllm.triton_utils import HAS_TRITON, triton
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -25,7 +26,8 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
-from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
+from vllm_ascend.ops.rope_dsv4 import RopeDataProxy, get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
+from vllm_ascend.ops.triton.dsa_cp import build_local_metadata_triton
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -151,7 +153,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
     # Does this backend/builder support ACL Graphs for attention (default: no).
     aclgraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     hadamard = None
-    start_pos_prefill: torch.Tensor | None = None
+    start_pos_prefill: torch.Tensor
     req_sas_metadata: torch.Tensor
     req_qli_metadata: torch.Tensor
     block_size: int = 128
@@ -304,9 +306,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.common_ratio_to_sas_metadata["num_decode_tokens"] = self.num_decode_tokens
             self.common_ratio_to_sas_metadata["num_prefill_tokens"] = self.num_prefill_tokens
             input_positions = common_attn_metadata.positions[:num_input_tokens].long()
-            input_positions_cpu = common_attn_metadata.positions_cpu[:num_input_tokens].long()
             self.common_ratio_to_sas_metadata["input_positions"] = input_positions
-            self.common_ratio_to_sas_metadata["input_positions_cpu"] = input_positions_cpu
             cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=not has_prefill)
             self.common_ratio_to_sas_metadata["cos"] = cos
             self.common_ratio_to_sas_metadata["sin"] = sin
@@ -330,7 +330,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 self.common_ratio_to_sas_metadata["num_prefill_tokens"],
             )
             input_positions = self.common_ratio_to_sas_metadata["input_positions"]
-            input_positions_cpu = self.common_ratio_to_sas_metadata["input_positions_cpu"]
             cos, sin = self.common_ratio_to_sas_metadata["cos"], self.common_ratio_to_sas_metadata["sin"]
             self.seq_lens = self.common_ratio_to_sas_metadata["seq_lens"]
             self.seq_lens_cpu = self.common_ratio_to_sas_metadata["seq_lens_cpu"]
@@ -341,7 +340,13 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.block_table = common_attn_metadata.block_table_tensor[:num_reqs]
 
         req_metadata = self.build_req_metadata(
-            common_attn_metadata, input_positions, input_positions_cpu, num_input_tokens, num_reqs_actual, attn_state
+            common_attn_metadata,
+            input_positions,
+            num_input_tokens,
+            num_reqs_actual,
+            attn_state,
+            cos=cos,
+            sin=sin,
         )
 
         return self.metadata_cls(  # type: ignore
@@ -403,6 +408,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             common_attn_metadata=common_attn_metadata,
             input_positions=input_positions,
             num_input_tokens=num_input_tokens,
+            cos=cos,
+            sin=sin,
         )
 
         return self.metadata_cls(  # type: ignore
@@ -429,6 +436,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         common_attn_metadata: AscendCommonAttentionMetadata,
         input_positions: torch.Tensor,
         num_input_tokens: int,
+        cos: RopeDataProxy,
+        sin: RopeDataProxy,
     ) -> AscendDSAReqMetadata:
         """Build DSA-CP metadata for one draft step."""
         num_reqs = common_attn_metadata.num_reqs
@@ -437,7 +446,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
         has_prefill = _has_prefill(common_attn_metadata.attn_state)
 
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
         (
             local_start,
             local_end_with_pad,
@@ -445,28 +453,24 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
-            local_cos,
-            local_sin,
         ) = self._build_local_token_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
-            input_positions=input_positions,
             query_start_loc=query_start_loc,
             seq_lens=self.seq_lens[:num_reqs],
-            use_cache=False,
             local_query_start_loc=self.spec_local_query_start_loc[draft_index - 1],
             local_seq_lens=self.spec_local_seq_lens[draft_index - 1],
         )
         local_query_start_loc = local_query_start_loc.clone()
         local_seq_lens = local_seq_lens.clone()
+        local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
+        local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
 
-        _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu, _, _ = self._build_local_token_metadata(
+        _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu = self._build_local_token_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
-            input_positions=None,
             query_start_loc=query_start_loc_cpu,
             seq_lens=self.seq_lens_cpu[:num_reqs],
-            use_cache=False,
         )
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
@@ -554,14 +558,77 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_tokens = self.num_actual_tokens
         return min(num_tokens, num_tokens // self.compressor_ratio + common_attn_metadata.num_reqs)
 
+    def _ensure_device_local_metadata(
+        self,
+        num_reqs: int,
+        num_input_tokens: int,
+        query_start_loc: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ):
+        """Return device local metadata, cached across kv-cache groups.
+
+        The computation (clamp + cumsum + offset + mask) is identical for
+        all attention groups, so we compute once and cache the results.
+        """
+        cache = self.common_ratio_to_sas_metadata.get("_device_local")
+        if cache is None:
+            # Calc and cache device tensor results
+            (
+                local_start,
+                local_end_with_pad,
+                tokens_per_rank,
+                num_tokens_pad,
+                local_query_start_loc,
+                local_seq_lens,
+            ) = self._build_local_token_metadata(
+                num_reqs=num_reqs,
+                num_input_tokens=num_input_tokens,
+                query_start_loc=query_start_loc,
+                seq_lens=seq_lens,
+                local_query_start_loc=self.local_query_start_loc,
+                local_seq_lens=self.local_seq_lens,
+                start_pos_out=self.start_pos_prefill,
+            )
+            self.common_ratio_to_sas_metadata["_device_local"] = {
+                "local_start": local_start,
+                "local_end": local_end_with_pad,
+                "tokens_per_rank": tokens_per_rank,
+                "num_tokens_pad": num_tokens_pad,
+                "qsl": self.local_query_start_loc[: num_reqs + 1].clone(),
+                "sl": self.local_seq_lens[:num_reqs].clone(),
+                "sp": self.start_pos_prefill[:num_reqs].clone(),
+            }
+        else:
+            # copy from cache
+            assert cache is not None
+            local_start = cache["local_start"]
+            local_end_with_pad = cache["local_end"]
+            tokens_per_rank = cache["tokens_per_rank"]
+            num_tokens_pad = cache["num_tokens_pad"]
+            self.local_query_start_loc[: num_reqs + 1].copy_(cache["qsl"])
+            self.local_seq_lens[:num_reqs].copy_(cache["sl"])
+            self.start_pos_prefill[:num_reqs].copy_(cache["sp"])
+            local_query_start_loc = self.local_query_start_loc[: num_reqs + 1]
+            local_seq_lens = self.local_seq_lens[:num_reqs]
+
+        return (
+            local_start,
+            local_end_with_pad,
+            tokens_per_rank,
+            num_tokens_pad,
+            local_query_start_loc,
+            local_seq_lens,
+        )
+
     def build_req_metadata(
         self,
         common_attn_metadata: AscendCommonAttentionMetadata,
-        input_positions: torch.Tensor,
-        input_positions_cpu: torch.Tensor,
+        input_positions: torch.Tensor | None,
         num_input_tokens: int,
         num_reqs_actual: int | None,
         attn_state: AscendAttentionState,
+        cos: RopeDataProxy,
+        sin: RopeDataProxy,
     ) -> AscendDSAReqMetadata:
         """Build a single unified metadata for all requests (prefill + decode)."""
         num_reqs = common_attn_metadata.num_reqs
@@ -569,11 +636,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 
-        seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
-
-        # cos/sin for all tokens
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=not has_prefill)
-
+        # ── GPU local metadata (cached across kv-cache groups) ──
         (
             local_start,
             local_end_with_pad,
@@ -581,38 +644,48 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc,
             local_seq_lens,
-            local_cos,
-            local_sin,
-        ) = self._build_local_token_metadata(
+        ) = self._ensure_device_local_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
-            input_positions=input_positions,
             query_start_loc=query_start_loc,
             seq_lens=self.seq_lens[:num_reqs],
-            use_cache=not has_prefill,
-            local_query_start_loc=self.local_query_start_loc,
-            local_seq_lens=self.local_seq_lens,
         )
-        local_seq_lens_q = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
 
-        _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu, _, _ = self._build_local_token_metadata(
-            num_reqs=num_reqs,
-            num_input_tokens=num_input_tokens,
-            input_positions=None,
-            query_start_loc=query_start_loc_cpu,
-            seq_lens=self.seq_lens_cpu[:num_reqs],
-            use_cache=False,
-        )
+        # RoPE local slices (cached across kv-cache groups: same cos/sin,
+        # num_tokens_pad, local_start, local_end_with_pad for all groups)
+        if input_positions is not None:
+            rope_local = self.common_ratio_to_sas_metadata.get("_rope_local")
+            if rope_local is None:
+                local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
+                local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
+                self.common_ratio_to_sas_metadata["_rope_local"] = (local_cos, local_sin)
+            else:
+                assert rope_local is not None
+                local_cos, local_sin = rope_local
+        else:
+            local_cos = None
+            local_sin = None
+
+        # ── CPU local metadata (cached) ──
+        cpu_cache = self.common_ratio_to_sas_metadata.get("_cpu_local")
+        if cpu_cache is None:
+            _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu = self._build_local_token_metadata(
+                num_reqs=num_reqs,
+                num_input_tokens=num_input_tokens,
+                query_start_loc=query_start_loc_cpu,
+                seq_lens=self.seq_lens_cpu[:num_reqs],
+            )
+            self.common_ratio_to_sas_metadata["_cpu_local"] = {
+                "qsl_cpu": local_query_start_loc_cpu.clone(),
+                "sl_cpu": local_seq_lens_cpu.clone(),
+            }
+        else:
+            assert cpu_cache is not None
+            local_query_start_loc_cpu = cpu_cache["qsl_cpu"]
+            local_seq_lens_cpu = cpu_cache["sl_cpu"]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seqlen = max(1, int(local_seq_lens_cpu.max().item()))
-
-        # start_pos: context length before current query
-        start_pos = self.seq_lens[:num_reqs] - seq_lens_q
-
-        assert self.start_pos_prefill is not None
-        self.start_pos_prefill.fill_(0)
-        self.start_pos_prefill[:num_reqs] = start_pos
 
         if num_reqs_actual is None:
             num_reqs_actual = num_reqs
@@ -699,12 +772,11 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self,
         num_reqs,
         num_input_tokens,
-        input_positions,
         query_start_loc,
         seq_lens,
-        use_cache,
         local_query_start_loc=None,
         local_seq_lens=None,
+        start_pos_out=None,
     ):
         """
         For example:
@@ -735,42 +807,51 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             local_query_start_loc.fill_(0)
             local_seq_lens.fill_(0)
 
-        # Intersect each request's global token interval with this rank's local
-        # token interval, then build the per-rank query_start_loc from lengths.
-        local_query_start = torch.clamp(query_start_loc[:-1], min=local_start, max=local_end)
-        local_query_end = torch.clamp(query_start_loc[1:], min=local_start, max=local_end)
-        local_query_lens = local_query_end - local_query_start
-        if local_query_start_loc is not None:
-            local_query_start_loc[1 : num_reqs + 1] = torch.cumsum(local_query_lens, dim=0)
-        else:
-            local_query_start_loc = torch.cat(
-                [
-                    torch.tensor([0], dtype=local_query_lens.dtype, device=local_query_lens.device),
-                    torch.cumsum(local_query_lens, dim=0),
-                ],
-                0,
+        if query_start_loc.device.type != "cpu" and HAS_TRITON:
+            assert local_query_start_loc is not None and local_seq_lens is not None
+            # Use next-power-of-2 block size to avoid wasted compute.
+            build_local_metadata_triton[(1,)](
+                query_start_loc,
+                seq_lens,
+                local_query_start_loc,
+                local_seq_lens,
+                local_start,
+                local_end,
+                num_reqs,
+                start_pos_out if start_pos_out is not None else self._zero_i32,
+                BLOCK_NUM_REQS=triton.next_power_of_2(num_reqs),
+                COMPUTE_START_POS=start_pos_out is not None,
             )
-
-        # For requests that cross the local slice boundary, offset removes the
-        # tokens that live on later ranks so local_seq_lens matches local queries.
-        offset = query_start_loc[1:] - local_query_end
-        if local_seq_lens is not None:
-            local_seq_lens[:num_reqs] = (local_query_lens > 0) * (seq_lens - offset)
         else:
-            local_seq_lens = (local_query_lens > 0) * (seq_lens - offset)
+            # torch fallback.
+            # Intersect each request's global token interval with this rank's local
+            # token interval, then build the per-rank query_start_loc from lengths.
+            local_query_start = torch.clamp(query_start_loc[:-1], min=local_start, max=local_end)
+            local_query_end = torch.clamp(query_start_loc[1:], min=local_start, max=local_end)
+            local_query_lens = local_query_end - local_query_start
+            if local_query_start_loc is not None:
+                local_query_start_loc[1 : num_reqs + 1] = torch.cumsum(local_query_lens, dim=0)
+            else:
+                local_query_start_loc = torch.cat(
+                    [
+                        torch.tensor([0], dtype=local_query_lens.dtype, device=local_query_lens.device),
+                        torch.cumsum(local_query_lens, dim=0),
+                    ],
+                    0,
+                )
 
-        # RoPE tables are generated on the padded global positions first, then
-        # sliced to this rank so local tokens keep their original positions.
-        if input_positions is not None:
-            pad_tokens = num_tokens_pad - input_positions.shape[0]
-            if pad_tokens > 0:
-                input_positions = F.pad(input_positions, (0, pad_tokens), value=0)
-            local_cos, local_sin = get_cos_and_sin_dsa(input_positions, use_cache=use_cache)
-            local_cos = local_cos[local_start:local_end]
-            local_sin = local_sin[local_start:local_end]
-        else:
-            local_cos = None
-            local_sin = None
+            # For requests that cross the local slice boundary, offset removes the
+            # tokens that live on later ranks so local_seq_lens matches local queries.
+            offset = query_start_loc[1:] - local_query_end
+            if local_seq_lens is not None:
+                local_seq_lens[:num_reqs] = (local_query_lens > 0) * (seq_lens - offset)
+            else:
+                local_seq_lens = (local_query_lens > 0) * (seq_lens - offset)
+
+            if start_pos_out is not None:
+                seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
+                start_pos_out[:num_reqs] = seq_lens[:num_reqs] - seq_lens_q
+
         return (
             local_start,
             local_end,
@@ -778,8 +859,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_tokens_pad,
             local_query_start_loc[: num_reqs + 1],
             local_seq_lens[:num_reqs],
-            local_cos,
-            local_sin,
         )
 
     def _get_cmp_seqlens_for_metadata(self, has_prefill):

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -683,6 +683,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             assert cpu_cache is not None
             local_query_start_loc_cpu = cpu_cache["qsl_cpu"]
             local_seq_lens_cpu = cpu_cache["sl_cpu"]
+        local_seq_lens_q = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seqlen = max(1, int(local_seq_lens_cpu.max().item()))

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch_npu
 from vllm.config import VllmConfig
 from vllm.platforms import current_platform
@@ -24,6 +25,26 @@ class RopeDataProxy:
     def __init__(self, data_map, is_cos=True):
         self._data = data_map
         self.idx = 0 if is_cos else 1
+
+    def pad_to(self, target_len: int, dim: int = 0) -> "RopeDataProxy":
+        """
+        Return a new proxy whose underlying tensors are padded to ``target_len`` along ``dim``.
+        """
+        new_data: dict = {}
+        for config_key, groups in self._data.items():
+            new_data[config_key] = {}
+            for group_name, (cos_t, sin_t) in groups.items():
+                pad_size = target_len - cos_t.shape[dim]
+                if pad_size > 0:
+                    ndim = cos_t.ndim
+                    pad = [0] * (2 * ndim)
+                    # F.pad pads from the last dimension backward:
+                    #   (dim_{N-1}_left, dim_{N-1}_right, ..., dim_0_left, dim_0_right)
+                    pad[-(1 + 2 * dim)] = pad_size  # right side of the target dim
+                    cos_t = F.pad(cos_t, pad)
+                    sin_t = F.pad(sin_t, pad)
+                new_data[config_key][group_name] = (cos_t, sin_t)
+        return RopeDataProxy(new_data, is_cos=(self.idx == 0))
 
     def __getitem__(self, index):
         if not isinstance(index, str):

--- a/vllm_ascend/ops/triton/dsa_cp.py
+++ b/vllm_ascend/ops/triton/dsa_cp.py
@@ -1,0 +1,41 @@
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def build_local_metadata_triton(
+    query_start_loc_ptr,  # [num_reqs + 1], int32
+    seq_lens_ptr,  # [num_reqs], int32
+    local_query_start_loc_ptr,  # [max_num_seqs + 1], int32  (output, pre-zeroed)
+    local_seq_lens_ptr,  # [max_num_seqs], int32      (output, pre-zeroed)
+    local_start,
+    local_end,
+    num_reqs,
+    start_pos_out_ptr,  # [max_num_seqs], int32      (output)
+    BLOCK_NUM_REQS: tl.constexpr,
+    COMPUTE_START_POS: tl.constexpr,
+):
+    """Fused NPU kernel for local token metadata computation
+
+    reduce kernel launch overhead.
+    """
+    offsets = tl.arange(0, BLOCK_NUM_REQS)
+    mask = offsets < num_reqs
+
+    q_start = tl.load(query_start_loc_ptr + offsets, mask=mask, other=0)
+    q_end = tl.load(query_start_loc_ptr + offsets + 1, mask=mask, other=0)
+    seq_len = tl.load(seq_lens_ptr + offsets, mask=mask, other=0)
+
+    lqs = tl.maximum(tl.minimum(q_start, local_end), local_start)
+    lqe = tl.maximum(tl.minimum(q_end, local_end), local_start)
+    lql = lqe - lqs
+
+    cum = tl.cumsum(lql, axis=0)
+
+    tl.store(local_query_start_loc_ptr + 1 + offsets, cum, mask=mask)
+
+    offset = q_end - lqe
+    result = tl.where(lql > 0, seq_len - offset, 0)
+    tl.store(local_seq_lens_ptr + offsets, result, mask=mask)
+
+    if COMPUTE_START_POS:
+        tl.store(start_pos_out_ptr + offsets, seq_len - (q_end - q_start), mask=mask)


### PR DESCRIPTION
### What this PR does / why we need it?

In DSA context-parallel mode, `AscendDSACPMetadataBuilder.build()` runs once per attention group within a step. Under DeepSeek-V4's dsv4 attention, there can be 8 build() per step, and each build independently recomputes metadata from scratch.

Across all groups, the following data are identical:

- `query_start_loc`, `seq_lens`, `num_reqs`, `num_input_tokens`
- Clamp + cumsum + offset + mask results
- RoPE local slices
- `start_pos`

This PR caches these intermediate results so that only the first group computes them; subsequent groups reuse the cached values. Additionally, the fused `_build_local_metadata_npu_kernel` is introduced to reduce kernel launch overhead.

The metadata building phase dropped from approximately 23ms to 10ms per step (measured on DeepSeek-V4 Flash, mtp=1).

before (main)

<img width="1618" height="485" alt="c5fa490ea22b40dbaafa4c2dab1f760d_IMAGE_1784202330638" src="https://github.com/user-attachments/assets/f7145c7f-f78a-4fd0-b367-c45ef95d66d3" />

after (this pr)

<img width="889" height="479" alt="7281c93267ea4205b34526f9fb6ebd3a_IMAGE_1784202321384" src="https://github.com/user-attachments/assets/eeb12a34-17bd-4be7-8b8b-8f94c6c2ee1b" />

**Changes summary**

- New `_ensure_gpu_local_metadata` method that computes GPU local metadata once and caches the result in `common_ratio_to_sas_metadata["_gpu_local"]`.
- Cross-group caching for CPU local metadata (`"_cpu_local"`) and RoPE local slices (`"_rope_local"`).
- New Triton kernel `_build_local_metadata_npu_kernel` that fuses clamp, cumsum, offset, mask, and start_pos into a single kernel launch.
- Refactored `build_req_metadata` to use the cached results and inlined RoPE slicing.
- Cleaned up `_build_local_token_metadata` by removing unused parameters (`input_positions`, `use_cache`, `seq_lens_q`).

### Does this PR introduce *any* user-facing change?

No. Behavior is identical.

### How was this patch tested?

- Added a unit test for `RopeDataProxy.pad_to`.
- GMS8K evaluation results passed.

```
before (main)
+---------+-----------+----------+----------+-------+---------+---------+
| Model   | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=========+===========+==========+==========+=======+=========+=========+
| dsv4-f    | gsm8k     | mean_acc | main     |  1319 |  0.9682 | default |
+---------+-----------+----------+----------+-------+---------+---------+ 
```

aftet (this pr)

```
+---------+-----------+----------+----------+-------+---------+---------+
| Model   | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=========+===========+==========+==========+=======+=========+=========+
| dsv4-f    | gsm8k     | mean_acc | main     |  1319 |  0.9712 | default |
+---------+-----------+----------+----------+-------+---------+---------+ 
```


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
