### PR TITLE
[BugFix][Worker] Preserve FusedMoE storage during online weight reload

### DIFF
--- a/tests/ut/ops/test_fused_moe_online_reload.py
+++ b/tests/ut/ops/test_fused_moe_online_reload.py
@@ -1,0 +1,240 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
+from vllm_ascend.ops.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod
+
+
+def _build_method(monkeypatch, release_branch=False):
+    method = AscendUnquantizedFusedMoEMethod.__new__(AscendUnquantizedFusedMoEMethod)
+    method.dynamic_eplb = False
+    method._maybe_pad_weight = lambda weight: weight
+
+    monkeypatch.setattr(
+        fused_moe_module,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_fused_mc2=False),
+    )
+    monkeypatch.setattr(fused_moe_module, "maybe_trans_nz", lambda weight: weight)
+    monkeypatch.setattr(fused_moe_module, "vllm_version_is", lambda version: release_branch)
+    return method
+
+
+def _build_layer():
+    layer = torch.nn.Module()
+    layer.w13_weight = torch.nn.Parameter(torch.randn(2, 3, 4), requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(torch.randn(2, 4, 3), requires_grad=False)
+    layer.register_buffer("e_score_correction_bias", torch.zeros(2), persistent=True)
+    return layer
+
+
+def _copy_loader(param, loaded_weight):
+    with torch.no_grad():
+        param.copy_(loaded_weight)
+
+
+def test_unquantized_moe_declares_native_reload_support():
+    assert AscendUnquantizedFusedMoEMethod.requires_native_layerwise_reload is True
+
+
+@pytest.mark.parametrize("release_branch", [False, True], ids=["main", "release"])
+def test_native_reload_preserves_runtime_storage_and_numerics(monkeypatch, release_branch):
+    from vllm.model_executor.model_loader.reload import (
+        finalize_layerwise_reload,
+        initialize_layerwise_reload,
+        record_metadata_for_reloading,
+    )
+
+    method = _build_method(monkeypatch, release_branch=release_branch)
+    layer = _build_layer()
+    object.__setattr__(layer, "quant_method", method)
+    layer.w13_weight.weight_loader = _copy_loader
+    layer.w2_weight.weight_loader = _copy_loader
+
+    record_metadata_for_reloading(layer)
+    method.process_weights_after_loading(layer)
+
+    # Simulate wake_up's checkpoint-layout views before native reload starts.
+    processed_storage = (
+        layer.w13_weight.untyped_storage().data_ptr(),
+        layer.w2_weight.untyped_storage().data_ptr(),
+    )
+    layer.w13_weight = method.make_weight_loading_view(layer.w13_weight)
+    layer.w2_weight = method.make_weight_loading_view(layer.w2_weight)
+    assert method.prepare_for_native_layerwise_reload(layer) is True
+    assert (
+        layer.w13_weight.untyped_storage().data_ptr(),
+        layer.w2_weight.untyped_storage().data_ptr(),
+    ) == processed_storage
+
+    runtime_w13 = layer.w13_weight
+    runtime_w2 = layer.w2_weight
+    runtime_correction_bias = layer.e_score_correction_bias
+    runtime_pointers = (
+        runtime_w13.data_ptr(),
+        runtime_w13.untyped_storage().data_ptr(),
+        runtime_w2.data_ptr(),
+        runtime_w2.untyped_storage().data_ptr(),
+        runtime_correction_bias.data_ptr(),
+        runtime_correction_bias.untyped_storage().data_ptr(),
+    )
+    model_input = torch.tensor([[1.0, -0.25, 0.5]], dtype=runtime_w13.dtype)
+
+    for seed in (17, 29):
+        generator = torch.Generator().manual_seed(seed)
+        checkpoint_w13 = torch.randn((2, 3, 4), generator=generator)
+        checkpoint_w2 = torch.randn((2, 4, 3), generator=generator)
+        checkpoint_correction_bias = torch.randn((2,), generator=generator)
+
+        initialize_layerwise_reload(layer)
+        with torch.no_grad():
+            layer.e_score_correction_bias.copy_(checkpoint_correction_bias)
+        layer.w13_weight.weight_loader(layer.w13_weight, checkpoint_w13)
+        layer.w2_weight.weight_loader(layer.w2_weight, checkpoint_w2)
+        finalize_layerwise_reload(layer, SimpleNamespace(dtype=torch.float32))
+
+        assert layer.w13_weight is runtime_w13
+        assert layer.w2_weight is runtime_w2
+        assert layer.e_score_correction_bias is runtime_correction_bias
+        assert (
+            runtime_w13.data_ptr(),
+            runtime_w13.untyped_storage().data_ptr(),
+            runtime_w2.data_ptr(),
+            runtime_w2.untyped_storage().data_ptr(),
+            runtime_correction_bias.data_ptr(),
+            runtime_correction_bias.untyped_storage().data_ptr(),
+        ) == runtime_pointers
+
+        torch.testing.assert_close(runtime_w13, checkpoint_w13.transpose(1, 2))
+        torch.testing.assert_close(runtime_w2, checkpoint_w2.transpose(1, 2))
+        torch.testing.assert_close(runtime_correction_bias, checkpoint_correction_bias)
+        runtime_output = model_input @ runtime_w13[0].T @ runtime_w2[0].T
+        checkpoint_reference = model_input @ checkpoint_w13[0] @ checkpoint_w2[0]
+        torch.testing.assert_close(runtime_output, checkpoint_reference)
+
+
+def test_loading_view_round_trip_is_zero_copy_and_preserves_loader(monkeypatch):
+    method = _build_method(monkeypatch)
+    layer = _build_layer()
+    layer.w13_weight.weight_loader = _copy_loader
+    layer.w2_weight.weight_loader = _copy_loader
+    method.process_weights_after_loading(layer)
+    layer.w13_weight.unrelated_mutable_metadata = []
+    layer.w2_weight.unrelated_mutable_metadata = []
+
+    runtime_shape_stride = {
+        "w13_weight": (layer.w13_weight.shape, layer.w13_weight.stride()),
+        "w2_weight": (layer.w2_weight.shape, layer.w2_weight.stride()),
+    }
+    runtime_storage = {name: getattr(layer, name).untyped_storage().data_ptr() for name in ("w13_weight", "w2_weight")}
+
+    for name in ("w13_weight", "w2_weight"):
+        setattr(layer, name, method.make_weight_loading_view(getattr(layer, name)))
+        assert getattr(getattr(layer, name), "_ascend_moe_checkpoint_layout_view", False) is True
+        assert callable(getattr(layer, name).weight_loader)
+        assert not hasattr(getattr(layer, name), "unrelated_mutable_metadata")
+
+    assert method.prepare_for_native_layerwise_reload(layer) is True
+    assert method.prepare_for_native_layerwise_reload(layer) is False
+
+    for name in ("w13_weight", "w2_weight"):
+        param = getattr(layer, name)
+        assert (param.shape, param.stride()) == runtime_shape_stride[name]
+        assert param.untyped_storage().data_ptr() == runtime_storage[name]
+        assert not hasattr(param, "_ascend_moe_checkpoint_layout_view")
+        assert callable(param.weight_loader)
+        assert not hasattr(param, "unrelated_mutable_metadata")
+
+
+@pytest.mark.parametrize("release_branch", [False, True], ids=["main", "release"])
+def test_direct_reload_remains_usable_for_two_updates(monkeypatch, release_branch):
+    method = _build_method(monkeypatch, release_branch=release_branch)
+    layer = _build_layer()
+    layer.w13_weight.weight_loader = _copy_loader
+    layer.w2_weight.weight_loader = _copy_loader
+    method.process_weights_after_loading(layer)
+    runtime_storage = (
+        layer.w13_weight.untyped_storage().data_ptr(),
+        layer.w2_weight.untyped_storage().data_ptr(),
+    )
+
+    for seed in (41, 53):
+        generator = torch.Generator().manual_seed(seed)
+        checkpoint_w13 = torch.randn((2, 3, 4), generator=generator)
+        checkpoint_w2 = torch.randn((2, 4, 3), generator=generator)
+
+        layer.w13_weight = method.make_weight_loading_view(layer.w13_weight)
+        layer.w2_weight = method.make_weight_loading_view(layer.w2_weight)
+        layer.w13_weight.weight_loader(layer.w13_weight, checkpoint_w13)
+        layer.w2_weight.weight_loader(layer.w2_weight, checkpoint_w2)
+        method.process_weights_after_loading(layer)
+
+        torch.testing.assert_close(layer.w13_weight, checkpoint_w13.transpose(1, 2))
+        torch.testing.assert_close(layer.w2_weight, checkpoint_w2.transpose(1, 2))
+        assert callable(layer.w13_weight.weight_loader)
+        assert callable(layer.w2_weight.weight_loader)
+        assert not hasattr(layer.w13_weight, "_ascend_moe_checkpoint_layout_view")
+        assert not hasattr(layer.w2_weight, "_ascend_moe_checkpoint_layout_view")
+        assert (
+            layer.w13_weight.untyped_storage().data_ptr(),
+            layer.w2_weight.untyped_storage().data_ptr(),
+        ) == runtime_storage
+
+
+def test_native_reload_rejects_mixed_fused_moe_layouts(monkeypatch):
+    method = _build_method(monkeypatch)
+    layer = _build_layer()
+    method.process_weights_after_loading(layer)
+    layer.w13_weight = method.make_weight_loading_view(layer.w13_weight)
+
+    with pytest.raises(RuntimeError, match="mixed runtime and checkpoint-layout"):
+        method.prepare_for_native_layerwise_reload(layer)
+
+
+def test_dynamic_eplb_split_weights_reject_online_reload(monkeypatch):
+    from vllm.model_executor.model_loader.reload import (
+        initialize_layerwise_reload,
+        record_metadata_for_reloading,
+    )
+
+    method = _build_method(monkeypatch)
+    method.dynamic_eplb = True
+    layer = _build_layer()
+    object.__setattr__(layer, "quant_method", method)
+    layer.w13_weight.weight_loader = _copy_loader
+    layer.w2_weight.weight_loader = _copy_loader
+    monkeypatch.setattr(
+        fused_moe_module,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_fused_mc2=1),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_format_cast", lambda weight, _: weight)
+    monkeypatch.setattr(fused_moe_module.torch.npu, "empty_cache", lambda: None)
+
+    record_metadata_for_reloading(layer)
+    method.process_weights_after_loading(layer)
+    assert hasattr(layer, "w13_weight_list")
+    assert hasattr(layer, "w2_weight_list")
+
+    initialize_layerwise_reload(layer)
+    layer.w13_weight.weight_loader(layer.w13_weight, torch.randn(2, 3, 4))
+    with pytest.raises(RuntimeError, match="dynamic EPLB"):
+        layer.w2_weight.weight_loader(layer.w2_weight, torch.randn(2, 4, 3))

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -249,6 +249,66 @@ class TestNPUWorker(TestBase):
             mock_allocator.wake_up.assert_called_once_with(tags=["test_tag"])
             worker.sleep_wakeup_manager.wakeup.assert_called_once_with(["test_tag"])
 
+    @patch("vllm_ascend.worker.worker.CaMemAllocator")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_wake_up_uses_backend_loading_view_hook(self, mock_get_config, mock_allocator_class):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        class NativeReloadMethod:
+            def __init__(self):
+                self.loading_view_calls = 0
+
+            def make_weight_loading_view(self, param):
+                self.loading_view_calls += 1
+                loading_param = torch.nn.Parameter(param.transpose(1, 2), requires_grad=False)
+                loading_param.test_loading_view = True
+                return loading_param
+
+        model = torch.nn.Module()
+        model.experts = torch.nn.Module()
+        native_reload_method = NativeReloadMethod()
+        model.experts.quant_method = native_reload_method
+        model.experts.w13_weight = torch.nn.Parameter(torch.randn(2, 3, 4), requires_grad=False)
+        model.experts.w2_weight = torch.nn.Parameter(torch.randn(2, 4, 3), requires_grad=False)
+        original_w13 = model.experts.w13_weight
+        original_w2 = model.experts.w2_weight
+
+        model.legacy_experts = torch.nn.Module()
+        model.legacy_experts.w13_weight = torch.nn.Parameter(torch.randn(2, 3, 4), requires_grad=False)
+        model.legacy_experts.w2_weight = torch.nn.Parameter(torch.randn(2, 4, 3), requires_grad=False)
+        legacy_w13 = model.legacy_experts.w13_weight
+        legacy_w2 = model.legacy_experts.w2_weight
+
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 0
+        mock_config.enable_sleep_mode_extra_cleanup = False
+        mock_get_config.return_value = mock_config
+        mock_allocator_class.get_instance.return_value = MagicMock()
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+        worker.model_runner = MagicMock(model=model)
+        worker.vllm_config = MagicMock()
+        worker.vllm_config.quant_config = None
+        worker.vllm_config.model_config.hf_text_config.hidden_size = 3
+        worker._sleep_saved_buffers = {}
+        worker.sleep_wakeup_manager = MagicMock()
+
+        worker.wake_up(tags=["weights"])
+
+        assert tuple(model.experts.w13_weight.shape) == (2, 4, 3)
+        assert tuple(model.experts.w2_weight.shape) == (2, 3, 4)
+        assert model.experts.w13_weight.test_loading_view is True
+        assert model.experts.w2_weight.test_loading_view is True
+        assert model.experts.w13_weight.untyped_storage().data_ptr() == original_w13.untyped_storage().data_ptr()
+        assert model.experts.w2_weight.untyped_storage().data_ptr() == original_w2.untyped_storage().data_ptr()
+        assert native_reload_method.loading_view_calls == 2
+
+        assert tuple(model.legacy_experts.w13_weight.shape) == (2, 4, 3)
+        assert tuple(model.legacy_experts.w2_weight.shape) == (2, 3, 4)
+        assert model.legacy_experts.w13_weight.untyped_storage().data_ptr() == legacy_w13.untyped_storage().data_ptr()
+        assert model.legacy_experts.w2_weight.untyped_storage().data_ptr() == legacy_w2.untyped_storage().data_ptr()
+
     @patch("vllm_ascend.worker.worker.current_platform")
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
@@ -1388,14 +1448,63 @@ class TestNPUWorkerWeightUpdate(TestBase):
         engine.parse_init_info.assert_called_once_with(init_info)
         engine.init_transfer_engine.assert_called_once_with("typed_init")
 
+    def test_prepare_model_for_native_reload_dispatches_capability(self):
+        worker = self._make_worker(engine=MagicMock())
+        model = torch.nn.Module()
+        model.layer = torch.nn.Module()
+        prepare = MagicMock()
+        model.layer.quant_method = MagicMock(
+            requires_native_layerwise_reload=True,
+            prepare_for_native_layerwise_reload=prepare,
+        )
+
+        worker.prepare_model_for_native_layerwise_reload(model)
+
+        prepare.assert_called_once_with(model.layer)
+
+    def test_prepare_model_for_native_reload_rejects_missing_hook(self):
+        worker = self._make_worker(engine=MagicMock())
+        model = torch.nn.Module()
+        model.layer = torch.nn.Module()
+        model.layer.quant_method = MagicMock(requires_native_layerwise_reload=True)
+        model.layer.quant_method.prepare_for_native_layerwise_reload = None
+
+        with self.assertRaisesRegex(RuntimeError, "does not provide prepare_for_native_layerwise_reload"):
+            worker.prepare_model_for_native_layerwise_reload(model)
+
+    @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_rejects_dynamic_eplb_before_initialize(self, mock_init_reload):
+        from vllm_ascend.ops.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod
+
+        worker = self._make_worker(engine=MagicMock())
+        model = torch.nn.Module()
+        model.layer = torch.nn.Module()
+        method = AscendUnquantizedFusedMoEMethod.__new__(AscendUnquantizedFusedMoEMethod)
+        method.dynamic_eplb = True
+        model.layer.quant_method = method
+        model.layer.w13_weight_list = [torch.empty(1)]
+        worker.model_runner.model = model
+
+        with self.assertRaisesRegex(RuntimeError, "dynamic EPLB"):
+            worker.start_weight_update(is_checkpoint_format=True)
+
+        mock_init_reload.assert_not_called()
+        self.assertFalse(worker._weight_update_active)
+
     @patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload")
     @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
     def test_start_weight_update_checkpoint_format(self, mock_init_reload):
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
+        events = []
+        worker.prepare_model_for_native_layerwise_reload = MagicMock(side_effect=lambda model: events.append("prepare"))
+        mock_init_reload.side_effect = lambda model: events.append("initialize")
 
         worker.start_weight_update(is_checkpoint_format=True)
 
+        self.assertEqual(events, ["prepare", "initialize"])
+        worker.prepare_model_for_native_layerwise_reload.assert_called_once_with(worker.model_runner.model)
         mock_init_reload.assert_called_once_with(worker.model_runner.model)
         self.assertTrue(worker._weight_update_active)
         self.assertTrue(worker._is_checkpoint_format)
@@ -1405,9 +1514,11 @@ class TestNPUWorkerWeightUpdate(TestBase):
     def test_start_weight_update_kernel_format(self, mock_init_reload):
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
+        worker.prepare_model_for_native_layerwise_reload = MagicMock()
 
         worker.start_weight_update(is_checkpoint_format=False)
 
+        worker.prepare_model_for_native_layerwise_reload.assert_not_called()
         mock_init_reload.assert_not_called()
         self.assertTrue(worker._weight_update_active)
         self.assertFalse(worker._is_checkpoint_format)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.fused_moe.layer import (
     MoERunner,
 )
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
+from vllm.model_executor.utils import set_weight_attrs
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -90,6 +91,9 @@ def mock_true():
 
 
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
+    # Native layerwise reload preserves the runtime storage used by ACLGraph.
+    requires_native_layerwise_reload = True
+
     def __init__(self, moe: FusedMoEConfig = None, tid2eid=None):
         super().__init__(moe=moe)
         self.dynamic_eplb = get_ascend_config().eplb_config.dynamic_eplb
@@ -104,23 +108,80 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # Do not let upstream modular-kernel initialization replace it.
         return None
 
+    @staticmethod
+    def make_weight_loading_view(param: torch.nn.Parameter) -> torch.nn.Parameter:
+        """Create a tagged checkpoint-layout view for online weight loading."""
+        loading_param = AscendUnquantizedFusedMoEMethod._make_parameter_with_weight_loader(
+            param,
+            param.transpose(1, 2),
+        )
+        loading_param._ascend_moe_checkpoint_layout_view = True
+        return loading_param
+
+    @staticmethod
+    def _make_parameter_with_weight_loader(
+        source: torch.nn.Parameter,
+        data: torch.Tensor,
+    ) -> torch.nn.Parameter:
+        """Create a Parameter that preserves vLLM's weight-loader attribute."""
+        result = torch.nn.Parameter(data, requires_grad=False)
+        weight_loader = getattr(source, "weight_loader", None)
+        if callable(weight_loader):
+            set_weight_attrs(result, {"weight_loader": weight_loader})
+        return result
+
+    def prepare_for_native_layerwise_reload(self, layer: torch.nn.Module) -> bool:
+        """Restore tagged checkpoint-layout views to the runtime layout."""
+        if self.dynamic_eplb and (hasattr(layer, "w13_weight_list") or hasattr(layer, "w2_weight_list")):
+            raise RuntimeError(
+                "Native layerwise reload does not support unquantized FusedMoE after dynamic EPLB "
+                "splits weights into per-expert tensor lists."
+            )
+
+        weights = (layer.w13_weight, layer.w2_weight)
+        loading_view_flags = tuple(
+            getattr(weight, "_ascend_moe_checkpoint_layout_view", False) is True for weight in weights
+        )
+        if not any(loading_view_flags):
+            return False
+        if not all(loading_view_flags):
+            raise RuntimeError("Cannot prepare Ascend FusedMoE with mixed runtime and checkpoint-layout weights.")
+
+        for name in ("w13_weight", "w2_weight"):
+            loading_param = getattr(layer, name)
+            runtime_param = self._make_parameter_with_weight_loader(
+                loading_param,
+                loading_param.transpose(1, 2),
+            )
+            if runtime_param.untyped_storage().data_ptr() != loading_param.untyped_storage().data_ptr():
+                raise RuntimeError(f"Preparing {name} for native reload changed its storage.")
+            setattr(layer, name, runtime_param)
+        return True
+
     def process_weights_after_loading(self, layer):
+        if self.dynamic_eplb and (hasattr(layer, "w13_weight_list") or hasattr(layer, "w2_weight_list")):
+            raise RuntimeError(
+                "Online layerwise reload does not support unquantized FusedMoE after dynamic EPLB "
+                "splits weights into per-expert tensor lists."
+            )
+
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
+
+        checkpoint_w13 = layer.w13_weight
+        checkpoint_w2 = layer.w2_weight
 
         # vLLM PR #44589 landed after the v0.24 main-line cut point
         # (798185d) and is present in the verified main commit only.
         if not vllm_version_is("0.24.0"):
             w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2)
