### PR TITLE
[BugFix][Worker] Fix MoE sleep wakeup layout

### DIFF
--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -73,10 +73,10 @@ For dense models, `wake_up()` simply restores the model weights to NPU memory; t
 
 For **unquantized MoE models** (`quant_config is None`), the fused expert weights are stored in a transposed layout for NPU matmul efficiency. This layout is produced once at model load time by `process_weights_after_loading()`: after the weights are loaded, the method transposes the second and third dimensions (`transpose(1, 2)`) of `w13_weight` and `w2_weight` to convert the standard checkpoint layout into the format required by the `torch_npu.npu_grouped_matmul` operator.
 
-After the sleep-mode allocator restores the original (untransposed) memory, `wake_up()` re-applies the same transpose to the affected expert weights when the `"weights"` tag is being restored:
+The sleep-mode allocator restores the same tensor layout that was saved before sleep. For the normal sleep/wake path, the expert weights are already in the runtime layout and `wake_up()` leaves them unchanged. If an external weight reload leaves unquantized MoE expert weights in the checkpoint layout, `wake_up()` transposes the affected weights when the `"weights"` tag is being restored:
 
-- `w13_weight` (gate/up projection): transposed back to the runtime layout when its second dimension matches `hidden_size`;
-- `w2_weight` (down projection): transposed back to the runtime layout when its third dimension matches `hidden_size`.
+- `w13_weight` (gate/up projection): transposed to the runtime layout when its third dimension matches `hidden_size`;
+- `w2_weight` (down projection): transposed to the runtime layout when its second dimension matches `hidden_size`.
 
 This step is skipped entirely for dense models (which have no expert weights) and for quantized models (whose weights are handled by the quantization method).
 

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -249,6 +249,66 @@ class TestNPUWorker(TestBase):
             mock_allocator.wake_up.assert_called_once_with(tags=["test_tag"])
             worker.sleep_wakeup_manager.wakeup.assert_called_once_with(["test_tag"])
 
+    def _make_wake_up_worker(self, model, hidden_size):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+            worker.model_runner.model = model
+            worker.vllm_config = MagicMock()
+            worker.vllm_config.quant_config = None
+            worker.vllm_config.model_config.hf_text_config.hidden_size = hidden_size
+            worker._sleep_saved_buffers = {}
+            worker.sleep_wakeup_manager = MagicMock()
+            return worker
+
+    @patch("vllm_ascend.worker.worker.CaMemAllocator")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_wake_up_keeps_unquantized_moe_runtime_layout(self, mock_get_config, mock_allocator_class):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 0
+        mock_config.enable_sleep_mode_extra_cleanup = False
+        mock_get_config.return_value = mock_config
+        mock_allocator_class.get_instance.return_value = MagicMock()
+
+        hidden_size = 4
+        model = torch.nn.Module()
+        model.experts = torch.nn.Module()
+        model.experts.w2_weight = torch.nn.Parameter(torch.randn(2, 3, hidden_size), requires_grad=False)
+        model.experts.w13_weight = torch.nn.Parameter(torch.randn(2, hidden_size, 6), requires_grad=False)
+        original_w2 = model.experts.w2_weight.detach().clone()
+        original_w13 = model.experts.w13_weight.detach().clone()
+
+        worker = self._make_wake_up_worker(model, hidden_size)
+        worker.wake_up(tags=["weights"])
+
+        torch.testing.assert_close(model.experts.w2_weight, original_w2)
+        torch.testing.assert_close(model.experts.w13_weight, original_w13)
+
+    @patch("vllm_ascend.worker.worker.CaMemAllocator")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_wake_up_transposes_unquantized_moe_checkpoint_layout(self, mock_get_config, mock_allocator_class):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 0
+        mock_config.enable_sleep_mode_extra_cleanup = False
+        mock_get_config.return_value = mock_config
+        mock_allocator_class.get_instance.return_value = MagicMock()
+
+        hidden_size = 4
+        model = torch.nn.Module()
+        model.experts = torch.nn.Module()
+        model.experts.w2_weight = torch.nn.Parameter(torch.randn(2, hidden_size, 3), requires_grad=False)
+        model.experts.w13_weight = torch.nn.Parameter(torch.randn(2, 6, hidden_size), requires_grad=False)
+        original_w2 = model.experts.w2_weight.detach().clone()
+        original_w13 = model.experts.w13_weight.detach().clone()
+
+        worker = self._make_wake_up_worker(model, hidden_size)
+        worker.wake_up(tags=["weights"])
+
+        torch.testing.assert_close(model.experts.w2_weight, original_w2.transpose(1, 2))
+        torch.testing.assert_close(model.experts.w13_weight, original_w13.transpose(1, 2))
+
     @patch("vllm_ascend.worker.worker.current_platform")
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -256,7 +256,7 @@ class NPUWorker(WorkerBase):
         model = self.model_runner.model
         if self.vllm_config.quant_config is None and (tags is None or "weights" in tags):
             for name, param in model.named_parameters():
