### PR TITLE
[BugFix][v0.23.0][Worker] Restore pre-#12027 model runner dispatch

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1_with_device.py
+++ b/tests/ut/worker/a2/test_model_runner_v1_with_device.py
@@ -341,13 +341,6 @@ def test_determine_batch_execution_and_padding(
 
     try:
         runner.input_batch.num_computed_tokens_cpu[:num_reqs] = num_computed_tokens
-        computed_tokens = np.asarray(num_computed_tokens, dtype=np.int32)
-        scheduled_tokens = np.asarray(num_scheduled_tokens, dtype=np.int32)
-        runner.input_batch.num_prompt_tokens[:num_reqs] = np.where(
-            computed_tokens == 0,
-            scheduled_tokens,
-            computed_tokens,
-        )
         num_scheduled_tokens_np = np.array(num_scheduled_tokens, dtype=np.int32)
 
         kwargs = dict(
@@ -398,37 +391,3 @@ def test_determine_batch_execution_and_padding(
     finally:
         runner.speculative_config = saved_spec_config
         runner.uniform_decode_query_len = saved_query_len
-
-
-@pytest.mark.parametrize(
-    ("num_prompt_tokens", "expected_uniform_decode"),
-    [
-        pytest.param(8, False, id="one_token_pd_prefill"),
-        pytest.param(7, True, id="decode_after_prompt"),
-    ],
-)
-def test_uniform_decode_requires_completed_prompt_without_mtp(
-    model_runner,
-    num_prompt_tokens: int,
-    expected_uniform_decode: bool,
-):
-    runner = model_runner
-    runner.speculative_config = None
-    runner.uniform_decode_query_len = 1
-    runner.input_batch.num_computed_tokens_cpu[0] = 7
-    runner.input_batch.num_prompt_tokens[0] = num_prompt_tokens
-
-    with patch.object(
-        runner.cudagraph_dispatcher,
-        "dispatch",
-        wraps=runner.cudagraph_dispatcher.dispatch,
-    ) as dispatch:
-        runner._determine_batch_execution_and_padding(
-            num_tokens=1,
-            num_reqs=1,
-            num_scheduled_tokens_np=np.array([1], dtype=np.int32),
-            max_num_scheduled_tokens=1,
-            use_cascade_attn=False,
-        )
-
-    assert bool(dispatch.call_args.kwargs["uniform_decode"]) is expected_uniform_decode

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2891,13 +2891,10 @@ class NPUModelRunner(GPUModelRunner):
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         # A one-token chunk can still be a prefill, notably at a PD handoff.
         # Dispatch a decode graph only after every prompt is fully computed.
-        is_all_decode = np.all(
-            self.input_batch.num_computed_tokens_cpu[:num_reqs]
-            >= self.input_batch.num_prompt_tokens[:num_reqs]
-        )
+        is_all_decode = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
         uniform_decode = (
             (
-                is_all_decode
+                (is_all_decode if self.speculative_config else True)
                 and (max_num_scheduled_tokens == self.uniform_decode_query_len)
                 and (num_tokens == max_num_scheduled_tokens * num_reqs)
             )


### PR DESCRIPTION
### What this PR does / why we need it?

Revert the two model-runner dispatch changes introduced by #12027 on `releases/v0.23.0`.

- Restore `is_all_decode` to the pre-#12027 `num_computed_tokens > 0` check.
- Restore the non-speculative uniform-decode path to bypass the `is_all_decode` gate, as it did before #12027.
- Remove the model-runner test setup and completed-prompt regression case introduced with those dispatch changes.

This is a focused revert of the #12027 model-runner behavior and its associated test coverage. It does not include the broader #12255 changes.

### Does this PR introduce any user-facing change?

No API change. This restores the previous model-runner graph-dispatch behavior on the v0.23.0 release branch.

### How was this patch tested?

- `uvx ruff check tests/ut/worker/a2/test_model_runner_v1_with_device.py`
- `uvx ruff format --check tests/ut/worker/a2/test_model_runner_v1_with_device.py`
- `python3 -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1_with_device.py`
- `git diff --check`

The local macOS Python environment does not provide `pytest`; NPU runtime validation is delegated to PR CI.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
