### PR TITLE
[CI] Set HCCL_IF_BASE_PORT for 560T cluster to avoid port overflow

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node_560t.yaml
@@ -220,7 +220,7 @@ jobs:
 
           benchmark_job_name="${{ steps.vars.outputs.benchmark_job_name }}"
 
-          jinja2 tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2 \
+          jinja2 tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2 \
             -D lws_name="$LWS_NAME" \
             -D log_prefix="$LOG_PREFIX" \
             -D size="$size" \

--- a/.github/workflows/_e2e_nightly_single_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_560t.yaml
@@ -98,6 +98,7 @@ jobs:
     env:
       HF_HUB_OFFLINE: 1
       VLLM_USE_MODELSCOPE: True
+      HCCL_IF_BASE_PORT: 55000
       UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
       UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
       UV_INDEX_STRATEGY: unsafe-best-match
@@ -138,7 +139,7 @@ jobs:
 
       - name: Set MAX_JOBS based on runner
         run: |
-          CARDS=$(echo "${{ inputs.runner }}" | grep -oE '[0-9]+$')
+          CARDS=$(echo "${{ inputs.runner }}" | sed -E 's/.*a3-([0-9]+).*/\1/')
           echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
 
       - name: Install vllm-project/vllm-ascend

--- a/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
@@ -1,0 +1,173 @@
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: {{ lws_name | default("vllm") }}
+  namespace: vllm-project
+spec:
+  replicas: {{ replicas | default(1) }}
+  leaderWorkerTemplate:
+    size: {{ size | default(2) }}
+    restartPolicy: None
+    leaderTemplate:
+      metadata:
+        labels:
+          role: leader
+      spec:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "night"
+            effect: "NoSchedule"
+        containers:
+          - name: vllm-leader
+            imagePullPolicy: Always
+            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3") }}
+            env:
+              - name: CONFIG_YAML_PATH
+                value: {{ config_file_path | default("DeepSeek-V3.yaml") }}
+              - name: CONFIG_BASE_PATH
+                value: "{{ config_base_path | default("") }}"
+              - name: LOG_PREFIX
+                value: {{ log_prefix | default("/root/.cache/ascend-logs") }}
+              - name: WORKSPACE
+                value: "/vllm-workspace"
+              - name: FAIL_TAG
+                value: {{ fail_tag | default("FAIL_TAG") }}
+              - name: IS_PR_TEST
+                value: "{{ is_pr_test | default("false") }}"
+              - name: VLLM_ASCEND_REF
+                value: {{ vllm_ascend_ref | default("main") }}
+              - name: VLLM_ASCEND_REMOTE_URL
+                value: {{ vllm_ascend_remote_url | default("https://github.com/vllm-project/vllm-ascend.git") }}
+              - name: BENCHMARK_JOB_NAME
+                value: {{ benchmark_job_name | default("") }}
+              - name: VLLM_CI_RUNNER
+                value: {{ runner | default("linux-aarch64-a3-0") }}
+              - name: VLLM_ASCEND_VERSION
+                value: {{ vllm_ascend_ref | default("main") }}
+              - name: AOP_MULTI_ENABLED
+                value: "{{ aop_multi_enabled }}"
+              - name: GOOD_TABLE
+                value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
+              - name: HCCL_IF_BASE_PORT
+                value: "55000"
+            command:
+              - sh
+              - -c
+              - |
+                bash /root/.cache/tests/run.sh
+            resources:
+              limits:
+                huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
+                memory: 512Gi
+                ephemeral-storage: 100Gi
+              requests:
+                huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
+                ephemeral-storage: 100Gi
+                cpu: 125
+            ports:
+              - containerPort: 8080
+            volumeMounts:
+              - mountPath: /root/.cache
+                name: shared-volume
+              - mountPath: /usr/local/Ascend/driver/tools
+                name: driver-tools
+              - mountPath: /dev/shm
+                name: dshm
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 512Gi
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ pvc_name | default("nv-action-vllm-benchmarks-v2") }}
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+    workerTemplate:
+      spec:
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "night"
+            effect: "NoSchedule"
+        containers:
+          - name: vllm-worker
+            imagePullPolicy: Always
+            image: {{ image | default("swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-a3") }}
+            env:
+              - name: CONFIG_YAML_PATH
+                value: {{ config_file_path | default("DeepSeek-V3.yaml") }}
+              - name: CONFIG_BASE_PATH
+                value: "{{ config_base_path | default("") }}"
+              - name: LOG_PREFIX
+                value: {{ log_prefix | default("/root/.cache/ascend-logs") }}
+              - name: WORKSPACE
+                value: "/vllm-workspace"
+              - name: FAIL_TAG
+                value: {{ fail_tag | default("FAIL_TAG") }}
+              - name: IS_PR_TEST
+                value: "{{ is_pr_test | default("false") }}"
+              - name: VLLM_ASCEND_REF
+                value: {{ vllm_ascend_ref | default("main") }}
+              - name: VLLM_ASCEND_REMOTE_URL
+                value: {{ vllm_ascend_remote_url | default("https://github.com/vllm-project/vllm-ascend.git") }}
+              - name: BENCHMARK_JOB_NAME
+                value: {{ benchmark_job_name | default("") }}
+              - name: VLLM_CI_RUNNER
+                value: {{ runner | default("linux-aarch64-a3-0") }}
+              - name: AOP_MULTI_ENABLED
+                value: "{{ aop_multi_enabled }}"
+              - name: GOOD_TABLE
+                value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
+              - name: HCCL_IF_BASE_PORT
+                value: "55000"
+            command:
+              - sh
+              - -c
+              - |
+                bash /root/.cache/tests/run.sh
+            resources:
+              limits:
+                huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
+                memory: 512Gi
+                ephemeral-storage: 100Gi
+              requests:
+                huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
+                ephemeral-storage: 100Gi
+                cpu: 125
+            volumeMounts:
+              - mountPath: /root/.cache
+                name: shared-volume
+              - mountPath: /usr/local/Ascend/driver/tools
+                name: driver-tools
+              - mountPath: /dev/shm
+                name: dshm
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 512Gi
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: {{ pvc_name | default("nv-action-vllm-benchmarks-v2") }}
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ lws_name | default("vllm") }}-leader
+  namespace: vllm-project
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    leaderworkerset.sigs.k8s.io/name: {{ lws_name | default("vllm") }}
+    role: leader
+  type: ClusterIP


### PR DESCRIPTION
### What this PR does / why we need it?

The 560T cluster uses shared/non-exclusive machines where HCCL port calculation may overflow past 65535 due to non-zero-based physical device IDs. Explicitly set HCCL_IF_BASE_PORT to 55000 to keep the computed listen ports within the valid TCP range (0-65535).

- Add dedicated lws_560t.yaml.jinja2 template with hardcoded HCCL_IF_BASE_PORT=55000 for both leader and worker containers
- Switch multi-node 560T workflow to use the new template
- Set HCCL_IF_BASE_PORT=55000 in single-node 560T workflow
- Original A3 lws.yaml.jinja2 and workflows are untouched

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
