### PR TITLE
[BugFix][MRV2] Fix DP for eager mode

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -958,11 +958,6 @@ class NPUPlatform(Platform):
         is_draft_model_prefill = False
         sinks = False
         in_profile_run = get_mrv2_in_profile_run()
-        moe_comm_type = select_moe_comm_method(
-            num_tokens,
-            vllm_config,
-        )
-        moe_comm_method = get_moe_comm_method(moe_comm_type)
 
         tp_world_size = get_tensor_model_parallel_world_size()
 
@@ -999,6 +994,15 @@ class NPUPlatform(Platform):
                 pad_size = padded_length - num_tokens
         else:
             max_tokens_across_dp = num_tokens
+
+        # NOTE: Must use max_tokens_across_dp instead of num_tokens for MoE comm method selection
+        # to ensure consistent communication method across all DP ranks
+        moe_comm_type = select_moe_comm_method(
+            max_tokens_across_dp,
+            vllm_config,
+        )
+        moe_comm_method = get_moe_comm_method(moe_comm_type)
+
         mc2_mask = None
         padded_num_tokens = None
         if num_tokens is not None:


### PR DESCRIPTION
### What this PR does / why we need it?
- MoE Communication Method Selection: Moved the selection of the MoE communication method to occur after the calculation of max_tokens_across_dp to ensure consistency across all Data Parallel (DP) ranks.
- Bug Fix: Resolved an issue in eager mode where using the local num_tokens instead of the global max_tokens_across_dp caused inconsistencies in communication method selection.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

export PYTHONPATH=/mnt/share/z00909740/dev/vllm:$PYTHONPATH
export VLLM_VERSION=0.25.0
export HCCL_OP_EXPANSION_MODE="AIV"
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export VLLM_ASCEND_BALANCE_SCHEDULING=1
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10

export VLLM_TORCH_PROFILER_WITH_STACK=0
export HCCL_BUFFSIZE=4096
export TASK_QUEUE_ENABLE=1
export VLLM_ENGINE_READY_TIMEOUT_S=6000
export VLLM_USE_V2_MODEL_RUNNER=1

vllm serve /mnt/weight/DeepSeek-V3.1-w4a8-perchannle \
    --host xx.xx.xx.xx \
    --port xxxx \
    --data-parallel-size 2 \
    --tensor-parallel-size 8 \
    --quantization ascend \
    --seed 1024 \
    --served-model-name deepseek_v3 \
    --enable-expert-parallel \
    --max-num-seqs 32 \
    --max-model-len 5500 \
    --max-num-batched-tokens 5000 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --gpu-memory-utilization 0.92 \
    --no-async-scheduling \
    --compilation-config '{"cudagraph_mode": "PIECEWISE"}' \


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
