### PR TITLE
[Feature] add synthetic mode for speculative decode

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -33,7 +33,7 @@ a2:
         config_file_path: MiniMax-M2.5-w8a8-QuaRot-A2.yaml
       - name: rejection-sample
         os: linux-aarch64-a2b3-1
-        config_file_path: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+        tests: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -187,9 +187,6 @@ a3:
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-nightly-a3-2
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
-      - name: rejection-sample-a3
-        os: linux-aarch64-nightly-a3-2
-        config_file_path: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
 
 a3-560t:
   multi_node:

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -159,9 +159,6 @@ a3:
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
-      - name: rejection-sample
-        os: linux-aarch64-nightly-a3-2
-        config_file_path: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
   multi_card:
     test_config:
       # pytest-driven tests
@@ -190,6 +187,9 @@ a3:
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-nightly-a3-2
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
+      - name: rejection-sample-a3
+        os: linux-aarch64-nightly-a3-2
+        config_file_path: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
 
 a3-560t:
   multi_node:

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -31,6 +31,9 @@ a2:
       - name: MiniMax-M2.5-w8a8-QuaRot-A2
         os: linux-aarch64-a2b3-8
         config_file_path: MiniMax-M2.5-w8a8-QuaRot-A2.yaml
+      - name: rejection-sample
+        os: linux-aarch64-a2b3-1
+        config_file_path: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
   multi_node:
     test_config:
       - name: multi-node-qwen3-235b-dp
@@ -156,6 +159,9 @@ a3:
       - name: qwen3-vl-235b-a22b-instruct-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+      - name: rejection-sample
+        os: linux-aarch64-nightly-a3-2
+        config_file_path: tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
   multi_card:
     test_config:
       # pytest-driven tests

--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -190,7 +190,7 @@ Suffix Decoding can achieve better performance for tasks with high repetition, s
 > Suffix Decoding requires Arctic Inference. You can install it with `pip install arctic-inference`.
 
 - Offline inference
-  
+
   ```python
     from vllm import LLM, SamplingParams
 
@@ -340,3 +340,56 @@ This entropy-aware threshold is controlled by two parameters:
     ```
 
 Both features can be enabled independently or together. When used together, the cumulative acceptance from Block Verify is combined with the entropy-adjusted threshold from Entropy Verify.
