### PR TITLE
[CI][xlite] Match xlite backend with the current main and add e2e MoE model test coverage

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -578,6 +578,7 @@
   tests:
     - tests/ut/xlite
     - tests/e2e/pull_request/one_card/test_xlite.py
+    - tests/e2e/pull_request/two_card/test_xlite.py
 
 # Batch Invariant
 - name: batch_invariant
@@ -756,6 +757,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/test_shared_expert_dp.py: 400
   tests/e2e/pull_request/two_card/test_sp_pass.py: 260
   tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py: 110
+  tests/e2e/pull_request/two_card/test_xlite.py: 180
   tests/e2e/pull_request/four_card/_310p/test_dense_model_310p.py: 410
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 510
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 360

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ scipy
 soundfile
 pytest_mock
 mindstudio-probe>=8.3.0
-xlite==0.1.0rc11.dev210
+xlite==0.1.0rc12.dev210
 uc-manager
 ninja
 coverage

--- a/tests/e2e/pull_request/one_card/test_xlite.py
+++ b/tests/e2e/pull_request/one_card/test_xlite.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 # Copyright 2023 The vLLM team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,39 +27,53 @@ import os
 
 import pytest
 
-from tests.e2e.pull_request.utils import PROMPTS_SHORT, LLMTestCase, compare_logprobs
+from tests.e2e.conftest import wait_until_npu_memory_free
+from tests.e2e.pull_request.utils import PROMPTS_SHORT, compare_logprobs
 
 os.environ["VLLM_ASCEND_ENABLE_NZ"] = "2"
 
