### PR TITLE
[Feature] Support batch job aware scheduler

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -191,6 +191,7 @@
   tests:
     - tests/ut/core
     - tests/ut/test_compressed_prefix_cache.py
+    - tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py
 
 # Device
 - name: device
@@ -731,6 +732,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_simple_cpu_offload.py: 220
   tests/e2e/pull_request/one_card/test_vlm.py: 860
   tests/e2e/pull_request/one_card/test_xlite.py: 170
+  tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py: 263
   tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py: 20
   tests/e2e/pull_request/two_card/lora/test_ilama_lora_tp2.py: 150
   tests/e2e/pull_request/two_card/lora/test_llama32_lora_tp2.py: 510

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -152,6 +152,7 @@ The legacy top-level `enable_balance_scheduling`, `recompute_scheduler_enable`, 
 | `recompute_scheduler_enable` | bool | `False` | Whether to enable the recompute scheduler. **Only valid on PD-disaggregated D nodes** (`kv_role` is `kv_consumer`). **Do not enable on P nodes or in PD-mixed mode** (no `kv_transfer_config`, `kv_role` is `kv_producer`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
 | `profiling_chunk_config` | dict | `{}` | Configuration options for dynamic chunked pipeline parallel. See [Dynamic Chunked Pipeline Parallel](../feature_guide/dynamic_chunk_pipeline_parallel.md) for details. |
 | `short_request_first_config` | dict | `{}` | Configuration options for ShortRequestFirst prefill scheduling on the PD prefill (P) node. Used with `recompute_scheduler_enable=true`. |
+| `batch_job_sched_config` | dict | `{}` | Configuration options for the batch-job-aware scheduler. See [Batch-Job-Aware Scheduler](../feature_guide/batch_job_aware_scheduler.md) for details. |
 
 **scheduler_config.profiling_chunk_config**
 
@@ -183,6 +184,17 @@ ShortRequestFirst is a waiting-queue policy wired through the recompute schedule
 | `enabled`                | bool  | `False` | Whether to enable ShortRequestFirst scheduling. |
 | `threshold`              | int   | `256`   | Prompt-length threshold (tokens). Requests with `num_prompt_tokens <= threshold` are treated as short prefills and prioritized over long prefills. |
 | `long_max_wait_ms`       | float | `0.0`   | Maximum time a long prefill may wait behind short prefills before it can be promoted ahead of them. `0` disables long-request promotion and keeps strict short-request priority. |
+
+**scheduler_config.batch_job_sched_config**
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enabled` | bool | `false` | Enable the batch-job-aware scheduler. |
+| `max_jobs` | int | `20` | Maximum number of tracked jobs. `0` means unlimited. |
+| `reserve_margin_blocks` | int | `2` | Extra block margin added to the KV cache reserve as safety buffer. |
+| `reserve_max_blocks` | int | `8` | Maximum number of blocks that can be reserved. |
+| `low_available_tokens_threshold` | int | `4096` | Threshold for prioritising long vs short decode jobs. When available tokens > threshold, long decode jobs are prioritised; when ≤ threshold, short decode jobs are prioritised. |
+| `short_decode_token_threshold` | int | `32` | Threshold for classifying a job as "short decode". |
 
 ### Example
 

--- a/docs/source/user_guide/feature_guide/batch_job_aware_scheduler.md
+++ b/docs/source/user_guide/feature_guide/batch_job_aware_scheduler.md
@@ -1,0 +1,150 @@
+# Batch-Job-Aware Scheduler
+
+Batch-Job-Aware Scheduler is a specialized scheduler designed for **offline batch inference** scenarios where throughput and hardware utilisation are the primary goals. It is particularly effective when processing multiple batch jobs concurrently, each with a distinct set of requests.
+
+> **Note:** This scheduler **does not implement starvation prevention**. It is intended solely for **batch processing scenarios** or **online inference scenarios where request waiting time is not a concern**. If requests have strict latency or fairness requirements, this scheduler may not be suitable.
+
+## Overview
+
+The scheduler implements three key strategies to improve throughput:
+
+1. **LPT (Longest Processing Time first) scheduling**: Prioritises longer tasks first and schedules shorter ones to fill gaps, particularly during the decode step. This improves the average number of tokens computed per scheduling round.
+
+2. **KV cache reservation**: Estimates and reserves KV cache budget in advance for running requests, reducing preemption overhead.
+
+3. **Job-aware request grouping**: Groups requests by **job name** (extracted from the request ID), assigns each job its own request bucket, and dynamically adjusts job scheduling order based on KV cache availability:
+   - When available tokens > threshold (default 4096): prioritise long decode jobs
+   - When available tokens ≤ threshold: prioritise short decode jobs
+
+The scheduler is implemented by extending the **waiting queue** with **dynamic priority scheduling**, while inheriting most features from the original scheduler class, including chunked prefill, async scheduling, and more.
+
+## How It Works
+
+### Job Name Extraction
+
+The scheduler identifies which job a request belongs to via a `#job_name[${JOB_NAME}]#` tag embedded in the request ID. For example:
+
+```python
+request_id = "req_001#job_name[my_batch_job]#"
+```
+
+Requests without a job name tag are grouped under the `__default__` job.
+
+### Decode Length Estimation
+
+Each job's decode length is predicted using a pure **EWMA (Exponentially Weighted Moving Average)** estimator:
+
+- **No samples yet**: Returns a cold-start default value (128 tokens).
+- **First observation**: EWMA is initialised to the observed decode length.
+- **Subsequent observations**: EWMA is updated incrementally, giving more weight to recent data while smoothing out fluctuations.
+
+This approach is simple, responsive, and avoids the complexity of multi-phase estimation while producing stable predictions even with limited data.
+
+This enables the scheduler to distinguish between "long decode" jobs (which benefit from being scheduled first when resources are abundant) and "short decode" jobs (which are prioritised when resources are scarce).
+
+## Getting Started
+
+### Prerequisites
+
+- **vLLM v1 engine** is required (the batch-job-aware scheduler is built on the v1 scheduling framework).
+- **Ascend NPU** with sufficient memory for the target model(s).
+
+### Enabling the Feature
+
+The batch-job-aware scheduler is enabled via the `additional_config` parameter. It is currently only supported in **offline batch** mode.
+
+```bash
+python -m vllm.entrypoints.openai.run_batch \
+    --model /path/to/model \
+    -i /path/to/input.jsonl \
+    -o /path/to/output.jsonl \
+    --additional-config '{"scheduler_config": {"batch_job_sched_config": {"enabled": true}}}'
+```
+
+### Request ID Format
+
+To take advantage of job-aware scheduling, embed the `#job_name[...]#` tag into the request ID inside your batch input file:
+
+```jsonl
+# In your batch input file (e.g., input.jsonl):
+{"custom_id": "#job_name[job_A]#req_001", "method": "POST", "url": "/v1/chat/completions", "body": {"request_id": "#job_name[job_A]#req_001", "messages": [{"role": "user", "content": "Hello"}], "n": 1}}
+{"custom_id": "#job_name[job_A]#req_002", "method": "POST", "url": "/v1/chat/completions", "body": {"request_id": "#job_name[job_A]#req_002", "messages": [{"role": "user", "content": "What is AI?"}], "n": 1}}
+{"custom_id": "#job_name[job_B]#req_003", "method": "POST", "url": "/v1/chat/completions", "body": {"request_id": "#job_name[job_B]#req_003", "messages": [{"role": "user", "content": "Explain quantum computing"}], "n": 1}}
+```
+
+Requests without a job name tag will be grouped under the default job and still benefit from the scheduler's KV cache reservation and LPT scheduling.
+
+## Configuration Parameters
+
+All parameters are nested under `batch_job_sched_config` in the `additional_config: {"scheduler_config":: {}}`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the batch-job-aware scheduler |
+| `max_jobs` | int | `20` | Maximum number of tracked jobs |
+| `reserve_margin_blocks` | int | `2` | Extra block margin added to the KV cache reserve as safety buffer |
+| `reserve_max_blocks` | int | `8` | Maximum number of blocks that can be reserved |
+| `low_available_tokens_threshold` | int | `4096` | Threshold for prioritising long vs short decode jobs |
+| `short_decode_token_threshold` | int | `32` | Threshold for classifying a job as "short decode" |
+
+## Usage
+
+### Basic Offline Batch
+
+```bash
+python -m vllm.entrypoints.openai.run_batch \
+    --model /path/to/model \
+    -i /path/to/input.jsonl \
+    -o /path/to/output.jsonl \
+    --max-model-len 4096 \
+    --gpu-memory-utilization 0.9 \
+    --additional-config '{"scheduler_config": {"batch_job_sched_config": {"enabled": true}}}'
+```
+
+### Offline Batch with Custom Configuration
+
+```bash
+python -m vllm.entrypoints.openai.run_batch \
+    --model /path/to/model \
+    -i /path/to/input.jsonl \
+    -o /path/to/output.jsonl \
+    --max-model-len 4096 \
+    --gpu-memory-utilization 0.9 \
+    --additional-config '{
+        "scheduler_config": {
+            "batch_job_sched_config": {
+                "enabled": true,
+                "max_jobs": 10,
+                "reserve_margin_blocks": 4,
+                "reserve_max_blocks": 12,
+                "low_available_tokens_threshold": 2048,
+                "short_decode_token_threshold": 32
+            }
+        }
+    }'
+```
+
+### Using via Python API
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="/path/to/model",
+    max_model_len=4096,
+    gpu_memory_utilization=0.9,
+    additional_config={
+        "scheduler_config": {
+            "batch_job_sched_config": {
+                "enabled": True,
+            },
+        },
+    },
+)
+```
+
+## Best Practices
+
+1. **Encode job names in request IDs**: Use the `#job_name[${JOB_NAME}]#` prefix in your request IDs to help the scheduler group and prioritise requests effectively.
+
+2. **Adjust `low_available_tokens_threshold`**: If your workload is consistently long-decode-heavy, consider lowering this threshold to keep long jobs prioritised. For mixed workloads, keep the default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -266,6 +266,7 @@ nav:
         - user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
         - user_guide/feature_guide/short_request_first.md
         - user_guide/feature_guide/flash_attention.md
+        - user_guide/feature_guide/batch_job_aware_scheduler.md
     - Deployment Guide:
         - user_guide/deployment_guide/index.md
         - user_guide/deployment_guide/using_volcano_kthena.md

