### PR TITLE
[Feature] DyntraLB: Dynamic Intra-decoder Data-parallel Load Balancing

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -68,7 +68,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `finegrained_tp_config`             | dict | `{}`    | Configuration options for module tensor parallelism                                                       |
 | `ascend_compilation_config`         | dict | `{}`    | Configuration options for ascend compilation                                                              |
 | `eplb_config`                       | dict | `{}`    | Runner-specific EPLB extensions. See [Expert Parallelism Load Balancer](../feature_guide/expert_parallelism_load_balancer.md). |
-| `scheduler_config`                  | dict | `{}`    | Configuration options for Ascend scheduler extensions, including balance scheduling, recompute scheduling, ShortRequestFirst, and dynamic chunked pipeline parallel. |
+| `scheduler_config`                  | dict | `{}`    | Configuration options for Ascend scheduler extensions, including balance scheduling, recompute scheduling, DyntraLB, ShortRequestFirst, and dynamic chunked pipeline parallel. |
 | `refresh`                           | bool | `false` | Whether to refresh global Ascend configuration content. This is usually used by rlhf or ut/e2e test case. |
 | `dump_config`                       | dict | `None`  | Inline msprobe dump configuration. vLLM-Ascend will materialize it to a temporary JSON file and pass that file to the debugger. |
 | `dump_config_path`                  | str  | `None`  | Configuration file path for msprobe dump (compatible legacy option).                                      |
@@ -162,6 +162,7 @@ The legacy top-level `enable_balance_scheduling`, `recompute_scheduler_enable`, 
 | `profiling_chunk_config` | dict | `{}` | Configuration options for dynamic chunked pipeline parallel. See [Dynamic Chunked Pipeline Parallel](../feature_guide/dynamic_chunk_pipeline_parallel.md) for details. |
 | `short_request_first_config` | dict | `{}` | Configuration options for ShortRequestFirst prefill scheduling on FCFS synchronous or asynchronous, PD-prefill (P), or PD-mixed nodes. |
 | `batch_job_sched_config` | dict | `{}` | Configuration options for the batch-job-aware scheduler. See [Batch-Job-Aware Scheduler](../feature_guide/batch_job_aware_scheduler.md) for details. |
+| `dyntra_lb_config` | dict | `{}` | Configuration options for DyntraLB load balancing on PD-disaggregated decode nodes. |
 
 **scheduler_config.profiling_chunk_config**
 
@@ -172,6 +173,24 @@ The legacy top-level `enable_balance_scheduling`, `recompute_scheduler_enable`, 
 | `min_chunk`     | int   | `4096`  | Minimum chunk size for dynamic calculation. Should be smaller than `max-num-batched-tokens`. |
 | `need_timing` | bool | True | Enable/disable Online Calibration |
 | `max_fit_chunk` | int | 30 | Number of chunk-time data for Online Calibration |
