### PR TITLE
[Doc][Misc] Update documentation header notification bar

### DIFF
--- a/docs/hooks/macros_main.py
+++ b/docs/hooks/macros_main.py
@@ -15,14 +15,14 @@ UI_STRINGS = {
     "en": {
         "banner_preview": "You are viewing the latest developer preview docs.",
         "banner_link": "Click here",
-        "banner_suffix": "to view docs for the latest stable release (v0.18.0).",
+        "banner_suffix": "to view docs for the latest stable release (v0.23.0).",
         "btn_report": "report issue",
         "aria_report": "Report a documentation issue",
     },
     "zh": {
         "banner_preview": "您正在查看最新的开发者预览版文档。",
         "banner_link": "点击此处",
-        "banner_suffix": "查看最新稳定版（v0.18.0）的文档。",
+        "banner_suffix": "查看最新稳定版（v0.23.0）的文档。",
         "btn_report": "反馈问题",
         "aria_report": "报告文档问题",
     },

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -24,7 +24,7 @@
 {% if not config.extra.is_release %}
 <div class="md-announce">
   {{ t.banner_preview }}
-  <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">{{ t.banner_link }}</a>
+  <a href="https://docs.vllm.ai/projects/ascend/en/v0.23.0">{{ t.banner_link }}</a>
   {{ t.banner_suffix }}
 </div>
 {% endif %}

--- a/docs/source/_templates/sections/header.html
+++ b/docs/source/_templates/sections/header.html
@@ -54,5 +54,5 @@
   </style>
   
   <div class="notification-bar">
-    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">Click here</a> to view docs for the latest stable release(v0.18.0).</p>
+    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/projects/ascend/en/v0.23.0">Click here</a> to view docs for the latest stable release(v0.23.0).</p>
   </div>


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the hardcoded stable documentation version from `v0.18.0` to `v0.23.0` in the notification banner across English and Chinese translations, as well as the HTML templates. This ensures users viewing the developer preview docs are directed to the correct latest stable release.

### Does this PR introduce _any_ user-facing change?
Yes, it updates the notification bar text and links in the documentation header to point to `v0.23.0` instead of `v0.18.0`.

### How was this patch tested?
No tests were added as this is a documentation template change.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