--- a/tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py
+++ b/tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py
@@ -1,0 +1,207 @@
+"""
+End-to-end tests for BatchJobAwareScheduler.
+
+This test module verifies the correctness of the BatchJobAwareScheduler
+by comparing outputs with the default scheduler.
+"""
+
+import pytest
+
+from tests.e2e.conftest import VllmRunner
+from tests.e2e.model_utils import check_outputs_equal
+
+MODEL = "Qwen/Qwen3-0.6B"
+
+example_prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+# Extended prompts for testing with 20 samples
+extended_prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+    "Machine learning is a subset of",
+    "The largest ocean in the world is",
+    "Python is a programming language that",
+    "The speed of light is approximately",
+    "The human brain consists of",
+    "Climate change is primarily caused by",
+    "The Eiffel Tower is located in",
+    "Artificial intelligence can be defined as",
+    "The Great Wall of China was built to",
+    "Quantum computing uses principles of",
+    "The theory of relativity was proposed by",
+    "Solar energy is generated through",
+    "The human heart pumps approximately",
+    "Blockchain technology enables",
+    "The Amazon rainforest is home to",
+    "Electric vehicles are powered by",
+]
+
+
+@pytest.mark.parametrize("max_tokens", [4])
+def test_batch_job_aware_scheduler_basic(max_tokens: int) -> None:
+    """Test basic functionality of BatchJobAwareScheduler.
+
+    Compare outputs between BatchJobAwareScheduler and default scheduler
+    to ensure correctness.
+    """
+    with VllmRunner(
+        MODEL,
+        additional_config={
+            "scheduler_config": {
+                "batch_job_sched_config": {
+                    "enabled": True,
+                },
+            },
+        },
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+    ) as vllm_model:
+        batch_job_output = vllm_model.generate_greedy(example_prompts, max_tokens)
+
+    with VllmRunner(
+        MODEL,
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+        async_scheduling=False,
+    ) as vllm_model:
+        vllm_default_output = vllm_model.generate_greedy(example_prompts, max_tokens)
+
+    check_outputs_equal(
+        outputs_0_lst=vllm_default_output,
+        outputs_1_lst=batch_job_output,
+        name_0="default_scheduler",
+        name_1="batch_job_aware_scheduler",
+    )
+
+
+@pytest.mark.parametrize("max_tokens", [4])
+def test_batch_job_aware_scheduler_with_async_scheduling(max_tokens: int) -> None:
+    """Test basic functionality of BatchJobAwareAsyncScheduler.
+
+    Compare outputs between BatchJobAwareAsyncScheduler and default scheduler
+    to ensure correctness.
+    """
+    with VllmRunner(
+        MODEL,
+        additional_config={
+            "scheduler_config": {
+                "batch_job_sched_config": {
+                    "enabled": True,
+                },
+            },
+        },
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+        async_scheduling=True,
+    ) as vllm_model:
+        batch_job_output = vllm_model.generate_greedy(example_prompts, max_tokens)
+
+    with VllmRunner(
+        MODEL,
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+    ) as vllm_model:
+        vllm_default_output = vllm_model.generate_greedy(example_prompts, max_tokens)
+
+    check_outputs_equal(
+        outputs_0_lst=vllm_default_output,
+        outputs_1_lst=batch_job_output,
+        name_0="default_scheduler",
+        name_1="batch_job_aware_async_scheduler",
+    )
+
+
+@pytest.mark.parametrize("max_tokens", [4])
+@pytest.mark.parametrize("chunked_prefill_token_size", [16])
+def test_batch_job_aware_scheduler_with_chunked_prefill(max_tokens: int, chunked_prefill_token_size: int) -> None:
+    """Test BatchJobAwareScheduler with chunked prefill enabled.
+
+    Verify that BatchJobAwareScheduler works correctly with chunked prefill,
+    comparing outputs with the default scheduler using 20 test samples.
+    """
+    max_num_seqs = chunked_prefill_token_size
+    max_num_batched_tokens = chunked_prefill_token_size
+
+    with VllmRunner(
+        MODEL,
+        additional_config={
+            "scheduler_config": {
+                "batch_job_sched_config": {
+                    "enabled": True,
+                },
+            },
+        },
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+        enable_chunked_prefill=True,
+        async_scheduling=False,
+    ) as vllm_model:
+        batch_job_output = vllm_model.generate_greedy(extended_prompts, max_tokens)
+
+    with VllmRunner(
+        MODEL,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+        enable_chunked_prefill=True,
+    ) as vllm_model:
+        default_output = vllm_model.generate_greedy(extended_prompts, max_tokens)
+
+    check_outputs_equal(
+        outputs_0_lst=default_output,
+        outputs_1_lst=batch_job_output,
+        name_0="default_scheduler_chunked_prefill",
+        name_1="batch_job_aware_scheduler_chunked_prefill",
+    )
+
+
+@pytest.mark.parametrize("max_tokens", [4])
+def test_batch_job_aware_scheduler_with_custom_config(max_tokens: int) -> None:
+    """Test BatchJobAwareScheduler with custom configuration parameters.
+
+    Verify that BatchJobAwareScheduler works correctly with custom EWMA
+    parameters and other configuration options using 20 test samples.
+    """
+    with VllmRunner(
+        MODEL,
+        additional_config={
+            "scheduler_config": {
+                "batch_job_sched_config": {
+                    "enabled": True,
+                    "max_jobs": 10,
+                    "reserve_margin_blocks": 4,
+                    "reserve_max_blocks": 12,
+                    "low_available_tokens_threshold": 2048,
+                    "short_decode_token_threshold": 32,
+                },
+            },
+        },
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+    ) as vllm_model:
+        batch_job_output = vllm_model.generate_greedy(extended_prompts, max_tokens)
+
+    with VllmRunner(
+        MODEL,
+        max_model_len=2048,
+        gpu_memory_utilization=0.7,
+        async_scheduling=False,
+    ) as vllm_model:
+        default_output = vllm_model.generate_greedy(extended_prompts, max_tokens)
+
+    check_outputs_equal(
+        outputs_0_lst=default_output,
+        outputs_1_lst=batch_job_output,
+        name_0="default_scheduler",
+        name_1="batch_job_aware_scheduler_custom_config",
+    )

