### PR TITLE
[CI][xlite] Match xlite backend with the current main and add e2e MoE model test coverage

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -577,6 +577,7 @@
   tests:
     - tests/ut/xlite
     - tests/e2e/pull_request/one_card/test_xlite.py
+    - tests/e2e/pull_request/two_card/test_xlite.py
 
 # Batch Invariant
 - name: batch_invariant
@@ -756,6 +757,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/test_shared_expert_dp.py: 400
   tests/e2e/pull_request/two_card/test_sp_pass.py: 260
   tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py: 110
+  tests/e2e/pull_request/two_card/test_xlite.py: 180
   tests/e2e/pull_request/four_card/_310p/test_dense_model_310p.py: 410
   tests/e2e/pull_request/four_card/_310p/test_moe_model_310p.py: 510
   tests/e2e/pull_request/four_card/_310p/test_vl_model_310p.py: 360

--- a/tests/e2e/pull_request/two_card/test_xlite.py
+++ b/tests/e2e/pull_request/two_card/test_xlite.py
@@ -13,67 +13,74 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# This file is a part of the vllm-ascend project.
 #
-"""
-Compare the outputs of vLLM with and without xlite via logprob-based accuracy
-check (3 tokens: 1 prefill + 2 decode).
+"""Verify MoE serving with xlite graph mode on two NPU cards.
 