-            layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
-
             w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2)
-            layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
         else:
             w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
-            layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
-
             w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
-            layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
+
+        # Keep weight loaders available for subsequent online updates.
+        layer.w13_weight = self._make_parameter_with_weight_loader(checkpoint_w13, w13_data)
+        layer.w2_weight = self._make_parameter_with_weight_loader(checkpoint_w2, w2_data)
 
         # TODO: Current dispatch_ffn_combine fusion operator ONLY supports NZ format.
         # Therefore, we must cast weights to NZ when fusion is enabled.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -256,19 +256,24 @@ class NPUWorker(WorkerBase):
         model = self.model_runner.model
         if self.vllm_config.quant_config is None and (tags is None or "weights" in tags):
             for name, param in model.named_parameters():
-                if "w2_weight" in name and param.shape[2] == hidden_size:
-                    parts = name.split(".")
-                    param_name = parts[-1]
-                    parent_module = model.get_submodule(".".join(parts[:-1]))
+                is_legacy_w2 = "w2_weight" in name and param.shape[2] == hidden_size
+                is_legacy_w13 = "w13_weight" in name and param.shape[1] == hidden_size
+                if not (is_legacy_w2 or is_legacy_w13):
+                    continue
 
+                parts = name.split(".")
+                param_name = parts[-1]
+                parent_module = model.get_submodule(".".join(parts[:-1]))
+                quant_method = getattr(parent_module, "quant_method", None)
+                make_loading_view = getattr(quant_method, "make_weight_loading_view", None)
+                if callable(make_loading_view):
+                    # Preserve the backend weight loader on checkpoint-layout views.
+                    setattr(parent_module, param_name, make_loading_view(param))
+                elif is_legacy_w2:
                     w2_data = param.transpose(1, 2)
                     w2_data = torch.nn.Parameter(w2_data, requires_grad=False)
                     setattr(parent_module, param_name, w2_data)
