### PR TITLE
[Ops][BugFix] Fix Qwen2 compiled-path outputs on Ascend

### DIFF
--- a/tests/ut/ops/test_rotary_embedding.py
+++ b/tests/ut/ops/test_rotary_embedding.py
@@ -80,9 +80,14 @@ def patch_init_side_effects():
 def make_embedding(patch_init_side_effects):
     """Factory that creates an AscendRotaryEmbedding with controllable use_mtp."""
 
-    def _factory(use_mtp: bool = False, is_neox_style: bool = True):
+    def _factory(
+        use_mtp: bool = False,
+        is_neox_style: bool = True,
+        architecture: str | None = None,
+    ):
         spec_cfg = MagicMock(method="mtp") if use_mtp else None
         patch_init_side_effects.return_value.speculative_config = spec_cfg
+        patch_init_side_effects.return_value.model_config.architectures = [architecture] if architecture else []
 
         with patch("vllm_ascend.ops.rotary_embedding.RotaryEmbedding.__init__") as mock_parent_init:
             mock_parent_init.return_value = None
@@ -134,6 +139,38 @@ def make_yarn_embedding(patch_init_side_effects):
 
 
 class TestAscendEmbeddingForwardOOT:
+    @patch("torch.ops.vllm.npu_rotary_embedding")
+    @patch("vllm_ascend.ops.rotary_embedding.RotaryEmbedding.forward_static")
+    def test_qwen2_uses_native_rotary_path(
+        self,
+        mock_forward_static,
+        mock_npu_op,
+        make_embedding,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE", "1")
+        expected_output = (MagicMock(), MagicMock())
+        mock_forward_static.return_value = expected_output
+        emb = make_embedding(architecture="Qwen2ForCausalLM")
+        matched_cache = MagicMock()
+        emb._match_cos_sin_cache_dtype = MagicMock(return_value=matched_cache)
+        positions, query, key = _make_tensors()
+
+        result = emb.forward_oot(positions, query, key)
+
+        assert result is expected_output
+        emb._match_cos_sin_cache_dtype.assert_called_once_with(query)
+        mock_forward_static.assert_called_once_with(
+            positions,
+            query,
+            key,
+            HEAD_SIZE,
+            ROTARY_DIM,
+            matched_cache,
+            emb.is_neox_style,
+        )
+        mock_npu_op.assert_not_called()
+
     @patch("torch.ops.vllm.npu_rotary_embedding")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     def test_basic_call_delegates_to_npu_op(self, mock_get_forward_context, mock_npu_op, make_embedding):

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -228,6 +228,10 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         super().__init__(head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype, init_cache)
         vllm_config = get_current_vllm_config()
         self.use_mtp = vllm_config.speculative_config and vllm_config.speculative_config.method == "mtp"
+        self.force_native_qwen2_rope = (
+            "Qwen2ForCausalLM" in getattr(vllm_config.model_config, "architectures", [])
+            and os.environ.get("VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE", "1") != "0"
+        )
         _record_cos_sin_cache(self.cos_sin_cache)
         _record_cos_and_sin_cache_interleaved(self.cos_sin_cache)
 
@@ -242,6 +246,17 @@ class AscendRotaryEmbedding(RotaryEmbedding):
         is_neox_style = self.is_neox_style
         if is_neox_style_override is not None:
             is_neox_style = is_neox_style_override
+        if getattr(self, "force_native_qwen2_rope", False):
+            cos_sin_cache = self._match_cos_sin_cache_dtype(query)
+            return RotaryEmbedding.forward_static(
+                positions,
+                query,
+                key,
+                self.head_size,
+                self.rotary_dim,
+                cos_sin_cache,
+                is_neox_style,
+            )
         is_draft_model = _EXTRA_CTX.is_draft_model if is_forward_context_available() else False
         flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled if is_forward_context_available() else False
         if is_draft_model and self.use_mtp and flash_comm_v1_enabled:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -473,6 +473,30 @@ class NPUPlatform(Platform):
 
         from vllm.config.compilation import CUDAGraphMode
 
+        architecture = None
+        if model_config is not None:
+            architectures = getattr(model_config, "architectures", None)
+            if architectures:
+                architecture = architectures[0]
+
+        if model_config is not None and architecture == "Qwen2ForCausalLM":
+            if os.environ.get("VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE", "1") != "0":
+                logger.warning(
+                    "Using native rotary fallback for %s on NPU to avoid incorrect outputs on the compiled path.",
+                    architecture,
+                )
+            elif os.environ.get("VLLM_ASCEND_ALLOW_UNSAFE_QWEN2_ACLGRAPH", "0") != "1":
+                logger.warning(
+                    "Disabling NPU graph compilation for %s because native rotary fallback was disabled and the "
+                    "default ACL graph path can produce incorrect outputs. Set VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE=1 "
+                    "to use the default safe fix, or VLLM_ASCEND_ALLOW_UNSAFE_QWEN2_ACLGRAPH=1 to restore the "
+                    "previous behavior.",
+                    architecture,
+                )
+                enforce_eager = True
+                model_config.enforce_eager = True
+                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+
         if ascend_config.xlite_graph_config.enabled:
             if ascend_config.xlite_graph_config.full_mode and vllm_config.speculative_config is None:
                 logger.info("ACLGraph has been disabled when speculation is disabled in xlite full mode")


### PR DESCRIPTION
### What this PR does / why we need it?

Qwen2 can produce incorrect outputs when the Ascend compiled path uses the NPU rotary operator. Falling back the whole model to eager mode avoids the affected operator but also disables graph execution.

This patch routes `Qwen2ForCausalLM` rotary embedding through `RotaryEmbedding.forward_static` while leaving graph compilation enabled. If `VLLM_ASCEND_USE_NATIVE_QWEN2_ROPE=0` explicitly disables the safe path, graph compilation is disabled unless `VLLM_ASCEND_ALLOW_UNSAFE_QWEN2_ACLGRAPH=1` explicitly restores the known-unsafe behavior. Other architectures continue using the existing NPU rotary operator.

### Does this PR introduce _any_ user-facing change?

Yes. Qwen2 uses the native rotary path by default on Ascend. Two environment variables control explicit fallback behavior as described above.

### How was this patch tested?

Static/unit checks:

- Added `test_qwen2_uses_native_rotary_path`, which verifies that Qwen2 selects the native implementation and does not call `torch.ops.vllm.npu_rotary_embedding`.
- `ruff check vllm_ascend/ops/rotary_embedding.py vllm_ascend/platform.py tests/ut/ops/test_rotary_embedding.py`
- `ruff format --check vllm_ascend/ops/rotary_embedding.py vllm_ascend/platform.py tests/ut/ops/test_rotary_embedding.py`
- `python3 -m compileall -q vllm_ascend/ops/rotary_embedding.py vllm_ascend/platform.py tests/ut/ops/test_rotary_embedding.py`
- `python -m pytest -q tests/ut/ops/test_rotary_embedding.py -k qwen2_uses_native_rotary_path` (1 passed)

Fixed-commit real-NPU validation (2026-07-22):

- Ascend 910B2, one NPU, TP=1
- Qwen2.5-7B-Instruct, BF16, max model length 4096
- vLLM `85c09e9885e346ea1612da30ebff5a75f67d2350` (reports version `0.21.0`)
- base `f583c2fa15b3151529cb1885e8e62f2d50edbe7f`
- candidate `428627c15b32ce5f11ee2b016610244cce554545`
- FULL_DECODE_ONLY graph capture sizes 1, 2, 4, 8; Npugraph_ex enabled

Correctness: candidate safe graph matched the candidate eager reference exactly on four deterministic short prompts and an exact 1-through-64 long-sequence oracle. The base graph also passed these oracles in this environment, so this run validates the candidate but does not claim that it reproduced the base failure.

Repeated performance: 16 requests per repetition, 128 output tokens per request, temperature 0, seed 12343, one warm-up per concurrency, then five repetitions.

| Variant | Concurrency | Output throughput median (range) | TTFT median | TPOT median |
|---|---:|---:|---:|---:|
| Base graph | 1 | 67.68 tok/s (67.07–67.72) | 71.40 ms | 14.31 ms |
| Candidate safe graph | 1 | 53.36 tok/s (46.52–55.03) | 92.42 ms | 18.44 ms |
| Base graph | 4 | 251.85 tok/s (251.23–252.03) | 137.39 ms | 14.88 ms |
| Candidate safe graph | 4 | 221.49 tok/s (220.98–221.61) | 151.36 ms | 16.98 ms |

The safe path reduced output throughput by 21.17% at concurrency 1 and 12.05% at concurrency 4 in this workload. This PR therefore makes no zero-overhead or performance-improvement claim.

Compatibility disclosure: the available CANN 9.0.0 image did not export `aclnnAddRmsNormBias`, although its prebuilt vLLM-Ascend extension expected it. In a dedicated container the incompatible prebuilt extension was disabled, and the pinned source's existing torch_npu fallback was pre-cached before Dynamo tracing. The same condition was used for base, candidate, and eager reference; no git worktree or rotary/model implementation was modified. These measurements apply to that disclosed compatibility configuration, not an unmodified stock image.

Readiness conclusion (2026-07-22): this PR is Draft again. The disclosed environment did not reproduce an incorrect baseline output, while the candidate showed a measurable 12–21% output-throughput regression. Before returning to Ready, the PR needs an unmodified matching runtime that reproduces the baseline failure and fixed-input compiled-rotary numerical/logit/token parity evidence demonstrating baseline failure and candidate success.