+
+**scheduler_config.dyntra_lb_config**
+
+DyntraLB balances decode requests across data-parallel ranks. It is supported only on
+PD-disaggregated decode nodes (`kv_role="kv_consumer"`) with `data_parallel_size > 1`.
+`dyntra_lb_config.enabled` and `recompute_scheduler_enable` are independent sibling
+settings; enabling both selects the combined DyntraLB recompute scheduler.
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enabled` | bool | `False` | Enable DyntraLB and select a DyntraLB-aware scheduler. |
+| `mode` | str | `"dynamic"` | Use `"static"` or `"dynamic"` activation. |
+| `start_step` | int | `250` | First completed engine-step snapshot allowed to generate a plan. |
+| `end_step` | int | `-1` | Exclusive final snapshot step; `-1` means no upper bound. |
+| `bubble_threshold` | float | `5.0` | Minimum maximum-to-average rank-load difference required to modify scheduling. Values greater than or equal to `1` are KV-cache blocks; values below `1` are normalized ratios. |
+| `long_req_block_threshold` | int | `700` | In dynamic mode, a newly added request above this block count activates balancing. The default threshold corresponds to approximately 89,600 tokens when `block_size=128`. |
+| `dynamic_max_step` | int | `256` | Stop dynamic balancing after this many active steps without another newly added long request. |
+| `enable_diagnostics` | bool | `False` | Enable verbose logs for feature validation and debugging only. It is disabled by default and should remain disabled in production. |
 
 **rejection_sampler_config**
 

--- a/docs/source/user_guide/feature_guide/dyntra_lb.md
+++ b/docs/source/user_guide/feature_guide/dyntra_lb.md
@@ -1,0 +1,210 @@
+# DyntraLB: Dynamic Intra-Decoder Data-Parallel Load Balancing
+
+DyntraLB is a load-aware scheduler for data-parallel Decode nodes in a
+prefill/decode (P/D) disaggregated deployment. It reduces the time that lightly
+loaded DP ranks spend waiting for the busiest rank when request lengths are
+uneven.
+
+DyntraLB does not move requests between DP ranks. Instead, every DP rank shares a
+snapshot of its running and admissible waiting requests. The planner estimates
+each request's load from its KV-cache block count and tells each rank which
+local requests to admit, keep running, or pause. A request paused by DyntraLB
+keeps its allocated KV cache and can be resumed by the same rank later.
+
+## When to use it
+
+Consider enabling DyntraLB when all of the following are true:
+
+- the deployment uses P/D disaggregation
+- the Decode instance uses internal data parallelism on a single node
+- request lengths are skewed enough to create visible DP bubbles
+- Decode throughput is more important than preserving strict local request
+  execution order
+
+Keep it disabled for a uniformly sized workload, a single-DP-rank Decode
+instance, or a multi-node Decode DP instance.
+
+## Requirements
+
+DyntraLB has the following startup requirements:
+
+- it must be enabled only on a P/D-disaggregated Decode node with
+  `kv_role="kv_consumer"`
+- `data_parallel_size` must be greater than `1`
+- all DP ranks of the Decode instance must be on one node
+
+Configure DyntraLB only on Decode nodes. Do not add `dyntra_lb_config` with
+`enabled=true` to Prefill nodes.
+
+DyntraLB cannot be combined with:
+
+- `scheduler_config.enable_balance_scheduling`
+- `scheduler_config.profiling_chunk_config.enabled`
+
+The service rejects these unsupported combinations during startup.
+
+## Configuration
+
+Add `dyntra_lb_config` under `scheduler_config` in the Decode node's
+`--additional-config`.
+
+DyntraLB and recompute scheduling remain independent sibling configurations.
+When both `dyntra_lb_config.enabled` and `recompute_scheduler_enable` are `true`,
+the Decode node uses the combined DyntraLB recompute scheduler.
+
+Add the following arguments to an existing, working single-node Decode command.
+This fragment enables dynamic mode by default, which is recommended for production scenario:
+
+```bash
+  --additional-config '{
+    "scheduler_config": {
+      "dyntra_lb_config": {
+        "enabled": true
+      }
+    }
+  }'
+```
+
+Keep the existing `--kv-transfer-config` for the Decode node and verify that it
+sets `kv_role` to `kv_consumer`.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | bool | `false` | Enables DyntraLB and selects `DyntraLBScheduler` on the Decode node. |
+| `mode` | str | `"dynamic"` | Selects `"static"` or `"dynamic"` activation. Use `"static"` only for troubleshooting; use `"dynamic"` for production scenarios. |
+| `start_step` | int | `250` | First completed engine-step snapshot from which DyntraLB can generate a plan for the next step. Must be greater than or equal to `0`. |
+| `end_step` | int | `-1` | Exclusive final snapshot step. `-1` means no final step. Otherwise, it must be greater than `start_step`. |
+| `bubble_threshold` | float | `5.0` | Minimum imbalance that triggers planner modifications. Values greater than or equal to `1` are interpreted as an absolute KV-block difference between the maximum and average rank load. Values below `1` are interpreted as the normalized ratio `(maximum - average) / maximum`. Therefore, `1` means one KV-cache block, not 100%. |
+| `long_req_block_threshold` | int | `700` | In dynamic mode, a newly added request with more than this number of KV-cache blocks activates balancing. |
+| `dynamic_max_step` | int | `256` | In dynamic mode, disables balancing after this many active steps without another newly added long request. |
+| `enable_diagnostics` | bool | `false` | Enable verbose logs for feature validation and debugging only. It is disabled by default and should remain disabled in production.  |
+
+`long_req_block_threshold` and an absolute `bubble_threshold` are expressed in
+KV-cache blocks, not tokens. Their token equivalents therefore depend on the
+configured block size.
+
+## Static and dynamic modes
+
+### Static mode
+
+Static mode evaluates the DP load on every coordinated engine step in the
+configured interval:
+
+```json
+{
+  "scheduler_config": {
+    "dyntra_lb_config": {
+      "enabled": true,
+      "mode": "static"
+    }
+  }
+}
+```
+
+Static mode is intended only for troubleshooting and short validation runs. It
+keeps load balancing active throughout the configured interval, which makes
+DyntraLB behavior easier to observe. Do not use static mode for production.
+Set `start_step` to `0` during a short diagnostic run so that the run actually
+exercises DyntraLB.
+
+### Dynamic mode
+
+Dynamic mode remains inactive until a newly added request exceeds
+`long_req_block_threshold`. It then evaluates load until
+`dynamic_max_step` consecutive active steps pass without another newly added
+long request:
+
+```json
+{
+  "scheduler_config": {
+    "dyntra_lb_config": {
+      "enabled": true,
+      "mode": "dynamic"
+    }
+  }
+}
+```
+
+Dynamic mode is recommended for production because it activates load
+balancing only when a long request indicates that DP imbalance is likely. The
+`start_step` and `end_step` interval still applies in dynamic mode.
+
+## How scheduling works
+
+DyntraLB pipelines each load-balancing decision across two engine steps:
+
+1. the current step runs scheduling and model execution
+2. all DP ranks synchronize their wave/idle state
+3. each active rank prepares the local waiting requests whose remote KV cache
+   is ready
+4. the ranks all-gather the KV-block counts of running and admissible waiting
+   requests across the Decode DP group
+5. the planner generates a per-rank plan that can pause local running requests,
+   admit selected local waiting requests, or freeze new admission
+6. the next engine step applies that plan before normal scheduling and model
+   execution
+
+The first engine step of a new wave has no plan from a preceding active step and
+therefore follows the normal scheduler path. In dynamic mode, detecting a new
+long request after that step immediately generates a plan for the following
+step. `start_step` and `end_step` select the completed-step snapshots from which
+plans may be generated; each generated plan is consumed by the next step.
+
+The planner uses request block counts as a lightweight load estimate. The
+estimate is intended to reduce DP bubbles; it is not a latency or throughput
+guarantee for every model and traffic distribution.
+
+## Tuning and validation
+
+Start with a controlled A/B comparison using the same model, prompts, sampling
+parameters, concurrency, and P/D topology.
+
+1. Set `start_step=0`, `mode="static"`, and
+   `enable_diagnostics=true` for a short troubleshooting or functional run.
+2. Confirm that every Decode rank enters the same workload-collection steps
+   and that requests complete without persistent KV-waiting states.
+3. Compare throughput and latency with DyntraLB disabled.
+4. Turn diagnostics off for performance measurement.
+5. Switch to `mode="dynamic"` for workload testing. Tune `bubble_threshold`,
+   `long_req_block_threshold`, and `dynamic_max_step` from the observed request
+   block-count distribution.
+
+A very small `bubble_threshold` can cause frequent request pausing and
+admission changes. A very large value makes DyntraLB rarely modify the normal
+scheduler plan.
+
+## Diagnostics
+
+Set `enable_diagnostics=true` only while validating or troubleshooting:
+
+```json
+{
+  "scheduler_config": {
+    "dyntra_lb_config": {
+      "enabled": true,
+      "enable_diagnostics": true
+    }
+  }
+}
+```
+
+Rank 0 prints `[dyntra_lb]` workload snapshots and the generated `Out`, `In`, and
+`Freeze` modifications. Scheduler summaries and engine-step diagnostics are
+also emitted. These logs can be verbose and should normally remain disabled in
+throughput benchmarks.
+
+## Limitations
+
+- Only single-node, internally data-parallel Decode instances are supported.
+- DyntraLB does not route or migrate a request to another DP rank.
+- The planner estimates work from KV-cache blocks and uses a fixed throughput
+  heuristic. Model-specific costs, speculative-draft work, and operator-level
+  variation may require workload-specific tuning.
+- Combinations with speculative decoding or async scheduling should be
+  validated with the exact model, vLLM version, and vLLM Ascend version used in
+  production.
+
+For the complete `additional_config` schema, see
+[Additional Configuration](../configuration/additional_config.md).

--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -21,6 +21,7 @@ kv_pool
 layerwise_kv_pool
 layerwise_and_sparse_kv_cache_offloading
 kv_cache_cpu_offload
+dyntra_lb
 large_scale_ep
 ucm_deployment
 Fine_grained_TP

--- a/tests/ut/core/test_dyntra_lb_recompute_scheduler.py
+++ b/tests/ut/core/test_dyntra_lb_recompute_scheduler.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+from vllm.v1.request import RequestStatus
+
+import vllm_ascend.core.recompute_scheduler as recompute_scheduler_module
+from tests.ut.core.test_dyntra_lb_scheduler import (
+    create_dyntra_lb_scheduler,
+    make_dyntra_test_config,
+)
+from tests.ut.kv_offload.utils import (
+    create_model_runner_output,
+    create_request,
+)
+from vllm_ascend.core.dyntra_lb_scheduler import DyntraLBPolicyMixin
+from vllm_ascend.core.recompute_scheduler import (
+    AsyncDyntraLBRecomputeScheduler,
+    DyntraLBRecomputeScheduler,
+)
+
+
+def _create_dyntra_lb_recompute_scheduler():
+    vllm_config = make_dyntra_test_config()
+    vllm_config.kv_transfer_config = None
+    vllm_config.additional_config = {
+        "scheduler_config": {
+            "dyntra_lb_config": {
+                "enabled": True,
+            }
+        }
+    }
+    return create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBRecomputeScheduler,
+    )
+
+
+def test_dyntra_lb_recompute_schedulers_use_policy_mixin():
+    assert issubclass(DyntraLBRecomputeScheduler, DyntraLBPolicyMixin)
+    assert issubclass(AsyncDyntraLBRecomputeScheduler, DyntraLBPolicyMixin)
+    assert (
+        DyntraLBRecomputeScheduler._apply_load_balance_modifications
+        is DyntraLBPolicyMixin._apply_load_balance_modifications
+    )
+    assert AsyncDyntraLBRecomputeScheduler._can_admit_waiting_request is DyntraLBPolicyMixin._can_admit_waiting_request
+
+
+def test_dyntra_lb_recompute_invokes_policy_hooks():
+    scheduler = _create_dyntra_lb_recompute_scheduler()
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    scheduler._apply_load_balance_modifications = MagicMock()
+    scheduler._can_admit_waiting_request = MagicMock(return_value=False)
+
+    scheduler_output = scheduler.schedule()
+
+    scheduler._apply_load_balance_modifications.assert_called_once_with()
+    scheduler._can_admit_waiting_request.assert_called_once_with(request)
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.running
+    assert request.request_id not in scheduler_output.num_scheduled_tokens
+
+
+def test_dyntra_lb_recompute_emits_scheduler_diagnostics(monkeypatch):
+    scheduler = _create_dyntra_lb_recompute_scheduler()
+    summaries = []
+    monkeypatch.setattr(
+        recompute_scheduler_module,
+        "diagnostics_enabled",
+        lambda _config: True,
+    )
+    monkeypatch.setattr(
+        recompute_scheduler_module,
+        "print_scheduler_summary",
+        lambda *args: summaries.append(args),
+    )
+
+    scheduler.schedule()
+
+    assert len(summaries) == 1
+
+
+def test_dyntra_lb_recompute_prefetch_waits_for_offload_store():
+    scheduler = _create_dyntra_lb_recompute_scheduler()
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    request.status = RequestStatus.PREEMPTED
+
+    scheduler.connector = MagicMock()
+    scheduler.connector.get_num_new_matched_tokens.return_value = (None, False)
+    scheduler._lb_kv_prefetch_enabled = True
+
+    candidates = scheduler.prepare_dyntra_lb_step()
+
+    assert candidates == []
+    assert request.status == RequestStatus.PREEMPTED
+    assert request in scheduler.waiting
+    assert request not in scheduler.skipped_waiting
+    scheduler.connector.update_state_after_alloc.assert_not_called()
+
+
+def test_dyntra_lb_recompute_prefetch_restores_ready_cpu_kv():
+    scheduler = _create_dyntra_lb_recompute_scheduler()
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    request.status = RequestStatus.PREEMPTED
+
+    scheduler.connector = MagicMock()
+    scheduler.connector.get_num_new_matched_tokens.return_value = (8, True)
+    scheduler._lb_kv_prefetch_enabled = True
+
+    candidates = scheduler.prepare_dyntra_lb_step()
+
+    assert candidates == []
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert request.num_computed_tokens == 8
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.waiting
+    assert request in scheduler._inflight_prefills
+    scheduler.connector.update_state_after_alloc.assert_called_once()
+    update_request, allocated_blocks, external_tokens = scheduler.connector.update_state_after_alloc.call_args.args
+    assert update_request is request
+    assert allocated_blocks.get_block_ids()
+    assert external_tokens == 8
+
+
+def test_dyntra_lb_pause_with_retained_kv_skips_prefetch():
+    scheduler = _create_dyntra_lb_recompute_scheduler()
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output([request]),
+    )
+    retained_block_ids = scheduler.kv_cache_manager.get_block_ids(request.request_id)
+
+    scheduler.running.remove(request)
+    scheduler._lb_pause_request(request, 0.0)
+    scheduler.connector = MagicMock()
+    scheduler._lb_kv_prefetch_enabled = True
+
+    candidates = scheduler.prepare_dyntra_lb_step()
+
+    assert candidates == [request]
+    assert request.status == RequestStatus.PREEMPTED
+    assert request.num_computed_tokens > 0
+    assert scheduler.kv_cache_manager.get_block_ids(request.request_id) == (retained_block_ids)
+    scheduler.connector.get_num_new_matched_tokens.assert_not_called()

--- a/tests/ut/core/test_dyntra_lb_scheduler.py
+++ b/tests/ut/core/test_dyntra_lb_scheduler.py
@@ -1,0 +1,1210 @@
+from types import SimpleNamespace
+from typing import TypeVar
+from unittest.mock import patch
+
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.models import ModelRegistry
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+from vllm.v1.request import RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
+
+import vllm_ascend.core.dyntra_lb_scheduler as dyntra_lb_scheduler_module
+from tests.ut.kv_offload.utils import (
+    create_model_runner_output,
+    create_request,
+    create_vllm_config,
+)
+from vllm_ascend.core.dyntra_lb_scheduler import (
+    AsyncDyntraLBScheduler,
+    DyntraLBPolicyMixin,
+    DyntraLBScheduler,
+    diagnostics_enabled,
+    print_scheduler_summary,
+)
+
+SchedulerT = TypeVar("SchedulerT", bound=Scheduler)
+
+
+def make_dyntra_test_config(
+    max_num_seqs: int = 16,
+    max_num_batched_tokens: int = 1024,
+    block_size: int = 128,
+) -> VllmConfig:
+    """Create a scheduler config without importing a real model class."""
+    # ModelConfig normally inspects OPTForCausalLM in a subprocess. These
+    # scheduler tests only need its static model capabilities.
+    model_info = SimpleNamespace(
+        architecture="OPTForCausalLM",
+        is_text_generation_model=True,
+        is_pooling_model=False,
+        attn_type="decoder",
+        default_seq_pooling_type=None,
+        default_tok_pooling_type=None,
+        score_type=None,
+        supports_multimodal=False,
+        supports_multimodal_raw_input_only=False,
+        requires_raw_input_tokens=False,
+        supports_multimodal_encoder_tp_data=False,
+        supports_pp=True,
+        has_inner_state=False,
+        is_attention_free=False,
+        is_hybrid=False,
+        has_noops=False,
+        supports_mamba_prefix_caching=False,
+        supports_replayssm=False,
+        supports_transcription=False,
+        supports_transcription_only=False,
+        supported_video_pruning_methods=(),
+    )
+    with patch.object(
+        ModelRegistry,
+        "inspect_model_cls",
+        return_value=(model_info, model_info.architecture),
+    ):
+        return create_vllm_config(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=max_num_batched_tokens,
+            block_size=block_size,
+        )
+
+
+def create_dyntra_lb_scheduler(
+    vllm_config: VllmConfig,
+    scheduler_cls: type[SchedulerT],
+    num_blocks: int = 10000,
+) -> SchedulerT:
+    """Create a scheduler subclass for DyntraLB unit tests."""
+    block_size = vllm_config.cache_config.block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            )
+        ],
+    )
+    vllm_config.cache_config.num_gpu_blocks = num_blocks
+
+    return scheduler_cls(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        log_stats=True,
+        block_size=block_size,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+    )
+
+
+def test_dyntra_lb_scheduler_uses_policy_mixin():
+    assert issubclass(DyntraLBScheduler, DyntraLBPolicyMixin)
+    assert issubclass(AsyncDyntraLBScheduler, DyntraLBScheduler)
+    assert issubclass(AsyncDyntraLBScheduler, AsyncScheduler)
+
+
+def _create_scheduler_with_diagnostics(enable_diagnostics: bool):
+    vllm_config = make_dyntra_test_config()
+    vllm_config.additional_config = {
+        "scheduler_config": {
+            "dyntra_lb_config": {
+                "enabled": True,
+                "enable_diagnostics": enable_diagnostics,
+            }
+        }
+    }
+    return create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+
+
+def test_dyntra_lb_scheduler_diagnostics_are_disabled_by_default(monkeypatch):
+    scheduler = _create_scheduler_with_diagnostics(False)
+    summaries = []
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module,
+        "print_scheduler_summary",
+        lambda *args: summaries.append(args),
+    )
+
+    scheduler.schedule()
+
+    assert summaries == []
+
+
+def test_dyntra_lb_scheduler_diagnostics_can_be_enabled(monkeypatch):
+    scheduler = _create_scheduler_with_diagnostics(True)
+    summaries = []
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module,
+        "print_scheduler_summary",
+        lambda *args: summaries.append(args),
+    )
+
+    scheduler.schedule()
+
+    assert len(summaries) == 1
+
+
+def test_dyntra_lb_keeps_async_kv_load_in_skipped_waiting():
+    vllm_config = make_dyntra_test_config(max_num_seqs=2)
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+
+    remote_request = create_request(
+        request_id=1,
+        do_remote_prefill=True,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    ready_request = create_request(
+        request_id=2,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(remote_request)
+    scheduler.add_request(ready_request)
+
+    scheduler_output = scheduler.schedule()
+
+    assert remote_request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert remote_request in scheduler.skipped_waiting
+    assert remote_request not in scheduler.waiting
+    assert ready_request in scheduler.running
+    assert ready_request.request_id in scheduler_output.num_scheduled_tokens
+
+
+def test_dyntra_lb_blocked_statuses_are_enqueued_in_skipped_waiting():
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+
+    request = create_request(request_id=1)
+    request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+    scheduler._enqueue_waiting_request(request)
+
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.waiting
+
+
+def test_dyntra_lb_invalid_async_load_scans_skipped_waiting(monkeypatch):
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(request_id=1)
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.skipped_waiting.add_request(request)
+    scanned_requests = []
+
+    def _capture_requests(requests, *args, **kwargs):
+        scanned_requests.append(list(requests))
+        return set(), 0, []
+
+    monkeypatch.setattr(
+        scheduler,
+        "_update_requests_with_invalid_blocks",
+        _capture_requests,
+    )
+
+    assert scheduler._handle_invalid_blocks({1}, {}) == set()
+    assert scanned_requests[0] == [request]
+
+
+def test_dyntra_lb_prepare_moves_prefetched_request_to_skipped_waiting():
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(
+        request_id=1,
+        do_remote_prefill=True,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+    scheduler._lb_kv_prefetch_enabled = True
+
+    candidates = scheduler.prepare_dyntra_lb_step()
+
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.waiting
+    assert request not in candidates
+    assert request in scheduler._inflight_prefills
+
+
+def test_dyntra_lb_priority_merges_waiting_queues_in_schedule_order():
+    vllm_config = make_dyntra_test_config()
+    vllm_config.scheduler_config.policy = "priority"
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    highest_priority = create_request(request_id=1)
+    middle_priority = create_request(request_id=2)
+    lowest_priority = create_request(request_id=3)
+    highest_priority.priority = 0
+    middle_priority.priority = 1
+    lowest_priority.priority = 2
+    highest_priority.arrival_time = 3.0
+    middle_priority.arrival_time = 2.0
+    lowest_priority.arrival_time = 1.0
+    scheduler.waiting.add_request(highest_priority)
+    scheduler.waiting.add_request(lowest_priority)
+    scheduler.skipped_waiting.add_request(middle_priority)
+
+    ordered = scheduler._waiting_requests_in_schedule_order()
+
+    assert ordered == [highest_priority, middle_priority, lowest_priority]
+
+
+def test_dyntra_lb_priority_preempts_lowest_priority_request():
+    block_size = 16
+    vllm_config = make_dyntra_test_config(
+        max_num_seqs=3,
+        max_num_batched_tokens=200,
+        block_size=block_size,
+    )
+    vllm_config.kv_transfer_config = None
+    vllm_config.scheduler_config.policy = "priority"
+    vllm_config.scheduler_config.watermark = 0.0
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+        num_blocks=6,
+    )
+    low_priority = create_request(
+        request_id=1,
+        num_tokens=2 * block_size,
+        block_size=block_size,
+    )
+    low_priority.priority = 5
+    low_priority.arrival_time = 1.0
+    scheduler.add_request(low_priority)
+    first_output = scheduler.schedule()
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([low_priority]),
+    )
+
+    high_priority = create_request(
+        request_id=2,
+        num_tokens=2 * block_size,
+        block_size=block_size,
+    )
+    high_priority.priority = 0
+    high_priority.arrival_time = 2.0
+    scheduler.add_request(high_priority)
+    second_output = scheduler.schedule()
+    scheduler.update_from_output(
+        second_output,
+        create_model_runner_output([low_priority, high_priority]),
+    )
+
+    scheduler.schedule()
+
+    assert low_priority.status == RequestStatus.PREEMPTED
+    assert low_priority in scheduler.waiting
+    assert high_priority in scheduler.running
+
+
+def test_dyntra_lb_preemption_drops_stale_output_when_kv_delivery_requires_it(
+    monkeypatch,
+):
+    vllm_config = make_dyntra_test_config()
+    vllm_config.kv_transfer_config = None
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    first_output = scheduler.schedule()
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([request]),
+    )
+
+    # Emulate the stale-output fields provided by the pinned vLLM main.
+    request.num_stale_output_tokens = 0
+    request.drop_stale_output = False
+    scheduler.requires_kv_delivery = True
+    preempt_calls = []
+
+    def preempt_request(request, timestamp, *, drop_stale_output=False):
+        preempt_calls.append((request, timestamp, drop_stale_output))
+        request.status = RequestStatus.PREEMPTED
+        scheduler.waiting.prepend_request(request)
+
+    monkeypatch.setattr(scheduler, "_preempt_request", preempt_request)
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "allocate_slots",
+        lambda *args, **kwargs: None,
+    )
+
+    scheduler.schedule()
+
+    assert len(preempt_calls) == 1
+    assert preempt_calls[0][0] is request
+    assert preempt_calls[0][2] is True
+
+
+def test_dyntra_lb_does_not_resume_deliverable_stale_output():
+    vllm_config = make_dyntra_test_config()
+    vllm_config.kv_transfer_config = None
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    request.num_stale_output_tokens = 1
+    request.drop_stale_output = False
+
+    blocked_output = scheduler.schedule()
+
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.running
+    assert request.request_id not in blocked_output.num_scheduled_tokens
+
+    request.num_stale_output_tokens = 0
+    resumed_output = scheduler.schedule()
+
+    assert request in scheduler.running
+    assert request.request_id in resumed_output.num_scheduled_tokens
+
+
+def test_dyntra_lb_v026_waits_for_paused_in_flight_output():
+    scheduler = SimpleNamespace(_lb_paused_req_ids={"paused"})
+    paused_request = SimpleNamespace(
+        request_id="paused",
+        num_in_flight_tokens=1,
+    )
+    normally_preempted_request = SimpleNamespace(
+        request_id="other",
+        num_in_flight_tokens=1,
+    )
+
+    assert DyntraLBPolicyMixin._has_pending_deliverable_output(
+        scheduler,
+        paused_request,
+    )
+    assert not DyntraLBPolicyMixin._has_pending_deliverable_output(
+        scheduler,
+        normally_preempted_request,
+    )
+
+
+def test_dyntra_lb_reconciles_connector_hit_with_local_partial_tail(monkeypatch):
+    block_size = 16
+    vllm_config = make_dyntra_test_config(block_size=block_size)
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(
+        request_id=1,
+        num_tokens=block_size,
+        block_size=block_size,
+    )
+    scheduler.add_request(request)
+    empty_blocks = scheduler.kv_cache_manager.empty_kv_cache_blocks
+    connector_local_token_counts = []
+    truncate_calls = []
+
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "get_computed_blocks_for_connector",
+        lambda request: (empty_blocks, 5, 0, False),
+        raising=False,
+    )
+
+    def truncate_computed_blocks(blocks, num_tokens):
+        truncate_calls.append((blocks, num_tokens))
+        return empty_blocks
+
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "truncate_computed_blocks",
+        truncate_computed_blocks,
+        raising=False,
+    )
+
+    def get_num_new_matched_tokens(request, num_local_tokens):
+        connector_local_token_counts.append(num_local_tokens)
+        return 8, True
+
+    monkeypatch.setattr(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        get_num_new_matched_tokens,
+    )
+
+    scheduler.schedule()
+
+    assert connector_local_token_counts == [0]
+    assert truncate_calls == [(empty_blocks, 0)]
+    assert request.num_computed_tokens == 8
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+
+def test_dyntra_lb_v026_uses_release_connector_lookup(monkeypatch):
+    block_size = 16
+    vllm_config = make_dyntra_test_config(block_size=block_size)
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(
+        request_id=1,
+        num_tokens=block_size,
+        block_size=block_size,
+    )
+    scheduler.add_request(request)
+    empty_blocks = scheduler.kv_cache_manager.empty_kv_cache_blocks
+    connector_local_token_counts = []
+
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "get_computed_blocks_for_connector",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "truncate_computed_blocks",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "record_prefix_cache_stats",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "get_computed_blocks",
+        lambda request: (empty_blocks, 5, 0),
+    )
+
+    def get_num_new_matched_tokens(request, num_local_tokens):
+        connector_local_token_counts.append(num_local_tokens)
+        return 8, True
+
+    monkeypatch.setattr(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        get_num_new_matched_tokens,
+    )
+
+    scheduler.schedule()
+
+    assert connector_local_token_counts == [5]
+    assert request.num_computed_tokens == 13
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+
+def test_dyntra_lb_forwards_partial_tail_and_encoder_cache_metadata(monkeypatch):
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    partial_tail_offloads = [object()]
+    encoder_cache_metadata = object()
+
+    class RecordingSchedulerOutput(SimpleNamespace):
+        __dataclass_fields__ = {
+            "partial_tail_offloads": object(),
+            "ec_manager_metadata": object(),
+        }
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module,
+        "SchedulerOutput",
+        RecordingSchedulerOutput,
+    )
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "take_partial_tail_offloads",
+        lambda: partial_tail_offloads,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler.encoder_cache_manager,
+        "get_manager_metadata",
+        lambda: encoder_cache_metadata,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_build_kv_connector_meta",
+        lambda connector, scheduler_output: None,
+    )
+
+    scheduler_output = scheduler.schedule()
+
+    assert scheduler_output.partial_tail_offloads is partial_tail_offloads
+    assert scheduler_output.ec_manager_metadata is encoder_cache_metadata
+
+
+def test_dyntra_lb_v026_omits_unsupported_scheduler_output_fields(monkeypatch):
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+
+    class V026SchedulerOutput(SimpleNamespace):
+        __dataclass_fields__ = {}
+
+        def __init__(self, **kwargs):
+            assert "partial_tail_offloads" not in kwargs
+            assert "ec_manager_metadata" not in kwargs
+            super().__init__(**kwargs)
+
+    def unexpected_call():
+        raise AssertionError("unsupported v0.26 extension was called")
+
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module,
+        "SchedulerOutput",
+        V026SchedulerOutput,
+    )
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "take_partial_tail_offloads",
+        unexpected_call,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler.encoder_cache_manager,
+        "get_manager_metadata",
+        unexpected_call,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_build_kv_connector_meta",
+        lambda connector, scheduler_output: None,
+    )
+
+    scheduler_output = scheduler.schedule()
+
+    assert not hasattr(scheduler_output, "partial_tail_offloads")
+    assert not hasattr(scheduler_output, "ec_manager_metadata")
+
+
+def test_dyntra_lb_refreshes_blocked_waiting_requests(monkeypatch):
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    blocked_request = create_request(request_id=1)
+    blocked_request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.skipped_waiting.add_request(blocked_request)
+    promoted = []
+    monkeypatch.setattr(
+        scheduler,
+        "_try_promote_blocked_waiting_request",
+        lambda request: promoted.append(request),
+    )
+
+    scheduler._refresh_blocked_waiting_requests()
+
+    assert promoted == [blocked_request]
+
+
+def test_dyntra_lb_prefetch_tracks_connector_and_capacity_failures(monkeypatch):
+    vllm_config = make_dyntra_test_config(max_num_seqs=1)
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    requests = [create_request(request_id=request_id) for request_id in range(1, 5)]
+    for request in requests:
+        scheduler.add_request(request)
+    scheduler._lb_kv_prefetch_enabled = True
+    connector_results = iter(((None, False), (0, False)))
+    monkeypatch.setattr(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        lambda *args: next(connector_results),
+    )
+
+    not_ready_req_ids = scheduler._run_lb_kv_prefetch()
+
+    assert not_ready_req_ids == {
+        requests[0].request_id,
+        requests[2].request_id,
+        requests[3].request_id,
+    }
+
+
+def test_dyntra_lb_prefetch_tracks_allocation_failure(monkeypatch):
+    vllm_config = make_dyntra_test_config()
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    scheduler._lb_kv_prefetch_enabled = True
+    monkeypatch.setattr(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        lambda *args: (8, True),
+    )
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "allocate_slots",
+        lambda *args, **kwargs: None,
+    )
+
+    not_ready_req_ids = scheduler._run_lb_kv_prefetch()
+
+    assert not_ready_req_ids == {request.request_id}
+    assert request in scheduler.waiting
+
+
+def test_dyntra_lb_in_blk_builds_admission_mask():
+    vllm_config = make_dyntra_test_config(
+        max_num_seqs=2,
+        block_size=8,
+    )
+    vllm_config.kv_transfer_config = None
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    short_request = create_request(request_id=1, num_tokens=9, block_size=8)
+    long_request = create_request(request_id=2, num_tokens=17, block_size=8)
+    scheduler.add_request(short_request)
+    scheduler.add_request(long_request)
+    scheduler.prepare_dyntra_lb_step()
+    scheduler.modifications = {
+        "out_blk": [],
+        "in_blk": [3],
+        "freeze": False,
+    }
+
+    scheduler_output = scheduler.schedule()
+
+    assert long_request in scheduler.running
+    assert long_request.request_id in scheduler_output.num_scheduled_tokens
+    assert short_request in scheduler.skipped_waiting
+    assert short_request.request_id not in scheduler_output.num_scheduled_tokens
+
+
+def test_dyntra_lb_empty_in_blk_blocks_all_admission():
+    vllm_config = make_dyntra_test_config()
+    vllm_config.kv_transfer_config = None
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    scheduler.prepare_dyntra_lb_step()
+    scheduler.modifications = {
+        "out_blk": [],
+        "in_blk": [],
+        "freeze": False,
+    }
+
+    scheduler_output = scheduler.schedule()
+
+    assert not scheduler.running
+    assert request in scheduler.skipped_waiting
+    assert request.request_id not in scheduler_output.num_scheduled_tokens
+
+
+def test_dyntra_lb_same_block_count_uses_candidate_order():
+    vllm_config = make_dyntra_test_config(max_num_seqs=2)
+    vllm_config.kv_transfer_config = None
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    first_request = create_request(request_id=1)
+    second_request = create_request(request_id=2)
+    scheduler.add_request(first_request)
+    scheduler.add_request(second_request)
+    candidates = scheduler.prepare_dyntra_lb_step()
+    block_num = (len(first_request.all_token_ids) + scheduler.block_size - 1) // scheduler.block_size
+    scheduler.modifications = {
+        "out_blk": [],
+        "in_blk": [block_num],
+        "freeze": False,
+    }
+
+    scheduler.schedule()
+
+    assert candidates == [first_request, second_request]
+    assert first_request in scheduler.running
+    assert second_request in scheduler.skipped_waiting
+
+
+def test_dyntra_lb_out_request_is_not_readmitted_in_same_step():
+    vllm_config = make_dyntra_test_config()
+    vllm_config.kv_transfer_config = None
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=DyntraLBScheduler,
+    )
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    first_output = scheduler.schedule()
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([request]),
+    )
+    scheduler.prepare_dyntra_lb_step()
+    block_num = (len(request.all_token_ids) + scheduler.block_size - 1) // scheduler.block_size
+    scheduler.modifications = {
+        "out_blk": [block_num],
+        "in_blk": [block_num],
+        "freeze": False,
+    }
+
+    scheduler.schedule()
+
+    assert request.status == RequestStatus.PREEMPTED
+    assert request.request_id in scheduler._lb_paused_req_ids
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.running
+
+
+def _create_dyntra_lb_scheduler(async_scheduling: bool):
+    vllm_config = make_dyntra_test_config(max_num_seqs=2)
+    vllm_config.kv_transfer_config = None
+    vllm_config.scheduler_config.async_scheduling = async_scheduling
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=AsyncDyntraLBScheduler if async_scheduling else DyntraLBScheduler,
+    )
+    return vllm_config, scheduler
+
+
+def test_dyntra_lb_async_finished_lb_paused_request_is_removed_from_skipped_waiting():
+    vllm_config, scheduler = _create_dyntra_lb_scheduler(async_scheduling=True)
+    request = create_request(
+        request_id=1,
+        max_tokens=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+
+    # Schedule one token but deliberately delay its output.
+    first_output = scheduler.schedule()
+    assert request.status == RequestStatus.RUNNING
+    assert request.num_output_placeholders == 1
+
+    # Pause the running request through the DyntraLB out_blk path.
+    scheduler.prepare_dyntra_lb_step()
+    block_num = (len(request.all_token_ids) + scheduler.block_size - 1) // scheduler.block_size
+    scheduler.modifications = {
+        "out_blk": [block_num],
+        "in_blk": [],
+        "freeze": False,
+    }
+
+    scheduler.schedule()
+
+    assert request.status == RequestStatus.PREEMPTED
+    assert request in scheduler.skipped_waiting
+    assert request not in scheduler.waiting
+
+    # The delayed token reaches max_tokens=1 and finishes the paused request.
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([request]),
+    )
+
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+    assert request not in scheduler.waiting
+    assert request not in scheduler.skipped_waiting
+
+    # Dynamic LB may become inactive on the following step. A stale finished
+    # request must not be picked up again.
+    scheduler.modifications = None
+    scheduler.schedule()
+
+
+def test_dyntra_lb_async_schedules_running_request_in_consecutive_steps():
+    vllm_config, scheduler = _create_dyntra_lb_scheduler(async_scheduling=True)
+    request = create_request(
+        request_id=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+
+    assert request.request_id in first_output.num_scheduled_tokens
+    assert request.num_output_placeholders == 1
+
+    second_output = scheduler.schedule()
+
+    assert request.request_id in second_output.num_scheduled_tokens
+    assert request.num_output_placeholders == 2
+
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([request]),
+    )
+    assert request.num_output_placeholders == 1
+
+    scheduler.update_from_output(
+        second_output,
+        create_model_runner_output([request]),
+    )
+    assert request.num_output_placeholders == 0
+    assert request.num_output_tokens == 2
+
+
+def test_dyntra_lb_async_v2_sets_pp_decode_cadence():
+    vllm_config = make_dyntra_test_config(max_num_seqs=2)
+    vllm_config.scheduler_config.async_scheduling = True
+    vllm_config.parallel_config.pipeline_parallel_size = 2
+    scheduler = create_dyntra_lb_scheduler(
+        vllm_config,
+        scheduler_cls=AsyncDyntraLBScheduler,
+    )
+    scheduler.use_v2_model_runner = True
+    request = create_request(
+        request_id=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+
+    assert request.request_id in scheduler_output.num_scheduled_tokens
+    assert scheduler.pp_size == 2
+    assert request.next_decode_eligible_step == scheduler.current_step + scheduler.pp_size
+
+
+def test_dyntra_lb_sync_skips_until_previous_output_arrives():
+    vllm_config, scheduler = _create_dyntra_lb_scheduler(async_scheduling=False)
+    request = create_request(
+        request_id=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+    second_output = scheduler.schedule()
+
+    assert request.request_id in first_output.num_scheduled_tokens
+    assert request.request_id not in second_output.num_scheduled_tokens
+    assert request.num_output_placeholders == 0
+
+
+def test_dyntra_lb_async_reclaims_placeholder_for_lb_paused_request():
+    vllm_config, scheduler = _create_dyntra_lb_scheduler(async_scheduling=True)
+    request = create_request(
+        request_id=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    num_preemptions = request.num_preemptions
+
+    scheduler.running.remove(request)
+    scheduler._lb_pause_request(request, 0.0)
+    scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output([request]),
+    )
+
+    assert request.status == RequestStatus.PREEMPTED
+    assert request.request_id in scheduler._lb_paused_req_ids
+    assert request in scheduler.waiting
+    assert request.num_preemptions == num_preemptions
+    assert request.num_output_placeholders == 0
+    assert request.num_output_tokens == 1
+
+
+def test_dyntra_lb_paused_request_resumes_as_cached():
+    vllm_config, scheduler = _create_dyntra_lb_scheduler(async_scheduling=False)
+    request = create_request(
+        request_id=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(request)
+    first_output = scheduler.schedule()
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([request]),
+    )
+    scheduler.running.remove(request)
+    num_computed_tokens = request.num_computed_tokens
+    num_preemptions = request.num_preemptions
+    block_ids = scheduler.kv_cache_manager.get_blocks(request.request_id).get_block_ids()
+
+    scheduler._lb_pause_request(request, 0.0)
+
+    assert request.status == RequestStatus.PREEMPTED
+    assert request.request_id in scheduler._lb_paused_req_ids
+    assert request.num_computed_tokens == num_computed_tokens
+    assert request.num_preemptions == num_preemptions
+    assert scheduler.kv_cache_manager.get_blocks(request.request_id).get_block_ids() == block_ids
+    assert request.request_id not in scheduler.reset_preempted_req_ids
+
+    resumed_output = scheduler.schedule()
+
+    assert request.status == RequestStatus.RUNNING
+    assert request.request_id not in scheduler._lb_paused_req_ids
+    assert request.request_id in resumed_output.scheduled_cached_reqs.resumed_req_ids
+    assert not resumed_output.scheduled_new_reqs
+
+
+def test_dyntra_lb_paused_request_keeps_watermark_enabled(monkeypatch):
+    vllm_config, scheduler = _create_dyntra_lb_scheduler(async_scheduling=False)
+    running_request = create_request(
+        request_id=1,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    paused_request = create_request(
+        request_id=2,
+        block_size=vllm_config.cache_config.block_size,
+    )
+    scheduler.add_request(running_request)
+    scheduler.add_request(paused_request)
+    first_output = scheduler.schedule()
+    scheduler.update_from_output(
+        first_output,
+        create_model_runner_output([running_request, paused_request]),
+    )
+    scheduler.running.remove(paused_request)
+    scheduler._lb_pause_request(paused_request, 0.0)
+
+    original_allocate_slots = scheduler.kv_cache_manager.allocate_slots
+    has_scheduled_reqs_values = []
+
+    def allocate_slots(request, *args, **kwargs):
+        if request is paused_request:
+            has_scheduled_reqs_values.append(kwargs["has_scheduled_reqs"])
+        return original_allocate_slots(request, *args, **kwargs)
+
+    monkeypatch.setattr(
+        scheduler.kv_cache_manager,
+        "allocate_slots",
+        allocate_slots,
+    )
+
+    scheduler.schedule()
+
+    assert has_scheduled_reqs_values == [True]
+
+
+def test_dyntra_lb_pause_emits_diagnostics(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    scheduler = _create_scheduler_with_diagnostics(True)
+    request = create_request(request_id=1)
+    scheduler.add_request(request)
+    scheduler.schedule()
+    scheduler.running.remove(request)
+
+    scheduler._lb_pause_request(request, 0.0)
+
+    assert f"DYNTRA_LB_PAUSE request_id={request.request_id}" in messages
+    assert request in scheduler.waiting
+
+
+def _diagnostic_request(
+    request_id: str,
+    status: RequestStatus,
+    num_tokens: int,
+):
+    return SimpleNamespace(
+        request_id=request_id,
+        status=status,
+        all_token_ids=list(range(num_tokens)),
+        num_prompt_tokens=num_tokens - 1,
+        num_computed_tokens=num_tokens - 2,
+    )
+
+
+def test_print_scheduler_summary_includes_waiting_queues(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    scheduler = SimpleNamespace(
+        running=[
+            _diagnostic_request(
+                "running",
+                RequestStatus.RUNNING,
+                17,
+            )
+        ],
+        waiting=[
+            _diagnostic_request(
+                "waiting",
+                RequestStatus.WAITING,
+                9,
+            )
+        ],
+        skipped_waiting=[
+            _diagnostic_request(
+                "remote",
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                5,
+            )
+        ],
+        block_size=8,
+        cache_config=SimpleNamespace(block_size=8),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={
+            "request-1": 1,
+            "request-2": 1,
+        }
+    )
+
+    print_scheduler_summary(scheduler, scheduler_output)
+
+    output = "\n".join(messages)
+    assert "schedule() | scheduler req num: [1, 2, 1, 1, 0, 0]" in output
+    assert "blk num [3, 3, 2]" in output
+    assert "block size [scheduler=8, dyntra_lb=8]" in output
+    assert "running request |" not in output
+    assert "waiting request |" not in output
+
+
+def test_print_scheduler_summary_distinguishes_lb_pause_from_preemption(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    scheduler = SimpleNamespace(
+        running=[],
+        waiting=[
+            _diagnostic_request(
+                "waiting",
+                RequestStatus.WAITING,
+                9,
+            ),
+            _diagnostic_request(
+                "lb-paused",
+                RequestStatus.PREEMPTED,
+                17,
+            ),
+            _diagnostic_request(
+                "preempted",
+                RequestStatus.PREEMPTED,
+                25,
+            ),
+        ],
+        skipped_waiting=[],
+        block_size=8,
+        cache_config=SimpleNamespace(block_size=8),
+        _lb_paused_req_ids={"lb-paused"},
+    )
+    scheduler_output = SimpleNamespace(num_scheduled_tokens={})
+
+    print_scheduler_summary(scheduler, scheduler_output)
+
+    output = "\n".join(messages)
+    assert "schedule() | scheduler req num: [0, 3, 2, 0, 0, 1]" in output
+    assert "blk num [0, 9, 5]" in output
+
+
+def test_print_scheduler_summary_uses_effective_attention_block_size(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_scheduler_module.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    scheduler = SimpleNamespace(
+        running=[
+            _diagnostic_request(
+                "running",
+                RequestStatus.RUNNING,
+                90438,
+            )
+        ],
+        waiting=[],
+        skipped_waiting=[],
+        block_size=14080000,
+        cache_config=SimpleNamespace(block_size=2048),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={
+            "running": 2,
+        }
+    )
+
+    print_scheduler_summary(scheduler, scheduler_output)
+
+    output = "\n".join(messages)
+    assert "blk num [45, 0, 0]" in output
+    assert "block size [scheduler=14080000, dyntra_lb=2048]" in output
+
+
+def test_diagnostics_enabled_reads_nested_dyntra_lb_config():
+    vllm_config = SimpleNamespace(
+        additional_config={
+            "scheduler_config": {
+                "dyntra_lb_config": {
+                    "enabled": False,
+                    "enable_diagnostics": True,
+                }
+            }
+        }
+    )
+
+    assert diagnostics_enabled(vllm_config) is True
+
+
+def test_diagnostics_enabled_is_false_for_missing_or_invalid_config():
+    assert diagnostics_enabled(SimpleNamespace(additional_config=None)) is False
+    assert diagnostics_enabled(SimpleNamespace(additional_config={})) is False
+    assert (
+        diagnostics_enabled(
+            SimpleNamespace(
+                additional_config={
+                    "scheduler_config": {
+                        "dyntra_lb_config": {
+                            "enable_diagnostics": "true",
+                        }
+                    }
+                }
+            )
+        )
+        is False
+    )

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -17,7 +17,8 @@ What is guarded here (everything reachable from CPU UT):
 * upstream ``run_engine_core`` still instantiates ``DPEngineCoreProc`` by
   module-global name -- the whole reason we can swap the module-level symbol
   instead of copying ``run_engine_core``;
-* the module-level class swaps actually took effect;
+* the module-level class swaps and the DyntraLB -> balance wrapper chain
+  actually took effect;
 * the upstream Scheduler/DPEngineCoreProc methods the patch calls/super-calls
   still exist;
 * the 3 balance deltas remain present in ``schedule()`` (intent lock);
@@ -53,7 +54,6 @@ import pytest
 import vllm.v1.core.sched.scheduler as _upstream_sched_mod
 import vllm.v1.engine.core as _upstream_engine_mod
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
-from vllm.v1.core.sched.scheduler import Scheduler as _UpstreamScheduler
 from vllm.v1.engine.core import DPEngineCoreProc as _UpstreamDPEngineCoreProc
 from vllm.v1.engine.core import EngineCoreProc as _UpstreamEngineCoreProc
 
@@ -76,12 +76,19 @@ _UPSTREAM_SCHED_FILE = _upstream_sched_mod.__file__
 #   EngineCoreProc.run_engine_core = _balance_run_engine_core            (eager)
 #   vllm.v1.engine.core.DPEngineCoreProc = BalanceDPEngineCoreProc       (DEFERRED:
 #       swapped inside _balance_run_engine_core only when balance is enabled)
+from vllm_ascend.patch.platform import patch_dyntra_lb_core as _dyntra_patch  # noqa: E402
 from vllm_ascend.patch.platform.patch_balance_schedule import (  # noqa: E402
     BalanceScheduler,
     _balance_run_engine_core,
     _balance_scheduling_enabled,
     _OriginalRunEngineCore,
 )
+
+# Importing any vLLM module can activate the Ascend platform plugin before this
+# test module finishes importing, so a direct ``Scheduler`` import may already
+# resolve to ``BalanceScheduler``. Its base class is the installed upstream
+# scheduler and remains unmodified by the BalanceScheduler class replacement.
+_UpstreamScheduler = BalanceScheduler.__bases__[0]
 
 # ---------------------------------------------------------------------------
 # Scheduler config compatibility
@@ -436,13 +443,14 @@ def test_upstream_run_engine_core_instantiates_dp_proc_by_name():
 # ---------------------------------------------------------------------------
 
 
-def test_module_level_swaps_take_effect():
-    """The patch rebinds ``Scheduler`` eagerly and installs the
-    ``run_engine_core`` wrapper eagerly, but DEFERS the ``DPEngineCoreProc``
-    swap to wrapper-call-time (conditional on balance being enabled), so that
-    balance does not touch configs that don't use it (e.g. PD-disaggregated
-    recompute). At import time the engine-core class must therefore still be
-    the pristine upstream one, and the wrapper must be installed.
+def test_module_level_swaps_and_wrapper_chain_take_effect():
+    """The balance patch rebinds ``Scheduler`` eagerly and installs its
+    ``run_engine_core`` wrapper, while the subsequently loaded DyntraLB patch
+    becomes the outer wrapper. DyntraLB delegates to the balance wrapper when
+    disabled; the two features are rejected by configuration validation when
+    both are enabled. The ``DPEngineCoreProc`` swap remains deferred until the
+    selected wrapper runs, so at import time the engine-core class must still
+    be the pristine upstream one.
     (``Scheduler`` propagating into ``vllm.v1.engine.core.Scheduler``
     additionally depends on the platform patch loading before engine.core is
     imported -- that ordering is enforced by the platform patch system and is
@@ -457,8 +465,11 @@ def test_module_level_swaps_take_effect():
         "patch swapped vllm.v1.engine.core.DPEngineCoreProc at import time; "
         "the swap must be deferred to run_engine_core entry (conditional)."
     )
-    assert _UpstreamEngineCoreProc.run_engine_core is _balance_run_engine_core, (  # type: ignore[comparison-overlap]
-        "patch did not install the _balance_run_engine_core wrapper on EngineCoreProc.run_engine_core"
+    assert _UpstreamEngineCoreProc.run_engine_core is _dyntra_patch._dyntra_lb_run_engine_core, (
+        "DyntraLB must be the outer EngineCoreProc.run_engine_core wrapper"
+    )
+    assert _dyntra_patch._PreviousRunEngineCore is _balance_run_engine_core, (
+        "DyntraLB must delegate to the balance wrapper when DyntraLB is disabled"
     )
 
 

--- a/tests/ut/patch/platform/test_patch_dyntra_lb_core.py
+++ b/tests/ut/patch/platform/test_patch_dyntra_lb_core.py
@@ -1,0 +1,605 @@
+import importlib
+from unittest.mock import MagicMock
+
+import numpy as np
+import torch
+import vllm.v1.request as request_module
+
+from vllm_ascend.core.recompute_scheduler import (
+    AsyncRecomputeScheduler,
+    RecomputeScheduler,
+)
+
+NativeRequestStatus = request_module.RequestStatus
+dyntra_lb_core = importlib.import_module("vllm_ascend.patch.platform.patch_dyntra_lb_core")
+
+RequestStatus = request_module.RequestStatus
+
+
+def test_dyntra_lb_core_uses_native_request_status():
+    assert request_module.RequestStatus is NativeRequestStatus
+    assert dyntra_lb_core.RequestStatus is NativeRequestStatus
+
+
+def test_dyntra_lb_uses_main_upstream_engine_core_entrypoint():
+    assert dyntra_lb_core._UpstreamRunEngineCore is dyntra_lb_core._balance_patch._OriginalRunEngineCore
+
+
+def test_dyntra_lb_disabled_delegates_to_balance_wrapper(monkeypatch):
+    expected = object()
+    calls = []
+
+    def balance_wrapper(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_get_dyntra_lb_config",
+        lambda _config: MagicMock(enabled=False),
+    )
+    monkeypatch.setattr(dyntra_lb_core, "_PreviousRunEngineCore", balance_wrapper)
+
+    vllm_config = object()
+    result = dyntra_lb_core._dyntra_lb_run_engine_core(
+        "engine-arg",
+        vllm_config=vllm_config,
+        dp_rank=1,
+        local_dp_rank=2,
+    )
+
+    assert result is expected
+    assert calls == [
+        (
+            ("engine-arg",),
+            {
+                "vllm_config": vllm_config,
+                "dp_rank": 1,
+                "local_dp_rank": 2,
+            },
+        )
+    ]
+
+
+def test_dyntra_lb_enabled_bypasses_balance_wrapper(monkeypatch):
+    expected = object()
+    balance_wrapper = MagicMock(side_effect=AssertionError("balance wrapper must be bypassed"))
+
+    def upstream_entrypoint(*args, **kwargs):
+        assert dyntra_lb_core._engine_core_mod.DPEngineCoreProc is dyntra_lb_core.DyntraLBDPEngineCoreProc
+        return expected
+
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_get_dyntra_lb_config",
+        lambda _config: MagicMock(enabled=True, enable_diagnostics=False),
+    )
+    monkeypatch.setattr(dyntra_lb_core, "_PreviousRunEngineCore", balance_wrapper)
+    monkeypatch.setattr(dyntra_lb_core, "_UpstreamRunEngineCore", upstream_entrypoint)
+
+    result = dyntra_lb_core._dyntra_lb_run_engine_core(vllm_config=object())
+
+    assert result is expected
+    balance_wrapper.assert_not_called()
+    assert dyntra_lb_core._engine_core_mod.DPEngineCoreProc is dyntra_lb_core._OriginalDPEngineCoreProc
+
+
+def test_dyntra_lb_enabled_reads_nested_scheduler_config(monkeypatch):
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "get_ascend_config",
+        MagicMock(side_effect=RuntimeError("not initialized")),
+    )
+    vllm_config = MagicMock()
+    vllm_config.additional_config = {
+        "scheduler_config": {
+            "dyntra_lb_config": {
+                "enabled": True,
+            }
+        }
+    }
+
+    assert dyntra_lb_core._dyntra_lb_enabled(vllm_config) is True
+
+
+def test_dyntra_lb_diagnostics_read_nested_scheduler_config(monkeypatch):
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "get_ascend_config",
+        MagicMock(side_effect=RuntimeError("not initialized")),
+    )
+    vllm_config = MagicMock()
+    vllm_config.additional_config = {
+        "scheduler_config": {
+            "dyntra_lb_config": {
+                "enabled": True,
+                "enable_diagnostics": True,
+            }
+        }
+    }
+
+    assert dyntra_lb_core._get_dyntra_lb_config(vllm_config).enable_diagnostics is True
+
+
+def test_dyntra_lb_enabled_ignores_top_level_config(monkeypatch):
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "get_ascend_config",
+        MagicMock(side_effect=RuntimeError("not initialized")),
+    )
+    vllm_config = MagicMock()
+    vllm_config.additional_config = {"DYNTRA_LB_ENABLE": 1}
+
+    assert dyntra_lb_core._dyntra_lb_enabled(vllm_config) is False
+
+
+def _diagnostics_config(enable_diagnostics: bool):
+    vllm_config = MagicMock()
+    vllm_config.additional_config = {
+        "scheduler_config": {
+            "dyntra_lb_config": {
+                "enabled": False,
+                "enable_diagnostics": enable_diagnostics,
+            }
+        }
+    }
+    return vllm_config
+
+
+def test_dyntra_lb_does_not_patch_default_dp_core_diagnostics_method():
+    assert (
+        dyntra_lb_core.DPEngineCoreProc._has_global_unfinished_reqs
+        is dyntra_lb_core._ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS
+    )
+    assert AsyncRecomputeScheduler.schedule is RecomputeScheduler.schedule
+
+
+def test_default_dp_core_diagnostics_are_disabled_by_default(monkeypatch):
+    log_info = MagicMock()
+    monkeypatch.setattr(dyntra_lb_core.logger, "info", log_info)
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS",
+        lambda self, local_unfinished: True,
+    )
+    engine_core = MagicMock()
+    engine_core.vllm_config = _diagnostics_config(False)
+    engine_core.step_counter = 7
+
+    assert dyntra_lb_core._has_global_unfinished_reqs_with_diagnostics(engine_core, True) is True
+    log_info.assert_not_called()
+
+
+def test_bl_dp_core_diagnostics_can_be_enabled(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_core.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS",
+        lambda self, local_unfinished: True,
+    )
+    engine_core = MagicMock()
+    engine_core.vllm_config = _diagnostics_config(True)
+    engine_core.step_counter = 7
+
+    assert dyntra_lb_core._has_global_unfinished_reqs_with_diagnostics(engine_core, True) is True
+    output = "\n".join(messages)
+    assert output.count("step_counter: 7") == 1
+
+
+def test_dp_engine_core_initializes_ascend_config(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_core.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    vllm_config = MagicMock()
+    vllm_config.scheduler_config.max_num_seqs = 4
+
+    ascend_config = MagicMock()
+    dyntra_lb_config = ascend_config.scheduler_config.dyntra_lb_config
+    dyntra_lb_config.enabled = True
+    dyntra_lb_config.enable_diagnostics = True
+    dyntra_lb_config.mode = "static"
+    dyntra_lb_config.start_step = 0
+    dyntra_lb_config.end_step = -1
+    dyntra_lb_config.bubble_threshold = 5.0
+    dyntra_lb_config.long_req_block_threshold = 700
+    dyntra_lb_config.dynamic_max_step = 256
+
+    init_ascend_config = MagicMock(return_value=ascend_config)
+    monkeypatch.setattr(dyntra_lb_core, "init_ascend_config", init_ascend_config)
+
+    def init_data_parallel(engine_core, _config):
+        engine_core.dp_group = MagicMock()
+        engine_core.dp_rank = 0
+
+    monkeypatch.setattr(
+        dyntra_lb_core.DPEngineCoreProc,
+        "_init_data_parallel",
+        init_data_parallel,
+    )
+    monkeypatch.setattr(dyntra_lb_core.dist, "get_world_size", lambda group: 2)
+
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core._init_data_parallel(vllm_config)
+
+    init_ascend_config.assert_called_once_with(vllm_config)
+    assert engine_core._lb_mode == "static"
+    assert engine_core._lb_dp_size_cached == 2
+
+    output = "\n".join(messages)
+    assert "dyntra_lb_config.enabled = True" in output
+    assert "dyntra_lb_config.enable_diagnostics = True" in output
+    assert "dyntra_lb_config.mode = static" in output
+    assert "dyntra_lb_config.start_step = 0" in output
+    assert "dyntra_lb_config.end_step = -1" in output
+    assert "dyntra_lb_config.bubble_threshold = 5.0" in output
+    assert "dyntra_lb_config.long_req_block_threshold = 700" in output
+    assert "dyntra_lb_config.dynamic_max_step = 256" in output
+
+
+def test_balance_load_runs_after_global_unfinished_sync(monkeypatch):
+    events: list[object] = []
+
+    def has_global_unfinished(engine_core, local_unfinished):
+        events.append(("global_unfinished", local_unfinished))
+        engine_core.step_counter += 1
+        return True
+
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS",
+        has_global_unfinished,
+    )
+
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.vllm_config = _diagnostics_config(False)
+    engine_core.step_counter = 7
+    engine_core.scheduler = MagicMock()
+    engine_core.run_balance_load = lambda: events.append(("balance_load", engine_core.step_counter))
+
+    assert engine_core._has_global_unfinished_reqs(False) is True
+    assert events == [
+        ("global_unfinished", False),
+        ("balance_load", 8),
+    ]
+
+
+def test_run_balance_load_prepares_snapshot_before_allgather():
+    events: list[object] = []
+    candidates = [MagicMock(request_id="candidate")]
+    scheduler = MagicMock()
+
+    def prepare_dyntra_lb_step():
+        events.append("prepare")
+        return candidates
+
+    scheduler.prepare_dyntra_lb_step.side_effect = prepare_dyntra_lb_step
+
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.scheduler = scheduler
+    engine_core._lb_mode = "static"
+    engine_core._lb_dynamic_enable = False
+    engine_core.step_counter = 0
+    engine_core._lb_start_step = 0
+    engine_core._lb_end_step = -1
+
+    def do_lb_allgather(snapshot):
+        events.append(("allgather", snapshot))
+        return False
+
+    engine_core._do_lb_allgather = do_lb_allgather
+
+    engine_core.run_balance_load()
+
+    assert events == ["prepare", ("allgather", candidates)]
+
+
+def test_dynamic_activation_prepares_next_step_plan_immediately(monkeypatch):
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.scheduler = MagicMock()
+    engine_core.scheduler.prepare_dyntra_lb_step.return_value = []
+    engine_core._lb_mode = "dynamic"
+    engine_core._lb_dynamic_enable = False
+    engine_core._lb_dynamic_step = 9
+    engine_core._lb_pending_long_req = True
+    engine_core._lb_pending_long_req_blk = 8
+    engine_core._lb_dynamic_flag_np = np.zeros(2, dtype=np.int32)
+    engine_core._lb_dynamic_flag_t = torch.as_tensor(engine_core._lb_dynamic_flag_np)
+    engine_core.step_counter = 1
+    engine_core._lb_start_step = 0
+    engine_core._lb_end_step = -1
+    engine_core._lb_long_req_threshold = 4
+    engine_core.current_wave = 0
+    engine_core.dp_rank = 0
+    engine_core.dp_group = MagicMock()
+    engine_core._lb_enable_diagnostics = False
+    engine_core._do_lb_allgather = MagicMock(return_value=False)
+    monkeypatch.setattr(dyntra_lb_core.dist, "all_reduce", lambda *args, **kwargs: None)
+
+    engine_core.run_balance_load()
+
+    assert engine_core._lb_dynamic_enable is True
+    assert engine_core._lb_dynamic_step == 0
+    assert engine_core.scheduler._lb_kv_prefetch_enabled is True
+    engine_core._do_lb_allgather.assert_called_once_with([])
+
+
+def test_dynamic_long_request_uses_effective_attention_block_size(monkeypatch):
+    added_requests = []
+    monkeypatch.setattr(
+        dyntra_lb_core.DPEngineCoreProc,
+        "add_request",
+        lambda _self, request, request_wave=0: added_requests.append((request, request_wave)),
+    )
+
+    request = MagicMock(
+        request_id="long-request",
+        all_token_ids=list(range(8193)),
+    )
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.scheduler = MagicMock()
+    engine_core.scheduler.block_size = 14080000
+    engine_core.scheduler.cache_config.block_size = 2048
+    engine_core._lb_mode = "dynamic"
+    engine_core._lb_long_req_threshold = 4
+    engine_core._lb_pending_long_req = False
+    engine_core._lb_pending_long_req_blk = 0
+
+    engine_core.add_request(request, request_wave=3)
+
+    assert engine_core._lb_pending_long_req is True
+    assert engine_core._lb_pending_long_req_blk == 5
+    assert added_requests == [(request, 3)]
+
+
+def test_dyntra_lb_diagnostics_are_disabled_by_default(monkeypatch):
+    log_info = MagicMock()
+    monkeypatch.setattr(dyntra_lb_core.logger, "info", log_info)
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS",
+        lambda self, local_unfinished: False,
+    )
+
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.vllm_config = _diagnostics_config(False)
+    engine_core._lb_enable_diagnostics = False
+    engine_core.step_counter = 7
+    engine_core.scheduler = MagicMock()
+    engine_core.scheduler.modifications = {"freeze": True}
+    engine_core.scheduler.lb_freeze = True
+    engine_core.scheduler._lb_kv_prefetch_enabled = True
+    engine_core.run_balance_load = MagicMock()
+
+    assert engine_core._has_global_unfinished_reqs(True) is False
+    log_info.assert_not_called()
+    assert engine_core.scheduler.modifications is None
+    assert engine_core.scheduler.lb_freeze is False
+    assert engine_core.scheduler._lb_kv_prefetch_enabled is False
+    engine_core.run_balance_load.assert_not_called()
+
+
+def test_dyntra_lb_diagnostics_print_step_counter_once(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_core.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    monkeypatch.setattr(
+        dyntra_lb_core,
+        "_ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS",
+        lambda self, local_unfinished: True,
+    )
+
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.vllm_config = _diagnostics_config(True)
+    engine_core._lb_enable_diagnostics = True
+    engine_core.step_counter = 7
+    engine_core.scheduler = MagicMock()
+    engine_core.run_balance_load = MagicMock()
+
+    assert engine_core._has_global_unfinished_reqs(True) is True
+    output = "\n".join(messages)
+    assert output.count("step_counter: 7") == 1
+    engine_core.run_balance_load.assert_called_once_with()
+
+
+def test_print_balance_summary(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_core.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    dyntra_lb_core._print_requests_by_rank(
+        [([8, 4, 2, 0], 2)],
+        dp_rank=0,
+        enable_diagnostics=True,
+    )
+    dyntra_lb_core._print_modifications(
+        [{"out_blk": [8], "in_blk": [2], "freeze": False}],
+        dp_rank=0,
+        enable_diagnostics=True,
+    )
+
+    output = "\n".join(messages)
+    assert "DP0 | Run(2): [  8,   4]" in output
+    assert "Wait(1): [  2]" in output
+    assert "Out: [  8]" in output
+    assert "In: [  2]" in output
+    assert "Freeze: False" in output
+
+
+def test_balance_load_threshold_one_is_one_absolute_block():
+    modifications = dyntra_lb_core.DyntraLBDPEngineCoreProc._balance_load(
+        [
+            ([3], 1),
+            ([1, 2], 1),
+        ],
+        dev_num=2,
+        threshold=1.0,
+    )
+
+    assert modifications[1]["out_blk"] == [1]
+    assert modifications[1]["in_blk"] == [2]
+
+
+def test_balance_load_threshold_below_one_is_normalized_ratio():
+    modifications = dyntra_lb_core.DyntraLBDPEngineCoreProc._balance_load(
+        [
+            ([3], 1),
+            ([1, 2], 1),
+        ],
+        dev_num=2,
+        threshold=0.5,
+    )
+
+    assert modifications == [
+        {"out_blk": [], "in_blk": [], "freeze": True},
+        {"out_blk": [], "in_blk": [], "freeze": True},
+    ]
+
+
+def test_balance_load_does_not_drop_when_fixed_latency_dominates():
+    modifications = dyntra_lb_core.DyntraLBDPEngineCoreProc._balance_load(
+        [
+            ([60, 40], 2),
+            ([60], 1),
+        ],
+        dev_num=2,
+        threshold=5.0,
+    )
+
+    assert modifications == [
+        {"out_blk": [], "in_blk": [], "freeze": True},
+        {"out_blk": [], "in_blk": [], "freeze": True},
+    ]
+
+
+def test_balance_load_drops_request_for_modeled_throughput_gain():
+    modifications = dyntra_lb_core.DyntraLBDPEngineCoreProc._balance_load(
+        [
+            ([4000, 1000], 2),
+            ([1000], 1),
+        ],
+        dev_num=2,
+        threshold=1.0,
+    )
+
+    assert modifications[0]["out_blk"] == [4000]
+
+
+def test_balance_summary_is_suppressed_on_nonzero_dp_rank(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_core.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    dyntra_lb_core._print_requests_by_rank(
+        [([8, 4, 2, 0], 2)],
+        dp_rank=1,
+        enable_diagnostics=True,
+    )
+    dyntra_lb_core._print_modifications(
+        [{"out_blk": [8], "in_blk": [2], "freeze": False}],
+        dp_rank=1,
+        enable_diagnostics=True,
+    )
+
+    assert messages == []
+
+
+def test_balance_summary_is_suppressed_when_diagnostics_are_disabled(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        dyntra_lb_core.logger,
+        "info",
+        lambda message, *args: messages.append(message % args if args else message),
+    )
+    dyntra_lb_core._print_requests_by_rank(
+        [([8, 4, 2, 0], 2)],
+        dp_rank=0,
+        enable_diagnostics=False,
+    )
+    dyntra_lb_core._print_modifications(
+        [{"out_blk": [8], "in_blk": [2], "freeze": False}],
+        dp_rank=0,
+        enable_diagnostics=False,
+    )
+
+    assert messages == []
+
+
+def test_dyntra_lb_allgather_uses_admission_candidate_snapshot(monkeypatch):
+    waiting_request = MagicMock(
+        request_id="waiting",
+        all_token_ids=list(range(17)),
+        status=RequestStatus.WAITING,
+    )
+    paused_request = MagicMock(
+        request_id="paused",
+        all_token_ids=list(range(33)),
+        status=RequestStatus.PREEMPTED,
+    )
+    skipped_request = MagicMock(
+        request_id="skipped",
+        all_token_ids=list(range(65)),
+        status=RequestStatus.WAITING,
+    )
+    scheduler = MagicMock()
+    scheduler.block_size = 14080000
+    scheduler.cache_config.block_size = 8
+    scheduler.running = []
+    scheduler._lb_admission_candidates = [
+        skipped_request,
+        waiting_request,
+        paused_request,
+    ]
+
+    engine_core = object.__new__(dyntra_lb_core.DyntraLBDPEngineCoreProc)
+    engine_core.scheduler = scheduler
+    engine_core.dp_group = MagicMock()
+    engine_core.dp_rank = 0
+    engine_core._lb_enable_diagnostics = False
+    engine_core._lb_max_slots_cached = 4
+    engine_core._lb_dp_size_cached = 1
+    engine_core._lb_max_num_seqs = 2
+    engine_core._lb_threshold = 5.0
+    engine_core._lb_pending_long_req = False
+    engine_core._lb_pending_long_req_blk = 0
+    engine_core._lb_data_np = np.zeros(6, dtype=np.int32)
+    engine_core._lb_data_t = torch.as_tensor(engine_core._lb_data_np)
+    gathered: np.ndarray = np.zeros(6, dtype=np.int32)
+    engine_core._lb_all_data_np = [gathered]
+    engine_core._lb_all_data_t_buf = [torch.as_tensor(gathered)]
+
+    def all_gather(output_tensors, input_tensor, group):
+        output_tensors[0].copy_(input_tensor)
+
+    captured = {}
+
+    def balance_load(requests_by_rank, dev_num, max_num_seqs, threshold):
+        captured["requests_by_rank"] = requests_by_rank
+        return [{"out_blk": [], "in_blk": [], "freeze": True}]
+
+    monkeypatch.setattr(dyntra_lb_core.dist, "all_gather", all_gather)
+    monkeypatch.setattr(
+        dyntra_lb_core.DyntraLBDPEngineCoreProc,
+        "_balance_load",
+        staticmethod(balance_load),
+    )
+    monkeypatch.setattr(dyntra_lb_core, "_print_requests_by_rank", lambda *args: None)
+    monkeypatch.setattr(dyntra_lb_core, "_print_modifications", lambda *args: None)
+
+    engine_core._do_lb_allgather(scheduler._lb_admission_candidates)
+
+    assert captured["requests_by_rank"] == [([9, 3, 5, 0], 0)]

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -16,6 +16,7 @@
 import json
 import os
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 from vllm.config import KVTransferConfig, VllmConfig
@@ -23,6 +24,7 @@ from vllm.config import KVTransferConfig, VllmConfig
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
     AscendConfig,
+    DyntraLBConfig,
     EplbConfig,
     SchedulerConfig,
     ShortRequestFirstConfig,
@@ -170,6 +172,16 @@ class TestAscendConfig(TestBase):
                 "recompute_scheduler_enable": True,
                 "short_request_first_config": {"enabled": True, "threshold": 512},
                 "profiling_chunk_config": {"enabled": False},
+                "dyntra_lb_config": {
+                    "enabled": True,
+                    "enable_diagnostics": True,
+                    "mode": "dynamic",
+                    "start_step": 100,
+                    "end_step": 500,
+                    "bubble_threshold": 3.0,
+                    "long_req_block_threshold": 512,
+                    "dynamic_max_step": 128,
+                },
             }
         }
 
@@ -180,6 +192,11 @@ class TestAscendConfig(TestBase):
         self.assertTrue(scheduler_config.short_request_first_config.enabled)
         self.assertEqual(scheduler_config.short_request_first_config.threshold, 512)
         self.assertFalse(scheduler_config.profiling_chunk_config.enabled)
+        self.assertTrue(scheduler_config.dyntra_lb_config.enabled)
+        self.assertTrue(scheduler_config.dyntra_lb_config.enable_diagnostics)
+        self.assertEqual(scheduler_config.dyntra_lb_config.mode, "dynamic")
+        self.assertEqual(scheduler_config.dyntra_lb_config.start_step, 100)
+        self.assertEqual(scheduler_config.dyntra_lb_config.end_step, 500)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -532,6 +549,61 @@ class TestShortRequestFirstConfig(TestBase):
         self.assertEqual(cfg.long_max_wait_ms, 0.0)
 
 
+class TestDyntraLBConfig(TestBase):
+    def test_defaults(self):
+        config = DyntraLBConfig()
+
+        self.assertFalse(config.enabled)
+        self.assertFalse(config.enable_diagnostics)
+        self.assertEqual(config.mode, "dynamic")
+        self.assertEqual(config.start_step, 250)
+        self.assertEqual(config.end_step, -1)
+        self.assertEqual(config.bubble_threshold, 5.0)
+        self.assertEqual(config.long_req_block_threshold, 700)
+        self.assertEqual(config.dynamic_max_step, 256)
+
+    def test_configures_dynamic_mode(self):
+        config = DyntraLBConfig(
+            {
+                "enabled": True,
+                "enable_diagnostics": True,
+                "mode": "dynamic",
+                "start_step": 100,
+                "end_step": 500,
+                "bubble_threshold": 3,
+                "long_req_block_threshold": 512,
+                "dynamic_max_step": 128,
+            }
+        )
+
+        self.assertTrue(config.enabled)
+        self.assertTrue(config.enable_diagnostics)
+        self.assertEqual(config.mode, "dynamic")
+        self.assertEqual(config.start_step, 100)
+        self.assertEqual(config.end_step, 500)
+        self.assertEqual(config.bubble_threshold, 3.0)
+        self.assertEqual(config.long_req_block_threshold, 512)
+        self.assertEqual(config.dynamic_max_step, 128)
+
+    def test_rejects_invalid_config(self):
+        invalid_configs: tuple[tuple[Any, str], ...] = (
+            ([], "must be a dict"),
+            ({"unknown": True}, "Unknown dyntra_lb_config keys"),
+            ({"enabled": 1}, "enabled must be a bool"),
+            ({"enable_diagnostics": 1}, "enable_diagnostics must be a bool"),
+            ({"mode": "invalid"}, "mode must be one of"),
+            ({"start_step": -1}, "start_step must be >= 0"),
+            ({"start_step": 10, "end_step": 10}, "end_step must be greater than start_step"),
+            ({"bubble_threshold": 0}, "bubble_threshold must be > 0"),
+            ({"long_req_block_threshold": 0}, "long_req_block_threshold must be > 0"),
+            ({"dynamic_max_step": 0}, "dynamic_max_step must be > 0"),
+        )
+
+        for user_config, message in invalid_configs:
+            with self.subTest(user_config=user_config), self.assertRaisesRegex(ValueError, message):
+                DyntraLBConfig(user_config)
+
+
 class TestSchedulerConfig(TestBase):
     def test_defaults(self):
         config = SchedulerConfig({}, balance_env_value=False)
@@ -540,6 +612,7 @@ class TestSchedulerConfig(TestBase):
         self.assertFalse(config.recompute_scheduler_enable)
         self.assertFalse(config.short_request_first_config.enabled)
         self.assertFalse(config.profiling_chunk_config.enabled)
+        self.assertFalse(config.dyntra_lb_config.enabled)
 
     @patch("vllm_ascend.ascend_config.logger.warning_once")
     def test_none_config_uses_defaults_and_legacy_fallback(self, mock_warning_once):
@@ -570,6 +643,13 @@ class TestSchedulerConfig(TestBase):
                         "long_max_wait_ms": 2000,
                     },
                     "profiling_chunk_config": {"enabled": True, "need_timing": False},
+                    "dyntra_lb_config": {
+                        "enabled": True,
+                        "enable_diagnostics": True,
+                        "mode": "dynamic",
+                        "start_step": 100,
+                        "end_step": 500,
+                    },
                 }
             },
             balance_env_value=False,
@@ -582,6 +662,11 @@ class TestSchedulerConfig(TestBase):
         self.assertEqual(config.short_request_first_config.long_max_wait_ms, 2000.0)
         self.assertTrue(config.profiling_chunk_config.enabled)
         self.assertFalse(config.profiling_chunk_config.need_timing)
+        self.assertTrue(config.dyntra_lb_config.enabled)
+        self.assertTrue(config.dyntra_lb_config.enable_diagnostics)
+        self.assertEqual(config.dyntra_lb_config.mode, "dynamic")
+        self.assertEqual(config.dyntra_lb_config.start_step, 100)
+        self.assertEqual(config.dyntra_lb_config.end_step, 500)
 
     @patch("vllm_ascend.ascend_config.logger.warning_once")
     def test_legacy_top_level_config_warns_and_remains_supported(self, mock_warning_once):

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -34,6 +34,7 @@ class TestNPUPlatform(TestBase):
         mock_vllm_config.parallel_config.pipeline_parallel_size = 1
         mock_vllm_config.parallel_config.context_parallel_size = 1
         mock_vllm_config.parallel_config.decode_context_parallel_size = 1
+        mock_vllm_config.parallel_config.nnodes_within_dp = 1
         mock_vllm_config.use_v2_model_runner = False
         mock_vllm_config.parallel_config.enable_eplb = False
         mock_vllm_config.parallel_config.eplb_config = MagicMock(use_async=False, communicator=None)
@@ -66,6 +67,7 @@ class TestNPUPlatform(TestBase):
         mock_ascend_config.enable_shared_expert_dp = False
         mock_ascend_config.scheduler_config.short_request_first_config.enabled = False
         mock_ascend_config.scheduler_config.profiling_chunk_config.enabled = False
+        mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = False
         mock_ascend_config.update_compile_ranges_split_points = MagicMock()
         return mock_ascend_config
 
@@ -162,6 +164,44 @@ class TestNPUPlatform(TestBase):
             _validate_eplb_config(vllm_config)
         self.assertEqual(NPUPlatform.dispatch_key, "PrivateUse1")
         self.assertEqual(NPUPlatform.supported_quantization, [ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD])
+
+    def test_get_recompute_scheduler_cls(self):
+        from vllm_ascend import platform
+
+        cases = (
+            (
+                False,
+                False,
+                "vllm_ascend.core.recompute_scheduler.RecomputeScheduler",
+            ),
+            (
+                True,
+                False,
+                "vllm_ascend.core.recompute_scheduler.AsyncRecomputeScheduler",
+            ),
+            (
+                False,
+                True,
+                "vllm_ascend.core.recompute_scheduler.DyntraLBRecomputeScheduler",
+            ),
+            (
+                True,
+                True,
+                "vllm_ascend.core.recompute_scheduler.AsyncDyntraLBRecomputeScheduler",
+            ),
+        )
+        for async_scheduling, dyntra_lb_enabled, expected_scheduler_cls in cases:
+            with self.subTest(
+                async_scheduling=async_scheduling,
+                dyntra_lb_enabled=dyntra_lb_enabled,
+            ):
+                self.assertEqual(
+                    platform._get_recompute_scheduler_cls(
+                        async_scheduling=async_scheduling,
+                        dyntra_lb_enabled=dyntra_lb_enabled,
+                    ),
+                    expected_scheduler_cls,
+                )
 
     def test_is_sleep_mode_available(self):
         self.assertTrue(self.platform.is_sleep_mode_available())
@@ -745,6 +785,7 @@ class TestNPUPlatform(TestBase):
         vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
         vllm_config.cache_config.block_size = 1
         vllm_config.scheduler_config = MagicMock()
+        vllm_config.scheduler_config.async_scheduling = False
 
         from vllm_ascend import platform
 
@@ -759,6 +800,68 @@ class TestNPUPlatform(TestBase):
 
         mock_init_recompute.assert_called_once_with(vllm_config)
         self.assertIs(vllm_config.scheduler_config, recompute_scheduler_config)
+        self.assertEqual(
+            recompute_scheduler_config.scheduler_cls,
+            "vllm_ascend.core.recompute_scheduler.RecomputeScheduler",
+        )
+
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
+    def test_check_and_update_config_selects_dyntra_lb_recompute_scheduler(
+        self,
+        mock_init_recompute,
+        mock_init_ascend,
+        mock_soc_version,
+        mock_auto_detect,
+    ):
+        cases = (
+            (
+                False,
+                "vllm_ascend.core.recompute_scheduler.DyntraLBRecomputeScheduler",
+            ),
+            (
+                True,
+                "vllm_ascend.core.recompute_scheduler.AsyncDyntraLBRecomputeScheduler",
+            ),
+        )
+        for async_scheduling, expected_scheduler_cls in cases:
+            with self.subTest(async_scheduling=async_scheduling):
+                mock_init_recompute.reset_mock()
+                mock_init_ascend.reset_mock()
+
+                mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+                mock_ascend_config.scheduler_config.recompute_scheduler_enable = True
+                mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = True
+                mock_init_ascend.return_value = mock_ascend_config
+
+                recompute_scheduler_config = MagicMock()
+                mock_init_recompute.return_value = recompute_scheduler_config
+
+                vllm_config = TestNPUPlatform.mock_vllm_config()
+                vllm_config.scheduler_config.async_scheduling = async_scheduling
+                vllm_config.kv_transfer_config = MagicMock(kv_role="kv_consumer", engine_id="engine0")
+                vllm_config.parallel_config.data_parallel_size = 2
+                vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
+                vllm_config.cache_config.block_size = 1
+
+                from vllm_ascend import platform
+
+                importlib.reload(platform)
+                self.platform = platform.NPUPlatform()
+
+                with (
+                    patch.object(platform, "_fix_incompatible_config"),
+                    patch.object(platform, "check_kv_extra_config"),
+                ):
+                    self.platform.check_and_update_config(vllm_config)
+
+                mock_init_recompute.assert_called_once_with(vllm_config)
+                self.assertIs(vllm_config.scheduler_config, recompute_scheduler_config)
+                self.assertEqual(recompute_scheduler_config.scheduler_cls, expected_scheduler_cls)
+                self.assertTrue(mock_ascend_config.scheduler_config.recompute_scheduler_enable)
+                self.assertTrue(mock_ascend_config.scheduler_config.dyntra_lb_config.enabled)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
@@ -913,6 +1016,135 @@ class TestNPUPlatform(TestBase):
             from vllm_ascend import platform
 
             platform._validate_kv_load_failure_policy(vllm_config)
+
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    def test_check_and_update_config_selects_dyntra_lb_scheduler(
+        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+    ):
+        mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+        mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = True
+        mock_init_ascend.return_value = mock_ascend_config
+
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.kv_transfer_config = MagicMock(kv_role="kv_consumer", engine_id="engine0")
+        vllm_config.parallel_config.data_parallel_size = 2
+        vllm_config.parallel_config.decode_context_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.parallel_config.tensor_parallel_size = 1
+        vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
+        vllm_config.cache_config.block_size = 1
+        vllm_config.scheduler_config = MagicMock()
+        vllm_config.scheduler_config.async_scheduling = False
+
+        from vllm_ascend import platform
+
+        importlib.reload(platform)
+        self.platform = platform.NPUPlatform()
+
+        with (
+            patch.object(platform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+            patch("vllm_ascend.logger.configure_ascend_file_logging"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
+
+        self.assertEqual(
+            vllm_config.scheduler_config.scheduler_cls,
+            "vllm_ascend.core.dyntra_lb_scheduler.DyntraLBScheduler",
+        )
+
+    def test_get_dyntra_lb_scheduler_cls(self):
+        from vllm_ascend import platform
+
+        cases = (
+            (
+                False,
+                "vllm_ascend.core.dyntra_lb_scheduler.DyntraLBScheduler",
+            ),
+            (
+                True,
+                "vllm_ascend.core.dyntra_lb_scheduler.AsyncDyntraLBScheduler",
+            ),
+        )
+        for async_scheduling, expected_scheduler_cls in cases:
+            with self.subTest(async_scheduling=async_scheduling):
+                self.assertEqual(
+                    platform._get_dyntra_lb_scheduler_cls(async_scheduling=async_scheduling),
+                    expected_scheduler_cls,
+                )
+
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    def test_check_and_update_config_rejects_dyntra_lb_outside_disaggregated_d_node(
+        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+    ):
+        for kv_role in (None, "kv_both", "kv_producer"):
+            with self.subTest(kv_role=kv_role):
+                mock_init_ascend.reset_mock()
+
+                mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+                mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = True
+                mock_init_ascend.return_value = mock_ascend_config
+
+                vllm_config = TestNPUPlatform.mock_vllm_config()
+                vllm_config.kv_transfer_config = (
+                    None if kv_role is None else MagicMock(kv_role=kv_role, engine_id="engine0")
+                )
+                vllm_config.parallel_config.data_parallel_size = 2
+                vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
+                vllm_config.cache_config.block_size = 1
+                vllm_config.scheduler_config = MagicMock()
+
+                from vllm_ascend import platform
+
+                importlib.reload(platform)
+                self.platform = platform.NPUPlatform()
+
+                with (
+                    pytest.raises(
+                        ValueError,
+                        match=r"DyntraLB is only supported on PD-disaggregated D nodes",
+                    ),
+                    patch.object(platform, "_fix_incompatible_config"),
+                    patch.object(platform, "check_kv_extra_config"),
+                ):
+                    self.platform.check_and_update_config(vllm_config)
+
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    def test_check_and_update_config_rejects_multinode_dyntra_lb_decoder(
+        self, mock_init_ascend, mock_soc_version, mock_auto_detect
+    ):
+        mock_ascend_config = TestNPUPlatform.mock_vllm_ascend_config()
+        mock_ascend_config.scheduler_config.dyntra_lb_config.enabled = True
+        mock_init_ascend.return_value = mock_ascend_config
+
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.kv_transfer_config = MagicMock(kv_role="kv_consumer", engine_id="engine0")
+        vllm_config.parallel_config.data_parallel_size = 2
+        vllm_config.parallel_config.nnodes_within_dp = 2
+        vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
+        vllm_config.cache_config.block_size = 1
+        vllm_config.scheduler_config = MagicMock()
+
+        from vllm_ascend import platform
+
+        importlib.reload(platform)
+        self.platform = platform.NPUPlatform()
+
+        with (
+            pytest.raises(
+                ValueError,
+                match=r"DyntraLB only supports decoder instances.*single node",
+            ),
+            patch.object(platform, "_fix_incompatible_config"),
+            patch.object(platform, "check_kv_extra_config"),
+        ):
+            self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -945,6 +945,87 @@ class ShortRequestFirstConfig:
             raise ValueError(f"short_request_first_config.long_max_wait_ms must be >= 0; got {self.long_max_wait_ms}")
 
 
+class DyntraLBConfig:
+    """Configuration object for ``additional_config["scheduler_config"]["dyntra_lb_config"]``."""
+
+    _defaults = {
+        "enabled": False,
+        "enable_diagnostics": False,
+        "mode": "dynamic",
+        "start_step": 250,
+        "end_step": -1,
+        "bubble_threshold": 5.0,
+        "long_req_block_threshold": 700,
+        "dynamic_max_step": 256,
+    }
+    _valid_modes = {"static", "dynamic"}
+
+    def __init__(self, user_config: dict | None = None):
+        if user_config is None:
+            user_config = {}
+        elif not isinstance(user_config, dict):
+            raise ValueError(f"dyntra_lb_config must be a dict, got {type(user_config).__name__}.")
+
+        unknown = set(user_config) - set(self._defaults)
+        if unknown:
+            raise ValueError(f"Unknown dyntra_lb_config keys: {sorted(unknown)}")
+
+        self.enabled = user_config.get("enabled", self._defaults["enabled"])
+        self.enable_diagnostics = user_config.get(
+            "enable_diagnostics",
+            self._defaults["enable_diagnostics"],
+        )
+        self.mode = user_config.get("mode", self._defaults["mode"])
+        self.start_step = user_config.get("start_step", self._defaults["start_step"])
+        self.end_step = user_config.get("end_step", self._defaults["end_step"])
+        self.bubble_threshold = user_config.get("bubble_threshold", self._defaults["bubble_threshold"])
+        self.long_req_block_threshold = user_config.get(
+            "long_req_block_threshold",
+            self._defaults["long_req_block_threshold"],
+        )
+        self.dynamic_max_step = user_config.get("dynamic_max_step", self._defaults["dynamic_max_step"])
+        self._validate_config()
+
+    def _validate_config(self):
+        if not isinstance(self.enabled, bool):
+            raise ValueError(f"dyntra_lb_config.enabled must be a bool, got {type(self.enabled).__name__}.")
+        if not isinstance(self.enable_diagnostics, bool):
+            raise ValueError(
+                f"dyntra_lb_config.enable_diagnostics must be a bool, got {type(self.enable_diagnostics).__name__}."
+            )
+        if not isinstance(self.mode, str) or self.mode not in self._valid_modes:
+            raise ValueError(f"dyntra_lb_config.mode must be one of {sorted(self._valid_modes)}, got {self.mode!r}.")
+
+        for key in ("start_step", "end_step", "long_req_block_threshold", "dynamic_max_step"):
+            value = getattr(self, key)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(f"dyntra_lb_config.{key} must be an int, got {type(value).__name__}.")
+
+        if not isinstance(self.bubble_threshold, (int, float)) or isinstance(self.bubble_threshold, bool):
+            raise ValueError(
+                f"dyntra_lb_config.bubble_threshold must be a number, got {type(self.bubble_threshold).__name__}."
+            )
+        self.bubble_threshold = float(self.bubble_threshold)
+
+        if self.start_step < 0:
+            raise ValueError(f"dyntra_lb_config.start_step must be >= 0, got {self.start_step}.")
+        if self.end_step < -1:
+            raise ValueError(f"dyntra_lb_config.end_step must be -1 or >= 0, got {self.end_step}.")
+        if self.end_step != -1 and self.end_step <= self.start_step:
+            raise ValueError(
+                "dyntra_lb_config.end_step must be greater than start_step when it is set, "
+                f"got start_step={self.start_step}, end_step={self.end_step}."
+            )
+        if self.bubble_threshold <= 0:
+            raise ValueError(f"dyntra_lb_config.bubble_threshold must be > 0, got {self.bubble_threshold}.")
+        if self.long_req_block_threshold <= 0:
+            raise ValueError(
+                f"dyntra_lb_config.long_req_block_threshold must be > 0, got {self.long_req_block_threshold}."
+            )
+        if self.dynamic_max_step <= 0:
+            raise ValueError(f"dyntra_lb_config.dynamic_max_step must be > 0, got {self.dynamic_max_step}.")
+
+
 class SchedulerConfig:
     """Configuration object for ``additional_config[\"scheduler_config\"]``."""
 
@@ -978,6 +1059,7 @@ class SchedulerConfig:
         self.batch_job_sched_config = BatchJobSchedConfig(
             self._get_config_value(scheduler_config, additional_config, "batch_job_sched_config", {})
         )
+        self.dyntra_lb_config = DyntraLBConfig(scheduler_config.get("dyntra_lb_config"))
 
     @staticmethod
     def _get_config_value(

--- a/vllm_ascend/core/dyntra_lb_scheduler.py
+++ b/vllm_ascend/core/dyntra_lb_scheduler.py
@@ -1,0 +1,1205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import itertools
+import time
+from typing import TYPE_CHECKING, Any
+
+from vllm.config import VllmConfig
+from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
+from vllm.logger import logger
+from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.interface import PauseState
+from vllm.v1.core.sched.output import (
+    NewRequestData,
+    SchedulerOutput,
+)
+from vllm.v1.core.sched.request_queue import (
+    SchedulingPolicy,
+    create_request_queue,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.engine import EngineCoreEventType
+from vllm.v1.metrics.stats import PrefixCacheStats
+from vllm.v1.request import Request, RequestStatus
+from vllm.v1.utils import record_function_or_nullcontext
+
+from vllm_ascend.ascend_config import DyntraLBConfig
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.scheduler import Scheduler as _SchedulerBase
+else:
+    _SchedulerBase = object
+
+
+def get_dyntra_lb_block_size(scheduler: Any) -> int:
+    """Return the effective attention block size used as DyntraLB load unit."""
+    block_size = scheduler.cache_config.block_size
+    if not isinstance(block_size, int) or block_size <= 0:
+        raise RuntimeError(f"Invalid DyntraLB block size: {block_size}")
+    return block_size
+
+
+def get_dyntra_lb_request_block_num(scheduler: Any, request: Any) -> int:
+    """Estimate a request's attention KV-cache blocks for load balancing."""
+    block_size = get_dyntra_lb_block_size(scheduler)
+    return (len(request.all_token_ids) + block_size - 1) // block_size
+
+
+def diagnostics_enabled(vllm_config: Any) -> bool:
+    """Read the diagnostic toggle independently of DyntraLB activation."""
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if not isinstance(additional_config, dict):
+        return False
+
+    scheduler_config = additional_config.get("scheduler_config")
+    if not isinstance(scheduler_config, dict):
+        return False
+
+    dyntra_lb_config = scheduler_config.get("dyntra_lb_config")
+    if not isinstance(dyntra_lb_config, dict):
+        return False
+
+    return dyntra_lb_config.get("enable_diagnostics") is True
+
+
+def print_scheduler_summary(scheduler: Any, scheduler_output: Any) -> None:
+    waiting_reqs = list(itertools.chain(scheduler.waiting, scheduler.skipped_waiting))
+    lb_paused_req_ids: set[str] = getattr(
+        scheduler,
+        "_lb_paused_req_ids",
+        set(),
+    )
+
+    def is_schedulable_waiting(request: Any) -> bool:
+        return request.status == RequestStatus.WAITING or request.request_id in lb_paused_req_ids
+
+    waiting_num = sum(is_schedulable_waiting(request) for request in waiting_reqs)
+    waiting_for_remote_kvs_num = sum(request.status == RequestStatus.WAITING_FOR_REMOTE_KVS for request in waiting_reqs)
+    structured_output_waiting_status = RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+    waiting_for_fsm_num = sum(request.status == structured_output_waiting_status for request in waiting_reqs)
+    preempted_num = sum(
+        request.status == RequestStatus.PREEMPTED and request.request_id not in lb_paused_req_ids
+        for request in waiting_reqs
+    )
+    running_block_num = sum(get_dyntra_lb_request_block_num(scheduler, request) for request in scheduler.running)
+    waiting_queue_block_num = sum(get_dyntra_lb_request_block_num(scheduler, request) for request in waiting_reqs)
+    waiting_block_num = sum(
+        get_dyntra_lb_request_block_num(scheduler, request)
+        for request in waiting_reqs
+        if is_schedulable_waiting(request)
+    )
+    logger.info(
+        "schedule() | scheduler req num: [%d, %d, %d, %d, %d, %d] | "
+        "blk num [%d, %d, %d] | block size [scheduler=%d, dyntra_lb=%d]",
+        len(scheduler.running),
+        len(waiting_reqs),
+        waiting_num,
+        waiting_for_remote_kvs_num,
+        waiting_for_fsm_num,
+        preempted_num,
+        running_block_num,
+        waiting_queue_block_num,
+        waiting_block_num,
+        scheduler.block_size,
+        get_dyntra_lb_block_size(scheduler),
+    )
+
+
+class DyntraLBPolicyMixin(_SchedulerBase):
+    """Provide DyntraLB planning and request-lifecycle policy to a scheduler.
+
+    Scheduler implementations remain responsible for invoking
+    ``_apply_load_balance_modifications`` before scheduling running requests
+    and ``_can_admit_waiting_request`` while traversing waiting requests.
+    """
+
+    running: list[Request]
+    connector_prefix_cache_stats: PrefixCacheStats | None
+    finished_req_ids: set[str]
+    reset_preempted_req_ids: set[str]
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, vllm_config=vllm_config, **kwargs)
+
+        additional_config = vllm_config.additional_config or {}
+        scheduler_extension_config = additional_config.get("scheduler_config") or {}
+        dyntra_lb_user_config = scheduler_extension_config.get("dyntra_lb_config") or {}
+        self._enable_diagnostics = DyntraLBConfig(dyntra_lb_user_config).enable_diagnostics
+        self.modifications: dict | None = None
+        self.lb_freeze: bool = False
+        self._lb_paused_req_ids: set[str] = set()
+        self._lb_kv_prefetch_enabled: bool = False
+        self._lb_admission_candidates: list[Request] = []
+        self._lb_admit_req_ids: set[str] | None = None
+
+    def _waiting_requests_in_schedule_order(self) -> list[Request]:
+        if self.policy == SchedulingPolicy.FCFS:
+            return [*self.skipped_waiting, *self.waiting]
+
+        waiting = list(self.waiting)
+        skipped = list(self.skipped_waiting)
+        ordered: list[Request] = []
+        waiting_idx = skipped_idx = 0
+        while waiting_idx < len(waiting) and skipped_idx < len(skipped):
+            if waiting[waiting_idx] < skipped[skipped_idx]:
+                ordered.append(waiting[waiting_idx])
+                waiting_idx += 1
+            else:
+                ordered.append(skipped[skipped_idx])
+                skipped_idx += 1
+        ordered.extend(waiting[waiting_idx:])
+        ordered.extend(skipped[skipped_idx:])
+        return ordered
+
+    def _refresh_blocked_waiting_requests(self) -> None:
+        for request in list(self.skipped_waiting):
+            if self._is_blocked_waiting_status(request.status):
+                self._try_promote_blocked_waiting_request(request)
+
+    def _run_lb_kv_prefetch(self) -> set[str]:
+        if self.connector is None or not self._lb_kv_prefetch_enabled:
+            return set()
+
+        kv_prefetch_limit = 2 * self.max_num_running_reqs - len(self.running)
+        kv_prefetch_count = 0
+        kv_not_ready_req_ids: set[str] = set()
+        requests_to_move: list[Request] = []
+        for request in self._waiting_requests_in_schedule_order():
+            if request.status not in (
+                RequestStatus.WAITING,
+                RequestStatus.PREEMPTED,
+            ):
+                continue
+            if request.num_computed_tokens != 0:
+                continue
+            if kv_prefetch_count >= kv_prefetch_limit:
+                kv_not_ready_req_ids.add(request.request_id)
+                continue
+            kv_prefetch_count += 1
+
+            (
+                new_computed_blocks,
+                num_new_local_computed_tokens,
+                request.shared_prefix_boundary,
+            ) = self.kv_cache_manager.get_computed_blocks(request)
+            ext_tokens, load_async = self.connector.get_num_new_matched_tokens(
+                request,
+                num_new_local_computed_tokens,
+            )
+            if ext_tokens is None:
+                kv_not_ready_req_ids.add(request.request_id)
+                continue
+            if not load_async or not ext_tokens:
+                continue
+
+            new_blocks = self.kv_cache_manager.allocate_slots(
+                request,
+                0,
+                num_new_computed_tokens=num_new_local_computed_tokens,
+                new_computed_blocks=new_computed_blocks,
+                num_lookahead_tokens=0,
+                num_external_computed_tokens=ext_tokens,
+                delay_cache_blocks=True,
+                full_sequence_must_fit=self.scheduler_reserve_full_isl,
+            )
+            if new_blocks is None:
+                kv_not_ready_req_ids.add(request.request_id)
+                continue
+
+            self.connector.update_state_after_alloc(
+                request,
+                self.kv_cache_manager.get_blocks(request.request_id),
+                ext_tokens,
+            )
+            request.num_computed_tokens = num_new_local_computed_tokens + ext_tokens
+            request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+            self._inflight_prefills.add(request)
+            if request in self.waiting:
+                requests_to_move.append(request)
+
+        if requests_to_move:
+            self.waiting.remove_requests(requests_to_move)
+            for request in requests_to_move:
+                self.skipped_waiting.add_request(request)
+        return kv_not_ready_req_ids
+
+    def prepare_dyntra_lb_step(self) -> list[Request]:
+        """Prepare requests for the next cross-rank load-balancing decision."""
+        self._refresh_blocked_waiting_requests()
+        kv_not_ready_req_ids = self._run_lb_kv_prefetch()
+        self._lb_admission_candidates = [
+            request
+            for request in self._waiting_requests_in_schedule_order()
+            if request.status in (RequestStatus.WAITING, RequestStatus.PREEMPTED)
+            and request.request_id not in kv_not_ready_req_ids
+        ]
+        return self._lb_admission_candidates
+
+    def _apply_load_balance_modifications(self) -> None:
+        self._lb_admit_req_ids = None
+        if self.modifications is None:
+            self.lb_freeze = False
+            return
+
+        out_blks = self.modifications["out_blk"]
+        in_blks = self.modifications["in_blk"]
+        self.lb_freeze = self.modifications["freeze"]
+        scheduled_timestamp = time.monotonic()
+
+        def req_blk_num(req: Request) -> int:
+            return get_dyntra_lb_request_block_num(self, req)
+
+        remaining_out = list(out_blks)
+        for priority_filter in (
+            lambda r: getattr(r, "lb_newly_added", False),
+            lambda r: True,
+        ):
+            if not remaining_out:
+                break
+            for req in list(self.running):
+                if not remaining_out:
+                    break
+                blk_num = req_blk_num(req)
+                if blk_num in remaining_out and priority_filter(req):
+                    remaining_out.remove(blk_num)
+                    self.running.remove(req)
+                    self._lb_pause_request(req, scheduled_timestamp)
+
+        remaining_in = [] if self.lb_freeze else list(in_blks)
+        admit_req_ids: set[str] = set()
+        for req in self._lb_admission_candidates:
+            if not remaining_in:
+                break
+            blk_num = req_blk_num(req)
+            if blk_num in remaining_in:
+                remaining_in.remove(blk_num)
+                admit_req_ids.add(req.request_id)
+        self._lb_admit_req_ids = admit_req_ids
+
+    def _can_admit_waiting_request(self, request: Request) -> bool:
+        return self._lb_admit_req_ids is None or request.request_id in self._lb_admit_req_ids
+
+    @staticmethod
+    def _scheduler_output_supports(field_name: str) -> bool:
+        fields = getattr(SchedulerOutput, "__dataclass_fields__", {})
+        return field_name in fields
+
+    def _has_pending_deliverable_output(self, request: Request) -> bool:
+        if hasattr(request, "num_stale_output_tokens"):
+            return request.num_stale_output_tokens > 0 and not request.drop_stale_output
+
+        # vLLM v0.26 tracks async work with num_in_flight_tokens. Only apply
+        # this fallback to requests paused by DyntraLB: regular preemption in
+        # that release has its own async_tokens_to_discard lifecycle.
+        return request.request_id in self._lb_paused_req_ids and getattr(request, "num_in_flight_tokens", 0) > 0
+
+    def _get_connector_computed_blocks(
+        self,
+        request: Request,
+    ) -> tuple[KVCacheBlocks, int, int, bool, bool]:
+        get_for_connector = getattr(
+            self.kv_cache_manager,
+            "get_computed_blocks_for_connector",
+            None,
+        )
+        truncate_blocks = getattr(
+            self.kv_cache_manager,
+            "truncate_computed_blocks",
+            None,
+        )
+        if callable(get_for_connector) and callable(truncate_blocks):
+            blocks, num_local, shared_boundary, hit_diverged = get_for_connector(request)
+            return blocks, num_local, shared_boundary, hit_diverged, True
+
+        # vLLM v0.26 keeps this hybrid/Mamba connector lookup in Scheduler
+        # instead of KVCacheManager. Preserve that release's behavior.
+        coordinator = self.kv_cache_manager.coordinator
+        if self.has_mamba_layers and isinstance(
+            coordinator,
+            HybridKVCacheCoordinator,
+        ):
+            computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
+                request.block_hashes,
+                request.num_tokens - 1,
+            )
+            blocks = self.kv_cache_manager.create_kv_cache_blocks(computed)
+            num_local = max(per_group_hits)
+            if self.kv_cache_manager.log_stats:
+                assert self.kv_cache_manager.prefix_cache_stats is not None
+                self.kv_cache_manager.prefix_cache_stats.record(
+                    num_tokens=request.num_tokens,
+                    num_hits=num_local,
+                    preempted=request.num_preemptions > 0,
+                )
+            return blocks, num_local, 0, False, False
+
+        blocks, num_local, shared_boundary = self.kv_cache_manager.get_computed_blocks(request)
+        return blocks, num_local, shared_boundary, False, False
+
+    def _record_prefix_cache_stats(
+        self,
+        request: Request,
+        num_local_tokens: int,
+    ) -> None:
+        record_stats = getattr(
+            self.kv_cache_manager,
+            "record_prefix_cache_stats",
+            None,
+        )
+        if callable(record_stats):
+            record_stats(request, num_local_tokens)
+
+    def _preempt_request(
+        self,
+        request: Request,
+        timestamp: float,
+        drop_stale_output: bool = False,
+    ) -> None:
+        self._lb_paused_req_ids.discard(request.request_id)
+        if hasattr(request, "num_stale_output_tokens"):
+            super()._preempt_request(
+                request,
+                timestamp,
+                drop_stale_output=drop_stale_output,
+            )
+        else:
+            # Compatibility with vLLM releases before stale async output
+            # tracking was added to Request and Scheduler._preempt_request.
+            super()._preempt_request(request, timestamp)
+
+    def _lb_pause_request(
+        self,
+        request: Request,
+        timestamp: float,
+    ) -> None:
+        """Pause a request for DyntraLB load balancing without freeing KV."""
+        assert request.status == RequestStatus.RUNNING, "Only running requests can be lb-paused"
+        request.status = RequestStatus.PREEMPTED
+        self._lb_paused_req_ids.add(request.request_id)
+        if self._enable_diagnostics:
+            logger.info("DYNTRA_LB_PAUSE request_id=%s", request.request_id)
+        if self.log_stats:
+            request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
+        self.waiting.prepend_request(request)
+
+    def _handle_stopped_request(self, request: Request) -> bool:
+        was_preempted = request.status != RequestStatus.RUNNING
+        finished = super()._handle_stopped_request(request)
+        if was_preempted:
+            self.skipped_waiting.remove_requests((request,))
+        return finished
+
+    def _update_after_schedule(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        super()._update_after_schedule(scheduler_output)
+        for req_id in scheduler_output.num_scheduled_tokens:
+            self._lb_paused_req_ids.discard(req_id)
+
+    def _free_request(
+        self,
+        request: Request,
+        delay_free_blocks: bool = False,
+    ) -> dict[str, Any] | None | tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        self._lb_paused_req_ids.discard(request.request_id)
+        return super()._free_request(request, delay_free_blocks)
+
+
+class DyntraLBScheduler(DyntraLBPolicyMixin, Scheduler):
+    prefill_capacity_bound: bool
+
+    def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
+        self.current_step += 1
+        # NOTE(woosuk) on the scheduling algorithm:
+        # There's no "decoding phase" nor "prefill phase" in the scheduler.
+        # Each request just has the num_computed_tokens and
+        # num_tokens_with_spec. num_tokens_with_spec =
+        # len(prompt_token_ids) + len(output_token_ids) + len(spec_token_ids).
+        # At each step, the scheduler tries to assign tokens to the requests
+        # so that each request's num_computed_tokens can catch up its
+        # num_tokens_with_spec. This is general enough to cover
+        # chunked prefills, prefix caching, speculative decoding,
+        # and the "jump decoding" optimization in the future.
+
+        scheduled_new_reqs: list[Request] = []
+        scheduled_resumed_reqs: list[Request] = []
+        scheduled_running_reqs: list[Request] = []
+        preempted_reqs: list[Request] = []
+
+        # delta for dyntra_lb: apply cross-rank load-balancing decisions.
+        self._apply_load_balance_modifications()
+
+        req_to_new_blocks: dict[str, KVCacheBlocks] = {}
+        num_scheduled_tokens: dict[str, int] = {}
+        token_budget = self.max_num_scheduled_tokens
+        if self._pause_state == PauseState.PAUSED_ALL:
+            # Do not schedule any requests when paused.
+            token_budget = 0
+
+        # Encoder-related.
+        scheduled_encoder_inputs: dict[str, list[int]] = {}
+        encoder_compute_budget = self.max_num_encoder_input_tokens
+        # Spec decode-related.
+        scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        # Whether the running batch contains any prefill requests.
+        prefill_scheduled = False
+
+        # For logging.
+        scheduled_timestamp = time.monotonic()
+
+        self.kv_cache_manager.new_step_starts()
+
+        # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
+        # all prefill compute unless saturated.
+        defer_prefills = (throttle_prefills and not self.prefill_capacity_bound) and any(
+            not r.is_prefill_chunk for r in self.running
+        )
+
+        # First, schedule the RUNNING requests.
+        req_index = 0
+        while req_index < len(self.running) and token_budget > 0:
+            request = self.running[req_index]
+
+            if (
+                request.num_output_placeholders > 0
+                # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).
+                # Since output placeholders are also included in the computed tokens
+                # count, we subtract (num_output_placeholders - 1) to remove any draft
+                # tokens, so that we can be sure no further steps are needed even if
+                # they are all rejected.
+                and request.num_computed_tokens + 2 - request.num_output_placeholders
+                >= request.num_prompt_tokens + request.max_tokens
+            ):
+                # Async scheduling: Avoid scheduling an extra step when we are sure that
+                # the previous step has reached request.max_tokens. We don't schedule
+                # partial draft tokens since this prevents uniform decode optimizations.
+                req_index += 1
+                continue
+
+            if self.current_step < request.next_decode_eligible_step:
+                # V2+PP+async: enforce `pp_size` steps between same-req decodes
+                # to match worker-side sampled-tokens broadcast slot ring cadence.
+                req_index += 1
+                continue
+
+            if defer_prefills and request.is_prefill_chunk:
+                # DP prefill balancing: defer this in-progress prefill chunk to a
+                # cadence-aligned step; decodes still run to fill this step.
+                req_index += 1
+                continue
+
+            num_new_tokens = (
+                request.num_tokens_with_spec + request.num_output_placeholders - request.num_computed_tokens
+            )
+            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
+                num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+            num_new_tokens = min(num_new_tokens, token_budget)
+
+            # Make sure the input position does not exceed the max model len.
+            # This is necessary when using spec decoding.
+            num_new_tokens = min(
+                num_new_tokens,
+                self.max_model_len - request.num_computed_tokens - self.num_sampled_tokens_per_step,
+            )
+
+            # Schedule encoder inputs.
+            encoder_inputs_to_schedule = None
+            external_load_encoder_input: list[int] = []
+            new_encoder_compute_budget = encoder_compute_budget
+            if request.has_encoder_inputs:
+                (
+                    encoder_inputs_to_schedule,
+                    num_new_tokens,
+                    new_encoder_compute_budget,
+                    external_load_encoder_input,
+                ) = self._try_schedule_encoder_inputs(
+                    request,
+                    request.num_computed_tokens,
+                    num_new_tokens,
+                    encoder_compute_budget,
+                    shift_computed_tokens=1 if self.use_eagle else 0,
+                )
+
+            if self.need_mamba_block_aligned_split:
+                num_new_tokens = self._mamba_block_aligned_split(request, num_new_tokens)
+
+            if num_new_tokens == 0:
+                # The request cannot be scheduled because one of the following
+                # reasons:
+                # 1. No new tokens to schedule. This may happen when
+                #    (1) PP>1 and we have already scheduled all prompt tokens
+                #    but they are not finished yet.
+                #    (2) Async scheduling and the request has reached to either
+                #    its max_total_tokens or max_model_len.
+                # 2. The encoder budget is exhausted.
+                # 3. The encoder cache is exhausted.
+                # 4. Insufficient budget for a block-aligned chunk in hybrid
+                #    models with mamba cache mode \"align\".
+                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
+                # we do not strictly follow the FCFS scheduling policy and
+                # allow the lower-priority requests to be scheduled.
+                req_index += 1
+                continue
+
+            # Schedule newly needed KV blocks for the request.
+            with record_function_or_nullcontext("schedule: allocate_slots"):
+                while True:
+                    new_blocks = self.kv_cache_manager.allocate_slots(
+                        request,
+                        num_new_tokens,
+                        num_lookahead_tokens=self.num_lookahead_tokens,
+                    )
+
+                    if new_blocks is not None:
+                        # The request can be scheduled.
+                        break
+
+                    # The request cannot be scheduled.
+                    # Preempt the lowest-priority request.
+                    if self.policy == SchedulingPolicy.PRIORITY:
+                        preempted_req = max(
+                            self.running,
+                            key=lambda r: (r.priority, r.arrival_time),
+                        )
+                        self.running.remove(preempted_req)
+                        if preempted_req in scheduled_running_reqs:
+                            preempted_req_id = preempted_req.request_id
+                            scheduled_running_reqs.remove(preempted_req)
+                            token_budget += num_scheduled_tokens.pop(preempted_req_id)
+                            req_to_new_blocks.pop(preempted_req_id)
+                            scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                            preempted_encoder_inputs = scheduled_encoder_inputs.pop(preempted_req_id, None)
+                            if preempted_encoder_inputs:
+                                # Restore encoder compute budget if the preempted
+                                # request had encoder inputs scheduled in this step.
+                                num_embeds_to_restore = sum(
+                                    preempted_req.get_num_encoder_embeds(i) for i in preempted_encoder_inputs
+                                )
+                                encoder_compute_budget += num_embeds_to_restore
+                            req_index -= 1
+                    else:
+                        preempted_req = self.running.pop()
+
+                    self._preempt_request(
+                        preempted_req,
+                        scheduled_timestamp,
+                        drop_stale_output=getattr(
+                            self,
+                            "requires_kv_delivery",
+                            False,
+                        ),
+                    )
+                    preempted_reqs.append(preempted_req)
+                    if preempted_req == request:
+                        # No more request to preempt. Cannot schedule this request.
+                        break
+
+            if new_blocks is None:
+                # Cannot schedule this request.
+                break
+
+            # Schedule the request.
+            scheduled_running_reqs.append(request)
+            prefill_scheduled |= request.is_prefill_chunk
+            request_id = request.request_id
+            req_to_new_blocks[request_id] = new_blocks
+            num_scheduled_tokens[request_id] = num_new_tokens
+            token_budget -= num_new_tokens
+            req_index += 1
+
+            # Speculative decode related.
+            if request.spec_token_ids:
+                num_scheduled_spec_tokens = (
+                    num_new_tokens + request.num_computed_tokens - request.num_tokens - request.num_output_placeholders
+                )
+                if num_scheduled_spec_tokens > 0:
+                    spec_token_ids = request.spec_token_ids
+                    if len(spec_token_ids) > num_scheduled_spec_tokens:
+                        spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
+                    scheduled_spec_decode_tokens[request.request_id] = spec_token_ids
+
+                # New spec tokens will be set in `update_draft_token_ids` before the
+                # next step when applicable.
+                request.spec_token_ids = []
+
+            # Encoder-related.
+            if encoder_inputs_to_schedule:
+                scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                # Allocate the encoder cache.
+                for i in encoder_inputs_to_schedule:
+                    self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector is not None:
+                        self.ec_connector.update_state_after_alloc(request, i)
+                encoder_compute_budget = new_encoder_compute_budget
+            if external_load_encoder_input:
+                for i in external_load_encoder_input:
+                    self.encoder_cache_manager.allocate(request, i)
+                    if self.ec_connector is not None:
+                        self.ec_connector.update_state_after_alloc(request, i)
+
+        # Record the LoRAs in scheduled_running_reqs
+        scheduled_loras: set[int] = set()
+        if self.lora_config:
+            scheduled_loras = set(
+                req.lora_request.lora_int_id
+                for req in scheduled_running_reqs
+                if req.lora_request and req.lora_request.lora_int_id > 0
+            )
+            assert len(scheduled_loras) <= self.lora_config.max_loras
+
+        # Next, schedule the WAITING requests.
+        if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
+            step_skipped_waiting = create_request_queue(self.policy)
+
+            while (self.waiting or self.skipped_waiting) and token_budget > 0:
+                # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
+                # in `running` but still hold a model-runner request slot.
+                num_running = len(self.running) + self.num_waiting_for_streaming_input
+                if num_running >= self.max_num_running_reqs:
+                    break
+
+                request_queue = self._select_waiting_queue_for_scheduling()
+                assert request_queue is not None
+
+                request = request_queue.peek_request()
+                request_id = request.request_id
+
+                # try to promote blocked statuses while traversing skipped queue.
+                if self._is_blocked_waiting_status(request.status) and not self._try_promote_blocked_waiting_request(
+                    request
+                ):
+                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                        logger.debug(
+                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                            request_id,
+                        )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                if self._has_pending_deliverable_output(request):
+                    # Deliverable stale output still in flight: resuming now
+                    # could resample a position that output later delivers.
+                    # It drains within the pipeline depth.
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                # delta for dyntra_lb: admit requests selected by the load-balancing plan.
+                if not self._can_admit_waiting_request(request):
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                # Check that adding the request still respects the max_loras
+                # constraint.
+                if (
+                    self.lora_config
+                    and request.lora_request
+                    and (
+                        len(scheduled_loras) == self.lora_config.max_loras
+                        and request.lora_request.lora_int_id not in scheduled_loras
+                    )
+                ):
+                    # Scheduling would exceed max_loras, skip.
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                num_external_computed_tokens = 0
+                load_kv_async = False
+                connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                did_prefix_cache_lookup = False
+
+                # Get already-cached tokens.
+                if request.num_computed_tokens == 0:
+                    did_prefix_cache_lookup = True
+                    hit_diverged = False
+                    # Get locally-cached tokens.
+                    if self.connector is not None:
+                        # A KV connector transfers the missing suffix, which needs a
+                        # hybrid-aware lookup that can diverge across groups.
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            request.shared_prefix_boundary,
+                            hit_diverged,
+                            supports_partial_tail,
+                        ) = self._get_connector_computed_blocks(request)
+                    else:
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            # Marconi shared-prefix junction to pin; 0 if none.
+                            request.shared_prefix_boundary,
+                        ) = self.kv_cache_manager.get_computed_blocks(request)
+
+                    # Get externally-cached tokens if using a KVConnector.
+                    if self.connector is not None:
+                        # Present a block-aligned local hit to the connector so
+                        # a strictly longer remote hit can supersede a local
+                        # sub-block tail without racing its copy-on-write.
+                        partial_tail = num_new_local_computed_tokens % self.block_size if supports_partial_tail else 0
+                        block_aligned_local = num_new_local_computed_tokens - partial_tail
+                        ext_tokens, load_kv_async = self.connector.get_num_new_matched_tokens(
+                            request, block_aligned_local
+                        )
+
+                        if ext_tokens is None:
+                            # The request cannot be scheduled because
+                            # the KVConnector couldn't determine
+                            # the number of matched tokens.
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+
+                        if partial_tail and ext_tokens > partial_tail:
+                            # Remote strictly exceeds the full local hit: drop the
+                            # sub-block tail so no CoW is needed, and let the load
+                            # cover it. Trim the partial block out of the local
+                            # computed blocks so it is not adopted from the cache.
+                            new_computed_blocks = self.kv_cache_manager.truncate_computed_blocks(
+                                new_computed_blocks,
+                                block_aligned_local,
+                            )
+                            num_new_local_computed_tokens = block_aligned_local
+                            num_external_computed_tokens = ext_tokens
+                        elif partial_tail:
+                            # Remote does not exceed the full local hit: keep the
+                            # local sub-block tail and load nothing external.
+                            num_external_computed_tokens = 0
+                            # Nothing to load remotely -> not an async-load step;
+                            # clearing avoids the `load_kv_async` assert below.
+                            load_kv_async = False
+                        else:
+                            num_external_computed_tokens = ext_tokens
+
+                        if hit_diverged and num_external_computed_tokens == 0:
+                            # No external tokens back the deeper local hit, so its
+                            # resume boundary would have no valid Mamba state.
+                            # Reconcile to the boundary every group agrees on.
+                            (
+                                new_computed_blocks,
+                                num_new_local_computed_tokens,
+                                request.shared_prefix_boundary,
+                            ) = self.kv_cache_manager.get_computed_blocks(request)
+
+                        connector_prefix_cache_queries = request.num_tokens - num_new_local_computed_tokens
+                        connector_prefix_cache_hits = num_external_computed_tokens
+
+                    # Total computed tokens (local + external).
+                    num_computed_tokens = num_new_local_computed_tokens + num_external_computed_tokens
+                    assert num_computed_tokens <= request.num_tokens
+
+                    # Skip request with pending mm encoding prefetches
+                    if (
+                        self.ec_connector is not None
+                        and request.mm_features
+                        and not self.ec_connector.ensure_cache_available(request, num_computed_tokens)
+                    ):
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
+                        continue
+
+                    # Track first scheduled prefill, not post-preemption repeat prefills
+                    if request.prefill_stats and request.num_preemptions <= 0:
+                        assert num_computed_tokens <= request.num_prompt_tokens
+                        request.prefill_stats.set(
+                            num_prompt_tokens=request.num_prompt_tokens,
+                            num_local_cached_tokens=num_new_local_computed_tokens,
+                            num_external_cached_tokens=num_external_computed_tokens,
+                        )
+                else:
+                    # KVTransfer: WAITING reqs have num_computed_tokens > 0
+                    # after async KV recvs are completed.
+                    new_computed_blocks = self.kv_cache_manager.empty_kv_cache_blocks
+                    num_new_local_computed_tokens = 0
+                    num_computed_tokens = request.num_computed_tokens
+
+                encoder_inputs_to_schedule = None
+                external_load_encoder_input = []
+                new_encoder_compute_budget = encoder_compute_budget
+                pad_spec_decode = False
+
+                if load_kv_async:
+                    # KVTransfer: loading remote KV, do not allocate for new work.
+                    assert num_external_computed_tokens > 0
+                    num_new_tokens = 0
+                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                    # DP prefill balancing: defer this step's local prefill
+                    # compute to a cadence-aligned step.
+                    break
+                else:
+                    # Number of tokens to be scheduled.
+                    # We use `request.num_tokens` instead of
+                    # `request.num_prompt_tokens` to consider the resumed
+                    # requests, which have output tokens.
+                    num_new_tokens = request.num_tokens - num_computed_tokens
+
+                    # Pad new decode requests to uniform spec decoding size to
+                    # preserve full cudagraph for this step.
+                    # Not for diffusion where draft tokens can't be padded.
+                    if (
+                        (self.num_spec_tokens > 0 and self.dynamic_sd_lookup is None)
+                        and self.num_sampled_tokens_per_step > 0
+                        and num_new_tokens == 1
+                        and (scheduled_running_reqs and not prefill_scheduled)
+                    ):
+                        num_new_tokens = 1 + self.num_spec_tokens
+                        if num_new_tokens > token_budget or num_computed_tokens + num_new_tokens > self.max_model_len:
+                            # Prefer to not schedule than schedule un-padded here.
+                            break
+                        pad_spec_decode = True
+
+                    threshold = self.scheduler_config.long_prefill_token_threshold
+                    if 0 < threshold < num_new_tokens:
+                        num_new_tokens = threshold
+
+                    # chunked prefill has to be enabled explicitly to allow
+                    # pooling requests to be chunked
+                    if not self.scheduler_config.enable_chunked_prefill and num_new_tokens > token_budget:
+                        # If chunked_prefill is disabled,
+                        # we can stop the scheduling here.
+                        break
+
+                    num_new_tokens = min(num_new_tokens, token_budget)
+                    assert num_new_tokens > 0
+
+                    # Schedule encoder inputs.
+                    if request.has_encoder_inputs:
+                        (
+                            encoder_inputs_to_schedule,
+                            num_new_tokens,
+                            new_encoder_compute_budget,
+                            external_load_encoder_input,
+                        ) = self._try_schedule_encoder_inputs(
+                            request,
+                            num_computed_tokens,
+                            num_new_tokens,
+                            encoder_compute_budget,
+                            shift_computed_tokens=1 if self.use_eagle else 0,
+                        )
+                        if num_new_tokens == 0:
+                            # The request cannot be scheduled.
+                            break
+
+                # Skip block alignment when setting up async receive (no local work).
+                if self.need_mamba_block_aligned_split and not load_kv_async:
+                    num_new_tokens = self._mamba_block_aligned_split(
+                        request,
+                        num_new_tokens,
+                        num_new_local_computed_tokens,
+                        num_external_computed_tokens,
+                    )
+                    if num_new_tokens == 0:
+                        break
+
+                # During async KV load, no forward pass is run yet.
+                # Allocate speculative lookahead slots later to avoid
+                # mismatching local and remote block counts.
+                limit_lookahead_tokens = load_kv_async and self.num_lookahead_tokens > 0
+                effective_lookahead_tokens = 0 if limit_lookahead_tokens else self.num_lookahead_tokens
+
+                # Determine if we need to allocate cross-attention blocks.
+                num_encoder_tokens = 0
+                if self.is_encoder_decoder and request.has_encoder_inputs and encoder_inputs_to_schedule:
+                    num_encoder_tokens = sum(request.get_num_encoder_embeds(i) for i in encoder_inputs_to_schedule)
+
+                reserved_blocks = 0
+                if load_kv_async:
+                    # An async load holds its blocks for the whole transfer with
+                    # no forward progress and isn't preemptible here. Admit it
+                    # only if it fits in (free - other in-flight reservations), to
+                    # avoid deadlock and predictable preemptions.
+                    reserved_blocks = self._inflight_prefill_reserved_blocks()
+
+                new_blocks = self.kv_cache_manager.allocate_slots(
+                    request,
+                    num_new_tokens,
+                    num_new_computed_tokens=num_new_local_computed_tokens,
+                    new_computed_blocks=new_computed_blocks,
+                    num_lookahead_tokens=effective_lookahead_tokens,
+                    num_external_computed_tokens=num_external_computed_tokens,
+                    delay_cache_blocks=load_kv_async,
+                    num_encoder_tokens=num_encoder_tokens,
+                    full_sequence_must_fit=self.scheduler_reserve_full_isl,
+                    reserved_blocks=reserved_blocks,
+                    has_scheduled_reqs=bool(self.running),
+                )
+
+                if new_blocks is None:
+                    # The request cannot be scheduled.
+
+                    # NOTE: we need to untouch the request from the encode cache
+                    # manager
+                    if request.has_encoder_inputs:
+                        self.encoder_cache_manager.free(request)
+                    break
+
+                # KVTransfer: the connector uses this info to determine
+                # if a load is needed. Note that
+                # This information is used to determine if a load is
+                # needed for this request.
+                if self.connector is not None:
+                    self.connector.update_state_after_alloc(
+                        request,
+                        self.kv_cache_manager.get_blocks(request_id),
+                        num_external_computed_tokens,
+                    )
+                    if self.connector_prefix_cache_stats is not None and connector_prefix_cache_queries != 0:
+                        self.connector_prefix_cache_stats.record(
+                            num_tokens=connector_prefix_cache_queries,
+                            num_hits=connector_prefix_cache_hits,
+                            preempted=request.num_preemptions > 0,
+                        )
+
+                # Record at admission so unscheduled lookups are not counted.
+                if did_prefix_cache_lookup:
+                    self._record_prefix_cache_stats(
+                        request,
+                        num_new_local_computed_tokens,
+                    )
+
+                request = request_queue.pop_request()
+                if load_kv_async:
+                    # If loading async, allocate memory and put request
+                    # into the WAITING_FOR_REMOTE_KV state.
+                    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                    step_skipped_waiting.prepend_request(request)
+                    # Set num_computed_tokens even though KVs are not yet loaded.
+                    # request.num_computed_tokens will not be used anywhere until
+                    # the request finished the KV transfer.
+                    #
+                    # If a transfer error is reported by the connector,
+                    # request.num_computed_tokens will be re-set accordingly in
+                    # _update_requests_with_invalid_blocks.
+                    #
+                    # When the transfer is finished, either successfully or not,
+                    # request.num_computed_tokens will correctly reflect the number
+                    # of computed tokens.
+                    # _update_waiting_for_remote_kv will then cache
+                    # only the successfully loaded tokens.
+                    request.num_computed_tokens = num_computed_tokens
+                    self._inflight_prefills.add(request)
+                    if self.needs_kv_cache_zeroing:
+                        # Skip zeroing of the blocks the async load will
+                        # overwrite; the zeroing could race the write.
+                        self._skip_zero_block_ids.update(
+                            self.kv_cache_manager.get_zeroing_block_ids_in_range(
+                                request.request_id,
+                                num_new_local_computed_tokens,
+                                num_computed_tokens,
+                            )
+                        )
+                    continue
+
+                self.running.append(request)
+                if self.log_stats:
+                    request.record_event(EngineCoreEventType.SCHEDULED, scheduled_timestamp)
+                if request.status == RequestStatus.WAITING:
+                    scheduled_new_reqs.append(request)
+                elif request.status == RequestStatus.PREEMPTED:
+                    scheduled_resumed_reqs.append(request)
+                else:
+                    raise RuntimeError(f"Invalid request status: {request.status}")
+
+                if self.lora_config and request.lora_request:
+                    scheduled_loras.add(request.lora_request.lora_int_id)
+                req_to_new_blocks[request_id] = self.kv_cache_manager.get_blocks(request_id)
+                num_scheduled_tokens[request_id] = num_new_tokens
+                token_budget -= num_new_tokens
+                request.status = RequestStatus.RUNNING
+                request.num_computed_tokens = num_computed_tokens
+                if pad_spec_decode:
+                    scheduled_spec_decode_tokens[request_id] = [-1] * self.num_spec_tokens
+                # Only track requests that will still be prefilling after this chunk.
+                if num_computed_tokens + num_new_tokens < request.num_tokens:
+                    self._inflight_prefills.add(request)
+                # Encoder-related.
+                if encoder_inputs_to_schedule:
+                    scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
+                    # Allocate the encoder cache.
+                    for i in encoder_inputs_to_schedule:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+                    encoder_compute_budget = new_encoder_compute_budget
+                # Allocate for external load encoder cache
+                if external_load_encoder_input:
+                    for i in external_load_encoder_input:
+                        self.encoder_cache_manager.allocate(request, i)
+                        if self.ec_connector is not None:
+                            self.ec_connector.update_state_after_alloc(request, i)
+
+            # re-queue requests skipped in this pass ahead of older skipped items.
+            if step_skipped_waiting:
+                self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+            # DP prefill balancing: on a step that admitted prefills (release),
+            # record whether it was capacity-bound.
+            if not defer_prefills:
+                self.prefill_capacity_bound = bool(self.waiting)
+
+        # Check if the scheduling constraints are satisfied.
+        total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
+        assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+
+        assert token_budget >= 0
+        assert len(self.running) <= self.max_num_running_reqs
+        # Since some requests in the RUNNING queue may not be scheduled in
+        # this step, the total number of scheduled requests can be smaller than
+        # len(self.running).
+        assert len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(scheduled_running_reqs) <= len(self.running)
+
+        # Get the longest common prefix among all requests in the running queue.
+        # This can be potentially used for cascade attention.
+        num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
+        with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
+            if self.running:
+                any_request_id = self.running[0].request_id
+                num_common_prefix_blocks = self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)
+
+        # Construct the scheduler output.
+        if self.use_v2_model_runner:
+            scheduled_new_reqs.extend(scheduled_resumed_reqs)
+            scheduled_resumed_reqs.clear()
+            new_reqs_data = [
+                NewRequestData.from_request(
+                    req,
+                    req_to_new_blocks[req.request_id].get_block_ids(),
+                    req._all_token_ids,
+                )
+                for req in scheduled_new_reqs
+            ]
+        else:
+            new_reqs_data = [
+                NewRequestData.from_request(req, req_to_new_blocks[req.request_id].get_block_ids())
+                for req in scheduled_new_reqs
+            ]
+
+        with record_function_or_nullcontext("schedule: make_cached_request_data"):
+            cached_reqs_data = self._make_cached_request_data(
+                scheduled_running_reqs,
+                scheduled_resumed_reqs,
+                num_scheduled_tokens,
+                scheduled_spec_decode_tokens,
+                req_to_new_blocks,
+            )
+
+        # Record the request ids that were scheduled in this step (MRV1-only).
+        if not self.use_v2_model_runner:
+            self.prev_step_scheduled_req_ids.clear()
+            self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
+
+        # Producer partial-tail hand-off for external KV connectors. Drained
+        # before the CoW retentions are released below, so the pin lands while
+        # the cow block still holds a retention ref. Without a producer-side
+        # connector nothing consumes the hand-off, so skip the drain (and its
+        # pin); the manager drops stale entries when the request's blocks are
+        # popped for free.
+        pending_partial_tail_offloads = None
+        if (
+            self._scheduler_output_supports("partial_tail_offloads")
+            and self.connector is not None
+            and self.vllm_config.kv_transfer_config is not None
+            and self.vllm_config.kv_transfer_config.is_kv_producer
+        ):
+            take_partial_tail_offloads = getattr(
+                self.kv_cache_manager,
+                "take_partial_tail_offloads",
+                None,
+            )
+            if callable(take_partial_tail_offloads):
+                pending_partial_tail_offloads = take_partial_tail_offloads() or None
+
+        kv_cache_block_copies, cow_retained_blocks = self.kv_cache_manager.take_kv_cache_block_copies()
+        if kv_cache_block_copies:
+            # The copies run with this step's execution; the first non-empty
+            # step at or after it gets seq `sched_step_seq + 1` (0-token steps
+            # do not advance the seq), and its completion implies the copies
+            # have run.
+            self._free_cow_retained_blocks(cow_retained_blocks, self.sched_step_seq + 1)
+        pending_kv_cache_block_copies = kv_cache_block_copies or None
+
+        # Dynamic speculative decoding: compute optimal K
+        num_spec_tokens_to_schedule = self.num_spec_tokens
+        if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
+            num_spec_tokens_to_schedule = self.dynamic_sd_lookup[len(num_scheduled_tokens)]
+
+        scheduled_encoder_input_stats = None
+        if self.log_stats and self.observability_config.enable_logging_iteration_details:
+            scheduled_encoder_input_stats = self._make_scheduled_encoder_input_stats(scheduled_encoder_inputs)
+
+        scheduler_output_kwargs = dict(
+            scheduled_new_reqs=new_reqs_data,
+            scheduled_cached_reqs=cached_reqs_data,
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=total_num_scheduled_tokens,
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            scheduled_encoder_inputs=scheduled_encoder_inputs,
+            scheduled_encoder_input_stats=scheduled_encoder_input_stats,
+            num_common_prefix_blocks=num_common_prefix_blocks,
+            preempted_req_ids=self.reset_preempted_req_ids,
+            # finished_req_ids is an existing state in the scheduler,
+            # instead of being newly scheduled in this step.
+            # It contains the request IDs that are finished in between
+            # the previous and the current steps.
+            finished_req_ids=self.finished_req_ids,
+            free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
+            new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
+            kv_cache_block_copies=pending_kv_cache_block_copies,
+            num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+        )
+        if self._scheduler_output_supports("partial_tail_offloads"):
+            scheduler_output_kwargs["partial_tail_offloads"] = pending_partial_tail_offloads
+        if self._scheduler_output_supports("ec_manager_metadata"):
+            get_manager_metadata = getattr(
+                self.encoder_cache_manager,
+                "get_manager_metadata",
+                None,
+            )
+            if callable(get_manager_metadata):
+                scheduler_output_kwargs["ec_manager_metadata"] = get_manager_metadata()
+        scheduler_output = SchedulerOutput(**scheduler_output_kwargs)
+
+        # NOTE(Kuntai): this function is designed for multiple purposes:
+        # 1. Plan the KV cache store
+        # 2. Wrap up all the KV cache load / save ops into an opaque object
+        # 3. Clear the internal states of the connector
+        if self.connector is not None:
+            meta = self._build_kv_connector_meta(self.connector, scheduler_output)
+            scheduler_output.kv_connector_metadata = meta
+
+        # Build the connector meta for ECConnector
+        if self.ec_connector is not None:
+            ec_meta: ECConnectorMetadata = self.ec_connector.build_connector_meta(scheduler_output)
+            scheduler_output.ec_connector_metadata = ec_meta
+
+        # Advance the fence only for non-empty steps (those that actually
+        # write KV and have their output processed later in update_from_output).
+        if self.defer_block_free and total_num_scheduled_tokens > 0:
+            self.sched_step_seq += 1
+
+        with record_function_or_nullcontext("schedule: update_after_schedule"):
+            self._update_after_schedule(scheduler_output)
+        # delta for dyntra_lb: print optional scheduler diagnostics.
+        if self._enable_diagnostics:
+            print_scheduler_summary(self, scheduler_output)
+        return scheduler_output
+
+
+class AsyncDyntraLBScheduler(DyntraLBScheduler, AsyncScheduler):
+    """DyntraLB scheduler with vLLM's asynchronous scheduling semantics."""
+
+    pass

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -50,6 +50,13 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
+# delta for dyntra_lb: reuse the load-balancing policy mixin and scheduler diagnostics.
+from vllm_ascend.core.dyntra_lb_scheduler import (
+    DyntraLBPolicyMixin,
+    diagnostics_enabled,
+    print_scheduler_summary,
+)
+
 
 @dataclass
 class RecomputeSchedulerConfig(SchedulerConfig):
@@ -133,6 +140,16 @@ class RecomputeScheduler(Scheduler):
         blocks, num_local, shared_prefix_boundary = kv_cache_manager.get_computed_blocks(request)
         return blocks, num_local, shared_prefix_boundary, False
 
+    # delta for dyntra_lb: provide an overridable no-op hook for applying a cross-rank plan.
+    def _apply_load_balance_modifications(self) -> None:
+        """Apply optional scheduling-policy changes before running requests."""
+        return
+
+    # delta for dyntra_lb: provide an overridable no-op hook for filtering waiting-request admission.
+    def _can_admit_waiting_request(self, request: Request) -> bool:
+        """Return whether an optional policy allows this waiting request."""
+        return True
+
     def _update_waiting_for_remote_kv(self, request: Request) -> None:
         """
         KV Connector: update request state after async recv is finished.
@@ -198,6 +215,9 @@ class RecomputeScheduler(Scheduler):
         preempted_reqs: list[Request] = []
         preempted_req_data: list[PreemptedRequestData] = []
         recomputed_reqs: list[RecomputeReqInfo] = []
+
+        # delta for dyntra_lb: apply cross-rank request migrations before allocating this scheduling step.
+        self._apply_load_balance_modifications()
 
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
         num_scheduled_tokens: dict[str, int] = {}
@@ -494,6 +514,12 @@ class RecomputeScheduler(Scheduler):
                             "[RecomputeScheduler] %s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                # delta for dyntra_lb: admit only waiting requests selected by the current load-balancing plan.
+                if not self._can_admit_waiting_request(request):
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
@@ -936,6 +962,9 @@ class RecomputeScheduler(Scheduler):
 
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
+        # delta for dyntra_lb: emit per-step queue and KV-block diagnostics when explicitly enabled.
+        if diagnostics_enabled(self.vllm_config):
+            print_scheduler_summary(self, scheduler_output)
         return scheduler_output
 
     def _build_kv_connector_meta(
@@ -1288,3 +1317,13 @@ class RecomputeScheduler(Scheduler):
 class AsyncRecomputeScheduler(AsyncScheduler, RecomputeScheduler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+
+# delta for dyntra_lb: combine the synchronous recompute scheduler with the DyntraLB policy.
+class DyntraLBRecomputeScheduler(DyntraLBPolicyMixin, RecomputeScheduler):
+    pass
+
+
+# delta for dyntra_lb: combine async recompute scheduling with the same DyntraLB policy.
+class AsyncDyntraLBRecomputeScheduler(DyntraLBPolicyMixin, AsyncRecomputeScheduler):
+    pass

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -84,7 +84,29 @@
 #       handles a pre-sharded visible-devices env var, or vLLM-Ascend stops
 #       relying on application-level device slicing for DP.
 #
-# ** 5. File: platform/patch_eplb.py**
+# ** 5. File: platform/patch_dyntra_lb_core.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
+#      `vllm.v1.engine.core.DPEngineCoreProc`
+#    Why:
+#       PD-disaggregated decoder serving can develop uneven attention KV-cache
+#       workloads across data-parallel ranks. Upstream vLLM does not currently
+#       expose an extension point for selecting an Ascend-specific DP engine
+#       core that coordinates dynamic cross-rank scheduling decisions.
+#    How:
+#       When DyntraLB is enabled, replace the DP engine-core process with the
+#       DyntraLB implementation at engine startup. The implementation exchanges
+#       lightweight scheduling metadata across DP ranks and applies the
+#       resulting admission, pause, and resume decisions through the DyntraLB
+#       scheduler while preserving the original path when the feature is off.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm-ascend/pull/12292
+#    Future Plan:
+#       Remove this patch after upstream vLLM provides stable scheduler and DP
+#       engine-core plugin interfaces, or equivalent dynamic intra-decoder DP
+#       load balancing that vllm-ascend can use without monkey-patching.
+#
+# ** 6. File: platform/patch_eplb.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.parallel.current_platform`
 #   2. `vllm.distributed.eplb.eplb_state._move_to_workspace`
