### PR TITLE
[Cherry-pick][releases/v0.23.0] [BugFix] Disable multistream_overlap_shared_expert when enable_fused_mc2 is enabled

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -674,7 +674,7 @@ Before you start, please
             --served-model-name glm-52 \
             --max-model-len 135000 \
             --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_sparse_c8":false, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -744,7 +744,7 @@ Before you start, please
             --served-model-name glm-52 \
             --max-model-len 135000 \
             --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_sparse_c8":false, "enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -816,7 +816,7 @@ Before you start, please
             --max-num-batched-tokens 164 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp", "enforce_eager": true}' \
-            --additional-config '{"enable_sparse_c8":false, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"enable_sparse_c8":false, "recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 48 \
             --gpu-memory-utilization 0.92 \
@@ -886,7 +886,7 @@ Before you start, please
             --max-num-batched-tokens 164 \
             --speculative-config '{"num_speculative_tokens": 5, "method":"deepseek_mtp", "enforce_eager": true}' \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"enable_sparse_c8":false,"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"enable_sparse_c8":false,"recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 48 \
             --gpu-memory-utilization 0.92 \

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -819,7 +819,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-5 \
             --max-model-len 131072 \
-            --additional-config '{"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -899,7 +899,7 @@ Before you start, please
             --seed 1024 \
             --served-model-name glm-5 \
             --max-model-len 131072 \
-            --additional-config '{"multistream_overlap_shared_expert": true, "enable_dsa_cp": true}' \
+            --additional-config '{"enable_dsa_cp": true}' \
             --max-num-batched-tokens 4096 \
             --trust-remote-code \
             --max-num-seqs 64 \
@@ -983,7 +983,7 @@ Before you start, please
             --max-model-len 200000 \
             --max-num-batched-tokens 32 \
             --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-            --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+            --additional-config '{"recompute_scheduler_enable": true}' \
             --trust-remote-code \
             --max-num-seqs 8 \
             --gpu-memory-utilization 0.92 \
@@ -1063,7 +1063,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \
@@ -1143,7 +1143,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \
@@ -1223,7 +1223,7 @@ Before you start, please
              --max-model-len 200000 \
              --max-num-batched-tokens 32 \
              --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-             --additional-config '{"multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+             --additional-config '{"recompute_scheduler_enable": true}' \
              --trust-remote-code \
              --max-num-seqs 8 \
              --gpu-memory-utilization 0.92 \

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
@@ -34,7 +34,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.95"
       - "--additional-config"
-      - '{"enable_cpu_binding":true, "multistream_overlap_shared_expert": true, "enable_weight_nz_layout":true}'
+      - '{"enable_cpu_binding":true, "enable_weight_nz_layout":true}'
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3,"enforce_eager": true}'
       - "--compilation-config"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs16-0.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs16-0.yaml
@@ -95,7 +95,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --no-enable-prefix-caching
@@ -157,7 +157,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --no-enable-prefix-caching
@@ -224,7 +224,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true,"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":2000,"algorithm_execution_interval":50, "eplb_policy_type":3, "num_redundant_experts":32}}'
+      - '{"recompute_scheduler_enable": true,"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":2000,"algorithm_execution_interval":50, "eplb_policy_type":3, "num_redundant_experts":32}}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -288,7 +288,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs20-90.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in32k_bs20-90.yaml
@@ -95,7 +95,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -156,7 +156,7 @@ templates:
       - --max-model-len
       - "65536"
       - --additional-config
-      - '{"multistream_overlap_shared_expert": true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -222,7 +222,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -285,7 +285,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in64k_bs16-90.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM_5_1_PD_in64k_bs16-90.yaml
@@ -97,7 +97,7 @@ templates:
       - --max-model-len
       - "140000"
       - --additional-config
-      - '{"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -158,7 +158,7 @@ templates:
       - --max-model-len
       - "140000"
       - --additional-config
-      - '{"multistream_overlap_shared_expert":true,"enable_dsa_cp": true}'
+      - '{"enable_dsa_cp": true}'
       - --max-num-batched-tokens
       - "4096"
       - --trust-remote-code
@@ -224,7 +224,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,64,96,128]}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
+      - '{"recompute_scheduler_enable":true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -287,7 +287,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,64,96,128]}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true}'
+      - '{"recompute_scheduler_enable":true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/MiniMax-PD-in32k-bs4-1.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/MiniMax-PD-in32k-bs4-1.yaml
@@ -137,7 +137,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",
@@ -191,7 +191,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable": true,"multistream_overlap_shared_expert": true}'
+      - '{"recompute_scheduler_enable": true}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -176,6 +176,12 @@ class AscendConfig:
             "VLLM_ASCEND_ENABLE_FUSED_MC2",
             ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
         )
+        if self.enable_fused_mc2 == 1 and self.multistream_overlap_shared_expert:
+            self.multistream_overlap_shared_expert = False
+            logger.warning_once(
+                "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "
+                "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
+            )
         self.enable_mlapo = self._get_config_value(
             additional_config,
             "enable_mlapo",


### PR DESCRIPTION

### What this PR does / why we need it?
Cherry-pick of PR #12237 onto releases/v0.23.0.

This PR disables `multistream_overlap_shared_expert` when `enable_fused_mc2` is enabled. These two features cannot be enabled at the same time, so we automatically set `multistream_overlap_shared_expert` to `False` and log a warning if both are configured. 

Cause:
1. When fused mc2 is enabled, the shared expert multi-stream feature cannot be used with CV parallelism, and there is no performance gain.
2. When fused mc2 is enabled, multistream_overlap_shared_expert (shared expert multi-stream) is enabled, but enable_shared_expert_dp (shared expert DP) is not enabled.
As a result, the MOE large fusion operator and the TP communication (AIV mode) of the shared expert exist on two streams respectively. If one card enters the MOE large fusion operator and the other card enters the TP communication, the two operators will be deadlocked. As a result, the system is suspended.

Co-authored-by: guanguan0308 <1546542263@qq.com>
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
