### PR TITLE
[CI][Misc] Use domestic npm mirror for OpenCode installation

### DIFF
--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -171,8 +171,13 @@ jobs:
           set -eu
           set -o pipefail
 
-          # install opencode (curl --retry handles transient SSL drops)
-          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors https://opencode.ai/install | bash
+          # Install through Huawei Cloud's domestic npm mirror. The official
+          # installer first queries GitHub for the latest release and then
+          # downloads the binary from GitHub, which is slow from this runner.
+          npm install --global \
+            --prefix "$HOME/.opencode" \
+            --registry https://repo.huaweicloud.com/repository/npm/ \
+            opencode-ai
           # configure opencode auth
           mkdir -p ~/.local/share/opencode
           cat > ~/.local/share/opencode/auth.json <<EOF
@@ -185,7 +190,7 @@ jobs:
           EOF
 
           # ensure opencode is on PATH within this step
-          export PATH="/root/.opencode/bin:$PATH"
+          export PATH="$HOME/.opencode/bin:$PATH"
 
           # verify opencode works
           echo "Verifying opencode..."
@@ -304,7 +309,7 @@ jobs:
           RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES: True
         run: |
           set -euo pipefail
-          export PATH="/root/.opencode/bin:$PATH"
+          export PATH="$HOME/.opencode/bin:$PATH"
           eval "${MAIN2MAIN_LOG_HELPERS}"
 
           rm -rf /tmp/main2main


### PR DESCRIPTION
## What this PR does / why we need it?

- Install `opencode-ai` through Huawei Cloud's domestic npm mirror in the `main2main` workflow.
- Keep the existing `$HOME/.opencode/bin` installation path and PATH usage.
- Avoid the official installer path that queries the GitHub API and downloads the release from GitHub, which is slow from Huawei Cloud runners in mainland China.

## Does this PR introduce any user-facing change?

No. This only changes the CI installation source for OpenCode.

## How was this patch tested?

- YAML parsing passed.
- `git diff --check` passed.
- The workflow installation itself requires the GitHub Actions Huawei Cloud runner.
- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
