### PR TITLE
[Doc]add Atlas inference products guidance to Qwen-VL-Dense tutorial

### DIFF
--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -150,6 +150,7 @@ Atlas inference products do not support `triton` or `triton-ascend`. Source inst
 ```bash
 pip uninstall -y triton-ascend triton
 ```
+
 :::
 
 **Installation Verification:**

--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -8,6 +8,10 @@ This document will show the main verification steps of the model, including supp
 
 This tutorial uses the vLLM-Ascend `v0.11.0rc3-a3` version for demonstration, showcasing the `Qwen3-VL-8B-Instruct` model as an example for single NPU and multi-NPU deployment.
 
+!!! note
+
+    For **Atlas inference products**, Qwen3-VL Dense requires vLLM-Ascend `v0.18.0` or later. Do not use the demonstration version above on this hardware.
+
 ## 2 Supported Features
 
 Refer to [Supported Features List](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
@@ -18,13 +22,13 @@ Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-Requires 1 card in 1 Atlas 800I A2 (64G × 8) node or 1 card in 1 Atlas 800 A3 (64G × 16) node:
+Requires 1 card on Atlas 800I A2 (64G × 8), Atlas 800 A3 (64G × 16), or Atlas inference products:
 
 - `Qwen3-VL-2B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-2B-Instruct)
 - `Qwen3-VL-4B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-4B-Instruct)
 - `Qwen3-VL-8B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-8B-Instruct)
 
-Requires 2 cards in 1 Atlas 800I A2 (64G × 8) node or 2 cards in 1 Atlas 800 A3 (64G × 16) node:
+Requires 2 cards on Atlas 800I A2 (64G × 8), Atlas 800 A3 (64G × 16), or Atlas inference products:
 
 - `Qwen3-VL-32B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct)
 
@@ -36,30 +40,60 @@ It is recommended to download the model weight to the shared directory of multip
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 
-**A3 series:**
+=== "A2 / A3 series"
 
-Start the docker image on each node.
+    ```bash
+    # Update the vllm-ascend image
+    # A2: quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+    # A3: quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
 
-``` bash
-# Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+    docker run --rm \
+    --name vllm-ascend \
+    --shm-size=1g \
+    --device /dev/davinci0 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -p 8000:8000 \
+    -it $IMAGE bash
+    ```
 
-docker run --rm \
---name vllm-ascend \
---shm-size=1g \
---device /dev/davinci0 \
---device /dev/davinci_manager \
---device /dev/devmm_svm \
---device /dev/hisi_hdc \
--v /usr/local/dcmi:/usr/local/dcmi \
--v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
--v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
--v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
--v /etc/ascend_install.info:/etc/ascend_install.info \
--v /root/.cache:/root/.cache \
--p 8000:8000 \
--it $IMAGE bash
-```
+=== "Atlas inference products"
+
+    ```bash
+    # Use the vllm-ascend image
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
+
+    docker run --rm \
+    --name vllm-ascend \
+    --shm-size=10g \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -p 8000:8000 \
+    -it $IMAGE bash
+    ```
 
 **Installation Verification:**
 
@@ -97,6 +131,14 @@ If you prefer not to use the Docker image, you can build from source. Install vL
    pip install -e .
    ```
 
+!!! note
+
+    Atlas inference products do not support `triton` or `triton-ascend`. Source installation may pull them in automatically; uninstall them manually before running:
+
+    ```bash
+    pip uninstall -y triton-ascend triton
+    ```
+
 **Installation Verification:**
 
 ```bash
@@ -105,9 +147,9 @@ pip show vllm vllm-ascend
 
 Expected result: The version information for both packages is displayed, confirming a successful installation.
 
-:::{note}
-If deploying a multi-node environment, set up the environment on each node.
-:::
+!!! note
+
+    If deploying a multi-node environment, set up the environment on each node.
 
 For more details, please refer to the [Installation Guide](../../installation.md).
 