-                elif "w13_weight" in name and param.shape[1] == hidden_size:
-                    parts = name.split(".")
-                    param_name = parts[-1]
-                    parent_module = model.get_submodule(".".join(parts[:-1]))
-
+                else:
                     w13_data = param.transpose(1, 2)
                     w13_data = torch.nn.Parameter(w13_data, requires_grad=False)
                     setattr(parent_module, param_name, w13_data)
@@ -304,6 +309,21 @@ class NPUWorker(WorkerBase):
                 "VLLM_ASCEND_ENABLE_NZ=0."
             )
 
+    def prepare_model_for_native_layerwise_reload(self, model: nn.Module) -> None:
+        """Prepare backend-specific layouts before layerwise reload initialization."""
+        for layer in model.modules():
+            quant_method = getattr(layer, "quant_method", None)
+            if getattr(quant_method, "requires_native_layerwise_reload", False) is not True:
+                continue
+
+            prepare = getattr(quant_method, "prepare_for_native_layerwise_reload", None)
+            if not callable(prepare):
+                raise RuntimeError(
+                    "A quantization method requires native layerwise reload but does not provide "
+                    "prepare_for_native_layerwise_reload()."
+                )
+            prepare(layer)
+
     def start_weight_update(self, is_checkpoint_format: bool = True) -> None:
         """Begin a new weight update; prepares the model for layerwise reload."""
         self._check_weight_transfer_engine()
