### PR TITLE
[CI][Test] Enable A5 nightly tests via /nightly comment

### DIFF
--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -45,6 +45,7 @@ jobs:
       dispatch_a3: ${{ steps.resolve.outputs.dispatch_a3 }}
       dispatch_a3_560t: ${{ steps.resolve.outputs.dispatch_a3_560t }}
       dispatch_310p: ${{ steps.resolve.outputs.dispatch_310p }}
+      dispatch_a5: ${{ steps.resolve.outputs.dispatch_a5 }}
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
       aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
       command: ${{ steps.resolve.outputs.command }}
@@ -179,6 +180,7 @@ jobs:
                 echo "dispatch_a2=true"
                 echo "dispatch_a3=true"
                 echo "dispatch_310p=true"
+                echo "dispatch_a5=true"
               } >> "$GITHUB_OUTPUT"
             fi
             exit 0
@@ -327,6 +329,47 @@ jobs:
           echo "a3_560t_run_id=$A3_560T_RUN_ID" >> "$GITHUB_OUTPUT"
           echo "Dispatched Nightly-A3-560T with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
 
+  dispatch-a5:
+    name: Trigger Nightly-A5
+    needs: [authorize]
+    if: needs.authorize.outputs.is_authorized == 'true' && needs.authorize.outputs.command == 'nightly' && needs.authorize.outputs.dispatch_a5 == 'true'
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
+    outputs:
+      a5_run_id: ${{ steps.dispatch_a5.outputs.a5_run_id }}
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo mkdir -p -m 755 /etc/apt/keyrings
+          curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install gh -y
+
+      - name: Dispatch nightly-a5 workflow
+        id: dispatch_a5
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          REPO='${{ github.event.client_payload.github.payload.repository.full_name }}'
+          REQUEST_ID='${{ github.run_id }}'
+          gh workflow run schedule_nightly_test_a5.yaml \
+            --repo "$REPO" \
+            --ref main \
+            -f test_cases='${{ needs.authorize.outputs.test_cases }}' \
+            -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
+            -f request_id="$REQUEST_ID" \
+            -f skip_build_image=true \
+            -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+          sleep 8
+          A5_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a5.yaml/runs?per_page=1" \
+            --jq '.workflow_runs[0].id')
+          echo "a5_run_id=$A5_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Dispatched Nightly-A5 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+
   dispatch-weekly-a2:
     name: Trigger Weekly-A2
     needs: [authorize]
@@ -451,7 +494,7 @@ jobs:
 
   post-links:
     name: Post workflow links
-    needs: [authorize, dispatch-a2, dispatch-a3, dispatch-a3-560t, dispatch-weekly-a2, dispatch-weekly-a3, dispatch-weekly-310p]
+    needs: [authorize, dispatch-a2, dispatch-a3, dispatch-a3-560t, dispatch-a5, dispatch-weekly-a2, dispatch-weekly-a3, dispatch-weekly-310p]
     if: always() && needs.authorize.outputs.is_authorized == 'true'
     runs-on: linux-amd64-cpu-2-hk
     steps:
@@ -470,6 +513,10 @@ jobs:
           if [[ "${{ needs.dispatch-a3-560t.result }}" == "success" ]]; then
             BODY="$BODY
           - Nightly-A3-560T: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-a3-560t.outputs.a3_560t_run_id }})"
+          fi
+          if [[ "${{ needs.dispatch-a5.result }}" == "success" ]]; then
+            BODY="$BODY
+          - Nightly-A5: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.dispatch-a5.outputs.a5_run_id }})"
           fi
           if [[ "${{ needs.dispatch-weekly-a2.result }}" == "success" ]]; then
             BODY="$BODY

--- a/.github/workflows/scripts/resolve_nightly_tests.py
+++ b/.github/workflows/scripts/resolve_nightly_tests.py
@@ -54,9 +54,12 @@ def cmd_dispatch(_args):
     """Resolve /nightly <name> tokens and emit dispatch flags.
 
     Reads NIGHTLY_MATRIX (base64-encoded nightly_config.yaml) and TEST_CASES
-    (comma-separated tokens from the /nightly comment). Writes to GITHUB_OUTPUT:
+    (comma-separated tokens from the /nightly comment).     Writes to GITHUB_OUTPUT:
       - dispatch_a2=true|false
       - dispatch_a3=true|false
+      - dispatch_a3_560t=true|false
+      - dispatch_310p=true|false
+      - dispatch_a5=true|false
       - test_cases=<group,model>  (only when a /<model> token matched an accuracy group)
     """
     # Prefer NIGHTLY_MATRIX for backward compatibility; fall back to WEEKLY_MATRIX
@@ -66,13 +69,14 @@ def cmd_dispatch(_args):
     a3_names = parse_nightly_matrix(matrix_b64, "a3")
     a3_560t_names = parse_nightly_matrix(matrix_b64, "a3-560t")
     _310p_names = parse_nightly_matrix(matrix_b64, "310p")
+    a5_names = parse_nightly_matrix(matrix_b64, "a5")
 
     is_a3_560t = os.environ.get("IS_A3_560T", "") == "true"
 
     raw = os.environ.get("TEST_CASES", "")
     test_cases = [tc.strip() for tc in raw.split(",") if tc.strip()]
 
-    da2, da3, da3_560t, d310p = False, False, False, False
+    da2, da3, da3_560t, d310p, da5 = False, False, False, False, False
     transformed = None
     for tc in test_cases:
         if "/" in tc:
@@ -94,6 +98,8 @@ def cmd_dispatch(_args):
                     da3 = True
                 if tc in _310p_names:
                     d310p = True
+                if tc in a5_names:
+                    da5 = True
 
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         if transformed:
@@ -102,6 +108,7 @@ def cmd_dispatch(_args):
         f.write(f"dispatch_a3={str(da3).lower()}\n")
         f.write(f"dispatch_a3_560t={str(da3_560t).lower()}\n")
         f.write(f"dispatch_310p={str(d310p).lower()}\n")
+        f.write(f"dispatch_a5={str(da5).lower()}\n")
 
 
 def cmd_matrix(_args):


### PR DESCRIPTION
### What this PR does / why we need it?

- resolve_nightly_tests.py: resolve a5 test-case names and emit dispatch_a5
- nightly_config.yaml: enable the a5 test matrix section
- pr_nightly_command.yml: add dispatch-a5 job, dispatch_a5 in `all` branch, and Nightly-A5 link in post-links

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