--- a/tests/ut/core/test_batch_job_aware_scheduler.py
+++ b/tests/ut/core/test_batch_job_aware_scheduler.py
@@ -1,0 +1,769 @@
+"""Unit tests for batch_job_aware_scheduler.py.
+
+Covers all public and internal components:
+
+    - ``_cdiv``
+    - ``_JobStat``
+    - ``JobNameParser``
+    - ``JobDecodeEstimator``
+    - ``RequestBucket``
+    - ``RunningBlockReserver``
+    - ``BatchJobAwareRequestQueue``
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from vllm.v1.request import Request
+
+from tests.ut.base import TestBase
+from vllm_ascend.ascend_config import BatchJobSchedConfig
+from vllm_ascend.core.batch_job_aware_scheduler import (
+    BatchJobAwareRequestQueue,
+    JobDecodeEstimator,
+    JobNameParser,
+    RequestBucket,
+    RunningBlockReserver,
+    _cdiv,
+    _JobStat,
+)
+
+# ===================================================================
+# _cdiv
+# ===================================================================
+
+
+class TestCdiv(TestBase):
+    """Ceiling division helper tests."""
+
+    def test_exact_division(self):
+        self.assertEqual(_cdiv(10, 5), 2)
+
+    def test_rounds_up(self):
+        self.assertEqual(_cdiv(11, 5), 3)
+
+    def test_single_block(self):
+        self.assertEqual(_cdiv(1, 16), 1)
+
+    def test_zero_numerator(self):
+        self.assertEqual(_cdiv(0, 16), 0)
+
+    def test_numerator_equals_denominator(self):
+        self.assertEqual(_cdiv(16, 16), 1)
+
+    def test_large_values(self):
+        self.assertEqual(_cdiv(1000000, 16), 62500)
+
+
+# ===================================================================
+# _JobStat
+# ===================================================================
+
+
+class TestJobStat(TestBase):
+    """Per‑job running statistics container tests."""
+
+    def test_initial_values(self):
+        stat = _JobStat()
+        self.assertEqual(stat.sample_count, 0)
+        self.assertEqual(stat.ewma_average, 0.0)
+
+    def test_after_observations(self):
+        stat = _JobStat()
+        stat.sample_count = 3
+        stat.ewma_average = 116.5
+        self.assertEqual(stat.sample_count, 3)
+        self.assertEqual(stat.ewma_average, 116.5)
+
+
+# ===================================================================
+# JobNameParser
+# ===================================================================
+
+
+class TestJobNameParser(TestBase):
+    """Job name extraction with caching."""
+
+    def setUp(self):
+        super().setUp()
+        self.parser = JobNameParser()
+
+    def test_parse_with_job_name(self):
+        result = self.parser.parse("req1#job_name[my_job]#")
+        self.assertEqual(result, "my_job")
+
+    def test_parse_without_job_name_returns_default(self):
+        result = self.parser.parse("req_no_job")
+        self.assertEqual(result, "__default__")
+
+    def test_parse_with_empty_job_name(self):
+        result = self.parser.parse("req1#job_name[]#")
+        self.assertEqual(result, "__default__")
+
+    def test_parse_caches_result(self):
+        first = self.parser.parse("req1#job_name[job1]#")
+        second = self.parser.parse("req1#job_name[job1]#")
+        self.assertEqual(first, second)
+        self.assertIn("req1#job_name[job1]#", self.parser._cache)
+
+    def test_remove_clears_cache(self):
+        self.parser.parse("req1#job_name[job1]#")
+        self.parser.remove("req1#job_name[job1]#")
+        self.assertNotIn("req1#job_name[job1]#", self.parser._cache)
+
+    def test_remove_non_existent_does_not_raise(self):
+        # Should not raise KeyError or other exceptions
+        self.parser.remove("non_existent_req")
+
+    def test_clear_empties_cache(self):
+        self.parser.parse("req1#job_name[job1]#")
+        self.parser.parse("req2#job_name[job2]#")
+        self.parser.clear()
+        self.assertEqual(len(self.parser._cache), 0)
+
+    def test_multiple_jobs_cached_correctly(self):
+        j1 = self.parser.parse("r1#job_name[alpha]#")
+        j2 = self.parser.parse("r2#job_name[beta]#")
+        self.assertEqual(j1, "alpha")
+        self.assertEqual(j2, "beta")
+
+
+# ===================================================================
+# JobDecodeEstimator
+# ===================================================================
+
+
+class TestJobDecodeEstimator(TestBase):
+    """EWMA decode length estimator tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.config = BatchJobSchedConfig()
+        self.estimator = JobDecodeEstimator(self.config)
+
+    def test_predict_no_samples_returns_default(self):
+        result = self.estimator.predict("unknown_job")
+        self.assertEqual(result, JobDecodeEstimator._COLD_START_DEFAULT_DECODE)
+
+    def test_observe_creates_job_stat_on_first_call(self):
+        self.estimator.observe("job1", 100)
+        self.assertIn("job1", self.estimator._job_stats)
+        self.assertEqual(self.estimator._job_stats["job1"].sample_count, 1)
+        # After first observation, EWMA is set to the observed value
+        self.assertEqual(self.estimator._job_stats["job1"].ewma_average, 100.0)
+
+    def test_cold_start_predict_uses_ewma(self):
+        """With samples < _COLD_START_MIN_SAMPLES, pure EWMA is used."""
+        estimator = JobDecodeEstimator(BatchJobSchedConfig())
+        # n=1: EWMA = 100
+        estimator.observe("job1", 100)
+        # n=2: EWMA = 0.1 * 150 + 0.9 * 100 = 105
+        estimator.observe("job1", 150)
+        result = estimator.predict("job1")
+        self.assertEqual(result, 105)
+
+    def test_stable_phase_predict_uses_ewma(self):
+        """When samples >= _COLD_START_MIN_SAMPLES, pure EWMA is used."""
+        estimator = JobDecodeEstimator(BatchJobSchedConfig())
+        # n=1: EWMA = 100
+        estimator.observe("job1", 100)
+        # n=2: EWMA = 0.1 * 150 + 0.9 * 100 = 105
+        estimator.observe("job1", 150)
+        # n=3: EWMA = 0.1 * 120 + 0.9 * 105 = 106.5
+        estimator.observe("job1", 120)
+        result = estimator.predict("job1")
+        self.assertEqual(result, 106)
+
+    def test_ewma_convergence(self):
+        """EWMA with α=0.1 converges to the steady value after many observations."""
+        estimator = JobDecodeEstimator(BatchJobSchedConfig())
+        for _ in range(50):
+            estimator.observe("job1", 100)
+        result = estimator.predict("job1")
+        self.assertEqual(result, 100)
+
+    def test_observe_max_jobs_exceeded_raises(self):
+        cfg = BatchJobSchedConfig({"max_jobs": 2})
+        estimator = JobDecodeEstimator(cfg)
+        estimator.observe("job1", 100)
+        estimator.observe("job2", 100)
+        with self.assertRaises(RuntimeError) as ctx:
+            estimator.observe("job3", 100)
+        self.assertIn("Maximum number of jobs", str(ctx.exception))
+
+    def test_observe_max_jobs_zero_allows_unlimited(self):
+        cfg = BatchJobSchedConfig({"max_jobs": 51})
+        estimator = JobDecodeEstimator(cfg)
+        for i in range(50):
+            estimator.observe(f"job{i}", 100)
+        self.assertEqual(len(estimator._job_stats), 50)
+
+    def test_observe_max_samples_per_job_stops_updating(self):
+        """When sample_count reaches _MAX_SAMPLES_PER_JOB, further updates are skipped."""
+        # _MAX_SAMPLES_PER_JOB = 10
+        estimator = JobDecodeEstimator(BatchJobSchedConfig())
+        for i in range(10):
+            estimator.observe("job1", 100)
+        # 11th call should be skipped, EWMA stays at 100.0
+        estimator.observe("job1", 300)
+        stat = estimator._job_stats["job1"]
+        self.assertEqual(stat.sample_count, 10)
+        self.assertEqual(stat.ewma_average, 100.0)
+
+    def test_get_stats_returns_human_readable_dict(self):
+        self.estimator.observe("job1", 100)
+        self.estimator.observe("job1", 150)
+        stats = self.estimator.get_stats()
+        self.assertIn("job1", stats)
+        self.assertEqual(stats["job1"]["sample_count"], 2)
+        self.assertEqual(stats["job1"]["ewma_average"], 105.0)
+
+    def test_get_stats_empty(self):
+        stats = self.estimator.get_stats()
+        self.assertEqual(stats, {})
+
+    def test_multiple_jobs_independent_estimates(self):
+        self.estimator.observe("long_job", 500)
+        self.estimator.observe("long_job", 600)
+        self.estimator.observe("short_job", 10)
+        long_pred = self.estimator.predict("long_job")
+        short_pred = self.estimator.predict("short_job")
+        self.assertGreater(long_pred, short_pred)
+
+    def test_observe_updates_ewma_average_correctly(self):
+        self.estimator.observe("job1", 10)
+        # n=1: EWMA = 10.0
+        self.assertEqual(self.estimator._job_stats["job1"].ewma_average, 10.0)
+        self.estimator.observe("job1", 20)
+        # n=2: EWMA = 0.1 * 20 + 0.9 * 10 = 11.0
+        self.assertEqual(self.estimator._job_stats["job1"].ewma_average, 11.0)
+        self.estimator.observe("job1", 30)
+        # n=3: EWMA = 0.1 * 30 + 0.9 * 11.0 = 12.9
+        self.assertAlmostEqual(self.estimator._job_stats["job1"].ewma_average, 12.9)
+
+
+# ===================================================================
+# RequestBucket
+# ===================================================================
+
+
+class _MockRequest:
+    """Minimal request-like object for RequestBucket tests.
+
+    Avoids importing the real ``Request`` which requires heavy vLLM
+    initialisation.  Only exposes the attributes that RequestBucket uses.
+    """
+
+    def __init__(self, request_id: str, num_prompt_tokens: int):
+        self.request_id = request_id
+        self.num_prompt_tokens = num_prompt_tokens
+        self.num_computed_tokens = 0
+        self.num_output_tokens = 0
+
+
+class TestRequestBucket(TestBase):
+    """O(log n) best-fit request bucket tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.bucket = RequestBucket()
+
+    def test_put_increases_length(self):
+        req = _MockRequest("req1", 100)
+        self.bucket.put(req)
+        self.assertEqual(len(self.bucket), 1)
+
+    def test_put_none_is_noop(self):
+        self.bucket.put(None)
+        self.assertTrue(self.bucket.is_empty())
+
+    def test_put_requests_with_same_length_grouped(self):
+        r1 = _MockRequest("req1", 100)
+        r2 = _MockRequest("req2", 100)
+        self.bucket.put(r1)
+        self.bucket.put(r2)
+        self.assertEqual(len(self.bucket), 2)
+
+    def test_is_empty_on_creation(self):
+        self.assertTrue(self.bucket.is_empty())
+
+    def test_is_empty_after_put_and_remove(self):
+        req = _MockRequest("req1", 100)
+        self.bucket.put(req)
+        self.bucket.remove(req)
+        self.assertTrue(self.bucket.is_empty())
+
+    def test_peek_best_fit_returns_none_when_empty(self):
+        self.assertIsNone(self.bucket.peek_best_fit_request(100))
+
+    def test_peek_best_fit_exact_match(self):
+        req = _MockRequest("req1", 100)
+        self.bucket.put(req)
+        # search_prefill_length=200: bisect_right on [100] returns idx=1,
+        # idx-1=0 yields best_length=100
+        result = self.bucket.peek_best_fit_request(200)
+        self.assertIs(result, req)
+
+    def test_peek_best_fit_returns_nearest_lower(self):
+        r1 = _MockRequest("req1", 50)
+        r2 = _MockRequest("req2", 200)
+        self.bucket.put(r1)
+        self.bucket.put(r2)
+        # search=150: bisect_right on [50,200] returns idx=1,
+        # idx-1=0 yields best_length=50
+        result = self.bucket.peek_best_fit_request(150)
+        self.assertIs(result, r1)
+
+    def test_peek_best_fit_when_search_less_than_all(self):
+        r1 = _MockRequest("req1", 100)
+        r2 = _MockRequest("req2", 200)
+        self.bucket.put(r1)
+        self.bucket.put(r2)
+        # search=50: bisect_right on [50,100,200] -> idx=0 (no lower),
+        # idx=0 < len -> returns first bucket entry
+        result = self.bucket.peek_best_fit_request(50)
+        self.assertIs(result, r1)
+
+    def test_remove_existing_request_returns_true(self):
+        req = _MockRequest("req1", 100)
+        self.bucket.put(req)
+        self.assertTrue(self.bucket.remove(req))
+
+    def test_remove_none_returns_false(self):
+        self.assertFalse(self.bucket.remove(None))
+
+    def test_remove_non_existent_request_returns_false(self):
+        req = _MockRequest("req1", 100)
+        self.assertFalse(self.bucket.remove(req))
+
+    def test_remove_request_wrong_length_returns_false(self):
+        self.bucket.put(_MockRequest("req1", 100))
+        other = _MockRequest("req2", 200)
+        self.assertFalse(self.bucket.remove(other))
+
+    def test_remove_cleans_up_empty_bucket_entry(self):
+        req = _MockRequest("req1", 100)
+        self.bucket.put(req)
+        self.bucket.remove(req)
+        self.assertEqual(len(self.bucket._bucket), 0)
+        self.assertEqual(len(self.bucket._sorted_lengths), 0)
+
+    def test_iteration_yields_all_requests(self):
+        reqs = [_MockRequest(f"req{i}", i * 100) for i in range(3)]
+        for r in reqs:
+            self.bucket.put(r)
+        iterated = list(self.bucket)
+        self.assertEqual(len(iterated), 3)
+        for r in reqs:
+            self.assertIn(r, iterated)
+
+    def test_bool_empty_is_false(self):
+        self.assertFalse(self.bucket)
+
+    def test_bool_non_empty_is_true(self):
+        self.bucket.put(_MockRequest("req1", 100))
+        self.assertTrue(self.bucket)
+
+    def test_peek_best_fit_no_sorted_lengths_returns_none(self):
+        # Direct manipulation to test edge case
+        self.bucket._bucket[100] = deque()
+        self.bucket._sorted_lengths = []
+        self.assertIsNone(self.bucket.peek_best_fit_request(50))
+
+
+# ===================================================================
+# RunningBlockReserver
+# ===================================================================
+
+
+class TestRunningBlockReserver(TestBase):
+    """KV‑block demand prediction with incremental cache tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.config = BatchJobSchedConfig(
+            {
+                "reserve_margin_blocks": 2,
+                "reserve_max_blocks": 8,
+            }
+        )
+
+        # Build a minimal mock scheduler
+        self.mock_scheduler = MagicMock()
+        self.mock_scheduler.block_size = 16
+        self.mock_scheduler.max_num_scheduled_tokens = 32
+        self.mock_scheduler.num_lookahead_tokens = 0
+        self.mock_scheduler.running = []
+
+        self.reserver = RunningBlockReserver(self.mock_scheduler, self.config)
+
+    @staticmethod
+    def _make_request(num_prompt_tokens=100, num_computed_tokens=0):
+        req = MagicMock(spec=Request)
+        req.num_prompt_tokens = num_prompt_tokens
+        req.num_computed_tokens = num_computed_tokens
+        req.request_id = f"req_{id(req)}"
+        return req
+
+    def test_invalidate_cache_sets_cache_stale(self):
+        self.reserver._cached_running_queue_len = 5
+        self.reserver.invalidate_cache()
+        self.assertEqual(self.reserver._cached_running_queue_len, -1)
+
+    def test_predict_empty_running_returns_margin(self):
+        # _finalize_reserve(0) = min(0 + 2, 8) = 2
+        result = self.reserver.predict()
+        self.assertEqual(result, 2)
+
+    def test_predict_cache_hit_returns_cached(self):
+        req = self._make_request()
+        self.mock_scheduler.running = [req]
+        # First call populates cache
+        first = self.reserver.predict()
+        # Second call should hit cache
+        second = self.reserver.predict()
+        self.assertEqual(first, second)
+
+    def test_predict_incremental_update_single_request(self):
+        req1 = self._make_request(num_prompt_tokens=100, num_computed_tokens=0)
+        self.mock_scheduler.running = [req1]
+        first = self.reserver.predict()
+
+        req2 = self._make_request(num_prompt_tokens=50, num_computed_tokens=0)
+        self.mock_scheduler.running = [req1, req2]
+        # Running grew by 1 -> incremental update
+        second = self.reserver.predict()
+
+        # Should be >= first since new request was added
+        self.assertGreaterEqual(second, first)
+
+    def test_predict_full_recompute_on_complex_change(self):
+        req1 = self._make_request()
+        self.mock_scheduler.running = [req1]
+        self.reserver.predict()
+
+        # Change running length by more than 1 (simulating preemption)
+        self.mock_scheduler.running = []
+        third = self.reserver.predict()
+        self.assertEqual(third, 2)  # just margin
+
+    def test_compute_one_prefill_phase(self):
+        """Request in prefill phase: num_computed < num_prompt."""
+        req = self._make_request(num_prompt_tokens=100, num_computed_tokens=0)
+        # _compute_one simulation:
+        # remaining_prompt = 100 - 0 = 100
+        # this_round_tokens = min(100, 32) = 32
+        # num_computed_after = 0 + 32 = 32
+        # Still in prefill: remaining_prompt_after = 100 - 32 = 68
+        # next_round_tokens = min(68, 32) = 32
+        # pos_in_block = 32 % 16 = 0
+        # remaining = 0
+        # next_round_tokens(32) > remaining(0) -> _cdiv(32 - 0, 16) = 2
+        blocks = self.reserver._compute_one(req)
+        self.assertEqual(blocks, 2)
+
+    def test_compute_one_decode_phase(self):
+        """Request that has completed prefill."""
+        req = self._make_request(num_prompt_tokens=100, num_computed_tokens=100)
+        # this_round_tokens = 1 + 0 = 1
+        # num_computed_after = 100 + 1 = 101
+        # num_computed_after(101) >= num_prompt(100) -> decode
+        # next_round_tokens = 1 + 0 = 1
+        # pos_in_block = 101 % 16 = 5
+        # remaining = 16 - 5 = 11
+        # next_round_tokens(1) <= remaining(11) -> 0
+        blocks = self.reserver._compute_one(req)
+        self.assertEqual(blocks, 0)
+
+    def test_compute_one_decode_at_block_boundary(self):
+        """Request at block boundary needs a new block."""
+        req = self._make_request(num_prompt_tokens=100, num_computed_tokens=99)
+        # this_round_tokens = 1 + 0 = 1
+        # num_computed_after = 99 + 1 = 100
+        # decode: next_round_tokens = 1
+        # pos_in_block = 100 % 16 = 4
+        # remaining = 16 - 4 = 12
+        # next_round_tokens(1) <= remaining(12) -> 0
+        blocks = self.reserver._compute_one(req)
+        self.assertEqual(blocks, 0)
+
+    def test_finalize_reserve_caps_at_max_blocks(self):
+        self.reserver._config.reserve_max_blocks = 5
+        self.reserver._config.reserve_margin_blocks = 10
+        result = self.reserver._finalize_reserve(100)
+        self.assertEqual(result, 5)
+
+
+# ===================================================================
+# BatchJobAwareRequestQueue
+# ===================================================================
+
+
+class TestBatchJobAwareRequestQueue(TestBase):
+    """Job‑grouped request queue with reserve‑aware admission tests."""
+
+    def setUp(self):
+        super().setUp()
+        self.config = BatchJobSchedConfig(
+            {
+                "short_decode_token_threshold": 32,
+                "low_available_tokens_threshold": 4096,
+                "max_jobs": 20,
+            }
+        )
+
+        # Mock scheduler with minimal attributes
+        self.mock_scheduler = MagicMock()
+        self.mock_scheduler.block_size = 16
+        self.mock_scheduler.max_num_scheduled_tokens = 32
+        self.mock_scheduler.num_lookahead_tokens = 0
+        # Mock kv_cache_manager.block_pool.get_num_free_blocks
+        type(self.mock_scheduler).kv_cache_manager = PropertyMock(
+            return_value=MagicMock(block_pool=MagicMock(get_num_free_blocks=MagicMock(return_value=1000)))
+        )
+
+        self.job_decode_estimator = JobDecodeEstimator(self.config)
+        self.block_reserver = RunningBlockReserver(self.mock_scheduler, self.config)
+        self.job_name_parser = JobNameParser()
+
+        with patch(
+            "vllm.v1.core.sched.request_queue.RequestQueue.__init__",
+            MagicMock(return_value=None),
+        ):
+            self.queue = BatchJobAwareRequestQueue(
+                self.mock_scheduler,
+                self.job_decode_estimator,
+                self.block_reserver,
+                self.job_name_parser,
+                self.config,
+            )
+
+    @staticmethod
+    def _make_request(request_id: str, num_prompt_tokens: int = 100):
+        req = MagicMock(spec=Request)
+        req.request_id = request_id
+        req.num_prompt_tokens = num_prompt_tokens
+        req.num_computed_tokens = 0
+        req.num_output_tokens = 0
+        return req
+
+    def test_add_request_increases_length(self):
+        req = self._make_request("req1")
+        self.queue.add_request(req)
+        self.assertEqual(len(self.queue), 1)
+
+    def test_add_request_none_is_noop(self):
+        self.queue.add_request(None)
+        self.assertEqual(len(self.queue), 0)
+
+    def test_add_request_routes_to_correct_job_bucket(self):
+        req = self._make_request("r1#job_name[job1]#")
+        self.queue.add_request(req)
+        self.assertIn("job1", self.queue._job_buckets)
+        self.assertEqual(len(self.queue._job_buckets["job1"]), 1)
+
+    def test_add_request_tracks_cold_start(self):
+        req = self._make_request("r1#job_name[job1]#")
+        self.queue.add_request(req)
+        self.assertIn("job1", self.queue._cold_start_reqs)
+        self.assertIn(req.request_id, self.queue._cold_start_reqs["job1"])
+
+    def test_add_request_beyond_cold_start_requests_not_tracked(self):
+        """With _COLD_START_MIN_SAMPLES=3, only first 3 requests are cold-start tracked."""
+        cfg = BatchJobSchedConfig()
+        with patch(
+            "vllm.v1.core.sched.request_queue.RequestQueue.__init__",
+            MagicMock(return_value=None),
+        ):
+            queue = BatchJobAwareRequestQueue(
+                self.mock_scheduler,
+                JobDecodeEstimator(cfg),
+                self.block_reserver,
+                self.job_name_parser,
+                cfg,
+            )
+        # First 3 requests -> cold start tracked
+        for i in range(3):
+            r = self._make_request(f"r{i}#job_name[job1]#")
+            queue.add_request(r)
+            self.assertIn("job1", queue._cold_start_reqs)
+            self.assertIn(r.request_id, queue._cold_start_reqs["job1"])
+        # 4th request -> exceeds _COLD_START_MIN_SAMPLES, not tracked
+        r4 = self._make_request("r4#job_name[job1]#")
+        queue.add_request(r4)
+        self.assertIn("job1", queue._cold_start_reqs)  # job key remains
+        self.assertNotIn(r4.request_id, queue._cold_start_reqs["job1"])
+
+    def test_remove_request_decreases_length(self):
+        req = self._make_request("r1#job_name[job1]#")
+        self.queue.add_request(req)
+        self.queue.remove_request(req)
+        self.assertEqual(len(self.queue), 0)
+
+    def test_remove_request_none_is_noop(self):
+        self.queue.remove_request(None)  # should not raise
+
+    def test_remove_request_unknown_job_is_noop(self):
+        req = self._make_request("r1")
+        # Not added yet
+        self.queue.remove_request(req)
+        self.assertEqual(len(self.queue), 0)
+
+    def test_remove_request_cleans_up_empty_job_bucket(self):
+        req = self._make_request("r1#job_name[job1]#")
+        self.queue.add_request(req)
+        self.queue.remove_request(req)
+        self.assertNotIn("job1", self.queue._job_buckets)
+
+    def test_remove_request_cleans_up_cold_start_tracking(self):
+        req = self._make_request("r1#job_name[job1]#")
+        self.queue.add_request(req)
+        self.queue.remove_request(req)
+        self.assertNotIn("job1", self.queue._cold_start_reqs)
+
+    def test_remove_requests_removes_multiple(self):
+        reqs = [self._make_request(f"r{i}#job_name[job1]#") for i in range(3)]
+        for r in reqs:
+            self.queue.add_request(r)
+        self.queue.remove_requests(reqs)
+        self.assertEqual(len(self.queue), 0)
+
+    def test_prepend_requests_adds_all(self):
+        reqs = [self._make_request(f"r{i}#job_name[job1]#") for i in range(3)]
+        mock_queue = MagicMock()
+        mock_queue.__iter__.return_value = iter(reqs)
+        self.queue.prepend_requests(mock_queue)
+        self.assertEqual(len(self.queue), 3)
+
+    def test_peek_request_returns_admittable(self):
+        req = self._make_request("r1#job_name[job1]#", num_prompt_tokens=50)
+        self.queue.add_request(req)
+        result = self.queue.peek_request()
+        self.assertIsNotNone(result)
+
+    def test_peek_request_raises_on_empty(self):
+        with self.assertRaises(IndexError):
+            self.queue.peek_request()
+
+    def test_pop_request_returns_and_removes(self):
+        req = self._make_request("r1#job_name[job1]#")
+        self.queue.add_request(req)
+        popped = self.queue.pop_request()
+        self.assertIs(popped, req)
+        self.assertEqual(len(self.queue), 0)
+
+    def test_pop_request_raises_on_empty(self):
+        with self.assertRaises(IndexError):
+            self.queue.pop_request()
+
+    def test_get_cold_start_request_returns_prioritized(self):
+        r1 = self._make_request("r1#job_name[job1]#")
+        r2 = self._make_request("r2#job_name[job2]#")
+        self.queue.add_request(r1)
+        self.queue.add_request(r2)
+        # Both are cold-start; should return one of them
+        result = self.queue._get_cold_start_request()
+        self.assertIsNotNone(result)
+        self.assertIn(result, [r1, r2])
+
+    def test_collect_job_decode_info_separates_long_short(self):
+        # long_job: 1 sample → EWMA = 100.0 → > 32 (long)
+        # short_job: 2 samples → both 10 → EWMA = 10.0 → <= 32 (short)
+        self.job_decode_estimator.observe("long_job", 100)
+        self.job_decode_estimator.observe("short_job", 10)
+        self.job_decode_estimator.observe("short_job", 10)
+        req_long = self._make_request("r1#job_name[long_job]#")
+        req_short = self._make_request("r2#job_name[short_job]#")
+        self.queue.add_request(req_long)
+        self.queue.add_request(req_short)
+
+        long_jobs, short_jobs = self.queue._collect_job_decode_info()
+        long_names = [name for name, _ in long_jobs]
+        short_names = [name for name, _ in short_jobs]
+        self.assertIn("long_job", long_names)
+        self.assertIn("short_job", short_names)
+
+    def test_sort_jobs_prioritizes_long_when_many_tokens(self):
+        """When admission_budget > low_available_tokens_threshold, long jobs first."""
+        # admission_budget=5000 > threshold=4096 → prioritize_long=True
+        long_jobs = [("job_a", 100), ("job_b", 50)]
+        short_jobs = [("job_c", 10)]
+        ordered = self.queue._sort_jobs(5000, long_jobs, short_jobs)
+        # Both categories sorted descending; long jobs concatenated first
+        self.assertEqual(ordered, [("job_a", 100), ("job_b", 50), ("job_c", 10)])
+
+    def test_sort_jobs_prioritizes_short_when_few_tokens(self):
+        """When admission_budget <= low_available_tokens_threshold, short jobs first."""
+        # admission_budget=3000 <= threshold=4096 → prioritize_long=False
+        long_jobs = [("job_a", 100)]
+        short_jobs = [("job_b", 10)]
+        ordered = self.queue._sort_jobs(3000, long_jobs, short_jobs)
+        # Both categories sorted descending; short jobs concatenated first
+        self.assertEqual(ordered, [("job_b", 10), ("job_a", 100)])
+
+    def test_sort_jobs_only_long_high_budget_descending(self):
+        """With only long jobs and high budget, sort by decode length descending."""
+        long_jobs = [("job_b", 50), ("job_a", 100)]
+        ordered = self.queue._sort_jobs(5000, long_jobs, [])
+        self.assertEqual(ordered, [("job_a", 100), ("job_b", 50)])
+
+    def test_sort_jobs_only_long_low_budget_ascending(self):
+        """With only long jobs and low budget, sort by decode length ascending."""
+        long_jobs = [("job_a", 100), ("job_b", 50)]
+        ordered = self.queue._sort_jobs(3000, long_jobs, [])
+        self.assertEqual(ordered, [("job_b", 50), ("job_a", 100)])
+
+    def test_sort_jobs_only_short_high_budget_descending(self):
+        """With only short jobs and high budget, sort by decode length descending."""
+        short_jobs = [("job_b", 5), ("job_a", 10)]
+        ordered = self.queue._sort_jobs(5000, [], short_jobs)
+        self.assertEqual(ordered, [("job_a", 10), ("job_b", 5)])
+
+    def test_sort_jobs_only_short_low_budget_ascending(self):
+        """With only short jobs and low budget, sort by decode length ascending."""
+        short_jobs = [("job_a", 10), ("job_b", 5)]
+        ordered = self.queue._sort_jobs(3000, [], short_jobs)
+        self.assertEqual(ordered, [("job_b", 5), ("job_a", 10)])
+
+    def test_admission_budget_zero_when_no_free_blocks(self):
+        type(self.mock_scheduler).kv_cache_manager = PropertyMock(
+            return_value=MagicMock(block_pool=MagicMock(get_num_free_blocks=MagicMock(return_value=0)))
+        )
+        budget = self.queue._admission_budget()
+        self.assertEqual(budget, 0)
+
+    def test_find_admittable_returns_none_with_zero_budget(self):
+        type(self.mock_scheduler).kv_cache_manager = PropertyMock(
+            return_value=MagicMock(block_pool=MagicMock(get_num_free_blocks=MagicMock(return_value=0)))
+        )
+        result = self.queue._find_admittable()
+        self.assertIsNone(result)
+
+    def test_queue_bool_checks_admittable(self):
+        # Empty queue should be falsy
+        self.assertFalse(self.queue)
+
+    def test_queue_bool_with_admittable_request(self):
+        req = self._make_request("r1#job_name[job1]#", num_prompt_tokens=50)
+        self.queue.add_request(req)
+        self.assertTrue(self.queue)
+
+    def test_max_jobs_exceeded_raises_in_get_or_create(self):
+        cfg = BatchJobSchedConfig({"max_jobs": 1})
+        with patch(
+            "vllm.v1.core.sched.request_queue.RequestQueue.__init__",
+            MagicMock(return_value=None),
+        ):
+            queue = BatchJobAwareRequestQueue(
+                self.mock_scheduler,
+                JobDecodeEstimator(cfg),
+                self.block_reserver,
+                self.job_name_parser,
+                cfg,
+            )
+        queue.add_request(self._make_request("r1#job_name[job1]#"))
+        with self.assertRaises(RuntimeError) as ctx:
+            queue.add_request(self._make_request("r2#job_name[job2]#"))
+        self.assertIn("Maximum number of jobs", str(ctx.exception))

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -680,6 +680,65 @@ class ProfilingChunkConfig:
             raise ValueError(f"Recommend to use at least 30 data points for fitting, got {self.max_fit_chunk}")
 
 
