### PR TITLE
[CI] Disable HCCL inter-HCCS to avoid port conflicts on 560T shared c…

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_560t.yaml
@@ -98,7 +98,6 @@ jobs:
     env:
       HF_HUB_OFFLINE: 1
       VLLM_USE_MODELSCOPE: True
-      HCCL_IF_BASE_PORT: 55000
       UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
       UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
       UV_INDEX_STRATEGY: unsafe-best-match

--- a/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
@@ -49,8 +49,8 @@ spec:
                 value: "{{ aop_multi_enabled }}"
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
-              - name: HCCL_IF_BASE_PORT
-                value: "55000"
+              - name: HCCL_INTER_HCCS_DISABLE
+                value: "TRUE"
             command:
               - sh
               - -c
@@ -121,8 +121,8 @@ spec:
                 value: "{{ aop_multi_enabled }}"
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
-              - name: HCCL_IF_BASE_PORT
-                value: "55000"
+              - name: HCCL_INTER_HCCS_DISABLE
+                value: "TRUE"
             command:
               - sh
               - -c


### PR DESCRIPTION
…luster

### What this PR does / why we need it?

On the 560T non-exclusive cluster, HCCS inter-chip buses are not properly isolated between pods, causing HCCL port binding conflicts. Set HCCL_INTER_HCCS_DISABLE=TRUE to force HCCL to use the network (RoCE) path, which is correctly namespaced in Kubernetes.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