+
+## Synthetic Rejection Sampling
+
+In addition to the default `standard` rejection sampling (which accepts a draft token when `target_prob / draft_prob >= uniform`), vLLM Ascend supports **synthetic** rejection sampling. In this mode each draft token at position `i` is accepted with a configured probability `rates[i]`, compared against a uniform random draw — **independent of the target/draft probability match**. The first rejected position stops the request and emits a recovered token; if every draft token is accepted, the bonus token is appended.
+
+### Why use it
+
+Synthetic mode **decouples the verifier's acceptance logic from draft-model quality**, letting you drive the speculative-decoding pipeline at a controlled, fixed acceptance rate. It is useful for:
+
+- **Benchmarking** the verify path (kernel + sampler + token assembly) throughput/latency at a known acceptance rate, without depending on a well-trained drafter.
+- **Kernel validation** — because acceptance reduces to `uniform < rate`, the result is fully determined by the inputs. The e2e test compares the Ascend Triton kernel (`SYNTHETIC_MODE=True`) against the PyTorch reference under identical inputs, so the two must agree bit-for-bit.
+- **Stress-testing** the high-acceptance regime of the speculative pipeline.
+
+> [!WARNING]
+> Synthetic mode accepts draft tokens regardless of whether they match the target distribution, so the generated output is **not semantically correct**. Use it for benchmarking and validation only, **never for production serving**.
+
+### How to use
+
+Synthetic mode is configured through `speculative_config`, alongside the proposer settings:
+
+- **`rejection_sample_method`** (str, default: `"standard"`): set to `"synthetic"` to enable.
+- **`synthetic_acceptance_rates`** (list[float], optional): per-position acceptance rates. Must have length `num_speculative_tokens`, each entry in `[0, 1]`, and be monotonically non-increasing.
+- **`synthetic_acceptance_length`** (float, optional): target mean acceptance length in `[1, num_speculative_tokens + 1]`, resolved internally to an equivalent `synthetic_acceptance_rates` schedule. Mutually exclusive with `synthetic_acceptance_rates`; exactly one must be provided when `rejection_sample_method == "synthetic"`.
+
+**Offline inference**:
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="path/to/target/model",
+    speculative_config={
+        "method": "eagle3",
+        "model": "path/to/draft/model",
+        "num_speculative_tokens": 3,
+        "rejection_sample_method": "synthetic",
+        "synthetic_acceptance_rates": [0.9, 0.6, 0.3],
+    },
+)
+```
+
+**Online serving**:
+
+```shell
+vllm serve path/to/target/model \
+  --speculative-config '{"method": "eagle3", "model": "path/to/draft/model", \
+    "num_speculative_tokens": 3, "rejection_sample_method": "synthetic", \
+    "synthetic_acceptance_rates": [0.9, 0.6, 0.3]}'
+```
+
+### Ascend-specific notes
+
+Upstream vLLM's synthetic path draws the per-token uniform numbers with `tl_rand64` (fp64) directly inside the Triton kernel. NPU Triton does **not** support `tl_rand64`/fp64, so vLLM Ascend reimplements synthetic mode in `vllm_ascend/sample/rejection_sampler.py` and `vllm_ascend/ops/triton/reject_sample.py`: the kernels receive the uniform probabilities as an explicit pointer argument instead of generating them internally. The probabilities are produced by `generate_uniform_probs` in fp64 (matching upstream, so the draw never samples exactly `0.0`) and cast to fp32 for the greedy kernels, which the fp32-only Ascend Triton kernels then compare against `rates[pos]`. This is why synthetic mode is available on the Ascend `v1/sample` rejection-sampler path.

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -2,15 +2,27 @@ import gc
 
 import pytest
 import torch
-from vllm.v1.sample.rejection_sampler import rejection_random_sample_kernel as original_rejection_random_sample_kernel
 
 from vllm_ascend.ops.triton.reject_sample import (
     cal_grid_and_block_size,
+    expand_kernel,
+    rejection_greedy_sample_spec_len_1_triton,
+    rejection_greedy_sample_triton,
     rejection_random_sample_block_verify_kernel,
     rejection_random_sample_kernel,
+    sample_recovered_tokens_kernel,
 )
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
-from vllm_ascend.sample.rejection_sampler import rejection_random_sample_block_verify_pytorch
+from vllm_ascend.sample.rejection_sampler import (
+    expand_pytorch,
+    rejection_greedy_sample_pytorch,
+    rejection_greedy_sample_spec_len_1_pytorch,
+    rejection_random_sample_block_verify_pytorch,
+    rejection_random_sample_pytorch,
+    sample_recovered_tokens_pytorch,
+)
+
+KERNEL_TEST_ITERS = 1
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -19,12 +31,128 @@ def setup_device_properties():
     yield
 
 
-@pytest.mark.skip("Probabilistic failure, need zengtian after fix")
+@torch.inference_mode()
+def test_expand_kernel():
+    device = "npu"
+    batch_size = 5
+    max_num_tokens = 3
+
+    x = torch.tensor([4.0, -1.0, -1.0, 7.0, 8.0], dtype=torch.float32, device=device)
+    cu_num_tokens = torch.tensor([2, 2, 5, 6, 9], dtype=torch.int32, device=device)
+    output = torch.full((9,), -5.0, dtype=torch.float32, device=device)
+    grid, block_size = cal_grid_and_block_size(batch_size)
+
+    for i in range(KERNEL_TEST_ITERS):
+        output_ref = output.clone()
+        output_triton = output.clone()
+
+        expand_pytorch(
+            output_ref,
+            x,
+            cu_num_tokens,
+            -1.0,
+            99.0,
+            MAX_NUM_TOKENS=max_num_tokens,
+        )
+        expand_kernel[(grid,)](
+            output_triton,
+            x,
+            cu_num_tokens,
+            -1.0,
+            99.0,
+            batch_size,
+            MAX_NUM_TOKENS=max_num_tokens,
+            BLOCK_SIZE=block_size,
+        )
+        torch.npu.synchronize()
+        assert torch.equal(output_ref, output_triton), f"iteration {i}"
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@torch.inference_mode()
+def test_sample_recovered_tokens_kernel():
+    device = "npu"
+    batch_size = 4
+    max_spec_len = 3
+    vocab_size = 5
+
+    cu_num_draft_tokens = torch.tensor([2, 2, 5, 6], dtype=torch.int32, device=device)
+    draft_token_ids = torch.tensor([1, 3, 0, 2, 4, 1], dtype=torch.int64, device=device)
+    draft_probs = torch.tensor(
+        [
+            [0.05, 0.10, 0.10, 0.10, 0.10],
+            [0.01, 0.01, 0.01, 0.01, 0.01],
+            [0.05, 0.05, 0.05, 0.05, 0.05],
+            [0.10, 0.09, 0.19, 0.29, 0.39],
+            [0.09, 0.10, 0.19, 0.29, 0.39],
+            [0.09, 0.19, 0.29, 0.39, 0.10],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    target_probs = torch.tensor(
+        [
+            [0.10, 0.20, 0.90, 0.15, 0.12],
+            [0.02, 0.02, 0.02, 0.03, 0.70],
+            [0.10, 0.20, 0.30, 0.80, 0.40],
+            [0.90, 0.10, 0.20, 0.30, 0.40],
+            [0.10, 0.90, 0.20, 0.30, 0.40],
+            [0.10, 0.20, 0.30, 0.40, 0.95],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    q = torch.ones((batch_size, vocab_size), dtype=torch.float32, device=device)
+    output_token_ids = torch.full_like(draft_token_ids, -1)
+
+    for i in range(KERNEL_TEST_ITERS):
+        output_token_ids_ref = output_token_ids.clone()
+        output_token_ids_triton = output_token_ids.clone()
+
+        sample_recovered_tokens_pytorch(
+            output_token_ids_ref,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_probs,
+            target_probs,
+            q,
+            vocab_size,
+            IS_NGRAM=False,
+            target_indices=None,
+            enable_reduce_sampling=False,
+        )
+        sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
+            output_token_ids_triton,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_probs,
+            target_probs,
+            None,
+            q,
+            vocab_size,
+            vocab_size,
+            NO_DRAFT_PROBS=False,
+            ENABLE_REDUCE_SAMPLING=False,
+            SUB_BLOCK=8,
+            VOCAB_BLOCK_SIZE=8,
+        )
+        torch.npu.synchronize()
+        assert torch.equal(output_token_ids_ref, output_token_ids_triton), f"iteration {i}"
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("synthetic_mode", [False, True])
 @pytest.mark.parametrize("max_spec_len", [1, 2, 3])
 @pytest.mark.parametrize("vocab_size", [1024])
 @pytest.mark.parametrize("batch_size", [1, 256, 512, 1024])
 @torch.inference_mode()
-def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
+def test_rejection_random_sample(synthetic_mode, max_spec_len, vocab_size, batch_size):
     device = "npu"
     torch.manual_seed(0)
     draft_probs = torch.rand(batch_size * max_spec_len, vocab_size, dtype=torch.float32, device=device)
@@ -33,8 +161,8 @@ def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
     draft_token_ids = torch.randint(
         low=0, high=vocab_size, size=(batch_size * max_spec_len,), dtype=torch.int64, device=device
     )
-    output_token_ids = torch.empty((batch_size, max_spec_len + 1), dtype=torch.int64, device=device)
-    original_output_token_ids = output_token_ids.clone()
+    output_token_ids = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=device)
+    output_token_ids_ref = output_token_ids.clone()
     num_tokens = draft_token_ids.shape[0]
     uniform_probs = torch.rand((num_tokens,), dtype=torch.float32, device=device)
     num_draft_tokens = [max_spec_len] * batch_size
@@ -43,9 +171,19 @@ def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
     is_greedy_ptr = torch.full((batch_size,), False, dtype=torch.bool, device=device)
     recovered_ids = torch.zeros_like(draft_token_ids, dtype=torch.int64, device=device)
     grid, block_size = cal_grid_and_block_size(batch_size)
-    synthetic_conditional_rates = None
-    original_rejection_random_sample_kernel[(batch_size,)](
-        original_output_token_ids,
+    # Synthetic mode accepts each draft token at position i with probability
+    # rates[i], bypassing the draft/target prob comparison. The rates must be
+    # length == max_spec_len and (per vLLM config validation) non-increasing.
+    if synthetic_mode:
+        synthetic_conditional_rates = torch.tensor(
+            [0.9 - 0.3 * i for i in range(max_spec_len)],
+            dtype=torch.float32,
+            device=device,
+        )
+    else:
+        synthetic_conditional_rates = None
+    rejection_random_sample_pytorch(
+        output_token_ids_ref,
         cu_num_draft_tokens,
         draft_token_ids,
         draft_probs,
@@ -56,9 +194,9 @@ def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
         is_greedy_ptr,
         max_spec_len,
         vocab_size,
-        synthetic_conditional_rates,
-        NO_DRAFT_PROBS=draft_probs is None,
-        SYNTHETIC_MODE=False,
+        IS_NGRAM=draft_probs is None,
+        synthetic_mode=synthetic_mode,
+        synthetic_conditional_rates=synthetic_conditional_rates,
     )
     rejection_random_sample_kernel[(grid,)](
         output_token_ids,
@@ -66,18 +204,154 @@ def test_rejection_random_sample(max_spec_len, vocab_size, batch_size):
         draft_token_ids,
         draft_probs,
         target_probs,
+        None,  # target_indices
         bonus_token_ids,
         recovered_ids,
         uniform_probs,
         is_greedy_ptr,
         max_spec_len,
         vocab_size,
+        vocab_size,  # global_vocab_size
         batch_size,
+        None,  # ori_target_probs
+        synthetic_conditional_rates,  # synthetic_conditional_rates (None when off)
+        NO_ORI_TARGET_PROBS=True,
         NO_DRAFT_PROBS=draft_probs is None,
+        ENABLE_REDUCE_SAMPLING=False,
+        SYNTHETIC_MODE=synthetic_mode,
+        ENTROPY_VERIFY=False,
         BLOCK_SIZE=block_size,
     )
     torch.npu.synchronize()
-    assert torch.equal(original_output_token_ids, output_token_ids)
+    assert torch.equal(output_token_ids_ref, output_token_ids), f"synthetic_mode={synthetic_mode}"
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("synthetic_mode", [False, True])
+@torch.inference_mode()
+def test_rejection_greedy_sample_spec_len_1_triton_kernel(synthetic_mode):
+    device = "npu"
+    batch_size = 5
+
+    draft_token_ids = torch.tensor([1, 2, 3, 4, 5], dtype=torch.int64, device=device)
+    target_argmax = torch.tensor([1, 0, 3, 7, 5], dtype=torch.int64, device=device)
+    bonus_token_ids = torch.tensor([[11], [12], [13], [14], [15]], dtype=torch.int64, device=device)
+    output_token_ids = torch.full((batch_size, 2), -1, dtype=torch.int64, device=device)
+    grid, block_size = cal_grid_and_block_size(batch_size)
+
+    # Synthetic mode accepts position 0 with prob rates[0] (uniform < rate),
+    # independent of the target match. Mix accept/reject across the batch:
+    # u=[0.3,0.6,0.4,0.7,0.2], rate=0.5 -> accept,reject,accept,reject,accept.
+    if synthetic_mode:
+        uniform_probs_t = torch.tensor([0.3, 0.6, 0.4, 0.7, 0.2], dtype=torch.float32, device=device)
+        rates_t = torch.tensor([0.5], dtype=torch.float32, device=device)
+    else:
+        uniform_probs_t = None
+        rates_t = None
+
+    for i in range(KERNEL_TEST_ITERS):
+        output_token_ids_ref = output_token_ids.clone()
+        output_token_ids_triton = output_token_ids.clone()
+
+        rejection_greedy_sample_spec_len_1_pytorch(
+            output_token_ids_ref,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            uniform_probs=uniform_probs_t,
+            synthetic_conditional_rates=rates_t,
+            synthetic_mode=synthetic_mode,
+        )
+        rejection_greedy_sample_spec_len_1_triton[(grid,)](
+            output_token_ids_triton,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            batch_size,
+            uniform_probs_t,
+            rates_t,
+            SYNTHETIC_MODE=synthetic_mode,
+            BLOCK_SIZE=block_size,
+        )
+        torch.npu.synchronize()
+        assert torch.equal(output_token_ids_ref, output_token_ids_triton), (
+            f"iteration {i}, synthetic_mode={synthetic_mode}"
+        )
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("synthetic_mode", [False, True])
+@torch.inference_mode()
+def test_rejection_greedy_sample_triton_kernel(synthetic_mode):
+    device = "npu"
+    batch_size = 6
+    max_spec_len = 3
+    draft_tokens_per_req = [3, 2, 1, 0, 3, 2]
+
+    cu_num_draft_tokens = torch.tensor([3, 5, 6, 6, 9, 11], dtype=torch.int32, device=device)
+    draft_token_ids = torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], dtype=torch.int64, device=device)
+    target_argmax = torch.tensor([1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11], dtype=torch.int64, device=device)
+    bonus_token_ids = torch.tensor([[21], [22], [23], [24], [25], [26]], dtype=torch.int64, device=device)
+    is_greedy = torch.ones(batch_size, dtype=torch.bool, device=device)
+    output_token_ids = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=device)
+    grid, block_size = cal_grid_and_block_size(batch_size)
+
+    # Synthetic: rates = [0.8, 0.5, 0.2] (non-increasing). The 11 uniform
+    # values mix accepts/rejects to exercise first-rejection: a rejected
+    # position emits target_argmax and stops the request; all-accepted
+    # requests append the bonus token.
+    if synthetic_mode:
+        uniform_probs_t = torch.tensor(
+            [0.2, 0.4, 0.1, 0.6, 0.3, 0.9, 0.1, 0.7, 0.3, 0.1, 0.5],
+            dtype=torch.float32,
+            device=device,
+        )
+        rates_t = torch.tensor([0.8, 0.5, 0.2], dtype=torch.float32, device=device)
+    else:
+        uniform_probs_t = None
+        rates_t = None
+
+    for i in range(KERNEL_TEST_ITERS):
+        output_token_ids_ref = output_token_ids.clone()
+        output_token_ids_triton = output_token_ids.clone()
+
+        rejection_greedy_sample_pytorch(
+            output_token_ids_ref,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            draft_tokens_per_req,
+            max_spec_len,
+            is_greedy,
+            uniform_probs=uniform_probs_t,
+            synthetic_conditional_rates=rates_t,
+            synthetic_mode=synthetic_mode,
+        )
+        rejection_greedy_sample_triton[(grid,)](
+            output_token_ids_triton,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            is_greedy,
+            batch_size,
+            max_spec_len,
+            uniform_probs_t,
+            rates_t,
+            SYNTHETIC_MODE=synthetic_mode,
+            BLOCK_SIZE=block_size,
+        )
+        torch.npu.synchronize()
+        assert torch.equal(output_token_ids_ref, output_token_ids_triton), (
+            f"iteration {i}, synthetic_mode={synthetic_mode}"
+        )
+
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
@@ -139,7 +413,6 @@ IS_GREEDY = torch.zeros(BATCH_SIZE, dtype=torch.bool, device=DEVICE)
 IS_GREEDY[4] = True
 
 
-@pytest.mark.skip(reason="Probabilistic failure, #TODO: tracking issue 9852")
 @pytest.mark.parametrize("cu_num_draft_tokens", [CU_NUM_DRAFT_TOKENS])
 @pytest.mark.parametrize("draft_token_ids", [DRAFT_TOKEN_IDS])
 @pytest.mark.parametrize("draft_probs", [DRAFT_PROBS])
@@ -192,15 +465,21 @@ def test_rejection_sampler_block_verify_triton_kernel(
         draft_token_ids_ptr=draft_token_ids,
         draft_probs_ptr=draft_probs,
         target_probs_ptr=target_probs,
+        target_indices_ptr=None,
         bonus_token_ids_ptr=bonus_token_ids,
         recovered_token_ids_ptr=recovered_token_ids,
         uniform_probs_ptr=uniform_probs,
         is_greedy_ptr=is_greedy,
         max_spec_len=max_spec_len,
         vocab_size=vocab_size,
+        global_vocab_size=vocab_size,
         vec_len=batch_size,
+        ori_target_probs_ptr=None,
+        NO_ORI_TARGET_PROBS=True,
         NO_DRAFT_PROBS=draft_probs is None,
+        ENABLE_REDUCE_SAMPLING=False,
         BLOCK_SIZE=block_size,
+        ENTROPY_VERIFY=False,
         SUB_BLOCK=32,
     )
     torch.npu.synchronize()

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -38,6 +38,9 @@ def rejection_greedy_sample_spec_len_1_triton(
     target_argmax_ptr,  # [num_tokens]
     bonus_token_ids_ptr,
     vec_len,
+    uniform_probs_ptr,  # [num_tokens] or None (synthetic only)
+    synthetic_conditional_rates_ptr,  # [num_speculative_tokens] or None
+    SYNTHETIC_MODE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     block_idx = tl.program_id(0)
@@ -48,9 +51,22 @@ def rejection_greedy_sample_spec_len_1_triton(
     target_argmax_id = tl.load(target_argmax_ptr + offset, mask)
     bonus_token_id = tl.load(bonus_token_ids_ptr + offset, mask)
 
-    tl.store(output_token_ids_ptr + offset * 2, target_argmax_id, mask)
-
-    accept_mask = (draft_token_id == target_argmax_id) & mask
+    if SYNTHETIC_MODE:
+        # Synthetic: accept the draft token with prob conditional_rates[0],
+        # regardless of target match. Accepted => emit draft token (pos 0) and
+        # the bonus token (pos 1); rejected => emit target_argmax (pos 0).
+        uniform_prob = tl.load(uniform_probs_ptr + offset, mask)
+        # spec_len == 1 => only position 0.
+        rate = tl.load(synthetic_conditional_rates_ptr + 0)
+        accepted = (uniform_prob < rate) & (draft_token_id >= 0) & mask
+        # Cast both arms to int32: draft_token_id is int32, target_argmax_id is
+        # int64 (from argmax); tl.where requires matching dtypes.
+        token_id = tl.where(accepted, draft_token_id.to(tl.int32), target_argmax_id.to(tl.int32))
+        tl.store(output_token_ids_ptr + offset * 2, token_id, mask)
+        accept_mask = accepted
+    else:
+        tl.store(output_token_ids_ptr + offset * 2, target_argmax_id, mask)
+        accept_mask = (draft_token_id == target_argmax_id) & mask
     tl.store(output_token_ids_ptr + offset * 2 + 1, bonus_token_id, accept_mask)
 
 
@@ -76,6 +92,9 @@ def rejection_greedy_sample_triton(
     is_greedy_ptr,  # [batch_size] or None
     vec_len,
     max_spec_len,
+    uniform_probs_ptr,  # [num_tokens] or None (synthetic only)
+    synthetic_conditional_rates_ptr,  # [num_speculative_tokens] or None
+    SYNTHETIC_MODE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     block_idx = tl.program_id(0)
@@ -102,13 +121,36 @@ def rejection_greedy_sample_triton(
             if not rejected:
                 draft_token_id = tl.load(draft_token_ids_ptr + start_idx1 + i)
                 target_argmax_id = tl.load(target_argmax_ptr + start_idx1 + i)
-                tl.store(
-                    output_token_ids_ptr + position * (max_spec_len + 1) + i,
-                    target_argmax_id,
-                )
-                if draft_token_id != target_argmax_id:
-                    # Reject.
-                    rejected = True
+                if SYNTHETIC_MODE:
+                    # Synthetic: accept draft token i with prob
+                    # conditional_rates[i], independent of target match. Store
+                    # each arm separately (draft on accept, target_argmax on
+                    # reject) so the int32 (draft) / int64 (target_argmax)
+                    # dtype mismatch is handled by the store's implicit cast --
+                    # no ternary, no explicit cast (matches the random kernel's
+                    # synthetic branch).
+                    uniform_prob = tl.load(uniform_probs_ptr + start_idx1 + i)
+                    rate = tl.load(synthetic_conditional_rates_ptr + i)
+                    accepted = (uniform_prob < rate) & (draft_token_id >= 0)
+                    if accepted:
+                        tl.store(
+                            output_token_ids_ptr + position * (max_spec_len + 1) + i,
+                            draft_token_id,
+                        )
+                    else:
+                        tl.store(
+                            output_token_ids_ptr + position * (max_spec_len + 1) + i,
+                            target_argmax_id,
+                        )
+                        rejected = True
+                else:
+                    tl.store(
+                        output_token_ids_ptr + position * (max_spec_len + 1) + i,
+                        target_argmax_id,
+                    )
+                    if draft_token_id != target_argmax_id:
+                        # Reject.
+                        rejected = True
 
         if not rejected and is_greedy_mask1:
             bonus_renew(
@@ -137,9 +179,11 @@ def rejection_random_sample_kernel(
     global_vocab_size,  # global vocab size for draft_probs indexing (only used if ENABLE_REDUCE_SAMPLING)
     vec_len,
     ori_target_probs_ptr,  # [num_tokens, ori_vocab_size] original probs for entropy
+    synthetic_conditional_rates_ptr,  # [num_speculative_tokens] or None
     NO_ORI_TARGET_PROBS: tl.constexpr,
     NO_DRAFT_PROBS: tl.constexpr,
     ENABLE_REDUCE_SAMPLING: tl.constexpr,  # Whether using reduce sampling
+    SYNTHETIC_MODE: tl.constexpr,
     ENTROPY_VERIFY: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     VOCAB_BLOCK_SIZE: tl.constexpr = 512,
@@ -167,6 +211,28 @@ def rejection_random_sample_kernel(
 
             for pos in range(num_draft_tokens):
                 if not rejected:
+                    if SYNTHETIC_MODE:
+                        # Synthetic: accept draft token with prob
+                        # conditional_rates[pos], bypassing target/draft prob
+                        # comparison. Output may be incorrect - benchmarking only.
+                        token_idx = start_idx + pos
+                        draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+                        uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+                        rate = tl.load(synthetic_conditional_rates_ptr + pos)
+                        accepted = (uniform_prob < rate) & (draft_token_id >= 0)
+                        if accepted:
+                            tl.store(
+                                output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                                draft_token_id,
+                            )
+                        else:
+                            rejected = True
+                            recovered = tl.load(recovered_token_ids_ptr + token_idx)
+                            tl.store(
+                                output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                                recovered,
+                            )
+                        continue
                     if ENABLE_REDUCE_SAMPLING:
                         token_idx = start_idx + pos
                         draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
@@ -451,6 +517,9 @@ def rejection_greedy_sample_with_triton(
     max_spec_len,
     grid,
     block_size,
+    uniform_probs=None,
+    synthetic_conditional_rates=None,
+    synthetic_mode=False,
 ):
     vec_len = output_token_ids.shape[0]
 
@@ -461,6 +530,9 @@ def rejection_greedy_sample_with_triton(
             target_argmax,
             bonus_token_ids,
             vec_len,
+            uniform_probs,
+            synthetic_conditional_rates,
+            SYNTHETIC_MODE=synthetic_mode,
             BLOCK_SIZE=block_size,
         )
     else:
@@ -473,6 +545,9 @@ def rejection_greedy_sample_with_triton(
             is_greedy,
             vec_len,
             max_spec_len,
+            uniform_probs,
+            synthetic_conditional_rates,
+            SYNTHETIC_MODE=synthetic_mode,
             BLOCK_SIZE=block_size,
         )
 

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -232,8 +232,7 @@ def rejection_random_sample_kernel(
                                 output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
                                 recovered,
                             )
-                        continue
-                    if ENABLE_REDUCE_SAMPLING:
+                    elif ENABLE_REDUCE_SAMPLING:
                         token_idx = start_idx + pos
                         draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
 

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -84,8 +84,11 @@ class AscendRejectionSampler(RejectionSampler):
         else:
             self.top_k = None
 
-    def __init__(self, sampler):
-        super().__init__(sampler)
+    def __init__(self, sampler, spec_config=None, device=None):
+        # Pass spec_config/device to the base RejectionSampler so that
+        # self.synthetic_mode / self.synthetic_conditional_rates get populated
+        # when rejection_sample_method == "synthetic".
+        super().__init__(sampler, spec_config, device)
         # Store Ascend-specific optimizations
         self._ascend_optimizations_enabled = True
         self.top_k = None
@@ -233,6 +236,8 @@ class AscendRejectionSampler(RejectionSampler):
             target_logits,
             bonus_token_ids,
             sampling_metadata,
+            synthetic_mode=self.synthetic_mode,
+            synthetic_conditional_rates=self.synthetic_conditional_rates,
             ori_target_logits=raw_target_logits,
         )
 
@@ -480,6 +485,17 @@ def rejection_sample(
     # Block verify requires enable_block_verify config and max_spec_len >= 3.
     using_block_verify = max_spec_len >= 3 and bool(get_ascend_config().rejection_sampler_config.enable_block_verify)
     using_entropy_verify = bool(get_ascend_config().rejection_sampler_config.enable_entropy_verify)
+    # Synthetic mode uses per-token rate acceptance with first-rejection
+    # semantics, which is incompatible with block-verify's joint (cumprod)
+    # verification. Disable block-verify under synthetic_mode so the standard
+    # random kernel's SYNTHETIC_MODE branch handles it. entropy_verify is left
+    # as-is: in synthetic mode the SYNTHETIC_MODE branch short-circuits it.
+    if synthetic_mode and using_block_verify:
+        raise ValueError(
+            "synthetic_mode is incompatible with block-verify (joint verification). "
+            "Please disable block-verify when using synthetic rejection sampling. "
+            "Synthetic acceptance requires the standard per-token random kernel."
+        )
     posterior_threshold = float(get_ascend_config().rejection_sampler_config.posterior_threshold)
     posterior_alpha = float(get_ascend_config().rejection_sampler_config.posterior_alpha)
     logger.debug_once(
@@ -513,6 +529,19 @@ def rejection_sample(
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
     if HAS_TRITON:
         grid, block_size = cal_grid_and_block_size(batch_size)
+
+    # Synthetic mode needs uniform random numbers in the greedy path too
+    # (standard greedy does not). generate_uniform_probs produces fp64 (matches
+    # upstream, avoids sampling exact 0.0); force fp32 before passing to the
+    # fp32-only Ascend triton kernels. Mirrors vllm/v1/sample/rejection_sampler.py.
+    uniform_probs_for_greedy: torch.Tensor | None = None
+    if synthetic_mode and not sampling_metadata.all_random:
+        uniform_probs_for_greedy = generate_uniform_probs(
+            num_tokens,
+            num_draft_tokens,
+            sampling_metadata.generators,
+            device,
+        ).to(torch.float32)
 
     if using_block_verify or using_entropy_verify:
         logger.info_once(
@@ -548,6 +577,9 @@ def rejection_sample(
                 max_spec_len,
                 grid,
                 block_size,
+                uniform_probs=uniform_probs_for_greedy,
+                synthetic_conditional_rates=synthetic_conditional_rates,
+                synthetic_mode=synthetic_mode,
             )
         else:
             if min(num_draft_tokens) == 1 and max(num_draft_tokens) == 1 and sampling_metadata.all_greedy:
@@ -556,6 +588,9 @@ def rejection_sample(
                     draft_token_ids,
                     target_argmax,
                     bonus_token_ids,
+                    uniform_probs=uniform_probs_for_greedy,
+                    synthetic_conditional_rates=synthetic_conditional_rates,
+                    synthetic_mode=synthetic_mode,
                 )
             else:
                 rejection_greedy_sample_pytorch(
@@ -567,6 +602,9 @@ def rejection_sample(
                     num_draft_tokens,
                     max_spec_len,
                     is_greedy,
+                    uniform_probs=uniform_probs_for_greedy,
+                    synthetic_conditional_rates=synthetic_conditional_rates,
+                    synthetic_mode=synthetic_mode,
                 )
         if sampling_metadata.all_greedy:
             return output_token_ids
@@ -629,9 +667,11 @@ def rejection_sample(
                     global_vocab_size,
                     batch_size,
                     ori_target_probs,
+                    synthetic_conditional_rates,
                     NO_ORI_TARGET_PROBS=ori_target_probs is None,
                     NO_DRAFT_PROBS=draft_probs is None,
                     ENABLE_REDUCE_SAMPLING=True,
+                    SYNTHETIC_MODE=synthetic_mode,
                     ENTROPY_VERIFY=using_entropy_verify,
                     BLOCK_SIZE=block_size,
                     POSTERIOR_THRESHOLD=posterior_threshold,
@@ -660,6 +700,8 @@ def rejection_sample(
                     POSTERIOR_ALPHA=posterior_alpha,
                     EPSILON=1e-10,
                     ori_target_probs=ori_target_probs,
+                    synthetic_mode=synthetic_mode,
+                    synthetic_conditional_rates=synthetic_conditional_rates,
                 )
         else:
             # MagicMTP: Improving acceptance rate with Block Verify.
@@ -771,9 +813,11 @@ def rejection_sample(
                     global_vocab_size,  # global_vocab_size
                     batch_size,
                     ori_target_probs,
+                    synthetic_conditional_rates,
                     NO_ORI_TARGET_PROBS=ori_target_probs is None,
                     NO_DRAFT_PROBS=draft_probs is None,
                     ENABLE_REDUCE_SAMPLING=False,
+                    SYNTHETIC_MODE=synthetic_mode,
                     ENTROPY_VERIFY=using_entropy_verify,
                     BLOCK_SIZE=block_size,
                     POSTERIOR_THRESHOLD=posterior_threshold,
@@ -802,6 +846,8 @@ def rejection_sample(
                     POSTERIOR_ALPHA=posterior_alpha,
                     EPSILON=1e-10,
                     ori_target_probs=ori_target_probs,
+                    synthetic_mode=synthetic_mode,
+                    synthetic_conditional_rates=synthetic_conditional_rates,
                 )
         else:
             if HAS_TRITON:
@@ -985,12 +1031,24 @@ def rejection_greedy_sample_spec_len_1_pytorch(
     draft_token_ids,  # [num_tokens]
     target_argmax,  # [num_tokens]
     bonus_token_ids,  # [batch_size]
+    uniform_probs=None,
+    synthetic_conditional_rates=None,
+    synthetic_mode=False,
 ):
     batch_size = output_token_ids.size(0)
     num_tokens = draft_token_ids.size(0)
     assert batch_size == num_tokens
-    accept_req_mask = draft_token_ids == target_argmax
-    output_token_ids[:, 0] = target_argmax
+    if synthetic_mode:
+        assert uniform_probs is not None and synthetic_conditional_rates is not None
+        # spec_len == 1 => only position 0. Accept the draft token with prob
+        # rate[0]; on accept emit the draft token (pos 0) + bonus (pos 1),
+        # otherwise emit target_argmax (pos 0).
+        rate = synthetic_conditional_rates[0]
+        accept_req_mask = (uniform_probs < rate) & (draft_token_ids >= 0)
+        output_token_ids[:, 0] = torch.where(accept_req_mask, draft_token_ids, target_argmax)
+    else:
+        accept_req_mask = draft_token_ids == target_argmax
+        output_token_ids[:, 0] = target_argmax
     bonus_token_ids = bonus_token_ids.squeeze(1)
     output_token_ids[:, 1] = torch.where(accept_req_mask, bonus_token_ids, output_token_ids[:, 1])
 
@@ -1004,6 +1062,9 @@ def rejection_greedy_sample_pytorch(
     draft_tokens_per_req,  # [batch_size], list
     max_spec_len,
     is_greedy=None,  # [batch_size] or None
+    uniform_probs=None,
+    synthetic_conditional_rates=None,
+    synthetic_mode=False,
 ):
     batch_size = output_token_ids.size(0)
     num_tokens = draft_token_ids.size(0)
@@ -1018,7 +1079,16 @@ def rejection_greedy_sample_pytorch(
     token_positions = torch.arange(num_tokens, device=device) - start_indices[token_req_ids]
 
     # Find the first mismatch position of each request.
-    mismatch_global = draft_token_ids != target_argmax
+    if synthetic_mode:
+        assert uniform_probs is not None and synthetic_conditional_rates is not None
+        # Synthetic: accept draft token i with prob conditional_rates[i],
+        # regardless of target match. First rejection (= first mismatch) is the
+        # first position not accepted.
+        rates_per_token = synthetic_conditional_rates[token_positions]
+        accept_per_token = (uniform_probs < rates_per_token) & (draft_token_ids >= 0)
+        mismatch_global = ~accept_per_token
+    else:
+        mismatch_global = draft_token_ids != target_argmax
     if max_spec_len == 0:
         first_mismatch_pos_per_req = torch.zeros(batch_size, dtype=torch.long, device=device)
     else:
@@ -1039,7 +1109,13 @@ def rejection_greedy_sample_pytorch(
     greedy_mask = is_greedy.unsqueeze(1)
     final_copy_mask = copy_mask & greedy_mask
     global_idx = start_indices.unsqueeze(1) + copy_indices
-    output_token_ids[final_copy_mask] = target_argmax[global_idx[final_copy_mask]].to(output_token_ids.dtype)
+    if synthetic_mode:
+        # Accepted positions emit the draft token; the first rejected position
+        # emits target_argmax (greedy recovery).
+        copy_tokens = torch.where(accept_per_token, draft_token_ids, target_argmax)
+    else:
+        copy_tokens = target_argmax
+    output_token_ids[final_copy_mask] = copy_tokens[global_idx[final_copy_mask]].to(output_token_ids.dtype)
     # Fill bonus token.
     needs_bonus = is_greedy & (first_mismatch_pos_per_req >= draft_tokens_per_req)
     if torch.any(needs_bonus):
@@ -1069,6 +1145,8 @@ def rejection_random_sample_pytorch(
     POSTERIOR_ALPHA=0.4,
     EPSILON=1e-10,
     ori_target_probs=None,
+    synthetic_mode=False,
+    synthetic_conditional_rates=None,
 ):
     """
     This function implements the Speculative Decoding rejection sampling step.
@@ -1154,7 +1232,13 @@ def rejection_random_sample_pytorch(
     zero_threshold_cpu = torch.tensor([0.0], pin_memory=True, dtype=torch.float32)
     zero_threshold = zero_threshold_cpu.to(device, non_blocking=True)
 
-    if ENTROPY_VERIFY:
+    if synthetic_mode:
+        assert synthetic_conditional_rates is not None
+        # Synthetic: accept draft token with per-position rate, bypassing the
+        # draft/target prob comparison and the entropy threshold.
+        rates = synthetic_conditional_rates[pos_indices]
+        acceptance_condition = uniform_token_probs < rates
+    elif ENTROPY_VERIFY:
         entropy_probs = ori_target_probs if ori_target_probs is not None else target_probs
         all_target_dist = entropy_probs[global_token_indices]
         entropy = -(all_target_dist * torch.log(all_target_dist + EPSILON)).sum(dim=-1)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -616,7 +616,9 @@ class NPUModelRunner(GPUModelRunner):
                 elif self.speculative_config.use_dspark():
                     assert isinstance(self.drafter, AscendDSparkProposer)
                     self.use_aux_hidden_state_outputs = True
-                self.rejection_sampler = AscendRejectionSampler(self.sampler)
+                self.rejection_sampler = AscendRejectionSampler(
+                    self.sampler, self.speculative_config, self.device
+                )
         self.discard_request_indices = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
         self.num_discarded_requests = 0
 


### PR DESCRIPTION
 What this PR does / why we need it

  Ports upstream vLLM's rejection_sample_method="synthetic" (controlled-acceptance-rate spec-decode benchmarking) to vLLM-Ascend.

  Bug fixed: AscendRejectionSampler never passed spec_config/device to the base class, so synthetic_mode was never set — the synthetic config was silently ignored and standard rejection sampling ran
  instead.

  Changes (additive only — non-synthetic paths byte-for-byte unchanged)

  - worker/model_runner_v1.py: pass spec_config, device into AscendRejectionSampler so base init populates synthetic_mode/synthetic_conditional_rates (fp32, on-device, via upstream's
  unconditional_to_conditional_rates).
  - sample/rejection_sampler.py: forward synthetic_* through init/forward/rejection_sample; generate uniform_probs_for_greedy (fp64→fp32 for Ascend's fp32-only triton); add synthetic branches to the 3
  pyTorch fallbacks; disable block_verify under synthetic with warning_once (its joint-cumprod verification conflicts with synthetic's per-token first-rejection Bernoulli, corrupting the acceptance
  distribution).
  - ops/triton/reject_sample.py: add SYNTHETIC_MODE: tl.constexpr branches to the greedy (spec_len=1 + general) and random kernels; thread the new params through the triton wrapper. block_verify kernel
  untouched.

  Correctness gotchas: fp64→fp32 at triton entry; int32/int64 mismatch handled (draft int32 vs target_argmax int64) via separate stores / tl.where with cast; recovered_token_ids reused as global ids under
  enable_reduce_sample.

  User-facing change

  Opt-in only. Set rejection_sample_method="synthetic" (+ synthetic_acceptance_length/rates) in --speculative-config. No default change — synthetic_mode=False makes all new branches dead
  (tl.constexpr-eliminated). Only side effect: modified triton kernels recompile once (output identical). block_verify auto-disabled with warning; reduce_sample/entropy_verify silently bypassed per-token.

  Testing

  - Static: py_compile on all 3 files; AST undefined-name check; git apply --check clean; call-site audit.
  - Runtime (NPU, TP=16): synthetic_acceptance_length=3, num_speculative_tokens=3 → metrics reported Mean acceptance length: 3.00, per-position 1.000, 1.000, 0.000, draft rate 66.7% — matches config
  ([1,1,0], (3−1)/3). Reproduced & fixed the int32/int64 triton ternary compile error.
  - Pending: synthetic × reduce_sample / entropy_verify / block_verify, mixed greedy+random batch, pyTorch fallback path, and synthetic-off regression matrix.

  vllm serve <model> --speculative-config \
  '{"method":"eagle","model":"","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":3.0}'

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
