### PR TITLE
[Doc][Misc] Fix documentation navigation and formatting issues

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/index.md
+++ b/docs/source/developer_guide/performance_and_debug/index.md
@@ -1,1 +1,8 @@
 # Performance and Debug
+
+This section provides guides for benchmarking, performance tuning, profiling, and debugging vLLM Ascend.
+
+- **[Performance Benchmark](performance_benchmark.md)** — Benchmarking guide
+- **[Optimization and Tuning](optimization_and_tuning.md)** — Performance optimization
+- **[Service Profiling Guide](service_profiling_guide.md)** — Service profiling
+- **[msprobe Guide](msprobe_guide.md)** — Debugging with msprobe

--- a/docs/source/developer_guide/performance_and_debug/optimization_and_tuning.md
+++ b/docs/source/developer_guide/performance_and_debug/optimization_and_tuning.md
@@ -155,9 +155,7 @@ This section describes operating system–level optimizations applied on the hos
 
     These settings must be applied on the host OS and with root privileges. Not inside containers.
 
-#### 4.1
-
-Set CPU Frequency Governor to `performance`
+#### 4.1 Set CPU Frequency Governor to `performance`
 
 ```shell
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor

--- a/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
+++ b/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
@@ -193,8 +193,6 @@ After parsing, the `output` directory will contain:
 
 ### 6. Appendix related to MS Service Profiler
 
-(profiling-configuration-file)=
-
 #### 6.1 Profiling Configuration File
 
 The profiling configuration file controls profiling parameters and behavior.
@@ -228,8 +226,6 @@ The configuration is in JSON format. Main parameters:
 ```
 
 ---
-
-(symbols-configuration-file)=
 
 #### 6.2 Symbols Configuration File
 

--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -29,7 +29,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Qwen3-Next | 🔵 |  | ✅ | A2/A3 | ✅ |  |  |  |  |  | ✅ |  |  | ✅ |  | ✅ | ✅ |  | [Qwen3-Next](../../tutorials/models/Qwen3-Next.md) |
 | GLM-4.x | 🔵 |  |  | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | 198k | [GLM-4.x](../../tutorials/models/GLM4.x.md) |
 | GLM-5/5.1 | 🔵 |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k | [GLM-5](../../tutorials/models/GLM5.md) |
-| GLM-5.2 | 🔵 |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k | [GLM-5](../../tutorials/models/GLM5.2.md) |
+| GLM-5.2 | 🔵 |  | ✅ | A2/A3 | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 200k | [GLM-5.2](../../tutorials/models/GLM5.2.md) |
 | Gemma4 | 🔵 |  | ✅ | A2/A3/Ascend950 |  | ✅ | ✅ |  |  | ✅ | ✅ |  |  | ✅ |  | ✅ | ✅ |  | [Gemma4](../../tutorials/models/Gemma4.md) |
 | Kimi-K2-Thinking | 🔵 |  |  | A2/A3 |  |  |  |  |  |  |  |  |  |  |  |  |  |  | [Kimi-K2-Thinking](../../tutorials/models/Kimi-K2-Thinking.md) |
 | DeepSeekOCR2 | ✅ |  | ✅ | A2/A3 |  | ✅ |  |  |  | ✅ |  |  |  |  |  |  |  |  | [DeepSeekOCR2](../../tutorials/models/DeepSeekOCR2.md) |


### PR DESCRIPTION
### What this PR does / why we need it?

This PR groups four small documentation corrections found while reviewing the current site:

- turns the Performance and Debug landing page into a useful directory linking to its four guides;
- restores the missing title on the CPU frequency governor subsection;
- removes two obsolete Sphinx-style anchor lines that were visible as unnecessary section content after the MkDocs migration;
- corrects the GLM-5.2 model link label in the supported-models table.

These changes improve navigation and remove confusing or incomplete content without changing runtime behavior.

### Relevant documentation

- [Performance and Debug landing page](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/performance_and_debug/index.html)
- [CPU frequency governor section](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/performance_and_debug/optimization_and_tuning.html#41-set-cpu-frequency-governor-to-performance)
- [Service profiler configuration appendix](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/performance_and_debug/service_profiling_guide.html#61-profiling-configuration-file)
- [Service profiler symbols appendix](https://docs.vllm.ai/projects/ascend/en/latest/developer_guide/performance_and_debug/service_profiling_guide.html#62-symbols-configuration-file)
- [Core supported models](https://docs.vllm.ai/projects/ascend/en/latest/user_guide/support_matrix/supported_models.html#core-supported-models)

### Does this PR introduce _any_ user-facing change?

Documentation-only change. Readers see corrected navigation, headings, and link text.

### How was this patch tested?

- `DOCS_LANG=en SITE_DIR=/private/tmp/vllm-ascend-doc-fixes-site uv run --offline --with-requirements docs/requirements-docs.txt bash tools/rtd_build.sh`
- `uv run --offline --with-requirements requirements-lint.txt bash format.sh ci`
- Browser verification of the generated site confirmed:
  - all four Performance and Debug directory links resolve to the expected pages;
  - the `4.1 Set CPU Frequency Governor to performance` heading renders correctly;
  - the two profiling appendix headings render without stray Sphinx anchor text;
  - the supported-models table displays `GLM-5.2` and links to `GLM5.2.html`;
  - no browser console errors were reported.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
