### PR TITLE
[v0.23.0][BugFix][Graph] Bypass decode-only replay for GDN prefill

### DIFF
--- a/tests/ut/compilation/a2/test_acl_graph.py
+++ b/tests/ut/compilation/a2/test_acl_graph.py
@@ -20,6 +20,7 @@ import torch
 from vllm.compilation.cuda_graph import CUDAGraphOptions
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor, ForwardContext
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
 from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import AscendMetadata, AscendMetadataForDecode
@@ -213,6 +214,47 @@ class TestACLGraphWrapper(TestBase):
         # Should call the runnable directly without graph capture
         self.mock_runnable.assert_called_once_with("arg1", "arg2")
         self.assertEqual(result, "test_output")
+
+    @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
+    @patch("vllm_ascend.compilation.acl_graph.current_platform")
+    @patch("vllm_ascend.compilation.acl_graph.envs")
+    def test_full_decode_only_bypasses_graph_for_gdn_prefill(
+        self,
+        mock_envs,
+        mock_current_platform,
+        mock_get_forward_context,
+    ):
+        mock_envs.VLLM_LOGGING_LEVEL = "INFO"
+        mock_current_platform.get_global_graph_pool.return_value = self.mock_graph_pool
+        self.mock_vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        self.mock_forward_context.cudagraph_runtime_mode = CUDAGraphMode.FULL
+        self.mock_forward_context.skip_compiled = False
+        self.mock_forward_context.attn_metadata = {
+            "gdn": GDNAttentionMetadata(
+                num_prefills=1,
+                num_prefill_tokens=1,
+                num_decodes=0,
+                num_decode_tokens=0,
+                num_spec_decodes=0,
+                num_spec_decode_tokens=0,
+                num_actual_tokens=1,
+            )
+        }
+        mock_get_forward_context.return_value = self.mock_forward_context
+        wrapper = ACLGraphWrapper(
+            runnable=self.mock_runnable,
+            vllm_config=self.mock_vllm_config,
+            runtime_mode=CUDAGraphMode.FULL,
+            cudagraph_options=self.mock_cudagraph_options,
+        )
+
+        result = wrapper("arg1", "arg2")
+
+        self.mock_runnable.assert_called_once_with("arg1", "arg2")
+        self.assertEqual(result, "test_output")
+        self.assertEqual(wrapper.concrete_aclgraph_entries, {})
+        self.assertEqual(self.mock_forward_context.cudagraph_runtime_mode, CUDAGraphMode.FULL)
+        self.assertFalse(self.mock_forward_context.skip_compiled)
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
     @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -19,6 +19,7 @@ from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
@@ -49,6 +50,16 @@ def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
 
 def _raise_stream_resource_capture_error(exc: RuntimeError) -> None:
     raise RuntimeError(f"{_STREAM_RESOURCE_GUIDANCE}\nOriginal error:\n{exc}") from exc
+
+
+def _has_gdn_prefill(attn_metadata: Any) -> bool:
+    metadata_groups = attn_metadata if isinstance(attn_metadata, list) else [attn_metadata]
+    return any(
+        isinstance(metadata, GDNAttentionMetadata) and metadata.num_prefills > 0
+        for metadata_group in metadata_groups
+        if isinstance(metadata_group, dict)
+        for metadata in metadata_group.values()
+    )
 
 
 @dataclasses.dataclass
@@ -148,6 +159,24 @@ class ACLGraphWrapper:
             # CUDAGraphWrapper when nesting multiple instances with different
             # runtime modes.
             return self.runnable(*args, **kwargs)
+
+        if (
+            self.runtime_mode == CUDAGraphMode.FULL
+            and self.compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
+            and _has_gdn_prefill(forward_context.attn_metadata)
+        ):
+            # Shape-only dispatch can mistake a one-token tail prefill for
+            # decode. Keep its GDN prefill/PCP semantics by bypassing the
+            # decode-only graph for this invocation.
+            previous_runtime_mode = forward_context.cudagraph_runtime_mode
+            previous_skip_compiled = forward_context.skip_compiled
+            forward_context.cudagraph_runtime_mode = CUDAGraphMode.NONE
+            forward_context.skip_compiled = True
+            try:
+                return self.runnable(*args, **kwargs)
+            finally:
+                forward_context.cudagraph_runtime_mode = previous_runtime_mode
+                forward_context.skip_compiled = previous_skip_compiled
 
         if batch_descriptor not in self.concrete_aclgraph_entries:
             # create a new entry for this batch descriptor


### PR DESCRIPTION
### What this PR does / why we need it?

This is a minimal `releases/v0.23.0` fix for a Qwen3.5 GDN correctness boundary under `FULL_DECODE_ONLY`.

Graph dispatch is shape based. A final one-token chunk can therefore look like uniform decode even when `CommonAttentionMetadata.is_prefilling` still identifies it as prompt work. Replaying a decode-only graph in that state bypasses the GDN prefill/PCP path; in PCP, rank-local query lengths can be asymmetric (`1` on one rank and `0` on another), so normalizing the row to decode inside the GDN builder would change state-propagation semantics.

This PR leaves `model_runner_v1.py` unchanged. Instead, `ACLGraphWrapper` checks the already-built GDN metadata immediately before a `FULL_DECODE_ONLY` replay. If any GDN metadata still has `num_prefills > 0`, that invocation temporarily bypasses the full graph and compiled model, runs with eager prefill semantics, and restores the forward context afterward.

The guard is limited to:

- runtime `FULL` under configured `FULL_DECODE_ONLY`;
- GDN attention metadata; and
- batches that still contain semantic prefill work.

Ordinary GDN decode replay, non-GDN models, and configured `FULL` mode are unchanged. The performance cost is limited to the tail-prefill invocation that would otherwise use the wrong decode-only graph.

This preserves the non-MTP dispatch restored by #12283 and does not reclassify stateful one-token prefills as decodes.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. It prevents a semantic GDN prefill from replaying a decode-only graph.

### How was this patch tested?

Added a focused ACL graph wrapper regression test that verifies:

- GDN metadata with `num_prefills > 0` bypasses `FULL_DECODE_ONLY` graph capture/replay;
- the eager runnable is used for that invocation;
- no graph entry is created; and
- `cudagraph_runtime_mode` and `skip_compiled` are restored afterward.

Local checks:

- `python3 -m py_compile vllm_ascend/compilation/acl_graph.py tests/ut/compilation/a2/test_acl_graph.py`
- `uvx ruff check vllm_ascend/compilation/acl_graph.py tests/ut/compilation/a2/test_acl_graph.py`
- `uvx ruff format --check vllm_ascend/compilation/acl_graph.py tests/ut/compilation/a2/test_acl_graph.py`
- `pre-commit run --files vllm_ascend/compilation/acl_graph.py tests/ut/compilation/a2/test_acl_graph.py`
- `git diff --check origin/releases/v0.23.0...HEAD`

All checks above passed. The local macOS environment does not provide `pytest`, `torch`, `vllm`, or an NPU runtime, so target CI and the exact Qwen3.5 nightly remain required before merge:

- `Qwen3.5-397B-A17B-w8a8-mtp-longseq`
- TP=8, PCP=2, DCP=4, MTP=3
- GPQA Diamond, 50 prompts
- `FULL_DECODE_ONLY`

Nightly status: the exact case was requested in the PR, but the
[`Handle /nightly Command` workflow](https://github.com/vllm-project/vllm-ascend/actions/runs/29613730469)
rejected the request because the initiator does not have `triage+` permission.
A maintainer-authorized trigger is still required.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
