### PR TITLE
[Doc] fix broken anchor links in service_profiling_guide

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
+++ b/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
@@ -112,8 +112,6 @@ After analysis, the `*ascend_pt` directory will contain many files, with the mai
 
 - `trace_view.json`: Chrome tracing format data, can be opened with [MindStudio Insight](https://www.hiascend.com/document/detail/zh/mindstudio/81RC1/GUI_baseddevelopmenttool/msascendinsightug/Insight_userguide_0002.html)
 
-[↑ Back to Top](#service-profiling-guide)
-
 ---
 
 ## MS Service Profiler  
@@ -367,5 +365,3 @@ def custom_handler(original_func, this, *args, **kwargs):
 ```
 
 If the custom handler fails to import, the system will automatically fall back to the default timer mode.
-
-[↑ Back to Top](#service-profiling-guide)


### PR DESCRIPTION
### What this PR does / why we need it?

fix broken anchor links in service_profiling_guide

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
