### PR TITLE
[BugFix][Ops] Remove QSFA tiling debug printf

### DIFF
--- a/csrc/attention/kv_quant_sparse_flash_attention/op_host/kv_quant_sparse_flash_attention_tiling.cpp
+++ b/csrc/attention/kv_quant_sparse_flash_attention/op_host/kv_quant_sparse_flash_attention_tiling.cpp
@@ -1669,7 +1669,6 @@ ge::graphStatus QSFAInfoParser::GetAttrParaInfo()
     opParamInfo_.tileSize = attrs->GetAttrPointer<int64_t>(TILE_SIZE_ATTR_INDEX);
     opParamInfo_.ropeHeadDim = attrs->GetAttrPointer<int64_t>(ROPE_HEAD_DIM_ATTR_INDEX);
     opParamInfo_.returnSoftmaxLse = attrs->GetAttrPointer<bool>(RETURN_SOFTMAX_LSE_ATTR_INDEX);
-    printf(" ============ tiling入口处 =========== \n");
     OP_LOGE("ccccc"," ============ tiling入口 ============");
     return ge::GRAPH_SUCCESS;
 }


### PR DESCRIPTION
### What this PR does / why we need it?

Removes the unconditional `printf` from `QSFAInfoParser::GetAttrParaInfo()` that was reintroduced when #12149 reverted #11969.

The debug output is emitted during QSFA tiling parameter parsing and should not be printed directly to standard output. This PR is intentionally scoped to the single `printf` removal; the existing operator log remains unchanged.

### Does this PR introduce _any_ user-facing change?

No. It only removes unintended debug output.

### How was this patch tested?

- `git diff --check`
- `bash format.sh ci`: all checks relevant to this change passed, including `clang-format`. The release branch still reports the unrelated baseline ShellCheck `SC2328` at `csrc/build.sh:524`.

NPU runtime testing is not required for this one-line logging cleanup.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
