### PR TITLE
[Doc][Misc] Disable flashcomm1 in Qwen3-Omni-30B-A3B-Thinking tutorial

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -941,7 +941,7 @@ Before you start, please
     # change ip to your own
     python launch_online_dp.py --dp-size 16 --tp-size 2 --dp-size-local 8 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
     ```
-        
+
 **Notice:**
 The parameters are explained as follows:
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -941,7 +941,6 @@ Before you start, please
     # change ip to your own
     python launch_online_dp.py --dp-size 16 --tp-size 2 --dp-size-local 8 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
     ```
-
         
 **Notice:**
 The parameters are explained as follows:
@@ -1511,7 +1510,7 @@ Refer to [Using AISBench for performance evaluation](../../developer_guide/evalu
 Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/) for more details.
 
 **Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#deployment)** chapter.
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **Deployment** chapter.
 
 ## FAQ
 

--- a/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
+++ b/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
@@ -230,7 +230,6 @@ export HCCL_BUFFSIZE=1024
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
 
 vllm serve your_model_path \
     --served-model-name qwen3-omni \
@@ -246,7 +245,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --gpu-memory-utilization 0.95 \
-    --additional-config '{"weight_nz_mode": 2}' \
+    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
     --port 8000 
 ```
 
@@ -483,7 +482,6 @@ export HCCL_BUFFSIZE=1024
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
 
 vllm serve your_model_path \
     --served-model-name qwen3-omni \
@@ -498,7 +496,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"weight_nz_mode": 2}' \
+    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
     --speculative-config '{"method": "eagle3","model": "your_eagle3_model_path", "num_speculative_tokens": 3}'
@@ -557,7 +555,6 @@ export HCCL_BUFFSIZE=1024
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
 
 vllm serve your_model_path \
     --served-model-name qwen3-omni \
@@ -572,7 +569,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"weight_nz_mode": 2}' \
+    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
     --hf-overrides '{"rope_parameters": {"rope_type":"yarn","factor":4,"original_max_position_embeddings":32768}}'

--- a/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
+++ b/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
@@ -245,7 +245,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --gpu-memory-utilization 0.95 \
-    --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
+    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
     --port 8000 
 ```
 

--- a/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
+++ b/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
@@ -230,6 +230,7 @@ export HCCL_BUFFSIZE=1024
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
 
 vllm serve your_model_path \
     --served-model-name qwen3-omni \
@@ -245,7 +246,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --gpu-memory-utilization 0.95 \
-    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
+    --additional-config '{"weight_nz_mode": 2}' \
     --port 8000 
 ```
 
@@ -482,6 +483,7 @@ export HCCL_BUFFSIZE=1024
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
 
 vllm serve your_model_path \
     --served-model-name qwen3-omni \
@@ -496,7 +498,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
+    --additional-config '{"weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
     --speculative-config '{"method": "eagle3","model": "your_eagle3_model_path", "num_speculative_tokens": 3}'
@@ -555,6 +557,7 @@ export HCCL_BUFFSIZE=1024
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
 
 vllm serve your_model_path \
     --served-model-name qwen3-omni \
@@ -569,7 +572,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
+    --additional-config '{"weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
     --hf-overrides '{"rope_parameters": {"rope_type":"yarn","factor":4,"original_max_position_embeddings":32768}}'

--- a/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
+++ b/docs/source/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
@@ -496,7 +496,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
+    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
     --speculative-config '{"method": "eagle3","model": "your_eagle3_model_path", "num_speculative_tokens": 3}'
@@ -569,7 +569,7 @@ vllm serve your_model_path \
     --async-scheduling \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
+    --additional-config '{"enable_flashcomm1": false, "weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
     --hf-overrides '{"rope_parameters": {"rope_type":"yarn","factor":4,"original_max_position_embeddings":32768}}'


### PR DESCRIPTION
### What this PR does / why we need it?

This PR sets `enable_flashcomm1` to `false` in the `--additional-config`
of all three serving examples (baseline, speculative decoding, and
long-context configurations) in the Qwen3-Omni-30B-A3B-Thinking tutorial.

With the current vLLM-Ascend release, enabling flashcomm1 on this model
is not recommended. Disabling it aligns the tutorial with the verified,
stable configuration for inference.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only updates are not considered user-facing changes.

### How was this patch tested?

Documentation-only change, no tests required. Verified the markdown
renders correctly and the three serving commands are consistently
updated.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
