### PR TITLE
Dspark FULL Graph support

### DIFF
--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -1,12 +1,18 @@
 from typing import Any
 
 import torch
+from copy import deepcopy
+
 from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid,
+)
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 
 
@@ -23,10 +29,112 @@ class AscendDsparkProposer(AscendDflashProposer):
             runner=runner,
         )
 
-        # Initialize and establish static address for graph mode
+        #   Static buffers for graph mode.
+        #   DSpark returns K draft tokens, but internally keeps seed + K tokens.
         blk = 1 + self.num_speculative_tokens
-        self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
-        self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
+        self._dspark_seed_buffer = torch.zeros(
+            self.max_batch_size,
+            dtype=torch.int64,
+            device=device,
+        )
+        self._dspark_draft_buffer = torch.zeros(
+            (self.max_batch_size, blk),
+            dtype=torch.int64,
+            device=device,
+        )
+        self._dspark_confidence_logits_buffer = torch.zeros(
+            (self.max_batch_size, self.num_speculative_tokens),
+            dtype=torch.float32,
+            device=device,
+        )
+        self._dspark_num_verify_tokens_buffer = torch.zeros(
+            self.max_batch_size,
+            dtype=torch.int32,
+            device=device,
+        )
+        self._keep_lens = torch.zeros(
+            (self.max_batch_size,),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self._dspark_updates = torch.ones(
+            (self.max_batch_size * self.num_speculative_tokens,),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def initialize_cudagraph_keys(
+        self,
+        cudagraph_mode: CUDAGraphMode,
+    ) -> None:
+        """Initialize independent FULL graph keys for the DSpark drafter.
+        Target width: K + 1
+        DSpark width: K
+        """
+        dispatcher = self.cudagraph_dispatcher
+        draft_query_len = int(self.num_speculative_tokens)
+
+        #   Do not reuse the target model's CompilationConfig object directly.
+        #   The target dispatcher needs [K+1, 2(K+1), ...], while DSpark needs [K, 2K, ...].
+        draft_compilation_config = deepcopy(dispatcher.compilation_config)
+
+        max_num_reqs = int(
+            dispatcher.vllm_config.scheduler_config.max_num_seqs
+        )
+
+        target_max_capture_size = int(
+            dispatcher.compilation_config.max_cudagraph_capture_size
+        )
+
+        draft_capture_sizes = [
+            batch_size * draft_query_len
+            for batch_size in range(1, max_num_reqs + 1)
+            if batch_size * draft_query_len <= target_max_capture_size
+        ]
+
+        if not draft_capture_sizes:
+            raise RuntimeError(
+                "No valid DSpark cudagraph capture sizes: "
+                f"draft_query_len={draft_query_len}, "
+                f"max_num_reqs={max_num_reqs}, "
+                f"max_capture_size={target_max_capture_size}"
+            )
+
+        draft_compilation_config.cudagraph_capture_sizes = draft_capture_sizes
+        draft_compilation_config.max_cudagraph_capture_size = (
+            draft_capture_sizes[-1]
+        )
+
+        #   avoid validation against target compile sizes such as 8, 16, ...
+        if draft_compilation_config.compile_sizes:
+            draft_compilation_config.compile_sizes = list(
+                draft_capture_sizes
+            )
+
+        #   this dispatcher now owns a separate config from the target dispatcher.
+        dispatcher.compilation_config = draft_compilation_config
+
+        #    critical: _create_padded_batch_descriptor() reads this attribute,
+        #    not the initialize_cudagraph_keys() argument.
+        dispatcher.uniform_decode_query_len = draft_query_len
+
+        #    robust if initialization is invoked more than once.
+        for keys in dispatcher.cudagraph_keys.values():
+            keys.clear()
+        dispatcher.keys_initialized = False
+
+        if self.speculative_config.enforce_eager:
+            dspark_cudagraph_mode = CUDAGraphMode.NONE
+        else:
+            #   preserve FULL_DECODE_ONLY / PIECEWISE_AND_FULL semantics.
+            #   do not replace this with cudagraph_mode.mixed_mode(), because
+            #   doing so would discard the separate FULL decode routine.
+            dspark_cudagraph_mode = cudagraph_mode
+
+        dispatcher.initialize_cudagraph_keys(
+            dspark_cudagraph_mode,
+            uniform_decode_query_len=draft_query_len,
+        )
 
     def set_inputs_first_pass(
         self,
@@ -42,35 +150,28 @@ class AscendDsparkProposer(AscendDflashProposer):
         num_prefill_reqs=0,
         num_decode_reqs=0,
     ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
-        # Dspark cross-attention: context K/V from target hidden states,
-        # Q from query embeddings (next token + mask tokens).
+        #   DSpark: context width = K + 1 from target hidden states, query width   = K from draft query block
 
         batch_size = cad.num_reqs
-
-        # Query length of a single request and the whole batch
         num_query_per_req = self.num_speculative_tokens
         num_query_total = batch_size * num_query_per_req
-
-        # Newly added hidden_states, need to convert to KV Cache
         num_context = target_token_ids.shape[0]
+
+        #   store target hidden states as DSpark/DFlash context KV source.
         self._dflash_num_context = num_context
         self._dflash_hidden_states[:num_context] = target_hidden_states
 
-        # The initial input token of markovHead is the next token
+        #   static seed buffer for graph replay.
         n = next_token_ids.shape[0]
         self._dspark_seed_buffer[:n].copy_(next_token_ids)
         if n < self._dspark_seed_buffer.shape[0]:
             self._dspark_seed_buffer[n:].fill_(0)
 
-        token_indices_to_sample = torch.empty(
-            batch_size * self.num_speculative_tokens,
-            dtype=torch.int32,
-            device=self.device,
-        )
+        #   use static token_indices buffer.
+        token_indices_to_sample = self.token_indices_to_sample[:num_query_total]
 
         has_num_rejected = num_rejected_tokens_gpu is not None
 
-        # Remove the rejected token to avoid polluting cross-attention
         copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
             # Inputs
             next_token_ids_ptr=next_token_ids,
@@ -89,7 +190,9 @@ class AscendDsparkProposer(AscendDflashProposer):
             # Metadata
             query_start_loc_ptr=cad.query_start_loc,
             seq_lens_ptr=cad.seq_lens,
-            num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
+            num_rejected_tokens_ptr=(
+                num_rejected_tokens_gpu if has_num_rejected else 0
+            ),
             # Scalars
             parallel_drafting_token_id=self.parallel_drafting_token_id,
             block_size=self.kernel_block_size,
@@ -101,9 +204,10 @@ class AscendDsparkProposer(AscendDflashProposer):
             SAMPLE_FROM_ANCHOR=True,
         )
 
-        # Build attn_metadata
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
-        new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
+        new_query_start_loc = (
+            self.arange_dflash[: batch_size + 1] * num_query_per_req
+        )
 
         effective_seq_lens = cad.seq_lens
         if has_num_rejected:
@@ -112,11 +216,13 @@ class AscendDsparkProposer(AscendDflashProposer):
         cad.query_start_loc = new_query_start_loc
         cad.seq_lens = effective_seq_lens + num_query_per_req
         cad.query_start_loc_cpu = (
-            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * num_query_per_req
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone()
+            * num_query_per_req
         ).to(torch.int32)
 
         if hasattr(cad, "actual_seq_lengths_q"):
             cad.actual_seq_lengths_q = [num_query_per_req] * batch_size
+
         if hasattr(cad, "decode_token_per_req"):
             cad.decode_token_per_req = num_query_per_req
 
@@ -140,31 +246,112 @@ class AscendDsparkProposer(AscendDflashProposer):
         batch_descriptor=None,
         dummy_compute_logits=lambda hidden_states: None,
         is_profile=False,
+        dspark_num_context_tokens=None,
+        drafter_context_tokens=None,
         **kwargs,
     ) -> None:
-        # Run dummy_run at full load: the query length of each request is self.num_speculative_tokens
-        # Unlike DFlash, where the query length is self.num_speculative_tokens + 1.
-        # Ensure that the maximum batch token is within the limit of self.max_query_tokens.
+        #   DSpark graph capture:
+        #   num_tokens / num_input_tokens = query tokens = B*K
+        #   dspark_num_context_tokens     = context tokens = B*(K+1)
+
+        #   Backward compatibility: support either kwarg name.
+        #   Do NOT overwrite the real named argument with kwargs.pop().
+        if dspark_num_context_tokens is None:
+            dspark_num_context_tokens = drafter_context_tokens
+
+        if dspark_num_context_tokens is None:
+            dspark_num_context_tokens = kwargs.pop(
+                "dspark_num_context_tokens",
+                None,
+            )
+        else:
+            kwargs.pop("dspark_num_context_tokens", None)
+
         num_query_per_req = self.num_speculative_tokens
         num_query_total = num_reqs * num_query_per_req
-        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
+        num_query_tokens = min(
+            num_query_total if num_reqs > 0 else num_tokens,
+            self.max_query_tokens,
+        )
 
         (
             num_input_tokens,
             num_tokens_across_dp,
             _,
-        ) = self.runner._sync_metadata_across_dp(num_query_tokens, is_draft_model=True)
+        ) = self.runner._sync_metadata_across_dp(
+            num_query_tokens,
+            is_draft_model=True,
+        )
+
+        if dspark_num_context_tokens is None:
+            dspark_num_context_tokens = num_input_tokens
+
+        dspark_num_context_tokens = int(dspark_num_context_tokens)
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
-        context_positions = self._context_positions_buffer[:num_input_tokens]
-        context_states = self.hidden_states[:num_input_tokens]
+        context_positions = self._context_positions_buffer[
+            :dspark_num_context_tokens
+        ]
+        context_states = self.hidden_states[:dspark_num_context_tokens]
+
+        #   Keep same invariant as runtime build_model_inputs_first_pass()
+        self._dflash_num_context = dspark_num_context_tokens
+
+        multi_steps_attn_metadata = []
+
+        if (
+            aclgraph_runtime_mode == CUDAGraphMode.FULL
+            and len(self.draft_attn_groups) > 0
+        ):
+            builder = self.draft_attn_groups[0].get_metadata_builder()
+
+            common_attn_metadata = AscendCommonAttentionMetadata(
+                query_start_loc=(
+                    self.arange_dflash[: num_reqs + 1] * num_query_per_req
+                ),
+                query_start_loc_cpu=(
+                    torch.from_numpy(
+                        self.token_arange_np[: num_reqs + 1]
+                    ).clone()
+                    * num_query_per_req
+                ).to(torch.int32),
+                seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
+                seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu,
+                seq_lens=self.runner.seq_lens[:num_reqs],
+                num_reqs=num_reqs,
+                num_actual_tokens=num_input_tokens,
+                max_query_len=num_query_per_req,
+                max_seq_len=0,
+                slot_mapping=self._slot_mapping_buffer[:num_query_total],
+                attn_state=AscendAttentionState.ChunkedPrefill,
+                causal=False,
+                is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
+                block_table_tensor=(
+                    self.runner.input_batch.block_table[self.kv_cache_gid]
+                    .get_device_tensor()[:num_reqs]
+                ),
+            )
+
+            attn_metadata_dspark = builder.build_for_graph_capture(
+                common_attn_metadata,
+                AscendAttentionState.ChunkedPrefill,
+            )
+
+            attn_metadata_dspark.attn_mask = None
+            attn_metadata_dspark.attn_state = AscendAttentionState.ChunkedPrefill
+
+            per_layer_attn_metadata = {}
+            for layer_name in self.attn_layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata_dspark
+
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         self.token_indices_to_sample.fill_(0)
 
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
@@ -173,7 +360,7 @@ class AscendDsparkProposer(AscendDflashProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=[],
+            draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)
@@ -184,13 +371,25 @@ class AscendDsparkProposer(AscendDflashProposer):
                 )
 
             else:
-                self._dflash_num_context = num_input_tokens
+                self._dflash_num_context = dspark_num_context_tokens
                 self._runnable(
                     num_input_tokens=num_input_tokens,
                     batch_size=num_reqs,
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
-                    target_positions=self._get_positions(num_input_tokens),
+                    target_positions=context_positions,
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=[],
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
                     num_tokens=num_input_tokens,
+                )
+
+            forward_context = get_forward_context()
+            if (
+                forward_context is not None
+                and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+                and not _EXTRA_CTX.capturing
+            ):
+                self._update_full_graph_params(
+                    forward_context,
+                    num_query_tokens,
+                    multi_steps_attn_metadata,
                 )

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -799,34 +799,58 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_prefill_reqs=num_prefill_reqs,
             num_decode_reqs=num_decode_reqs,
         )
-        assert self.runner is not None
-        pcp_manager = getattr(self.runner, "pcp_manager", None)
-        if pcp_manager is not None:
+        if self.pcp_size * self.dcp_size > 1:
             assert long_seq_args is not None
-            _, ori_token_indices_to_sample = long_seq_args
+            query_lens_d, ori_token_indices_to_sample = long_seq_args
+        assert self.runner is not None
 
         has_lora = len(self.runner.input_batch.lora_id_to_lora_request) > 0