@@ -106,7 +128,7 @@
 #       available in the supported vLLM version. Retain only the NPU backend,
 #       operator, communicator, load normalization, and weight views.
 #
-# ** 6. File: platform/patch_fused_moe.py**
+# ** 7. File: platform/patch_fused_moe.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.layers.fused_moe.FusedMoEFactory`
 #    Why:
@@ -126,7 +148,7 @@
 #       Remove this patch once upstream exposes a backend dispatch / plugin hook
 #       for selecting the MoE runner implementation.
 #
-# ** 7. File: platform/patch_kv_cache_coordinator.py**
+# ** 8. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.HybridKVCacheCoordinator.find_longest_cache_hit_per_group`
 #    Why:
@@ -150,7 +172,7 @@
 #       Remove this patch when vLLM PR #42524 and #44243 is included in the supported
 #       upstream vLLM version.
 #
-# ** 8. File: platform/patch_kv_cache_utils.py**
+# ** 9. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
 #      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
@@ -169,7 +191,7 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
-# ** 9. File: platform/patch_mamba_config.py**
+# ** 10. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -181,7 +203,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM merges the PR.
 #
-# ** 10. File: platform/patch_mamba_config_310.py**
+# ** 11. File: platform/patch_mamba_config_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -198,7 +220,7 @@
 #    Future Plan:
 #       Remove this patch once upstream supports 310P-aligned mamba block sizing.
 #