+class BatchJobSchedConfig:
+    """Configuration for batch-job-aware scheduler.
+
+    All parameters can be configured via ``additional_config.batch_job_sched_config``
+    in the vLLM config.
+
+    Usage (offline)::
+
+        llm = LLM(model, additional_config={"batch_job_sched_config": {"enabled": true}})
+    """
+
+    def __init__(self, config: dict | None = None):
+        if config is None:
+            config = {}
+
+        # Enable batch-job-aware scheduler
+        self.enabled: bool = config.get("enabled", False)
+
+        # Maximum number of tracked jobs (0 = unlimited)
+        self.max_jobs: int = int(config.get("max_jobs", 20))
+
+        # Extra block margin added to the reserve as safety buffer
+        self.reserve_margin_blocks: int = int(config.get("reserve_margin_blocks", 2))
+
+        # Maximum number of blocks that can be reserved
+        self.reserve_max_blocks: int = int(config.get("reserve_max_blocks", 8))
+
+        # Threshold for prioritizing long vs short decode jobs
+        self.low_available_tokens_threshold: int = int(config.get("low_available_tokens_threshold", 4096))
+
+        # Threshold for identifying short decoding jobs
+        self.short_decode_token_threshold: int = int(config.get("short_decode_token_threshold", 32))
+
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validate the validity of configuration parameters."""
+        if self.max_jobs < 0:
+            raise ValueError(f"batch_job_sched_config.max_jobs must be non-negative, got {self.max_jobs}")
+        if self.reserve_margin_blocks < 0:
+            raise ValueError(
+                f"batch_job_sched_config.reserve_margin_blocks must be non-negative, got {self.reserve_margin_blocks}"
+            )
+        if self.reserve_max_blocks <= 0:
+            raise ValueError(
+                f"batch_job_sched_config.reserve_max_blocks must be positive, got {self.reserve_max_blocks}"
+            )
+        if self.low_available_tokens_threshold <= 0:
+            raise ValueError(
+                f"batch_job_sched_config.low_available_tokens_threshold must be positive, "
+                f"got {self.low_available_tokens_threshold}"
+            )
+        if self.short_decode_token_threshold <= 0:
+            raise ValueError(
+                f"batch_job_sched_config.short_decode_token_threshold must be positive, "
+                f"got {self.short_decode_token_threshold}"
+            )
+
+
 class RejectionSamplerConfig:
     """Configuration for Block Verify and Entropy Verify in Rejection Sampler.
 
