### PR TITLE
[v0.23.0][BugFix] Support Qwen3-Omni ModelSlim checkpoint loading

### DIFF
--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -522,6 +522,15 @@ class AscendModelSlimConfig(QuantizationConfig):
         """
         if self._mapper_applied and self.hf_to_vllm_mapper is hf_to_vllm_mapper:
             return
+        vllm_config = get_current_vllm_config()
+        model_type = vllm_config.model_config.hf_config.model_type
+
+        if model_type == "qwen3_omni_moe":
+            hf_to_vllm_mapper.orig_to_new_prefix = {
+                **hf_to_vllm_mapper.orig_to_new_prefix,
+                "model.": "language_model.model.",
+                "lm_head.": "language_model.lm_head.",
+            }
 
         self.hf_to_vllm_mapper = hf_to_vllm_mapper
         self._mapper_applied = True
@@ -617,7 +626,10 @@ class AscendModelSlimConfig(QuantizationConfig):
             prefix = prefix.replace("linear_attn", "attention")
             prefix = prefix.replace("self_attn", "attention")
         if model_type in packed_modules_model_mapping:
-            self.packed_modules_mapping = packed_modules_model_mapping[model_type]
+            self.packed_modules_mapping = packed_modules_model_mapping.get(
+                model_type,
+                {}
+            )
         prefix = self.quant_prefix_mapper(model_type, prefix)
 
         if isinstance(layer, LinearBase):
@@ -652,6 +664,13 @@ class AscendModelSlimConfig(QuantizationConfig):
             logger.debug("Select AscendFusedMoEMethod for %s (layer=%s)", prefix, "FusedMoE")
             return AscendFusedMoEMethod(scheme, layer.moe_config, tid2eid)
         elif isinstance(layer, VocabParallelEmbedding):
+            if not self._has_quant_weight(prefix,self.packed_modules_mapping):
+                logger.debug(
+                    "No ModelSlim quant entry for %s; "
+                    "select UnquantizedEmbeddingMethod",
+                    prefix,
+                )
+                return UnquantizedEmbeddingMethod()
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):
                 logger.debug("Select UnquantizedEmbeddingMethod for %s (layer=%s)", prefix, "VocabParallelEmbedding")
                 return UnquantizedEmbeddingMethod()

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -31,7 +31,7 @@ from typing import Any, Optional
 import regex as re
 import torch
 from transformers import PretrainedConfig
-from vllm.config import get_current_vllm_config
+from vllm.config import get_current_vllm_config, get_current_vllm_config_or_none
 from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.linear import LinearBase
@@ -522,8 +522,10 @@ class AscendModelSlimConfig(QuantizationConfig):
         """
         if self._mapper_applied and self.hf_to_vllm_mapper is hf_to_vllm_mapper:
             return
-        vllm_config = get_current_vllm_config()
-        model_type = vllm_config.model_config.hf_config.model_type
+        vllm_config = get_current_vllm_config_or_none()
+        model_type = None
+        if vllm_config is not None:
+            model_type = vllm_config.model_config.hf_config.model_type
 
         if model_type == "qwen3_omni_moe":
             hf_to_vllm_mapper.orig_to_new_prefix = {
@@ -626,10 +628,7 @@ class AscendModelSlimConfig(QuantizationConfig):
             prefix = prefix.replace("linear_attn", "attention")
             prefix = prefix.replace("self_attn", "attention")
         if model_type in packed_modules_model_mapping:
-            self.packed_modules_mapping = packed_modules_model_mapping.get(
-                model_type,
-                {}
-            )
+            self.packed_modules_mapping = packed_modules_model_mapping.get(model_type, {})
         prefix = self.quant_prefix_mapper(model_type, prefix)
 
         if isinstance(layer, LinearBase):
@@ -664,10 +663,9 @@ class AscendModelSlimConfig(QuantizationConfig):
             logger.debug("Select AscendFusedMoEMethod for %s (layer=%s)", prefix, "FusedMoE")
             return AscendFusedMoEMethod(scheme, layer.moe_config, tid2eid)
         elif isinstance(layer, VocabParallelEmbedding):
-            if not self._has_quant_weight(prefix,self.packed_modules_mapping):
+            if not self._has_quant_weight(prefix, self.packed_modules_mapping):
                 logger.debug(
-                    "No ModelSlim quant entry for %s; "
-                    "select UnquantizedEmbeddingMethod",
+                    "No ModelSlim quant entry for %s; select UnquantizedEmbeddingMethod",
                     prefix,
                 )
                 return UnquantizedEmbeddingMethod()


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes ModelSlim quantized checkpoint loading for Qwen3-Omni models.

Qwen3-Omni ModelSlim checkpoints use weight names with top-level prefixes such as:

```text
model.layers.*
lm_head.*
```
while the vLLM Qwen3-Omni implementation exposes the corresponding modules under:
```text
language_model.model.layers.*
language_model.lm_head.*
```

Without applying the proper weight mapping, the ModelSlim quantization metadata does not match the vLLM model parameter names, causing model initialization failures.

This PR:

extends Qwen3-Omni weight mapper handling for ModelSlim quantization metadata;
handles token embedding layers without ModelSlim quantization entries by falling back to UnquantizedEmbeddingMethod.

This fixes model loading failures when serving Qwen3-Omni ModelSlim W8A8 checkpoints.

### Does this PR introduce _any_ user-facing change?
No.

This change only affects internal ModelSlim quantization configuration handling for Qwen3-Omni models.

No API, CLI, or inference behavior changes are introduced.
Existing models and quantization flows are unchanged.

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
