### PR TITLE
[BugFix][Doc] Enable MathJax rendering for formulas

### DIFF
--- a/docs/source/javascripts/mathjax.js
+++ b/docs/source/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
+  MathJax.typesetPromise()
+})

--- a/docs/source/javascripts/mathjax.js
+++ b/docs/source/javascripts/mathjax.js
@@ -12,6 +12,13 @@ window.MathJax = {
 };
 
 document$.subscribe(() => {
+  if (
+    typeof MathJax === "undefined" ||
+    typeof MathJax.typesetPromise !== "function"
+  ) {
+    return
+  }
+
   MathJax.startup.output.clearCache()
   MathJax.typesetClear()
   MathJax.texReset()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,10 @@ markdown_extensions:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
 extra:
   # Toggle via DOCS_IS_RELEASE env var (set by .readthedocs.yaml for tag builds).
   is_release: !ENV [DOCS_IS_RELEASE, false]


### PR DESCRIPTION
### What this PR does / why we need it?

The MkDocs configuration enables `pymdownx.arithmatex`, which converts Markdown formulas to `\(...\)` and `\[...\]`, but the generated site did not load a browser-side math renderer. As a result, formulas were displayed as raw LaTeX delimiters and commands.

This PR:

- loads MathJax 3 for the generated documentation site;
- adds the Material for MkDocs-compatible initialization for inline and display formulas;
- re-renders formulas when Material emits a document navigation event.

### Relevant documentation

- [Quadratic Latency Model](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.html#quadratic-latency-model)

### Does this PR introduce _any_ user-facing change?

No. This is a documentation rendering fix. Mathematical formulas now render correctly instead of appearing as raw LaTeX text.

### How was this patch tested?

- `uv run --offline --with-requirements docs/requirements-docs.txt mkdocs build --strict`
- `PATH=".venv/bin:$PATH" bash format.sh ci`
- `node --check docs/source/javascripts/mathjax.js`
- Browser verification of `dynamic_chunked_pipeline_parallel.html`: all 15 formula roots rendered through MathJax, no raw delimiters remained, and the browser console reported no errors.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