@@ -872,6 +931,9 @@ class SchedulerConfig:
         )
         self.profiling_chunk_config = ProfilingChunkConfig(
             self._get_config_value(scheduler_config, additional_config, "profiling_chunk_config", {})
+        )
+        self.batch_job_sched_config = BatchJobSchedConfig(
+            self._get_config_value(scheduler_config, additional_config, "batch_job_sched_config", {})
         )
 
     @staticmethod

--- a/vllm_ascend/core/batch_job_aware_scheduler.py
+++ b/vllm_ascend/core/batch_job_aware_scheduler.py
@@ -1,0 +1,685 @@
+"""
+Batch-Job-Aware Scheduler for vLLM v1
+=====================================
+
+Designed for **offline batch** scenarios where throughput and hardware
+utilisation are the primary goals.
+
+The main strategy is as follows:
+
+1. By adopting the LPT (Longest Processing Time first) strategy, we
+   prioritize longer tasks first and schedule shorter ones to fill
+   in the gaps, particularly during the decoding step. This approach
+   improves the average number of tokens computed per scheduling round.
+2. Estimate and reserve KV cache budget in advance for running requests
+   to reduce preemption.
+
+Inherits from the base ``Scheduler`` and replaces the waiting queue with
+a custom queue that:
+
+1. Groups requests by **job name** (extracted from ``#job_name[${JOB_NAME}]#``
+   prefix), estimates decode length per job via **EWMA**.
+2. Predicts next-step **KV block needs** for running requests (reserve),
+   uses **reserve-aware budget** to suppress preemption.
+3. Each job has its own **RequestBucket** for efficient request management,
+   uses **RequestBucket** for O(log n) best-fit search by prefill length.
+4. Dynamically adjusts job scheduling order based on KV Cache availability:
+   - When available tokens > threshold (default 4096): prioritize long decode jobs
+   - When available tokens <= threshold: prioritize short decode jobs
+
+Usage
+-----
+
+Pass the class (or its fully-qualified name) via ``scheduler_cls``::
+
+    from vllm.v1.core.sched.batch_job_aware_scheduler import BatchJobAwareScheduler
+
+    engine = LLMEngine.from_engine_args(EngineArgs(model=..., scheduler_cls=BatchJobAwareScheduler))
+
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections import deque
+from collections.abc import Iterator
+from typing import Any
+
+import regex as re
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.request_queue import RequestQueue
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.request import Request, RequestStatus
+
+from vllm_ascend.ascend_config import BatchJobSchedConfig
+
+
+class JobNameParser:
+    """Job name parser with caching for better performance."""
+
+    __slots__ = ("_pattern", "_cache")
+
+    def __init__(self) -> None:
+        self._pattern = re.compile(r"#job_name\[([^\[\]]+)\]#")
+        self._cache: dict[str, str] = {}
+
+    def parse(self, request_id: str) -> str:
+        """Extract the job name from a request ID with caching."""
+        job_name = self._cache.get(request_id)
+        if job_name is not None:
+            return job_name
+        m = self._pattern.search(request_id)
+        job_name = m.group(1) if m else "__default__"
+        self._cache[request_id] = job_name
+        return job_name
+
+    def remove(self, request_id: str) -> None:
+        """Remove a request ID from the cache."""
+        self._cache.pop(request_id, None)
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        self._cache.clear()
+
+
+class _JobStat:
+    """Per‑job running statistics."""
+
+    __slots__ = ("sample_count", "ewma_average")
+
+    def __init__(self) -> None:
+        self.sample_count: int = 0
+        # a sensible value before any observation has been recorded.
+        self.ewma_average: float = 0.0
+
+
+class JobDecodeEstimator:
+    """Per‑job decode‑length estimator with EWMA.
+
+    This estimator uses EWMA (Exponentially Weighted Moving Average) for
+    predicting decode lengths. When no samples exist for a job, it returns
+    a cold-start default value. Once the first sample is observed, the
+    EWMA average is set to that value and refined with each new sample.
+
+    EWMA Formula:
+        EWMA_t = α * x_t + (1 - α) * EWMA_{t-1}
+
+        Where:
+            - EWMA_t: New EWMA average at time t
+            - α: Smoothing factor (_EWMA_ALPHA = 0.1), 0 < α <= 1
+            - x_t: Current observation (decode_len)
+            - EWMA_{t-1}: Previous EWMA average
+
+    Properties of EWMA:
+        1. **Weight decay**: Older observations have exponentially decreasing
+           influence. The weight of observation x_{t-k} is α(1-α)^k.
+        2. **Effective window size**: The "half-life" of observations is
+           approximately ln(0.5)/ln(1-α). With α=0.1, half-life ≈ 6.58 samples.
+        3. **Initialization**: For the first sample (n=1), EWMA is simply
+           set to the observed value: EWMA_1 = x_1
+        4. **Sensitivity control**:
+           - Higher α (e.g., 0.3): More responsive to recent changes
+           - Lower α (e.g., 0.1): More stable, slower to adapt
+    """
+
+    # Fallback predicted decode length when no samples exist.
+    _COLD_START_DEFAULT_DECODE: int = 128
+    # EWMA smoothing factor (0 < α <= 1).
+    _EWMA_ALPHA: float = 0.1
+    # Maximum samples per job for decode length estimation.
+    _MAX_SAMPLES_PER_JOB: int = 10
+
+    def __init__(self, config: BatchJobSchedConfig) -> None:
+        self._config = config
+        self._job_stats: dict[str, _JobStat] = {}
+
+    def predict(self, job_name: str) -> int:
+        """Return the predicted decode length for *job*."""
+        job_stat = self._job_stats.get(job_name)
+        if job_stat is None:
+            return self._COLD_START_DEFAULT_DECODE
+        return int(job_stat.ewma_average)
+
+    def observe(self, job_name: str, decode_len: int) -> None:
+        """Record one decode‑length observation for *job*.
+
+        This method updates the job statistics using the EWMA (Exponentially
+        Weighted Moving Average) formula for online learning.
+
+        Args:
+            job_name: The name of the job to record observation for.
+            decode_len: The observed decode length to record.
+        """
+        job_stat = self._job_stats.get(job_name)
+        if job_stat is None:
+            # Check max_jobs limit before creating a new job stat
+            if len(self._job_stats) >= self._config.max_jobs:
+                raise RuntimeError(
+                    f"Maximum number of jobs ({self._config.max_jobs}) exceeded in JobDecodeEstimator. "
+                    f"Cannot create new job stat for '{job_name}'. "
+                    f"Current number of jobs: {len(self._job_stats)}."
+                )
+            job_stat = _JobStat()
+            self._job_stats[job_name] = job_stat
+
+        # Skip update when max samples reached for performance
+        if job_stat.sample_count >= self._MAX_SAMPLES_PER_JOB:
+            return
+
+        job_stat.sample_count += 1
+        if job_stat.sample_count == 1:
+            job_stat.ewma_average = float(decode_len)
+        else:
+            job_stat.ewma_average = self._EWMA_ALPHA * decode_len + (1 - self._EWMA_ALPHA) * job_stat.ewma_average
+
+    def get_stats(self) -> dict[str, dict[str, int | float]]:
+        """Return human‑readable statistics for all tracked jobs."""
+        return {
+            job: {
+                "sample_count": s.sample_count,
+                "ewma_average": round(s.ewma_average, 1),
+            }
+            for job, s in self._job_stats.items()
+        }
+
+
+def _cdiv(a: int, b: int) -> int:
+    """Ceiling division: smallest integer >= a/b."""
+    return -(a // -b)
+
+
+class RunningBlockReserver:
+    """Predict the KV‑block demand of the next running‑loop pass.
+
+    Results are cached per scheduling step to avoid redundant iteration
+    over the running-request list. The cache uses **incremental updates**:
+    when a new request is appended to the running set between consecutive
+    ``predict()`` calls within the same admission loop, only the delta
+    for that single request is computed (O(1)) instead of scanning the
+    entire running list (O(N)).
+
+    Call ``invalidate_cache()`` at the start of each ``schedule()``
+    round to force a full recompute on the first ``predict()`` call.
+    """
+
+    def __init__(self, scheduler: Scheduler, config: BatchJobSchedConfig) -> None:
+        self._scheduler = scheduler
+        self._config = config
+        # Pre-margin sum of per-request block predictions.
+        self._cached_predict_blocks: int = 0
+        # Number of running requests that _cached_raw_reserve corresponds to.
+        # -1 means the cache is invalid and a full recompute is needed.
+        self._cached_running_queue_len: int = -1
+
+    def invalidate_cache(self) -> None:
+        """Mark the cached prediction as stale so the next call recomputes."""
+        self._cached_running_queue_len = -1
+
+    def predict(self) -> int:
+        """Return the number of blocks to reserve for the current running set."""
+        current_len = len(self._scheduler.running)
+
+        # Case 1: Length unchanged → cache hit
+        if current_len == self._cached_running_queue_len:
+            return self._finalize_reserve(self._cached_predict_blocks)
+
+        # Case 2: Running grew by exactly 1 request within the same admission
+        if current_len == self._cached_running_queue_len + 1 and self._cached_running_queue_len >= 0:
+            new_request = self._scheduler.running[-1]
+            self._cached_predict_blocks += self._compute_one(new_request)
+            self._cached_running_queue_len = current_len
+            return self._finalize_reserve(self._cached_predict_blocks)
+
+        # Case 3: Complex change (new schedule round)
+        self._cached_predict_blocks = self._compute_all()
+        self._cached_running_queue_len = current_len
+        return self._finalize_reserve(self._cached_predict_blocks)
+
+    def _finalize_reserve(self, predict_blocks: int) -> int:
+        return min(
+            predict_blocks + self._config.reserve_margin_blocks,
+            self._config.reserve_max_blocks,
+        )
+
+    def _compute_one(self, request: Request) -> int:
+        """Return the raw (pre-margin) number of new KV blocks *request*
+        will need in the next scheduling step.
+
+        This method simulates the effect of the *current* scheduling round
+        on the request's position, then predicts blocks needed for the
+        *next* round from that advanced position. This eliminates a one-step
+        timeline misalignment: when this method is called (during the waiting-
+        queue admission phase of ``schedule()``), the running requests have
+        already been assigned ``num_new_tokens`` for this round but their
+        ``num_computed_tokens`` has not yet been advanced (that happens in
+        ``update_from_output`` post-execution). By simulating the advance we
+        get the correct starting position for the next round's prediction.
+        """
+        num_computed = request.num_computed_tokens
+        num_prompt = request.num_prompt_tokens
+        block_size = self._scheduler.block_size
+
+        # Step 1: estimate how many tokens this round will advance
+        if num_computed < num_prompt:
+            remaining_prompt = num_prompt - num_computed
+            this_round_tokens = min(remaining_prompt, self._scheduler.max_num_scheduled_tokens)
+        else:
+            this_round_tokens = 1 + self._scheduler.num_lookahead_tokens
+
+        # Step 2: simulate position after this round's execution
+        num_computed_after = num_computed + this_round_tokens
+
+        # Step 3: estimate the NEXT round's token demand
+        if num_computed_after < num_prompt:
+            # Still in prefill next round
+            remaining_prompt_after = num_prompt - num_computed_after
+            next_round_tokens = min(remaining_prompt_after, self._scheduler.max_num_scheduled_tokens)
+        else:
+            # Transitions to (or stays in) decode
+            next_round_tokens = 1 + self._scheduler.num_lookahead_tokens
+
+        # Step 4: compute new blocks needed from that position
+        pos_in_block = num_computed_after % block_size
+        remaining = block_size - pos_in_block if pos_in_block > 0 else 0
+
+        if next_round_tokens > remaining:
+            return _cdiv(next_round_tokens - remaining, block_size)
+        return 0
+
+    def _compute_all(self) -> int:
+        return sum(self._compute_one(req) for req in self._scheduler.running)
+
+
+class RequestBucket:
+    """Request bucket based on prefill length, supports O(log n) best-fit search."""
+
+    def __init__(self) -> None:
+        self._bucket: dict[int, deque[Request]] = {}
+        self._sorted_lengths: list[int] = []
+        self._num_requests: int = 0
+
+    def put(self, request: Request) -> None:
+        """Put request into bucket."""
+        if request is None:
+            return
+
+        prefill_length = request.num_prompt_tokens
+
+        if prefill_length not in self._bucket:
+            self._bucket[prefill_length] = deque()
+            bisect.insort(self._sorted_lengths, prefill_length)
+
+        self._bucket[prefill_length].append(request)
+        self._num_requests += 1
+
+    def peek_best_fit_request(self, search_prefill_length: int) -> Request | None:
+        """Find best-fit request from bucket based on available token count."""
+        if self.is_empty() or not self._bucket or not self._sorted_lengths:
+            return None
+
+        idx = bisect.bisect_right(self._sorted_lengths, search_prefill_length)
+        if idx > 0:
+            best_length = self._sorted_lengths[idx - 1]
+            queue = self._bucket.get(best_length)
+            if queue:
+                return queue[0]
+
+        if idx < len(self._sorted_lengths):
+            best_length = self._sorted_lengths[idx]
+            queue = self._bucket.get(best_length)
+            if queue:
+                return queue[0]
+
+        return None
+
+    def remove(self, request: Request) -> bool:
+        """Remove specified request from bucket."""
+        if request is None:
+            return False
+
+        prefill_length = request.num_prompt_tokens
+        queue = self._bucket.get(prefill_length)
+        if queue is None:
+            return False
+
+        try:
+            queue.remove(request)
+            self._num_requests -= 1
+            if not queue:
+                del self._bucket[prefill_length]
+                idx = bisect.bisect_left(self._sorted_lengths, prefill_length)
+                if idx < len(self._sorted_lengths) and self._sorted_lengths[idx] == prefill_length:
+                    self._sorted_lengths.pop(idx)
+            return True
+        except ValueError:
+            return False
+
+    def is_empty(self) -> bool:
+        """Check if bucket is empty."""
+        return self._num_requests == 0
+
+    def __len__(self) -> int:
+        return self._num_requests
+
+    def __bool__(self) -> bool:
+        return not self.is_empty()
+
+    def __iter__(self) -> Iterator[Request]:
+        for queue in self._bucket.values():
+            yield from queue
+
+
+class BatchJobAwareRequestQueue(RequestQueue):
+    """Request queue with job‑grouped sorting and reserve‑aware admission.
+
+    Bucket Structure:
+        - Each job has its own RequestBucket: dict[job_name, RequestBucket]
+        - Jobs are classified as LONG/SHORT based on predicted decode length
+
+    Scheduling Priority:
+        1. Cold-start requests (first N requests per job) - highest priority
+        2. Regular scheduling based on available tokens:
+           - Available tokens > threshold (default 4096): prioritize long decode jobs
+           - Available tokens <= threshold: prioritize short decode jobs
+           - Job length is determined by short_decode_token_threshold (default 32)
+
+    Job Classification:
+        - Short decode job: predicted decode length < short_decode_token_threshold
+        - Long decode job: predicted decode length >= short_decode_token_threshold
+
+    Within-Category Sorting:
+        - Long jobs: sorted by decode length descending (longest first)
+        - Short jobs: sorted by decode length ascending (shortest first)
+    """
+
+    # Minimum samples needed to exit cold-start scheduling priority.
+    _COLD_START_MIN_SAMPLES: int = 3
+
+    def __init__(
+        self,
+        scheduler: Scheduler,
+        job_decode_estimator: JobDecodeEstimator,
+        block_reserver: RunningBlockReserver,
+        job_name_parser: JobNameParser,
+        config: BatchJobSchedConfig,
+    ) -> None:
+        self._scheduler = scheduler
+        self._job_decode_estimator = job_decode_estimator
+        self._block_reserver = block_reserver
+        self._job_name_parser = job_name_parser
+        self._config = config
+
+        # Each job has its own RequestBucket
+        self._job_buckets: dict[str, RequestBucket] = {}
+        self._cold_start_reqs: dict[str, set[str]] = {}
+        self._job_req_count: dict[str, int] = {}
+        self._num_requests: int = 0
+        self._peeked: Request | None = None
+
+    def add_request(self, request: Request) -> None:
+        """Add a request to the queue."""
+        if request is None:
+            return
+
+        job_name = self._get_job_name(request)
+        bucket = self._get_or_create_job_bucket(job_name)
+        bucket.put(request)
+        self._num_requests += 1
+        self._track_cold_start_req(request)
+
+    def prepend_request(self, request: Request) -> None:
+        self.add_request(request)
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.add_request(request)
+
+    def remove_request(self, request: Request) -> None:
+        """Remove a specific request from the queue."""
+        if request is None:
+            return
+
+        job_name = self._get_job_name(request)
+        if job_name is None:
+            return
+        bucket = self._job_buckets.get(job_name)
+        if bucket is None:
+            return
+
+        if bucket.remove(request):
+            self._num_requests -= 1
+            if job_name in self._cold_start_reqs:
+                self._cold_start_reqs[job_name].discard(request.request_id)
+                if not self._cold_start_reqs[job_name]:
+                    del self._cold_start_reqs[job_name]
+            if bucket.is_empty():
+                del self._job_buckets[job_name]
+                self._job_req_count.pop(job_name, None)
+
+    def remove_requests(self, requests: Any) -> None:
+        for request in requests:
+            self.remove_request(request)
+
+    def peek_request(self) -> Request:
+        if self._peeked is not None:
+            return self._peeked
+        request = self._find_admittable()
+        if request is None:
+            raise IndexError("no admittable request under reserve")
+        self._peeked = request
+        return request
+
+    def pop_request(self) -> Request:
+        request = self._peeked if self._peeked is not None else self._find_admittable()
+        if request is None:
+            raise IndexError("pop from empty admittable set")
+        self.remove_request(request)
+        self._peeked = None
+        return request
+
+    def _get_job_name(self, request):
+        return self._job_name_parser.parse(request.request_id)
+
+    def _track_cold_start_req(self, request: Request) -> None:
+        """Track a request as a cold-start request if applicable."""
+        job_name = self._get_job_name(request)
+
+        if job_name not in self._job_req_count:
+            self._job_req_count[job_name] = 0
+        self._job_req_count[job_name] += 1
+
+        if self._job_req_count[job_name] <= self._COLD_START_MIN_SAMPLES:
+            if job_name not in self._cold_start_reqs:
+                self._cold_start_reqs[job_name] = set()
+            self._cold_start_reqs[job_name].add(request.request_id)
+
+    def _get_or_create_job_bucket(self, job_name: str) -> RequestBucket:
+        """Get or create a RequestBucket for a job."""
+        if job_name not in self._job_buckets:
+            # Check max_jobs limit before creating a new job bucket
+            if self._config.max_jobs and len(self._job_buckets) >= self._config.max_jobs:
+                raise RuntimeError(
+                    f"Maximum number of jobs ({self._config.max_jobs}) exceeded. "
+                    f"Cannot create new job '{job_name}'. "
+                    f"Current number of jobs: {len(self._job_buckets)}."
+                )
+            self._job_buckets[job_name] = RequestBucket()
+        return self._job_buckets[job_name]
+
+    def _free_blocks(self) -> int:
+        return self._scheduler.kv_cache_manager.block_pool.get_num_free_blocks()
+
+    def _admission_budget(self) -> int:
+        """Calculate admission budget in tokens."""
+        free_blocks = self._free_blocks()
+        reserve_blocks = self._block_reserver.predict()
+        block_size = self._scheduler.block_size
+        return max(0, (free_blocks - reserve_blocks) * block_size)
+
+    def _find_admittable(self) -> Request | None:
+        """Return the highest‑priority admittable request, or ``None``.
+
+        Scheduling Priority:
+            1. Cold-start requests (first N requests per job) - highest priority
+            2. Regular scheduling based on available tokens:
+               - Available tokens > threshold: prioritize long decode jobs
+               - Available tokens <= threshold: prioritize short decode jobs
+        """
+        admission_budget = self._admission_budget()
+        if admission_budget == 0:
+            return None
+
+        # Priority 1: Cold-start requests
+        request = self._get_cold_start_request()
+        if request is not None:
+            return request
+
+        # Collect job decode information
+        long_jobs, short_jobs = self._collect_job_decode_info()
+
+        # Priority 2: Regular scheduling based on available tokens
+        return self._try_schedule_by_available_tokens(admission_budget, long_jobs, short_jobs)
+
+    def _get_cold_start_request(self) -> Request | None:
+        """Try to get a cold-start request with highest priority."""
+        for job_name, cold_start_reqs in self._cold_start_reqs.items():
+            bucket = self._job_buckets.get(job_name)
+            if bucket is None:
+                continue
+            for request in bucket:
+                if request.request_id in cold_start_reqs:
+                    return request
+        return None
+
+    def _collect_job_decode_info(self) -> tuple[list[tuple[str, int]], list[tuple[str, int]]]:
+        """Collect job decode length information."""
+        # Separate jobs into long and short categories
+        long_jobs: list[tuple[str, int]] = []
+        short_jobs: list[tuple[str, int]] = []
+
+        short_threshold = self._config.short_decode_token_threshold
+
+        for job_name, bucket in self._job_buckets.items():
+            if bucket.is_empty():
+                continue
+            predict_decode = self._job_decode_estimator.predict(job_name)
+            if predict_decode > short_threshold:
+                long_jobs.append((job_name, predict_decode))
+            else:
+                short_jobs.append((job_name, predict_decode))
+
+        return long_jobs, short_jobs
+
+    def _try_schedule_by_available_tokens(
+        self, admission_budget: int, long_jobs: list[tuple[str, int]], short_jobs: list[tuple[str, int]]
+    ) -> Request | None:
+        """Schedule requests based on job decode length.
+
+        Strategy:
+            - When available tokens > threshold: prioritize long decode jobs
+            - When available tokens <= threshold: prioritize short decode jobs
+        """
+        # Sort jobs
+        ordered_jobs = self._sort_jobs(admission_budget, long_jobs, short_jobs)
+
+        for job_name, _ in ordered_jobs:
+            bucket = self._job_buckets.get(job_name)
+            if bucket is None or bucket.is_empty():
+                continue
+            request = bucket.peek_best_fit_request(admission_budget)
+            if request is not None:
+                return request
+
+        return None
+
+    def _sort_jobs(
+        self, admission_budget: int, long_jobs: list[tuple[str, int]], short_jobs: list[tuple[str, int]]
+    ) -> list[tuple[str, int]]:
+        prioritize_long = admission_budget > self._config.low_available_tokens_threshold
+
+        if len(long_jobs) > 0 and len(short_jobs) > 0:
+            long_jobs.sort(key=lambda x: x[1], reverse=True)
+            short_jobs.sort(key=lambda x: x[1], reverse=True)
+            ordered_jobs = long_jobs + short_jobs if prioritize_long else short_jobs + long_jobs
+        else:
+            long_jobs.sort(key=lambda x: x[1], reverse=prioritize_long)
+            short_jobs.sort(key=lambda x: x[1], reverse=prioritize_long)
+            ordered_jobs = long_jobs + short_jobs
+
+        return ordered_jobs
+
+    def __len__(self) -> int:
+        return self._num_requests
+
+    def __iter__(self) -> Iterator[Request]:
+        for bucket in self._job_buckets.values():
+            yield from bucket
+
+    def __bool__(self) -> bool:
+        return self._find_admittable() is not None
+
+
+class BatchJobAwareScheduler(Scheduler):
+    """Batch‑job‑aware scheduler for offline / batched inference workloads."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Initialize scheduler configuration.
+        from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+
+        init_ascend_config(self.vllm_config)
+        scheduler_extension_config = get_ascend_config().scheduler_config
+        _config: BatchJobSchedConfig = scheduler_extension_config.batch_job_sched_config
+
+        self._job_name_parser = JobNameParser()
+        self._job_decode_estimator = JobDecodeEstimator(_config)
+        self._block_reserver = RunningBlockReserver(self, _config)
+
+        self.waiting = BatchJobAwareRequestQueue(
+            self, self._job_decode_estimator, self._block_reserver, self._job_name_parser, _config
+        )
+
+    def schedule(self, *args, **kwargs):
+        """Override to invalidate the block-reserve cache before each step.
+
+        Inside the parent ``schedule()``, the waiting queue calls
+        ``RunningBlockReserver.predict()`` for each request being checked.
+        The cache auto-detects changes to the running set and computes
+        incremental O(1) deltas when a single request is added, avoiding
+        redundant full scans.
+        """
+        self._block_reserver.invalidate_cache()
+        return super().schedule(*args, **kwargs)
+
+    def _free_request(self, request: Request, delay_free_blocks: bool = False) -> dict[str, Any] | None:
+        """Observe the decode length for naturally stopped requests."""
+        if request.status == RequestStatus.FINISHED_STOPPED:
+            job_name = self._job_name_parser.parse(request.request_id)
+            self._job_decode_estimator.observe(job_name, request.num_output_tokens)
+        self._job_name_parser.remove(request.request_id)
+        return super()._free_request(request, delay_free_blocks)
+
+
+class BatchJobAwareAsyncScheduler(AsyncScheduler, BatchJobAwareScheduler):
+    """Batch-job-aware + asynchronous scheduling, combined via multiple inhernce.
+
+    This class inherits from both ``AsyncScheduler`` and
+    ``BatchJobAwareScheduler`` to compose asynchronous scheduling with
+    batch-job-aware scheduling logic.
+
+    Dependency import chain
+    -----------------------
+    - ``AsyncScheduler`` — imported from ``vllm.v1.core.sched.async_scheduler``,
+      provides the asynchronous scheduling loop and async-schedule interface.
+    - ``BatchJobAwareScheduler`` — defined in this same module, inherits from
+      ``Scheduler`` and provides batch-job-aware scheduling logic (LPT
+      strategy, KV cache reservation, job grouping, etc.).
+    - ``Scheduler`` — base class imported from
+      ``vllm.v1.core.scheduler`` (via ``BatchJobAwareScheduler``), provides
+      the core scheduling primitive that the async scheduler wraps.
+
+    MRO: BatchJobAwareAsyncScheduler -> AsyncScheduler -> BatchJobAwareScheduler -> Scheduler
+    """
+
+    pass

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -689,6 +689,17 @@ class NPUPlatform(Platform):
             )
             import vllm_ascend.patch.platform.patch_profiling_chunk  # noqa
 
