### PR TITLE
[Doc][Misc] Unify the modification of 310 naming of PaddleOCRVL.

### DIFF
--- a/docs/source/tutorials/models/PaddleOCR-VL.md
+++ b/docs/source/tutorials/models/PaddleOCR-VL.md
@@ -405,3 +405,11 @@ For common environment, installation, and general parameter issues, please refer
 - **Q: What are the deployment requirements for Atlas inference products?**
 
   A: On Atlas inference products, only `float16` dtype is supported. Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**; if your CANN version is lower, use `--enforce-eager` instead.
+
+- **Q: What should I do if I encounter dependency conflicts during installation on Atlas inference products?**
+
+  A: Uninstall `triton` and `triton-ascend` before starting the service:
+
+  ```bash
+  pip uninstall -y triton triton-ascend
+  ```

--- a/docs/source/tutorials/models/PaddleOCR-VL.md
+++ b/docs/source/tutorials/models/PaddleOCR-VL.md
@@ -92,10 +92,6 @@ If you don't want to use the docker image as above, you can also build all from 
 
 - Install `vllm-ascend` from source, refer to [installation](../../installation.md).
 
-:::{note}
-If you are using Atlas inference products, you may need to uninstall `triton-ascend` to avoid dependency conflicts.
-:::
-
 ## 5 Online Service Deployment
 
 ### 5.1 Single-Node Online Deployment
@@ -409,7 +405,3 @@ For common environment, installation, and general parameter issues, please refer
 - **Q: What are the deployment requirements for Atlas inference products?**
 
   A: On Atlas inference products, only `float16` dtype is supported. Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**; if your CANN version is lower, use `--enforce-eager` instead.
