### PR TITLE
[CI][BugFix]fix: use hook argument and prepare-commit-msg stage for signoff hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_install_hook_types:
   - pre-commit
-  - commit-msg
+  - prepare-commit-msg
 
 default_stages:
   - pre-commit # Run locally
@@ -76,12 +76,13 @@ repos:
     args:
       - -c
       - |
-        if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" "$(git rev-parse --git-path COMMIT_EDITMSG)"; then
-          printf "\nSigned-off-by: $(git config user.name) <$(git config user.email)>\n" >> "$(git rev-parse --git-path COMMIT_EDITMSG)"
+        if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" "$1"; then
+          printf "\nSigned-off-by: $(git config user.name) <$(git config user.email)>\n" >> "$1"
         fi
+      - --
     language: system
     verbose: true
-    stages: [commit-msg]
+    stages: [prepare-commit-msg]
   - id: check-filenames
     name: Check for spaces in all filenames
     entry: bash


### PR DESCRIPTION
Two fixes for the signoff-commit hook:

1. Use prepare-commit-msg instead of commit-msg stage, which covers all commit operations (commit, amend, merge, revert, cherry-pick, rebase) and is not bypassed by --no-verify.

2. Use $1 (the file path passed by git to the hook) instead of hardcoding $(git rev-parse --git-path COMMIT_EDITMSG).  This fixes merge commits where the actual message file is .git/MERGE_MSG. The -- separator ensures $1 receives the correct argument under bash -c.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
