### PR TITLE
[BugFix][v0.20.2rc] Fix GLM tool-call schema streaming

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
+++ b/tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py
@@ -2,16 +2,127 @@
 
 import json
 
+import pytest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
 )
+from vllm.tool_parsers.glm4_moe_tool_parser import Glm4MoeModelToolParser
 
 from vllm_ascend.patch.platform import (
     patch_glm_tool_call_streaming as glm_streaming_patch,
 )
+
+
+class _Tokenizer:
+    def get_vocab(self):
+        return {"<tool_call>": 1, "</tool_call>": 2}
+
+
+def _stream_tool_arguments(schema, value_chunks, tool_name="run", argument_name="value"):
+    tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name=tool_name,
+                parameters={
+                    "type": "object",
+                    "properties": {argument_name: schema},
+                },
+            ),
+        ),
+    ]
+    request = ChatCompletionRequest(model="test", messages=[], tools=tools)
+    parser = Glm4MoeModelToolParser(_Tokenizer(), tools=tools)
+    chunks = [
+        "<tool_call>",
+        tool_name,
+        "<arg_key>",
+        argument_name,
+        "</arg_key>",
+        "<arg_value>",
+        *value_chunks,
+        "</arg_value>",
+        "</tool_call>",
+    ]
+
+    current_text = ""
+    argument_fragments = []
+    for chunk in chunks:
+        previous_text = current_text
+        current_text += chunk
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=chunk,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+        if result is not None and result.tool_calls:
+            for tool_call in result.tool_calls:
+                function = tool_call.function
+                if isinstance(function, dict):
+                    arguments = function.get("arguments")
+                else:
+                    arguments = function.arguments
+                if arguments:
+                    argument_fragments.append(arguments)
+
+    return "".join(argument_fragments)
+
+
+def test_issue_12261_nullable_string_schema_streams_valid_json():
+    schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+
+    arguments = _stream_tool_arguments(
+        schema,
+        ["P", "ura", "90"],
+        tool_name="start_app",
+        argument_name="hvd",
+    )
+
+    assert json.loads(arguments) == {"hvd": "Pura90"}
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {},
+        True,
+        {"type": ["string", "null"]},
+        {"oneOf": [{"type": "string"}, {"type": "null"}]},
+    ],
+)
+def test_unknown_and_nullable_string_schemas_stream_as_strings(schema):
+    arguments = _stream_tool_arguments(schema, ["P", "ura", "90"])
+
+    assert json.loads(arguments) == {"value": "Pura90"}
+
+
+@pytest.mark.parametrize(
+    ("schema", "value_chunks", "expected"),
+    [
+        ({"type": "object"}, ["{", '"x"', ":", "1", "}"], {"x": 1}),
+        ({"type": "number"}, ["1", "e", "3"], 1000.0),
+        (
+            {"oneOf": [{"type": "integer"}, {"type": "null"}]},
+            ["1", "2", "3"],
+            123,
+        ),
+    ],
+)
+def test_confirmed_non_string_values_wait_for_complete_serialization(schema, value_chunks, expected):
+    arguments = _stream_tool_arguments(schema, value_chunks)
+
+    assert json.loads(arguments) == {"value": expected}
 
 
 def test_remaining_args_delta_omits_metadata_by_default():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -165,22 +165,27 @@
 # ** 7a. File: platform/patch_glm_tool_call_streaming.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#      `vllm.tool_parsers.glm4_moe_tool_parser.Glm4MoeModelToolParser`
 #    Why:
 #       GLM tool-call streaming can emit final remaining-argument chunks with
 #       repeated tool-call metadata, and can combine terminal argument bytes with
-#       `finish_reason="tool_calls"` in the same SSE chunk.
+#       `finish_reason="tool_calls"` in the same SSE chunk. Nullable or unknown
+#       argument schemas can also stream string values without an opening quote,
+#       while normalized non-string values can rewrite an already-sent prefix.
 #    How：
 #       Monkey-patch remaining-argument delta construction to emit only argument
 #       fragments by default, and split terminal argument chunks into an argument
-#       chunk followed by an empty finish chunk.
+#       chunk followed by an empty finish chunk. Default unknown schemas to string
+#       and buffer confirmed non-string values until their closing tag.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/issues/44098
 #       https://github.com/vllm-project/vllm/pull/44099
 #       https://github.com/vllm-project/vllm-ascend/issues/8327
 #       https://github.com/vllm-project/vllm-ascend/pull/8178
+#       https://github.com/vllm-project/vllm-ascend/issues/12261
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains the upstream
-#       GLM tool-call final chunk fixes.
+#       GLM tool-call streaming fixes.
 #
 # ** 7b. File: platform/patch_glm47_tool_call_parser.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