@@ -320,6 +340,7 @@ class NPUWorker(WorkerBase):
 
             model = self.model_runner.model
             with torch.device(self.device):
+                self.prepare_model_for_native_layerwise_reload(model)
                 initialize_layerwise_reload(model)
 
         self._is_checkpoint_format = is_checkpoint_format


### PR DESCRIPTION
### What this PR does / why we need it?

This PR preserves the runtime storage of Ascend unquantized FusedMoE parameters across checkpoint-format online weight reloads.

Ascend FusedMoE loads checkpoint-layout weights and post-processes them into a transposed runtime layout. ACLGraph captures the runtime tensors by storage address. During sleep/wake and subsequent online reload, the weight loader needs a temporary checkpoint-layout view. If reload begins while model attributes expose that view, or if post-processing replaces the runtime storage, graph replay can continue reading the previously captured storage after new weights have been loaded.

This change introduces a backend capability at the FusedMoE method level instead of adding model-specific logic:

- `AscendUnquantizedFusedMoEMethod` declares that it requires native layerwise reload preparation;
- wake-up delegates checkpoint-layout view creation to the backend method when that capability is available;
- the temporary checkpoint-layout `Parameter` is a transposed view that shares the original storage and preserves the callable `weight_loader`;
- before `initialize_layerwise_reload()` starts, the backend restores the tagged view to runtime shape/stride and verifies that the storage pointer is unchanged;
- post-processing preserves the callable `weight_loader` when replacing a `Parameter`;
- the existing vLLM-main versus v0.24.0 contiguous-layout behavior is retained;
- the worker dispatches preparation generically through `quant_method` capabilities;
- the existing legacy wake-up transpose remains available for methods without the capability;
- dynamic EPLB layouts that have already split weights into per-expert tensor lists fail explicitly because their storage cannot be restored safely by this path.