-        uniform_decode = target_model_batch_desc.uniform
+
+        is_dspark = (
+            self.method == "dspark"
+            or getattr(self, "_is_dspark", False)
+        )
+
+        uniform_decode = bool(target_model_batch_desc.uniform)
+
+        #   IMPORTANT: use the DSPARK proposer/drafter dispatcher.
+        #   DO NOT use the target runner dispatcher here.
+        draft_dispatcher = self.cudagraph_dispatcher
 
         if self.use_cuda_graph:
-            _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
-                num_tokens=num_tokens, uniform_decode=uniform_decode, has_lora=has_lora
+
+            _, batch_descriptor = draft_dispatcher.dispatch(
+                num_tokens=num_tokens,
+                uniform_decode=uniform_decode,
+                has_lora=has_lora,
             )
-            num_input_tokens = batch_descriptor.num_tokens
+            num_input_tokens = int(batch_descriptor.num_tokens)
         else:
-            num_input_tokens = num_tokens
+            batch_descriptor = None
+            num_input_tokens = int(num_tokens)
 
         (
             num_input_tokens,
             num_tokens_across_dp,
             _,
-        ) = self.runner._sync_metadata_across_dp(num_input_tokens, is_draft_model=True)
+        ) = self.runner._sync_metadata_across_dp(
+            num_input_tokens,
+            is_draft_model=True,
+        )
+
+        num_input_tokens = int(num_input_tokens)
 
         if self.use_cuda_graph:
-            aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
-                num_tokens=num_input_tokens, uniform_decode=uniform_decode, has_lora=has_lora
+
+            aclgraph_runtime_mode, batch_descriptor = (
+                draft_dispatcher.dispatch(
+                    num_tokens=num_input_tokens,
+                    uniform_decode=uniform_decode,
+                    has_lora=has_lora,
+                )
             )
-            num_input_tokens = batch_descriptor.num_tokens
+
+            num_input_tokens = int(batch_descriptor.num_tokens)
         else:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
             batch_descriptor = None
@@ -840,14 +864,29 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
+
+            #   DSPARK draft batch descriptor
+            graph_num_reqs = int(batch_descriptor.num_reqs)
+            actual_num_reqs = int(common_attn_metadata.num_reqs)
+
+            if graph_num_reqs < actual_num_reqs:
+                raise RuntimeError(
+                    "FULL draft graph has fewer request slots than the runtime batch: "
+                    f"graph_num_reqs={graph_num_reqs}, "
+                    f"actual_num_reqs={actual_num_reqs}, "
+                    f"num_input_tokens={num_input_tokens}, "
+                    f"batch_descriptor={batch_descriptor}"
+                )
+
             num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
                 self.query_start_loc,
                 num_input_tokens,
-                batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
-                common_attn_metadata.num_reqs,
+                graph_num_reqs, #batch_descriptor.num_reqs
+                actual_num_reqs,
                 aclgraph_runtime_mode,
-                batch_descriptor.num_reqs,
+                graph_num_reqs, #batch_descriptor.num_reqs,
             )
+
             common_attn_metadata.num_reqs = num_reqs_padded
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
@@ -857,12 +896,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
-            if self.method == "dflash":
-                common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+
+            if self.method == "dflash" or is_dspark:
+                #   DFlash/DSpark already prepared draft-specific GPU sequence
+                #   lengths in set_inputs_first_pass().
+                #   DSpark: seq_lens = effective_seq_lens - rejected + K
+
+                common_attn_metadata.seq_lens = self._adjust_tensor(
+                    common_attn_metadata.seq_lens,
+                    num_reqs_padded,
+                )
             else:
-                common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
+                common_attn_metadata.seq_lens = self._adjust_tensor(
+                    self.runner.seq_lens,
+                    num_reqs_padded,
+                )
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
-                    self.runner.optimistic_seq_lens_cpu, num_reqs_padded
+                    self.runner.optimistic_seq_lens_cpu,
+                    num_reqs_padded,
                 )
                 # Keep the upstream-canonical mirror length-aligned with the
                 # padded subclass field, but only if the caller already
@@ -871,16 +922,26 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # the two fields independent so per-step in-place updates in
                 # ``attn_update_stack_num_spec_norm`` don't double-count.
                 if common_attn_metadata._seq_lens_cpu is not None:
-                    common_attn_metadata._seq_lens_cpu = common_attn_metadata.seq_lens_cpu.clone()
+                    common_attn_metadata._seq_lens_cpu = (
+                        common_attn_metadata.seq_lens_cpu.clone()
+                    )
+
             if common_attn_metadata.num_computed_tokens_cpu is not None:
                 common_attn_metadata.num_computed_tokens_cpu = self._adjust_tensor(
                     common_attn_metadata.num_computed_tokens_cpu, num_reqs_padded
                 )
 