+++ b/vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# OpenAI chat streaming: backport GLM tool-call final chunk fixes.
+# OpenAI chat streaming: backport GLM tool-call parser fixes.
 #
 
 from __future__ import annotations
@@ -29,6 +29,75 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     DeltaToolCall,
 )
+from vllm.tool_parsers.glm4_moe_tool_parser import Glm4MoeModelToolParser
+from vllm.tool_parsers.utils import partial_tag_overlap
+
+
+def _schema_allows_string(schema: Any) -> bool:
+    if not isinstance(schema, dict):
+        return True
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        return "string" in schema_type
+    if schema_type is not None:
+        return schema_type == "string"
+
+    for choice_field in ("anyOf", "oneOf"):
+        choices = schema.get(choice_field)
+        if isinstance(choices, list) and choices:
+            return any(not isinstance(choice, dict) or _schema_allows_string(choice) for choice in choices)
+    return True
+
+
+def _patched_is_string_type(
+    tool_name: str,
+    arg_name: str,
+    tools: list[Any] | None,
+) -> bool:
+    if tools is None:
+        return True
+    for tool in tools:
+        if tool.function.name != tool_name:
+            continue
+        if tool.function.parameters is None:
+            return True
+        schema = tool.function.parameters.get("properties", {}).get(arg_name, {})
+        return _schema_allows_string(schema)
+    return True
+
+
+def _patched_build_args_json_so_far(
+    self: Glm4MoeModelToolParser,
+    tool_name: str,
+    inner_text: str,
+    is_complete: bool,
+) -> str:
+    args_so_far = self._ascend_original_build_args_json_so_far(tool_name, inner_text, is_complete)
+    if is_complete:
+        return args_so_far
+
+    last_val_start = inner_text.rfind(self.arg_val_start)
+    last_val_end = inner_text.rfind(self.arg_val_end)
+    if last_val_start == -1 or last_val_end > last_val_start:
+        return args_so_far
+
+    last_key_match = None
+    for match in self._arg_key_pattern.finditer(inner_text[:last_val_start]):
+        last_key_match = match
+    if last_key_match is None:
+        return args_so_far
+
+    partial_key = last_key_match.group(1).strip()
+    if self._is_string_type(tool_name, partial_key, self.tools):
+        return args_so_far
+
+    partial_content = inner_text[last_val_start + len(self.arg_val_start) :]
+    overlap = partial_tag_overlap(partial_content, self.arg_val_end)
+    if overlap:
+        partial_content = partial_content[:-overlap]
+    if partial_content and args_so_far.endswith(partial_content):
+        return args_so_far[: -len(partial_content)]
+    return args_so_far
 
 
 def _create_remaining_args_delta(
@@ -119,6 +188,12 @@ async def _wrapped_chat_completion_stream_generator(
             yield chunk
 
 
+if not hasattr(Glm4MoeModelToolParser, "_ascend_original_build_args_json_so_far"):
+    Glm4MoeModelToolParser._ascend_original_build_args_json_so_far = Glm4MoeModelToolParser._build_args_json_so_far
+
+
+Glm4MoeModelToolParser._is_string_type = staticmethod(_patched_is_string_type)
+Glm4MoeModelToolParser._build_args_json_so_far = _patched_build_args_json_so_far
 OpenAIServingChat._create_remaining_args_delta = staticmethod(_create_remaining_args_delta)
 _wrapped_chat_completion_stream_generator.__module__ = OpenAIServingChat.__module__
 _wrapped_chat_completion_stream_generator.__qualname__ = (


### PR DESCRIPTION
### What this PR does / why we need it?

- Extend the existing v0.20.2rc GLM streaming monkey patch to classify unknown or ambiguous argument schemas as strings unless the schema conclusively selects non-string types.
- Buffer confirmed non-string partial values until `</arg_value>` so final JSON serialization cannot rewrite an already-streamed prefix.
- Add regression coverage for the exact nullable `hvd=Pura90` case, type arrays, `oneOf`, boolean schemas, objects, and scientific numbers.

Fixes #12261.

### Does this PR introduce _any_ user-facing change?

Yes. GLM tool-call streaming now emits valid JSON arguments for nullable or ambiguous string schemas and preserves non-string argument types.

### How was this patch tested?

- `PYTHONPATH=<vllm-ascend-worktree>:<vllm-v0.20.2-worktree> python -m pytest -q tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py` (`12 passed`)
- Replayed the exact `input.json` schema and `raw_completion_stream.json` chunks from #12261; the streamed arguments rebuild as `{"hvd": "Pura90"}` and pass `json.loads`.
- `ruff check vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py`
- `ruff format --check vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py`
- `python -m py_compile vllm_ascend/patch/platform/patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py`
- `git diff --check`
- `bash format.sh ci` could not run locally because the installed `pre-commit` launcher references a removed Python 3.12 interpreter; focused Ruff checks passed and CI should run the repository-wide hooks.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
