### PR TITLE
[CI][Misc] Stabilize domestic main2main dependency installation

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -166,6 +166,9 @@ jobs:
           FORCE_COLOR: "1"
           TERM: xterm-256color
           SHELLCHECK_OPTS: "--exclude=SC2046,SC2006,SC2086"
+          # Keep golang-based pre-commit hooks on a domestic module proxy.
+          GOPROXY: https://repo.huaweicloud.com/repository/goproxy/
+          GONOSUMDB: '*'
         run: |
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
           pre-commit run --all-files --hook-stage manual --show-diff-on-failure

--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -62,6 +62,11 @@ jobs:
         UV_HTTP_TIMEOUT: 120
         UV_NO_CACHE: 1
         UV_SYSTEM_PYTHON: 1
+        PRE_COMMIT_HOME: /tmp/main2main-pre-commit
+        # Use Huawei Cloud's domestic Go module proxy for pre-commit hooks
+        # such as actionlint, whose golangenv otherwise accesses proxy.golang.org.
+        GOPROXY: https://repo.huaweicloud.com/repository/goproxy/
+        GONOSUMDB: '*'
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
## What this PR does / why we need it?

- Set up Node.js 24 ARM64 before installing OpenCode because the main2main container does not include `npm`.
- Download Node.js through Huawei Cloud's Node mirror.
- Configure npm to use Huawei Cloud's domestic registry.
- Configure Go-based pre-commit hooks to use Huawei Cloud's Go module proxy.
- Move pre-commit state to `/tmp` instead of the NFS-backed `/root/.cache` path.

The first failed run showed actionlint's golang environment timing out against `proxy.golang.org`. A later run, https://github.com/vllm-project/vllm-ascend/actions/runs/29646428422/job/88085360082, failed earlier with `npm: command not found` while installing OpenCode.

## Does this PR introduce any user-facing change?

No. This only changes CI dependency sources and temporary cache placement.

## How was this patch tested?

- Both modified workflow files pass YAML parsing.
- `git diff --check` passes.
- Huawei Cloud's Node mirror metadata resolves a Linux ARM64 Node 24 release.
- Huawei Cloud's npm registry exposes the `opencode-ai` package.

Note: `main2main_flow` currently hardcodes its own `PRE_COMMIT_HOME`; its corresponding fix is prepared separately as commit `f1ae25b` in `vllm-ascend/main2main_flow` and must be merged for the main2main cache setting to take effect.