-
-- **Q: What should I do if I encounter dependency conflicts during installation on Atlas inference products?**
-
-  A: You may need to uninstall `triton-ascend` to avoid dependency conflicts. See [Section 4.2](#42-source-code-installation) for details.

--- a/docs/source/tutorials/models/PaddleOCR-VL.md
+++ b/docs/source/tutorials/models/PaddleOCR-VL.md
@@ -58,7 +58,7 @@ docker run --rm \
 
 ::::
 
-::::{tab-item} Atlas 300 inference products
+::::{tab-item} Atlas inference products
 :sync: atlas300
 
 ```bash
@@ -93,14 +93,14 @@ If you don't want to use the docker image as above, you can also build all from 
 - Install `vllm-ascend` from source, refer to [installation](../../installation.md).
 
 :::{note}
-If you are using Atlas 300 inference products, you may need to uninstall `triton-ascend` to avoid dependency conflicts.
+If you are using Atlas inference products, you may need to uninstall `triton-ascend` to avoid dependency conflicts.
 :::
 
 ## 5 Online Service Deployment
 
 ### 5.1 Single-Node Online Deployment
 
-PaddleOCR-VL supports single-node single-card deployment on the A2 series and Atlas 300 inference products platform. Single-node deployment completes both Prefill and Decode within the same node.
+PaddleOCR-VL supports single-node single-card deployment on the A2 series and Atlas inference products platform. Single-node deployment completes both Prefill and Decode within the same node.
 
 Follow these steps to start the inference service:
 
@@ -135,9 +135,17 @@ vllm serve ${MODEL_PATH} \
           --port 8000
 ```
 
+Key Parameter Descriptions:
+
+- `--max-num-batched-tokens` specifies the maximum number of tokens batched in a single forward pass. Adjust this parameter for throughput optimization.
+- `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
+- `--mm-processor-cache-gb` sets the size of the multimodal processor cache (in GB). A value of `0` disables caching.
+- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full decode graph compilation for improved performance.
+- `--additional_config '{"enable_cpu_binding":true}'` enables CPU binding to improve performance.
+
 ::::
 
-::::{tab-item} Atlas 300 inference products
+::::{tab-item} Atlas inference products
 :sync: atlas300
 
 ```bash
@@ -159,11 +167,9 @@ vllm serve ${MODEL_PATH} \
           --port 8000
 ```
 
-::::
-:::::
-
 :::{note}
-On Atlas 300 inference products:
+
+On Atlas inference products:
 
 - Only `float16` dtype is supported.
 - The `--max_model_len` option is added to prevent errors when generating the attention operator mask.
@@ -173,13 +179,15 @@ On Atlas 300 inference products:
 
 Key Parameter Descriptions:
 
-- `--max-num-batched-tokens` specifies the maximum number of tokens batched in a single forward pass. Adjust this parameter for throughput optimization.
 - `--max_model_len` specifies the maximum context length — that is, the sum of input and output tokens for a single request.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
 - `--mm-processor-cache-gb` sets the size of the multimodal processor cache (in GB). A value of `0` disables caching.
-- `--dtype float16` specifies the model dtype. On Atlas 300 inference products, only `float16` is supported.
-- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full decode graph compilation for improved performance. On Atlas 300 inference products, `fuse_norm_quant` in graph compilation is disabled by default in `--additional_config`.
-- `--additional_config '{"enable_cpu_binding":true}'` enables CPU binding to improve performance.
+- `--dtype float16` specifies the model dtype. On Atlas inference products, only `float16` is supported.
+- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full decode graph compilation for improved performance. On Atlas inference products, `fuse_norm_quant` in graph compilation is disabled by default in `--additional_config`.
+- `--additional_config '{"ascend_compilation_config": {"fuse_norm_quant": false}, "enable_cpu_binding":true}'` disables `fuse_norm_quant` for graph compilation and enables CPU binding.
+
+::::
+:::::
 
 Common Issues Tip: If you encounter startup issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 
@@ -251,10 +259,10 @@ The A2 series device supports inference using the PaddlePaddle framework.
 
 ::::
 
-::::{tab-item} Atlas 300 inference products
+::::{tab-item} Atlas inference products
 :sync: atlas300
 
-The Atlas 300 inference products support only the OM model inference. For details about the process, see the guide provided in [ModelZoo](https://gitcode.com/Ascend/ModelZoo-PyTorch/tree/master/ACL_PyTorch/built-in/ocr/PP-DocLayoutV2).
+The Atlas inference products support only the OM model inference. For details about the process, see the guide provided in [ModelZoo](https://gitcode.com/Ascend/ModelZoo-PyTorch/tree/master/ACL_PyTorch/built-in/ocr/PP-DocLayoutV2).
 
 ::::
 :::::
@@ -373,7 +381,7 @@ PaddleOCR-VL is a lightweight model that runs on a single NPU. The key tuning pa
 | Scenario | Hardware | *Total NPUs | Weight Version | Key Considerations |
 |----------|----------|------------|---------------|-------------------|
 | High Throughput | A2 series | 1 | PaddleOCR-VL-0.9B | - |
-| High Throughput | Atlas 300 inference products | 1 | PaddleOCR-VL-0.9B | Graph compilation requires **CANN >= 9.0.0** |
+| High Throughput | Atlas inference products | 1 | PaddleOCR-VL-0.9B | Graph compilation requires **CANN >= 9.0.0** |
 
 > `*Total NPUs` indicates the total number of NPUs used across all nodes.
 
@@ -382,7 +390,7 @@ PaddleOCR-VL is a lightweight model that runs on a single NPU. The key tuning pa
 | Scenario | Configuration | NPUs | TP | DP | Max Model Len | Max Num Batched Tokens | Graph Compilation | dtype |
 |----------|-------------|------|----|----|---------------|------------------------|--------------------|-------|
 | High Throughput | A2 series / Single Machine | 1 | — | — | — | 16384 | FULL_DECODE_ONLY | bfloat16 (default) |
-| High Throughput | Atlas 300 inference products / Single Machine | 1 | — | — | 16384 | — | FULL_DECODE_ONLY; otherwise enforce-eager | float16 |
+| High Throughput | Atlas inference products / Single Machine | 1 | — | — | 16384 | — | FULL_DECODE_ONLY; otherwise enforce-eager | float16 |
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Section 5.1](#51-single-node-online-deployment).
 
@@ -398,10 +406,10 @@ Please refer to the [Feature Guide](../../user_guide/support_matrix/feature_matr
 
 For common environment, installation, and general parameter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html); this chapter only covers model-specific issues.
 
-- **Q: What are the deployment requirements for Atlas 300 inference products?**
+- **Q: What are the deployment requirements for Atlas inference products?**
 
-  A: On Atlas 300 inference products, only `float16` dtype is supported. Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**; if your CANN version is lower, use `--enforce-eager` instead.
+  A: On Atlas inference products, only `float16` dtype is supported. Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**; if your CANN version is lower, use `--enforce-eager` instead.
 
-- **Q: What should I do if I encounter dependency conflicts during installation on Atlas 300 inference products?**
+- **Q: What should I do if I encounter dependency conflicts during installation on Atlas inference products?**
 
   A: You may need to uninstall `triton-ascend` to avoid dependency conflicts. See [Section 4.2](#42-source-code-installation) for details.


### PR DESCRIPTION
What this PR does / why we need it?
add 310P3 guidance of PaddleOCR-VL model, refresh PaddleOCR-VL.md in the docs/source/tutorials/

Does this PR introduce any user-facing change?
no

How was this patch tested?
by CI

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
