### PR TITLE
[CI] set HCCL_INTER_HCCS_DISABLE and HCCL_IF_BASE_PORT for 560T cluster

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
@@ -51,6 +51,8 @@ spec:
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
               - name: HCCL_INTER_HCCS_DISABLE
                 value: "TRUE"
+              - name: HCCL_IF_BASE_PORT
+                value: "55000"
             command:
               - sh
               - -c
@@ -123,6 +125,8 @@ spec:
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
               - name: HCCL_INTER_HCCS_DISABLE
                 value: "TRUE"
+              - name: HCCL_IF_BASE_PORT
+                value: "55000"
             command:
               - sh
               - -c


### PR DESCRIPTION
### What this PR does / why we need it?
The 560T cluster uses shared/non-exclusive machines without HCCS support. HCCL port calculation may overflow past 65535 due to non-zero-based physical device IDs in the shared environment.

- Add HCCL_INTER_HCCS_DISABLE=TRUE to force RoCE (560T has no HCCS)
- Add HCCL_IF_BASE_PORT=55000 to keep listen ports within valid range
- Only affects 560T dedicated template and workflow; A3 is untouched

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
