### PR TITLE
[BugFix] Disable multistream_overlap_shared_expert when enable_fused_mc2 is enabled

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -648,7 +648,7 @@ Before you start, please
             --served-model-name glm-52 \
             --max-model-len 135000 \
             --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_sparse_c8":false, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -718,7 +718,7 @@ Before you start, please
             --served-model-name glm-52 \
             --max-model-len 135000 \
             --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_sparse_c8":false, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -790,7 +790,7 @@ Before you start, please
             --max-num-batched-tokens 164 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"enable_sparse_c8":false, "recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 48 \
             --gpu-memory-utilization 0.92 \
@@ -860,7 +860,7 @@ Before you start, please
             --max-num-batched-tokens 164 \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp", "enforce_eager": true}' \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"enable_sparse_c8":false,"recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 48 \
             --gpu-memory-utilization 0.92 \

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -771,7 +771,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-5 \
             --max-model-len 131072 \
-            --additional-config '{"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -851,7 +851,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-5 \
             --max-model-len 131072 \
-            --additional-config '{"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -935,7 +935,7 @@ Before you start, please
             --max-model-len 200000 \
             --max-num-batched-tokens 32 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 8 \
             --gpu-memory-utilization 0.92 \
@@ -1015,7 +1015,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \
@@ -1095,7 +1095,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \
@@ -1175,7 +1175,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
@@ -33,7 +33,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.95"
       - "--additional-config"
-      - '{"enable_cpu_binding":true, "multistream_overlap_shared_expert": true, "enable_weight_nz_layout":true}'
+      - '{"enable_cpu_binding":true, "enable_weight_nz_layout":true}'
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3,"enforce_eager": true}'
       - "--compilation-config"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs16-0.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs16-0.yaml
@@ -95,7 +95,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --no-enable-prefix-caching
@@ -157,7 +157,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --no-enable-prefix-caching
@@ -224,7 +224,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -288,7 +288,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs20-90.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs20-90.yaml
@@ -95,7 +95,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -156,7 +156,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -222,7 +222,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -285,7 +285,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in64k_bs16-90.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in64k_bs16-90.yaml
@@ -97,7 +97,7 @@ templates:
       - --max-model-len
       - "140000"
       - --additional-config
-      - '{"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -158,7 +158,7 @@ templates:
       - --max-model-len
       - "140000"
       - --additional-config
-      - '{"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -224,7 +224,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,64,96,128]}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
+      - '{"recompute_scheduler_enable":true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -287,7 +287,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,64,96,128]}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
+      - '{"recompute_scheduler_enable":true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-128k-1k-TPOT50.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.5-W4A8-128k-1k-TPOT50.yaml
@@ -187,7 +187,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "2", "kv_connector_extra_config": {"use_ascend_direct": true, "prefill": {"dp_size": 4, "tp_size": 4}, "decode": {"dp_size": 8, "tp_size": 4}}}'
 
@@ -229,7 +229,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "2", "kv_connector_extra_config": {"use_ascend_direct": true, "prefill": {"dp_size": 4, "tp_size": 4}, "decode": {"dp_size": 8, "tp_size": 4}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/MiniMax-PD-in32k-bs4-1.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/MiniMax-PD-in32k-bs4-1.yaml
@@ -137,7 +137,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",
@@ -191,7 +191,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -162,6 +162,12 @@ class AscendConfig:
             ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
         )
         assert self.enable_fused_mc2 in (0, 1), f"enable_fused_mc2 must be 0 or 1, got {self.enable_fused_mc2}"
+        if self.enable_fused_mc2 == 1 and self.multistream_overlap_shared_expert:
+            self.multistream_overlap_shared_expert = False
+            logger.warning_once(
+                "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "
+                "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
+            )
         self.enable_mlapo = self._get_config_value(
             additional_config,
             "enable_mlapo",


### PR DESCRIPTION

### What this PR does / why we need it?
This PR disables `multistream_overlap_shared_expert` when `enable_fused_mc2` is enabled. These two features cannot be enabled at the same time, so we automatically set `multistream_overlap_shared_expert` to `False` and log a warning if both are configured. 

Cause:
1. When fused mc2 is enabled, the shared expert multi-stream feature cannot be used with CV parallelism, and there is no performance gain.
2. When fused mc2 is enabled, multistream_overlap_shared_expert (shared expert multi-stream) is enabled, but enable_shared_expert_dp (shared expert DP) is not enabled.
As a result, the MOE large fusion operator and the TP communication (AIV mode) of the shared expert exist on two streams respectively. If one card enters the MOE large fusion operator and the other card enters the TP communication, the two operators will be deadlocked. As a result, the system is suspended.

Co-authored-by: guanguan0308 <1546542263@qq.com>
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
