### PR TITLE
[BugFix][Ops] Fix inplace partial rotary tiling ownership

### DIFF
--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
@@ -17,6 +17,7 @@
 // #include "log/log.h"
 #include "tiling/tiling_api.h"
 // #include "tiling_base/tiling_templates_registry.h"
+#include <memory>
 #include <vector>
 namespace optiling {
 constexpr uint32_t MODE_ATTR_IDX = 0;
@@ -79,10 +80,10 @@ ge::graphStatus Tiling4RotaryPositionEmbedding(gert::TilingContext *context)
     if (socVersion == platform_ascendc::SocVersion::ASCEND950)
     {
         std::vector<std::unique_ptr<RopeRegBaseTilingClass>> regBaseTilingCases;
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassAAndB(context)));
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassAB(context)));
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassABAAndBA(context)));
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassBAB(context)));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassAAndB>(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassAB>(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassABAAndBA>(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassBAB>(context));
         OPS_LOG_I(context, "Using arch35 tiling for ASCEND950");
 
         for (const auto& ptr : regBaseTilingCases)

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.h
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.h
@@ -223,6 +223,8 @@ public:
     {
     }
 
+    virtual ~RopeRegBaseTilingClass() = default;
+
     void Reset(gert::TilingContext *context)
     {
         RopeRegBaseTilingClass::Reset(context);


### PR DESCRIPTION
### What this PR does / why we need it?

The ASCEND950 tiling path stores four derived tiling implementations in
`std::unique_ptr<RopeRegBaseTilingClass>`. The base class is polymorphic but
does not have a virtual destructor, so destroying the derived instances
through the base pointer has undefined behavior.

This PR keeps the existing tiling selection order and behavior unchanged and:

- constructs each tiling implementation with `std::make_unique`, avoiding
  direct ownership construction from raw `new`;
- adds a virtual default destructor to `RopeRegBaseTilingClass`, ensuring each
  derived object is destroyed through the correct dynamic type.

The ownership pattern follows the RAII approach used by other CANN tiling
implementations. No manual `delete` or tiling registry refactor is introduced.

### Does this PR introduce _any_ user-facing change?

No. This only makes host-side tiling object lifetime management safe.

### How was this patch tested?

- White-box checked the construction, polymorphic call, early-return, fallback,
  and scope-exit destruction paths.
- Confirmed the operator host project uses C++17, which supports
  `std::make_unique`.
- Confirmed the diff is limited to the ownership construction and virtual
  destruction contract for `inplace_partial_rotary_mul`.
- CANN compilation and NPU execution were not run locally; validation is left
  to the remote PR CI environment.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