@@ -117,12 +159,30 @@ For more details, please refer to the [Installation Guide](../../installation.md
 
 Run docker container to start the vLLM server on single-NPU:
 
-``` bash
-vllm serve Qwen/Qwen3-VL-8B-Instruct \
---dtype bfloat16 \
---max_model_len 16384 \
---max-num-batched-tokens 16384
-```
+=== "A2 / A3 series"
+
+    ```bash
+    vllm serve Qwen/Qwen3-VL-8B-Instruct \
+    --dtype bfloat16 \
+    --max_model_len 16384 \
+    --max-num-batched-tokens 16384
+    ```
+
+=== "Atlas inference products"
+
+    ```bash
+    vllm serve Qwen/Qwen3-VL-8B-Instruct \
+    --dtype float16 \
+    --max_model_len 16384 \
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}'
+    ```
+
+    !!! note
+
+        On Atlas inference products:
+
+        - Only `float16` dtype is supported.
+        - Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**. If your CANN version is lower, replace `--compilation-config` with `--enforce-eager`.
 
 Key Parameter Descriptions:
 
@@ -165,38 +225,60 @@ The service returns HTTP 200 OK.
 
 ## 7 Accuracy Evaluation
 
-### Using Language Model Evaluation Harness
-
 The accuracy of some models is already within our CI monitoring scope, including:
 
 - `Qwen3-VL-8B-Instruct`
 
-As an example, take the `mmmu_val` dataset as a test dataset, and run accuracy evaluation of `Qwen3-VL-8B-Instruct` in offline mode.
+=== "A2 / A3 series"
 
-1. Refer to [Using lm_eval](../../developer_guide/evaluation/using_lm_eval.md) for more details on `lm_eval` installation.
+    **Using Language Model Evaluation Harness**
 
-    ```shell
-    pip install lm_eval
-    ```
+    As an example, take the `mmmu_val` dataset as a test dataset, and run accuracy evaluation of `Qwen3-VL-8B-Instruct` in offline mode.
 
-2. Run `lm_eval` to execute the accuracy evaluation.
+    1. Refer to [Using lm_eval](../../developer_guide/evaluation/using_lm_eval.md) for more details on `lm_eval` installation.
 
-    ```shell
-    lm_eval \
-        --model vllm-vlm \
-        --model_args pretrained=Qwen/Qwen3-VL-8B-Instruct,max_model_len=8192,gpu_memory_utilization=0.7 \
-        --tasks mmmu_val \
-        --batch_size 32 \
-        --apply_chat_template \
-        --trust_remote_code \
-        --output_path ./results
-    ```
+        ```shell
+        pip install lm_eval
+        ```
 
-3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.11.0rc3` for reference only.
+    2. Run `lm_eval` to execute the accuracy evaluation.
 
-    |  Tasks  |Value |Stderr|
-    |---------|---|-----|
-    |mmmu_val |0.5389|0.0159|
+        ```shell
+        lm_eval \
+            --model vllm-vlm \
+            --model_args pretrained=Qwen/Qwen3-VL-8B-Instruct,max_model_len=8192,gpu_memory_utilization=0.7 \
+            --tasks mmmu_val \
+            --batch_size 32 \
+            --apply_chat_template \
+            --trust_remote_code \
+            --output_path ./results
+        ```
+
+    3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.11.0rc3` for reference only.
+
+    | Tasks    | Value  | Stderr |
+    | -------- | ------ | ------ |
+    | mmmu_val | 0.5389 | 0.0159 |
+
+=== "Atlas inference products"
+
+    **Using AISBench**
+
+    Take the `text_vqa` dataset as an example, and run accuracy evaluation of `Qwen3-VL-8B-Instruct`.
+
+    1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for installation, dataset download, and configuration details.
+
+    2. Run `ais_bench` to execute the accuracy evaluation.
+
+        ```shell
+        ais_bench --models vllm_api_general_chat --datasets textvqa_gen_base64 --mode all --debug
+        ```
+
+    3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.23.0` for reference only.
+
+    | dataset  | metric   | mode | vllm-api-general-chat |
+    | -------- | -------- | ---- | --------------------- |
+    | text_vqa | accuracy | gen  | 80.57                 |
 
 ## 8 Performance Evaluation
 

--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -8,9 +8,9 @@ This document will show the main verification steps of the model, including supp
 
 This tutorial uses the vLLM-Ascend `v0.11.0rc3-a3` version for demonstration, showcasing the `Qwen3-VL-8B-Instruct` model as an example for single NPU and multi-NPU deployment.
 
-!!! note
-
-    For **Atlas inference products**, Qwen3-VL Dense requires vLLM-Ascend `v0.18.0` or later. Do not use the demonstration version above on this hardware.
+:::{note}
+For **Atlas inference products**, Qwen3-VL Dense requires vLLM-Ascend `v0.18.0` or later. Do not use the demonstration version above on this hardware.
+:::
 
 ## 2 Supported Features
 
@@ -40,60 +40,73 @@ It is recommended to download the model weight to the shared directory of multip
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 
-=== "A2 / A3 series"
+::::::{tab-set}
+:sync-group: hardware
 
-    ```bash
-    # Update the vllm-ascend image
-    # A2: quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
-    # A3: quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
-    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+::::{tab-item} A2 / A3 series
+:sync: a2a3
 
-    docker run --rm \
-    --name vllm-ascend \
-    --shm-size=1g \
-    --device /dev/davinci0 \
-    --device /dev/davinci_manager \
-    --device /dev/devmm_svm \
-    --device /dev/hisi_hdc \
-    -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
-    -v /etc/ascend_install.info:/etc/ascend_install.info \
-    -v /root/.cache:/root/.cache \
-    -p 8000:8000 \
-    -it $IMAGE bash
-    ```
+```{code-block} bash
+   :substitutions:
 
-=== "Atlas inference products"
+# Update the vllm-ascend image
+# A2: quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+# A3: quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
 
-    ```bash
-    # Use the vllm-ascend image
-    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
+docker run --rm \
+--name vllm-ascend \
+--shm-size=1g \
+--device /dev/davinci0 \
+--device /dev/davinci_manager \
+--device /dev/devmm_svm \
+--device /dev/hisi_hdc \
+-v /usr/local/dcmi:/usr/local/dcmi \
+-v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+-v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+-v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+-v /etc/ascend_install.info:/etc/ascend_install.info \
+-v /root/.cache:/root/.cache \
+-p 8000:8000 \
+-it $IMAGE bash
+```
 
-    docker run --rm \
-    --name vllm-ascend \
-    --shm-size=10g \
-    --device /dev/davinci0 \
-    --device /dev/davinci1 \
-    --device /dev/davinci2 \
-    --device /dev/davinci3 \
-    --device /dev/davinci4 \
-    --device /dev/davinci5 \
-    --device /dev/davinci6 \
-    --device /dev/davinci7 \
-    --device /dev/davinci_manager \
-    --device /dev/devmm_svm \
-    --device /dev/hisi_hdc \
-    -v /usr/local/dcmi:/usr/local/dcmi \
-    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
-    -v /etc/ascend_install.info:/etc/ascend_install.info \
-    -v /root/.cache:/root/.cache \
-    -p 8000:8000 \
-    -it $IMAGE bash
-    ```
+::::
+::::{tab-item} Atlas inference products
+:sync: atlas
+
+```{code-block} bash
+   :substitutions:
+
+# Use the vllm-ascend image
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-310p
+
+docker run --rm \
+--name vllm-ascend \
+--shm-size=10g \
+--device /dev/davinci0 \
+--device /dev/davinci1 \
+--device /dev/davinci2 \
+--device /dev/davinci3 \
+--device /dev/davinci4 \
+--device /dev/davinci5 \
+--device /dev/davinci6 \
+--device /dev/davinci7 \
+--device /dev/davinci_manager \
+--device /dev/devmm_svm \
+--device /dev/hisi_hdc \
+-v /usr/local/dcmi:/usr/local/dcmi \
+-v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+-v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+-v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+-v /etc/ascend_install.info:/etc/ascend_install.info \
+-v /root/.cache:/root/.cache \
+-p 8000:8000 \
+-it $IMAGE bash
+```
+
+::::
+::::::
 
 **Installation Verification:**
 
@@ -131,13 +144,13 @@ If you prefer not to use the Docker image, you can build from source. Install vL
    pip install -e .
    ```
 
-!!! note
+:::{note}
+Atlas inference products do not support `triton` or `triton-ascend`. Source installation may pull them in automatically; uninstall them manually before running:
 
-    Atlas inference products do not support `triton` or `triton-ascend`. Source installation may pull them in automatically; uninstall them manually before running:
-
-    ```bash
-    pip uninstall -y triton-ascend triton
-    ```
+```bash
+pip uninstall -y triton-ascend triton
+```
+:::
 
 **Installation Verification:**
 
@@ -147,9 +160,9 @@ pip show vllm vllm-ascend
 
 Expected result: The version information for both packages is displayed, confirming a successful installation.
 
-!!! note
-
-    If deploying a multi-node environment, set up the environment on each node.
+:::{note}
+If deploying a multi-node environment, set up the environment on each node.
+:::
 
 For more details, please refer to the [Installation Guide](../../installation.md).
 
@@ -159,30 +172,39 @@ For more details, please refer to the [Installation Guide](../../installation.md
 
 Run docker container to start the vLLM server on single-NPU:
 
-=== "A2 / A3 series"
+::::::{tab-set}
+:sync-group: hardware
 
-    ```bash
-    vllm serve Qwen/Qwen3-VL-8B-Instruct \
-    --dtype bfloat16 \
-    --max_model_len 16384 \
-    --max-num-batched-tokens 16384
-    ```
+::::{tab-item} A2 / A3 series
+:sync: a2a3
 
-=== "Atlas inference products"
+```bash
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+--dtype bfloat16 \
+--max_model_len 16384 \
+--max-num-batched-tokens 16384
+```
 
-    ```bash
-    vllm serve Qwen/Qwen3-VL-8B-Instruct \
-    --dtype float16 \
-    --max_model_len 16384 \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}'
-    ```
+::::
+::::{tab-item} Atlas inference products
+:sync: atlas
 
-    !!! note
+```bash
+vllm serve Qwen/Qwen3-VL-8B-Instruct \
+--dtype float16 \
+--max_model_len 16384 \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}'
+```
 
-        On Atlas inference products:
+:::{note}
+On Atlas inference products:
 
-        - Only `float16` dtype is supported.
-        - Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**. If your CANN version is lower, replace `--compilation-config` with `--enforce-eager`.
+- Only `float16` dtype is supported.
+- Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**. If your CANN version is lower, replace `--compilation-config` with `--enforce-eager`.
+:::
+
+::::
+::::::
 
 Key Parameter Descriptions:
 
@@ -229,56 +251,65 @@ The accuracy of some models is already within our CI monitoring scope, including
 
 - `Qwen3-VL-8B-Instruct`
 
-=== "A2 / A3 series"
+::::::{tab-set}
+:sync-group: hardware
 
-    **Using Language Model Evaluation Harness**
+::::{tab-item} A2 / A3 series
+:sync: a2a3
 
-    As an example, take the `mmmu_val` dataset as a test dataset, and run accuracy evaluation of `Qwen3-VL-8B-Instruct` in offline mode.
+**Using Language Model Evaluation Harness**
 
-    1. Refer to [Using lm_eval](../../developer_guide/evaluation/using_lm_eval.md) for more details on `lm_eval` installation.
+As an example, take the `mmmu_val` dataset as a test dataset, and run accuracy evaluation of `Qwen3-VL-8B-Instruct` in offline mode.
 
-        ```shell
-        pip install lm_eval
-        ```
+1. Refer to [Using lm_eval](../../developer_guide/evaluation/using_lm_eval.md) for more details on `lm_eval` installation.
 
-    2. Run `lm_eval` to execute the accuracy evaluation.
+    ```shell
+    pip install lm_eval
+    ```
 
-        ```shell
-        lm_eval \
-            --model vllm-vlm \
-            --model_args pretrained=Qwen/Qwen3-VL-8B-Instruct,max_model_len=8192,gpu_memory_utilization=0.7 \
-            --tasks mmmu_val \
-            --batch_size 32 \
-            --apply_chat_template \
-            --trust_remote_code \
-            --output_path ./results
-        ```
+2. Run `lm_eval` to execute the accuracy evaluation.
 
-    3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.11.0rc3` for reference only.
+    ```shell
+    lm_eval \
+        --model vllm-vlm \
+        --model_args pretrained=Qwen/Qwen3-VL-8B-Instruct,max_model_len=8192,gpu_memory_utilization=0.7 \
+        --tasks mmmu_val \
+        --batch_size 32 \
+        --apply_chat_template \
+        --trust_remote_code \
+        --output_path ./results
+    ```
 
-    | Tasks    | Value  | Stderr |
-    | -------- | ------ | ------ |
-    | mmmu_val | 0.5389 | 0.0159 |
+3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.11.0rc3` for reference only.
 
-=== "Atlas inference products"
+| Tasks    | Value  | Stderr |
+| -------- | ------ | ------ |
+| mmmu_val | 0.5389 | 0.0159 |
 
-    **Using AISBench**
+::::
+::::{tab-item} Atlas inference products
+:sync: atlas
 
-    Take the `text_vqa` dataset as an example, and run accuracy evaluation of `Qwen3-VL-8B-Instruct`.
+**Using AISBench**
 
-    1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for installation, dataset download, and configuration details.
+Take the `text_vqa` dataset as an example, and run accuracy evaluation of `Qwen3-VL-8B-Instruct`.
 
-    2. Run `ais_bench` to execute the accuracy evaluation.
+1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for installation, dataset download, and configuration details.
 
-        ```shell
-        ais_bench --models vllm_api_general_chat --datasets textvqa_gen_base64 --mode all --debug
-        ```
+2. Run `ais_bench` to execute the accuracy evaluation.
 
-    3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.23.0` for reference only.
+    ```shell
+    ais_bench --models vllm_api_general_chat --datasets textvqa_gen_base64 --mode all --debug
+    ```
 
-    | dataset  | metric   | mode | vllm-api-general-chat |
-    | -------- | -------- | ---- | --------------------- |
-    | text_vqa | accuracy | gen  | 80.57                 |
+3. After execution, you can get the result, here is the result of `Qwen3-VL-8B-Instruct` in `vllm-ascend:0.23.0` for reference only.
+
+| dataset  | metric   | mode | vllm-api-general-chat |
+| -------- | -------- | ---- | --------------------- |
+| text_vqa | accuracy | gen  | 80.57                 |
+
+::::
+::::::
 
 ## 8 Performance Evaluation
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds support notes and configuration guidelines for deploying the Qwen3-VL Dense model on Atlas inference products using vLLM-Ascend. It includes hardware-specific requirements, Docker run commands, source installation notes, and optimized serving parameters.
### Does this PR introduce _any_ user-facing change?
yes
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