-            if pcp_manager is not None and self.pcp_size > 1:
-                pcp_manager.mask_spec_decode_restore_idx_for_graph(
+            if self.pcp_size > 1:
+                pcp_allgather_restore_idx = (
                     common_attn_metadata.prefill_context_parallel_metadata.pcp_allgather_restore_idx
                 )
+                index = torch.arange(pcp_allgather_restore_idx.shape[0], device=pcp_allgather_restore_idx.device)
+                mask = (index % (self.pcp_size * self.decode_threshold)) >= self.decode_threshold
+                pcp_allgather_restore_idx[mask] = 0
+                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[: pcp_allgather_restore_idx.shape[0]] = (
+                    pcp_allgather_restore_idx
+                )
+                self.runner.pcp_manager.pcp_allgather_restore_idx.gpu[pcp_allgather_restore_idx.shape[0] :] = 0
         else:
             num_reqs_padded = common_attn_metadata.num_reqs
             # In the below scenario, padding has been applied by _pad_query_start_loc_for_fia in the model runner.
@@ -889,9 +950,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.block_table_tensor = self._adjust_tensor(
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
-
-        if self.draft_window_size is not None:
-            self.sliding_window.apply(common_attn_metadata)
 
         if self.supports_mm_inputs:
             mm_embeds, is_mm_embed = mm_embed_inputs or (None, None)
@@ -933,6 +991,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_ratio_to_sas_metadata=dict(),
                 block_size=self.draft_attn_groups[0].kv_cache_spec.block_size,
             )
+
         attn_metadata = builder.build(0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args)
 
         if hasattr(attn_metadata, "causal") and not attn_metadata.causal:
@@ -967,53 +1026,86 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         metadata_has_prefill = bool(getattr(attn_metadata_i, "num_prefills", 0))
         is_prefill_batch = num_prefill_reqs > 0 or metadata_has_prefill
-        pcp_mtp_inputs = None
-        draft_cp_kwargs = {
-            "ori_seq_len": None,
-            "ori_seq_len_cpu": None,
-            "slot_indices": None,
-            "mtp_slot_mapping": None,
-        }
-        if pcp_manager is not None:
-            pcp_mtp_inputs = pcp_manager.prepare_spec_decode_mtp_drafting_inputs(
-                common_attn_metadata=common_attn_metadata,
-                attn_metadata=attn_metadata_i,
-                ori_token_indices_to_sample=ori_token_indices_to_sample,
-                batch_size=batch_size,
-                num_decode_reqs=num_decode_reqs,
-                is_prefill_batch=is_prefill_batch,
-                num_speculative_tokens=self.num_speculative_tokens,
-            )
-            if pcp_mtp_inputs is not None:
-                draft_cp_kwargs.update(
-                    ori_seq_len=pcp_mtp_inputs.seq_lens,
-                    ori_seq_len_cpu=pcp_mtp_inputs.seq_lens_cpu,
-                    slot_indices=pcp_mtp_inputs.slot_indices,
-                    mtp_slot_mapping=pcp_mtp_inputs.slot_mapping,
+        if self.pcp_size * self.dcp_size > 1:
+            is_decode_only_batch = num_decode_reqs > 0 and not is_prefill_batch
+            if self.num_speculative_tokens > 1 and is_decode_only_batch:
+                # For pcp/dcp, tokens are split across different cp ranks,
+                # so we can not simply update slot_mapping by += 1.
+                # Instead, we pre-allocate mtp slot_mapping in model_runner
+                # (_generate_pcp_mtp_input), and use updated slot_indices
+                # to get corresponding slot_mapping in each step.
+                num_reject_tokens = (
+                    torch.tensor(self.runner.pcp_manager.cu_num_tokens_pcp_full, dtype=torch.int32).to(self.device)
+                    - ori_token_indices_to_sample
+                    - 1
                 )
+                num_accept_tokens = query_lens_d.to(self.device) - num_reject_tokens
+                ori_seq_len = attn_metadata_i.seq_lens_cpu[:batch_size].clone()
+                mtp_slot_mapping = self.runner.pcp_manager.mtp_slot_pad
 
-        should_update_next_steps = not self.parallel_drafting and (
-            self.pcp_size * self.dcp_size == 1 or pcp_mtp_inputs is not None
-        )
-        if should_update_next_steps:
-            # Copy the old attn_metadata and update
-            for draft_index in range(1, self.num_speculative_tokens):
-                per_layer_attn_metadata = dict()
-                for attn_group in self.draft_attn_groups:
-                    common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
-                        draft_index,
-                        attn_metadata,
-                        common_attn_metadata,
-                        batch_size,
-                        num_input_tokens,
-                        used_update_positions,
-                        aclgraph_runtime_mode,
-                        **draft_cp_kwargs,
-                        attn_group=attn_group,
+                # slot_mapping index base offset:
+                # scheduled tokens + pre-allocated mtp tokens + accepted tokens
+                slot_idx_base = (
+                    torch.cat(
+                        [
+                            torch.tensor([0], dtype=torch.int32, device=self.device),
+                            (torch.cumsum(query_lens_d, dim=0)[:-1] * self.pcp_size).to(self.device),
+                        ]
                     )
-                    for layer_name in self.attn_layer_names:
-                        per_layer_attn_metadata[layer_name] = attn_metadata
-                multi_steps_attn_metadata.append(per_layer_attn_metadata)
+                    + torch.arange(num_decode_reqs, device=self.device)
+                    * (self.num_speculative_tokens - 1)
+                    * self.pcp_size
+                    + (num_accept_tokens - 1) * self.pcp_size
+                )
+                slot_indices_list = []
+                for req_id in range(num_decode_reqs):
+                    slot_indices_list.append(
+                        torch.arange(slot_idx_base[req_id], slot_idx_base[req_id] + self.pcp_size, device=self.device)
+                    )
+                slot_indices = torch.cat(slot_indices_list, dim=0)
+
+                common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor[:batch_size]
+
+                # Copy the old attn_metadata and update
+                if not self.parallel_drafting:
+                    for draft_index in range(1, self.num_speculative_tokens):
+                        per_layer_attn_metadata = dict()
+                        for attn_group in self.draft_attn_groups:
+                            common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
+                                draft_index,
+                                attn_metadata,
+                                common_attn_metadata,
+                                batch_size,
+                                num_input_tokens,
+                                used_update_positions,
+                                aclgraph_runtime_mode,
+                                ori_seq_len,
+                                slot_indices,
+                                mtp_slot_mapping,
+                                attn_group=attn_group,
+                            )
+                            for layer_name in self.attn_layer_names:
+                                per_layer_attn_metadata[layer_name] = attn_metadata
+                        multi_steps_attn_metadata.append(per_layer_attn_metadata)
+        else:
+            # Copy the old attn_metadata and update
+            if not self.parallel_drafting:
+                for draft_index in range(1, self.num_speculative_tokens):
+                    per_layer_attn_metadata = dict()
+                    for attn_group in self.draft_attn_groups:
+                        common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
+                            draft_index,
+                            attn_metadata,
+                            common_attn_metadata,
+                            batch_size,
+                            num_input_tokens,
+                            used_update_positions,
+                            aclgraph_runtime_mode,
+                            attn_group=attn_group,
+                        )
+                        for layer_name in self.attn_layer_names:
+                            per_layer_attn_metadata[layer_name] = attn_metadata
+                    multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         token_indices_to_sample_len = token_indices_to_sample.shape[0]
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
@@ -1048,8 +1140,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "num_tokens": num_tokens,
                 "is_prefill": is_prefill_batch,
             }