-CASE_DECODE_ONLY = LLMTestCase(
-    model="Qwen/Qwen3-0.6B",
-    prompts=PROMPTS_SHORT,
+MODELS: list[str] = ["/mnt/sdb/models/Qwen3-0.6B"]
+
+
+@pytest.mark.e2e_model(*MODELS)
+@pytest.mark.e2e_coverage(
+    arch="dense",
+    feature="xlite",
+    parallel="TP",
+    deploy="pd_mix",
+    hardware="A2",
+    quantization="BF16",
+    graph_mode="xlite_decode_only",
 )
-
-CASE_FULL = LLMTestCase(
-    model="Qwen/Qwen3-0.6B",
-    prompts=PROMPTS_SHORT,
-)
-
-
-@pytest.mark.skip(reason="TODO: Re-enable xlite_decode_only e2e test when stable.")
-@pytest.mark.parametrize("cur_case", [CASE_DECODE_ONLY])
-def test_models_with_xlite_decode_only(cur_case: LLMTestCase):
+@pytest.mark.parametrize("model", MODELS)
+@wait_until_npu_memory_free()
+def test_models_with_xlite_decode_only(model: str):
     runner_kwargs = {
-        "model_name": cur_case.model,
+        "model_name": model,
         "max_model_len": 1024,
         "block_size": 128,
-        "additional_config": {"xlite_graph_config": {"enabled": True}},
+        "additional_config": {"xlite_graph_config": {"enabled": True, "full_mode": False}},
     }
-    compare_logprobs(runner_kwargs=runner_kwargs, prompts=cur_case.prompts)
+    compare_logprobs(runner_kwargs=runner_kwargs, prompts=PROMPTS_SHORT)
 
 
-@pytest.mark.parametrize("cur_case", [CASE_FULL])
-def test_models_with_xlite_full_mode(cur_case: LLMTestCase):
+@pytest.mark.e2e_model(*MODELS)
+@pytest.mark.e2e_coverage(
+    arch="dense",
+    feature="xlite",
+    parallel="TP",
+    deploy="pd_mix",
+    hardware="A2",
+    quantization="BF16",
+    graph_mode="xlite_full",
+)
+@pytest.mark.parametrize("model", MODELS)
+@wait_until_npu_memory_free()
+def test_models_with_xlite_full_mode(model: str):
     runner_kwargs = {
-        "model_name": cur_case.model,
+        "model_name": model,
         "max_model_len": 1024,
         "block_size": 128,
         "additional_config": {"xlite_graph_config": {"enabled": True, "full_mode": True}},
     }
-    compare_logprobs(runner_kwargs=runner_kwargs, prompts=cur_case.prompts)
+    compare_logprobs(runner_kwargs=runner_kwargs, prompts=PROMPTS_SHORT)

--- a/tests/e2e/pull_request/two_card/test_xlite.py
+++ b/tests/e2e/pull_request/two_card/test_xlite.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Verify MoE serving with xlite graph mode on two NPU cards.
+
+Run `pytest tests/e2e/pull_request/two_card/test_xlite.py`.
+"""
+
+import os
+
+import pytest
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.pull_request.utils import PROMPTS_SHORT
+
+os.environ["VLLM_ASCEND_ENABLE_NZ"] = "2"
+
+MODELS: list[str] = ["/mnt/sdb/models/Qwen3-30B-A3B"]
+
+
+@pytest.mark.e2e_model(*MODELS)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="xlite",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="xlite_decode_only",
+)
+@pytest.mark.parametrize("model", MODELS)
+@wait_until_npu_memory_free()
+def test_models_with_xlite_decode_only(model: str):
+    with VllmRunner(
+        model,
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        distributed_executor_backend="mp",
+        block_size=128,
+        max_model_len=2048,
+        additional_config={"xlite_graph_config": {"enabled": True, "full_mode": False}},
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(PROMPTS_SHORT, 3)
+
+    assert all(output[1] for output in outputs)
+
+
+@pytest.mark.e2e_model(*MODELS)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="xlite",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="xlite_full",
+)
+@pytest.mark.parametrize("model", MODELS)
+@wait_until_npu_memory_free()
+def test_models_with_xlite_full_mode(model: str):
+    with VllmRunner(
+        model,
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        distributed_executor_backend="mp",
+        block_size=128,
+        max_model_len=2048,
+        additional_config={"xlite_graph_config": {"enabled": True, "full_mode": True}},
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(PROMPTS_SHORT, 3)
+
+    assert all(output[1] for output in outputs)

--- a/vllm_ascend/xlite/utils.py
+++ b/vllm_ascend/xlite/utils.py
@@ -46,24 +46,27 @@ class AttributeSetterMixin:
     Good for backwards compatibility. For subclasses, :mod:`AttributeSetterMixin` must be the first parent class in the
     inheritance chain to work properly (i.e., the second object in the method resolution order (MRO)).
 
+    **Notes**: Only works for classes with pure class attributes or `__slots__` defined.
+
     Example usage::
 
         class Model:
-            def __init__(self):
-                self.some_existing_attr = 0
+            __slots__ = ["some_existing_attr"]  # or set as a class attribute explicitly if not using __slots__
 
 
         class MyModel(AttributeSetterMixin, Model):
             _on_missing_attr = "ignore"  # silently ignore missing attributes
 
 
-        model = MyModel(...)
+        model = MyModel()
         model.some_existing_attr = 42  # sets the attribute as usual
         model.some_missing_attr = "hello"  # does nothing, no error raised
 
         with model.condition(lambda v: isinstance(v, int) and v > 0):
-            model.some_existing_attr = -1  # does not set because condition is not met
             model.some_existing_attr = 100  # sets because condition is met
+            model.some_existing_attr = -1  # does not set because condition is not met
+
+        print(model.some_existing_attr)  # prints 100, because the -1 assignment was ignored
     """
 
     _on_missing_attr: Literal["raise", "warn", "ignore"] = "warn"
@@ -96,27 +99,35 @@ class AttributeSetterMixin:
                     "%s has no attribute %s. Your `xlite` version might be incompatible.", type(self).__name__, name
                 )
             return
-        match_condition = getattr(self._get_thread_local(), "match_condition", None)
-        if match_condition is not None and not match_condition(value):
+        match_conditions: list[Callable[..., bool]] = getattr(self._get_thread_local(), "match_conditions", [])
+        if not all(condition(value) for condition in match_conditions):
             return
         super().__setattr__(name, value)
 
     @contextmanager
-    def condition(self, match_condition: Callable[..., bool]) -> Generator["AttributeSetterMixin", None, None]:
-        """Context manager that gates attribute setting on `match_condition`.
+    def condition(self, match_condition: Callable[..., bool], /) -> Generator["AttributeSetterMixin", None, None]:
+        """Context manager that gates attribute setting on `match_condition`. Supports nested conditions, which are
+        combined with logical AND.
+
+        Args:
+            match_condition (Callable[..., bool]): A callable that takes the value to be set and returns a boolean
+                indicating whether the value should be set to the instance attribute.
 
         Usage::
 
             with obj.condition(lambda v: v > 0):
                 obj.some_attr = 42  # only set if 42 > 0
