### PR TITLE
[Bugfix] Fix W4A4 MXFP4 weight scale K-dim mismatch

### DIFF
--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -19,8 +19,10 @@ from collections.abc import Callable
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 import torch_npu
 from vllm.config import CompilationMode, get_current_vllm_config
+from vllm.utils.math_utils import cdiv
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -60,7 +62,7 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
     ) -> dict[str, Any]:
         params_dict = {}
-        params_dict["weight_scale"] = torch.empty(output_size, input_size // self.group_size, dtype=torch.uint8)
+        params_dict["weight_scale"] = torch.empty(output_size, cdiv(input_size, self.group_size), dtype=torch.uint8)
         return params_dict
 
     def apply(
@@ -110,7 +112,12 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
         """
 
         n_dim, k_dim = layer.weight_scale.data.shape
-        layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
+        # Shape should be padded if it cannot be divided by 2
+        if k_dim % 2 != 0:
+            layer.weight_scale.data = F.pad(layer.weight_scale.data, (0, 1), mode="constant", value=0)
+            layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2 + 1, 2)
+        else:
+            layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
         layer.weight.data = layer.weight.data.transpose(0, 1)
         layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1)
 


### PR DESCRIPTION
### What this PR does / why we need it?
  Serving a W4A4 MXFP4 model(Qwen3.5-27B vit mxfp4) whose K is not a multiple of 64 fails at inference:
```
  aclnnQuantMatmulV5 ... error code 161002 Invalid_Argument(EZ0027):
  x1Scale K 68, x2Scale K 67 ... scale K must equal K ceildivided by 64.
```
  In `w4a4_mxfp4.py`, `get_pergroup_param` allocates `weight_scale` with floor division (`input_size // group_size`), dropping the trailing block for non-aligned K (67 blocks), while the activation scale uses ceil (68 blocks). The 68 vs 67 mismatch is rejected by the op. The MXFP8 linear scheme avoids this via `cdiv` + odd-length padding; MXFP4 was missing both.

 Fix

  Align the MXFP4 linear scheme with MXFP8 linear:
  - `get_pergroup_param`: use `cdiv(input_size, group_size)`.
  - `process_weights_after_loading`: pad `weight_scale` by one column when its K
    is odd before reshape.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?


- vLLM version: v0.25.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
