### PR TITLE
[BugFix][Doc] Avoid polib dependency during CPU UT collection

### DIFF
--- a/tools/generate_zh_docs.py
+++ b/tools/generate_zh_docs.py
@@ -13,7 +13,6 @@ import sys
 from pathlib import Path
 
 import regex as re
-from polib import pofile
 
 SOURCE_DIR = Path("docs/source")
 LOCALE_DIR = SOURCE_DIR / "locale" / "zh_CN" / "LC_MESSAGES"
@@ -28,6 +27,8 @@ MARKDOWN_BLOCK_PREFIX_RE = re.compile(r"(?:[-+*>#|]|\d+[.)])(?:\s|$)")
 
 def parse_po_file(po_path: Path) -> dict:
     """Parse a .po file and return msgid -> msgstr mapping."""
+    from polib import pofile
+
     po = pofile(str(po_path))
     translations = {}
     for entry in po:


### PR DESCRIPTION
### What this PR does / why we need it?

#### Root cause and provenance

The CPU unit-test lane in [run 29653393420](https://github.com/vllm-project/vllm-ascend/actions/runs/29653393420) fails while collecting `tests/ut/_tools/test_generate_zh_docs.py`:

```text
tests/ut/_tools/test_generate_zh_docs.py:1: in <module>
    from tools.generate_zh_docs import apply_translations
tools/generate_zh_docs.py:16: in <module>
    from polib import pofile
E   ModuleNotFoundError: No module named 'polib'
```

- [PR #11252](https://github.com/vllm-project/vllm-ascend/pull/11252), merged as `fbbf5167ada3f3b59909bcf947e69036fc4af425`, introduced the Chinese-doc generator, its top-level `polib` import, and `polib` in `docs/requirements-docs.txt`.
- [PR #12331](https://github.com/vllm-project/vllm-ascend/pull/12331), merged as `ff83573c37c0bc84e33111e0558086f2c4d73aea`, added `test_generate_zh_docs.py`. That test imports only the pure `apply_translations` helper.
- The selected-test CPU environment installs `requirements-dev.txt`, not `docs/requirements-docs.txt`, so it correctly does not contain the docs-only `polib` package. Both the [main CPU job](https://github.com/vllm-project/vllm-ascend/actions/runs/29653393420/job/88103795623) and [v0.24.0 CPU job](https://github.com/vllm-project/vllm-ascend/actions/runs/29653393420/job/88103795682) fail at the same collection point.

#### Minimal fix

Move `from polib import pofile` into `parse_po_file()`, the only path that actually reads PO files.

This keeps `polib` in the existing documentation dependency group, avoids adding a docs-only package to core/runtime or general test dependencies, and allows pure Markdown translation helpers to be imported and tested without the optional docs stack. Calling the real PO parsing path still imports and requires `polib` as intended.

This is an existing `main` issue and is independent of PR #12218 and its main2main changes.

### Does this PR introduce _any_ user-facing change?

No. It only narrows when an existing documentation dependency is imported.

### How was this patch tested?

From current `upstream/main` `e1bd15041af9d9e1a274ae381da0bc0dd8b50e4d`:

- Reproduced the collection failure in an isolated environment with `regex` and `pytest`, but no `polib`.
- Verified ordinary `tools.generate_zh_docs` import succeeds when `polib` is absent.
- `pytest -q --confcutdir=tests/ut/_tools tests/ut/_tools/test_generate_zh_docs.py` without `polib`: `4 passed`.
- `pytest --collect-only -q --confcutdir=tests/ut/_tools tests/ut/_tools/test_generate_zh_docs.py` without `polib`: `4 tests collected`.
- Parsed a temporary PO file through `parse_po_file()` with `polib` installed and verified the expected `{"Hello": "你好"}` mapping.
- `ruff check tools/generate_zh_docs.py tests/ut/_tools/test_generate_zh_docs.py`.
- `ruff format --check tools/generate_zh_docs.py tests/ut/_tools/test_generate_zh_docs.py`.
- `git diff --check`.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