+        # Extend original scheduler_config to use BatchJobAwareScheduler.
+        if scheduler_extension_config.batch_job_sched_config.enabled:
+            if vllm_config.scheduler_config.async_scheduling:
+                vllm_config.scheduler_config.scheduler_cls = (
+                    "vllm_ascend.core.batch_job_aware_scheduler.BatchJobAwareAsyncScheduler"
+                )
+            else:
+                vllm_config.scheduler_config.scheduler_cls = (
+                    "vllm_ascend.core.batch_job_aware_scheduler.BatchJobAwareScheduler"
+                )
+
         cp_size = parallel_config.decode_context_parallel_size * parallel_config.prefill_context_parallel_size
         use_sparse = model_uses_sfa_sparse(model_config)
         sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(vllm_config)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces a **Batch-Job-Aware Scheduler** designed for **offline batch inference** scenarios where throughput and hardware utilisation are the primary goals. It is particularly effective when processing multiple batch jobs concurrently, each with a distinct set of requests.

#### Background

In large-scale offline batch processing scenarios, the default FCFS (First-Come-First-Serve) scheduler suffers from the following issues:

1. **Low throughput during decode-heavy phases**: When a large number of requests in the running queue are in the decoding phase, the number of tokens computed per scheduling round is small, resulting in low throughput.