+                obj.some_attr = -1  # will not set because -1 > 0 is False
+
+            print(obj.some_attr)  # prints 42, because the second assignment was ignored
         """
         local = self._get_thread_local()
-        previous = getattr(local, "match_condition", None)  # save for nesting
-        local.match_condition = match_condition
+        previous = getattr(local, "match_conditions", [])
+        local.match_conditions = previous + [match_condition]
         try:
             yield self
         finally:
-            local.match_condition = previous  # always restore, even on exception
+            local.match_conditions = previous  # always restore, even on exception
 
 
 class XModel(AttributeSetterMixin, Model):
@@ -323,7 +334,7 @@ def get_dotted_attr(obj: Any, dotted_attr: str, /, *, default: Any = None, raise
     return get_nested_attr(obj, *dotted_attr.split("."), default=default, raises=raises)
 
 
-class WeightGetterConfig(TypedDict):
+class WeightGetterConfig(TypedDict, total=False):
     """Configuration dictionary for layer weight extraction in `get_layer_weights`.
 
     This class is written as a TypedDict for better type checking with `mypy` in the `xlite` module.
@@ -335,9 +346,8 @@ class WeightGetterConfig(TypedDict):
 
 def get_layer_weights(
     layers: Sequence[nn.Module],
-    layer_attr: str,
     /,
-    *,
+    *layer_attrs: str,
     secondary_flattening: str | slice | None = None,
     post_processor: Callable[[torch.Tensor], torch.Tensor] | None = None,
     **kwargs: Any,
@@ -351,15 +361,17 @@ def get_layer_weights(
 
     Args:
         layers (Sequence[nn.Module]): Sequence of layers to retrieve weights from.
-        layer_attr (str): Dotted attribute string specifying the layer attribute to retrieve (`layers.[i].[layer_attr]`)
-            , e.g., "self_attn.q_norm.weight".
+        *layer_attrs (str): Dotted attribute string(s) specifying the layer attribute candidate(s) to check and
+            retrieve (`layers[i].[layer_attr]`), e.g., "self_attn.q_norm.weight".
+
+            For a list of string candidates, the first one returning a non-empty list of weights is used.
         secondary_flattening (str | slice | None, optional): If specified, indicates that the retrieved layer attribute
             is a list of tensors and we need to further flatten it. The expansion can be specified as:
 
-            - `str`: A dotted attribute string such that `layers.[i].[secondary_flattening]` gives the number of items
+            - `str`: A dotted attribute string such that `layers[i].[secondary_flattening]` gives the number of items
               to flatten for that layer.
-            - `slice`: A slice specifying how to slice `layers.[i].[layer_attr]` and then flatten the sliced part.
-            - `None`: No secondary flattening; `layers.[i].[layer_attr]` is directly collected.
+            - `slice`: A slice specifying how to slice `layers[i].[layer_attr]` and then flatten the sliced part.
+            - `None`: No secondary flattening; `layers[i].[layer_attr]` is directly collected.
         post_processor (Callable[[torch.Tensor], torch.Tensor] | None, optional): An optional function to apply to
             each retrieved tensor before returning the final list of weights.
         **kwargs: Additional keyword arguments for future extensions.
@@ -367,29 +379,35 @@ def get_layer_weights(
     Returns:
         list[torch.Tensor]: List of retrieved weights.
     """
-    if not secondary_flattening:
-        weights = [
-            weight for layer in layers if (weight := get_dotted_attr(layer, layer_attr, default=None)) is not None
-        ]
-    elif isinstance(secondary_flattening, str):
-        weights = [
-            weight
-            for layer in layers
-            if (weight_lst := get_dotted_attr(layer, layer_attr, default=[])) is not None
-            for weight in weight_lst[: get_dotted_attr(layer, secondary_flattening, default=0)]
-        ]
-    elif isinstance(secondary_flattening, slice):
-        weights = [
-            weight
-            for layer in layers
-            if (weight_lst := get_dotted_attr(layer, layer_attr, default=[])) is not None
-            for weight in weight_lst[secondary_flattening]
-        ]
-    else:
-        raise ValueError(
-            f"Invalid type for secondary_flattening: {type(secondary_flattening)}. Expected str, slice, or None."
-        )
+    for layer_attr in layer_attrs:
+        if not isinstance(layer_attr, str):
+            raise TypeError(f"layer_attr must be a string or list of strings, got {type(layer_attr)}.")
+        if not secondary_flattening:
+            weights = [
+                weight for layer in layers if (weight := get_dotted_attr(layer, layer_attr, default=None)) is not None
+            ]
+        elif isinstance(secondary_flattening, str):
+            weights = [
+                weight
+                for layer in layers
+                if (weight_lst := get_dotted_attr(layer, layer_attr, default=[])) is not None
+                for weight in weight_lst[: get_dotted_attr(layer, secondary_flattening, default=0)]
+            ]
+        elif isinstance(secondary_flattening, slice):
+            weights = [
+                weight
+                for layer in layers
+                if (weight_lst := get_dotted_attr(layer, layer_attr, default=[])) is not None
+                for weight in weight_lst[secondary_flattening]
+            ]
+        else:
+            raise ValueError(
+                f"Invalid type for secondary_flattening: {type(secondary_flattening)}. Expected str, slice, or None."
+            )
 
-    if not post_processor:
-        return weights
-    return [post_processor(weight) for weight in weights]
+        if post_processor:
+            weights = [post_processor(weight) for weight in weights]
+
+        if weights:
+            return weights
+    return []

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -436,7 +436,7 @@ class QwenMoeXliteModel(LlamaXliteModel):
         layers, _ = self._get_layers_and_model_prefix()
 
         xlite_model.gate = get_layer_weights(layers, "mlp.gate.weight")
-        prefix = "mlp.experts."
+        prefix = "mlp.experts.routed_experts."
         kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
         xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
         xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
@@ -444,7 +444,7 @@ class QwenMoeXliteModel(LlamaXliteModel):
 
         if self.quantization:
             kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale_fp32", **kwargs)
+            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
             xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
 
 
@@ -486,7 +486,7 @@ class Glm4MoeXliteModel(LlamaXliteModel):
         self.init_matmul_weights(layers, "se_up_gate", "mlp.shared_experts.gate_up_proj")
         self.init_matmul_weights(layers, "se_down", "mlp.shared_experts.down_proj")
 
-        prefix = "mlp.experts."
+        prefix = "mlp.experts.routed_experts."
         kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
         xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
         xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
@@ -495,7 +495,7 @@ class Glm4MoeXliteModel(LlamaXliteModel):
 
         if self.quantization:
             kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale_fp32", **kwargs)
+            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
             xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
 
 
@@ -530,7 +530,7 @@ class MiniMaxM2XliteModel(LlamaXliteModel):
             layers, "block_sparse_moe.e_score_correction_bias", post_processor=lambda b: b.to(torch.float32)
         )
 
-        prefix = "block_sparse_moe.experts."
+        prefix = "block_sparse_moe.experts.routed_experts."
         kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
         xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
         xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
@@ -539,7 +539,7 @@ class MiniMaxM2XliteModel(LlamaXliteModel):
 
         if self.quantization:
             kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale_fp32", **kwargs)
+            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
             xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
 
 

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -48,11 +48,11 @@ from vllm_ascend.xlite.utils import (
 XliteInitResult: TypeAlias = tuple[XModel, torch.Tensor, int, torch.dtype]
 XliteForwardResult: TypeAlias = torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]
 
-_architecture_strategy_map: dict[str, type[XliteModel]] = {}
+_architecture_strategy_map: dict[str, type[XliteModelBase]] = {}
 """Mapping from model architecture names in `config.json` to their corresponding xlite adapter classes."""
 
 
-class XliteModel(ABC):
+class XliteModelBase(ABC):
     """Base adapter for converting vLLM models into xlite runtime models.
 
     Subclasses are responsible for mapping architecture-specific configuration and weights into the `xlite._C.Model`
@@ -63,8 +63,8 @@ class XliteModel(ABC):
             extraction for xlite model construction.
         vllm_config (VllmConfig): The configuration object provided by vLLM. Used to build xlite configuration at
             runtime.
-        xlite_config (ModelConfig): Native xlite configuration object populated by subclasses.
-        xlite_model (Model): Native xlite model container populated by subclasses.
+        xlite_config (XModelConfig): Native xlite configuration object populated by subclasses.
+        xlite_model (XModel): Native xlite model container populated by subclasses.
     """
 
     _attn_metadata_type: type | tuple[type, ...]
@@ -73,6 +73,9 @@ class XliteModel(ABC):
     _supported_architectures: Sequence[str] | str
     """The list of model architecture names (from HuggingFace `config.json` "architectures" field) supported by this
     adapter. Used for automatic adapter selection and registration."""
+    _decoder_layer_mlp_module: str = "mlp"
+    """The module name used to identify MLP modules (including MoE) in the decoder layers (nn.Module) of the runnable
+    model: e.g., in `Glm4MoeForCausalLM`, the MLP modules need to be accessed via `.model.layers[i].mlp`, thus `mlp`."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Automatically register subclasses in the architecture strategy map and metadata type set."""
@@ -196,11 +199,11 @@ class XliteModel(ABC):
         return format == torch_npu.Format.FRACTAL_NZ
 
     @staticmethod
-    def all_tensors_zero(tensors: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor] | None) -> bool:
+    def all_tensors_zero(tensors: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...] | None) -> bool:
         """Check if all tensors in the list/tuple are zero tensors.
 
         Args:
-            tensors (torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor] | None): The tensors to check.
+            tensors (torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...] | None): The tensors to check.
 
         Returns:
             bool: True if all tensors are zero tensors (or empty), False otherwise.
@@ -215,11 +218,16 @@ class XliteModel(ABC):
 
     @staticmethod
     def _transform_deq_scale(deq_scale: torch.Tensor) -> torch.Tensor:
-        """
-        The data format required by the fixpipe hardware is as follows:
+        """Repack a dequantization scale into the fixpipe hardware's expected format.
 
-        Data is stored in uint64_t, with the upper 32 bits being 0 and the lower 32 bits storing the FP32 format. The
-        lower 10 bits of the FP32 format are not involved in computation, and the actual data format is TF32.
+        Data is stored in ``uint64_t``: the upper 32 bits are 0 and the lower 32 bits hold an FP32 value whose lower 10
+        bits are not involved in computation, making the effective data format TF32.
+
+        Args:
+            deq_scale (torch.Tensor): The original dequantization scale tensor.
+
+        Returns:
+            torch.Tensor: The repacked scale tensor for fixpipe computation.
         """
         deq_scale_fp32 = deq_scale.to(torch.float32)
         scale = deq_scale_fp32.new_zeros(deq_scale.shape[0] * 2)
@@ -247,11 +255,20 @@ class XliteModel(ABC):
         return getattr(self.vllm_config.model_config.hf_config, "vision_config", None)
 
 
-class LlamaXliteModel(XliteModel):
-    """xlite adapter base for Llama-like architectures.
+class StandardXliteModel(XliteModelBase):
+    """xlite adapter base for standard architectures.
 
-    This is the *de facto* base adapter for all xlite-supported architectures and may contain configurations beyond
-    Llama-like dense models. `XliteModel` subclasses should inherit from this class unless there is a major divergence.
+    This is the *de facto* base adapter for all xlite-supported architectures. Configurations for various model types,
+    dense and MoE, are included.
+
+    Subclasses of :class:`XliteModelBase`, i.e., xlite model adapters, should inherit from :class:`StandardXliteModel`,
+    unless there is a major divergence.
+
+    **Developer Guide**: The :class:`StandardXliteModel` class is designed to be a flexible base for xlite adapters.
+    When developing a new adapter for a specific architecture to dock with the xlite backend, consider adding weight
+    loading lines in :meth:`StandardXliteModel._build_model` directly if feasible, using the highly flexible and
+    error-checked `get_layer_weights` utility. For :meth:`_build_model_config`, override it in the subclass only if the
+    architecture has unique configuration needs.
     """
 
     _attn_metadata_type = AscendMetadata
@@ -326,33 +343,54 @@ class LlamaXliteModel(XliteModel):
         self.init_matmul_weights(layers, "mha_qkv", "self_attn.qkv_proj")
         self.init_matmul_weights(layers, "attn_out", "self_attn.o_proj")
 
-        mha_qkv_bias = get_layer_weights(layers, "self_attn.qkv_proj.bias")
-        xlite_config.qkv_bias = len(mha_qkv_bias) == xlite_config.n_layers
-        xlite_model.mha_qkv_bias = mha_qkv_bias if xlite_config.qkv_bias else []
-        q_norm = get_layer_weights(layers, "self_attn.q_norm.weight")
-        k_norm = get_layer_weights(layers, "self_attn.k_norm.weight")
-        xlite_config.qk_norm = len(q_norm) == len(k_norm) == xlite_config.n_layers
-        xlite_model.mha_q_norm = q_norm if xlite_config.qk_norm else []
-        xlite_model.mha_k_norm = k_norm if xlite_config.qk_norm else []
+        with xlite_model.condition(lambda tensors: len(tensors) == xlite_config.n_layers):
+            xlite_model.mha_q_norm = get_layer_weights(layers, "self_attn.q_norm.weight")
+            xlite_model.mha_k_norm = get_layer_weights(layers, "self_attn.k_norm.weight")
+            xlite_config.qk_norm = bool(xlite_model.mha_q_norm) and bool(xlite_model.mha_k_norm)
 
+        # Dense MLP weights
         self.init_matmul_weights(layers, "mlp_up_gate", "mlp.gate_up_proj")
         self.init_matmul_weights(layers, "mlp_down", "mlp.down_proj")
         xlite_model.mlp_norm = get_layer_weights(layers, "post_attention_layernorm.weight")
 
-        if not self.quantization:
-            return
+        # MoE-specific weights
+        mlp_prefix = self._decoder_layer_mlp_module
+        xlite_model.gate = get_layer_weights(layers, f"{mlp_prefix}.gate.weight")
+        xlite_model.gate_bias = get_layer_weights(
+            layers,
+            f"{mlp_prefix}.gate.e_score_correction_bias",
+            f"{mlp_prefix}.e_score_correction_bias",  # for MiniMax-2.x compatibility
+            post_processor=lambda b: b.to(torch.float32),  # type conversion for numerical stability in xlite backend
+        )
+        self.init_matmul_weights(layers, "se_up_gate", f"{mlp_prefix}.shared_experts.gate_up_proj")
+        self.init_matmul_weights(layers, "se_down", f"{mlp_prefix}.shared_experts.down_proj")
 
-        if xlite_model.mha_qkv:
-            xlite_config.quant_attn_weight_nz = self.is_tensor_nz(xlite_model.mha_qkv[0])
-            xlite_config.quant_attn_weight_transpose = True
+        re_prefix = f"{mlp_prefix}.experts.routed_experts"
+        re_kwargs: WeightGetterConfig = {"secondary_flattening": f"{re_prefix}.local_num_experts"}
+        xlite_model.re_up_gate = get_layer_weights(layers, f"{re_prefix}.w13_weight", **re_kwargs)
+        xlite_model.re_down = get_layer_weights(layers, f"{re_prefix}.w2_weight", **re_kwargs)
+        xlite_config.experts_weight_nz = bool(xlite_model.re_up_gate) and self.is_tensor_nz(xlite_model.re_up_gate[0])
 
+        # bias terms
         with xlite_model.condition(lambda tensors: not self.all_tensors_zero(tensors)):
+            xlite_model.mha_qkv_bias = get_layer_weights(layers, "self_attn.qkv_proj.bias")
+            xlite_config.qkv_bias = len(xlite_model.mha_qkv_bias) == xlite_config.n_layers
             xlite_model.norm_bias = get_dotted_attr(self.runnable, f"{model_prefix}model.norm.bias", raises=True)
             xlite_model.attn_norm_bias = get_layer_weights(layers, "input_layernorm.bias")
             xlite_model.mlp_norm_bias = get_layer_weights(layers, "post_attention_layernorm.bias")
             if xlite_config.qk_norm:
                 xlite_model.mha_q_norm_bias = get_layer_weights(layers, "self_attn.q_norm.bias")
                 xlite_model.mha_k_norm_bias = get_layer_weights(layers, "self_attn.k_norm.bias")
+
+        if not self.quantization:
+            return
+
+        xlite_config.quant_attn_weight_nz = bool(xlite_model.mha_qkv) and self.is_tensor_nz(xlite_model.mha_qkv[0])
+        xlite_config.quant_attn_weight_transpose = bool(xlite_model.mha_qkv)
+
+        re_kwargs["post_processor"] = self._transform_deq_scale
+        xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{re_prefix}.w13_weight_scale", **re_kwargs)
+        xlite_model.re_down_scale = get_layer_weights(layers, f"{re_prefix}.w2_weight_scale", **re_kwargs)
 
     def _precompute_freqs_cis(self) -> torch.Tensor:
         """Precompute rotary cosine/sine cache on NPU.
@@ -397,7 +435,7 @@ class LlamaXliteModel(XliteModel):
         if not self.quantization:
             return
 
-        def set_xlite_attr(xlite_attr: str, layer_attr: str):
+        def set_xlite_attr(xlite_attr: str, layer_attr: str) -> None:
             setattr(xlite_model, xlite_attr, get_layer_weights(layers, layer_attr))
 
         deq_scale = get_layer_weights(layers, f"{model_prefix}.deq_scale", post_processor=self._transform_deq_scale)
@@ -413,7 +451,7 @@ class LlamaXliteModel(XliteModel):
             setattr(xlite_model, f"{xlite_prefix}_deq_scale", weight_scale)
 
 
-class QwenMoeXliteModel(LlamaXliteModel):
+class QwenMoeXliteModel(StandardXliteModel):
     """xlite adapter for Qwen MoE architectures."""
 
     _attn_metadata_type = AscendMetadata
@@ -430,25 +468,8 @@ class QwenMoeXliteModel(LlamaXliteModel):
         xlite_config.moe_intermediate_size = hf_config.moe_intermediate_size
         xlite_config.norm_topk_prob = hf_config.norm_topk_prob
 
-    def _build_model(self) -> None:
-        super()._build_model()
-        xlite_model, xlite_config = self.xlite_model, self.xlite_config
-        layers, _ = self._get_layers_and_model_prefix()
 
-        xlite_model.gate = get_layer_weights(layers, "mlp.gate.weight")
-        prefix = "mlp.experts.routed_experts."
-        kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
-        xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
-        xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
-        xlite_config.experts_weight_nz = self.is_tensor_nz(xlite_model.re_up_gate[0])
-
-        if self.quantization:
-            kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
-            xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
-
-
-class Glm4MoeXliteModel(LlamaXliteModel):
+class Glm4MoeXliteModel(StandardXliteModel):
     """xlite adapter for GLM4 MoE architectures."""
 
     _attn_metadata_type = AscendMetadata
@@ -473,37 +494,13 @@ class Glm4MoeXliteModel(LlamaXliteModel):
         xlite_config.route_scale = hf_config.routed_scaling_factor
         xlite_config.gate_captured = False
 
-    def _build_model(self) -> None:
-        super()._build_model()
-        xlite_model, xlite_config = self.xlite_model, self.xlite_config
-        layers, _ = self._get_layers_and_model_prefix()
 
-        xlite_model.gate = get_layer_weights(layers, "mlp.gate.weight")
-        # NOTE: type conversion for numerical stability in xlite's implementation
-        xlite_model.gate_bias = get_layer_weights(
-            layers, "mlp.gate.e_score_correction_bias", post_processor=lambda b: b.to(torch.float32)
-        )
-        self.init_matmul_weights(layers, "se_up_gate", "mlp.shared_experts.gate_up_proj")
-        self.init_matmul_weights(layers, "se_down", "mlp.shared_experts.down_proj")
-
-        prefix = "mlp.experts.routed_experts."
-        kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
-        xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
-        xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
-        if xlite_model.re_up_gate:
-            xlite_config.experts_weight_nz = self.is_tensor_nz(xlite_model.re_up_gate[0])
-
-        if self.quantization:
-            kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
-            xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
-
-
-class MiniMaxM2XliteModel(LlamaXliteModel):
+class MiniMaxM2XliteModel(StandardXliteModel):
     """xlite adapter for MiniMax M2 architectures."""
 
     _attn_metadata_type = AscendMetadata
     _supported_architectures = ["MiniMaxM2ForCausalLM"]
+    _decoder_layer_mlp_module = "block_sparse_moe"
 
     def _build_model_config(self) -> None:
         super()._build_model_config()
@@ -519,31 +516,8 @@ class MiniMaxM2XliteModel(LlamaXliteModel):
         xlite_config.qk_norm_full = True
         xlite_config.scoring_func = ScoringFuncSigmoid
 
-    def _build_model(self) -> None:
-        super()._build_model()
-        xlite_model, xlite_config = self.xlite_model, self.xlite_config
-        layers, _ = self._get_layers_and_model_prefix()
 
-        xlite_model.gate = get_layer_weights(layers, "block_sparse_moe.gate.weight")
-        # NOTE: type conversion for numerical stability in xlite's implementation
-        xlite_model.gate_bias = get_layer_weights(
-            layers, "block_sparse_moe.e_score_correction_bias", post_processor=lambda b: b.to(torch.float32)
-        )
-
-        prefix = "block_sparse_moe.experts.routed_experts."
-        kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
-        xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
-        xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
-        if xlite_model.re_up_gate:
-            xlite_config.experts_weight_nz = self.is_tensor_nz(xlite_model.re_up_gate[0])
-
-        if self.quantization:
-            kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
-            xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
-
-
-def get_adapter_xlite_model(runnable: nn.Module, vllm_config: VllmConfig) -> XliteModel:
+def get_adapter_xlite_model(runnable: nn.Module, vllm_config: VllmConfig) -> XliteModelBase:
     """Look up and initialize the appropriate xlite model adapter based on the architecture specified in vLLM config and
     the runnable model.
 
@@ -555,7 +529,7 @@ def get_adapter_xlite_model(runnable: nn.Module, vllm_config: VllmConfig) -> Xli
         ValueError: If the model architecture is not supported by xlite.
 
     Returns:
-        XliteModel: An initialized xlite model adapter ready for inference.
+        XliteModelBase: An initialized xlite model adapter ready for inference.
     """
     architecture = vllm_config.model_config.architectures[0]
     if not (strategy_class := _architecture_strategy_map.get(architecture)):
@@ -656,8 +630,8 @@ class XliteWrapper:
         Args:
             input_ids (torch.Tensor): Token IDs for current step.
             positions (torch.Tensor): Position IDs used by attention.
-            intermediate_tensors (Optional[IntermediateTensors]): Optional intermediate tensors from pipeline stages.
-            inputs_embeds (Optional[torch.Tensor]): Optional external input embeddings (e.g. multimodal/deepstack
+            intermediate_tensors (IntermediateTensors | None): Optional intermediate tensors from pipeline stages.
+            inputs_embeds (torch.Tensor | None): Optional external input embeddings (e.g. multimodal/deepstack
                 scenarios).
             **model_kwargs (Any): Additional keyword arguments for the runnable.
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR brings the `xlite` backend in line with the current main and `vllm==0.24.0`, refactors xlite model adapter/docking with its backend implementation, re-enables and adds e2e coverage for the xlite graph mode, and bumps the pinned `xlite` dependency to the latest dev release.

Refer to PR #12019 for the context.

More specifically,

1. The earliest commit completes the `main2main` update for `xlite`;
2. The second commit refactors xlite model adapters to remove duplicated model weight extraction;
3. The third commit adds a two-card e2e test coverage using an MoE model, to catch future main2main discrepancies;
4. The last commit bumps the `xlite` package to its latest dev vesion.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

#### e2e test

The following tests were run locally on Atlas A3 and passed:

```bash
python tests/e2e/pull_request/one_card/test_xlite.py
python tests/e2e/pull_request/two_card/test_xlite.py
```

#### main2main update + refactoring

We benchmarked model accuracies with multiple models using `aisbench`. The [batch_aisbench.py](https://atomgit.com/openeuler/GVirt/blob/master/xlite/tests/e2e/batch_aisbench.py) script was used with 208 questions from the `ceval` dataset:

```bash
# on one Atlas A3
python batch_aisbench.py "/root/benchmark" \
--num-prompts 4 \
--model-dir "/mnt/sdb/models" \
--models "Qwen3-32B-w8a8-nopdmix" "Qwen3-30B-A3B" "Qwen3-VL-32B-Instruct" "MiniMax-M2.7-w8a8-QuaRot" "GLM-4.7-W8A8-floatmtp" \
--tps 2 2 2 4 8 \
--dps 1 1 1 1 1 \
--eps 0 1 0 1 1 \
-MNS 32 \
-MML 8192 \
--xlite 2 1 0 \
--broadcast-xlite
```

**For most models**, no accuracy regression was observed, except:

1. `Qwen3-VL-32B-Instruct` served with `xlite decode-only` mode showed degraded accuracy - upon further investigation, the model's outputs contained random texts for certain questions, likely a previously existing issue (e.g., PR #11380).
2. `MiniMax-M2.7-w8a8-QuaRot` served with `xlite decode-only + aclgraph for prefill` and `aclgraph` threw an `AttributionError` during serving, likely not related to `xlite` since `xlite full mode` worked correctly.

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-32B-w8a8-nopdmix | ceval-weighted | 2 | N | 1 | xlite full | weighted_average | 88.78 |  |
| Qwen3-32B-w8a8-nopdmix | ceval-weighted | 2 | N | 1 | xlite decode-only | weighted_average | 88.63 |  |
| Qwen3-32B-w8a8-nopdmix | ceval-weighted | 2 | N | 1 | aclgraph | weighted_average | 87.09 |  |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | xlite full | weighted_average | 87.74 |  |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | xlite decode-only | weighted_average | 85.68 |  |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | aclgraph | weighted_average | 86.13 |  |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-VL-32B-Instruct | ceval-weighted | 2 | N | 1 | xlite full | weighted_average | 85.46 |  |
| Qwen3-VL-32B-Instruct | ceval-weighted | 2 | N | 1 | xlite decode-only | weighted_average | 77.84 |  |
| Qwen3-VL-32B-Instruct | ceval-weighted | 2 | N | 1 | aclgraph | weighted_average | 88.52 |  |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 1 | xlite full | weighted_average | 84.16 |  |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 1 | xlite decode-only | weighted_average | 0.00 | AttributeError: 'AscendMoERunner' object has no attribute 'maybe_all_reduce_tensor_model_parallel' |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 1 | aclgraph | weighted_average | 0.00 | AttributeError: 'AscendMoERunner' object has no attribute 'maybe_all_reduce_tensor_model_parallel' |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite full | weighted_average | 87.41 |  |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite decode-only | weighted_average | 87.82 |  |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | aclgraph | weighted_average | 87.74 |

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
