### PR TITLE
[CI] add nightly test workflow and config for A3 560T clusters

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,6 +10,7 @@ self-hosted-runner:
     - linux-aarch64-a3-4
     - linux-aarch64-a3-8
     - linux-aarch64-a3-0
+    - linux-aarch64-a3-0-cn12-001
     - linux-amd64-cpu-2-hk
     - linux-amd64-cpu-4-hk
     - linux-amd64-cpu-8-hk

--- a/.github/workflows/_e2e_nightly_multi_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node_560t.yaml
@@ -1,0 +1,463 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+name: 'e2e nightly test multi_node 560t'
+
+on:
+  workflow_call:
+    inputs:
+      soc_version:
+        required: true
+        type: string
+        description: use a3 or a3-560t
+      runner:
+        required: false
+        type: string
+        default: linux-aarch64-a3-0-cn12-001
+      image:
+        required: false
+        type: string
+        description: base image for pods
+        default: "swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.1-910b-ubuntu22.04-py3.12"
+      config_file_path:
+        required: true
+        type: string
+        description: the model config for multi_node test
+      config_base_path:
+        required: false
+        type: string
+        default: ''
+        description: override CONFIG_BASE_PATH used by the yaml loader inside the pod (defaults to nightly path)
+      replicas:
+        required: false
+        default: "1"
+        type: string
+        description: replicas of the k8s cluster
+      size:
+        required: false
+        default: "2"
+        type: string
+        description: how many pods will be pulled up via lws.yaml, indicates number of nodes we need
+      vllm_ascend_remote_url:
+        required: false
+        default: https://github.com/vllm-project/vllm-ascend.git
+        type: string
+        description: used for pr level tests
+      vllm_ascend_ref:
+        required: false
+        default: main
+        type: string
+        description: used for pr level tests
+      should_run:
+        required: true
+        type: boolean
+      ascend_log_prefix:
+        required: false
+        default: /root/.cache/ascend-logs
+        type: string
+        description: the prefix path for shared PVC, default to /root/.cache/ascend-logs
+      name:
+        required: false
+        type: string
+        default: ''
+        description: job name used as benchmark artifact identifier, defaults to config_file_path stem
+      vllm_ascend_branch:
+        required: false
+        type: string
+        default: ''
+        description: branch name used as prefix in artifact names to distinguish dual-branch test runs
+      request_id:
+        required: false
+        type: string
+        default: ''
+        description: non-empty when triggered by PR /nightly command
+      testcase_timeout:
+        required: false
+        default: 120
+        type: string
+        description: test case execution timeout period,default:120 minutes
+      aop_multi_enabled:
+        required: false
+        type: boolean
+        default: false
+        description: enable Pod AOP pipeline on failure
+    secrets:
+      KUBECONFIG_B64_560T:
+        required: true
+      OBS_ACCESS_KEY_ID:
+        required: false
+      OBS_SECRET_ACCESS_KEY:
+        required: false
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ascend-nightly-${{ github.workflow_ref }}-${{ github.ref }}-${{ inputs.soc_version }}-${{ inputs.config_file_path }}${{ inputs.request_id && format('-{0}', inputs.request_id) || '' }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: ${{ inputs.config_file_path }}
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
+    runs-on: ${{ inputs.runner }}
+    if: ${{ inputs.should_run }}
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-cpu
+      env:
+        KUBECONFIG: /tmp/kubeconfig
+        NAMESPACE: vllm-project
+    steps:
+      - name: Decode kubeconfig
+        run: echo "${{ secrets.KUBECONFIG_B64_560T }}" | base64 -d > "$KUBECONFIG"
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set job variables
+        id: vars
+        run: |
+          config_file="${{ inputs.config_file_path }}"
+          config_stem="${config_file%.yaml}"
+          lws_suffix=$(echo "$config_stem" | tr '[:upper:]' '[:lower:]' | tr '._' '-' | cut -c1-43)
+          rand_suffix=$(tr -d '-' < /proc/sys/kernel/random/uuid | cut -c1-6)
+          LWS_NAME="vllm-${lws_suffix}-${rand_suffix}"
+
+          branch="${{ inputs.vllm_ascend_branch }}"
+          if [ -n "$branch" ]; then
+            ARTIFACT_NAME="${branch}-${config_stem}-ascend-logs"
+          else
+            ARTIFACT_NAME="${config_stem}-ascend-logs"
+          fi
+
+          job_name="${{ inputs.name }}"
+          if [ -z "$job_name" ]; then
+            job_name="$config_stem"
+          fi
+          BENCHMARK_JOB_NAME="${branch}-${job_name}"
+
+          {
+            echo "LWS_NAME=${LWS_NAME}"
+            echo "LEADER_POD=${LWS_NAME}-0"
+            echo "LOG_PREFIX=${{ inputs.ascend_log_prefix }}/${LWS_NAME}"
+          } >> $GITHUB_ENV
+
+          {
+            echo "artifact_name=${ARTIFACT_NAME}"
+            echo "benchmark_job_name=${BENCHMARK_JOB_NAME}"
+          } >> $GITHUB_OUTPUT
+
+      - name: Prepare scripts
+        run: |
+          install -D tests/e2e/nightly/multi_node/scripts/run.sh /root/.cache/tests/run.sh
+
+      - name: Clear resources
+        run: |
+          set -euo pipefail
+          TIMEOUT=120
+          SLEEP_INTERVAL=2
+
+          echo "Deleting leaderworkerset [$LWS_NAME] in namespace [$NAMESPACE]..."
+          kubectl delete leaderworkerset "$LWS_NAME" -n "$NAMESPACE" --ignore-not-found
+          kubectl delete service "${LWS_NAME}-leader" -n "$NAMESPACE" --ignore-not-found
+
+          echo "Waiting for pods of leaderworkerset [$LWS_NAME] to be deleted..."
+          START_TIME=$(date +%s)
+          while true; do
+            ELAPSED=$(( $(date +%s) - START_TIME ))
+            if [[ $ELAPSED -ge $TIMEOUT ]]; then
+              echo "Timeout reached ($TIMEOUT seconds), some pods still exist:"
+              kubectl get pods -n "$NAMESPACE" | grep "^${LWS_NAME}-" || true
+              exit 1
+            fi
+            PODS_EXIST=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
+              | tr ' ' '\n' | grep "^${LWS_NAME}-" || true)
+            if [[ -z "$PODS_EXIST" ]]; then
+              echo "All pods for [$LWS_NAME] deleted."
+              break
+            fi
+            echo "Waiting for pods to be deleted: $PODS_EXIST"
+            sleep $SLEEP_INTERVAL
+          done
+
+      - name: Launch cluster
+        run: |
+          set -euo pipefail
+
+          size="${{ inputs.size }}"
+          replicas="${{ inputs.replicas }}"
+          image="${{ inputs.image }}"
+          config_file_path="${{ inputs.config_file_path }}"
+          config_base_path="${{ inputs.config_base_path }}"
+          fail_tag="FAIL_TAG_${{ inputs.config_file_path }}"
+          is_pr_test="${{ inputs.request_id != '' }}"
+          vllm_ascend_ref="${{ inputs.vllm_ascend_ref }}"
+          vllm_ascend_remote_url="${{ inputs.vllm_ascend_remote_url }}"
+          runner="${{ inputs.soc_version }}"
+          echo "FAIL_TAG=${fail_tag}" >> $GITHUB_ENV
+
+          npu_per_node=16
+          pvc_name=gy005-az5-vllm-ascend
+
+          benchmark_job_name="${{ steps.vars.outputs.benchmark_job_name }}"
+
+          jinja2 tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2 \
+            -D lws_name="$LWS_NAME" \
+            -D log_prefix="$LOG_PREFIX" \
+            -D size="$size" \
+            -D replicas="$replicas" \
+            -D image="$image" \
+            -D config_file_path="$config_file_path" \
+            -D config_base_path="$config_base_path" \
+            -D npu_per_node="$npu_per_node" \
+            -D fail_tag="$fail_tag" \
+            -D is_pr_test="$is_pr_test" \
+            -D vllm_ascend_ref="$vllm_ascend_ref" \
+            -D vllm_ascend_remote_url="$vllm_ascend_remote_url" \
+            -D pvc_name="$pvc_name" \
+            -D benchmark_job_name="$benchmark_job_name" \
+            -D runner="$runner" \
+            -D aop_multi_enabled="${{ inputs.aop_multi_enabled }}" \
+            -D good_table="/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch }}/nightly/good_table.csv" \
+            --outfile lws.yaml
+
+          kubectl apply -f ./lws.yaml
+
+      - name: Wait for pods ready
+        run: |
+          set -euo pipefail
+          SIZE="${{ inputs.size }}"
+          TIMEOUT=1200
+
+          echo "Waiting for all pods to become Running and Ready (timeout ${TIMEOUT}s)..."
+          START_TIME=$(date +%s)
+          while true; do
+            ELAPSED=$(( $(date +%s) - START_TIME ))
+            if [[ $ELAPSED -ge $TIMEOUT ]]; then
+              echo "Timeout reached after ${ELAPSED}s, dumping pod status:"
+              kubectl get pods -n "$NAMESPACE"
+              kubectl describe pod "$LEADER_POD" -n "$NAMESPACE"
+              exit 1
+            fi
+
+            ALL_READY=true
+            for ((i=1; i<SIZE; i++)); do
+              POD="${LWS_NAME}-0-${i}"
+              PHASE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+              READY=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null)
+              echo "Worker [$POD] phase=$PHASE ready=$READY"
+              if [[ "$PHASE" != "Running" || "$READY" != "true" ]]; then
+                ALL_READY=false
+                break
+              fi
+            done
+
+            LEADER_PHASE=$(kubectl get pod "$LEADER_POD" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+            LEADER_READY=$(kubectl get pod "$LEADER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[*].ready}' 2>/dev/null)
+            echo "Leader [$LEADER_POD] phase=$LEADER_PHASE ready=$LEADER_READY"
+            if [[ "$LEADER_PHASE" != "Running" || "$LEADER_READY" != "true" ]]; then
+              ALL_READY=false
+            fi
+
+            if [[ "$ALL_READY" == "true" ]]; then
+              echo "All pods are Running and Ready."
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Stream logs
+        id: stream_logs
+        run: |
+          set -euo pipefail
+
+          size="${{ inputs.size }}"
+          pids=()
+
+          cleanup() {
+            echo "Cleaning up background log streams..."
+            for pid in "${pids[@]}"; do
+              kill "$pid" 2>/dev/null || true
+            done
+          }
+          trap cleanup EXIT
+
+          for i in $(seq 0 $((size - 1))); do
+            if [ "${i}" -eq 0 ]; then
+              POD="${LWS_NAME}-0"
+            else
+              POD="${LWS_NAME}-0-${i}"
+            fi
+            echo "==== Collecting logs from worker pod: $POD ===="
+            kubectl logs -f "$POD" -n "$NAMESPACE" \
+              > "/tmp/${POD}_logs.txt" 2>&1 &
+
+            pids+=($!)
+          done
+
+          LEADER_TMP=$(mktemp)
+          kubectl logs -f "$LEADER_POD" -n "$NAMESPACE" | tee "$LEADER_TMP" | while IFS= read -r line; do
+            echo "$line"
+            if echo "$line" | grep -q "$FAIL_TAG"; then
+              exit 1
+            fi
+          done
+
+          eval "$(awk '
+            /^vLLM Git information$/        { sec="vllm"; next }
+            /^vLLM-Ascend Git information$/ { sec="vllm_ascend"; next }
+            sec && /^Commit hash: / {
+              print "HASH_" sec "=" $NF
+              sec=""
+            }
+          ' "$LEADER_TMP")"
+          echo "vllm_hash=${HASH_vllm:-N/A}" >> "$GITHUB_OUTPUT"
+          echo "vllm_ascend_hash=${HASH_vllm_ascend:-N/A}" >> "$GITHUB_OUTPUT"
+          rm -f "$LEADER_TMP"
+
+      - name: Fetch benchmark results from PVC
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/benchmark_results
+          echo "Fetching benchmark results from PVC at /root/.cache/benchmark_results/${{ steps.vars.outputs.benchmark_job_name }}..."
+          SRC="/root/.cache/benchmark_results/${{ steps.vars.outputs.benchmark_job_name }}"
+          if [ -d "$SRC" ] && [ "$(ls -A "$SRC" 2>/dev/null)" ]; then
+            cp -r "$SRC"/. /tmp/benchmark_results/
+            echo "Benchmark results fetched successfully from PVC:"
+            ls -la /tmp/benchmark_results/
+            echo "Cleaning up PVC contents at $SRC..."
+            rm -rf "${SRC:?}"/*
+            echo "PVC contents cleaned up successfully"
+          else
+            echo "Warning: No benchmark results found in PVC at $SRC"
+            echo "Directory contents (if exists):"
+            ls -la "$SRC" 2>/dev/null || echo "Directory does not exist"
+          fi
+
+      - name: Post process
+        if: always()
+        run: |
+          echo "Current pod status:"
+          kubectl get pods -n "$NAMESPACE" --ignore-not-found=true
+
+          echo "Deleting resources for [$LWS_NAME]..."
+          kubectl delete -f ./lws.yaml --ignore-not-found=true || true
+
+          echo "Waiting for pods of [$LWS_NAME] to fully terminate..."
+          TIMEOUT=300
+          SLEEP_INTERVAL=5
+          START_TIME=$(date +%s)
+          while true; do
+            ELAPSED=$(( $(date +%s) - START_TIME ))
+            if [[ $ELAPSED -ge $TIMEOUT ]]; then
+              echo "Timeout reached ($TIMEOUT seconds) waiting for termination, continuing anyway."
+              kubectl get pods -n "$NAMESPACE" | grep "^${LWS_NAME}-" || true
+              break
+            fi
+            PODS_EXIST=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
+              | tr ' ' '\n' | grep "^${LWS_NAME}-" || true)
+            if [[ -z "$PODS_EXIST" ]]; then
+              echo "All pods for [$LWS_NAME] have terminated."
+              break
+            fi
+            echo "Waiting for pods to terminate: $PODS_EXIST"
+            sleep $SLEEP_INTERVAL
+          done
+
+      - name: Collect Ascend logs
+        if: always()
+        run: |
+          set -euo pipefail
+          size="${{ inputs.size }}"
+          DEST="/tmp/collected-logs"
+          PLOG_PATH=/root/ascend/log
+          KUBE_LOG_PATH=/var/log
+          EXT_LOG_PATH=/external-dp
+          for i in $(seq 0 $((size - 1))); do
+            if [ "${i}" -eq 0 ]; then
+              POD="${LWS_NAME}-0"
+            else
+              POD="${LWS_NAME}-0-${i}"
+            fi
+            mkdir -p "${DEST}/node${i}/${PLOG_PATH}" "${DEST}/node${i}/${KUBE_LOG_PATH}"
+            cp "/tmp/${POD}_logs.txt" "${DEST}/node${i}/${KUBE_LOG_PATH}/" 2>/dev/null || true
+            SRC="${LOG_PREFIX}/node_${i}_plogs"
+            if [ -d "$SRC" ]; then
+              cp -r "$SRC"/. "${DEST}/node${i}/${PLOG_PATH}/" 2>/dev/null || true
+            fi
+            EXT_SRC="${LOG_PREFIX}/node_${i}_external_dp_logs.tar.gz"
+            if [ -f "$EXT_SRC" ]; then
+              mkdir -p "${DEST}/node${i}/${EXT_LOG_PATH}"
+              cp "$EXT_SRC" "${DEST}/node${i}/${EXT_LOG_PATH}/" 2>/dev/null || true
+            fi
+          done
+
+          tar -czf /tmp/ascend-logs.tar.gz -C /tmp collected-logs
+
+      - name: Upload Ascend logs
+        if: always()
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+          name: ${{ inputs.config_file_path }}-ascend-logs
+          path: /tmp/ascend-logs.tar.gz
+          retention-days: 7
+
+      - name: Upload Ascend logs (GitHub Artifacts)
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.vars.outputs.artifact_name }}
+          path: /tmp/ascend-logs.tar.gz
+          retention-days: 7
+
+      - name: Set benchmark artifact timestamp
+        if: always()
+        id: bench_ts
+        run: echo "artifact_ts=$(date -u +%Y%m%dT%H%M%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Upload benchmark results
+        if: always()
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+          name: nightly-test-benchmark-results-${{ inputs.name || inputs.config_file_path }}-${{ steps.bench_ts.outputs.artifact_ts }}
+          path: /tmp/benchmark_results/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload benchmark results (GitHub Artifacts)
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-test-benchmark-results-${{ steps.vars.outputs.benchmark_job_name }}-${{ steps.bench_ts.outputs.artifact_ts }}
+          path: /tmp/benchmark_results/
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 0

--- a/.github/workflows/_e2e_nightly_single_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_560t.yaml
@@ -1,0 +1,370 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+name: 'e2e nightly test 560t'
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      image:
+        required: false
+        type: string
+        default: "swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.1-910b-ubuntu22.04-py3.12"
+      tests:
+        required: false
+        type: string
+      config_file_path:
+        required: false
+        type: string
+      config_base_path:
+        required: false
+        type: string
+        default: ''
+        description: override CONFIG_BASE_PATH used by the yaml loader (defaults to nightly path)
+      name:
+        required: false
+        type: string
+      should_run:
+        required: true
+        type: boolean
+      vllm_ascend_branch:
+        required: false
+        type: string
+        default: ''
+        description: branch name used as prefix in artifact/benchmark names to distinguish dual-branch test runs
+      request_id:
+        required: false
+        type: string
+        default: ''
+        description: non-empty when triggered by PR /nightly command
+      vllm_ascend_ref:
+        required: false
+        type: string
+        default: ''
+        description: PR commit SHA for PR-triggered checkout
+      testcase_timeout:
+        required: false
+        default: 120
+        type: string
+        description: test case execution timeout period,default:120 minutes
+      aop_single_enabled:
+        required: false
+        type: boolean
+        default: false
+        description: enable AOP hooks (capture / classify / skip-or-process)
+    secrets:
+      OBS_ACCESS_KEY_ID:
+        required: false
+      OBS_SECRET_ACCESS_KEY:
+        required: false
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+# only cancel in-progress runs of the same workflow
+concurrency:
+  group: ascend-nightly-${{ github.workflow_ref }}-${{ github.ref }}-${{ inputs.config_file_path || inputs.tests }}${{ inputs.request_id && format('-{0}', inputs.request_id) || '' }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-nightly:
+    name: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
+    runs-on: ${{ inputs.runner }}
+    if: ${{ inputs.should_run }}
+    timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
+    container:
+      image: ${{ inputs.image }}
+    env:
+      HF_HUB_OFFLINE: 1
+      VLLM_USE_MODELSCOPE: True
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+      UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+      UV_INDEX_STRATEGY: unsafe-best-match
+      UV_NO_CACHE: 1
+      UV_SYSTEM_PYTHON: 1
+      VLLM_ENGINE_READY_TIMEOUT_S: 1800
+    steps:
+      - name: Check npu and CANN info
+        run: |
+          npu-smi info
+          cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info
+          sed -Ei 's@(ports|archive).ubuntu.com@cache-service.nginx-pypi-cache.svc.cluster.local:8081@g' /etc/apt/sources.list
+          pip config set global.index-url http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+          pip config set global.trusted-host cache-service.nginx-pypi-cache.svc.cluster.local
+          pip install uv
+
+      - name: uninstall vlm vllm-ascend and remove code (if pr test)
+        if: ${{ inputs.request_id != '' }}
+        run: |
+          pip uninstall -y vllm-ascend || true
+          cp -r /vllm-workspace/vllm-ascend/benchmark /tmp/aisbench-backup || true
+          rm -rf  /vllm-workspace/vllm-ascend
+
+      - name: Checkout vllm-project/vllm-ascend repo
+        if: ${{ inputs.request_id != '' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_ref }}
+          path: ./temp-vllm-ascend
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Move code to /vllm-workspace
+        if: ${{ inputs.request_id != '' }}
+        run: |
+          mv ./temp-vllm-ascend /vllm-workspace/vllm-ascend
+          ls -R /vllm-workspace
+
+      - name: Set MAX_JOBS based on runner
+        run: |
+          CARDS=$(echo "${{ inputs.runner }}" | grep -oE '[0-9]+$')
+          echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
+
+      - name: Install vllm-project/vllm-ascend
+        if: ${{ inputs.request_id != '' }}
+        working-directory: /vllm-workspace/vllm-ascend
+        env:
+          MAX_JOBS: ${{ env.MAX_JOBS }}
+          PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://triton-ascend.osinfra.cn/pypi/simple https://download.pytorch.org/whl/cpu/"
+        run: |
+          git config --global --add safe.directory /vllm-workspace/vllm-ascend
+          pip install uc-manager
+          uv pip install -r requirements-dev.txt
+          uv pip install -e .
+
+      - name: Install aisbench
+        if: ${{ inputs.request_id != '' }}
+        shell: bash -l {0}
+        run: |
+          cp -r /tmp/aisbench-backup /vllm-workspace/vllm-ascend/benchmark
+          cd /vllm-workspace/vllm-ascend/benchmark
+          pip install pytest asyncio pytest-asyncio
+          pip install -e . -r requirements/api.txt -r requirements/extra.txt
+          python3 -m pip cache purge
+
+      - name: Show vLLM and vLLM-Ascend version
+        working-directory: /vllm-workspace
+        run: |
+          echo "Installed vLLM-related Python packages:"
+          pip list | grep vllm || echo "No vllm packages found."
+
+          echo ""
+          echo "============================"
+          echo "vLLM Git information"
+          echo "============================"
+          cd vllm
+          if [ -d .git ]; then
+            echo "Branch:      $(git rev-parse --abbrev-ref HEAD)"
+            echo "Commit hash: $(git rev-parse HEAD)"
+            echo "Author:      $(git log -1 --pretty=format:'%an <%ae>')"
+            echo "Date:        $(git log -1 --pretty=format:'%ad' --date=iso)"
+            echo "Message:     $(git log -1 --pretty=format:'%s')"
+            echo "Tags:        $(git tag --points-at HEAD || echo 'None')"
+            echo "Remote:      $(git remote -v | head -n1)"
+            echo ""
+          else
+            echo "No .git directory found in vllm"
+          fi
+          cd ..
+
+          echo ""
+          echo "============================"
+          echo "vLLM-Ascend Git information"
+          echo "============================"
+          cd vllm-ascend
+          if [ -d .git ]; then
+            echo "Branch:      $(git rev-parse --abbrev-ref HEAD)"
+            echo "Commit hash: $(git rev-parse HEAD)"
+            echo "Author:      $(git log -1 --pretty=format:'%an <%ae>')"
+            echo "Date:        $(git log -1 --pretty=format:'%ad' --date=iso)"
+            echo "Message:     $(git log -1 --pretty=format:'%s')"
+            echo "Tags:        $(git tag --points-at HEAD || echo 'None')"
+            echo "Remote:      $(git remote -v | head -n1)"
+            echo ""
+            echo "VLLM_ASCEND_VERSION=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          else
+            echo "No .git directory found in vllm-ascend"
+          fi
+          cd ..
+
+      - name: Install clang
+        shell: bash -l {0}
+        run: |
+          apt-get update && apt-get -y install clang-15
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20
+
+      - name: Validate Inputs
+        run: |
+          if [[ -z "${{ inputs.tests }}" && -z "${{ inputs.config_file_path }}" ]]; then
+            echo "Error: Either 'tests' or 'config_file_path' must be provided."
+            exit 1
+          fi
+
+      - name: Run Pytest (py-driven)
+        id: pytest-driven
+        if: ${{ inputs.tests != '' }}
+        env:
+          VLLM_WORKER_MULTIPROC_METHOD: spawn
+          VLLM_USE_MODELSCOPE: True
+          VLLM_CI_RUNNER: ${{ inputs.runner }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+          echo "Running pytest with tests path: ${{ inputs.tests }}"
+          mkdir -p /tmp/test-logs
+          set -o pipefail
+          pytest -sv "${{ inputs.tests }}" \
+            --ignore=tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py \
+            2>&1 | tee /tmp/test-logs/pytest-driven.log
+
+      - name: Run Pytest (YAML-driven)
+        id: yaml-test
+        if: ${{ always() && inputs.config_file_path != '' }}
+        env:
+          VLLM_WORKER_MULTIPROC_METHOD: spawn
+          VLLM_USE_MODELSCOPE: True
+          VLLM_CI_RUNNER: ${{ inputs.runner }}
+          CONFIG_YAML_PATH: ${{ inputs.config_file_path }}
+          CONFIG_BASE_PATH: ${{ inputs.config_base_path }}
+          BENCHMARK_JOB_NAME: ${{ inputs.vllm_ascend_branch }}-${{ inputs.name }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+          echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
+          echo "Running YAML-driven test with config: ${{ inputs.config_file_path }}"
+          mkdir -p /tmp/test-logs
+          set -o pipefail
+          pytest -sv tests/e2e/nightly/single_node/models/scripts/test_single_node.py \
+            2>&1 | tee /tmp/test-logs/yaml-test.log
+
+      - name: Capture test result
+        id: test-result
+        if: ${{ always() && inputs.aop_single_enabled && (inputs.config_file_path != '' || inputs.tests != '') }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          bash tests/e2e/nightly/scripts/aop_capture.sh \
+            "${{ steps.yaml-test.outcome }}" \
+            "${{ steps.pytest-driven.outcome }}"
+
+      - name: Classify failure
+        id: classify
+        if: ${{ always() && inputs.aop_single_enabled && steps.test-result.outputs.result == 'failure' }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          bash tests/e2e/nightly/scripts/aop_classify.sh \
+            "${{ steps.test-result.outputs.failed_test }}"
+
+      - name: Skip - env issue
+        if: >-
+          ${{ always() && inputs.aop_single_enabled &&
+          steps.classify.outputs.failure_type == 'env_failure' }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          bash tests/e2e/nightly/scripts/aop_skip.sh \
+            "env_failure" "" "" "" \
+            "${{ steps.test-result.outputs.pytest_summary }}" \
+            "${{ steps.test-result.outputs.yaml_summary }}"
+
+      - name: Check commit age
+        id: commit-age
+        if: ${{ always() && inputs.aop_single_enabled && steps.classify.outputs.failure_type == 'not_env_failure' }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          bash tests/e2e/nightly/scripts/aop_commit_age.sh \
+            "${{ inputs.name || inputs.config_file_path || inputs.tests }}" \
+            "/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch }}/nightly/good_table.csv"
+
+      - name: Skip - old commit
+        if: >-
+          ${{ always() && inputs.aop_single_enabled &&
+          steps.classify.outputs.failure_type == 'not_env_failure' &&
+          steps.commit-age.outputs.is_old == 'true' }}
+        working-directory: /vllm-workspace/vllm-ascend
+        run: |
+          bash tests/e2e/nightly/scripts/aop_skip.sh \
+            "not_env_failure" \
+            "${{ steps.commit-age.outputs.last_status }}" \
+            "${{ steps.commit-age.outputs.last_date }}" \
+            "${{ steps.commit-age.outputs.commit_age_days }}" \
+            "${{ steps.test-result.outputs.pytest_summary }}" \
+            "${{ steps.test-result.outputs.yaml_summary }}"
+
+      - name: Process - recent real failure
+        if: >-
+          ${{ always() && inputs.aop_single_enabled &&
+          steps.classify.outputs.failure_type == 'not_env_failure' &&
+          steps.commit-age.outputs.is_old == 'false' }}
+        working-directory: /vllm-workspace/vllm-ascend
+        env:
+          GOOD_TABLE: /root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch }}/nightly/good_table.csv
+        run: |
+          bash tests/e2e/nightly/scripts/aop_process.sh \
+            "${{ steps.classify.outputs.failure_type }}" \
+            "${{ steps.commit-age.outputs.commit_age_days }}" \
+            "${{ inputs.runner }}" \
+            "${{ inputs.tests }}" \
+            "${{ inputs.config_file_path }}" \
+            "${{ steps.test-result.outputs.pytest_summary }}" \
+            "${{ steps.test-result.outputs.yaml_summary }}" \
+            "single_node" \
+            "HEAD" \
+            "" \
+            "" \
+            "${{ inputs.name }}"
+
+      - name: On success
+        if: ${{ always() && inputs.aop_single_enabled && steps.test-result.outputs.result == 'success' }}
+        run: |
+          echo ">>> All tests passed!"
+
+      - name: Set benchmark artifact timestamp
+        if: ${{ always() && inputs.config_file_path != '' }}
+        id: bench_ts
+        run: |
+          echo "artifact_ts=$(date -u +%Y%m%dT%H%M%SZ)" >> $GITHUB_OUTPUT
+          echo "effective_name=${{ inputs.vllm_ascend_branch }}-${{ inputs.name }}" >> $GITHUB_OUTPUT
+
+      - name: Upload benchmark results
+        if: ${{ always() && inputs.config_file_path != '' }}
+        continue-on-error: true
+        uses: ascend-gha-runners/artifact/upload@v0.3
+        with:
+          access_key: ${{ secrets.OBS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+          name: nightly-test-benchmark-results-${{ inputs.name }}-${{ steps.bench_ts.outputs.artifact_ts }}
+          path: /vllm-workspace/vllm-ascend/benchmark_results/${{ inputs.name }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload benchmark results (GitHub Artifacts)
+        if: ${{ always() && inputs.config_file_path != '' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-test-benchmark-results-${{ steps.bench_ts.outputs.effective_name }}-${{ steps.bench_ts.outputs.artifact_ts }}
+          path: /vllm-workspace/vllm-ascend/benchmark_results/${{ steps.bench_ts.outputs.effective_name }}.json
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 0

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -1,8 +1,10 @@
-# Single source of truth for the Nightly-A2 / Nightly-A3 test matrix.
+# Single source of truth for the Nightly-A2 / Nightly-A3 / Nightly-A3-560T test matrix.
 # SOC differentiation: A2 runs on a2b3 runners and -a2 images, A3 runs on
-# a3 runners and -a3 images. Adding a new test case is just appending a
-# `- name: ...` entry under the matching section. PRs that add entries
-# here can be exercised via `/nightly <name>` without merging to main.
+# a3 runners and -a3 images, A3-560T runs on cn12-001-labeled a3 runners and
+# reuses -a3 images. Adding a new test case is just appending a `- name: ...`
+# entry under the matching section. PRs that add entries here can be exercised
+# via `/nightly <name>` (or `/nightly <name> --a3-560t` for the 560T cluster)
+# without merging to main.
 
 a2:
   single_node:
@@ -191,4 +193,118 @@ a3:
         config_file_path: Qwen3-30B-A3B-W4A8-llm-compressor.yaml
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-nightly-a3-2
+        config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
+
+a3-560t:
+  multi_node:
+    test_config:
+      - name: multi-node-deepseek-v3.2-W8A8-EP
+        config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
+        size: 4
+      - name: multi-node-deepseek-v3.1
+        config_file_path: DeepSeek-V3.1-BF16.yaml
+        size: 2
+      - name: multi-node-GLM-5.2-w8a8-A3
+        config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
+        size: 2
+  double_node:
+    test_config:
+      - name: multi-node-deepseek-r1-w8a8-longseq
+        config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+        size: 2
+      - name: multi-node-qwen3-dp
+        config_file_path: Qwen3-235B-A22B.yaml
+        size: 2
+      - name: multi-node-GLM-5.1-w8a8-A3
+        config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
+        size: 2
+      - name: multi-node-dpsk3.2-2node
+        config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+        size: 2
+      - name: multi-node-qwen-disagg-pd
+        config_file_path: Qwen3-235B-disagg-pd.yaml
+        size: 2
+      - name: multi-node-qwen-vl-disagg-pd
+        config_file_path: Qwen3-VL-235B-disagg-pd.yaml
+        size: 2
+      - name: multi-node-qwenw8a8-2node-eplb
+        config_file_path: Qwen3-235B-W8A8-EPLB.yaml
+        size: 2
+      - name: multi-node-qwenw8a8-2node-longseq
+        config_file_path: Qwen3-235B-W8A8-longseq.yaml
+        size: 2
+  single_node:
+    test_config:
+      - name: mtpx-deepseek-r1-0528-w8a8
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: MTPX-DeepSeek-R1-0528-W8A8.yaml
+      - name: deepseek-r1-0528-w8a8
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: DeepSeek-R1-0528-W8A8.yaml
+      - name: MiniMax-M2.5-w8a8-QuaRot-A3
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3.yaml
+      - name: DeepSeek-V4-Flash-W8A8-A3
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
+      - name: kimi-k2-thinking
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Kimi-K2-Thinking.yaml
+      - name: kimi-k2.5
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Kimi-K2.5.yaml
+      - name: Qwen3.5-122B-A10B-W8A8-A3
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
+      - name: Qwen3.5-397B-A17B-w8a8-mtp-longseq
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
+      - name: deepseek-v3-2-w8a8
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: DeepSeek-V3.2-W8A8.yaml
+      - name: glm-5.1-w8a8-prefill-mc2
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: GLM-5.1-W8A8-PrefillMC2.yaml
+      - name: qwen3-235b-a22b-w8a8
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Qwen3-235B-A22B-W8A8.yaml
+      - name: Qwen3.5-397B-A17B-w8a8-mtp
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
+      - name: deepseek-r1-0528-w8a8-prefix-cache
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+      - name: glm-4.7-w8a8
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: GLM-4.7.yaml
+      - name: qwen3-vl-235b-a22b-instruct-w8a8
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+  multi_card:
+    test_config:
+      # pytest-driven tests
+      - name: qwen3-30b-acc
+        os: linux-aarch64-a3-4-cn12-001
+        tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
+      # YAML-driven tests
+      - name: Qwen3.5-27B-w8a8-A3
+        os: linux-aarch64-a3-2-cn12-001
+        config_file_path: Qwen3.5-27B-w8a8-A3.yaml
+      - name: qwen3-32b-int8
+        os: linux-aarch64-a3-4-cn12-001
+        config_file_path: Qwen3-32B-Int8.yaml
+      - name: Qwen3-32B-QuaRot
+        os: linux-aarch64-a3-2-cn12-001
+        config_file_path: Qwen3-32B-QuaRot-eagle3.yaml
+      - name: qwen3-30b-a3b-w8a8
+        os: linux-aarch64-a3-4-cn12-001
+        config_file_path: Qwen3-30B-A3B-W8A8.yaml
+      - name: qwen3-32b-int8-prefix-cache
+        os: linux-aarch64-a3-4-cn12-001
+        config_file_path: Prefix-Cache-Qwen3-32B-Int8.yaml
+      - name: Qwen3-30B-A3B-W4A8-llm-compressor
+        os: linux-aarch64-a3-2-cn12-001
+        config_file_path: Qwen3-30B-A3B-W4A8-llm-compressor.yaml
+      - name: Qwen3-30B-QuaRot
+        os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -43,6 +43,7 @@ jobs:
       is_authorized: ${{ steps.auth.outputs.is_authorized }}
       dispatch_a2: ${{ steps.resolve.outputs.dispatch_a2 }}
       dispatch_a3: ${{ steps.resolve.outputs.dispatch_a3 }}
+      dispatch_a3_560t: ${{ steps.resolve.outputs.dispatch_a3_560t }}
       dispatch_310p: ${{ steps.resolve.outputs.dispatch_310p }}
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
       aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
@@ -129,6 +130,7 @@ jobs:
           BRANCH="main"
           TEST_CASES=""
           AOP_ENABLED="false"
+          IS_A3_560T="false"
           NEXT_IS_BRANCH=0
           for WORD in $ALL_ARGS; do
             if [ "$NEXT_IS_BRANCH" = "1" ]; then
@@ -138,6 +140,8 @@ jobs:
               NEXT_IS_BRANCH=1
             elif [ "$WORD" = "--aop_enabled" ]; then
               AOP_ENABLED="true"
+            elif [ "$WORD" = "--a3-560t" ]; then
+              IS_A3_560T="true"
             else
               if [ -z "$TEST_CASES" ]; then
                 TEST_CASES="$WORD"
@@ -166,11 +170,17 @@ jobs:
           echo "vllm_ascend_ref=$PR_SHA" >> "$GITHUB_OUTPUT"
 
           if [ "$TEST_CASES" = "all" ]; then
-            {
-              echo "dispatch_a2=true"
-              echo "dispatch_a3=true"
-              echo "dispatch_310p=true"
-            } >> "$GITHUB_OUTPUT"
+            if [ "$IS_A3_560T" = "true" ]; then
+              {
+                echo "dispatch_a3_560t=true"
+              } >> "$GITHUB_OUTPUT"
+            else
+              {
+                echo "dispatch_a2=true"
+                echo "dispatch_a3=true"
+                echo "dispatch_310p=true"
+              } >> "$GITHUB_OUTPUT"
+            fi
             exit 0
           fi
 
@@ -190,6 +200,7 @@ jobs:
           export NIGHTLY_MATRIX
           export WEEKLY_MATRIX
           export TEST_CASES
+          export IS_A3_560T
 
           python3 .github/workflows/scripts/resolve_nightly_tests.py --mode=dispatch
 
@@ -274,6 +285,47 @@ jobs:
             --jq '.workflow_runs[0].id')
           echo "a3_run_id=$A3_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "Dispatched Nightly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+
+  dispatch-a3-560t:
+    name: Trigger Nightly-A3-560T
+    needs: [authorize]
+    if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.command == 'nightly' && needs.authorize.outputs.dispatch_a3_560t == 'true'
+    runs-on: linux-aarch64-a3-0-cn12-001
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
+    outputs:
+      a3_560t_run_id: ${{ steps.dispatch_a3_560t.outputs.a3_560t_run_id }}
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo mkdir -p -m 755 /etc/apt/keyrings
+          curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install gh -y
+
+      - name: Dispatch nightly-a3-560t workflow
+        id: dispatch_a3_560t
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          REPO='${{ github.event.client_payload.github.payload.repository.full_name }}'
+          REQUEST_ID='${{ github.run_id }}'
+          gh workflow run schedule_nightly_test_a3_560t.yaml \
+            --repo "$REPO" \
+            --ref main \
+            -f test_cases='${{ needs.authorize.outputs.test_cases }}' \
+            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
+            -f request_id="$REQUEST_ID" \
+            -f skip_build_image=true \
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+          sleep 8
+          A3_560T_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3_560t.yaml/runs?per_page=1" \
+            --jq '.workflow_runs[0].id')
+          echo "a3_560t_run_id=$A3_560T_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Dispatched Nightly-A3-560T with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
 
   dispatch-weekly-a2:
     name: Trigger Weekly-A2
@@ -399,7 +451,7 @@ jobs:
 
   post-links:
     name: Post workflow links
-    needs: [authorize, dispatch-a2, dispatch-a3, dispatch-weekly-a2, dispatch-weekly-a3, dispatch-weekly-310p]
+    needs: [authorize, dispatch-a2, dispatch-a3, dispatch-a3-560t, dispatch-weekly-a2, dispatch-weekly-a3, dispatch-weekly-310p]
     if: always() && needs.authorize.outputs.is_authorized == 'true'
     runs-on: linux-amd64-cpu-2-hk
     steps:
@@ -414,6 +466,10 @@ jobs:
           if [[ "${{ needs.dispatch-a3.result }}" == "success" ]]; then
             BODY="$BODY
           - Nightly-A3: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-a3.outputs.a3_run_id }})"
+          fi
+          if [[ "${{ needs.dispatch-a3-560t.result }}" == "success" ]]; then
+            BODY="$BODY
+          - Nightly-A3-560T: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-a3-560t.outputs.a3_560t_run_id }})"
           fi
           if [[ "${{ needs.dispatch-weekly-a2.result }}" == "success" ]]; then
             BODY="$BODY

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -1,0 +1,345 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# This workflow related to the resources atlas 800 A3 560T (non-exclusive / shared machines)
+# Multi-node and double-node tests use K8s LWS for scheduling and resource allocation.
+# Single-node and multi-card tests run directly on dedicated runners labeled in nightly_config.yaml.
+name: Nightly-A3-560T
+
+on:
+  workflow_dispatch:
+    inputs:
+      vllm_ascend_branch:
+        description: 'Branch to test'
+        required: true
+        default: 'main'
+        type: string
+      test_cases:
+        description: 'Test cases to run (comma-separated, e.g., "test_custom_op,qwen3-32b,accuracy-group" or "all" for all tests)'
+        required: false
+        default: 'all'
+        type: string
+      request_id:
+        description: 'Unique request ID from the triggering workflow for run identification'
+        required: false
+        default: ''
+        type: string
+      skip_build_image:
+        description: 'Skip build-image job (used when triggered by /nightly command)'
+        required: false
+        default: 'false'
+        type: string
+      vllm_ascend_ref:
+        description: 'PR commit SHA for PR-triggered tests'
+        required: false
+        default: ''
+        type: string
+      aop_enabled:
+        description: 'Enable AOP hooks (capture / classify / skip-or-process)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+concurrency:
+  group: ascend-nightly-${{ github.ref }}-a3-560t${{ inputs.request_id && format('-{0}', inputs.request_id) || '' }}
+  cancel-in-progress: true
+
+env:
+  # Single source of truth for all shared variables across jobs.
+  # NOTE: GitHub Actions does not support env context in reusable workflow `with:` inputs,
+  # so these values are exported as job outputs via the `setup-vars` job below.
+  ASCEND_LOG_PREFIX: '/root/.cache/ascend-logs'
+
+jobs:
+  parse-trigger:
+    name: Parse trigger and determine test scope
+    if: >-
+      github.event_name == 'workflow_dispatch'
+    runs-on: linux-aarch64-a3-0-cn12-001
+    outputs:
+      run: ${{ steps.parse.outputs.run }}
+      filter: ${{ steps.parse.outputs.filter }}
+      ref: ${{ steps.parse.outputs.ref }}
+    steps:
+      - name: Parse trigger
+        id: parse
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const eventName = context.eventName;
+            const testCases = '${{ inputs.test_cases }}'.trim();
+
+            core.setOutput('ref', context.sha || 'unknown');
+
+            if (testCases) {
+              core.setOutput('run', 'true');
+              if (testCases === 'all') {
+                core.setOutput('filter', 'all');
+              } else {
+                core.setOutput('filter', ',' + testCases.split(',').map(s => s.trim()).join(',') + ',');
+              }
+              return;
+            }
+
+            core.setOutput('run', 'false');
+            core.setOutput('filter', '');
+
+  setup-vars:
+    name: Export global env vars as job outputs
+    needs: parse-trigger
+    runs-on: linux-aarch64-a3-0-cn12-001
+    outputs:
+      ascend_log_prefix: ${{ steps.export.outputs.ascend_log_prefix }}
+      vllm_ascend_branches: ${{ steps.export.outputs.vllm_ascend_branches }}
+      multi_node: ${{ steps.set-matrix.outputs.multi_node }}
+      double_node: ${{ steps.set-matrix.outputs.double_node }}
+      single_node: ${{ steps.set-matrix.outputs.single_node }}
+      multi_card: ${{ steps.set-matrix.outputs.multi_card }}
+    steps:
+      - id: export
+        run: |
+          {
+            echo "ascend_log_prefix=${{ env.ASCEND_LOG_PREFIX }}"
+            input_branch="${{ inputs.vllm_ascend_branch }}"
+            normalized=$(echo "$input_branch" | tr '/' '-')
+            echo "vllm_ascend_branches=[\"${normalized}\"]"
+          } >> $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+
+      - name: Checkout PR code
+        if: github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_ref != ''
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_ref }}
+          sparse-checkout: .github/workflows/configs/
+          path: ./pr
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Read A3 560T test matrix config
+        id: set-matrix
+        env:
+          MATRIX_FILE: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_ref != '' && './pr/.github/workflows/configs/nightly_config.yaml' || '.github/workflows/configs/nightly_config.yaml' }}
+          MATRIX_OUTPUTS: '{"multi_node":"a3-560t.multi_node.test_config","double_node":"a3-560t.double_node.test_config","single_node":"a3-560t.single_node.test_config","multi_card":"a3-560t.multi_card.test_config"}'
+        run: |
+          python3 -m pip install pyyaml -q
+          python3 .github/workflows/scripts/resolve_nightly_tests.py --mode=matrix
+
+  build-image:
+    name: Build nightly-a3 image
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.skip_build_image != 'true')
+    strategy:
+      matrix:
+        vllm_ascend_branch: >-
+          ${{ fromJSON(format('["{0}"]', inputs.vllm_ascend_branch)) }}
+    uses: ./.github/workflows/_nightly_image_build.yaml
+    with:
+      target: a3
+      vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+    secrets:
+      HW_USERNAME: ${{ secrets.HW_USERNAME }}
+      HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+
+  multi-node-tests:
+    name: multi-node
+    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
+        test_config: ${{ fromJson(needs.setup-vars.outputs.multi_node) }}
+    uses: ./.github/workflows/_e2e_nightly_multi_node_560t.yaml
+    with:
+      soc_version: a3-560t
+      runner: linux-aarch64-a3-0-cn12-001
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
+      vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      replicas: 1
+      size: ${{ matrix.test_config.size }}
+      config_file_path: ${{ matrix.test_config.config_file_path }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
+      aop_multi_enabled: ${{ inputs.aop_enabled }}
+      request_id: ${{ inputs.request_id || '' }}
+      should_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' && (
+            needs.parse-trigger.outputs.filter == 'all' ||
+            contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+          )
+        }}
+    secrets:
+      KUBECONFIG_B64_560T: ${{ secrets.KUBECONFIG_B64_560T }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+
+  double-node-tests:
+    name: double-node
+    needs: [setup-vars, parse-trigger, build-image, single-node-tests, multi-card-tests]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
+        test_config: ${{ fromJson(needs.setup-vars.outputs.double_node) }}
+    uses: ./.github/workflows/_e2e_nightly_multi_node_560t.yaml
+    with:
+      soc_version: a3-560t
+      runner: linux-aarch64-a3-0-cn12-001
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
+      vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      replicas: 1
+      size: ${{ matrix.test_config.size }}
+      config_file_path: ${{ matrix.test_config.config_file_path }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
+      aop_multi_enabled: ${{ inputs.aop_enabled }}
+      request_id: ${{ inputs.request_id || '' }}
+      should_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' && (
+            needs.parse-trigger.outputs.filter == 'all' ||
+            contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+          )
+        }}
+    secrets:
+      KUBECONFIG_B64_560T: ${{ secrets.KUBECONFIG_B64_560T }}
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+
+  single-node-tests:
+    name: single-node
+    needs: [setup-vars, parse-trigger, build-image]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      max-parallel: 9
+      matrix:
+        vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
+        test_config: ${{ fromJson(needs.setup-vars.outputs.single_node) }}
+    uses: ./.github/workflows/_e2e_nightly_single_node_560t.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      config_file_path: ${{ matrix.test_config.config_file_path }}
+      name: ${{ matrix.test_config.name }}
+      should_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' && (
+            needs.parse-trigger.outputs.filter == 'all' ||
+            contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+          )
+        }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
+      aop_single_enabled: ${{ inputs.aop_enabled }}
+
+  multi-card-tests:
+    name: single-node
+    needs: [setup-vars, parse-trigger, build-image]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
+        test_config: ${{ fromJson(needs.setup-vars.outputs.multi_card) }}
+    uses: ./.github/workflows/_e2e_nightly_single_node_560t.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      tests: ${{ matrix.test_config.tests }}
+      config_file_path: ${{ matrix.test_config.config_file_path }}
+      name: ${{ matrix.test_config.name }}
+      should_run: >-
+        ${{
+          needs.parse-trigger.outputs.run == 'true' && (
+            needs.parse-trigger.outputs.filter == 'all' ||
+            contains(needs.parse-trigger.outputs.filter, format(',{0},', matrix.test_config.name))
+          )
+        }}
+      request_id: ${{ inputs.request_id || '' }}
+      vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
+      aop_single_enabled: ${{ inputs.aop_enabled }}
+    secrets:
+      OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
+      OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+
+  clear-pre-logs:
+    runs-on: linux-aarch64-a3-0-cn12-001
+    needs: [multi-node-tests, double-node-tests]
+    if: (needs.multi-node-tests.result != 'skipped' || needs.double-node-tests.result != 'skipped')
+    steps:
+      - name: Clear pre-logs on pvc
+        run: |
+          # Clear logs generated before the test to avoid confusion
+          rm -rf "${ASCEND_LOG_PREFIX:?}"/* || true
+
+  merge-benchmark-artifacts:
+    name: Merge benchmark artifacts into nightly-a3-560t.zip
+    needs: [parse-trigger, single-node-tests, multi-node-tests, double-node-tests, multi-card-tests]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-amd64-cpu-8-hk
+    steps:
+      - name: Merge all benchmark result artifacts
+        continue-on-error: true
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: nightly-a3-560t
+          pattern: nightly-test-benchmark-results-*
+          compression-level: 0
+          delete-merged: true

--- a/.github/workflows/scripts/resolve_nightly_tests.py
+++ b/.github/workflows/scripts/resolve_nightly_tests.py
@@ -64,12 +64,15 @@ def cmd_dispatch(_args):
     matrix_b64 = os.environ.get("NIGHTLY_MATRIX", "") or os.environ.get("WEEKLY_MATRIX", "")
     a2_names = parse_nightly_matrix(matrix_b64, "a2")
     a3_names = parse_nightly_matrix(matrix_b64, "a3")
+    a3_560t_names = parse_nightly_matrix(matrix_b64, "a3-560t")
     _310p_names = parse_nightly_matrix(matrix_b64, "310p")
+
+    is_a3_560t = os.environ.get("IS_A3_560T", "") == "true"
 
     raw = os.environ.get("TEST_CASES", "")
     test_cases = [tc.strip() for tc in raw.split(",") if tc.strip()]
 
-    da2, da3, d310p = False, False, False
+    da2, da3, da3_560t, d310p = False, False, False, False
     transformed = None
     for tc in test_cases:
         if "/" in tc:
@@ -81,18 +84,23 @@ def cmd_dispatch(_args):
         elif tc == "accuracy-group":
             da2 = True
         else:
-            if tc in a2_names:
-                da2 = True
-            if tc in a3_names:
-                da3 = True
-            if tc in _310p_names:
-                d310p = True
+            if is_a3_560t:
+                if tc in a3_560t_names:
+                    da3_560t = True
+            else:
+                if tc in a2_names:
+                    da2 = True
+                if tc in a3_names:
+                    da3 = True
+                if tc in _310p_names:
+                    d310p = True
 
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         if transformed:
             f.write(f"test_cases={transformed}\n")
         f.write(f"dispatch_a2={str(da2).lower()}\n")
         f.write(f"dispatch_a3={str(da3).lower()}\n")
+        f.write(f"dispatch_a3_560t={str(da3_560t).lower()}\n")
         f.write(f"dispatch_310p={str(d310p).lower()}\n")
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

Add A3 560T nightly test support for non-exclusive shared machines:

- New _e2e_nightly_multi_node_560t.yaml reusable workflow for K8s-scheduled multi-node and double-node tests on shared 560T nodes
- New _e2e_nightly_single_node_560t.yaml reusable workflow for single-node and multi-card tests running on dedicated runners
- Refactor schedule_nightly_test_a3_560t.yaml with 560T-specific config paths and optimized job ordering: single/multi-card → double-node → multi-node
- Extend resolve_nightly_tests.py and pr_nightly_command.yml to dispatch /nightly command tests to A3 560T workflow

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