-# ** 11. File: platform/patch_mamba_manager.py**
+# ** 12. File: platform/patch_mamba_manager.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.single_type_kv_cache_manager.MambaManager`
 #    Why:
@@ -218,7 +240,7 @@
 #          hybrid prefix cache lookup for DCP.
 #       2. Remove this patch once upstream accept 46892 pr or fixed the bug by other pr.
 #
-# ** 12. File: platform/patch_minimax_m2_config.py**
+# ** 13. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.ModelConfig._verify_quantization`
 #    Why:
@@ -279,7 +301,7 @@
 #       Drop the alias once upstream registry includes it or the checkpoint
 #       standardizes architecture strings.
 #
-# ** 13. File: platform/patch_mla_prefill_backend.py**
+# ** 14. File: platform/patch_mla_prefill_backend.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.attention.backends.mla.common.get_mla_prefill_backend`
 #    Why:
@@ -301,7 +323,7 @@
 #       platform/device hook so Ascend can be selected (or skipped) without
 #       monkey-patching.
 #
-# ** 14. File: platform/patch_multiproc_executor.py**
+# ** 15. File: platform/patch_multiproc_executor.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.executor.multiproc_executor.MultiprocExecutor`
 #    Why:
@@ -314,7 +336,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM fix the issue.
 #