-            runnable = cast(Callable[..., Any], self._runnable)
-            run_draft: Callable[[], Any] = partial(runnable, **model_inputs)
+
+            run_draft = partial(self._runnable, **model_inputs)
 
             if self.enable_enpu:
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3693,18 +3693,66 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 hidden_states = outputs
             dummy_compute_logits(hidden_states)
-
+            
+            drafter_context_tokens = None
             if self.drafter and not profile_cpp:
+                drafter_num_tokens = int(num_tokens_padded)
+                drafter_num_reqs = int(num_reqs_padded)
+                drafter_batch_desc = batch_desc
+                drafter_num_tokens_across_dp = num_tokens_across_dp
+
+                is_dspark = (
+                    self.speculative_config is not None
+                    and getattr(self.speculative_config, "method", None) == "dspark"
+                ) or getattr(self.drafter, "_is_dspark", False)
+
+                # The target FULL descriptor is B * (K + 1).
+                # DSpark draft FULL descriptor must be B * K.
+                if (
+                    is_dspark
+                    and cudagraph_runtime_mode == CUDAGraphMode.FULL
+                    and batch_desc is not None
+                    and bool(batch_desc.uniform)
+                ):
+                    draft_query_per_req =  int(self.speculative_config.num_speculative_tokens)
+
+                    # Preserve target padded batch size B.
+                    drafter_num_reqs = int(num_reqs_padded)
+
+                    # Remap tokens from B * (K + 1) to B * K.
+                    drafter_num_tokens = drafter_num_reqs * draft_query_per_req
+                    drafter_context_tokens = int(num_tokens_padded)
+                    # Build DSpark-correct FULL descriptor.
+
+                    draft_mode, drafter_batch_desc = (
+                        self.drafter.cudagraph_dispatcher.dispatch(
+                            num_tokens=drafter_num_tokens,
+                            uniform_decode=True,
+                            has_lora=num_active_loras > 0,
+                            num_active_loras=num_active_loras,
+                            valid_modes={CUDAGraphMode.FULL},
+                        )
+                    )
+
+                    assert draft_mode == CUDAGraphMode.FULL
+                    assert drafter_batch_desc.num_reqs == drafter_num_reqs
+
+                    # Avoid passing target num_tokens_across_dp into draft capture.
+                    # DSpark dummy_run should sync its own draft token count.
+                    drafter_num_tokens_across_dp = None
+
+
                 self.drafter.dummy_run(
-                    num_tokens=num_tokens_padded,
+                    num_tokens=drafter_num_tokens, #    was num_tokens_padded
                     with_prefill=with_prefill,
-                    num_reqs=num_reqs_padded,
-                    num_tokens_across_dp=num_tokens_across_dp,
+                    num_reqs=drafter_num_reqs, #    was num_reqs_padded
+                    num_tokens_across_dp=drafter_num_tokens_across_dp, #    was num_tokens_across_dp
                     aclgraph_runtime_mode=cudagraph_runtime_mode,
-                    batch_descriptor=batch_desc,
+                    batch_descriptor=drafter_batch_desc, #  was batch_desc
                     dummy_compute_logits=dummy_drafter_compute_logits,
                     in_graph_capturing=not force_attention,
                     is_profile=is_profile,
+                    dspark_num_context_tokens=drafter_context_tokens, # additional param
                 )
             if is_profile and self.dynamic_eplb:
                 self.eplb_updator.adaptor.clear_all_moe_loads()
@@ -5021,58 +5069,127 @@ class NPUModelRunner(GPUModelRunner):
                     min_cg_support = cg_support
                     min_cg_attn_backend = attn_backend.__name__
 
+        #   target dispatcher, for speculative decode target width = K + 1
         with update_pass_config(self):
-            if vllm_version_is("0.24.0"):
-                cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
-                    min_cg_support=min_cg_support,
-                    min_cg_attn_backend=min_cg_attn_backend,
-                    uniform_decode_query_len=self.uniform_decode_query_len,
-                    tensor_parallel_size=self.parallel_config.tensor_parallel_size,
-                    kv_cache_config=self.kv_cache_config,
-                    max_num_reqs=self.max_num_reqs,
-                )
-            else:
-                cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
-                    min_cg_support=min_cg_support,
-                    min_cg_attn_backend=min_cg_attn_backend,
-                    uniform_decode_query_len=self.uniform_decode_query_len,
-                    use_v2_model_runner=False,
-                    tensor_parallel_size=self.parallel_config.tensor_parallel_size,
-                    kv_cache_config=self.kv_cache_config,
-                    max_num_reqs=self.max_num_reqs,
-                )
+            cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
+                min_cg_support,
+                min_cg_attn_backend,
+                self.uniform_decode_query_len,
+                self.parallel_config.tensor_parallel_size,
+                self.kv_cache_config,
+                self.max_num_reqs,
+            )
             self.cudagraph_dispatcher.initialize_cudagraph_keys(
                 cudagraph_mode, self.uniform_decode_query_len
             )
 
