### PR TITLE
[BugFix] Fix qsfa

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -249,7 +249,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
             patch(
                 "vllm_ascend.device.device_op.torch_npu.npu_kv_quant_sparse_flash_attention",
                 create=True,
-                side_effect=AssertionError("C8 SFA must use the custom op"),
+                side_effect=AssertionError("Base must use _C_ascend custom op"),
             ),
         ):
             result = impl._execute_sparse_flash_attention_process(

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -612,8 +612,9 @@ class BaseDeviceAdaptor:
             )
         return topk_indices
 
-    @staticmethod
+    @classmethod
     def execute_sparse_flash_attention_process(
+        cls,
         sfa_impl,
         ql_nope: torch.Tensor,
         q_pe: torch.Tensor,
@@ -641,7 +642,7 @@ class BaseDeviceAdaptor:
             torch.float8_e5m2,
         )
         if use_kv_quant_sparse_attention:
-            return BaseDeviceAdaptor.execute_kv_quant_sparse_flash_attention(
+            return cls.execute_kv_quant_sparse_flash_attention(
                 sfa_impl,
                 ql_nope,
                 q_pe,
@@ -1123,6 +1124,48 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             scale=scale,
             **kwargs,
         )
+
+    @staticmethod
+    def execute_kv_quant_sparse_flash_attention(
+        sfa_impl,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv: torch.Tensor,
+        block_table: torch.Tensor,
+        topk_indices: torch.Tensor,
+        actual_seq_lengths_query: torch.Tensor,
+        actual_seq_lengths_key: torch.Tensor,
+        *,
+        sparse_mode: int = 3,
+        return_lse: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        query = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
+        result = torch_npu.npu_kv_quant_sparse_flash_attention(
+            query=query,
+            key=kv,
+            value=kv,
+            sparse_indices=topk_indices,
+            scale_value=sfa_impl.scale,
+            sparse_block_size=1,
+            block_table=block_table,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_kv=actual_seq_lengths_key,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=sparse_mode,
+            attention_mode=2,
+            quant_scale_repo_mode=1,
+            tile_size=getattr(sfa_impl, "sfa_qsfa_tile_size", 128),
+            key_quant_mode=2,
+            value_quant_mode=2,
+            rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
+        )
+        if return_lse:
+            raise RuntimeError(
+                "C8 sparse flash attention via torch_npu only returns attention_out; "
+                "cannot return softmax max/sum for DCP LSE merge."
+            )
+        return result
 
     @staticmethod
     def npu_moe_init_routing(


### PR DESCRIPTION
### What this PR does / why we need it?
  Fix QSFA (Quant Sparse Flash Attention) operator dispatch by routing through the device adaptor class hierarchy instead of hardcoding BaseDeviceAdaptor.

  Problem: The torch_npu C8 SFA binding only returns attention_out and rejects return_softmax_lse. However, DCP (Decoupled Context Parallel) needs the
  softmax max/sum tensors to build LSE for attention output merging. The _C_ascend custom op supports return_softmax_lse, but was previously only called on
  the LSE path — the non-LSE path incorrectly relied on torch_npu regardless of device type.

  Solution:
  - BaseDeviceAdaptor: Uses torch.ops._C_ascend.npu_kv_quant_sparse_flash_attention (custom op, LSE-capable). Always passes return_softmax_lse=True and
  strips the LSE output via _format_sparse_flash_attention_output when not needed.
  - A5DeviceAdaptor: Overrides execute_kv_quant_sparse_flash_attention with torch_npu.npu_kv_quant_sparse_flash_attention (no LSE support, matches A5's
  standard torch_npu binding). Raises RuntimeError if LSE is requested.
  - execute_sparse_flash_attention_process: Changed from @staticmethod to @classmethod, dispatches via cls.execute_kv_quant_sparse_flash_attention(...) so
  the correct device-specific implementation is invoked.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
