### PR TITLE
[v0.23.0][Performance] Use CPU slot mapping for regular decode

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1229,13 +1229,10 @@ class NPUModelRunner(GPUModelRunner):
         if self._needs_seq_lens_cpu_sync and async_spec_decode_active:
             self._correct_optimistic_seq_lens_cpu(num_reqs)
 
-        # For non-PCP, compute slot_mapping on GPU. PCP slot_mapping was
-        # already computed on GPU before PCP split the positions.
+        # For non-PCP, compute slot_mapping on CPU and copy it to the device.
         if self.pcp_size <= 1:
-            self.input_batch.block_table.compute_slot_mapping(
-                num_reqs,
-                self.query_start_loc.gpu[: num_reqs + 1],
-                self.positions[:total_num_scheduled_tokens],
+            self.input_batch.block_table.compute_slot_mapping_draft(
+                req_indices, positions_np
             )
 
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):


### PR DESCRIPTION
## Summary

Reuse the existing CPU slot mapping implementation for regular non-PCP decode to avoid the Triton slot mapping kernel overhead on the `releases/v0.23.0` baseline.

## Motivation

The Triton slot mapping kernel path introduced upstream adds meaningful overhead for regular (non-PCP) decode steps. Since the CPU path is already implemented and well-validated, routing regular decode through it removes the extra kernel launch and index-math cost without any correctness change.

## Changes

- `vllm_ascend/worker/model_runner_v1.py` (+3 / -6): route regular decode slot mapping to the existing CPU path.

## Validation

- Non-PCP decode functional tests pass.
- Slot mapping output matches the Triton kernel path bit-for-bit on the covered shapes.

## Test plan

- [ ] Run e2e single-card Qwen tests
- [ ] Confirm no regression in decode throughput on the target SoC
- [ ] Verify PCP path is untouched

---

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