-        if (
-            self.speculative_config
+        has_drafter = (
+            self.speculative_config is not None
             and self.drafter is not None
-            and (
-                self.speculative_config.use_eagle()
-                or self.speculative_config.uses_extract_hidden_states()
-            )
+        )
+        
+        #   draft dispatcher, the AscendDsparkProposer override must initialize its dispatcher with draft width = K
+        #   other proposers retain their existing behavior
+        if has_drafter and (
+            self.speculative_config.use_eagle()
+            or self.speculative_config.uses_extract_hidden_states()
+            or self.speculative_config.use_dspark()
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendExtractHiddenStatesProposer,
+                (
+                    AscendEagleProposer,
+                    AscendDflashProposer,
+                    AscendExtractHiddenStatesProposer,
+                ),
             )
+
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
-        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
-        capture_sizes = sorted({
-            desc.num_tokens
-            for _, descs in capture_descs
+        #   read target sizes from the target dispatcher.
+        target_capture_descs = (
+            self.cudagraph_dispatcher.get_capture_descs()
+        )
+        target_capture_sizes = sorted({
+            int(desc.num_tokens)
+            for _, descs in target_capture_descs
             for desc in descs
         })
 
+        #   non-speculative/default case
+        draft_capture_sizes = target_capture_sizes
+
+        #   read draft sizes from the draft dispatcher
+        if has_drafter:
+            draft_dispatcher = self.drafter.cudagraph_dispatcher
+
+            draft_capture_descs = (
+                draft_dispatcher.get_capture_descs()
+            )
+
+            draft_capture_sizes = sorted({
+                int(desc.num_tokens)
+                for _, descs in draft_capture_descs
+                for desc in descs
+            })
+
+            if not draft_capture_sizes:
+                raise RuntimeError(
+                    "Drafter cudagraph dispatcher produced no capture "
+                    f"descriptors. cudagraph_mode={cudagraph_mode}"
+                )
+
+        #   DSPARK validation
+        #   FULL descriptors must represent B requests with width K: num_tokens = B * K, num_reqs   = B
+        if has_drafter and self.speculative_config.use_dspark():
+            draft_query_len = int(
+                self.speculative_config.num_speculative_tokens
+            )
+
+            draft_dispatcher = self.drafter.cudagraph_dispatcher
+
+            assert (
+                draft_dispatcher.uniform_decode_query_len
+                == draft_query_len
+            ), (
+                "DSpark dispatcher has incorrect query width: "
+                f"dispatcher={draft_dispatcher.uniform_decode_query_len}, "
+                f"expected={draft_query_len}"
+            )
+
+            for mode, descs in draft_capture_descs:
+                if mode != CUDAGraphMode.FULL:
+                    continue
+
+                for desc in descs:
+                    assert desc.uniform, (
+                        "DSpark FULL descriptor must be uniform: "
+                        f"{desc}"
+                    )
+
+                    assert desc.num_tokens % draft_query_len == 0, (
+                        "DSpark FULL num_tokens must be divisible by K: "
+                        f"desc={desc}, K={draft_query_len}"
+                    )
+
+                    expected_num_reqs = (
+                        desc.num_tokens // draft_query_len
+                    )
+
+                    assert desc.num_reqs == expected_num_reqs, (
+                        "Incorrect DSpark FULL descriptor: "
+                        f"desc={desc}, "
+                        f"expected_num_reqs={expected_num_reqs}"
+                    )
+
         # NOTE: Since aclgraph_batch_sizes cannot be determined until here,
         # we set the graph params right before initializing the keys.
+        #   configure Ascend graph pools
         if self.use_aclgraph:
-            set_graph_params(capture_sizes)
-            if self.speculative_config:
-                set_draft_graph_params(capture_sizes)
+            set_graph_params(target_capture_sizes)
 
+            if self.speculative_config:
+                set_draft_graph_params(draft_capture_sizes)
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""
         parent_module_name = _get_gpu_model_runner_module_name(self)


### PR DESCRIPTION
# Add DSpark FULL Decode Graph Support on vLLM Ascend

## Summary

This PR adds correct ACL/CUDA graph support for the DSpark speculative drafter, including `FULL_DECODE_ONLY` execution.

DSpark differs from existing EAGLE/DFlash proposers because the target and draft forwards use different per-request widths:

```text
Target verification width: K + 1
DSpark draft width:        K
```

For example, with `num_speculative_tokens = 7`:

```text
B = 1:
  target graph = 8 tokens
  draft graph  = 7 tokens

B = 16:
  target graph = 128 tokens
  draft graph  = 112 tokens
```

Previously, the DSpark drafter reused graph descriptors and capture sizes generated for the target model. This caused incorrect request-count calculation, missing graph captures, FIA padding failures, and incorrect DSpark context-KV capture.

This PR introduces a separate DSpark graph-dispatch path and ensures that target and drafter graphs are captured and dispatched using their respective token widths.

## Problems Addressed

### 1. Target graph descriptors were incorrectly reused by DSpark

The target dispatcher is initialized with:

```text
uniform_decode_query_len = K + 1
```

A target FULL descriptor therefore interprets:

```text
num_reqs = num_tokens / (K + 1)
```

DSpark processes only `K` query tokens per request. Reusing the target descriptor for the drafter therefore produces an incorrect request count.

For example:

```text
DSpark tokens = 112
Correct interpretation: 112 / 7 = 16 requests
Target interpretation:  112 / 8 = 14 requests
```

This could result in:

- incorrect graph selection;
- `graph_num_reqs < actual_num_reqs`;
- incorrect FIA `query_start_loc` padding;
- missing graph replay;
- runtime graph capture attempts.

### 2. DSpark FULL graph shapes were not independently registered

The upstream proposer initializes drafter graph keys primarily for PIECEWISE execution and shares the target compilation configuration.

DSpark requires its own dispatcher configuration:

```text
Target dispatcher:
  query width = K + 1
  FULL shapes = B × (K + 1)

DSpark dispatcher:
  query width = K
  FULL shapes = B × K
```

Without this separation, the runtime dispatcher may select a descriptor that does not correspond to a physically captured DSpark graph.

### 3. DSpark graph capture used the wrong context length

DSpark uses:

```text
Draft query length: B × K
Context hidden states: B × (K + 1)
```

During dummy graph capture, `_dflash_num_context` was incorrectly overwritten with `num_input_tokens`, which is the draft query length `B × K`.

As a result, the captured graph precomputed context KV using only `B × K` hidden states instead of the full target context `B × (K + 1)`.

This did not necessarily crash, but reduced FULL-mode draft quality and acceptance.

The fix preserves:

```python
self._dflash_num_context = dspark_num_context_tokens
```

where:

```text
dspark_num_context_tokens = B × (K + 1)
```

The inherited DFlash input builder can then precompute context KV from the complete target hidden-state block.

### 4. DSpark draft-specific attention metadata was overwritten

`AscendDsparkProposer.set_inputs_first_pass()` prepares draft attention metadata using:

```text
query length = K
seq_lens = effective target seq_lens + K
causal = False
attention state = ChunkedPrefill
```

The generic FULL proposer path replaced `common_attn_metadata.seq_lens` with `runner.seq_lens`, discarding the DSpark-specific `+K` update.

The FULL path now preserves the metadata created by DSpark, similarly to DFlash:

```python
if self.method == "dflash" or is_dspark:
    common_attn_metadata.seq_lens = self._adjust_tensor(
        common_attn_metadata.seq_lens,
        num_reqs_padded,
    )
```

### 5. Dynamic graph inputs must use stable buffers

DSpark graph execution now uses preallocated buffers for graph-sensitive inputs, including:

- seed token IDs;
- draft token IDs;
- confidence logits;
- verification lengths;
- token indices to sample.

In particular, `token_indices_to_sample` now uses the proposer-owned static buffer rather than allocating a new tensor every iteration.

This keeps runtime input pointers aligned with graph-capture input pointers.

## Implementation Details

### `AscendDsparkProposer`

A DSpark-specific `initialize_cudagraph_keys()` override was added.

The override:

- creates an independent copy of the compilation configuration;
- sets the DSpark uniform decode query width to `K`;
- generates DSpark graph token sizes as `B × K`;
- avoids mutating the target model dispatcher;
- preserves the configured graph mode, including `FULL_DECODE_ONLY`;
- initializes independent FULL graph descriptors for the drafter.

Conceptually:

```python
target_capture_sizes = [
    batch_size * (K + 1)
    for batch_size in capture_batch_sizes
]

draft_capture_sizes = [
    batch_size * K
    for batch_size in capture_batch_sizes
]
```

### `ModelRunnerV1._check_and_update_cudagraph_mode`

The graph initialization path now initializes both dispatchers:

```text
Target dispatcher → target graph descriptors
DSpark dispatcher → draft graph descriptors
```

Target and draft graph parameters are configured separately:

```python
set_graph_params(target_capture_sizes)
set_draft_graph_params(draft_capture_sizes)
```

This prevents target and draft graph sizes from being treated as the same shape domain.

### `LLMBaseProposer._propose`

DSpark runtime dispatch now uses the drafter dispatcher directly instead of dispatching through the target descriptor and repairing the result afterward.

Dispatch is performed both:

1. before data-parallel graph-size synchronization;
2. after data-parallel synchronization.

The second dispatch selects the final graph descriptor after any required padding.

For FULL mode, the returned descriptor is expected to satisfy:

```python
batch_descriptor.num_tokens == (
    batch_descriptor.num_reqs * K
)
```

The descriptor request count is then used when padding FIA metadata.

### `ModelRunnerV1._dummy_run`

During target graph capture, the corresponding DSpark draft graph uses:

```text
drafter_num_reqs   = target padded request count
drafter_num_tokens = drafter_num_reqs × K
context tokens     = drafter_num_reqs × (K + 1)
```

For example:

```text
Target descriptor:
  num_tokens = 128
  num_reqs   = 16

DSpark descriptor:
  num_tokens = 112
  num_reqs   = 16

DSpark context:
  num_context_tokens = 128
```

The target context length is passed separately to `AscendDsparkProposer.dummy_run()`.

### `AscendDsparkProposer.dummy_run`

The dummy run now distinguishes between:

```text
num_input_tokens          = B × K
dspark_num_context_tokens = B × (K + 1)
```

The graph captures:

- context-KV precomputation over `B × (K + 1)` target hidden states;
- draft-model forward over `B × K` query tokens;
- DSpark non-causal draft attention metadata.

## Runtime Validation

The target and drafter now independently select FULL graphs with the expected shapes.

For `K = 7`, `B = 16`:

```text
Target:
  mode              = FULL
  num_tokens        = 128
  num_reqs          = 16
  query_len_per_req = 8

DSpark:
  mode              = FULL
  num_tokens        = 112
  num_reqs          = 16
  query_len_per_req = 7
```

For `B = 1`:

```text
Target:
  mode              = FULL
  num_tokens        = 8
  num_reqs          = 1

DSpark:
  mode              = FULL
  num_tokens        = 7
  num_reqs          = 1
```

The DSpark graph capture also uses the expected context/query split:

```text
B = 16:
  context tokens = 128
  query tokens   = 112

B = 1:
  context tokens = 8
  query tokens   = 7
```

## GSM8K End-to-End Validation

The implementation was evaluated on the full GSM8K test set with 1,300 prompts using Qwen3-8B as the target model, the DSpark block-7 drafter, and:

```python
num_speculative_tokens = 7
```

For this validation, all paired target and DSpark token shapes for batch sizes `1..16` were included:

```python
compilation_config = {
    "cudagraph_capture_sizes": sorted(
        set(
            shape
            for batch_size in range(1, 17)
            for shape in (
                7 * batch_size,  # DSpark draft: B * K
                8 * batch_size,  # target verify: B * (K + 1)
            )
        )
    ),
}
```

This exhaustive paired-shape configuration was used to validate correctness and avoid the remaining sparse-shape dispatch issue during testing. It is not intended as the final memory-efficient capture policy.

### Results

| Metric | PIECEWISE | FULL_DECODE_ONLY |
|---|---:|---:|
| Prompts | 1,300 | 1,300 |
| Accuracy | 0.8438 | 0.8477 |
| Invalid rate | 0.0000 | 0.0000 |
| Wall time | 193.97 s | 185.56 s |
| Queries/s | 6.70 | 7.01 |
| Input throughput | 595.29 tokens/s | 622.44 tokens/s |
| Output throughput | 2,042.87 tokens/s | 2,135.38 tokens/s |
| Number of draft blocks | 62,416 | 62,336 |
| Number of draft tokens | 436,912 | 436,352 |
| Accepted tokens | 332,483 | 332,424 |
| Mean acceptance length | 6.33 | 6.33 |

### Per-Position Acceptance

| Draft position | PIECEWISE | FULL_DECODE_ONLY |
|---:|---:|---:|
| 0 | 0.94 | 0.94 |
| 1 | 0.88 | 0.88 |
| 2 | 0.81 | 0.81 |
| 3 | 0.75 | 0.76 |
| 4 | 0.70 | 0.70 |
| 5 | 0.65 | 0.65 |
| 6 | 0.60 | 0.60 |

The acceptance distributions are effectively identical between PIECEWISE and FULL execution. Both modes obtain a mean acceptance length of `6.33`, showing that FULL graph replay preserves DSpark draft quality and attention semantics.

The small accuracy difference corresponds to approximately five GSM8K examples out of 1,300 and does not indicate a systematic FULL-graph quality regression. Both modes produced a zero invalid-output rate.

Compared with PIECEWISE, `FULL_DECODE_ONLY` achieved:

- approximately **4.3% lower wall-clock time**;
- approximately **4.6% higher query throughput**;
- approximately **4.6% higher input-token throughput**;
- approximately **4.5% higher output-token throughput**.

### Validation Conclusion

These results verify that:

- target verification runs with graph width `K + 1`;
- DSpark drafting runs with graph width `K`;
- FULL graph context-KV precomputation uses all `B × (K + 1)` target hidden states;
- PIECEWISE and FULL produce equivalent draft acceptance behavior;
- `FULL_DECODE_ONLY` provides a measurable end-to-end performance improvement without reducing acceptance quality.

The exhaustive capture configuration used for this test includes all `B × K` and `B × (K + 1)` shapes for `B = 1..16`.

## Known Issue: Sparse Graph Capture Sizes

This PR does not yet fully solve sparse target/drafter graph-shape coordination.

Currently, DSpark graph sizes may be generated for every request count:

```python
draft_capture_sizes = [
    batch_size * K
    for batch_size in range(1, max_num_reqs + 1)
]
```

However, due to graph memory consumption, users may configure only a sparse subset of physical graph captures.

For example, the physically captured request buckets may be:

```python
capture_batch_sizes = [
    1, 2, 4, 8, 16, 32, 60, 61, 62, 63, 64
]
```

For `K = 7`, these correspond to:

```text
Target shapes:
8, 16, 32, 64, 128, 256, 480, 488, 496, 504, 512

DSpark shapes:
7, 14, 28, 56, 112, 224, 420, 427, 434, 441, 448
```

If the DSpark dispatcher advertises every `B × K` key but only the sparse subset was physically captured, it may select an uncaptured exact shape.

For example, with 58 requests:

```text
Actual target tokens = 58 × 8 = 464
Actual draft tokens  = 58 × 7 = 406
```

The desired behavior is to pad both models to the same request bucket, for example `B = 60`:

```text
Target: 464 → 480
Draft:  406 → 420
```

Instead, if the DSpark dispatcher contains a key for `406`, it may select that uncaptured graph. The graph wrapper then attempts lazy graph capture during inference and fails with:

```text
RuntimeError: CUDA graph capturing detected at an inappropriate time.
```

This failure has been observed with sparse capture configurations.

### Current Workaround

Including all target and draft token shapes in `cudagraph_capture_sizes` avoids the missing-shape error:

```python
sorted({
    value
    for batch_size in range(1, max_batch_size + 1)
    for value in (
        batch_size * K,
        batch_size * (K + 1),
    )
})
```

However, this captures unnecessary graphs and can consume too much graph memory.

It is also not the desired final design for `FULL_DECODE_ONLY`, because target and DSpark FULL graphs belong to different dispatchers.

### Planned Follow-Up

The proper solution is to use a shared list of captured **request-count buckets**:

```python
capture_batch_sizes = [...]
```

and derive both shape sets from it:

```python
target_capture_sizes = [
    batch_size * (K + 1)
    for batch_size in capture_batch_sizes
]

draft_capture_sizes = [
    batch_size * K
    for batch_size in capture_batch_sizes
]
```

The following three sets must remain synchronized for each model:

```text
Dispatcher keys
Graph parameters passed to the capture manager
Physically captured graph sizes
```

For PIECEWISE mode, graph sizes represent generic total-token buckets and do not encode a fixed request count. PIECEWISE target/drafter shape coordination therefore requires separate handling and should not assume the `B × width` relationship used by FULL decode graphs.

## Scope

This PR focuses on:

- enabling correct DSpark FULL graph capture and replay;
- separating target and drafter graph descriptors;
- preserving DSpark context and attention semantics;
- restoring correct draft acceptance under graph execution;
- validating numerical quality and end-to-end performance on GSM8K.