### PR TITLE
[BugFix] Persist enable_npugraph_ex override for worker processes

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -9,7 +9,7 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
-from vllm_ascend.platform import NPUPlatform
+from vllm_ascend.platform import NPUPlatform, _sync_npugraph_ex_to_additional_config
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
@@ -80,6 +80,35 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(NPUPlatform.device_control_env_var, "ASCEND_RT_VISIBLE_DEVICES")
         self.assertEqual(NPUPlatform.dispatch_key, "PrivateUse1")
         self.assertEqual(NPUPlatform.supported_quantization, [ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD])
+
+    @pytest.mark.parametrize(
+        "additional_config",
+        [None, {}, {"ascend_compilation_config": None}],
+    )
+    def test_sync_npugraph_ex_to_additional_config(self, additional_config):
+        vllm_config = self.mock_vllm_config()
+        vllm_config.additional_config = additional_config
+        ascend_config = self.mock_vllm_ascend_config()
+        ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+
+        _sync_npugraph_ex_to_additional_config(vllm_config, ascend_config)
+
+        assert vllm_config.additional_config == {"ascend_compilation_config": {"enable_npugraph_ex": False}}
+
+    def test_sync_npugraph_ex_preserves_other_compilation_config(self):
+        vllm_config = self.mock_vllm_config()
+        vllm_config.additional_config = {"ascend_compilation_config": {"enable_static_kernel": True}}
+        ascend_config = self.mock_vllm_ascend_config()
+        ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+
+        _sync_npugraph_ex_to_additional_config(vllm_config, ascend_config)
+
+        assert vllm_config.additional_config == {
+            "ascend_compilation_config": {
+                "enable_npugraph_ex": False,
+                "enable_static_kernel": True,
+            }
+        }
 
     def test_is_sleep_mode_available(self):
         self.assertTrue(self.platform.is_sleep_mode_available())

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -76,6 +76,31 @@ _CUSTOM_OP_REGISTERED = False
 MAX_CAPTURE_SIZES_FOR_950 = 4
 
 
+def _sync_npugraph_ex_to_additional_config(
+    vllm_config: VllmConfig,
+    ascend_config,
+) -> None:
+    """Persist *enable_npugraph_ex* into ``vllm_config.additional_config``.
+
+    ``platform.py`` may override ``enable_npugraph_ex`` (e.g. to ``False`` for
+    PIECEWISE / NONE cudagraph modes).  Worker processes spawned via
+    ``multiprocessing`` re-initialize their own ``AscendConfig`` from
+    ``vllm_config.additional_config``, so the override must be persisted there
+    as well.  Without this sync, workers silently fall back to the default
+    ``enable_npugraph_ex=True`` and use the wrong compilation backend
+    (``npugraph_ex_compile`` / torchair instead of ``fusion_pass_compile``),
+    producing ACL graphs with severely degraded NPU compute utilisation.
+    """
+    if vllm_config.additional_config is None:
+        vllm_config.additional_config = {}
+    additional = vllm_config.additional_config
+    asc_comp = additional.get("ascend_compilation_config")
+    if not isinstance(asc_comp, dict):
+        asc_comp = {}
+        additional["ascend_compilation_config"] = asc_comp
+    asc_comp["enable_npugraph_ex"] = ascend_config.ascend_compilation_config.enable_npugraph_ex
+
+
 def config_deprecated_logging():
     """Configure deprecated logging format, when used deprecated codes
     in vllm-ascend.
@@ -590,6 +615,12 @@ class NPUPlatform(Platform):
             compilation_config.cudagraph_mode = CUDAGraphMode.NONE
             compilation_config.mode = CompilationMode.NONE
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+
+        # Sync enable_npugraph_ex back to vllm_config.additional_config so that
+        # spawned worker processes (which re-init AscendConfig from additional_config)
+        # see the correct value.  Without this, workers default to
+        # enable_npugraph_ex=True and use the wrong compilation path.
+        _sync_npugraph_ex_to_additional_config(vllm_config, ascend_config)
 
         # TODO: Remove this check when ACL Graph supports ASCEND_LAUNCH_BLOCKING=1
         # Then, we will have to discuss the error handling strategy and user experience


### PR DESCRIPTION
## Problem

When `platform.py` overrides `enable_npugraph_ex = False` for PIECEWISE or NONE cudagraph modes, the change only affects the main-process `AscendConfig`. Spawned workers reconstruct their configuration from `vllm_config.additional_config`, which can still contain the default value. Workers can therefore select a different compilation path from the main process.

## Fix

Persist the final `enable_npugraph_ex` value into `additional_config` after cudagraph-mode selection and before workers are spawned.

- Preserve unrelated `ascend_compilation_config` keys.
- Safely replace a missing, `None`, or non-dictionary nested config.
- Keep full-graph behavior unchanged when the final value is already true.

## Validation

- Added regression coverage for a missing top-level config, an empty config, a `None` nested config, and preservation of existing nested keys.
- `ruff check vllm_ascend/platform.py tests/ut/test_platform.py`
- `ruff format --check vllm_ascend/platform.py tests/ut/test_platform.py`
- `python3 -m compileall -q vllm_ascend/platform.py tests/ut/test_platform.py`

This is a configuration-correctness fix; it makes no throughput or latency claim.
- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