-Run `pytest tests/e2e/pull_request/one_card/test_xlite.py`.
+Run `pytest tests/e2e/pull_request/two_card/test_xlite.py`.
 """
-
-# ruff: noqa: E501
 
 import os
 
 import pytest
 
-from tests.e2e.conftest import wait_until_npu_memory_free
-from tests.e2e.pull_request.utils import PROMPTS_SHORT, compare_logprobs
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.pull_request.utils import PROMPTS_SHORT
 
 os.environ["VLLM_ASCEND_ENABLE_NZ"] = "2"
 
-MODELS: list[str] = ["Qwen/Qwen3-0.6B"]
+MODELS: list[str] = ["Qwen/Qwen3-30B-A3B"]
 
 
 @pytest.mark.e2e_model(*MODELS)
 @pytest.mark.e2e_coverage(
-    arch="dense",
+    arch="moe",
     feature="xlite",
-    parallel="TP",
+    parallel="TP,EP",
     deploy="pd_mix",
-    hardware="A2",
+    hardware="A3",
     quantization="BF16",
     graph_mode="xlite_decode_only",
 )
 @pytest.mark.parametrize("model", MODELS)
 @wait_until_npu_memory_free()
 def test_models_with_xlite_decode_only(model: str):
-    runner_kwargs = {
-        "model_name": model,
-        "max_model_len": 1024,
-        "block_size": 128,
-        "additional_config": {"xlite_graph_config": {"enabled": True, "full_mode": False}},
-    }
-    compare_logprobs(runner_kwargs=runner_kwargs, prompts=PROMPTS_SHORT)
+    with VllmRunner(
+        model,
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        distributed_executor_backend="mp",
+        block_size=128,
+        max_model_len=2048,
+        additional_config={"xlite_graph_config": {"enabled": True, "full_mode": False}},
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(PROMPTS_SHORT, 3)
+
+    assert all(output[1] for output in outputs)
 
 
 @pytest.mark.e2e_model(*MODELS)
 @pytest.mark.e2e_coverage(
-    arch="dense",
+    arch="moe",
     feature="xlite",
-    parallel="TP",
+    parallel="TP,EP",
     deploy="pd_mix",
-    hardware="A2",
+    hardware="A3",
     quantization="BF16",
     graph_mode="xlite_full",
 )
 @pytest.mark.parametrize("model", MODELS)
 @wait_until_npu_memory_free()
 def test_models_with_xlite_full_mode(model: str):
-    runner_kwargs = {
-        "model_name": model,
-        "max_model_len": 1024,
-        "block_size": 128,
-        "additional_config": {"xlite_graph_config": {"enabled": True, "full_mode": True}},
-    }
-    compare_logprobs(runner_kwargs=runner_kwargs, prompts=PROMPTS_SHORT)
+    with VllmRunner(
+        model,
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        distributed_executor_backend="mp",
+        block_size=128,
+        max_model_len=2048,
+        additional_config={"xlite_graph_config": {"enabled": True, "full_mode": True}},
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(PROMPTS_SHORT, 3)
+
+    assert all(output[1] for output in outputs)

--- a/vllm_ascend/xlite/xlite.py
+++ b/vllm_ascend/xlite/xlite.py
@@ -436,7 +436,7 @@ class QwenMoeXliteModel(LlamaXliteModel):
         layers, _ = self._get_layers_and_model_prefix()
 
         xlite_model.gate = get_layer_weights(layers, "mlp.gate.weight")
-        prefix = "mlp.experts."
+        prefix = "mlp.experts.routed_experts."
         kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
         xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
         xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
@@ -444,7 +444,7 @@ class QwenMoeXliteModel(LlamaXliteModel):
 
         if self.quantization:
             kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale_fp32", **kwargs)
+            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
             xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
 
 
@@ -486,7 +486,7 @@ class Glm4MoeXliteModel(LlamaXliteModel):
         self.init_matmul_weights(layers, "se_up_gate", "mlp.shared_experts.gate_up_proj")
         self.init_matmul_weights(layers, "se_down", "mlp.shared_experts.down_proj")
 
-        prefix = "mlp.experts."
+        prefix = "mlp.experts.routed_experts."
         kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
         xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
         xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
@@ -495,7 +495,7 @@ class Glm4MoeXliteModel(LlamaXliteModel):
 
         if self.quantization:
             kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale_fp32", **kwargs)
+            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
             xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
 
 
@@ -530,7 +530,7 @@ class MiniMaxM2XliteModel(LlamaXliteModel):
             layers, "block_sparse_moe.e_score_correction_bias", post_processor=lambda b: b.to(torch.float32)
         )
 
-        prefix = "block_sparse_moe.experts."
+        prefix = "block_sparse_moe.experts.routed_experts."
         kwargs: WeightGetterConfig = {"secondary_flattening": f"{prefix}local_num_experts", "post_processor": None}
         xlite_model.re_up_gate = get_layer_weights(layers, f"{prefix}w13_weight", **kwargs)
         xlite_model.re_down = get_layer_weights(layers, f"{prefix}w2_weight", **kwargs)
@@ -539,7 +539,7 @@ class MiniMaxM2XliteModel(LlamaXliteModel):
 
         if self.quantization:
             kwargs["post_processor"] = self._transform_deq_scale
-            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale_fp32", **kwargs)
+            xlite_model.re_up_gate_scale = get_layer_weights(layers, f"{prefix}w13_weight_scale", **kwargs)
             xlite_model.re_down_scale = get_layer_weights(layers, f"{prefix}w2_weight_scale", **kwargs)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR brings the `xlite` backend in line with the current main and `vllm==0.24.0`, and adds e2e coverage for the xlite graph mode to catch future changes.

Refer to PR #12019 for the context.

### Does this PR introduce _any_ user-facing change?

No, bugfix only.

### How was this patch tested?

The following MoE models can now be successfully served: `Qwen3-30B-A3B`, `MiniMax-M2.7-w8a8-QuaRot`, and `GLM-4.7-W8A8-floatmtp`.

We also benchmarked model accuracies with multiple models using `aisbench`. The [batch_aisbench.py](https://atomgit.com/openeuler/GVirt/blob/master/xlite/tests/e2e/batch_aisbench.py) script was used with 208 questions from the `ceval` dataset:

```bash
# on one Atlas A3
python batch_aisbench.py "/root/benchmark" \
--num-prompts 4 \
--model-dir "/mnt/sdb/models" \
--models "Qwen3-32B-w8a8-nopdmix" "Qwen3-30B-A3B" "Qwen3-VL-32B-Instruct" "MiniMax-M2.7-w8a8-QuaRot" "GLM-4.7-W8A8-floatmtp" \
--tps 2 2 2 4 8 \
--dps 1 1 1 1 1 \
--eps 0 1 0 1 1 \
-MNS 32 \
-MML 8192 \
--xlite 2 1 0 \
--broadcast-xlite
```

**For most models**, no accuracy regression was observed, except:

1. `Qwen3-VL-32B-Instruct` served with `xlite decode-only` mode showed degraded accuracy - upon further investigation, the model's outputs contained random texts for certain questions, likely a previously existing issue (e.g., PR #11380).
2. `MiniMax-M2.7-w8a8-QuaRot` served with `xlite decode-only + aclgraph for prefill` and `aclgraph` threw an `AttributionError` during serving, likely not related to `xlite` since `xlite full mode` worked correctly.

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-32B-w8a8-nopdmix | ceval-weighted | 2 | N | 1 | xlite full | weighted_average | 88.78 |  |
| Qwen3-32B-w8a8-nopdmix | ceval-weighted | 2 | N | 1 | xlite decode-only | weighted_average | 88.63 |  |
| Qwen3-32B-w8a8-nopdmix | ceval-weighted | 2 | N | 1 | aclgraph | weighted_average | 87.09 |  |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | xlite full | weighted_average | 87.74 |  |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | xlite decode-only | weighted_average | 85.68 |  |
| Qwen3-30B-A3B | ceval-weighted | 2 | Y | 1 | aclgraph | weighted_average | 86.13 |  |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Qwen3-VL-32B-Instruct | ceval-weighted | 2 | N | 1 | xlite full | weighted_average | 85.46 |  |
| Qwen3-VL-32B-Instruct | ceval-weighted | 2 | N | 1 | xlite decode-only | weighted_average | 77.84 |  |
| Qwen3-VL-32B-Instruct | ceval-weighted | 2 | N | 1 | aclgraph | weighted_average | 88.52 |  |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 1 | xlite full | weighted_average | 84.16 |  |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 1 | xlite decode-only | weighted_average | 0.00 | AttributeError: 'AscendMoERunner' object has no attribute 'maybe_all_reduce_tensor_model_parallel' |
| MiniMax-M2.7-w8a8-QuaRot | ceval-weighted | 4 | Y | 1 | aclgraph | weighted_average | 0.00 | AttributeError: 'AscendMoERunner' object has no attribute 'maybe_all_reduce_tensor_model_parallel' |

| Model | Dataset | TP | EP | DP | Backend | Metric | Accuracy | Error |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite full | weighted_average | 87.41 |  |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | xlite decode-only | weighted_average | 87.82 |  |
| GLM-4.7-W8A8-floatmtp | ceval-weighted | 8 | Y | 1 | aclgraph | weighted_average | 87.74 |

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
