### PR TITLE
[Feature] SD spec decode op

### DIFF
--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -515,6 +515,7 @@ SD methods need to verify K tokens for each sequence during decoding. As BS incr
 
 - Variable concurrency workload using same deployment. K would decrease as concurrency increases.
 - During RL rollout where we start off with high BS but then end up with small BS due to very few long tail request which end up generating a lot of tokens stalling the progress of the current rollout. Here K would go up during the end of rollout.
+- Currently supports MTP, eagle3, dflash, ngram, etc, Suffix itself is' per request dynamic ', and the outer dynamic K is redundant/conflicting for it.This is an upstream constraint, and vLLM itself will also collapse, not a unique problem of Ascend. dspark、MTP+DCP+DSD Currently not supported.
 
 ### `--speculative-config` schema
 

--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -505,6 +505,76 @@ This entropy-aware threshold is controlled by two parameters:
 
 Both features can be enabled independently or together. When used together, the cumulative acceptance from Block Verify is combined with the entropy-adjusted threshold from Entropy Verify.
 
+## Dynamic Speculative Decoding
+
+### Why is Dynamic SD needed?
+
+SD methods need to verify K tokens for each sequence during decoding. As BS increases, the effective BS becomes BS\*K which increases the compute requirement during verification. When this BS\*K goes beyond a critical BS then SD negatively impacts the decode speed (TPOT). DSD helps by tuning the K to an optimal value such that we continue to reap the benefits from SD.
+
+### Use cases
+
+- Variable concurrency workload using same deployment. K would decrease as concurrency increases.
+- During RL rollout where we start off with high BS but then end up with small BS due to very few long tail request which end up generating a lot of tokens stalling the progress of the current rollout. Here K would go up during the end of rollout.
+
+### `--speculative-config` schema
+
+To use Dynamic SD, add `num_speculative_tokens_per_batch_size` to the config of an SD method which is a list of list. Here, an entry is `[start_bs, end_bs, optimal_K]` which means when the concurrency is within range `[start_bs, end_bs]` then `optimal_K` number of draft tokens are used. For e.g.,
+
+```bash
+--speculative-config '{
+    "method": "eagle",
+    "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
+    "num_speculative_tokens": 3,
+    "num_speculative_tokens_per_batch_size": [
+      [1, 64, 3],
+      [65, 128, 1],
+      [129, 512, 0]
+    ]
+  }'
+```
+
+implies that:
+
+- K=3 will be used when the concurrency is in range [1, 64]
+- K=1 will be used when the concurrency is in range [65, 128]
+- K=0 will be used when the concurrency is in range [129, 512], i.e., no draft tokens will be produced.
+
+### Online Examples
+
+#### Dynamic SD Eagle Drafter
+
+```bash
+VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
+  --speculative-config '{
+    "method": "eagle",
+    "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
+    "num_speculative_tokens": 3,
+    "num_speculative_tokens_per_batch_size": [
+      [1, 64, 3],
+      [65, 128, 1],
+      [129, 512, 0]
+    ]
+  }'
+```
+
+#### Dynamic SD Eagle3 Drafter
+
+```bash
+VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
+  --speculative-config '{
+    "method": "eagle3",
+    "model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",
+    "num_speculative_tokens": 3,
+    "num_speculative_tokens_per_batch_size": [
+      [1, 16, 5],
+      [17, 32, 4],
+      [33, 64, 3],
+      [65, 128, 1],
+      [129, 512, 0]
+    ]
+  }'
+```
+
 ## Synthetic Rejection Sampling
 
 In addition to the default `standard` rejection sampling (which accepts a draft token when `target_prob / draft_prob >= uniform`), vLLM Ascend supports **synthetic** rejection sampling. In this mode each draft token at position `i` is accepted with a configured probability `rates[i]`, compared against a uniform random draw — **independent of the target/draft probability match**. The first rejected position stops the request and emits a recovered token; if every draft token is accepted, the bonus token is appended.

--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -545,7 +545,7 @@ implies that:
 #### Dynamic SD Eagle Drafter
 
 ```bash
-VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
   --speculative-config '{
     "method": "eagle",
     "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
@@ -561,7 +561,7 @@ VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
 #### Dynamic SD Eagle3 Drafter
 
 ```bash
-VLLM_USE_V2_MODEL_RUNNER=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
   --speculative-config '{
     "method": "eagle3",
     "model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",

