### PR TITLE
test: trigger CI on shanghai-001 runner

### DIFF
--- a/.github/workflows/test_shanghai_runner.yml
+++ b/.github/workflows/test_shanghai_runner.yml
@@ -1,0 +1,13 @@
+name: Test Shanghai Runner
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test_shanghai_runner.yml'
+
+jobs:
+  test-runner:
+    runs-on: linux-aarch64-950dt-8
+    steps:
+      - name: Hello Shanghai
+        run: echo "Shanghai-001 runner is alive! $(uname -m)"

--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ We welcome and value any contributions and collaborations:
 ## License
 
 Apache License 2.0, as found in the [LICENSE](./LICENSE) file.
+# test shanghai-001 runner


### PR DESCRIPTION
Test PR to verify the new shanghai-001 cluster runner.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
