### PR TITLE
[BugFix] Fix QSFA

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -240,16 +240,16 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         expected = torch.randn(3, 2, 32)
 
         with (
+            patch(
+                "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
+                create=True,
+                return_value=(expected, torch.empty(0), torch.empty(0)),
+            ) as mock_qsfa,
             patch.object(
                 torch.ops._C_ascend,
                 "npu_kv_quant_sparse_flash_attention",
                 create=True,
-                return_value=(expected, torch.empty(0), torch.empty(0)),
-            ) as mock_qsfa,
-            patch(
-                "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
-                create=True,
-                side_effect=AssertionError("C8 SFA must use the custom op"),
+                side_effect=AssertionError("C8 SFA without LSE must use torch_npu"),
             ),
         ):
             result = impl._execute_sparse_flash_attention_process(
@@ -268,7 +268,6 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
         self.assertEqual(call_kwargs["key_quant_mode"], 2)
         self.assertEqual(call_kwargs["tile_size"], 128)
-        self.assertTrue(call_kwargs["return_softmax_lse"])
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -700,27 +700,37 @@ class BaseDeviceAdaptor:
         return_lse: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
-        result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
-            query=query,
-            key=kv,
-            value=kv,
-            sparse_indices=topk_indices,
-            scale_value=sfa_impl.scale,
-            sparse_block_size=1,
-            block_table=block_table,
-            actual_seq_lengths_query=actual_seq_lengths_query,
-            actual_seq_lengths_kv=actual_seq_lengths_key,
-            layout_query="TND",
-            layout_kv="PA_BSND",
-            sparse_mode=sparse_mode,
-            attention_mode=2,
-            quant_scale_repo_mode=1,
-            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
-            key_quant_mode=2,
-            value_quant_mode=2,
-            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-            return_softmax_lse=True,
-        )
+        common_kwargs = {
+            "query": query,
+            "key": kv,
+            "value": kv,
+            "sparse_indices": topk_indices,
+            "scale_value": sfa_impl.scale,
+            "sparse_block_size": 1,
+            "block_table": block_table,
+            "actual_seq_lengths_query": actual_seq_lengths_query,
+            "actual_seq_lengths_kv": actual_seq_lengths_key,
+            "layout_query": "TND",
+            "layout_kv": "PA_BSND",
+            "sparse_mode": sparse_mode,
+            "attention_mode": 2,
+            "quant_scale_repo_mode": 1,
+            "tile_size": getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            "key_quant_mode": 2,
+            "value_quant_mode": 2,
+            "rope_head_dim": getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+        }
+        if return_lse:
+            # The torch_npu C8 SFA binding used by current images only returns
+            # attention_out and rejects return_softmax_lse.  DCP needs the
+            # softmax max/sum tensors to build LSE, so use the vllm-ascend
+            # custom op added with LSE-capable C8 SFA only on that path.
+            result = torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention(
+                **common_kwargs,
+                return_softmax_lse=True,
+            )
+        else:
+            result = torch_npu.npu_kv_quant_sparse_flash_attention(**common_kwargs)
         if not isinstance(result, tuple):
             if return_lse:
                 raise RuntimeError("C8 sparse flash attention did not return softmax max/sum for DCP LSE merge.")


### PR DESCRIPTION
### What this PR does / why we need it?
  Fix QSFA (Quant Sparse Flash Attention) C8 operator dispatch to route calls correctly based on whether LSE (Log-Sum-Exp) output is required.

  The torch_npu C8 SFA binding used by current images only returns attention_out and rejects return_softmax_lse. However, DCP (Decoupled Context Parallel)
  needs the softmax max/sum tensors to build LSE for attention output merging across devices.

  This PR splits the QSFA call in device_op.py into two paths:
  - DCP path (return_lse=True): Uses the vllm-ascend custom op (torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention) which supports return_softmax_lse
  for LSE-capable C8 SFA.
  - Normal path (return_lse=False): Uses torch_npu.npu_kv_quant_sparse_flash_attention directly, matching the standard torch_npu binding.

  Also updates the unit test mocks in test_sfa_v1.py to reflect the new dispatch logic: the mock targets are swapped so that the return_lse=False path hits
  the torch_npu call while the custom op is only exercised on the LSE path.
### Does this PR introduce _any_ user-facing change?
 No.
### How was this patch tested?
  - Unit tests: pytest -sv tests/ut/attention/a2/test_sfa_v1.py::TestAscendSFAKVQuantSparseAttention
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
