### PR TITLE
[Test][Misc] Update Kimi weekly single-node test configs to K2.6

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -89,12 +89,12 @@ a3:
       - name: deepseek-v3-2-w8a8
         os: linux-aarch64-a3-16
         config_file_path: DeepSeek-V3.2-W8A8_A3_weekly.yaml
-      - name: kimi-k2.5
+      - name: kimi-k2.5-weekly
         os: linux-aarch64-a3-16
-        config_file_path: Kimi-K2.5.yaml
+        config_file_path: Kimi-K2.6.yaml
       - name: kimi-k2.5-32k-512
         os: linux-aarch64-a3-16
-        config_file_path: Kimi-K2.5-32k-512.yaml
+        config_file_path: Kimi-K2.6-32k-512.yaml
       - name: Qwen3.5-397B-A17B-w8a8-mtp
         os: linux-aarch64-a3-16
         config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3_weekly.yaml
@@ -123,10 +123,6 @@ a3:
 310p:
   single_node:
     test_config:
-      # pytest-driven tests
-      - name: engine-func-tests-310p
-        os: linux-aarch64-310p-4
-        tests: tests/e2e/weekly/single_node/engine_func_test_robot
       - name: Qwen3-8B-w8a8sc-310p
         os: linux-aarch64-310p-4
         config_file_path: Qwen3-8B-w8a8sc-310p.yaml

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -89,7 +89,7 @@ a3:
       - name: deepseek-v3-2-w8a8
         os: linux-aarch64-a3-16
         config_file_path: DeepSeek-V3.2-W8A8_A3_weekly.yaml
-      - name: kimi-k2.5-weekly
+      - name: kimi-k2.6-weekly
         os: linux-aarch64-a3-16
         config_file_path: Kimi-K2.6.yaml
       - name: kimi-k2.5-32k-512

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -287,7 +287,9 @@
       "vllm-ascend/Qwen3-14B-w8a8sc-310-vllm-tp1",
       "vllm-ascend/Qwen3-32B-w8a8sc-310-vllm-tp4",
       "Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp",
-      "Eco-Tech/DeepSeek-V3.1-Terminus-w8a8-mtp-QuaRot"
+      "Eco-Tech/DeepSeek-V3.1-Terminus-w8a8-mtp-QuaRot",
+      "Eco-Tech/Kimi-K2.6-w4a8",
+      "lightseekorg/kimi-k2.6-eagle3"
     ],
     "datasets": [
       "vllm-ascend/GSM8K-in1024-bs210",

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.6-32k-512.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.6-32k-512.yaml
@@ -93,8 +93,8 @@ _benchmark_TPOT20_32K_0_5K_pc90: &_benchmark_TPOT20_32K_0_5K_pc90
 # ==========================================
 
 test_cases:
-  - name: "Kimi-K2.5-W4A8-TOPT50-32k-0.5k"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT50-32k-0.5k"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
       HCCL_BUFFSIZE: "450"
@@ -112,13 +112,13 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[16,32,48,64,80,96,112,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp": true}'
     benchmarks:
       perf: *_benchmark_TPOT50_32K_0_5K
-  - name: "Kimi-K2.5-W4A8-TOPT50-32k-0.5k-prefix-cache90"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT50-32k-0.5k-prefix-cache90"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
       HCCL_BUFFSIZE: "450"
@@ -136,13 +136,13 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[16,32,48,64,80,96,112,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp": true}'
     benchmarks:
       perf: *_benchmark_TPOT50_32K_0_5K_pc90
-  - name: "Kimi-K2.5-W4A8-TOPT20-32k-0.5k"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT20-32k-0.5k"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
       HCCL_BUFFSIZE: "450"
@@ -160,13 +160,13 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[16,32,48,64,80,96,112,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp": true}'
     benchmarks:
       perf: *_benchmark_TPOT20_32K_0_5K
-  - name: "Kimi-K2.5-W4A8-TOPT20-32k-0.5k-pc90"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT20-32k-0.5k-pc90"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
       HCCL_BUFFSIZE: "450"
@@ -184,7 +184,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[16,32,48,64,80,96,112,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp": true}'
     benchmarks:

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.6.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.6.yaml
@@ -144,8 +144,8 @@ _benchmark_TPOT20_128K_1K_pc90: &_benchmark_TPOT20_128K_1K_pc90
 # ==========================================
 
 test_cases:
-  - name: "Kimi-K2.5-W4A8-Case"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-Case"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
     server_cmd: *server_cmd
@@ -161,13 +161,13 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[48,64,80,96,112,128], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp":true}'
     benchmarks:
       perf: *_benchmark_TPOT50_3_5k_1_5k
-  - name: "Kimi-K2.5-W4A8-TOPT50-16k-1k"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT50-16k-1k"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
     server_cmd: *server_cmd
@@ -183,13 +183,13 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[4,8,12,16,20], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp":true}'
     benchmarks:
       perf: *_benchmark_TPOT50_16K_1K
-  - name: "Kimi-K2.5-W4A8-TOPT20-16k-1k"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT20-16k-1k"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
     server_cmd: *server_cmd
@@ -204,7 +204,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[8], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":7}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":7}'
       - "--tool-call-parser"
       - "kimi_k2"
       - "--reasoning-parser"
@@ -212,8 +212,8 @@ test_cases:
       - "--enable-auto-tool-choice"
     benchmarks:
       perf: *_benchmark_TPOT20_16K_1K
-  - name: "Kimi-K2.5-W4A8-TOPT50-64k-1k-pc90"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT50-64k-1k-pc90"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
       HCCL_BUFFSIZE: "400"
@@ -238,11 +238,11 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[8,12], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
     benchmarks:
       perf: *_benchmark_TPOT50_64K_1K_pc90
-  - name: "Kimi-K2.5-W4A8-TOPT20-64k-1k-pc90"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT20-64k-1k-pc90"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
       HCCL_BUFFSIZE: "400"
@@ -279,15 +279,15 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[4,8,16], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--mm-processor-cache-gb"
       - "0"
       - "--mm-encoder-tp-mode"
       - "data"
     benchmarks:
       perf: *_benchmark_TPOT20_64K_1K_pc90
-  - name: "Kimi-K2.5-W4A8-TOPT50-128k-1k-pc90"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT50-128k-1k-pc90"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
     server_cmd: *server_cmd
@@ -302,13 +302,13 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[4,8,12,16,32], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp":true}'
     benchmarks:
       perf: *_benchmark_TPOT50_128K_1K_pc90
-  - name: "Kimi-K2.5-W4A8-TOPT20-128k-1k-pc90"
-    model: "Eco-Tech/Kimi-K2.5-W4A8"
+  - name: "Kimi-K2.6-W4A8-TOPT20-128k-1k-pc90"
+    model: "Eco-Tech/Kimi-K2.6-w4a8"
     envs:
       <<: *envs
     server_cmd: *server_cmd
@@ -323,7 +323,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_capture_sizes":[4,8,12,16,32], "cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--speculative-config"
-      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
+      - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens":3}'
       - "--additional-config"
       - '{"enable_shared_expert_dp":true}'
     benchmarks:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the weekly single-node end-to-end test configurations for Kimi, upgrading the model version from Kimi-K2.5 to Kimi-K2.6. This includes renaming the configuration files and updating the model paths, speculative model paths, and test case names accordingly.

### Does this PR introduce _any_ user-facing change?

No. This is a test configuration update and does not affect any user-facing APIs or behaviors.

### How was this patch tested?

Tested via the weekly single-node end-to-end test suite with the updated Kimi-K2.6 configurations.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
