### PR TITLE
[BugFix][v0.23.0] Harden GLM tool-call schema streaming

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py
@@ -13,7 +13,11 @@ if not vllm_version_is("0.23.0"):
         allow_module_level=True,
     )
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest  # noqa: E402
+from vllm.entrypoints.openai.chat_completion.protocol import (  # noqa: E402
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat  # noqa: E402
 
 # vLLM main removed the ``_WrappedParser`` helper; the base ``Parser``
@@ -70,8 +74,102 @@ def _collect_tool_args(tool_calls):
     return "".join(tc.function.arguments for tc in tool_calls if tc.function.arguments)
 
 
+def _stream_tool_arguments(properties, value_chunks):
+    tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="run",
+                parameters={
+                    "type": "object",
+                    "properties": properties,
+                },
+            ),
+        ),
+    ]
+    request = ChatCompletionRequest(model="test", messages=[], tools=tools)
+    parser = Glm47MoeModelToolParser(MOCK_TOKENIZER, tools=tools)
+    chunks = [
+        "<tool_call>",
+        "run",
+        "<arg_key>",
+        "value",
+        "</arg_key>",
+        "<arg_value>",
+        *value_chunks,
+        "</arg_value>",
+        "</tool_call>",
+    ]
+
+    current_text = ""
+    argument_fragments = []
+    for chunk in chunks:
+        previous_text = current_text
+        current_text += chunk
+        result = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=chunk,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+        if result is not None and result.tool_calls:
+            argument_fragments.extend(
+                tool_call.function.arguments for tool_call in result.tool_calls if tool_call.function.arguments
+            )
+
+    return "".join(argument_fragments)
+
+
 def _parse_delta(parser, *args, finished=False, **kwargs):
     return parser.parse_delta(*args, finished=finished, **kwargs)
+
+
+def test_glm47_nullable_string_schema_streams_valid_json():
+    properties = {
+        "value": {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "null"},
+            ]
+        }
+    }
+
+    arguments = _stream_tool_arguments(properties, ["P", "ura", "90"])
+
+    assert json.loads(arguments) == {"value": "Pura90"}
+
+
+def test_glm47_ambiguous_string_schema_streams_as_string():
+    properties = {
+        "value": {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "integer"},
+            ]
+        }
+    }
+
+    arguments = _stream_tool_arguments(properties, ["P", "ura", "90"])
+
+    assert json.loads(arguments) == {"value": "Pura90"}
+
+
+@pytest.mark.parametrize("properties", [None, True])
+def test_glm47_unknown_properties_stream_as_strings(properties):
+    arguments = _stream_tool_arguments(properties, ["P", "ura", "90"])
+
+    assert json.loads(arguments) == {"value": "Pura90"}
+
+
+def test_glm47_confirmed_number_waits_for_complete_serialization():
+    arguments = _stream_tool_arguments(
+        {"value": {"type": "number"}},
+        ["1", "e", "3"],
+    )
+
+    assert json.loads(arguments) == {"value": 1000.0}
 
 
 def test_glm47_streaming_inline_zero_arg_tool_call_waits_until_complete():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -189,17 +189,22 @@
 #    Why:
 #       vLLM's GLM47 streaming parser can drop complete inline zero-argument
 #       tool calls such as `<tool_call>get_current_time</tool_call>`, while
-#       non-streaming parses the same output correctly.
+#       non-streaming parses the same output correctly. Ambiguous argument
+#       schemas and partial non-string values can also produce invalid JSON.
 #    How：
 #       Monkey-patch GLM47 tool-call region extraction so complete inline
 #       zero-argument regions are normalized for the existing streaming name
 #       extractor without emitting partial names for incomplete regions.
+#       Treat schemas that may accept strings as strings, default unknown
+#       schemas to strings, and buffer confirmed non-string values until their
+#       closing tag.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/issues/44326
 #       https://github.com/vllm-project/vllm/pull/44327
+#       https://github.com/vllm-project/vllm-ascend/issues/12261
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains the upstream
-#       GLM47 inline zero-argument streaming parser fix.
+#       GLM47 streaming parser fixes.
 #
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py
@@ -20,6 +20,11 @@
 from __future__ import annotations
 
 from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser
+from vllm.tool_parsers.utils import (
+    extract_types_from_schema,
+    find_tool_properties,
+    partial_tag_overlap,
+)
 
 if not hasattr(Glm47MoeModelToolParser, "_ascend_original_extract_tool_call_regions"):
     Glm47MoeModelToolParser._ascend_original_extract_tool_call_regions = (
@@ -44,4 +49,55 @@ def _patched_extract_tool_call_regions(
     return normalized_regions
 
 
+def _patched_is_string_type(
+    self: Glm47MoeModelToolParser,
+    tool_name: str,
+    arg_name: str,
+) -> bool:
+    properties = find_tool_properties(self.tools, tool_name)
+    if not isinstance(properties, dict):
+        return True
+    return "string" in extract_types_from_schema(properties.get(arg_name))
+
+
+def _patched_build_args_json_so_far(
+    self: Glm47MoeModelToolParser,
+    tool_name: str,
+    inner_text: str,
+    is_complete: bool,
+) -> str:
+    args_so_far = self._ascend_original_build_args_json_so_far(tool_name, inner_text, is_complete)
+    if is_complete:
+        return args_so_far
+
+    last_val_start = inner_text.rfind(self.arg_val_start)
+    last_val_end = inner_text.rfind(self.arg_val_end)
+    if last_val_start == -1 or last_val_end > last_val_start:
+        return args_so_far
+
+    last_key_match = None
+    for match in self._arg_key_pattern.finditer(inner_text[:last_val_start]):
+        last_key_match = match
+    if last_key_match is None:
+        return args_so_far
+
+    partial_key = last_key_match.group(1).strip()
+    if self._is_string_type(tool_name, partial_key):
+        return args_so_far
+
+    partial_content = inner_text[last_val_start + len(self.arg_val_start) :]
+    overlap = partial_tag_overlap(partial_content, self.arg_val_end)
+    if overlap:
+        partial_content = partial_content[:-overlap]
+    if partial_content and args_so_far.endswith(partial_content):
+        return args_so_far[: -len(partial_content)]
+    return args_so_far
+
+
+if not hasattr(Glm47MoeModelToolParser, "_ascend_original_build_args_json_so_far"):
+    Glm47MoeModelToolParser._ascend_original_build_args_json_so_far = Glm47MoeModelToolParser._build_args_json_so_far
+
+
 Glm47MoeModelToolParser._extract_tool_call_regions = _patched_extract_tool_call_regions
+Glm47MoeModelToolParser._is_string_type = _patched_is_string_type
+Glm47MoeModelToolParser._build_args_json_so_far = _patched_build_args_json_so_far


### PR DESCRIPTION
### What this PR does / why we need it?

- Extend the existing v0.23-only GLM47 monkey patch to treat schemas that may accept strings as string-valued, while defaulting unknown or malformed schemas to strings.
- Buffer confirmed non-string partial values until `</arg_value>` so completed JSON serialization cannot rewrite an already-streamed prefix.
- Add regression coverage for nullable strings, ambiguous string unions, malformed `properties`, scientific numbers, and the existing inline zero-argument behavior.

vLLM v0.23.0 already handles the exact `string | null` schema reported in #12261. However, `string | integer` still streams without an opening quote, scientific-number normalization can corrupt an emitted prefix, and malformed `properties` can raise `AttributeError`. This patch closes those remaining cases through the release branch's existing GLM47 monkey-patch surface.

Related to #12261 and follows up #12282 for the v0.23.0 parser architecture.

### Does this PR introduce _any_ user-facing change?

Yes. GLM47 tool-call streaming now emits valid JSON for ambiguous or malformed schemas and preserves confirmed non-string argument types.

### How was this patch tested?

- Ran the focused platform tests against the vLLM `v0.23.0` tag (`0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665`): `12 passed`.
- Replayed the exact `input.json` schema and `raw_completion_stream.json` chunks from #12261; streamed arguments rebuild as `{"hvd": "Pura90"}` and pass `json.loads`.
- Reproduced the pre-patch failures for `string | integer`, scientific-number streaming, and `properties=None`; the new regression tests pass with the patch.
- `ruff check vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py`
- `ruff format --check vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py`
- `python -m py_compile vllm_ascend/patch/platform/patch_glm47_tool_call_parser.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py`
- `git diff --check`
- `bash format.sh ci` could not run locally because the installed `pre-commit` launcher references a removed Python 3.12 interpreter; focused Ruff checks passed and CI should run the repository-wide hooks.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
