### PR TITLE
[Doc][BugFix] Correct Kimi-K2.5 model name casing in deployment guides

### DIFF
--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -146,7 +146,7 @@ export VLLM_ASCEND_ENABLE_MLAPO=1
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
-vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
   --host 0.0.0.0 \
   --port 8088 \
   --quantization ascend \
@@ -276,7 +276,7 @@ Run the following scripts on two nodes respectively.
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
-    vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
     --host 0.0.0.0 \
     --port 8088 \
     --quantization ascend \
@@ -344,7 +344,7 @@ Run the following scripts on two nodes respectively.
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
-    vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
     --host 0.0.0.0 \
     --port 8088 \
     --quantization ascend \
@@ -481,7 +481,7 @@ Parameter descriptions:
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
         --host 0.0.0.0 \
         --port $2 \
         --data-parallel-size $3 \
@@ -562,7 +562,7 @@ Parameter descriptions:
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
         --host 0.0.0.0 \
         --port $2 \
         --data-parallel-size $3 \
@@ -643,7 +643,7 @@ Parameter descriptions:
     export VLLM_ASCEND_ENABLE_MLAPO=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
         --host 0.0.0.0 \
         --port $2 \
         --data-parallel-size $3 \
@@ -723,7 +723,7 @@ Parameter descriptions:
     export VLLM_ASCEND_ENABLE_MLAPO=1
     export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-W4A8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
         --host 0.0.0.0 \
         --port $2 \
         --data-parallel-size $3 \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects the casing of the Kimi-K2.5 model name from `Kimi-K2.5-W4A8` to `Kimi-K2.5-w4a8` in the deployment commands within the Kimi-K2.5 tutorial. This ensures that users copy-pasting the commands do not encounter "model not found" errors due to case mismatch with the actual model repository name.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation change only, no functional code changes.