### PR TITLE
[CI] Drop vllm main e2e test for v0.24.0rc

### DIFF
--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -184,7 +184,6 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.e2e-test.outputs.main_commit }}
           - ${{ needs.e2e-test.outputs.release_tag }}
     needs: [e2e-test]
     if: ${{ needs.e2e-test.outputs.has_tests == 'true' }}

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -212,7 +212,6 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.lint-and-select-tests.outputs.main_commit }}
           - ${{ needs.lint-and-select-tests.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:


### PR DESCRIPTION
### What this PR does / why we need it?

Drop vllm main e2e test for v0.24.0rc

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
