### PR TITLE
[Doc] Remove stray space in README language anchor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ vLLM Ascend Plugin
 </p>
 
 <p align="center">
-<a ><b>English</b></a> | <a href="README.zh.md"><b>中文</b></a>
+<a><b>English</b></a> | <a href="README.zh.md"><b>中文</b></a>
 </p>
 
 ---


### PR DESCRIPTION
### What this PR does / why we need it?
Removes a stray space inside the empty anchor tag (`<a >`) in the README language switcher, so the HTML is well-formed.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Doc-only change; rendered README locally.
- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
