### PR TITLE
[v0.23.0][Feature][KVCache] Finalize layerwise Memcache puts

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
@@ -44,8 +44,8 @@ class Backend(ABC):
     def batch_remove_lease(self, keys: list[str]) -> int:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_remove_lease")
 
-    def batch_put_end(self, keys: list[str], results: list[int]) -> list[int]:
-        raise NotImplementedError(f"{type(self).__name__} does not support batch_put_end")
+    def batch_write_finish(self, keys: list[str], results: list[int]) -> list[int]:
+        raise NotImplementedError(f"{type(self).__name__} does not support batch_write_finish")
 
     @abstractmethod
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
@@ -44,7 +44,7 @@ class Backend(ABC):
     def batch_remove_lease(self, keys: list[str]) -> int:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_remove_lease")
 
-    def batch_put_end(self, keys: list[str]) -> list[int]:
+    def batch_put_end(self, keys: list[str], results: list[int]) -> list[int]:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_put_end")
 
     @abstractmethod

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
@@ -44,6 +44,9 @@ class Backend(ABC):
     def batch_remove_lease(self, keys: list[str]) -> int:
         raise NotImplementedError(f"{type(self).__name__} does not support batch_remove_lease")
 
+    def batch_put_end(self, keys: list[str]) -> list[int]:
+        raise NotImplementedError(f"{type(self).__name__} does not support batch_put_end")
+
     @abstractmethod
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         pass

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -154,9 +154,9 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_remove_lease(keys)
 
-    def batch_put_end(self, keys: list[str], results: list[int]) -> list[int]:
+    def batch_write_finish(self, keys: list[str], results: list[int]) -> list[int]:
         assert self.store is not None
-        return self.store.batch_put_end(keys, results)
+        return self.store.batch_write_finish(keys, results)
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -154,9 +154,9 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_remove_lease(keys)
 
-    def batch_put_end(self, keys: list[str]) -> list[int]:
+    def batch_put_end(self, keys: list[str], results: list[int]) -> list[int]:
         assert self.store is not None
-        return self.store.batch_put_end(keys)
+        return self.store.batch_put_end(keys, results)
 
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -154,6 +154,10 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_remove_lease(keys)
 
+    def batch_put_end(self, keys: list[str]) -> list[int]:
+        assert self.store is not None
+        return self.store.batch_put_end(keys)
+
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
             logger.error(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1000,7 +1000,6 @@ class LayerBatchReqMeta:
     addr_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
     size_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
     gvas_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
-    save_keys: list[str] = field(default_factory=list)
     load_keys: list[str] = field(default_factory=list)
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -857,6 +857,7 @@ class ReqMeta:
 
     last_block_gva: int | None = None
     partial_block_index: int | None = None
+    save_keys: list[str] | None = None
     load_keys: list[str] | None = None
 
     starts: list[int] | None = None
@@ -999,6 +1000,7 @@ class LayerBatchReqMeta:
     addr_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
     size_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
     gvas_array: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
+    save_keys: list[str] = field(default_factory=list)
     load_keys: list[str] = field(default_factory=list)
 
 
@@ -1018,6 +1020,7 @@ class SharedBlockData:
     block_gvas_arr: np.ndarray
     req_ids: list[str]
     is_last_chunks: list[bool | None]
+    save_keys: list[str] = field(default_factory=list)
     load_keys: list[str] = field(default_factory=list)
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1340,7 +1340,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 logger.error("Layerwise %d save batch_copy failed with return code %d", physical_layer, res)
             if physical_layer == self.final_layer_id and all_save_keys:
                 save_keys = list(dict.fromkeys(all_save_keys))
-                self.m_store.batch_put_end(save_keys, [res] * len(save_keys))
+                self.m_store.batch_write_finish(save_keys, [res] * len(save_keys))
             for req_id in all_req_ids:
                 if self.try_finish_and_delete_stored_request(req_id):
                     self.set_finished_request(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -196,6 +196,7 @@ class LayerBatchBuilder:
         block_ids_arr, block_gvas_arr = self._ensure_buf(total)
         req_ids: list[str] = []
         is_last_chunks: list[bool | None] = []
+        all_save_keys: list[str] = []
         all_load_keys: list[str] = []
         offset = 0
 
@@ -203,6 +204,8 @@ class LayerBatchBuilder:
             request = block_range.request
             req_ids.append(request.req_id)
             is_last_chunks.append(request.is_last_chunk)
+            if request.save_keys:
+                all_save_keys.extend(request.save_keys)
             if request.load_keys:
                 all_load_keys.extend(request.load_keys)
             block_ids_np, block_gvas_np = self._require_request_arrays(block_range, is_save)
@@ -242,6 +245,7 @@ class LayerBatchBuilder:
             block_gvas_arr=block_gvas_arr,
             req_ids=req_ids,
             is_last_chunks=is_last_chunks,
+            save_keys=all_save_keys,
             load_keys=all_load_keys,
         )
 
@@ -262,6 +266,7 @@ class LayerBatchBuilder:
             addr_array=addr_array,
             size_array=size_array,
             gvas_array=gvas_array,
+            save_keys=shared.save_keys,
             load_keys=shared.load_keys,
         )
 
@@ -1296,6 +1301,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         all_addrs = []
         all_sizes = []
         all_req_ids = []
+        all_save_keys: list[str] = []
         for task in transfer_tasks:
             shared = task.shared_block_data
             if shared is None:
@@ -1306,6 +1312,8 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             for req_id in req_meta.req_ids:
                 self.dec_stored_request(req_id)
                 all_req_ids.append(req_id)
+            if req_meta.save_keys:
+                all_save_keys.extend(req_meta.save_keys)
             all_gvas.append(req_meta.gvas_array)
             all_addrs.append(req_meta.addr_array)
             all_sizes.append(req_meta.size_array)
@@ -1332,6 +1340,14 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 )
             if res != 0:
                 logger.error("Layerwise %d save batch_copy failed with return code %d", physical_layer, res)
+            if physical_layer == self.final_layer_id and all_save_keys:
+                save_keys = list(dict.fromkeys(all_save_keys))
+                self.m_store.batch_put_end(save_keys)
+                logger.info(
+                    "[KVPOOL] save_thread completed %d puts after final layer %d",
+                    len(save_keys),
+                    physical_layer,
+                )
             for req_id in all_req_ids:
                 if self.try_finish_and_delete_stored_request(req_id):
                     self.set_finished_request(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -266,7 +266,6 @@ class LayerBatchBuilder:
             addr_array=addr_array,
             size_array=size_array,
             gvas_array=gvas_array,
-            save_keys=shared.save_keys,
             load_keys=shared.load_keys,
         )
 
@@ -1312,8 +1311,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             for req_id in req_meta.req_ids:
                 self.dec_stored_request(req_id)
                 all_req_ids.append(req_id)
-            if req_meta.save_keys:
-                all_save_keys.extend(req_meta.save_keys)
+            all_save_keys.extend(shared.save_keys)
             all_gvas.append(req_meta.gvas_array)
             all_addrs.append(req_meta.addr_array)
             all_sizes.append(req_meta.size_array)
@@ -1342,12 +1340,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 logger.error("Layerwise %d save batch_copy failed with return code %d", physical_layer, res)
             if physical_layer == self.final_layer_id and all_save_keys:
                 save_keys = list(dict.fromkeys(all_save_keys))
-                self.m_store.batch_put_end(save_keys)
-                logger.info(
-                    "[KVPOOL] save_thread completed %d puts after final layer %d",
-                    len(save_keys),
-                    physical_layer,
-                )
+                self.m_store.batch_put_end(save_keys, [res] * len(save_keys))
             for req_id in all_req_ids:
                 if self.try_finish_and_delete_stored_request(req_id):
                     self.set_finished_request(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1248,6 +1248,7 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.sync_save_events = sync_save_events
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
+        self.write_results: dict[str, int] = {}
         self.group_builders: list[LayerBatchBuilder] | None = group_builders
         if group_builders is not None:
             self.layer_batch_builder = group_builders[0]
@@ -1338,9 +1339,13 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                 )
             if res != 0:
                 logger.error("Layerwise %d save batch_copy failed with return code %d", physical_layer, res)
-            if physical_layer == self.final_layer_id and all_save_keys:
+            if all_save_keys:
                 save_keys = list(dict.fromkeys(all_save_keys))
-                self.m_store.batch_write_finish(save_keys, [res] * len(save_keys))
+                for key in save_keys:
+                    self.write_results[key] = self.write_results.get(key, 0) or res
+                if physical_layer == self.final_layer_id:
+                    results = [self.write_results.pop(key) for key in save_keys]
+                    self.m_store.batch_write_finish(save_keys, results)
             for req_id in all_req_ids:
                 if self.try_finish_and_delete_stored_request(req_id):
                     self.set_finished_request(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1018,6 +1018,7 @@ class KVPoolWorker:
 
             all_group_gvas: list[np.ndarray] = []
             all_group_block_ids: list[np.ndarray] = []
+            all_group_save_keys: list[str] = []
             for group_id in range(self.num_kv_cache_groups):
                 group_block_size = self.grouped_block_size[group_id]
                 cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
@@ -1084,6 +1085,7 @@ class KVPoolWorker:
                     for pos, key, gva in zip(new_positions, new_keys, new_gvas):
                         block_gvas[pos] = gva
                         self._allocated_gvas[key] = gva
+                    all_group_save_keys.extend(new_keys)
 
                 logger.info(
                     "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
@@ -1108,6 +1110,7 @@ class KVPoolWorker:
                 all_group_block_ids.append(np.asarray(block_ids_by_group, dtype=np.int64))
 
             if all_group_gvas:
+                request.save_keys = all_group_save_keys
                 request.block_gvas_by_group_np = all_group_gvas
                 request.block_ids_by_group_np = all_group_block_ids
                 request.block_gvas_np = all_group_gvas[0]


### PR DESCRIPTION
### What this PR does / why we need it?

Memcache now requires the layerwise GVA save path to explicitly finish newly allocated objects after their data has been copied.

This PR:

- exposes the new `batch_write_finish(keys, results)` API through `MemcacheBackend`;
- carries keys created by `batch_alloc` through the layerwise save metadata; and
- accumulates every layer's L2G `batch_copy` result per key, preserving the first failure; and
- calls `batch_write_finish` after the final layer with matching key and aggregated-result lists.

### Does this PR introduce _any_ user-facing change?

No. This is an internal Memcache lifecycle update for layerwise AscendStore saves.

### How was this patch tested?

- All repository pre-commit hooks passed.
- Python syntax compilation and `git diff --check` passed.
- Existing `test_kv_transfer` tests passed in dependency-mock mode: 30 passed, 10 skipped.
- No new unit tests were added; end-to-end validation of `batch_write_finish` requires the new Memcache runtime and Ascend hardware.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