-                if "w2_weight" in name and param.shape[2] == hidden_size:
+                if "w2_weight" in name and param.shape[1] == hidden_size:
                     parts = name.split(".")
                     param_name = parts[-1]
                     parent_module = model.get_submodule(".".join(parts[:-1]))
@@ -264,7 +264,7 @@ class NPUWorker(WorkerBase):
                     w2_data = param.transpose(1, 2)
                     w2_data = torch.nn.Parameter(w2_data, requires_grad=False)
                     setattr(parent_module, param_name, w2_data)
-                elif "w13_weight" in name and param.shape[1] == hidden_size:
+                elif "w13_weight" in name and param.shape[2] == hidden_size:
                     parts = name.split(".")
                     param_name = parts[-1]
                     parent_module = model.get_submodule(".".join(parts[:-1]))


### PR DESCRIPTION
﻿### What this PR does / why we need it?

Fixes #12226.

Issue contract: fix the unquantized MoE sleep/wake path where `NPUWorker.wake_up()` can transpose expert weights a second time after the sleep-mode allocator restores weights that are already in the runtime layout.

Root cause:

- `process_weights_after_loading()` converts unquantized MoE `w13_weight` and `w2_weight` from checkpoint layout into the runtime layout used by `torch_npu.npu_grouped_matmul`.
- Level-1 sleep/wake restores the saved tensor memory layout; it does not convert runtime-layout weights back to checkpoint layout.
- `wake_up()` was checking the runtime-layout dimensions and transposing them again, which can make the grouped matmul K dimension mismatch after wakeup.

Minimal fix:

- Only transpose `w2_weight` when its second dimension matches `hidden_size`, which indicates checkpoint layout.
- Only transpose `w13_weight` when its third dimension matches `hidden_size`, which indicates checkpoint layout.
- Update the sleep mode guide to describe the actual normal wakeup path and the external-reload fallback.
- Add focused unit coverage for both runtime-layout preservation and checkpoint-layout restoration.

Scope Guard:

- Archetype: Unit-Test Efficiency And Reliability + Software Architecture And Build Dependency Analysis.
- Files changed only where needed for the issue contract: worker wakeup logic, the sleep mode guide, and the existing worker unit test file.
- No unrelated refactor, broad formatting, or quantized-model changes are included.

### Does this PR introduce _any_ user-facing change?

Yes. For unquantized MoE models using sleep mode, wakeup preserves already-transposed runtime expert weights instead of double-transposing them. This fixes post-wakeup inference failures caused by expert weight layout mismatch.

### How was this patch tested?

Local validation:

- `python -m py_compile vllm_ascend\worker\worker.py tests\ut\worker\a2\test_worker_v1.py`
- `python -m ruff check vllm_ascend\worker\worker.py tests\ut\worker\a2\test_worker_v1.py`
- `python -m ruff format --check vllm_ascend\worker\worker.py tests\ut\worker\a2\test_worker_v1.py`
- `pre-commit run markdownlint --hook-stage manual --files docs/source/user_guide/feature_guide/sleep_mode.md`
- `python .github\workflows\scripts\check_md_links.py docs/source/user_guide/feature_guide/sleep_mode.md`
- `git diff --check`

Attempted but blocked locally:

- `python -m pytest -q tests\ut\worker\a2\test_worker_v1.py::TestNPUWorker::test_wake_up_keeps_unquantized_moe_runtime_layout tests\ut\worker\a2\test_worker_v1.py::TestNPUWorker::test_wake_up_transposes_unquantized_moe_checkpoint_layout`
- Blocker: the local Windows environment does not have the `vllm` Python package installed, so pytest fails during `tests/ut/conftest.py` import before collecting these tests: `ModuleNotFoundError: No module named 'vllm'`.

Additional environment note:

- `pre-commit run --files ...` was attempted. Repository hooks reached `check-logger`, but this local Windows environment has no `/bin/bash` path for that hook. The Python and Markdown hooks listed above were run directly and passed.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