--- a/examples/offline_DSD_k_tuner/generate_config.py
+++ b/examples/offline_DSD_k_tuner/generate_config.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import pprint
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from transformers import AutoTokenizer
+
+from vllm import LLM
+from vllm.benchmarks.datasets import add_dataset_parser, get_samples
+from vllm.benchmarks.sweep.param_sweep import ParameterSweep
+from vllm.benchmarks.sweep.serve import SweepServeArgs, run_main
+from vllm.sampling_params import SamplingParams
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.metrics.reader import Counter, Vector
+from manager import DynamicSpeculativeDecodingManager
+import sys
+import os
+
+
+DEFAULT_CUDAGRAPH_CAPTURE_SIZES = (
+    1, 2, 4, 6, 8, 16, 24, 32, 64, 96, 128, 256, 384, 512
+)
+
+
+def build_compilation_config(
+    cudagraph_capture_sizes: Sequence[int],
+) -> dict[str, object]:
+    return {
+        "cudagraph_mode": "FULL_DECODE_ONLY",
+        "cudagraph_capture_sizes": list(cudagraph_capture_sizes),
+    }
+
+
+def build_serve_params(
+    method,
+    draft_dir,
+    tp,
+    num_speculative_tokens_list,
+    prompt_lookup_max,
+    prompt_lookup_min,
+    max_vllm_batch_size,
+):
+    """Build serve parameter sweep for vanilla + speculative decode configs.
+    Each entry becomes a separate server configuration in the sweep.
+    The sweep framework starts/stops the server for each serve config.
+    """
+    records: list[dict[str, object]] = []
+
+    # Vanilla config (no speculative decoding)
+    records.append({"_benchmark_name": "vanilla",
+                    "max_num_seqs":max_vllm_batch_size,
+                })
+
+    # Speculative decoding configs with varying num_speculative_tokens
+    if method == "ngram":
+        for k in num_speculative_tokens_list:
+            records.append(
+                {
+                    "_benchmark_name": f"ngram-k-{k}",
+                    "max_num_seqs":max_vllm_batch_size,
+                    "speculative_config": {
+                        "method": "ngram",
+                        "num_speculative_tokens": k,
+                        "prompt_lookup_max": prompt_lookup_max,
+                        "prompt_lookup_min": prompt_lookup_min,
+                    },
+                }
+            )
+    elif method in ("eagle", "eagle3"):
+        for k in num_speculative_tokens_list:
+            records.append(
+                {
+                    "_benchmark_name": f"{method}-k-{k}",
+                    "max_num_seqs":max_vllm_batch_size,
+                    "speculative_config": {
+                        "method": method,
+                        "model": draft_dir,
+                        "num_speculative_tokens": k,
+                        "draft_tensor_parallel_size": tp,
+                    },
+                }
+            )
+    elif method == "mtp":
+        for k in num_speculative_tokens_list:
+            records.append(
+                {
+                    "_benchmark_name": f"mtp-k-{k}",
+                    "max_num_seqs":max_vllm_batch_size,
+                    "speculative_config": {
+                        "method": "mtp",
+                        "num_speculative_tokens": k,
+                    },
+                }
+            )
+
+    return ParameterSweep.from_records(records)
+
+
+def build_bench_params(batch_size_list, num_batches):
+    """Build benchmark parameter sweep for different concurrencies.
+    Each entry varies max_concurrency (batch size) and num_prompts.
+    """
+    records = []
+    for bs in batch_size_list:
+        num_prompts = num_batches * bs
+        records.append(
+            {
+                "_benchmark_name": f"bs-{bs}",
+                "max_concurrency": bs,
+                "num_prompts": num_prompts,
+            }
+        )
+    return ParameterSweep.from_records(records)
+
+
+def parse_itl_from_dataframe(result_df):
+    """Parse ITL from sweep result DataFrame into batch_stats format.
+    Returns:
+        batch_stats: dict of {batch_size: {num_drafts: median_itl_ms}}
+        where num_drafts=0 corresponds to vanilla (no speculation).
+    """
+    batch_stats: dict[int, dict[int, float]] = {}
+    for _, row in result_df.iterrows():
+        bs = int(row["max_concurrency"])
+
+        # Determine k (num speculative tokens) from speculative_config.
+        # For vanilla rows, speculative_config is NaN (missing from serve
+        # params); for spec decode rows, it's a dict or JSON string.
+        spec_config = row.get("speculative_config")
+        if isinstance(spec_config, dict):
+            k = int(spec_config["num_speculative_tokens"])
+        elif isinstance(spec_config, str):
+            k = int(json.loads(spec_config)["num_speculative_tokens"])
+        else:
+            k = 0  # vanilla (NaN or None)
+
+        if bs not in batch_stats:
+            batch_stats[bs] = {}
+        batch_stats[bs][k] = row["median_itl_ms"]
+
+    return batch_stats
+
+
+def run_profiling_sweep(args):
+    """Run profiling benchmarks using vllm bench sweep serve."""
+    compilation_config = build_compilation_config(
+        args.cudagraph_capture_sizes
+    )
+
+    # Base serve command (static params shared across all serve configs)
+    serve_cmd = [
+        "vllm",
+        "serve",
+        "--model",
+        args.model_dir,
+        "--port",
+        str(args.port),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--max-num-seqs",
+        str(args.max_vllm_batch_size),
+        "--tensor-parallel-size",
+        str(args.tp),
+        "--enable-chunked-prefill",
+        "--no-enable-prefix-caching",
+        "--compilation-config",
+        json.dumps(compilation_config),
+    ]
+
+    # Base bench command (static params shared across all bench configs)
+    bench_cmd = [
+        "vllm",
+        "bench",
+        "serve",
+        "--model",
+        args.model_dir,
+        "--port",
+        str(args.port),
+        "--backend",
+        "openai-chat",
+        "--endpoint",
+        "/v1/chat/completions",
+        "--dataset-name",
+        args.dataset_name,
+        "--dataset-path",
+        args.dataset_path,
+        f"--temperature={args.temp}",
+        f"--top-p={args.top_p}",
+        f"--top-k={args.top_k}",
+    ]
+    # offline dataset
+    if args.dataset_name == "hf":
+        if args.hf_name:
+            bench_cmd.extend(["--hf-name", args.hf_name])
+        if args.hf_split:
+            bench_cmd.extend(["--hf-split", args.hf_split])
+
+    # Build parameter sweeps
+    serve_params = build_serve_params(
+        method=args.method,
+        draft_dir=args.draft_dir,
+        tp=args.tp,
+        num_speculative_tokens_list=args.num_speculative_tokens_list,
+        prompt_lookup_max=args.prompt_lookup_max,
+        prompt_lookup_min=args.prompt_lookup_min,
+        max_vllm_batch_size=args.max_vllm_batch_size,
+    )
+
+    bench_params = build_bench_params(
+        batch_size_list=args.batch_size_list,
+        num_batches=args.num_batches,
+    )
+
+    # Run the sweep
+    sweep_args = SweepServeArgs(
+        serve_cmd=serve_cmd,
+        bench_cmd=bench_cmd,
+        after_bench_cmd=[],
+        show_stdout=True,
+        serve_params=serve_params,
+        bench_params=bench_params,
+        output_dir=Path(args.result_dir),
+        num_runs=1,
+        dry_run=False,
+        resume=False,
+        link_vars=[],
+        server_ready_timeout=600,
+        experiment_name=f"{args.method}-{args.num_spec_tokens}",
+    )
+
+    result_df = run_main(sweep_args)
+    return result_df
+
+
+def get_acceptance_rate_per_pos(args):
+    """Get acceptance rate per position."""
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_dir)
+    prompts = get_samples(args, tokenizer)
+    llm_prompts: list[Any]
+    if args.enable_multimodal_chat:
+        llm_prompts = [p.prompt for p in prompts]
+    else:
+        # add_special_tokens is False to avoid adding bos twice
+        # when using chat templates
+        llm_prompts = [
+            {
+                "prompt_token_ids": tokenizer.encode(
+                    prompt.prompt, add_special_tokens=False
+                ),
+                "multi_modal_data": prompt.multi_modal_data,
+            }
+            for prompt in prompts
+        ]
+    if args.method == "eagle" or args.method == "eagle3":
+        eagle_dir = args.eagle_dir
+        if args.method == "eagle" and eagle_dir is None:
+            eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
+
+        elif args.method == "eagle3" and eagle_dir is None:
+            eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
+        speculative_config = {
+            "method": args.method,
+            "model": eagle_dir,
+            "num_speculative_tokens": args.num_spec_tokens,
+            "disable_padded_drafter_batch": args.disable_padded_drafter_batch,
+            "parallel_drafting": args.parallel_drafting,
+        }
+    elif args.method == "ngram":
+        speculative_config = {
+            "method": "ngram",
+            "num_speculative_tokens": args.num_spec_tokens,
+            "prompt_lookup_max": args.prompt_lookup_max,
+            "prompt_lookup_min": args.prompt_lookup_min,
+        }
+    elif args.method == "draft_model":
+        assert args.draft_model is not None and args.draft_model != ""
+        speculative_config = {
+            "method": args.method,
+            "model": args.draft_model,
+            "num_speculative_tokens": args.num_spec_tokens,
+            "enforce_eager": args.enforce_eager,
+            "max_model_len": args.max_model_len,
+            "parallel_drafting": args.parallel_drafting,
+        }
+    elif args.method == "mtp":
+        speculative_config = {
+            "method": "mtp",
+            "num_speculative_tokens": args.num_spec_tokens,
+        }
+    else:
+        raise ValueError(f"unknown method: {args.method}") 
+
+    llm = LLM(
+        model=args.model_dir,
+        trust_remote_code=True,
+        tensor_parallel_size=args.tp,
+        enable_chunked_prefill=args.enable_chunked_prefill,
+        enforce_eager=args.enforce_eager,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        speculative_config=speculative_config,
+        disable_log_stats=False,
+        max_model_len=args.max_model_len,
+        limit_mm_per_prompt={"image": 5},
+        disable_chunked_mm_input=True,
+        max_num_seqs=args.max_vllm_batch_size,
+        allowed_local_media_path=args.allowed_local_media_path,
+        compilation_config=build_compilation_config(
+            args.cudagraph_capture_sizes
+        ),
+    )
+
+    metrics_names = [m.name for m in llm.get_metrics()]
+    has_spec_metrics = any("spec_decode" in n for n in metrics_names)
+    print(f"[VERIFY] Spec decode metrics present: {has_spec_metrics}")
+    if not has_spec_metrics:
+        raise RuntimeError("Speculative decoding was NOT enabled! Check draft model path and config.")
+
+    sampling_params = SamplingParams(temperature=args.temp, max_tokens=args.output_len)
+    if args.backend == "openai-chat":
+        _ = llm.chat(llm_prompts, sampling_params=sampling_params)
+    else:
+        _ = llm.generate(
+            llm_prompts,
+            sampling_params=sampling_params,
+        )
+
+    metrics = llm.get_metrics()
+
+    num_drafts = 0
+    num_draft_tokens = 0
+    num_accepted_tokens = 0
+    acceptance_counts = [0] * args.num_spec_tokens
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_draft_tokens":
+            assert isinstance(metric, Counter)
+            num_draft_tokens += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens":
+            assert isinstance(metric, Counter)
+            num_accepted_tokens += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                acceptance_counts[pos] += metric.values[pos]
+
+    acceptance_length = 1 + (num_accepted_tokens / num_drafts) if num_drafts > 0 else 1
+    print(f"mean acceptance length: {acceptance_length:.2f}")
+    print("-" * 50)
+
+    # print acceptance at each token position
+    acceptance_rate_per_pos = []
+    for i in range(len(acceptance_counts)):
+        acceptance_rate = acceptance_counts[i] / num_drafts if num_drafts > 0 else 0
+        print(f"acceptance at token {i}: {acceptance_rate:.2f}")
+        acceptance_rate_per_pos.append(acceptance_rate)
+
+    return acceptance_length, acceptance_rate_per_pos
+
+
+def main():
+    parser = FlexibleArgumentParser()
+    add_dataset_parser(parser)
+
+    parser.add_argument("--model-dir", type=str, default=None)
+    parser.add_argument("--draft-dir", type=str, default=None)
+    parser.add_argument(
+        "--method",
+        type=str,
+        default="eagle",
+        choices=["ngram", "eagle", "eagle3", "mtp"],
+    )
+    parser.add_argument(
+        "--num-speculative-tokens-list", nargs="*", type=int, default=[1, 3, 5]
+    )
+    parser.add_argument(
+        "--batch-size-list", nargs="*", type=int, default=[1, 4, 16, 64, 256]
+    )
+    parser.add_argument(
+        "--cudagraph-capture-sizes",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_CUDAGRAPH_CAPTURE_SIZES),
+        help="Batch sizes to capture for CUDAGraph.",
+    )
+    parser.add_argument(
+        "--max-vllm-batch-size",
+        type=int,
+        help="Max vllm server batch size (max concurrency)",
+    )
+    parser.add_argument("--backend", type=str, default="openai")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--tp", type=int, default=1)
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--enable-chunked-prefill", action="store_true")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--disable-padded-drafter-batch", action="store_true")
+    parser.add_argument("--result-dir", type=str, default="./log/dynamic_sd")
+    parser.add_argument("--prompt-lookup-max", type=int, default=5)
+    parser.add_argument("--prompt-lookup-min", type=int, default=2)
+    parser.add_argument("--max-model-len", type=int, default=16384)
+    parser.add_argument("--temp", type=float, default=0)        
+    parser.add_argument("--top-p", type=float, default=1.0)     
+    parser.add_argument("--top-k", type=int, default=-1)         
+    parser.add_argument("--output-len", type=int, default=256)
+    parser.add_argument("--parallel-drafting", action="store_true")
+    parser.add_argument("--allowed-local-media-path", type=str, default="")
+    parser.add_argument(
+        "--num-batches",
+        type=int,
+        default=20,
+        help="Number of batches to run for each benchmark.",
+    )
+    parser.add_argument("--custom-mm-prompts", action="store_true")
+    args = parser.parse_args()
+    args.enable_chunked_prefill = True
+    args.enforce_eager = False
+    args.print_output = False
+    args.num_spec_tokens = max(args.num_speculative_tokens_list)
+    args.eagle_dir = args.draft_dir
+    args.result_dir = (
+        f"{args.result_dir}/tp-{args.tp}_temp-{args.temp}"
+        f"_top_p-{args.top_p}_top_k-{args.top_k}"
+        f"/{args.dataset_path}/"
+    )
+
+    assert args.max_vllm_batch_size == max(args.batch_size_list), (
+        "max_vllm_batch_size must be equal to max of batch_size_list"
+    )
+
+    pprint.pprint(vars(args))
+    start = time.time()
+
+    # Step 1: get acceptance_rate_per_pos
+    acceptance_length, acceptance_rate_per_pos = get_acceptance_rate_per_pos(args)
+    print(f"Acceptance length: {acceptance_length}")
+    print(f"Acceptance rate per position: {acceptance_rate_per_pos}")
+    print("✅ Step 1: obtained acceptance rate per position.")
+
+    # Step 2: generate benchmark data using vllm bench sweep serve
+    result_df = run_profiling_sweep(args)
+    print(f"✅ Step 2: benchmark data generated for vanilla and {args.method}.")
+
+    # Step 3: parse batch_stats from benchmark data
+    batch_stats = parse_itl_from_dataframe(result_df)
+    print("✅ Step 3: parsed batch statistics from benchmark data.")
+    print(json.dumps(batch_stats, indent=4))
+
+    manager = DynamicSpeculativeDecodingManager(
+        batch_stats=batch_stats,
+        acceptance_rate_per_pos=acceptance_rate_per_pos,
+        vllm_max_batch_size=args.max_vllm_batch_size,
+    )
+    num_speculative_tokens_per_batch_size = (
+        manager.get_num_speculative_tokens_per_batch_size()
+    )
+
+    # Step 4: Save the dynamic speculative decoding configuration.
+    dynamic_config = {
+        "num_speculative_tokens_per_batch_size": (
+            num_speculative_tokens_per_batch_size
+        ),
+        "batch_stats": batch_stats,
+        "max_num_speculative_tokens": len(acceptance_rate_per_pos),
+        "acceptance_rate_per_pos": acceptance_rate_per_pos,
+    }
+
+    config_path = f"{args.result_dir}/dynamic_speculative_config.json"
+    with open(config_path, "w") as f:
+        json.dump(dynamic_config, f, indent=4)
+
+    print("Reference num_speculative_tokens_per_batch_size:")
+    print(json.dumps(num_speculative_tokens_per_batch_size, indent=4))
+
+    print(f"✅ Step 4: config saved to {config_path}")
+
+    end = time.time()
+    print(f"Total time taken: {end - start:.2f} seconds")
+
+    print("Optimal K by batch size:")
+    bs = 1
+    while bs <= args.max_vllm_batch_size:
+        print(f"  BS {bs}: {manager.get_optimal_num_speculative_tokens(bs)}")
+        bs *= 2
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_DSD_k_tuner/generate_config.py
+++ b/examples/offline_DSD_k_tuner/generate_config.py
@@ -7,8 +7,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from manager import DynamicSpeculativeDecodingManager
 from transformers import AutoTokenizer