This is not a model addition or model patch. It changes only the generic Ascend FusedMoE method and worker reload lifecycle.

Companion veRL orchestration PR: https://github.com/verl-project/verl/pull/7087

### Related and duplicate-work check

The following open-PR searches were checked:

- [`"MTP online reload"`](https://github.com/vllm-project/vllm-ascend/pulls?q=is%3Apr%20is%3Aopen%20%22MTP%20online%20reload%22)
- [`"FusedMoE storage reload"`](https://github.com/vllm-project/vllm-ascend/pulls?q=is%3Apr%20is%3Aopen%20%22FusedMoE%20storage%20reload%22)
- [`"layerwise reload"`](https://github.com/vllm-project/vllm-ascend/pulls?q=is%3Apr%20is%3Aopen%20%22layerwise%20reload%22)

No matching MTP or FusedMoE weight-reload PR was found. The layerwise-reload query found [#10733](https://github.com/vllm-project/vllm-ascend/pull/10733), which implements a layerwise KV-cache pool for prefill reuse and does not modify model-weight reload or FusedMoE parameter storage.

### Does this PR introduce _any_ user-facing change?

Yes.

For supported unquantized Ascend FusedMoE online updates, checkpoint-format reload now preserves the runtime storage referenced by a captured graph.

If dynamic EPLB has already transformed FusedMoE parameters into per-expert tensor lists, online native reload now raises a clear error instead of continuing through an unsupported and potentially stale layout.

There is no new CLI argument, environment variable, configuration field, model implementation, or public API.

### How was this patch tested?

Added or extended unit coverage:

- `tests/ut/ops/test_fused_moe_online_reload.py`
  - capability declaration;
  - two consecutive native reloads;
  - parameter identity, data pointer, storage pointer, persistent-buffer identity, and numerical-reference checks after each reload;
  - both version-dependent post-processing branches: verified-main behavior and v0.24.0 release behavior;
  - zero-copy temporary loading-view round trip;
  - callable `weight_loader` preservation;
  - two consecutive direct reloads with storage-pointer checks;
  - mixed runtime/checkpoint-layout rejection;
  - dynamic EPLB split-weight rejection.
- `tests/ut/worker/a2/test_worker_v1.py`
  - backend loading-view dispatch and legacy fallback;
  - generic capability dispatch;
  - missing required hook rejection;
  - backend preparation before vLLM reload initialization;
  - checkpoint-format versus kernel-format behavior;
  - dynamic EPLB failure before vLLM initialization.

Formatting and static checks executed during preparation:

```powershell
uvx --from ruff==0.14.0 ruff check `
  vllm_ascend/ops/fused_moe/fused_moe.py `
  vllm_ascend/worker/worker.py `
  tests/ut/ops/test_fused_moe_online_reload.py `
  tests/ut/worker/a2/test_worker_v1.py

uvx --from ruff==0.14.0 ruff format --check `
  vllm_ascend/ops/fused_moe/fused_moe.py `
  vllm_ascend/worker/worker.py `
  tests/ut/ops/test_fused_moe_online_reload.py `
  tests/ut/worker/a2/test_worker_v1.py

git diff --check
```

All commands above passed.

The repository test selector was also executed:

```powershell
uv run --no-project --python 3.12 --with regex --with pyyaml `
  python .github/workflows/scripts/select_tests.py `
  --changed-files `
  vllm_ascend/ops/fused_moe/fused_moe.py `
  vllm_ascend/worker/worker.py `
  tests/ut/ops/test_fused_moe_online_reload.py `
  tests/ut/worker/a2/test_worker_v1.py
```

Result:

```text
has_tests=true
```

The selector includes the new FusedMoE regression test in the CPU test group and the modified worker test in the A2 test group.

The NPU-dependent pytest targets were not executed locally because this preparation host is Windows and does not provide the repository's `torch_npu` runtime.

The latest-main PR commit has also not yet been run on Ascend hardware. Before this Draft is marked Ready, the submitter will run:

- the new unit tests in the repository CI/NPU environment;
- at least two consecutive online weight updates;
- Qwen3.5 MTP rollout in eager mode;
- the same workload in ACLGraph mode;
- an accuracy comparison between eager and graph modes;
- a coarse weight-synchronization latency and memory-overhead check.

The earlier experiment implementation was validated by the submitter on Ascend A3 in both eager and graph modes, but that result is supporting evidence only and is not claimed as validation of this exact latest-main commit.

### Design boundaries

- No model file or model-specific class is added.
- No direct or indirect model patch is added.
- No model-runner behavior is changed.
- No environment variable is added.
- No mutable module-level state is added.
- No inference hot-path operation is added.
- No `tensor.item()` or additional per-token CPU/NPU synchronization is added.
- The new worker scan runs only during checkpoint-format weight-update preparation.
- The temporary checkpoint-layout transpose is zero-copy; this does not imply that the entire reload is zero-copy, because existing padding, contiguous conversion, and NPU format conversion may still allocate or copy.
- Only the callable `weight_loader` metadata is intentionally preserved; unrelated mutable attributes are not copied.
- Dynamic EPLB split-weight storage remains unsupported and is rejected explicitly.

### AI assistance and human accountability

OpenAI Codex was used to help analyze the failure, prepare the implementation and tests, and draft this PR description.

ZhangMinjie is the human submitter. This PR remains Draft until ZhangMinjie has reviewed every changed line, rerun the relevant tests on the exact commit, and attached the required NPU validation evidence.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350

