### PR TITLE
[v0.23.0][BugFix][GDN] Restore stateful one-token decode selection

### DIFF
--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -52,6 +52,33 @@ def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
     return torch.argsort(tensor, stable=True)
 
 
+def _treat_single_token_prefills_with_state_as_decodes(
+    common_attn_metadata: CommonAttentionMetadata,
+) -> CommonAttentionMetadata:
+    """Match the stateful Mamba/GDN contract for uniform one-token rows.
+
+    Full-graph selection is shape based. A final one-token prompt chunk at a
+    PD handoff can therefore replay the same update graph as an ordinary
+    decode. Once a request already has recurrent state, the two cases must
+    construct identical GDN metadata, otherwise the replayed graph consumes
+    stale state indices. First-token prefills stay on the prefill path
+    because they have no prior state to update.
+    """
+    is_prefilling = common_attn_metadata.is_prefilling
+    seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+    if is_prefilling is None or seq_lens_cpu is None:
+        return common_attn_metadata
+
+    query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
+    prefill_to_decode = is_prefilling & (query_lens_cpu == 1) & (seq_lens_cpu > 1)
+    if not torch.any(prefill_to_decode).item():
+        return common_attn_metadata
+
+    is_prefilling = is_prefilling.clone()
+    is_prefilling[prefill_to_decode] = False
+    return common_attn_metadata.replace(is_prefilling=is_prefilling)
+
+
 @dataclass
 class GDNChunkedPrefillMetadata:
     cu_seqlens_host: tuple[int, ...]
@@ -458,6 +485,57 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         )
         return attn_metadata
 
+    def _fold_spec_sized_prefill_chunks_into_spec(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        spec_sequence_masks_cpu: torch.Tensor,
+        num_accepted_tokens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Restore the pre-#11735 state contract for spec-sized prompt chunks.
+
+        Decode-graph dispatch is shape based: a prompt chunk of exactly
+        num_spec + 1 tokens (typically the final chunk of a prompt) is
+        shape-identical to a speculative decode row, so its step can replay a
+        decode graph. Before #11735 the replay refreshed conv1d parameters
+        from the live per-step metadata, so such a row still updated its own
+        state; afterwards the graph reads padded buffers that are only filled
+        for pure decode batches, leaving the row's conv/recurrent state stale
+        and its output garbled from the first decoded token. Fold the row
+        into the spec metadata with all tokens accepted, which advances its
+        state over the whole chunk exactly like the prefill path would. Rows
+        without prior state (first chunks) stay on the prefill path.
+        """
+        is_prefilling = common_attn_metadata.is_prefilling
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+        if is_prefilling is None or seq_lens_cpu is None or num_accepted_tokens is None:
+            return spec_sequence_masks_cpu, num_accepted_tokens
+
+        # The common metadata CPU tensors are padded; only the leading entries
+        # correspond to requests in this batch.
+        num_reqs = min(
+            spec_sequence_masks_cpu.numel(),
+            is_prefilling.numel(),
+            seq_lens_cpu.numel(),
+        )
+        is_prefilling = is_prefilling[:num_reqs]
+        seq_lens_cpu = seq_lens_cpu[:num_reqs]
+        query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)[:num_reqs]
+        fold = (
+            is_prefilling
+            & ~spec_sequence_masks_cpu
+            & (query_lens_cpu == self.num_spec + 1)
+            & (seq_lens_cpu > query_lens_cpu)
+        )
+        fold_indices = fold.nonzero(as_tuple=True)[0]
+        if fold_indices.numel() == 0:
+            return spec_sequence_masks_cpu, num_accepted_tokens
+
+        spec_sequence_masks_cpu = spec_sequence_masks_cpu.clone()
+        spec_sequence_masks_cpu[fold_indices] = True
+        num_accepted_tokens = num_accepted_tokens.clone()
+        num_accepted_tokens[fold_indices.to(num_accepted_tokens.device)] = self.num_spec + 1
+        return spec_sequence_masks_cpu, num_accepted_tokens
+
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -466,7 +544,7 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
-        m = common_attn_metadata
+        m = _treat_single_token_prefills_with_state_as_decodes(common_attn_metadata)
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
@@ -493,6 +571,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 num_decode_draft_tokens_cpu,
                 0,
                 out=spec_sequence_masks_cpu,
+            )
+            spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
+                m, spec_sequence_masks_cpu, num_accepted_tokens
             )
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
             if num_spec_decodes == 0:


### PR DESCRIPTION
## Problem

GDN models (e.g. Qwen3.5) can emit completely garbled output from the very first decoded token of a request, in two deployment shapes:

- **PD-disaggregated serving**: on the decode instance (recompute scheduler), a prompt's final recompute chunk can be exactly 1 token. Decode-graph dispatch is shape-only, so such a step is dispatched to a FULL_DECODE_ONLY decode graph even though it contains semantic prefill work.
- **Monolithic serving with MTP (spec decode)**: the same mis-dispatch happens when a prompt's final chunk is exactly `num_spec + 1` tokens — shape-identical to a speculative decode row in a uniform batch.

Since #11735 ("Move GDN conv1d metadata to device tensors"), the GDN metadata builder only fills the padded device buffers consumed by captured decode graphs when the batch is pure decode (`num_prefills == 0`). When a mis-dispatched step containing a semantic prefill row replays a decode graph, the graph reads stale buffers left over from a previous step, so the request's conv/recurrent state is never advanced over its prompt — output is garbage from token 0. Before #11735 this was harmless because graph replay refreshed conv1d parameters from the live per-step metadata (`update_conv1d_graph_params`), so the row still updated its own state.

The trigger depends on runtime batching (chunk boundaries vs. batch composition), so in monolithic nightly serving it manifests as a sporadic per-run accuracy swing: each run randomly loses a few requests to corrupted state (observed 0–6 per 50-question GPQA run, e.g. 34/50 vs 45/50 on identical code).

## Solution

Restore the pre-#11735 state contract inside the GDN metadata builder (no model runner changes): rows whose shape is indistinguishable from decode are folded into the decode-side metadata, which is mathematically equivalent to the prefill path for a state-bearing chunk:

- `_treat_single_token_prefills_with_state_as_decodes`: a one-token prefill chunk with existing state (`qlen == 1`, `seq_len > 1`) is treated as a decode row — a single-step recursion from its valid cached state.
- `_fold_spec_sized_prefill_chunks_into_spec`: in the spec path, a prefill chunk of exactly `num_spec + 1` tokens with existing state is folded into the spec metadata with `num_accepted = num_spec + 1` (accept-all), which advances its conv/recurrent state over the whole chunk exactly like the prefill path would.

First chunks of a prompt (no prior state) always stay on the prefill path. Pure decode/spec steps are unaffected, so there is no steady-state overhead.

## Verification

- PD-disaggregated Qwen3.6-27B (TP4, recompute scheduler, FULL_DECODE_ONLY): prefill+decode serving healthy, 8-way concurrent GPQA acceptance check passed with zero garbled / hung / empty responses.
- Monolithic Qwen3.5-397B nightly config (TP8, PCP2, DCP4, EP, MTP3, FULL_DECODE_ONLY, async scheduling, GPQA-50, batch 32, temp 0.6): **42/50** with 0 replacement chars and 0 empty outputs (the 2 invalid answers are answer-format misses, not corruption). Same code base without the fold randomly produced 34/50–45/50 across runs, with sporadic garbled or empty responses.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