-# ** 15. File: platform/patch_pp_mtp.py**
+# ** 16. File: platform/patch_pp_mtp.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.outputs.ModelRunnerOutput`
 #    Why:
@@ -404,7 +426,7 @@
 #       supports local drafter models with PP > 1, or moves the PP validation to a
 #       separate hook that can be overridden per-model-type.
 #
-# ** 16. File: platform/patch_profiling_chunk.py**
+# ** 17. File: platform/patch_profiling_chunk.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCore.__init__`
 #   2. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
@@ -432,7 +454,7 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 17. File: platform/patch_speculative_config.py**
+# ** 18. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -455,7 +477,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 18. File: platform/patch_structured_output.py**
+# ** 19. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -477,7 +499,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 19. File: platform/patch_torch_accelerator.py**
+# ** 20. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -497,7 +519,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 20. File: platform/patch_tool_choice_none_content.py**
+# ** 21. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -513,7 +535,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 21. File: platform/patch_use_v2_model_runner.py**
+# ** 22. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -37,6 +37,7 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
+import vllm_ascend.patch.platform.patch_dyntra_lb_core  # noqa
 
 import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
 import vllm_ascend.patch.platform.patch_speculative_config  # noqa

--- a/vllm_ascend/patch/platform/patch_dyntra_lb_core.py
+++ b/vllm_ascend/patch/platform/patch_dyntra_lb_core.py
@@ -1,0 +1,547 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections.abc import Sequence
+from typing import Literal, TypedDict
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import vllm.v1.engine.core as _engine_core_mod
+import vllm.v1.request as _request_module
+from vllm.logger import logger
+from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
+from vllm.v1.request import Request
+
+import vllm_ascend.patch.platform.patch_balance_schedule as _balance_patch
+from vllm_ascend.ascend_config import DyntraLBConfig, get_ascend_config, init_ascend_config
+from vllm_ascend.core.dyntra_lb_scheduler import (
+    diagnostics_enabled,
+    get_dyntra_lb_request_block_num,
+)
+
+RequestStatus = _request_module.RequestStatus
+_ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS = DPEngineCoreProc._has_global_unfinished_reqs
+
+
+class _RequestItem(TypedDict):
+    blk_num: int
+    newly_added: bool
+
+
+class _CardData(TypedDict):
+    card_idx: int
+    running: list[_RequestItem]
+    waiting: list[_RequestItem]
+    tot_blk: int
+
+
+class _Modification(TypedDict):
+    out_blk: list[int]
+    in_blk: list[int]
+    freeze: bool
+
+
+def _get_dyntra_lb_config(vllm_config) -> DyntraLBConfig:
+    try:
+        return get_ascend_config().scheduler_config.dyntra_lb_config
+    except Exception:
+        pass
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    scheduler_config = additional_config.get("scheduler_config") or {}
+    if not isinstance(scheduler_config, dict):
+        return DyntraLBConfig()
+    dyntra_lb_config = scheduler_config.get("dyntra_lb_config") or {}
+    if not isinstance(dyntra_lb_config, dict):
+        return DyntraLBConfig()
+    return DyntraLBConfig(dyntra_lb_config)
+
+
+def _dyntra_lb_enabled(vllm_config) -> bool:
+    return _get_dyntra_lb_config(vllm_config).enabled
+
+
+def _print_rank_0(message: str, dp_rank: int, enable_diagnostics: bool) -> None:
+    if not enable_diagnostics or dp_rank != 0:
+        return
+    logger.info("[dyntra_lb] %s", message)
+
+
+def _print_requests_by_rank(requests_by_rank, dp_rank: int, enable_diagnostics: bool) -> None:
+    if not enable_diagnostics or dp_rank != 0:
+        return
+
+    logger.info("%s", "=" * 85)
+    logger.info("[dyntra_lb] requests_by_rank (DP Workload Status):")
+    for rank, (blocks, split_idx) in enumerate(requests_by_rank):
+        running = blocks[:split_idx]
+        waiting = [block for block in blocks[split_idx:] if block > 0]
+        running_items = ", ".join(f"{block:3d}" for block in running)
+        waiting_items = ", ".join(f"{block:3d}" for block in waiting)
+        running_str = f"Run({len(running)}): [{running_items}]"
+        waiting_str = f"Wait({len(waiting)}): [{waiting_items}]"
+        logger.info(" DP%d | %-55s | %s", rank, running_str, waiting_str)
+    logger.info("%s", "=" * 85)
+
+
+def _print_modifications(modifications, dp_rank: int, enable_diagnostics: bool) -> None:
+    if not enable_diagnostics or dp_rank != 0:
+        return
+
+    logger.info("%s", "=" * 60)
+    logger.info("[dyntra_lb] modifications:")
+    for rank, modification in enumerate(modifications):
+        out_items = ", ".join(f"{block:3d}" for block in modification.get("out_blk", []))
+        in_items = ", ".join(f"{block:3d}" for block in modification.get("in_blk", []))
+        out_str = f"Out: [{out_items}]"
+        in_str = f"In: [{in_items}]"
+        freeze_str = f"Freeze: {bool(modification.get('freeze', False))}"
+        logger.info(" DP%d | %-15s | %-15s | %s", rank, out_str, in_str, freeze_str)
+    logger.info("%s", "=" * 60)
+
+
+def _has_global_unfinished_reqs_with_diagnostics(self, local_unfinished: bool) -> bool:
+    if diagnostics_enabled(self.vllm_config):
+        logger.info("_has_global_unfinished_reqs | step_counter: %d", self.step_counter)
+    return _ORIGINAL_HAS_GLOBAL_UNFINISHED_REQS(self, local_unfinished)
+
+
+class DyntraLBDPEngineCoreProc(DPEngineCoreProc):
+    @staticmethod
+    def _balance_load(
+        requests_by_rank: Sequence[tuple[Sequence[int], int]],
+        dev_num: int,
+        max_num_seqs: int | None = None,
+        max_iters: int = 1000,
+        threshold: float = 5,
+    ) -> list[_Modification]:
+        modifications: list[_Modification] = [{"out_blk": [], "in_blk": [], "freeze": False} for _ in range(dev_num)]
+
+        def calc_bubble(cards_info: Sequence[_CardData]) -> float:
+            tot_blks = [c["tot_blk"] for c in cards_info]
+            max_blk = max(tot_blks)
+            avg_blk = sum(tot_blks) / dev_num
+            if threshold < 1:
+                return (max_blk - avg_blk) / max_blk if max_blk > 0 else 0.0
+            return max_blk - avg_blk
+
+        def perform_swap(
+            run_item: _RequestItem,
+            wait_item: _RequestItem,
+            card: _CardData,
+        ) -> None:
+            card_idx = card["card_idx"]
+            modifications[card_idx]["out_blk"].append(run_item["blk_num"])
+            modifications[card_idx]["in_blk"].append(wait_item["blk_num"])
+            card["tot_blk"] += wait_item["blk_num"] - run_item["blk_num"]
+            card["running"].remove(run_item)
+            card["waiting"].remove(wait_item)
+            card["running"].append(wait_item)
+            card["waiting"].append(run_item)
+
+        def perform_pull_in(
+            wait_item: _RequestItem,
+            card: _CardData,
+        ) -> None:
+            card_idx = card["card_idx"]
+            modifications[card_idx]["in_blk"].append(wait_item["blk_num"])
+            card["tot_blk"] += wait_item["blk_num"]
+            card["waiting"].remove(wait_item)
+            card["running"].append(wait_item)
+
+        def fill_running_from_waiting(card: _CardData) -> bool:
+            if max_num_seqs is None:
+                return False
+            pulled_any = False
+            while len(card["running"]) < max_num_seqs and card["waiting"]:
+                item = card["waiting"][0]
+                item["newly_added"] = True
+                perform_pull_in(item, card)
+                pulled_any = True
+            return pulled_any
+
+        def find_best_swap(
+            card: _CardData,
+            mode: Literal["increase", "decrease"],
+        ) -> tuple[_RequestItem, _RequestItem] | None:
+            target_avg = sum(c["tot_blk"] for c in cards_data) / dev_num
+            best_swap: tuple[_RequestItem, _RequestItem] | None = None
+            best_dist = abs(card["tot_blk"] - target_avg)
+            best_newly_added = False
+
+            for run_item in card["running"]:
+                for wait_item in card["waiting"]:
+                    delta = wait_item["blk_num"] - run_item["blk_num"]
+                    if mode == "increase" and delta <= 0:
+                        continue
+                    if mode == "decrease" and delta >= 0:
+                        continue
+                    new_tot = card["tot_blk"] + delta
+                    new_avg = target_avg + delta / dev_num
+                    new_dist = abs(new_tot - new_avg)
+                    run_newly_added = run_item.get("newly_added", False)
+                    if new_dist < best_dist or (new_dist == best_dist and run_newly_added and not best_newly_added):
+                        best_dist = new_dist
+                        best_swap = (run_item, wait_item)
+                        best_newly_added = run_newly_added
+            return best_swap
+
+        def try_drop_for_throughput(max_card: _CardData) -> bool:
+            # Estimate single-step latency from the maximum block count.
+            STEP_LATENCY_FIXED_OVERHEAD = 20000
+            STEP_LATENCY_PER_BLOCK = 19.2
+
+            card_idx = max_card["card_idx"]
+            total_reqs = sum(len(c["running"]) for c in cards_data)
+            if total_reqs <= 1:
+                return False
+
+            max_blk = max_card["tot_blk"]
+            second_max_blk = max([c["tot_blk"] for c in cards_data if c["card_idx"] != card_idx] + [0])
+            current_latency = STEP_LATENCY_FIXED_OVERHEAD + STEP_LATENCY_PER_BLOCK * max_blk
+            current_tp = total_reqs / current_latency
+            best_drop: _RequestItem | None = None
+            best_tp = current_tp
+            best_newly_added = False
+
+            for run_item in max_card["running"]:
+                new_max_blk = max(
+                    max_blk - run_item["blk_num"],
+                    second_max_blk,
+                )
+                new_latency = STEP_LATENCY_FIXED_OVERHEAD + STEP_LATENCY_PER_BLOCK * new_max_blk
+                new_tp = (total_reqs - 1) / new_latency
+                run_newly_added = run_item.get("newly_added", False)
+                if new_tp > best_tp or (new_tp == best_tp and run_newly_added and not best_newly_added):
+                    best_tp = new_tp
+                    best_drop = run_item
+                    best_newly_added = run_newly_added
+
+            if best_drop:
+                modifications[card_idx]["out_blk"].append(best_drop["blk_num"])
+                max_card["tot_blk"] -= best_drop["blk_num"]
+                max_card["running"].remove(best_drop)
+                max_card["waiting"].append(best_drop)
+                return True
+            return False
+
+        cards_data: list[_CardData] = []
+        for rank in range(dev_num):
+            blks, split = requests_by_rank[rank] if rank < len(requests_by_rank) else ([], 0)
+            running: list[_RequestItem] = []
+            waiting: list[_RequestItem] = []
+            tot_run_blk = 0
+            for index, blk_num in enumerate(blks):
+                if blk_num == 0:
+                    break
+                req_obj: _RequestItem = {
+                    "blk_num": blk_num,
+                    "newly_added": False,
+                }
+                if index < split:
+                    running.append(req_obj)
+                    tot_run_blk += blk_num
+                else:
+                    waiting.append(req_obj)
+            cards_data.append(
+                {
+                    "card_idx": rank,
+                    "running": running,
+                    "waiting": waiting,
+                    "tot_blk": tot_run_blk,
+                }
+            )
+
+        for card in cards_data:
+            fill_running_from_waiting(card)
+
+        iteration = 0
+        while iteration < max_iters:
+            cards_data.sort(key=lambda x: x["tot_blk"], reverse=True)
+            if calc_bubble(cards_data) < threshold:
+                break
+
+            swapped_this_round = False
+            dropped_this_round = False
+            min_card = cards_data[-1]
+            best_min_swap = find_best_swap(min_card, mode="increase")
+            if best_min_swap:
+                perform_swap(best_min_swap[0], best_min_swap[1], min_card)
+                swapped_this_round = True
+
+            if swapped_this_round:
+                if calc_bubble(cards_data) < threshold:
+                    break
+                cards_data.sort(key=lambda x: x["tot_blk"], reverse=True)
+
+            max_card = cards_data[0]
+            best_max_swap = find_best_swap(max_card, mode="decrease")
+            if best_max_swap:
+                perform_swap(best_max_swap[0], best_max_swap[1], max_card)
+                swapped_this_round = True
+
+            if not swapped_this_round and try_drop_for_throughput(max_card):
+                dropped_this_round = True
+
+            if calc_bubble(cards_data) < threshold:
+                break
+            if not swapped_this_round and not dropped_this_round:
+                break
+            iteration += 1
+
+        for mod in modifications:
+            out_blks = mod["out_blk"][:]
+            in_blks = mod["in_blk"][:]
+            cancelled_out = [False] * len(out_blks)
+            cancelled_in = [False] * len(in_blks)
+            for in_index, in_blk in enumerate(in_blks):
+                for out_index, out_blk in enumerate(out_blks):
+                    if not cancelled_out[out_index] and out_blk == in_blk:
+                        cancelled_out[out_index] = True
+                        cancelled_in[in_index] = True
+                        break
+            mod["out_blk"] = [block for block, cancelled in zip(mod["out_blk"], cancelled_out) if not cancelled]
+            mod["in_blk"] = [block for block, cancelled in zip(mod["in_blk"], cancelled_in) if not cancelled]
+
+        for card in cards_data:
+            rank = card["card_idx"]
+            modifications[rank]["freeze"] = len(modifications[rank]["in_blk"]) == 0
+
+        return modifications
+
+    def _init_data_parallel(self, vllm_config):
+        super()._init_data_parallel(vllm_config)
+
+        ascend_config = init_ascend_config(vllm_config)
+        dyntra_lb_config = ascend_config.scheduler_config.dyntra_lb_config
+        self._lb_enable_diagnostics = dyntra_lb_config.enable_diagnostics
+        self._lb_mode = dyntra_lb_config.mode
+        self._lb_start_step = dyntra_lb_config.start_step
+        self._lb_end_step = dyntra_lb_config.end_step
+        self._lb_threshold = dyntra_lb_config.bubble_threshold
+        self._lb_long_req_threshold = dyntra_lb_config.long_req_block_threshold
+        self._lb_dynamic_max_step = dyntra_lb_config.dynamic_max_step
+        self._lb_dynamic_enable = False
+        self._lb_dynamic_step = 0
+        self._lb_pending_long_req = False
+        self._lb_pending_long_req_blk = 0
+
+        _print_rank_0("dyntra_lb_config.enabled = True", self.dp_rank, self._lb_enable_diagnostics)
+        _print_rank_0(
+            f"dyntra_lb_config.enable_diagnostics = {self._lb_enable_diagnostics}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_rank_0(
+            f"dyntra_lb_config.mode = {self._lb_mode}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_rank_0(
+            f"dyntra_lb_config.start_step = {self._lb_start_step}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_rank_0(
+            f"dyntra_lb_config.end_step = {self._lb_end_step}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_rank_0(
+            f"dyntra_lb_config.bubble_threshold = {self._lb_threshold}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_rank_0(
+            f"dyntra_lb_config.long_req_block_threshold = {self._lb_long_req_threshold}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_rank_0(
+            f"dyntra_lb_config.dynamic_max_step = {self._lb_dynamic_max_step}",
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+
+        max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+        dp_size = dist.get_world_size(self.dp_group)
+        max_slots = max_num_seqs * 2
+        self._lb_dp_size_cached = dp_size
+        self._lb_max_slots_cached = max_slots
+        self._lb_max_num_seqs = max_num_seqs
+
+        full_len = max_slots + 2
+        self._lb_data_np = np.zeros(full_len, dtype=np.int32)
+        self._lb_data_t = torch.as_tensor(self._lb_data_np)
+        self._lb_all_data_np = [np.zeros(full_len, dtype=np.int32) for _ in range(dp_size)]
+        self._lb_all_data_t_buf = [torch.as_tensor(arr) for arr in self._lb_all_data_np]
+        self._lb_dynamic_flag_np: np.ndarray = np.zeros(2, dtype=np.int32)
+        self._lb_dynamic_flag_t = torch.as_tensor(self._lb_dynamic_flag_np)
+
+    def add_request(self, request: Request, request_wave: int = 0):
+        if self._lb_mode == "dynamic":
+            blk_num = get_dyntra_lb_request_block_num(self.scheduler, request)
+            if blk_num > self._lb_long_req_threshold:
+                self._lb_pending_long_req = True
+                self._lb_pending_long_req_blk = max(self._lb_pending_long_req_blk, blk_num)
+        super().add_request(request, request_wave)
+
+    def run_balance_load(self):
+        static_lb_enable = self._lb_mode == "static"
+        dynamic_lb_mode = self._lb_mode == "dynamic"
+        dynamic_activated_this_step = False
+
+        if dynamic_lb_mode and not self._lb_dynamic_enable:
+            self._lb_dynamic_flag_np[0] = int(self._lb_pending_long_req)
+            self._lb_dynamic_flag_np[1] = self._lb_pending_long_req_blk
+            dist.all_reduce(self._lb_dynamic_flag_t, op=dist.ReduceOp.MAX, group=self.dp_group)
+            if self._lb_dynamic_flag_np[0]:
+                self._lb_dynamic_enable = True
+                self._lb_dynamic_step = 0
+                dynamic_activated_this_step = True
+                _print_rank_0(
+                    "Dynamic LB enabled by long request: "
+                    f"blk_num={self._lb_dynamic_flag_np[1]}, "
+                    f"threshold={self._lb_long_req_threshold}, "
+                    f"current_wave={self.current_wave}, "
+                    f"step_counter={self.step_counter}",
+                    self.dp_rank,
+                    self._lb_enable_diagnostics,
+                )
+            self._lb_pending_long_req = False
+            self._lb_pending_long_req_blk = 0
+
+        lb_active = (
+            (static_lb_enable or self._lb_dynamic_enable)
+            and self.step_counter >= self._lb_start_step
+            and (self._lb_end_step < 0 or self.step_counter < self._lb_end_step)
+        )
+        self.scheduler._lb_kv_prefetch_enabled = lb_active
+        if lb_active:
+            admission_candidates = self.scheduler.prepare_dyntra_lb_step()
+            has_new_long_req = self._do_lb_allgather(admission_candidates)
+            if dynamic_lb_mode and self._lb_dynamic_enable:
+                if dynamic_activated_this_step or has_new_long_req:
+                    self._lb_dynamic_step = 0
+                else:
+                    self._lb_dynamic_step += 1
+                    if self._lb_dynamic_step >= self._lb_dynamic_max_step:
+                        self._lb_dynamic_enable = False
+                        _print_rank_0(
+                            "Dynamic LB disabled after "
+                            f"{self._lb_dynamic_step} steps without long request: "
+                            f"current_wave={self.current_wave}, "
+                            f"step_counter={self.step_counter}",
+                            self.dp_rank,
+                            self._lb_enable_diagnostics,
+                        )
+        else:
+            self.scheduler.modifications = None
+            self.scheduler.lb_freeze = False
+
+    def _has_global_unfinished_reqs(self, local_unfinished: bool) -> bool:
+        result = _has_global_unfinished_reqs_with_diagnostics(self, local_unfinished)
+        # DyntraLB collectives must follow the DP wave/idle synchronization.
+        # The resulting plan is consumed by the next engine step.
+        if result:
+            self.run_balance_load()
+        else:
+            self.scheduler.modifications = None
+            self.scheduler.lb_freeze = False
+            self.scheduler._lb_kv_prefetch_enabled = False
+            if self._lb_enable_diagnostics:
+                logger.info(
+                    "[dyntra_lb] run_busy_loop() | No engines running, "
+                    "step_counter set to 0, current_wave incremented to %d.",
+                    self.current_wave + 1,
+                )
+        return result
+
+    def _do_lb_allgather(self, admission_candidates: list[Request]) -> bool:
+        max_slots = self._lb_max_slots_cached
+        dp_size = self._lb_dp_size_cached
+        max_num_seqs = self._lb_max_num_seqs
+
+        running_blks = [get_dyntra_lb_request_block_num(self.scheduler, req) for req in self.scheduler.running]
+        waiting_blks = [get_dyntra_lb_request_block_num(self.scheduler, req) for req in admission_candidates]
+
+        arr = self._lb_data_np
+        arr[:] = 0
+        run_cnt = min(len(running_blks), max_slots)
+        wait_cnt = min(len(waiting_blks), max_slots - run_cnt)
+        arr[:run_cnt] = running_blks[:run_cnt]
+        arr[run_cnt : run_cnt + wait_cnt] = waiting_blks[:wait_cnt]
+        arr[max_slots] = run_cnt
+        arr[max_slots + 1] = int(self._lb_pending_long_req)
+        self._lb_pending_long_req = False
+        self._lb_pending_long_req_blk = 0
+
+        dist.all_gather(self._lb_all_data_t_buf, self._lb_data_t, group=self.dp_group)
+
+        requests_by_rank = []
+        has_new_long_req = False
+        for rank_np in self._lb_all_data_np:
+            split = int(rank_np[max_slots])
+            blks = rank_np[:max_slots].tolist()
+            requests_by_rank.append((blks, split))
+            has_new_long_req = has_new_long_req or bool(rank_np[max_slots + 1])
+
+        modifications = self._balance_load(
+            requests_by_rank,
+            dp_size,
+            max_num_seqs=max_num_seqs,
+            threshold=self._lb_threshold,
+        )
+        _print_requests_by_rank(
+            requests_by_rank,
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        _print_modifications(
+            modifications,
+            self.dp_rank,
+            self._lb_enable_diagnostics,
+        )
+        self.scheduler.modifications = modifications[self.dp_rank]
+        return has_new_long_req
+
+
+_PreviousRunEngineCore = EngineCoreProc.run_engine_core
+_UpstreamRunEngineCore = _balance_patch._OriginalRunEngineCore
+_OriginalDPEngineCoreProc = DPEngineCoreProc
+
+
+def _dyntra_lb_run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
+    vllm_config = kwargs.get("vllm_config")
+    dyntra_lb_config = _get_dyntra_lb_config(vllm_config)
+    if not dyntra_lb_config.enabled:
+        return _PreviousRunEngineCore(*args, dp_rank=dp_rank, local_dp_rank=local_dp_rank, **kwargs)
+
+    _print_rank_0(
+        "Enable DyntraLB DP load balancing.",
+        dp_rank,
+        dyntra_lb_config.enable_diagnostics,
+    )
+    _engine_core_mod.DPEngineCoreProc = DyntraLBDPEngineCoreProc
+    try:
+        return _UpstreamRunEngineCore(*args, dp_rank=dp_rank, local_dp_rank=local_dp_rank, **kwargs)
+    finally:
+        _engine_core_mod.DPEngineCoreProc = _OriginalDPEngineCoreProc
+
+
+# Preserve the upstream staticmethod binding when replacing run_engine_core.
+EngineCoreProc.run_engine_core = staticmethod(_dyntra_lb_run_engine_core)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -816,7 +816,7 @@ def _check_ascend_config(vllm_config: VllmConfig, ascend_config) -> None:
 
     Covers the fused-MC2 / hierarchy-communication exclusivity and the scheduler
     extension policies (enable_balance_scheduling / short_request_first_config /
-    recompute_scheduler_enable). Reads from the AscendConfig singleton
+    dyntra_lb_config / recompute_scheduler_enable). Reads from the AscendConfig singleton
     initialized from vllm_config; env fallbacks are handled inside AscendConfig.
     """
     # Fused MC2 and hierarchy communication are mutually exclusive.
@@ -878,6 +878,36 @@ def _check_ascend_config(vllm_config: VllmConfig, ascend_config) -> None:
                 "vllm_ascend.core.short_request_first_scheduler.ShortRequestFirstAsyncScheduler"
             )
 
+    dyntra_lb_config = scheduler_extension_config.dyntra_lb_config
+    if dyntra_lb_config.enabled:
+        # DyntraLB targets decoder-only inference on the decode side of a
+        # PD-disaggregated deployment. It balances attention KV-cache load
+        # across multiple data-parallel ranks within one node.
+        # It is not available on prefill or PD-mixed nodes, across multiple
+        # DP nodes, or together with the other scheduling modes rejected
+        # below.
+        # Verified models: Qwen3-30B, Qwen3.5-35B
+        if scheduler_extension_config.enable_balance_scheduling:
+            raise ValueError("DyntraLB cannot be used with enable_balance_scheduling.")
+        kv_transfer_config = vllm_config.kv_transfer_config
+        kv_role = getattr(kv_transfer_config, "kv_role", None)
+        if kv_transfer_config is None or kv_role != "kv_consumer":
+            raise ValueError(
+                "DyntraLB is only supported on PD-disaggregated D nodes "
+                f"(kv_role='kv_consumer', but got kv_role={kv_role!r})."
+            )
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.data_parallel_size <= 1:
+            raise ValueError("DyntraLB requires data_parallel_size > 1.")
+        if parallel_config.nnodes_within_dp > 1:
+            raise ValueError(
+                "DyntraLB only supports decoder instances that run on a "
+                "single node; got "
+                f"nnodes_within_dp={parallel_config.nnodes_within_dp}."
+            )
+        if scheduler_extension_config.profiling_chunk_config.enabled:
+            raise ValueError("DyntraLB cannot be used with profiling_chunk_config.")
+
     # recompute_scheduler_enable: only supported on PD-disaggregated D nodes
     if scheduler_extension_config.recompute_scheduler_enable:
         kv_transfer_config = vllm_config.kv_transfer_config
@@ -902,7 +932,12 @@ def _check_ascend_config(vllm_config: VllmConfig, ascend_config) -> None:
                 f"(kv_role='kv_consumer', but got kv_role={kv_role!r}), and is not supported in PD-mixed mode."
             )
         else:
+            async_scheduling = vllm_config.scheduler_config.async_scheduling
             recompute_scheduler_config = RecomputeSchedulerConfig.initialize_from_config(vllm_config)
+            recompute_scheduler_config.scheduler_cls = _get_recompute_scheduler_cls(
+                async_scheduling=async_scheduling,
+                dyntra_lb_enabled=dyntra_lb_config.enabled,
+            )
             vllm_config.scheduler_config = recompute_scheduler_config
 
 
@@ -1113,6 +1148,11 @@ def _setup_worker_and_scheduler(
 
     # Select specialized scheduler class
     scheduler_config = ascend_config.scheduler_config
+    if scheduler_config.dyntra_lb_config.enabled and not scheduler_config.recompute_scheduler_enable:
+        vllm_config.scheduler_config.scheduler_cls = _get_dyntra_lb_scheduler_cls(
+            async_scheduling=vllm_config.scheduler_config.async_scheduling
+        )
+
     # Use ProfilingChunkScheduler when profiling-based chunk sizing is on.
     if scheduler_config.profiling_chunk_config.enabled:
         vllm_config.scheduler_config.scheduler_cls = (
@@ -1306,6 +1346,26 @@ def _prune_capture_sizes_for_950(vllm_config):
         len(original_sizes),
         MAX_CAPTURE_SIZES_FOR_950,
     )
+
+
+def _get_recompute_scheduler_cls(
+    *,
+    async_scheduling: bool,
+    dyntra_lb_enabled: bool,
+) -> str:
+    if dyntra_lb_enabled:
+        if async_scheduling:
+            return "vllm_ascend.core.recompute_scheduler.AsyncDyntraLBRecomputeScheduler"
+        return "vllm_ascend.core.recompute_scheduler.DyntraLBRecomputeScheduler"
+    if async_scheduling:
+        return "vllm_ascend.core.recompute_scheduler.AsyncRecomputeScheduler"
+    return "vllm_ascend.core.recompute_scheduler.RecomputeScheduler"
+
+
+def _get_dyntra_lb_scheduler_cls(*, async_scheduling: bool) -> str:
+    if async_scheduling:
+        return "vllm_ascend.core.dyntra_lb_scheduler.AsyncDyntraLBScheduler"
+    return "vllm_ascend.core.dyntra_lb_scheduler.DyntraLBScheduler"
 
 
 def _validate_parallel_config(vllm_config: VllmConfig) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces DyntraLB, a load-aware scheduler for intra-decoder data-parallel instances in prefill/decode (P/D) disaggregated deployments.

With uneven request lengths, Decode DP ranks may finish attention computation at different times. Because attention-MoE data-parallel/expert-parallel switching requires a global Dispatch, lightly loaded ranks must wait for the busiest rank. DyntraLB reduces these bubbles by coordinating request admission and execution across the Decode DP group, which relaxes the constraints of bulk synchronous parallel (BSP) execution.

DyntraLB does not migrate requests or KV cache between ranks. Each rank keeps ownership of its local requests. At coordinated engine steps, ranks exchange snapshots of running requests and admissible waiting requests. The planner estimates request load from KV-cache block counts and generates a per-rank plan that can:

- keep a local running request active;
- pause a local running request while retaining its KV cache;
- resume a previously paused request;
- admit selected local waiting requests; or
- freeze new admission on a rank for the next step.

The load-balancing decision is pipelined across two engine steps: the current step produces the workload snapshot and plan, and the following step applies that plan before normal scheduling and model execution.

The implementation includes:

- configurable activation windows and imbalance thresholds;
- synchronous and asynchronous scheduling paths;
- integration with recompute scheduling;
- support for MTP speculative decoding;
- preservation of waiting, skipped-waiting, running, paused, resumed, stopped, preempted, and finished request lifecycle semantics;
- startup validation for unsupported deployment and scheduler combinations;
- user documentation and unit-test coverage.

Refs #12257

The design and benchmark benefits for the target deployment were discussed and recognized in the weekly community meeting recorded in #10928.

#### Configuration

DyntraLB is configured under `scheduler_config` in `--additional-config`:

```bash
--additional-config '{
  "scheduler_config": {
    "dyntra_lb_config": {
      "enabled": true
    }
  }
}'
```

The configuration fields and defaults are:

| Field | Default | Meaning |
| --- | ---: | --- |
| `enabled` | `false` | Enable DyntraLB and select a DyntraLB-aware scheduler. |
| `mode` | `"dynamic"` | Use `"static"` or `"dynamic"` activation. |
| `start_step` | `250` | First completed engine-step snapshot allowed to generate a plan. |
| `end_step` | `-1` | Exclusive final snapshot step; `-1` means no upper bound. |
| `bubble_threshold` | `5.0` | Minimum maximum-to-average rank-load difference required to modify scheduling. Values `>= 1` are KV-cache blocks; values `< 1` are normalized ratios. |
| `long_req_block_threshold` | `700` | In dynamic mode, a newly added request above this block count activates balancing.  The default threshold corresponds to approximately 89,600 tokens when `block_size=128`.|
| `dynamic_max_step` | `256` | Stop dynamic balancing after this many active steps without another newly added long request. |
| `enable_diagnostics` | `false` | Enable verbose logs for feature validation and debugging only. It is disabled by default and should remain disabled in production. |

#### Supported deployment

DyntraLB currently requires:

- a P/D-disaggregated Decode node with `kv_role="kv_consumer"`;
- internal data parallelism with `data_parallel_size > 1`;
- all Decode DP ranks on a single node.

It is rejected at startup when combined with:

- `scheduler_config.enable_balance_scheduling`; or
- `scheduler_config.profiling_chunk_config.enabled`.

When recompute scheduling is enabled, the platform selects the corresponding DyntraLB recompute scheduler. Async scheduling selects its async variant.

### Does this PR introduce _any_ user-facing change?

Yes.

This PR adds the user-facing `scheduler_config.dyntra_lb_config` section to `--additional-config`, including the fields listed above. When enabled on a supported Decode deployment, it changes request admission and execution order to reduce DP imbalance.

The feature is disabled by default, so existing deployments retain their current scheduler behavior unless they explicitly enable DyntraLB.

The PR also adds a DyntraLB feature guide and extends the additional configuration documentation.

### How was this patch tested?

#### Unit tests

Unit tests cover:

- DyntraLB configuration parsing, defaults, type checks, range checks, and unknown fields;
- platform scheduler selection, supported P/D Decode topology, and rejection outside the supported role or across multiple nodes;
- waiting and skipped-waiting ordering and lifecycle behavior;
- pause, resume, finish, cleanup, and KV-cache retention behavior;
- load-balancing decisions, per-rank plan generation, plan application, and request admission;
- engine-core patch integration, rank gating, and DP coordination;
- diagnostics opt-in and default-off behavior;
- synchronous and asynchronous scheduling behavior and DyntraLB-recompute scheduler selection.

Relevant test files:

- `tests/ut/core/test_dyntra_lb_scheduler.py`
- `tests/ut/core/test_dyntra_lb_recompute_scheduler.py`
- `tests/ut/patch/platform/test_patch_dyntra_lb_core.py`
- `tests/ut/test_ascend_config.py`
- `tests/ut/test_platform.py`

#### Incremental line coverage

Incremental line coverage was measured with pytest and coverage.py against the
PR feature baseline, vLLM-Ascend commit
`ba58907c6d1ca16bb284b3fd1b9f246f960fc8db`. Only executable lines added by
this PR under `vllm_ascend/` were included in the calculation.

| Production file | Added executable lines | Covered lines | Line coverage |
| --- | ---: | ---: | ---: |
| `vllm_ascend/ascend_config.py` | 47 | 44 | 93.62% |
| `vllm_ascend/core/dyntra_lb_scheduler.py` | 521 | 431 | 82.73% |
| `vllm_ascend/core/recompute_scheduler.py` | 16 | 14 | 87.50% |
| `vllm_ascend/patch/platform/__init__.py` | 1 | 1 | 100.00% |
| `vllm_ascend/patch/platform/patch_dyntra_lb_core.py` | 351 | 319 | 90.88% |
| `vllm_ascend/platform.py` | 30 | 27 | 90.00% |
| **Total** | **966** | **836** | **86.54%** |

#### Accuracy benchmark

Accuracy was evaluated on the complete GPQA Diamond split with DyntraLB enabled.

Accuracy benchmark configuration:

- Evaluation framework: AISBench
- Dataset: GPQA Diamond, version `b1ed2c`
- Number of evaluated requests: `198`
- Model checkpoint: `Qwen3-30B-A3B-W8A8`
- Quantization backend: `ascend` (ModelSlim W8A8)
- Deployment topology: P/D disaggregation with Prefill TP8 and Decode Attention DP8 + MoE EP8
- Async scheduling: enabled
- DyntraLB: enabled in static mode
- Request rate: `0`
- Batch size: `128`
- Maximum output length: `32,768` tokens
- Warm-up requests: `1`
- Generation parameters: `temperature=0.6`, `top_p=0.95`, and `repetition_penalty=1.05`

| Dataset | Version | Metric | Mode |
| --- | --- | --- | --- |
| GPQA Diamond | `b1ed2c` | Accuracy | Generation |

| Configuration | Accuracy | Difference vs. original | Difference vs. DyntraLB disabled |
| --- | ---: | ---: | ---: |
| Original vLLM-Ascend | 58.08% | — | — |
| Feature code, DyntraLB disabled | 59.60% | +1.52 pp | — |
| Feature code, DyntraLB enabled | 60.61% | +2.53 pp | +1.01 pp |

These are the observed scores from the reported runs. Differences are shown in percentage points (`pp`). Without repeated runs or confidence intervals, the observed differences should not be interpreted as statistically significant accuracy changes.

For external reference, the official [vLLM-Ascend Qwen3-30B-A3B model tutorial](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-30B-A3B.html) publishes the following result:

| Item | Official reference configuration |
| --- | --- |
| Model | `Qwen3-30B-A3B-W8A8` |
| Weights | [`Eco-Tech/Qwen3-30B-A3B-w8a8`](https://www.modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8) |
| Inference framework | vLLM-Ascend `v0.22.1rc` |
| Hardware | Atlas 800I A3 |
| Evaluation framework | AISBench |
| Dataset task | `gpqa_gen_0_shot_cot_chat_prompt` |
| Evaluation | GPQA-Diamond, 0-shot CoT |
| Accuracy | **60.10%** |

The official 60.10% score is a published reference rather than a same-environment control because the vLLM-Ascend version, deployment topology, and other runtime details differ from this experiment. The DyntraLB-enabled run reached 60.61%, 0.51 percentage points above this reference value.

For the DyntraLB-enabled run, the 198 evaluated requests were also divided according to whether they were paused at least once during generation:

| Request group | Total | Correct | Accuracy |
| --- | ---: | ---: | ---: |
| Paused | 161 | 101 | 62.73% |
| Not paused | 37 | 19 | 51.35% |
| Overall | 198 | 120 | 60.61% |

The two request groups account for the full evaluated dataset. Their combined result, 120 correct responses out of 198, is consistent with the reported overall accuracy of 60.61%.

#### End-to-end performance benchmark

The complete inference service was deployed and benchmarked in an 8-NPU environment.

Performance benchmark environment and deployment configuration:

- Hardware: `Ascend 910, 2 dies per device, 8 devices`
- Model: `Qwen3.5-35B-A3B`
- CANN: `9.0.1`
- PyTorch: `2.10.0+cpu`
- torch-npu: `2.10.0.post2`
- Python: `3.12.13`
- Deployment topology: P/D disaggregation with Prefill TP8 and Decode Attention DP8 + MoE EP8
- Async scheduling: enabled
- KV-transfer backend: Mooncake (`MooncakeConnectorV1`)
- MTP speculative decoding: enabled with `num_speculative_tokens=3`
- DyntraLB: dynamic mode for the experimental configuration; disabled for the baseline

The latest DyntraLB implementation was compared with the baseline using the same model, serving configuration, dataset, request order, and MTP configuration. Both runs enabled MTP speculative decoding with `num_speculative_tokens=3`; the only intended difference was whether DyntraLB dynamic mode was enabled.

Performance workload configuration:

- Number of requests: `1000`
- Input-length distribution: `LogNormal(-2.3, 0.8)`, with 20 additional long requests of 45 blocks each
- Output-length distribution: normal distribution with a mean proportional to the input length, bounded between 512 and 4,096 tokens
- KV-cache block size: `2,048` tokens
- `long_req_block_threshold`: `40` blocks, so requests near the maximum length of 45 blocks activate DyntraLB dynamic mode
- Maximum request concurrency: `128`
- Request rate: `400`
- Dataset shuffle: disabled to preserve the same request order
- Temperature: `0`
- Runs per configuration: `10`

The following end-to-end behavior was verified during the benchmark:

- all ranks started successfully and the inference service became healthy;
- requests completed without deadlock, timeout, or collective communication errors;
- CPU-side Gloo collectives for small scheduling metadata completed correctly;
- no unexpected request loss, duplication, or scheduler queue corruption was observed;
- with DyntraLB disabled, the uneven request-length distribution produced a noticeable running-block imbalance across ranks; and
- DyntraLB dynamic mode activated and deactivated balancing from runtime workload signals, reducing imbalance while active.

| Configuration | Duration (s) | Output token throughput (tok/s) | Total token throughput (tok/s) |
| --- | ---: | ---: | ---: |
| Baseline | 401.14 | 3194.35 | 28493.35 |
| DyntraLB | 376.32 | 3405.27 | 30374.77 |

Improvement relative to the baseline:

| Configuration | Duration | Output token throughput | Total token throughput |
| --- | ---: | ---: | ---: |
| DyntraLB vs. baseline | +6.19% | +6.60% | +6.60% |

With MTP enabled, DyntraLB reduced duration by 6.19% and increased both output-token throughput and total-token throughput by 6.60% relative to the baseline.

### Scope and limitations

- Only a single-node Decode DP instance is supported.
- Requests and KV cache are not migrated between DP ranks.
- Load is estimated from KV-cache block counts rather than measured execution time.
- Static mode is intended for controlled validation; dynamic mode is recommended for normal workloads.
- Thresholds depend on the workload and KV-cache block size and may require tuning.
- Model-specific costs, speculative draft work, and operator-level variation are not directly modeled by the planner.
- The end-to-end results above validate the stated async P/D configuration with MTP speculative decoding. Recompute scheduling, other speculative-decoding configurations, and model-specific cache layouts should be validated with the exact target production configuration.

### Future work

DyntraLB currently requires all Decode DP ranks to run on a single node. Future work will extend the scheduler and its coordination mechanism to support Decode instances distributed across multiple nodes.

### Appendix: Benchmark metric definitions

| Metric | Definition | Better direction |
| --- | --- | --- |
| Duration (s) | Wall-clock time from the start of workload dispatch until all benchmark requests complete. | Lower |
| Output token throughput (tok/s) | Total number of output tokens generated by successful requests divided by benchmark duration. | Higher |
| Total token throughput (tok/s) | Total number of input and output tokens processed by successful requests divided by benchmark duration. | Higher |

Duration gain is calculated as `(baseline - DyntraLB) / baseline × 100%`, while output and total token throughput gains are calculated as `(DyntraLB - baseline) / baseline × 100%`; therefore, a positive gain always indicates an improvement over the baseline.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