-
 from vllm import LLM
 from vllm.benchmarks.datasets import add_dataset_parser, get_samples
 from vllm.benchmarks.sweep.param_sweep import ParameterSweep
@@ -16,14 +16,8 @@ from vllm.benchmarks.sweep.serve import SweepServeArgs, run_main
 from vllm.sampling_params import SamplingParams
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.v1.metrics.reader import Counter, Vector
-from manager import DynamicSpeculativeDecodingManager
-import sys
-import os
 
-
-DEFAULT_CUDAGRAPH_CAPTURE_SIZES = (
-    1, 2, 4, 6, 8, 16, 24, 32, 64, 96, 128, 256, 384, 512
-)
+DEFAULT_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 6, 8, 16, 24, 32, 64, 96, 128, 256, 384, 512)
 
 
 def build_compilation_config(
@@ -51,9 +45,12 @@ def build_serve_params(
     records: list[dict[str, object]] = []
 
     # Vanilla config (no speculative decoding)
-    records.append({"_benchmark_name": "vanilla",
-                    "max_num_seqs":max_vllm_batch_size,
-                })
+    records.append(
+        {
+            "_benchmark_name": "vanilla",
+            "max_num_seqs": max_vllm_batch_size,
+        }
+    )
 
     # Speculative decoding configs with varying num_speculative_tokens
     if method == "ngram":
@@ -61,7 +58,7 @@ def build_serve_params(
             records.append(
                 {
                     "_benchmark_name": f"ngram-k-{k}",
-                    "max_num_seqs":max_vllm_batch_size,
+                    "max_num_seqs": max_vllm_batch_size,
                     "speculative_config": {
                         "method": "ngram",
                         "num_speculative_tokens": k,
@@ -75,7 +72,7 @@ def build_serve_params(
             records.append(
                 {
                     "_benchmark_name": f"{method}-k-{k}",
-                    "max_num_seqs":max_vllm_batch_size,
+                    "max_num_seqs": max_vllm_batch_size,
                     "speculative_config": {
                         "method": method,
                         "model": draft_dir,
@@ -89,7 +86,7 @@ def build_serve_params(
             records.append(
                 {
                     "_benchmark_name": f"mtp-k-{k}",
-                    "max_num_seqs":max_vllm_batch_size,
+                    "max_num_seqs": max_vllm_batch_size,
                     "speculative_config": {
                         "method": "mtp",
                         "num_speculative_tokens": k,
@@ -147,9 +144,7 @@ def parse_itl_from_dataframe(result_df):
 
 def run_profiling_sweep(args):
     """Run profiling benchmarks using vllm bench sweep serve."""
-    compilation_config = build_compilation_config(
-        args.cudagraph_capture_sizes
-    )
+    compilation_config = build_compilation_config(args.cudagraph_capture_sizes)
 
     # Base serve command (static params shared across all serve configs)
     serve_cmd = [
@@ -249,9 +244,7 @@ def get_acceptance_rate_per_pos(args):
         # when using chat templates
         llm_prompts = [
             {
-                "prompt_token_ids": tokenizer.encode(
-                    prompt.prompt, add_special_tokens=False
-                ),
+                "prompt_token_ids": tokenizer.encode(prompt.prompt, add_special_tokens=False),
                 "multi_modal_data": prompt.multi_modal_data,
             }
             for prompt in prompts
@@ -293,7 +286,7 @@ def get_acceptance_rate_per_pos(args):
             "num_speculative_tokens": args.num_spec_tokens,
         }
     else:
-        raise ValueError(f"unknown method: {args.method}") 
+        raise ValueError(f"unknown method: {args.method}")
 
     llm = LLM(
         model=args.model_dir,
@@ -309,9 +302,7 @@ def get_acceptance_rate_per_pos(args):
         disable_chunked_mm_input=True,
         max_num_seqs=args.max_vllm_batch_size,
         allowed_local_media_path=args.allowed_local_media_path,
-        compilation_config=build_compilation_config(
-            args.cudagraph_capture_sizes
-        ),
+        compilation_config=build_compilation_config(args.cudagraph_capture_sizes),
     )
 
     metrics_names = [m.name for m in llm.get_metrics()]
@@ -376,12 +367,8 @@ def main():
         default="eagle",
         choices=["ngram", "eagle", "eagle3", "mtp"],
     )
-    parser.add_argument(
-        "--num-speculative-tokens-list", nargs="*", type=int, default=[1, 3, 5]
-    )
-    parser.add_argument(
-        "--batch-size-list", nargs="*", type=int, default=[1, 4, 16, 64, 256]
-    )
+    parser.add_argument("--num-speculative-tokens-list", nargs="*", type=int, default=[1, 3, 5])
+    parser.add_argument("--batch-size-list", nargs="*", type=int, default=[1, 4, 16, 64, 256])
     parser.add_argument(
         "--cudagraph-capture-sizes",
         nargs="+",
@@ -405,9 +392,9 @@ def main():
     parser.add_argument("--prompt-lookup-max", type=int, default=5)
     parser.add_argument("--prompt-lookup-min", type=int, default=2)
     parser.add_argument("--max-model-len", type=int, default=16384)
-    parser.add_argument("--temp", type=float, default=0)        
-    parser.add_argument("--top-p", type=float, default=1.0)     
-    parser.add_argument("--top-k", type=int, default=-1)         
+    parser.add_argument("--temp", type=float, default=0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=-1)
     parser.add_argument("--output-len", type=int, default=256)
     parser.add_argument("--parallel-drafting", action="store_true")
     parser.add_argument("--allowed-local-media-path", type=str, default="")
@@ -425,9 +412,7 @@ def main():
     args.num_spec_tokens = max(args.num_speculative_tokens_list)
     args.eagle_dir = args.draft_dir
     args.result_dir = (
-        f"{args.result_dir}/tp-{args.tp}_temp-{args.temp}"
-        f"_top_p-{args.top_p}_top_k-{args.top_k}"
-        f"/{args.dataset_path}/"
+        f"{args.result_dir}/tp-{args.tp}_temp-{args.temp}_top_p-{args.top_p}_top_k-{args.top_k}/{args.dataset_path}/"
     )
 
     assert args.max_vllm_batch_size == max(args.batch_size_list), (
@@ -457,15 +442,11 @@ def main():
         acceptance_rate_per_pos=acceptance_rate_per_pos,
         vllm_max_batch_size=args.max_vllm_batch_size,
     )
-    num_speculative_tokens_per_batch_size = (
-        manager.get_num_speculative_tokens_per_batch_size()
-    )
+    num_speculative_tokens_per_batch_size = manager.get_num_speculative_tokens_per_batch_size()
 
     # Step 4: Save the dynamic speculative decoding configuration.
     dynamic_config = {
-        "num_speculative_tokens_per_batch_size": (
-            num_speculative_tokens_per_batch_size
-        ),
+        "num_speculative_tokens_per_batch_size": (num_speculative_tokens_per_batch_size),
         "batch_stats": batch_stats,
         "max_num_speculative_tokens": len(acceptance_rate_per_pos),
         "acceptance_rate_per_pos": acceptance_rate_per_pos,

--- a/examples/offline_DSD_k_tuner/manager.py
+++ b/examples/offline_DSD_k_tuner/manager.py
@@ -1,0 +1,104 @@
+import bisect
+
+
+class DynamicSpeculativeDecodingManager:
+    """Build a batch-size schedule from offline profiling results."""
+
+    def __init__(
+        self,
+        *,
+        batch_stats: dict[int, dict[int, float]],
+        acceptance_rate_per_pos: list[float],
+        vllm_max_batch_size: int,
+    ):
+        if not batch_stats:
+            raise ValueError("batch_stats is required for dynamic speculative decoding")
+        if not acceptance_rate_per_pos:
+            raise ValueError("acceptance_rate_per_pos is required")
+
+        self.batch_stats = batch_stats
+        self.vllm_max_batch_size = vllm_max_batch_size
+        self.max_num_speculative_tokens = len(acceptance_rate_per_pos)
+        self.acceptance_rate_per_pos = acceptance_rate_per_pos
+        self.available_batch_sizes = sorted(batch_stats.keys())
+
+        # Sanity check
+        if not all(0.0 <= a <= 1.0 for a in self.acceptance_rate_per_pos):
+            raise ValueError("acceptance rates must be between 0 and 1")
+        if 1 not in self.batch_stats:
+            raise ValueError(f"BS 1 not found in {self.batch_stats.keys()}")
+        if vllm_max_batch_size not in self.batch_stats:
+            raise ValueError(
+                f"max BS {vllm_max_batch_size} not found in {self.batch_stats.keys()}"
+            )
+
+        for bs in self.available_batch_sizes:
+            if bs <= 0:
+                raise ValueError("batch sizes must be positive")
+            if 0 not in self.batch_stats[bs]:
+                raise ValueError(f"BS {bs} must have draft 0 stats")
+            if 1 not in self.batch_stats[bs]:
+                raise ValueError(f"BS {bs} must have draft 1 stats")
+            if sorted(self.batch_stats[bs]) != list(self.batch_stats[bs]):
+                raise ValueError(f"BS {bs} draft keys must be sorted")
+
+        self._optimal_k_table: dict[int, int] = {}
+        self._sorted_bs_keys: list[int] = []
+        self.update_optimal_num_speculative_tokens()
+
+    def update_optimal_num_speculative_tokens(self) -> None:
+        self._optimal_k_table = {}
+        for bs in self.available_batch_sizes:
+            stats = self.batch_stats[bs]
+            best_k = 0
+            best_goodput = 1.0 / stats.get(0, float('inf'))  # K=0: AL=1
+
+            for k in sorted(stats.keys()):
+                if k == 0:
+                    continue
+                itl = stats[k]
+                if itl <= 0:
+                    continue
+                al = self._compute_accepted_length(k)
+                goodput = al / itl       # https://arxiv.org/pdf/2406.14066  Goodput
+                if goodput > best_goodput:
+                    best_goodput = goodput
+                    best_k = k
+
+            self._optimal_k_table[bs] = best_k
+        self._sorted_bs_keys = sorted(self._optimal_k_table)
+
+    def get_optimal_num_speculative_tokens(self, batch_size: int) -> int:
+        """Return optimal K for a given batch size via binary search."""
+        idx = bisect.bisect_right(self._sorted_bs_keys, batch_size) - 1
+        if idx < 0:
+            return self._optimal_k_table[self._sorted_bs_keys[0]]
+        return self._optimal_k_table[self._sorted_bs_keys[idx]]
+
+    def get_num_speculative_tokens_per_batch_size(self) -> list[list[int]]:
+        """Return merged inclusive batch-size ranges for the optimal K table."""
+        sampled_batch_sizes = [
+            bs for bs in self._sorted_bs_keys if bs <= self.vllm_max_batch_size
+        ]
+        ranges: list[list[int]] = []
+
+        for index, range_start in enumerate(sampled_batch_sizes):
+            if index + 1 < len(sampled_batch_sizes):
+                range_end = sampled_batch_sizes[index + 1] - 1
+            else:
+                range_end = self.vllm_max_batch_size
+
+            optimal_k = self._optimal_k_table[range_start]
+            if ranges and ranges[-1][2] == optimal_k:
+                ranges[-1][1] = range_end
+            else:
+                ranges.append([range_start, range_end, optimal_k])
+
+        return ranges
+
+    def _compute_accepted_length(self, k: int) -> float:
+        """Compute expected accepted length for given K using unconditional rates."""
+        al = 1.0  # base token from target model
+        for i in range(min(k, len(self.acceptance_rate_per_pos))):
+            al += self.acceptance_rate_per_pos[i]
+        return al

--- a/examples/offline_DSD_k_tuner/manager.py
+++ b/examples/offline_DSD_k_tuner/manager.py
@@ -28,9 +28,7 @@ class DynamicSpeculativeDecodingManager:
         if 1 not in self.batch_stats:
             raise ValueError(f"BS 1 not found in {self.batch_stats.keys()}")
         if vllm_max_batch_size not in self.batch_stats:
-            raise ValueError(
-                f"max BS {vllm_max_batch_size} not found in {self.batch_stats.keys()}"
-            )
+            raise ValueError(f"max BS {vllm_max_batch_size} not found in {self.batch_stats.keys()}")
 
         for bs in self.available_batch_sizes:
             if bs <= 0:
@@ -51,7 +49,7 @@ class DynamicSpeculativeDecodingManager:
         for bs in self.available_batch_sizes:
             stats = self.batch_stats[bs]
             best_k = 0
-            best_goodput = 1.0 / stats.get(0, float('inf'))  # K=0: AL=1
+            best_goodput = 1.0 / stats.get(0, float("inf"))  # K=0: AL=1
 
             for k in sorted(stats.keys()):
                 if k == 0:
@@ -60,7 +58,7 @@ class DynamicSpeculativeDecodingManager:
                 if itl <= 0:
                     continue
                 al = self._compute_accepted_length(k)
-                goodput = al / itl       # https://arxiv.org/pdf/2406.14066  Goodput
+                goodput = al / itl  # https://arxiv.org/pdf/2406.14066  Goodput
                 if goodput > best_goodput:
                     best_goodput = goodput
                     best_k = k
@@ -77,9 +75,7 @@ class DynamicSpeculativeDecodingManager:
 
     def get_num_speculative_tokens_per_batch_size(self) -> list[list[int]]:
         """Return merged inclusive batch-size ranges for the optimal K table."""
-        sampled_batch_sizes = [
-            bs for bs in self._sorted_bs_keys if bs <= self.vllm_max_batch_size
-        ]
+        sampled_batch_sizes = [bs for bs in self._sorted_bs_keys if bs <= self.vllm_max_batch_size]
         ranges: list[list[int]] = []
 
         for index, range_start in enumerate(sampled_batch_sizes):

--- a/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
@@ -9,12 +9,22 @@ from vllm.v1.metrics.reader import Counter, Vector
 from tests.e2e.conftest import VllmRunner
 from tests.e2e.pull_request.one_card.spec_decode.utils import BASELINES, DFLASH, calculate_acceptance_per_pos
 
+MAX_NUM_SEQS = 256
+
 
 @pytest.mark.parametrize("method", DFLASH.keys())
 @pytest.mark.parametrize("num_speculative_tokens", [8])
+@pytest.mark.parametrize(
+    "dynamic_num_speculative_tokens",
+    [
+        pytest.param(None, id="static"),
+        pytest.param(4, id="dynamic"),
+    ],
+)
 def test_dflash_acceptance(
     method: str,
     num_speculative_tokens: int,
+    dynamic_num_speculative_tokens: int | None,
 ):
     main_model_name = DFLASH[method]["main"]
     spec_model_name = DFLASH[method]["spec"]
@@ -45,15 +55,26 @@ def test_dflash_acceptance(
         "model": spec_model_name,
         "num_speculative_tokens": num_speculative_tokens,
     }
+    if dynamic_num_speculative_tokens is not None:
+        speculative_config["num_speculative_tokens_per_batch_size"] = [
+            [1, MAX_NUM_SEQS, dynamic_num_speculative_tokens]
+        ]
+        dynamic_capture_size = len(prompts) * (dynamic_num_speculative_tokens + 1)
+        capture_sizes = [dynamic_capture_size, 9, 18]
+    else:
+        capture_sizes = [9, 18]
 
-    compilation_config = CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[9, 18])
+    compilation_config = CompilationConfig(
+        cudagraph_mode="FULL_DECODE_ONLY",
+        cudagraph_capture_sizes=capture_sizes,
+    )
 
     with VllmRunner(
         main_model_name,
         max_model_len=4096,
         disable_log_stats=False,
         tensor_parallel_size=1,
-        max_num_seqs=256,
+        max_num_seqs=MAX_NUM_SEQS,
         distributed_executor_backend="mp",
         gpu_memory_utilization=0.8,
         speculative_config=speculative_config,
@@ -71,7 +92,12 @@ def test_dflash_acceptance(
         print(f"Output tokens: {output_tokens}")
 
     acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
-    golden = BASELINES[method]
+    effective_num_speculative_tokens = (
+        num_speculative_tokens if dynamic_num_speculative_tokens is None else dynamic_num_speculative_tokens
+    )
+    golden = BASELINES[method][:effective_num_speculative_tokens]
 
     match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
+    if dynamic_num_speculative_tokens is not None:
+        assert all(rate == 0 for rate in acceptance_per_pos[dynamic_num_speculative_tokens:])

--- a/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
@@ -10,6 +10,11 @@ from tests.e2e.conftest import VllmRunner
 from tests.e2e.pull_request.one_card.spec_decode.utils import BASELINES, DFLASH, calculate_acceptance_per_pos
 
 MAX_NUM_SEQS = 256
+DYNAMIC_DFLASH_BASELINES = {
+    # DFlash drafts a block in parallel, so changing K changes the block input
+    # shape and its acceptance profile. Do not reuse the K=8 baseline for K=4.
+    ("dflash", 4): [0.8, 0.5, 0.3, 0.2],
+}
 
 
 @pytest.mark.parametrize("method", DFLASH.keys())
@@ -97,9 +102,14 @@ def test_dflash_acceptance(
     effective_num_speculative_tokens = (
         num_speculative_tokens if dynamic_num_speculative_tokens is None else dynamic_num_speculative_tokens
     )
-    golden = BASELINES[method][:effective_num_speculative_tokens]
+    if dynamic_num_speculative_tokens is None:
+        golden = BASELINES[method][:effective_num_speculative_tokens]
+    else:
+        golden = DYNAMIC_DFLASH_BASELINES[(method, dynamic_num_speculative_tokens)]
 
-    match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
+    assert len(acceptance_per_pos) == num_speculative_tokens
+    active_acceptance_per_pos = acceptance_per_pos[:effective_num_speculative_tokens]
+    match = all(abs(a - b) < 0.1 for a, b in zip(active_acceptance_per_pos, golden, strict=True))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
     if dynamic_num_speculative_tokens is not None:
         assert all(rate == 0 for rate in acceptance_per_pos[dynamic_num_speculative_tokens:])

--- a/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_dflash.py
@@ -61,11 +61,13 @@ def test_dflash_acceptance(
         ]
         dynamic_capture_size = len(prompts) * (dynamic_num_speculative_tokens + 1)
         capture_sizes = [dynamic_capture_size, 9, 18]
+        cudagraph_mode = "PIECEWISE"
     else:
         capture_sizes = [9, 18]
+        cudagraph_mode = "FULL_DECODE_ONLY"
 
     compilation_config = CompilationConfig(
-        cudagraph_mode="FULL_DECODE_ONLY",
+        cudagraph_mode=cudagraph_mode,
         cudagraph_capture_sizes=capture_sizes,
     )
 

--- a/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
@@ -10,7 +10,7 @@ from vllm.tokenizers.registry import resolve_tokenizer_args
 from vllm.v1.metrics.reader import Counter, Vector
 
 from tests.e2e.conftest import VllmRunner
-from tests.e2e.pull_request.one_card.spec_decode.utils import MODELS, calculate_acceptance_per_pos
+from tests.e2e.pull_request.one_card.spec_decode.utils import BASELINES, MODELS, calculate_acceptance_per_pos
 
 
 def test_qwen3_vl_eagle(
@@ -101,6 +101,110 @@ def test_qwen_eagle3_acceptance(
 
     acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
     golden = [0.68, 0.40, 0.18]
+
+    match = all(abs(a - b) < 0.08 for a, b in zip(acceptance_per_pos, golden))
+    assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
+
+
+@pytest.mark.parametrize("method", MODELS.keys())
+@pytest.mark.parametrize("num_speculative_tokens", [3])
+@pytest.mark.parametrize("draft_tensor_parallel_size", [1])
+@pytest.mark.parametrize("disable_padded_drafter_batch", [False])
+@pytest.mark.parametrize("async_scheduling", [True])
+@pytest.mark.parametrize(
+    "num_speculative_tokens_per_batch_size",
+    [[[1, 128, 2]]],
+)
+def test_qwen_eagle3_dynamic_acceptance(
+    method: str,
+    num_speculative_tokens: int,
+    draft_tensor_parallel_size: None | int,
+    disable_padded_drafter_batch: bool,
+    async_scheduling: bool,
+    num_speculative_tokens_per_batch_size: list[list[int]],
+):
+    """Dynamic speculative decoding for eagle3 that actually reduces K.
+
+    ``num_speculative_tokens_per_batch_size`` lets the scheduler pick K per step
+    from the running batch size, while ``num_speculative_tokens`` stays the
+    configured maximum (=3). The schedule here maps every batch size 1-128 to
+    K=2, so with this 4-prompt set (batch <= 4 requests per step) *every* step
+    deterministically drafts K=2 -- genuinely exercising the K-reduction path
+    (not just max-K pass-through), with no K=3 tail steps to make it flaky.
+
+    Because eagle3 drafts autoregressively, the first two draft tokens are
+    identical whether the drafter stops at K=2 or continues to K=3, so per-pos
+    acceptance at positions 0 and 1 must still match the static baseline. K=2
+    never drafts position 2, so it is excluded from the check (``golden[:2]``,
+    and ``zip`` compares only the overlapping positions). This asserts the
+    reduced-K path is both functional and precision-preserving.
+    """
+    main_model_name = MODELS[method]["main"]
+    spec_model_name = MODELS[method]["spec"]
+
+    tokenizer_path = resolve_tokenizer_args(main_model_name)[1]
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    prompts = [
+        {"role": "user", "content": "Hello, my name is"},
+        {"role": "user", "content": "The president of the United States is"},
+        {"role": "user", "content": "The capital of France is"},
+        {"role": "user", "content": "The future of AI is"},
+    ]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [prompt],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for prompt in prompts
+    ]
+
+    speculative_config = {
+        "method": method,
+        "num_speculative_tokens": num_speculative_tokens,
+        "draft_tensor_parallel_size": draft_tensor_parallel_size,
+        "disable_padded_drafter_batch": disable_padded_drafter_batch,
+        "num_speculative_tokens_per_batch_size": num_speculative_tokens_per_batch_size,
+        "model": spec_model_name,
+    }
+
+    compilation_config = CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[12])
+
+    with VllmRunner(
+        main_model_name,
+        max_model_len=2048,
+        disable_log_stats=False,
+        tensor_parallel_size=1,
+        max_num_seqs=256,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.7,
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        async_scheduling=async_scheduling,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"Output tokens: {output_tokens}")
+
+    acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
+    # K=2 only drafts positions 0 and 1; position 2 is never proposed, so compare
+    # against the first two baseline values (``zip`` stops at the shorter one).
+    golden = BASELINES[method][:2]
 
     match = all(abs(a - b) < 0.08 for a, b in zip(acceptance_per_pos, golden))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"

--- a/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
@@ -12,6 +12,8 @@ from vllm.v1.metrics.reader import Counter, Vector
 from tests.e2e.conftest import VllmRunner
 from tests.e2e.pull_request.one_card.spec_decode.utils import BASELINES, MODELS, calculate_acceptance_per_pos
 
+MAX_NUM_SEQS = 256
+
 
 def test_qwen3_vl_eagle(
     test_prompts: list[list[dict[str, Any]]],
@@ -31,13 +33,22 @@ def test_qwen3_vl_eagle(
 @pytest.mark.parametrize("draft_tensor_parallel_size", [1])
 @pytest.mark.parametrize("disable_padded_drafter_batch", [False])
 @pytest.mark.parametrize("async_scheduling", [True])
+@pytest.mark.parametrize(
+    "dynamic_num_speculative_tokens",
+    [
+        pytest.param(None, id="static"),
+        pytest.param(2, id="dynamic"),
+    ],
+)
 def test_qwen_eagle3_acceptance(
     method: str,
     num_speculative_tokens: int,
     draft_tensor_parallel_size: None | int,
     disable_padded_drafter_batch: bool,
     async_scheduling: bool,
+    dynamic_num_speculative_tokens: int | None,
 ):
+    """Check acceptance for static K and dynamic K reduction."""
     main_model_name = MODELS[method]["main"]
     spec_model_name = MODELS[method]["spec"]
 
@@ -74,6 +85,10 @@ def test_qwen_eagle3_acceptance(
         "disable_padded_drafter_batch": disable_padded_drafter_batch,
         "model": spec_model_name,
     }
+    if dynamic_num_speculative_tokens is not None:
+        speculative_config["num_speculative_tokens_per_batch_size"] = [
+            [1, MAX_NUM_SEQS, dynamic_num_speculative_tokens]
+        ]
 
     compilation_config = CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[12])
 
@@ -82,7 +97,7 @@ def test_qwen_eagle3_acceptance(
         max_model_len=2048,
         disable_log_stats=False,
         tensor_parallel_size=1,
-        max_num_seqs=256,
+        max_num_seqs=MAX_NUM_SEQS,
         distributed_executor_backend="mp",
         gpu_memory_utilization=0.7,
         speculative_config=speculative_config,
@@ -100,111 +115,12 @@ def test_qwen_eagle3_acceptance(
         print(f"Output tokens: {output_tokens}")
 
     acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
-    golden = [0.68, 0.40, 0.18]
+    effective_num_speculative_tokens = (
+        num_speculative_tokens if dynamic_num_speculative_tokens is None else dynamic_num_speculative_tokens
+    )
+    golden = BASELINES[method][:effective_num_speculative_tokens]
 
     match = all(abs(a - b) < 0.08 for a, b in zip(acceptance_per_pos, golden))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
-
-
-@pytest.mark.parametrize("method", MODELS.keys())
-@pytest.mark.parametrize("num_speculative_tokens", [3])
-@pytest.mark.parametrize("draft_tensor_parallel_size", [1])
-@pytest.mark.parametrize("disable_padded_drafter_batch", [False])
-@pytest.mark.parametrize("async_scheduling", [True])
-@pytest.mark.parametrize(
-    "num_speculative_tokens_per_batch_size",
-    [[[1, 128, 2]]],
-)
-def test_qwen_eagle3_dynamic_acceptance(
-    method: str,
-    num_speculative_tokens: int,
-    draft_tensor_parallel_size: None | int,
-    disable_padded_drafter_batch: bool,
-    async_scheduling: bool,
-    num_speculative_tokens_per_batch_size: list[list[int]],
-):
-    """Dynamic speculative decoding for eagle3 that actually reduces K.
-
-    ``num_speculative_tokens_per_batch_size`` lets the scheduler pick K per step
-    from the running batch size, while ``num_speculative_tokens`` stays the
-    configured maximum (=3). The schedule here maps every batch size 1-128 to
-    K=2, so with this 4-prompt set (batch <= 4 requests per step) *every* step
-    deterministically drafts K=2 -- genuinely exercising the K-reduction path
-    (not just max-K pass-through), with no K=3 tail steps to make it flaky.
-
-    Because eagle3 drafts autoregressively, the first two draft tokens are
-    identical whether the drafter stops at K=2 or continues to K=3, so per-pos
-    acceptance at positions 0 and 1 must still match the static baseline. K=2
-    never drafts position 2, so it is excluded from the check (``golden[:2]``,
-    and ``zip`` compares only the overlapping positions). This asserts the
-    reduced-K path is both functional and precision-preserving.
-    """
-    main_model_name = MODELS[method]["main"]
-    spec_model_name = MODELS[method]["spec"]
-
-    tokenizer_path = resolve_tokenizer_args(main_model_name)[1]
-    tokenizer = AutoTokenizer.from_pretrained(
-        tokenizer_path,
-        trust_remote_code=True,
-    )
-    sampling_params = SamplingParams(
-        temperature=0,
-        ignore_eos=False,
-        max_tokens=256,
-    )
-
-    prompts = [
-        {"role": "user", "content": "Hello, my name is"},
-        {"role": "user", "content": "The president of the United States is"},
-        {"role": "user", "content": "The capital of France is"},
-        {"role": "user", "content": "The future of AI is"},
-    ]
-    prompts = [
-        tokenizer.apply_chat_template(
-            [prompt],
-            tokenize=False,
-            add_generation_prompt=True,
-        )
-        for prompt in prompts
-    ]
-
-    speculative_config = {
-        "method": method,
-        "num_speculative_tokens": num_speculative_tokens,
-        "draft_tensor_parallel_size": draft_tensor_parallel_size,
-        "disable_padded_drafter_batch": disable_padded_drafter_batch,
-        "num_speculative_tokens_per_batch_size": num_speculative_tokens_per_batch_size,
-        "model": spec_model_name,
-    }
-
-    compilation_config = CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[12])
-
-    with VllmRunner(
-        main_model_name,
-        max_model_len=2048,
-        disable_log_stats=False,
-        tensor_parallel_size=1,
-        max_num_seqs=256,
-        distributed_executor_backend="mp",
-        gpu_memory_utilization=0.7,
-        speculative_config=speculative_config,
-        compilation_config=compilation_config,
-        async_scheduling=async_scheduling,
-    ) as llm:
-        outputs = llm.model.generate(prompts, sampling_params)
-        metrics = llm.model.get_metrics()
-
-    for output in outputs:
-        prompt = output.prompt
-        generated_text = output.outputs[0].text
-        output_tokens = output.outputs[0].token_ids
-        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
-        print(f"Output tokens: {output_tokens}")
-
-    acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
-    # K=2 only drafts positions 0 and 1; position 2 is never proposed, so compare
-    # against the first two baseline values (``zip`` stops at the shorter one).
-    golden = BASELINES[method][:2]
-
-    match = all(abs(a - b) < 0.08 for a, b in zip(acceptance_per_pos, golden))
-    assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
+    if dynamic_num_speculative_tokens is not None:
+        assert all(rate == 0 for rate in acceptance_per_pos[dynamic_num_speculative_tokens:])

--- a/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
@@ -119,9 +119,15 @@ def test_qwen_eagle3_acceptance(
     effective_num_speculative_tokens = (
         num_speculative_tokens if dynamic_num_speculative_tokens is None else dynamic_num_speculative_tokens
     )
+    assert len(acceptance_per_pos) == num_speculative_tokens
+    active_acceptance_per_pos = acceptance_per_pos[:effective_num_speculative_tokens]
     golden = BASELINES[method][:effective_num_speculative_tokens]
 
-    match = all(abs(a - b) < 0.08 for a, b in zip(acceptance_per_pos, golden))
+    # Eagle3 drafts autoregressively, so reducing K does not alter the active
+    # prefix within a drafting step. Keep the acceptance-quality regression
+    # against the corresponding baseline prefix; unlike DFlash, K does not
+    # change a parallel block-prediction input shape.
+    match = all(abs(a - b) < 0.08 for a, b in zip(active_acceptance_per_pos, golden, strict=True))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
     if dynamic_num_speculative_tokens is not None:
         assert all(rate == 0 for rate in acceptance_per_pos[dynamic_num_speculative_tokens:])

--- a/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_eagle.py
@@ -90,7 +90,8 @@ def test_qwen_eagle3_acceptance(
             [1, MAX_NUM_SEQS, dynamic_num_speculative_tokens]
         ]
 
-    compilation_config = CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[12])
+    cudagraph_mode = "FULL_DECODE_ONLY" if dynamic_num_speculative_tokens is None else "PIECEWISE"
+    compilation_config = CompilationConfig(cudagraph_mode=cudagraph_mode, cudagraph_capture_sizes=[12])
 
     with VllmRunner(
         main_model_name,

--- a/tests/e2e/pull_request/one_card/spec_decode/test_mtp_eagle_correctness.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_mtp_eagle_correctness.py
@@ -31,14 +31,26 @@ from tests.e2e.conftest import VllmRunner, cleanup_dist_env_and_memory
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 MODELS = ["wemaster/deepseek_mtp_main_random_bf16"]
+MAX_NUM_SEQS = 256
 
 
 @pytest.mark.parametrize("model_name", MODELS)
+@pytest.mark.parametrize(
+    "dynamic_num_speculative_tokens",
+    [
+        pytest.param(None, id="static"),
+        pytest.param(2, id="dynamic"),
+    ],
+)
 @pytest.mark.parametrize("num_speculative_tokens", [3])
 @pytest.mark.parametrize("cudagraph_mode", ["FULL_DECODE_ONLY"])
 @pytest.mark.parametrize("disable_padded_drafter_batch", [False])
 def test_deepseek_mtp(
-    model_name: str, num_speculative_tokens: int, cudagraph_mode: str, disable_padded_drafter_batch: bool
+    model_name: str,
+    dynamic_num_speculative_tokens: int | None,
+    num_speculative_tokens: int,
+    cudagraph_mode: str,
+    disable_padded_drafter_batch: bool,
 ):
     example_prompts = [
         "Hello, my name is",
@@ -50,22 +62,32 @@ def test_deepseek_mtp(
     Compare the outputs of a original LLM and a speculative LLM
     should be the same when using mtp speculative decoding.
     """
+    speculative_config = {
+        "method": "mtp",
+        "num_speculative_tokens": num_speculative_tokens,
+        "disable_padded_drafter_batch": disable_padded_drafter_batch,
+    }
+    if dynamic_num_speculative_tokens is not None:
+        speculative_config["num_speculative_tokens_per_batch_size"] = [
+            [1, MAX_NUM_SEQS, dynamic_num_speculative_tokens]
+        ]
+        dynamic_capture_size = len(example_prompts) * (dynamic_num_speculative_tokens + 1)
+        capture_sizes = [dynamic_capture_size, 20]
+    else:
+        capture_sizes = [20]
+
     with VllmRunner(
         model_name,
         tensor_parallel_size=1,
-        max_num_seqs=256,
+        max_num_seqs=MAX_NUM_SEQS,
         gpu_memory_utilization=0.7,
         distributed_executor_backend="mp",
         enable_expert_parallel=True,
-        speculative_config={
-            "method": "mtp",
-            "num_speculative_tokens": num_speculative_tokens,
-            "disable_padded_drafter_batch": disable_padded_drafter_batch,
-        },
+        speculative_config=speculative_config,
         max_model_len=2000,
         compilation_config=CompilationConfig(
             cudagraph_mode=cudagraph_mode,
-            cudagraph_capture_sizes=[20],
+            cudagraph_capture_sizes=capture_sizes,
         ),
     ) as spec_llm:
         sampling_config = SamplingParams(temperature=0, max_tokens=256, ignore_eos=False)

--- a/tests/e2e/pull_request/one_card/spec_decode/test_mtp_eagle_correctness.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_mtp_eagle_correctness.py
@@ -73,8 +73,10 @@ def test_deepseek_mtp(
         ]
         dynamic_capture_size = len(example_prompts) * (dynamic_num_speculative_tokens + 1)
         capture_sizes = [dynamic_capture_size, 20]
+        effective_cudagraph_mode = "PIECEWISE"
     else:
         capture_sizes = [20]
+        effective_cudagraph_mode = cudagraph_mode
 
     with VllmRunner(
         model_name,
@@ -86,7 +88,7 @@ def test_deepseek_mtp(
         speculative_config=speculative_config,
         max_model_len=2000,
         compilation_config=CompilationConfig(
-            cudagraph_mode=cudagraph_mode,
+            cudagraph_mode=effective_cudagraph_mode,
             cudagraph_capture_sizes=capture_sizes,
         ),
     ) as spec_llm:

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1640,7 +1640,8 @@ class TestEagleProposerPropose:
         assert 'self.kernel_block_size' in src
         sig = inspect.signature(RunnerCls._propose)
         sig_name = self.get_param_names(sig)
-        assert sig_name == ['self', 'target_token_ids', 'target_positions', 'target_hidden_states', 'next_token_ids',
+        assert sig_name == ['self', 'num_speculative_tokens', 'target_token_ids', 'target_positions',
+                            'target_hidden_states', 'next_token_ids',
                             'token_indices_to_sample', 'common_attn_metadata', 'target_model_batch_desc',
                             'sampling_metadata', 'mm_embed_inputs', 'req_scheduled_tokens', 'long_seq_metadata',
                             'num_prefill_reqs', 'num_decode_reqs', 'scheduler_output', 'num_scheduled_tokens',

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1337,7 +1337,8 @@ class TestEagleProposerPropose:
             patch.object(self.proposer, 'attn_update_stack_num_spec_norm', side_effect=side_effect),
             set_current_vllm_config(self.vllm_config),
         ):
-            self.proposer._propose(target_token_ids, target_positions, target_hidden_states, next_token_ids,
+            self.proposer._propose(self.proposer.num_speculative_tokens,
+                                target_token_ids, target_positions, target_hidden_states, next_token_ids,
                                 token_indices_to_sample, mock_common_attn_metadata, target_model_batch_desc, mock_sampling_metadata,
                                 mm_embed_inputs, req_scheduled_tokens, long_seq_metadata, num_prefill_reqs, num_decode_reqs,
                                 scheduler_output, num_scheduled_tokens, num_rejected_tokens_gpu,

--- a/tests/ut/spec_decode/test_dynamic_sd.py
+++ b/tests/ut/spec_decode/test_dynamic_sd.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+"""Regression tests for the dynamic speculative-decoding schedule helpers."""
+
+import pytest
+from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
+
+
+def _make_lookup(
+    num_speculative_tokens_per_batch_size: list[tuple[int, int, int]],
+    vllm_max_batch_size: int = 256,
+    vllm_num_speculative_tokens: int = 3,
+) -> list[int]:
+    return build_dynamic_sd_schedule_lookup(
+        num_speculative_tokens_per_batch_size=num_speculative_tokens_per_batch_size,
+        vllm_max_batch_size=vllm_max_batch_size,
+        vllm_num_speculative_tokens=vllm_num_speculative_tokens,
+    )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "expected_num_spec_tokens"),
+    [
+        (0, 0),
+        (1, 3),
+        (16, 3),
+        (17, 3),
+        (31, 3),
+        (32, 2),
+        (128, 2),
+        (129, 2),
+        (255, 2),
+        (256, 0),
+    ],
+)
+def test_dynamic_sd_schedule_boundaries_and_gaps(
+    batch_size: int,
+    expected_num_spec_tokens: int,
+) -> None:
+    """A gap inherits the speculative-token count from the prior range."""
+    lookup = _make_lookup([(1, 16, 3), (32, 128, 2), (256, 256, 0)])
+
+    assert lookup[batch_size] == expected_num_spec_tokens
+
+
+def test_dynamic_sd_schedule_clamps_to_runtime_max() -> None:
+    lookup = _make_lookup(
+        [(1, 16, 4)],
+        vllm_max_batch_size=16,
+        vllm_num_speculative_tokens=3,
+    )
+
+    assert lookup[1:] == [3] * 16
+
+
+@pytest.mark.parametrize(
+    ("schedule", "error"),
+    [
+        ([(2, 16, 3)], "must start at 1"),
+        ([(1, 16, 3), (16, 32, 2)], "non-overlapping and sorted"),
+        ([(1, 16, -1)], "values must be >= 0"),
+        ([], "must not be empty"),
+    ],
+)
+def test_dynamic_sd_schedule_rejects_invalid_ranges(
+    schedule: list[tuple[int, int, int]],
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        _make_lookup(schedule)
+
+
+def test_dynamic_sd_schedule_rejects_malformed_entry() -> None:
+    with pytest.raises(ValueError, match="3-item sequence"):
+        _make_lookup([(1, 16)])  # type: ignore[list-item]
+
+
+def test_dynamic_sd_schedule_is_required() -> None:
+    with pytest.raises(ValueError, match="is required"):
+        build_dynamic_sd_schedule_lookup(
+            num_speculative_tokens_per_batch_size=None,
+            vllm_max_batch_size=256,
+            vllm_num_speculative_tokens=5,
+        )
+
+
+def test_dynamic_sd_lookup_rejects_batch_size_above_max() -> None:
+    lookup = _make_lookup([(1, 256, 3)])
+
+    with pytest.raises(IndexError):
+        _ = lookup[257]

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1214,13 +1214,22 @@ def _validate_draft_decode_context_parallel_config(vllm_config: VllmConfig) -> N
     if speculative_config is None:
         return
 
-    draft_model_config = speculative_config.draft_model_config
-    if draft_model_config is None:
-        return
-
     parallel_config = vllm_config.parallel_config
     decode_context_parallel_size = parallel_config.decode_context_parallel_size
     if decode_context_parallel_size <= 1:
+        return
+
+    if speculative_config.method == "mtp" and speculative_config.num_speculative_tokens_per_batch_size:
+        raise ValueError(
+            "Dynamic speculative decoding with MTP and decode context "
+            "parallelism is not supported by vLLM Ascend. Please set "
+            "--decode-context-parallel-size to 1 or remove "
+            "num_speculative_tokens_per_batch_size from "
+            "--speculative-config."
+        )
+
+    draft_model_config = speculative_config.draft_model_config
+    if draft_model_config is None:
         return
 
     # MLA draft models do not use the GQA/MQA DCP head-sharding rule.

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1219,9 +1219,9 @@ def _validate_draft_decode_context_parallel_config(vllm_config: VllmConfig) -> N
     if decode_context_parallel_size <= 1:
         return
 
-    if speculative_config.method == "mtp" and speculative_config.num_speculative_tokens_per_batch_size:
+    if speculative_config.num_speculative_tokens_per_batch_size:
         raise ValueError(
-            "Dynamic speculative decoding with MTP and decode context "
+            "Dynamic speculative decoding and decode context "
             "parallelism is not supported by vLLM Ascend. Please set "
             "--decode-context-parallel-size to 1 or remove "
             "num_speculative_tokens_per_batch_size from "

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -739,6 +739,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
     def _propose(
         self,
+        num_speculative_tokens: int,
         # [num_tokens]
         target_token_ids: torch.Tensor,
         # [num_tokens] or [3, num_tokens] when M-RoPE is enabled
@@ -761,6 +762,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         num_rejected_tokens_gpu: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
+
+        # Dynamic SD: take the scheduled per-step K as an explicit argument and
+        # set it here -- mirroring vLLM's ``propose(num_speculative_tokens=...)``
+        # (which sets ``self.num_speculative_tokens`` on entry) and unified with
+        # the other proposers (ngram/suffix/medusa/extract) that also receive the
+        # scheduled K through their propose call. The value never exceeds the
+        # configured maximum, so pre-allocated buffers stay valid; K == 0 is
+        # handled just below.
+        self.num_speculative_tokens = num_speculative_tokens
 
         # Dynamic SD may schedule K == 0 draft tokens for the current batch
         # size. Return an empty [batch_size, 0] draft so downstream copy/unpack

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -762,6 +762,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
+        # Dynamic SD may schedule K == 0 draft tokens for the current batch
+        # size. Return an empty [batch_size, 0] draft so downstream copy/unpack
+        # paths (which key off ``draft_token_ids.shape[1]``) stay consistent.
+        # Mirrors vLLM's llm_base_proposer._propose empty-draft early return.
+        if self.num_speculative_tokens == 0:
+            return torch.empty(
+                batch_size,
+                0,
+                device=target_token_ids.device,
+                dtype=torch.int64,
+            )
+
         if token_indices_to_sample is None:
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 

--- a/vllm_ascend/spec_decode/medusa_proposer.py
+++ b/vllm_ascend/spec_decode/medusa_proposer.py
@@ -45,6 +45,7 @@ class AscendMedusaProposer(MedusaProposer):
 
     def propose(
         self,
+        num_speculative_tokens: int,
         valid_sampled_token_ids: list[list[int]],
         sampling_metadata: SamplingMetadata,
         spec_decode_metadata: SpecDecodeMetadata,
@@ -64,6 +65,7 @@ class AscendMedusaProposer(MedusaProposer):
             hidden_states = sample_hidden_states[indices]
 
         spec_token_ids = super().propose(
+            num_speculative_tokens,
             target_hidden_states=hidden_states,
             sampling_metadata=sampling_metadata,
         )

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -323,6 +323,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
 
     def _propose(
         self,
+        num_speculative_tokens: int,
         target_token_ids: torch.Tensor,
         target_positions: torch.Tensor,
         target_hidden_states: torch.Tensor,
@@ -340,8 +341,21 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         num_scheduled_tokens: int = 0,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # Dynamic SD: honor the scheduled per-step K, unified with
+        # ``AscendSpecDecodeBaseProposer._propose`` (this override does not call
+        # ``super()``, so it sets the value itself).
+        self.num_speculative_tokens = num_speculative_tokens
         self._last_draft_probs = None
         batch_size = common_attn_metadata.batch_size()
+
+        # Dynamic SD may schedule K == 0: return an empty [batch_size, 0] draft
+        # (mirrors AscendSpecDecodeBaseProposer._propose) so the downstream
+        # copy/unpack paths -- which key off ``draft_token_ids.shape[1]`` -- stay
+        # consistent. This override does not inherit the base's early return.
+        if self.num_speculative_tokens == 0:
+            return torch.empty(
+                batch_size, 0, device=target_token_ids.device, dtype=torch.int64
+            )
 
         if token_indices_to_sample is None:
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -353,9 +353,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         # copy/unpack paths -- which key off ``draft_token_ids.shape[1]`` -- stay
         # consistent. This override does not inherit the base's early return.
         if self.num_speculative_tokens == 0:
-            return torch.empty(
-                batch_size, 0, device=target_token_ids.device, dtype=torch.int64
-            )
+            return torch.empty(batch_size, 0, device=target_token_ids.device, dtype=torch.int64)
 
         if token_indices_to_sample is None:
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1

--- a/vllm_ascend/spec_decode/suffix_proposer.py
+++ b/vllm_ascend/spec_decode/suffix_proposer.py
@@ -23,10 +23,10 @@ class AscendSuffixDecodingProposer(SuffixDecodingProposer):
 
     def propose(
         self,
+        num_speculative_tokens: int,
         sampled_token_ids: list[list[int]],
         num_tokens_no_spec=None,
         token_ids_cpu=None,
-        num_speculative_tokens: int = 0,
         slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     ):
         return super().propose(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -938,7 +938,10 @@ class NPUModelRunner(GPUModelRunner):
                 # the K used last step. Under dynamic SD that width can be < the
                 # configured maximum, so use ``prev_num_spec_tokens`` (tracked in
                 # ``_copy_draft_token_ids_to_cpu``) rather than ``num_spec_tokens``.
-                self.prev_num_spec_tokens,
+                # ``prev_num_spec_tokens`` is only set once the first draft has
+                # been produced; before that (first step) fall back to the
+                # configured ``num_spec_tokens`` -- matching vLLM's base init.
+                getattr(self, "prev_num_spec_tokens", self.num_spec_tokens),
                 prev_positions=prev_positions_gpu,
             )
 
@@ -1169,7 +1172,10 @@ class NPUModelRunner(GPUModelRunner):
                 draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
                 # Previous step's draft width (see the note on the other
                 # generate_pcp_mtp_input call); matters when dynamic SD varies K.
-                num_spec_tokens=self.prev_num_spec_tokens,
+                # Not set until the first draft is produced, and never set when
+                # spec decoding is off but CP is on -- fall back to
+                # ``num_spec_tokens`` (0 when spec decoding is disabled).
+                num_spec_tokens=getattr(self, "prev_num_spec_tokens", self.num_spec_tokens),
                 prepare_input_ids=self._prepare_input_ids,
             )
         else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -940,8 +940,10 @@ class NPUModelRunner(GPUModelRunner):
                 # ``_copy_draft_token_ids_to_cpu``) rather than ``num_spec_tokens``.
                 # It is initialized in ``GPUModelRunner.__init__`` (to the
                 # configured max K, or 0 when spec decoding is off), so it is
-                # always present before the first draft is produced.
-                self.prev_num_spec_tokens,
+                # always present before the first draft is produced. The type
+                # is only assigned in the parent class, which mypy cannot
+                # resolve here (same reason as the assignment site below).
+                self.prev_num_spec_tokens,  # type: ignore[has-type]
                 prev_positions=prev_positions_gpu,
             )
 
@@ -1173,8 +1175,9 @@ class NPUModelRunner(GPUModelRunner):
                 # Previous step's draft width (see the note on the other
                 # generate_pcp_mtp_input call); matters when dynamic SD varies K.
                 # Initialized in ``GPUModelRunner.__init__`` (max K, or 0 when
-                # spec decoding is off), so it is always present here.
-                num_spec_tokens=self.prev_num_spec_tokens,
+                # spec decoding is off), so it is always present here. Type is
+                # only assigned in the parent class, unresolvable by mypy here.
+                num_spec_tokens=self.prev_num_spec_tokens,  # type: ignore[has-type]
                 prepare_input_ids=self._prepare_input_ids,
             )
         else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -934,15 +934,10 @@ class NPUModelRunner(GPUModelRunner):
                 cu_num_tokens,
                 self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
-                # Unpacks the *previous* step's draft tensor, whose width equals
-                # the K used last step. Under dynamic SD that width can be < the
-                # configured maximum, so use ``prev_num_spec_tokens`` (tracked in
-                # ``_copy_draft_token_ids_to_cpu``) rather than ``num_spec_tokens``.
-                # It is initialized in ``GPUModelRunner.__init__`` (to the
-                # configured max K, or 0 when spec decoding is off), so it is
-                # always present before the first draft is produced. The type
-                # is only assigned in the parent class, which mypy cannot
-                # resolve here (same reason as the assignment site below).
+                # Unpack the *previous* step's draft tensor, whose width is the K
+                # used last step -- may be < the configured max under dynamic SD,
+                # so use ``prev_num_spec_tokens`` (tracked in
+                # ``_copy_draft_token_ids_to_cpu``), not ``num_spec_tokens``.
                 self.prev_num_spec_tokens,  # type: ignore[has-type]
                 prev_positions=prev_positions_gpu,
             )
@@ -1172,11 +1167,8 @@ class NPUModelRunner(GPUModelRunner):
                 arange_np=self.arange_np,
                 cu_num_tokens=cu_num_tokens,
                 draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
-                # Previous step's draft width (see the note on the other
-                # generate_pcp_mtp_input call); matters when dynamic SD varies K.
-                # Initialized in ``GPUModelRunner.__init__`` (max K, or 0 when
-                # spec decoding is off), so it is always present here. Type is
-                # only assigned in the parent class, unresolvable by mypy here.
+                # Previous step's draft width (see the other generate_pcp_mtp_input
+                # call); matters when dynamic SD varies K.
                 num_spec_tokens=self.prev_num_spec_tokens,  # type: ignore[has-type]
                 prepare_input_ids=self._prepare_input_ids,
             )
@@ -1649,14 +1641,13 @@ class NPUModelRunner(GPUModelRunner):
                 else:
                     target_hidden_states = hidden_states[token_indices]
             assert self.drafter is not None
-            # Dynamic SD: the eagle/draft-model drafter drives its draft loop
-            # off ``num_speculative_tokens``. Set it to the scheduler's per-step
-            # K (== the configured maximum when the feature is disabled, so the
-            # default path is unchanged). The value never exceeds the maximum,
-            # so the drafter's pre-allocated buffers stay valid; K == 0 is
-            # handled inside ``_propose``.
-            self.drafter.num_speculative_tokens = scheduler_output.num_spec_tokens_to_schedule
+            # Dynamic SD: pass the scheduled per-step K explicitly, unified with
+            # the other proposers (ngram/suffix/medusa/extract) and matching
+            # vLLM's ``propose(num_speculative_tokens=...)``. ``_propose`` sets
+            # ``self.num_speculative_tokens`` from it, so the model runner no
+            # longer mutates the drafter's state here.
             draft_token_ids = self.drafter._propose(
+                num_speculative_tokens=scheduler_output.num_spec_tokens_to_schedule,
                 target_token_ids=target_token_ids,
                 target_positions=target_positions,
                 target_hidden_states=target_hidden_states,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1479,8 +1479,8 @@ class NPUModelRunner(GPUModelRunner):
             )
         elif isinstance(self.drafter, AscendSuffixDecodingProposer):
             draft_token_ids = self.drafter.propose(
-                valid_sampled_token_ids,
                 num_speculative_tokens=scheduler_output.num_spec_tokens_to_schedule,
+                sampled_token_ids=valid_sampled_token_ids,
             )
         elif isinstance(self.drafter, AscendNgramProposerNPU):
             batch_size = min(self.input_batch.num_reqs,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -938,10 +938,10 @@ class NPUModelRunner(GPUModelRunner):
                 # the K used last step. Under dynamic SD that width can be < the
                 # configured maximum, so use ``prev_num_spec_tokens`` (tracked in
                 # ``_copy_draft_token_ids_to_cpu``) rather than ``num_spec_tokens``.
-                # ``prev_num_spec_tokens`` is only set once the first draft has
-                # been produced; before that (first step) fall back to the
-                # configured ``num_spec_tokens`` -- matching vLLM's base init.
-                getattr(self, "prev_num_spec_tokens", self.num_spec_tokens),
+                # It is initialized in ``GPUModelRunner.__init__`` (to the
+                # configured max K, or 0 when spec decoding is off), so it is
+                # always present before the first draft is produced.
+                self.prev_num_spec_tokens,
                 prev_positions=prev_positions_gpu,
             )
 
@@ -1172,10 +1172,9 @@ class NPUModelRunner(GPUModelRunner):
                 draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
                 # Previous step's draft width (see the note on the other
                 # generate_pcp_mtp_input call); matters when dynamic SD varies K.
-                # Not set until the first draft is produced, and never set when
-                # spec decoding is off but CP is on -- fall back to
-                # ``num_spec_tokens`` (0 when spec decoding is disabled).
-                num_spec_tokens=getattr(self, "prev_num_spec_tokens", self.num_spec_tokens),
+                # Initialized in ``GPUModelRunner.__init__`` (max K, or 0 when
+                # spec decoding is off), so it is always present here.
+                num_spec_tokens=self.prev_num_spec_tokens,
                 prepare_input_ids=self._prepare_input_ids,
             )
         else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -934,7 +934,11 @@ class NPUModelRunner(GPUModelRunner):
                 cu_num_tokens,
                 self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
-                self.num_spec_tokens,
+                # Unpacks the *previous* step's draft tensor, whose width equals
+                # the K used last step. Under dynamic SD that width can be < the
+                # configured maximum, so use ``prev_num_spec_tokens`` (tracked in
+                # ``_copy_draft_token_ids_to_cpu``) rather than ``num_spec_tokens``.
+                self.prev_num_spec_tokens,
                 prev_positions=prev_positions_gpu,
             )
 
@@ -1163,7 +1167,9 @@ class NPUModelRunner(GPUModelRunner):
                 arange_np=self.arange_np,
                 cu_num_tokens=cu_num_tokens,
                 draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
-                num_spec_tokens=self.num_spec_tokens,
+                # Previous step's draft width (see the note on the other
+                # generate_pcp_mtp_input call); matters when dynamic SD varies K.
+                num_spec_tokens=self.prev_num_spec_tokens,
                 prepare_input_ids=self._prepare_input_ids,
             )
         else:
@@ -1511,7 +1517,13 @@ class NPUModelRunner(GPUModelRunner):
             )
         elif isinstance(self.drafter, AscendMedusaProposer):
             draft_token_ids = self.drafter.propose(
-                valid_sampled_token_ids, sampling_metadata, spec_decode_metadata, sample_hidden_states
+                # Dynamic SD: forward the scheduled K (equals the configured
+                # maximum when the feature is disabled).
+                scheduler_output.num_spec_tokens_to_schedule,
+                valid_sampled_token_ids,
+                sampling_metadata,
+                spec_decode_metadata,
+                sample_hidden_states,
             )
         elif self.speculative_config.uses_extract_hidden_states():
             # Handle extract_hidden_states method
@@ -1528,7 +1540,9 @@ class NPUModelRunner(GPUModelRunner):
             target_hidden_states = [h[:num_scheduled_tokens] for h in aux_hidden_states]
 
             draft_token_ids = self.drafter.propose(
-                self.speculative_config.num_speculative_tokens,
+                # Dynamic SD: honor the per-step K chosen by the scheduler
+                # (equals the configured maximum when the feature is disabled).
+                scheduler_output.num_spec_tokens_to_schedule,
                 sampled_token_ids=valid_sampled_token_ids,
                 target_hidden_states=target_hidden_states,
                 common_attn_metadata=common_attn_metadata,
@@ -1627,6 +1641,13 @@ class NPUModelRunner(GPUModelRunner):
                 else:
                     target_hidden_states = hidden_states[token_indices]
             assert self.drafter is not None
+            # Dynamic SD: the eagle/draft-model drafter drives its draft loop
+            # off ``num_speculative_tokens``. Set it to the scheduler's per-step
+            # K (== the configured maximum when the feature is disabled, so the
+            # default path is unchanged). The value never exceeds the maximum,
+            # so the drafter's pre-allocated buffers stay valid; K == 0 is
+            # handled inside ``_propose``.
+            self.drafter.num_speculative_tokens = scheduler_output.num_spec_tokens_to_schedule
             draft_token_ids = self.drafter._propose(
                 target_token_ids=target_token_ids,
                 target_positions=target_positions,
@@ -1696,6 +1717,13 @@ class NPUModelRunner(GPUModelRunner):
     def _copy_draft_token_ids_to_cpu(
         self, scheduler_output: "SchedulerOutput", zeros_only: bool = False
     ) -> None:
+        # Record the width of the drafts just produced so the next step unpacks
+        # the previous-step draft tensor with the right stride. Under dynamic SD
+        # this width can change step to step (mirrors vLLM's GPUModelRunner
+        # ``prev_num_spec_tokens`` bookkeeping). Kept before the early returns so
+        # it is updated even when the CPU copy itself is skipped.
+        if torch.is_tensor(self._draft_token_ids):  # type: ignore[has-type]
+            self.prev_num_spec_tokens = self._draft_token_ids.shape[1]  # type: ignore[has-type]
         if not self.num_spec_tokens:
             return
         if self.use_async_scheduling and not (
@@ -1714,14 +1742,18 @@ class NPUModelRunner(GPUModelRunner):
         assert self.draft_token_ids_cpu is not None
         default_stream = torch.npu.current_stream()
         num_reqs = draft_token_ids.shape[0]
+        # Slice the pre-allocated CPU buffer (sized for the configured maximum
+        # K) to the *actual* draft width. Under dynamic SD the produced width
+        # can be < max, so an unsliced copy would shape-mismatch.
+        num_spec_tokens = draft_token_ids.shape[1]
         with torch.npu.stream(self.draft_token_ids_copy_stream):
             if not zeros_only:
                 self.draft_token_ids_copy_stream.wait_stream(default_stream)
-                self.draft_token_ids_cpu[:num_reqs].copy_(
+                self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens].copy_(
                     draft_token_ids, non_blocking=True
                 )
             else:
-                self.draft_token_ids_cpu[:num_reqs] = 0
+                self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens] = 0
             self.draft_token_ids_event.record()
 
     @torch.inference_mode()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -934,11 +934,7 @@ class NPUModelRunner(GPUModelRunner):
                 cu_num_tokens,
                 self._draft_token_ids,  # type: ignore[has-type]
                 scheduler_output,
-                # Unpack the *previous* step's draft tensor, whose width is the K
-                # used last step -- may be < the configured max under dynamic SD,
-                # so use ``prev_num_spec_tokens`` (tracked in
-                # ``_copy_draft_token_ids_to_cpu``), not ``num_spec_tokens``.
-                self.prev_num_spec_tokens,  # type: ignore[has-type]
+                self.num_spec_tokens,
                 prev_positions=prev_positions_gpu,
             )
 
@@ -1167,9 +1163,7 @@ class NPUModelRunner(GPUModelRunner):
                 arange_np=self.arange_np,
                 cu_num_tokens=cu_num_tokens,
                 draft_token_ids=self._draft_token_ids,  # type: ignore[has-type]
-                # Previous step's draft width (see the other generate_pcp_mtp_input
-                # call); matters when dynamic SD varies K.
-                num_spec_tokens=self.prev_num_spec_tokens,  # type: ignore[has-type]
+                num_spec_tokens=self.num_spec_tokens,
                 prepare_input_ids=self._prepare_input_ids,
             )
         else:


### PR DESCRIPTION
### What this PR does / why we need it?
refer to: https://github.com/vllm-project/vllm-ascend/pull/10894 ,
Improve the SD of the current main branch in the following two aspects： 
Dynamically extending K to Medusa/extract_hidden_states/eagle/mtp.

### How was this patch tested?
```
qwen3-8b+eagle3, test results(bs 128): Output throughput：534 -> 652 , ttft : 63637-> 44785 , tpot: 83.9 -> 80
```
qwen3-8b+eagle3：
```
vllm serve /nas/disk1/Qwen3-8B --port 8898 --dtype bfloat16  \
--tensor-parallel-size 1 --gpu-memory-utilization 0.9 \
--max-model-len 32768 --trust-remote-code \
--no-enable-prefix-caching \
--async-scheduling \
--speculative_config '{"method":"eagle3","model":"/model/EAGLE3-Qwen3-8B","num_speculative_tokens":3,"draft_tensor_parallel_size":1, "num_speculative_tokens_per_batch_size":[[1,32,3],[33,64,2],[65,128,1]]}'
```

Test results of support for existing speculative decode algorithms：
- eagle3 : after testing, it supports SD
- dflash:  after testing, it supports SD
- mtp:  after testing, it supports SD
- ngram:  after testing, it supports SD
- suffix:   after testing, it not supports SD of this pr. Suffix itself is' per request dynamic ', and the outer dynamic K is redundant/conflicting for it.This is an upstream constraint, and vLLM itself will also collapse, not a unique problem of Ascend.
- dspark：Need to develop and adapt separately

vLLM version: v0.26.0
vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
