### PR TITLE
[v0.23.0][BugFix] Fix eager MTP with CudaGraph PIECEWISE Mode

### DIFF
--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -18,12 +18,14 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
-from vllm.config import CUDAGraphMode
+from vllm.config import CompilationMode, CUDAGraphMode
 
-from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer, _maybe_eager_context
 
 # CUDAGraphMode values whose ``has_full_cudagraphs()`` is True: FULL plus the
 # two composite modes that mix FULL with NONE / PIECEWISE.
@@ -38,6 +40,34 @@ NON_FULL_CUDAGRAPH_MODES = [
     CUDAGraphMode.NONE,
     CUDAGraphMode.PIECEWISE,
 ]
+
+
+def test_draft_config_is_created_before_entering_eager_context():
+    compilation_config = SimpleNamespace(mode=CompilationMode.VLLM_COMPILE)
+    vllm_config = SimpleNamespace(compilation_config=compilation_config)
+    proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+    proposer.method = "mtp"
+    proposer.speculative_config = SimpleNamespace(
+        draft_load_config=None,
+        draft_model_config=SimpleNamespace(model="draft"),
+    )
+    proposer.maybe_eager_context = _maybe_eager_context(vllm_config)
+
+    observed_modes = []
+    proposer._create_draft_vllm_config = lambda: observed_modes.append(compilation_config.mode) or vllm_config
+
+    def load_model(**kwargs):
+        observed_modes.append(compilation_config.mode)
+        return object()
+
+    with (
+        patch("vllm.compilation.backends.set_model_tag", return_value=nullcontext()),
+        patch("vllm_ascend.spec_decode.llm_base_proposer.get_model", side_effect=load_model),
+    ):
+        proposer._get_model()
+
+    assert observed_modes == [CompilationMode.VLLM_COMPILE, CompilationMode.NONE]
+    assert compilation_config.mode == CompilationMode.VLLM_COMPILE
 
 
 class TestDisablePaddedDrafterBatchWithFullGraph:

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -54,7 +54,12 @@ def test_draft_config_is_created_before_entering_eager_context():
     proposer.maybe_eager_context = _maybe_eager_context(vllm_config)
 
     observed_modes = []
-    proposer._create_draft_vllm_config = lambda: observed_modes.append(compilation_config.mode) or vllm_config
+
+    def create_draft_vllm_config():
+        observed_modes.append(compilation_config.mode)
+        return vllm_config
+
+    proposer._create_draft_vllm_config = create_draft_vllm_config
 
     def load_model(**kwargs):
         observed_modes.append(compilation_config.mode)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -298,7 +298,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             getattr(draft_load_config, "load_format", None),
             getattr(self.speculative_config.draft_model_config, "model", None),
         )
-        with set_model_tag("eagle_head"):
+        with self.maybe_eager_context, set_model_tag("eagle_head"):
             model = get_model(
                 vllm_config=draft_vllm_config,
                 model_config=self.speculative_config.draft_model_config,
@@ -311,8 +311,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         target_attn_layer_names = set(get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys())
 
-        with self.maybe_eager_context:
-            self.model = self._get_model()
+        self.model = self._get_model()
 
         # Find draft layers (attention layers added by draft model)
         all_attn_layers = get_layers_from_vllm_config(


### PR DESCRIPTION
### What this PR does / why we need it?

Construct the draft `VllmConfig` before entering the temporary eager context. This prevents layerwise PIECEWISE graph settings from being revalidated with compilation mode `NONE` while loading an eager MTP drafter.

### Does this PR introduce _any_ user-facing change?

Fixes worker initialization when AscendStore layerwise mode, sequence parallelism, and eager speculative decoding are enabled together.

### How was this patch tested?

- Added `test_draft_config_is_created_before_entering_eager_context`.
- `ws-verify hooks`
- `python -m py_compile vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/spec_decode/test_llm_base_proposer.py`

The focused pytest run was not completed locally because the lightweight macOS validation environment lacks the full vLLM runtime dependencies and Ascend build artifacts; CI will run the regression test in the supported environment.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