2. **Excessive preemption overhead**: When running queue requests are scheduled, if a request cannot acquire new KV cache blocks, preemption is triggered, which can cause a large number of requests to be recomputed, wasting computational resources.

Since the request lists of each job type share the same prompt template and task objective, their decode-phase token lengths tend to converge. We can predict a job's decode-phase token length by sampling its completed requests, and incorporate these predictions into scheduling optimization.

#### Key Design

The scheduler implements three key strategies to improve throughput:

1. **LPT (Longest Processing Time first) scheduling**: Prioritises longer tasks first and schedules shorter ones to fill gaps, particularly during the decode step. This improves the average number of tokens computed per scheduling round.

2. **KV cache reservation**: Estimates and reserves KV cache budget in advance for running requests. The `RunningBlockReserver` predicts the next-step KV block needs for each running request, using a two-level incremental cache (O(1) for single-request additions within the same admission loop) to avoid redundant full scans. This reduces preemption overhead significantly.

3. **Job-aware request grouping with dynamic priority**: Groups requests by **job name** (extracted from a `#job_name[${JOB_NAME}]#` tag embedded in the request ID), assigns each job its own `RequestBucket` for O(log n) best-fit prefill-length search, and dynamically adjusts job scheduling order based on KV cache availability:
   - When available tokens > threshold (default 4096): prioritise long decode jobs
   - When available tokens ≤ threshold: prioritise short decode jobs

