### PR TITLE
[Ops][BugFix] Fix NPU memory profiling on Python 3.12

### DIFF
--- a/tests/ut/patch/platform/test_patch_torch_accelerator.py
+++ b/tests/ut/patch/platform/test_patch_torch_accelerator.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm_ascend.patch.platform.patch_torch_accelerator import _get_npu_memory_info
+
+
+def test_torch_accelerator_get_memory_info_is_patched():
+    assert torch.accelerator.get_memory_info is _get_npu_memory_info
+
+
+@pytest.mark.parametrize(
+    ("device", "expected_device"),
+    [
+        (3, 3),
+        ("npu:2", 2),
+        (torch.device("npu:1"), 1),
+    ],
+)
+def test_get_npu_memory_info_uses_requested_device(monkeypatch, device, expected_device):
+    mem_get_info = MagicMock(return_value=(1024, 2048))
+    monkeypatch.setattr(torch.npu, "mem_get_info", mem_get_info)
+
+    assert _get_npu_memory_info(device) == (1024, 2048)
+    mem_get_info.assert_called_once_with(expected_device)
+
+
+@pytest.mark.parametrize("device", ["cuda:0", torch.device("cpu")])
+def test_get_npu_memory_info_rejects_non_npu_devices(device):
+    with pytest.raises(RuntimeError, match="Expected 'npu'"):
+        _get_npu_memory_info(device)
+
+
+def test_get_npu_memory_info_uses_current_device(monkeypatch):
+    monkeypatch.setattr(torch.npu, "current_device", MagicMock(return_value=4))
+    mem_get_info = MagicMock(return_value=(1024, 2048))
+    monkeypatch.setattr(torch.npu, "mem_get_info", mem_get_info)
+
+    assert _get_npu_memory_info() == (1024, 2048)
+    mem_get_info.assert_called_once_with(4)

--- a/vllm_ascend/patch/platform/patch_torch_accelerator.py
+++ b/vllm_ascend/patch/platform/patch_torch_accelerator.py
@@ -1,6 +1,29 @@
 import torch
 
 
+def _get_npu_memory_info(
+    device: int | str | torch.device | None = None,
+) -> tuple[int, int]:
+    if device is None:
+        device = torch.npu.current_device()
+    elif isinstance(device, torch.device):
+        if device.type != "npu":
+            raise RuntimeError(f"Expected 'npu' device, got '{device.type}'")
+        device = device.index if device.index is not None else torch.npu.current_device()
+    elif isinstance(device, str):
+        if not device.startswith("npu"):
+            raise RuntimeError(f"Expected 'npu' device string, got '{device}'")
+        parts = device.split(":")
+        if len(parts) == 1:
+            device = torch.npu.current_device()
+        elif len(parts) == 2:
+            device = int(parts[1])
+        else:
+            raise RuntimeError(f"Invalid device string format: '{device}'")
+
+    return torch.npu.mem_get_info(device)
+
+
 def patch_empty_cache() -> None:
     torch.npu.empty_cache()
 
@@ -12,12 +35,7 @@ torch.accelerator.empty_cache = patch_empty_cache
 # with torch.accelerator.memory_stats(), but torch.accelerator does not
 # properly delegate to NPU. We redirect to torch.npu.* equivalents.
 torch.accelerator.memory_stats = torch.npu.memory_stats  # type: ignore[attr-defined]
+torch.accelerator.get_memory_info = _get_npu_memory_info  # type: ignore[attr-defined]
 torch.accelerator.memory_reserved = torch.npu.memory_reserved  # type: ignore[attr-defined]
+torch.accelerator.memory_allocated = torch.npu.memory_allocated  # type: ignore[attr-defined]
 torch.accelerator.reset_peak_memory_stats = torch.npu.reset_peak_memory_stats  # type: ignore[attr-defined]
-# torch.accelerator.get_memory_info() routes through c10's
-# CachingDeviceAllocator and asserts the backend allocator is a
-# DeviceAllocator; NPU's caching allocator is not, so it crashes with
-# "Allocator for npu is not a DeviceAllocator". Redirect to the
-# NPU-native API. This is needed on v0.24.0+ where MemorySnapshot
-# is constructed with an explicit device arg that triggers this path.
-torch.accelerator.get_memory_info = torch.npu.mem_get_info  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

Generic vLLM memory profiling calls `torch.accelerator.get_memory_info` and `memory_allocated`. Under Python 3.12 with torch-npu, those generic APIs do not consistently delegate to the NPU allocator.

## Fix

Keep the compatibility mapping in the centralized accelerator patch module:

- Route `get_memory_info` to `torch.npu.mem_get_info` with validated integer, string, and `torch.device` handling.
- Route `memory_allocated` to `torch.npu.memory_allocated`.
- Avoid duplicate platform monkey-patches and import-cycle workarounds.

## Validation

- Added focused unit coverage for integer, string, `torch.device`, current-device, and invalid-device inputs.
- `ruff check vllm_ascend/patch/platform/patch_torch_accelerator.py tests/ut/patch/platform/test_patch_torch_accelerator.py`
- `ruff format --check vllm_ascend/patch/platform/patch_torch_accelerator.py tests/ut/patch/platform/test_patch_torch_accelerator.py`
- `python3 -m compileall -q vllm_ascend/patch/platform/patch_torch_accelerator.py tests/ut/patch/platform/test_patch_torch_accelerator.py`

This is a runtime-correctness fix and makes no throughput or latency claim.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350

## Fixed-head real-NPU validation (2026-07-22)

Evidence bundle: https://gist.github.com/ShuhaoZhangTony/34c58727ab59cff143aab1e60e9efef2

- Hardware/software: Ascend 910B2, CANN 9.0.0, Python 3.12.13, torch-npu 2.10.0.
- Fixed base: `92ff388f9dc8d28827446ce5f1a792071bdf7173`.
- Fixed candidate: `9c942a6721850ccad89f802a1008559870625f69`.
- The base reproduced the generic allocator failure: `torch.accelerator.memory_allocated(0)` hit the torch-npu `DeviceAllocator` internal assertion.
- On the candidate, integer, string, `torch.device`, and current-device forms of `get_memory_info` all succeeded; invalid CPU/CUDA devices were rejected.
- After a real 64 MiB NPU allocation, generic and native accounting both reported `67,109,376` allocated bytes.

Evidence classification: **real-NPU correctness smoke**. This PR makes no latency or throughput claim.