> **Note:** This scheduler **does not implement starvation prevention**. It is intended solely for **batch processing scenarios** or **online inference scenarios where request waiting time is not a concern**. If requests have strict latency or fairness requirements, this scheduler may not be suitable.

#### Architecture

The scheduler is implemented by extending the **waiting queue** with a custom `BatchJobAwareRequestQueue` that replaces the default FIFO queue, while inheriting most features from the original scheduler, including chunked prefill, async scheduling, and more.

Key components:

| Component | Description |
|-----------|-------------|
| `JobNameParser` | Extracts job names from request IDs with regex caching |
| `JobDecodeEstimator` | Per-job decode length prediction using EWMA + Bayesian cold-start shrinkage |
| `RunningBlockReserver` | KV cache demand prediction with incremental cache updates |
| `RequestBucket` | O(log n) best-fit search by prefill length |
| `BatchJobAwareRequestQueue` | Job-grouped waiting queue with reserve-aware admission |
| `BatchJobAwareScheduler` | Main scheduler class (sync) |
| `BatchJobAwareAsyncScheduler` | Combined async + batch-job-aware scheduler |

#### Decode Length Estimation

Each job's decode length is predicted using a pure **EWMA (Exponentially Weighted Moving Average)** estimator:

- **No samples yet**: Returns a cold-start default value (128 tokens).
- **First observation**: EWMA is initialised to the observed decode length.
- **Subsequent observations**: EWMA is updated incrementally, giving more weight to recent data while smoothing out fluctuations.

This enables the scheduler to distinguish between "long decode" jobs (which benefit from being scheduled first when resources are abundant) and "short decode" jobs (which are prioritised when resources are scarce).

#### Configuration

All parameters are nested under `batch_job_sched_config` in the `additional_config` dictionary:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `enabled` | bool | `false` | Enable the batch-job-aware scheduler |
| `max_jobs` | int | `20` | Maximum number of tracked jobs |
| `reserve_margin_blocks` | int | `2` | Extra block margin added to the KV cache reserve as safety buffer |
| `reserve_max_blocks` | int | `8` | Maximum number of blocks that can be reserved |
| `low_available_tokens_threshold` | int | `4096` | Threshold for prioritising long vs short decode jobs |
| `short_decode_token_threshold` | int | `32` | Threshold for classifying a job as "short decode" |

#### Files Changed

| File | Change |
|------|--------|
| `vllm_ascend/core/batch_job_aware_scheduler.py` | **New**: Core scheduler implementation  |
| `vllm_ascend/ascend_config.py` | **Modified**: Added `BatchJobSchedConfig` class and config loading |
| `vllm_ascend/platform.py` | **Modified**: Register scheduler classes when config enabled  |
| `docs/source/user_guide/feature_guide/batch_job_aware_scheduler.md` | **New**: Feature usage documentation  |
| `docs/source/user_guide/configuration/additional_config.md` | **Modified**: Add config documentation  |
| `tests/ut/core/test_batch_job_aware_scheduler.py` | **New**: Unit tests  |
| `tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py` | **New**: End-to-end tests |
| `‎mkdocs.yml` | **Modified**: Add doc index for user_guide |
| `test_config.yaml` | **Modified**: Add test config |

**Total**: 9 files changed.

---

### Does this PR introduce _any_ user-facing change?

Yes.

- **New configuration**: Adds `batch_job_sched_config` section to `additional_config: {"scheduler_config":: {}}` with 6 configurable parameters.
- **New request ID convention**: Users can optionally embed `#job_name[${JOB_NAME}]#` in request IDs to enable job-aware grouping.
- **New feature guide**: Added `docs/source/user_guide/feature_guide/batch_job_aware_scheduler.md` with usage documentation.
- **New feature index entry**: Added `batch_job_aware_scheduler` to the feature guide toctree.

Feature is disabled by default (`enabled: false`). Users opt in via `additional_config`:

```bash
python -m vllm.entrypoints.openai.run_batch \
    --model /path/to/model \
    -i /path/to/input.jsonl \
    -o /path/to/output.jsonl \
    --additional-config '{"scheduler_config": {"batch_job_sched_config": {"enabled": true}}}'
```

Or via Python API:

```python
from vllm import LLM

llm = LLM(
    model="/path/to/model",
    additional_config={
        "scheduler_config": {
            "batch_job_sched_config": {
                "enabled": True,
            },
        },
    },
)
```

---

### How was this patch tested?

#### Unit Tests

Added comprehensive unit tests in `tests/ut/core/test_batch_job_aware_scheduler.py` covering all components:

- **`_cdiv`** (6 tests): Exact division, rounding up, zero numerator, large values.
- **`_JobStat`** (2 tests): Initial values, after observations.
- **`JobNameParser`** (7 tests): With/without job name, caching, removal, clear, multiple jobs.
- **`JobDecodeEstimator`** (12 tests): Default prediction, observation, cold-start Bayesian shrinkage, stable EWMA phase, EWMA convergence, max_jobs limit, max_samples_per_job limit, get_stats, multiple independent jobs, cumulative sum.
- **`RequestBucket`** (16 tests): Put, remove, best-fit search, empty state, iteration, bool conversion, edge cases.
- **`RunningBlockReserver`** (8 tests): Cache invalidation, empty running, cache hit, incremental update, full recompute, prefill/decode phase computation, block boundary, max blocks cap.
- **`BatchJobAwareRequestQueue`** (22 tests): Add/remove request, job routing, cold-start tracking, peek/pop, job classification, sorting strategies, admission budget, bool conversion, max_jobs limit.

All tests can be run with:

```bash
# Unit tests
pytest -sv tests/ut/core/test_batch_job_aware_scheduler.py
```

#### End-to-End Tests

Added E2E tests in `tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py` with 4 test scenarios:

1. **Basic functionality**: Compares outputs between `BatchJobAwareScheduler` and default scheduler to ensure correctness (4 prompts).
2. **Async scheduling**: Tests `BatchJobAwareAsyncScheduler` against default async scheduler.
3. **Chunked prefill**: Verifies correctness with `enable_chunked_prefill=True` and `chunked_prefill_token_size=16` (20 prompts).
4. **Custom configuration**: Tests with custom EWMA parameters and other config options (20 prompts).

All E2E tests compare outputs using `check_outputs_equal` to verify that the batch-job-aware scheduler produces identical results to the default scheduler, ensuring correctness.

E2E tests can be run with:

```bash
# End-to-end tests (requires Ascend NPU)
pytest -sv tests/e2e/pull_request/one_card/test_batch_job_aware_scheduler_e2e.py
```

#### Performance Tests

We conducted benchmark tests comparing the **Batch-Job-Aware Scheduler** (experimental group) against the **default FCFS scheduler** (control group) in offline batch inference scenarios. Each test group was run 3 times and the average metrics are reported.

**Environment:**
- Framework: vLLM v0.21.0, vLLM-Ascend v0.21.0rc1
- Hardware: Ascend 910B3 NPU (single card)
- Model: Qwen3-14B (deep thinking disabled)
- GPU memory utilization: 0.8
- Chunked prefill enabled, max_num_seqs=500, max_num_batched_tokens=4096

**Test workloads:**

| Workload | Description | Prefill length | Avg decode length |
|----------|-------------|---------------|-------------------|
| News summarization (10,000 requests) | Summarise news in ~100 words | 500–10,000+ | 96 |
| Sentiment classification (30,000 requests) | Classify product review sentiment (positive/negative) | 40–100 | 3 |

- News summarization data: [Chinese Financial News 2019](https://www.modelscope.cn/datasets/tangzhiling/chinese-financial-news-2019/files)
- Sentiment classification data: [JD Product Reviews](https://www.modelscope.cn/datasets/DAMO_NLP/jd/file/view/master/dev.csv?id=350&status=1)

**Results:**

| Workload | Async | Metric | Control (FCFS) | Experimental (Batch-Job-Aware) | Improvement |
|----------|-------|--------|----------------|-------------------------------|-------------|
| News (3K) + Sentiment (30K) | Yes | Avg tokens/schedule | 2,107 | 2,587 | **+22.78%** |
| | | Preemption count | 65 | 1 | **−98.46%** |
| | | Total time (s) | 934.85 | 901.77 | +3.54% |
| News (3K) + Sentiment (30K) | No | Avg tokens/schedule | 2,090 | 2,634 | **+26.03%** |
| | | Preemption count | 73 | 1 | **−98.63%** |
| | | Total time (s) | 956.85 | 923.01 | +3.53% |
| News (10K) | Yes | Avg tokens/schedule | 1,471 | 1,455 | −1.09% |
| | | Preemption count | 220 | 23 | **−89.55%** |
| | | Total time (s) | 1,697.77 | 1,647.67 | +2.95% |
| News (10K) | No | Avg tokens/schedule | 1,468 | 1,465 | −0.20% |
| | | Preemption count | 190 | 19 | **−90.00%** |
| | | Total time (s) | 1,748.18 | 1,699.59 | +2.78% |

> **Note:** For the News (10K) workload, `reserve_margin_blocks` was set to 4 to accommodate longer decode sequences.

**Key findings:**
1. **Significant reduction in preemption**: The batch-job-aware scheduler reduces preemption counts by 89–98%, even in single-job workloads (News 10K) where preemption is reduced by ~90%, thanks to the KV cache reservation mechanism.
2. **Higher tokens per scheduling round in mixed workloads**: Average tokens computed per scheduling round increases by 22–26% in mixed workloads, as the LPT scheduling and job-aware grouping enable better batching of decode-phase requests. In single-job workloads (News 10K), the avg tokens/schedule remains comparable to the baseline while preemption is dramatically reduced.
3. **Consistent throughput improvement**: Overall end-to-end time is reduced by 2.8–3.5% across all workloads. Notably, in the News (10K) workload, the expanded test coverage (both async and non-async modes) shows consistent ~2.8–3.0% time reduction, achieved primarily through eliminating preemption overhead rather than increasing per-round token count.

The results confirm that the batch-job-aware scheduler is particularly effective in multi-job mixed workloads (e.g., news summarisation + sentiment classification) where job decode lengths vary significantly, achieving both higher throughput and dramatically fewer preemptions. It also delivers consistent gains in single-job workloads by minimising preemption overhead.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
