### PR TITLE
[Feature] Support mistral large3 675b nvfp4

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,296 +1,264 @@
 ---
 name: vllm-ascend
-description: Adapt, test, document, and review large MoE models and NVFP4 checkpoints for vLLM Ascend. Use when implementing an Ascend model adapter, mapping native Mistral or DeepSeek-style weights, registering a quantization backend, adding Linear or fused-MoE NVFP4 loading, creating e2e model YAML and deployment tutorials, or preparing an AI-assisted development report for a vllm-ascend issue.
+description: Adapt, deploy, troubleshoot, validate, and document large MoE or quantized checkpoints on vLLM Ascend. Use for Mistral Large 3 NVFP4 model configuration, Ascend NPU capacity gating, TP/EP service bring-up, real-weight OpenAI API acceptance, SSH migration, evidence archiving, and AI-assisted delivery reports.
 ---
 
-# vLLM Ascend 大模型适配
+# vLLM Ascend 模型适配与验收
 
-## 目标
+## 核心原则
 
-按最小改动原则完成新模型在 vLLM Ascend 上的架构注册、权重映射、量化后端、
-测试配置和部 署文档。对 dummy、静态检查、真实权重和 NPU 内核验证分别给出
-结论，不要用前一阶段替代后一阶段。
+1. 先确认仓库、运行时导入路径、模型配置、权重索引和硬件事实，再改代码。
+2. 绝不把架构适配 Python 文件当作模型权重；`--model` 必须指向完整检查点
+   目录或受支持的模型 ID。
+3. 不单独升级 `transformers`。保持 vLLM、vLLM-Ascend、torch、torch-npu、
+   triton-ascend 和 CANN 的版本组合一致。
+4. Dummy 只能作为快速隔离手段，不能替代真实权重。
+5. 真实权重门禁必须同时满足：服务就绪、`/v1/models` HTTP 200、至少一个
+   推理请求 HTTP 200 且输出非空。
+6. `Application startup complete` 不是通过；首请求崩溃属于 false-ready。
+7. 对 EP、FlashComm1、MTP、多模态和 ACLGraph 分别记录“已验证、不支持、
+   checkpoint missing、N/A 或未验证”，不要混写。
+8. 资源不足时明确标记 `blocked_by_hardware_capacity`，不能用小模型成功冒充
+   目标模型成功，也不能把容量阻塞写成软件失败。
+9. 操作云实例时先归档并校验交付物，再停服务，最后关机。
 
-本技能来源于
-[Issue #7338](https://github.com/vllm-project/vllm-ascend/issues/7338) 的
-Mistral Large 3 675B NVFP4 适配过程，正文可以直接作为该 Issue 的 AI 辅助
-开发记录粘贴。
+## 标准工作流
 
-## 本次使用的提示词
-
-### 1. 模型架构适配
-
-```text
-项目路径 C:\Users\wangc\vllm-ascend，进入
-vllm_ascend/model_executor/models 目录；参考同目录现有模型
-（deepseek_v4.py 等）的代码结构、模型装饰器注册、权重加载、MoE 前向传播、
-昇腾适配逻辑，新建 mistral_large3.py，实现
-MistralLarge3ForCausalLM 类；适配 Mistral Large3 MoE 架构，预留 NVFP4
-量化权重加载接口，代码补充基础注释，符合仓库原有编码规范。取消补丁导入
-方式，直接在对应目录新建目标 py、yaml、md 文件，不使用临时目录、patch
-脚本。
-```
-
-### 2. NVFP4 量化适配
-
-```text
-项目路径 C:\Users\wangc\vllm-ascend，进入
-vllm_ascend/model_executor/quantization 目录；参考目录内 AWQ、GPTQ 量化
-实现，新建 nvfp4.py；完成量化类注册、NVFP4 权重反量化、对接昇腾 NPU
-算子的基础代码骨架，适配 Mistral-Large-3-675B 的 NVFP4 量化权重。
-```
-
-### 3. 端到端测试配置
-
-```text
-项目路径 C:\Users\wangc\vllm-ascend，进入 tests/e2e/models/configs
-目录；复制仓库现有模型 yaml 测试配置格式，新建
-mistral_large3_675b_nvfp4.yaml；填入 HuggingFace 模型路径
-mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4、合理张量并行参数、
-多组测试 prompt（复杂推理、多语言、企业场景）、推理采样参数，预留服务器
-本地权重路径字段，满足端到端测试要求。
-```
-
-### 4. 部署教程
-
-```text
-项目路径 C:\Users\wangc\vllm-ascend，进入 docs/source/tutorials/models
-目录；参考现有模型教程格式，新建 mistral_large3_675b_nvfp4.md；编写内容
-包含：环境依赖准备、HuggingFace 模型下载命令、vLLM-Ascend 多卡推理启动
-命令、常见报错排查模板，适配 675B NVFP4 模型部署场景。
-```
-
-### 5. AI 辅助开发记录
-
-```text
-在项目根目录新建 SKILL.md，严格参照 https://agentskills.io/specification
-规范撰写；记录本次 AI 辅助开发全流程：使用的提示词、代码适配工作流、
-MoE+NVFP4 量化适配的解决思路、可复用开发经验；内容后续可直接粘贴到
-Issue #7338 评论区提交。
-```
-
-## 代码适配工作流
-
-### 1. 先确认仓库事实
-
-1. 读取根目录 `AGENTS.md`、适用技能和贡献规范。
-2. 检查工作树，保留用户已有修改，不重置或覆盖无关文件。
-3. 使用仓库搜索确认真实目录、注册入口、配置 schema 和现有测试。
-4. 当提示词路径与当前仓库布局不一致时，以可被运行时导入的真实路径为准，
-   并在交付说明中记录偏差。
-
-本次发现仓库没有 `vllm_ascend/model_executor/models` 和
-`vllm_ascend/model_executor/quantization` 下的对应实现体系。最终使用：
-
-- `vllm_ascend/models/mistral_large3.py`；
-- `vllm_ascend/quantization/nvfp4.py`；
-- `vllm_ascend/models/__init__.py` 的 `ModelRegistry.register_model`；
-- vLLM 的 `register_quantization_config` 和插件启动注册。
-
-不要为了逐字匹配提示词而创建运行时不会导入的重复目录。
-
-### 2. 分析模型和检查点
-
-1. 查看官方 `params.json`、模型卡和权重命名。
-2. 确认模型拓扑：MLA、61 层、128 个路由专家、每 token 选择 4 个专家、
-   1 个共享专家，以及前三层 dense MLP。
-3. 对比上游 vLLM 的 DeepSeek-V3、ModelOpt NVFP4 和 compressed-tensors
-   实现，不凭记忆猜测张量格式。
-4. 确认 Mistral 原生配置把 NVFP4 描述放在 `quantization_config`，格式为
-   `nvfp4-pack-quantized`，但 `quant_method` 标记为 `compressed-tensors`。
-5. 先列出权重名称、shape、dtype、分片维度和缩放因子，再写 loader。
-
-### 3. 复用兼容架构
-
-1. 优先复用已经验证的上游模型拓扑，不复制整套 forward。
-2. 让 `MistralLarge3ForCausalLM` 继承 `DeepseekV3ForCausalLM`，保留 MLA、
-   MoE、专家并行和 Ascend FusedMoE 路径。
-3. 使用锚定正则的 `WeightsMapper` 显式映射：
-   - attention norm、MLA Q/KV LoRA 投影和 output projection；
-   - dense `w1/w2/w3`；
-   - routed expert `w1/w2/w3`；
-   - shared expert `w1/w2/w3`；
-   - embedding、final norm 和 lm head。
-4. 映射量化后缀：
-   - `.qscale_act` 到 `.input_scale`；
-   - `.qscale_weight` 到 `.weight_scale`；
-   - `.qscale_weight_2` 到 `.weight_scale_2`。
-5. 使用 `AutoWeightsLoader` 统一加载，避免为每种精度复制 loader。
-
-### 4. 实现 NVFP4 量化后端
-
-1. 注册 `nvfp4` 配置，并在插件发现阶段加入平台支持列表。
-2. 同时识别显式 `--quantization nvfp4` 和原生
-   `nvfp4-pack-quantized` 配置，不能只检查 `quant_method=nvfp4`。
-3. 固定并校验 Mistral 检查点使用的 `group_size=16`。
-4. 为 Linear 分配：
-   - `weight`: `uint8[out, in/2]`；
-   - `weight_scale`: `float8_e4m3fn[out, in/16]`；
-   - `weight_scale_2`: FP32 全局权重 scale；
-   - `input_scale`: FP32 全局激活 scale。
-5. 为 MoE 分配：
-   - `w13_weight`: `uint8[experts, 2*intermediate, hidden/2]`；
-   - `w2_weight`: `uint8[experts, hidden, intermediate/2]`；
-   - 对应的 16 元素分组 scale、二级权重 scale 和激活 scale。
-6. 支持 `re:` 忽略规则，避免错误量化 attention、embedding、vision 或
-   lm head。
-7. 将 NPU 快路径接到 `_C_ascend.nvfp4_linear` 和
-   `_C_ascend.nvfp4_moe`。算子缺失时在 NPU 上快速报错，不要静默展开 675B
-   权重。
-8. 仅提供 CPU Linear 参考路径用于验证反量化数学；不要把它当作生产后端。
-
-## NVFP4 反量化思路
-
-每个 `uint8` 沿输入维打包两个 E2M1 FP4 值，低四位在前，高四位在后。
-使用下表解码 nibble：
-
-```text
-[0, 0.5, 1, 1.5, 2, 3, 4, 6,
- -0, -0.5, -1, -1.5, -2, -3, -4, -6]
-```
-
-将 FP8 E4M3 分组 scale 沿最后一维每 16 个元素展开，再乘 FP32 全局 scale：
-
-```text
-W_dequant = E2M1(unpack(weight)) * repeat(weight_scale, 16) * weight_scale_2
-```
-
-ModelOpt 风格的 `weight_scale_2` 是乘数 `amax / (6 * 448)`，不是倒数。
-compressed-tensors 的某些导出格式可能保存倒数；接入新检查点时必须先确认
-导出约定，不能复用名称后直接假设公式相同。
-
-避免在热路径调用 `tensor.item()`。shape、dtype 和 group size 校验应在创建
-权重或加载阶段完成。
-
-## 测试与文档工作流
-
-### 单元测试
-
-至少覆盖：
-
-- nibble 低位优先的解包顺序；
-- E2M1 正负数值表；
-- 分组 scale 和全局 scale 的组合；
-- 错误 scale shape；
-- 原生 Mistral `quantization_config` 自动识别；
-- `re:` ignore 规则；
-- 模型权重名称映射。
-
-先运行目标用例，再运行格式和静态检查：
+### 1. 收集事实
 
 ```shell
-python -m pytest -sv tests/ut/quantization/test_nvfp4.py
-python -m pytest -sv tests/ut/quantization/test_nvfp4_mistral_config.py
-python -m pytest -sv tests/ut/models/test_mistral_large3.py
-python -m py_compile vllm_ascend/models/mistral_large3.py
-python -m py_compile vllm_ascend/quantization/nvfp4.py
-git diff --check
+git status --short
+git branch --show-current
+python -c "import vllm,vllm_ascend;print(vllm.__version__,vllm.__file__);print(vllm_ascend.__file__)"
+python -c "import torch,torch_npu;print(torch.__version__,torch_npu.__version__);print(torch.npu.device_count())"
+npu-smi info
+df -h /data
 ```
 
-如果本地缺少 `torch`、vLLM 或 NPU，不要声称 pytest 或真实推理通过。记录
-阻塞依赖，并继续执行可以完成的 YAML、Markdown、AST、编译和 diff 检查。
+检查模型：
 
-### 端到端配置
+```shell
+find "${MODEL_PATH}" -maxdepth 1 -type f -printf '%f %s bytes\n' | sort
+python - <<'PY'
+import json, os
+p = json.load(open(os.path.join(os.environ["MODEL_PATH"], "config.json")))
+for k in ("architectures", "model_type", "quantization_config",
+          "max_position_embeddings", "seq_length", "num_experts"):
+    print(k, p.get(k))
+PY
+```
 
-保持 `tests/e2e/models/configs` 的标准字段：`model_name`、`model_type`、
-`hardware`、`serve`、`tasks`、`num_fewshot`。为 675B NVFP4 使用 A3
-TP16+EP、131072 初始上下文和 16 并发，并保留本地模型路径。
+### 2. 做资源门禁
 
-将服务 smoke prompt 放在独立扩展段，覆盖复杂推理、多语言和企业事故响应；
-不要破坏 lm-eval 对标准字段的读取。
+比较四类容量：模型仓库总大小、模型盘安全可用空间、主机加载内存、NPU HBM
+及 KV cache/图捕获余量。检查点无法落盘时立即停止真实权重部署尝试，记录：
 
-### 部署教程
+- 文件系统总量、原始可用量和预留日志后的安全上限；
+- NPU 数量、型号、单卡 HBM；
+- 目标权重预计大小；
+- 推荐硬件拓扑；
+- 可用的小模型同框架参考，但明确非等价。
 
-至少写明：
+本次 Mistral 事实：检查点约 403 GB；测试实例 `/data` 117.56 GiB，安全权重
+上限 100.74 GiB；两张 910B2C 每卡 65,536 MiB。结论是磁盘和 HBM 均不足。
 
-- A3 16 NPU、磁盘和版本依赖；
-- `hf download --local-dir` 下载及分片检查；
-- `/workspace` 下直接执行的 TP16+EP 启动命令；
-- readiness 与首个真实权重请求；
-- Eager 和低上下文隔离命令；
-- NVFP4 算子缺失、OOM、HCCL、ACLGraph、权重键异常模板；
-- dummy 与真实权重不等价；
-- 实测前不得将参考精度写成 Ascend 结果。
+### 3. 下载和稳定性校验
 
-## 两阶段 NPU 验证门禁
+```shell
+hf auth login
+hf download "${MODEL_ID}" --local-dir "${MODEL_PATH}"
+```
 
-### 阶段 A：dummy 快速门禁
+遇到 401/403 时检查仓库许可、fine-grained token 的 gated repository 权限、
+运行用户和 `HF_ENDPOINT`。不要记录 Token。若 `huggingface-cli` 提示废弃，
+使用客户端给出的等价 `hf download`，不要为此升级 transformers。
 
-验证架构构建、注册、基础算子路径和 API。必须同时满足 readiness 和至少一个
-非空文本响应。dummy 不能验证权重键、FP4 反量化或真实显存占用。
+启动前要求 config、索引和索引引用的所有分片存在；`.incomplete`、`.part`、
+`.tmp` 或 `.lock` 必须为零。连续多个采样周期确认大小和 mtime 不再变化。
 
-### 阶段 B：真实权重强制门禁
+### 4. 启动与上下文适配
 
-使用完整约 403 GB 检查点，验证：
+从 `/workspace` 直接启动。先使用模型配置声明的上下文长度，不复制其他模型
+的值。若 vLLM 报用户长度超过 derived length，应降低到 config 声明值；不要
+使用 `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` 强行越界。
 
-1. 所有分片完整加载；
-2. 无未处理的权重键或 scale；
-3. Linear 与 routed/shared expert 的 NVFP4 路径可执行；
-4. `GET /v1/models` 返回 200；
-5. 首个请求返回 200 且输出非空；
-6. TP16+EP、FlashComm1 和 ACLGraph 有运行证据；
-7. 记录 TTFT、TPOT、吞吐量及内存峰值。
+双卡 Dense 参考模板：
 
-`Application startup complete` 不是通过条件。readiness 正常但首请求崩溃属于
-false-ready，必须按运行时失败处理。
+```shell
+vllm serve "${MODEL_PATH}" \
+  --served-model-name "${SERVED_MODEL_NAME}" \
+  --trust-remote-code \
+  --tensor-parallel-size 2 \
+  --gpu-memory-utilization 0.90 \
+  --max-model-len "${MODEL_MAX_LEN}" \
+  --max-num-seqs 4 \
+  --port 8000
+```
 
-## 常见问题与可复用经验
+Mistral 675B NVFP4 目标模板使用 A3 TP16+EP、NVFP4、FlashComm1 和 ACLGraph；
+两张 910B2C 只用于较小模型的环境参考验证。
 
-1. **目录名不等于运行时入口。** 先搜索注册链，再决定文件位置。
-2. **架构相似时继承优于复制。** 复用 DeepSeek-V3 forward，只维护明确的
-   Mistral 权重映射。
-3. **量化方法名不可靠。** 同时检查 format、config group、dtype、group size
-   和实际权重字段。
-4. **MoE scale 必须区分 w1/w3。** `w13_weight_scale_2` 通常为
-   `[experts, 2]`，`w2_weight_scale_2` 为 `[experts]`。
-5. **融合层 scale 可能不一致。** 合并 q/k/v 或 gate/up 前先定义保守策略并
-   输出警告，不能静默假设完全相等。
-6. **不要在 NPU 上使用巨型反量化 fallback。** 缺少内核时快速失败，避免
-   OOM 或长时间假运行。
-7. **不要从 dummy 推断真实权重正确。** 权重命名、scale 配对和分片问题只在
-   阶段 B 暴露。
-8. **新增配置必须被现有 runner 消费。** 未被 runner 使用的 prompt 扩展应
-   与标准 lm-eval 字段隔离。
-9. **文档必须暴露限制。** 教程应明确内核依赖和未验证状态，而不是只给一个
-   看似可运行的命令。
-10. **每步形成单一、可审计提交。** 使用 Conventional Commit 和 sign-off，
-    保持代码、测试、配置和文档差异清晰。
+### 5. API 和功能门禁
 
-## 本次交付记录
+```shell
+curl -f http://127.0.0.1:8000/v1/models
+curl -f http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"MODEL","messages":[{"role":"user","content":"say hi"}],"temperature":0,"max_tokens":32}'
+```
 
-| 提交 | 内容 | 验证状态 |
-| --- | --- | --- |
-| `efce799c7e30be5c6c70ab6dde9f38043e60caf9` | 模型注册、权重映射、模型 UT、初版 YAML/教程 | `py_compile` 和映射静态检查通过 |
-| `afc8f833d38296c16bcafe750aad5d15c7e004ee` | NVFP4 配置、反量化、Linear/MoE NPU 骨架及 UT | 静态检查通过；本机缺少 torch，pytest 未执行 |
-| `2e6015594749716355f5299ea818b73a92741a5c` | NVFP4 e2e YAML 与三类 prompt | YAML 解析和字段断言通过 |
-| `0ae1a2a159000a195dfb5e19cd985ebf76cfd03c` | 中文下载、部署和排障教程 | Markdown 结构、引用和 diff 检查通过 |
+验证日志中的 Worker rank、权重加载、KV cache、图捕获和首请求。MoE 才检查
+EP/FlashComm1；Dense 模型标记 N/A。配置/索引没有 MTP 时标记 checkpoint
+missing；文本模型的多模态标记 N/A。
 
-主要文件：
+### 6. 故障排查阶梯
 
-- `vllm_ascend/models/mistral_large3.py`
-- `vllm_ascend/quantization/nvfp4.py`
-- `tests/ut/models/test_mistral_large3.py`
-- `tests/ut/quantization/test_nvfp4.py`
-- `tests/ut/quantization/test_nvfp4_mistral_config.py`
-- `tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml`
-- `docs/source/tutorials/models/mistral_large3_675b_nvfp4.md`
+1. 以相同参数复现一次并保留第一个错误。
+2. 检查端口、残留 APIServer、EngineCore 和 Worker_TP。
+3. 检查 config derived max length、模型架构、权重索引和缺失键。
+4. 图捕获失败时保持其他参数不变，使用 `--enforce-eager` 隔离一次。
+5. OOM 时先降低上下文和并发，不要破坏必要 TP/EP 拓扑。
+6. HCCL 错误先清残留 rank、核对网卡和通信端口。
+7. NVFP4 自定义算子缺失时更换或构建匹配镜像，不做巨型 CPU/NPU 反量化
+   fallback。
+8. 首请求失败时按运行时失败处理，不接受 readiness 假阳性。
 
-## 当前结论
+精确停进程：
 
-已完成模型适配、权重映射、NVFP4 配置和反量化参考实现、Linear/MoE 权重
-分配、NPU 算子接口、单元测试源码、e2e 配置及中文教程。
+```shell
+tr '\0' ' ' </proc/<PID>/cmdline
+kill <PID>
+for i in 1 2 3 4 5; do kill -0 <PID> 2>/dev/null || break; sleep 1; done
+```
 
-尚未完成真实 Ascend 服务器上的 403 GB 权重加载和首请求验证，也未在当前
-环境证明 `_C_ascend.nvfp4_linear` 与 `_C_ascend.nvfp4_moe` 已有可用实现。
-因此当前交付应表述为“适配代码与算子接口骨架已完成，等待真实 NPU 内核和
-权重门禁”，不能表述为 Issue #7338 已完全验证通过。
+### 7. 交付和关机顺序
 
-## 后续执行清单
+1. 更新 e2e YAML、模型教程、SKILL.md 和提示词归档。
+2. 校验 YAML、Markdown、链接、`git diff --check` 和相关测试。
+3. 生成一个带 sign-off 的 Conventional Commit。
+4. 在服务器归档完整 `run_logs`，生成 SHA256。
+5. 下载到本地并对比 SHA256，确认最终报告和接口响应存在。
+6. 精确终止推理服务，记录停服时间、PID、端口与 NPU 释放状态。
+7. 再次下载停服后的增量日志并校验。
+8. 最后执行云实例关机；操作系统关机不一定等于云控制台停止计费，应在控制台
+   复核实例状态和计费策略。
 
-1. 在匹配版本的 A3 镜像中确认 vLLM 和 vLLM Ascend import 路径。
-2. 下载并核对全部 Mistral Large 3 NVFP4 分片。
-3. 确认两个 `_C_ascend` NVFP4 算子已注册且 schema 与 Python 调用一致。
-4. 先以低上下文 Eager 模式验证真实权重加载和首请求。
-5. 再验证 TP16+EP、FlashComm1、ACLGraph、131072 上下文和 16 并发。
-6. 用实测结果替换参考精度和性能数据。
-7. 将本文件内容粘贴到 Issue #7338 评论区，附上真实验证日志或明确阻塞项。
+## 本次验证结论
+
+### Mistral Large 3 675B NVFP4
+
+- 测试配置和部署教程已提供。
+- 真实权重没有下载或加载，因为约 403 GB 权重大于 100.74 GiB 安全磁盘容量。
+- 两卡总 HBM 约 128 GiB，不具备可靠部署余量。
+- 状态：`blocked_by_hardware_capacity`。
+- GPQA `0.6717` 仅为参考目标，不是 Ascend 实测值。
+
+### Qwen-7B-Chat 同框架参考
+
+- 真实权重 8/8 分片，总计 15,442,677,288 字节。
+- 2 × Ascend 910B2C，TP=2，`gpu-memory-utilization=0.90`。
+- Qwen config `seq_length=8192`；从错误的 32768 调整到 8192 后启动成功。
+- `/v1/models` 与 chat 均 HTTP 200，输出非空。
+- ACLGraph 捕获和 replay 有日志证据。
+- 该结果证明环境、TP/HCCL、NPU 图和 OpenAI API 链路，不证明 Mistral
+  NVFP4/EP/FlashComm1。
+
+## 关键提示词归档
+
+以下内容按实际任务阶段归档。所有密码、Token、完整 SSH 用户标识和实例敏感
+信息均以 `[REDACTED]` 替换；复用提示词时通过安全凭据渠道注入。
+
+### A. 文件角色与启动参数
+
+```text
+区分 vllm_ascend/models 下的 Python 架构适配代码、需要额外下载的模型权重，
+说明运行时自动调用关系，并明确 vllm serve --model 应填写完整权重目录或模型 ID。
+```
+
+```text
+基于 vLLM-Ascend、Ascend NPU 和 Mistral Large 3，校验启动命令，补充显存比例、
+最大上下文长度、张量并行参数，并给出 OpenAI 格式 /v1/models 与 chat 示例。
+```
+
+### B. 仓库版本、安装与算子适配
+
+```text
+查阅当前 vllm-ascend README，确认要求的 vLLM 基准版本；在目标服务器执行
+VLLM_TARGET_DEVICE=empty python3 -m pip install -e .，完整保存日志并校验 import。
+```
+
+```text
+定位 build_aclnn.sh、LightningIndexer 和 SparseFlashAttention 的 socVersion
+校验，在支持列表加入 ascend910b2c；保存三处 diff，切换 CANN 8.5.1 对应发布
+分支，核对 torch、torch-npu、triton-ascend 后重装并运行模型测试。
+```
+
+### C. 双卡实例迁移与环境验证
+
+```text
+通过已配置 SSH 接入双卡实例，核验两张 Ascend 910B、CANN、vLLM-Ascend 环境；
+迁移完整项目、算子改动、run_logs 和文档，执行 editable install，准备 TP=2
+脚本与模型目录，全程记录操作日志。
+```
+
+```text
+实例重启后记录 npu-smi、torch_npu.device_count、两卡最小张量计算和 vLLM import；
+识别两卡则校验 TP=2，识别失败则把故障证据写入迁移报告。
+```
+
+### D. 容量门禁与自动监控
+
+```text
+把双卡 NPU 验证日志归档到迁移报告，统计 /data 原始与安全可用空间；等待完整
+config、索引和权重分片稳定后自动启动 TP=2，保存服务、接口和最终验收日志。
+```
+
+```text
+Mistral 675B 因模型盘与双卡 HBM 不足无法部署时，明确写为客观硬件限制，不得
+声称真实权重测试通过；使用可部署小模型验证同一 vLLM-Ascend 双卡链路。
+```
+
+### E. Llama 权重授权隔离
+
+```text
+创建 Llama-2-7B 目录并切换 TP=2 脚本；从官方 gated repository 下载配置与
+权重。若没有 Meta 许可或 Token 返回 403，记录授权阻塞，不绕过许可，不使用
+dummy 冒充真实权重。
+```
+
+### F. Qwen 双卡真实权重验收
+
+```text
+创建 /data/models/Qwen-7B-Chat；修改现有启动脚本指向该目录，保留 TP_SIZE=2
+和 gpu-memory-utilization=0.90；下载 Qwen/Qwen-7B-Chat，等待权重稳定后启动，
+调用 /v1/models 和 /v1/chat/completions，补齐 FINAL_ACCEPTANCE。
+```
+
+```text
+如果 huggingface-cli 已废弃，执行工具建议的 hf download 等价命令，不升级
+transformers；若 max_model_len 超过 config derived length，降到模型原生值后
+重试，保留首次失败和最终成功日志。
+```
+
+### G. 证据归档与下线
+
+```text
+将服务器 run_logs 整体压缩，生成 SHA256，下载到本地桌面并复核哈希、文件数、
+FINAL_ACCEPTANCE 和 MIGRATION_REPORT；云平台计费截图可选，但日志归档必须完成。
+```
+
+```text
+完成 Mistral YAML、部署教程和 SKILL.md 后归档全部文档；精确核验并终止推理
+PID，确认端口和 NPU 释放，下载最终增量日志，最后下发云实例关机指令。
+```
+
+## 可复用交付检查表
+
+- [ ] YAML 包含 `model_name`、`hardware`、`tasks.metrics` 和 `num_fewshot`。
+- [ ] 参考精度明确标注来源，不冒充 Ascend 实测。
+- [ ] 教程包含环境、下载、部署、接口、精度和性能章节。
+- [ ] 理论上下文与实际成功上下文分别记录。
+- [ ] 目标模型和小模型参考案例的结论严格分离。
+- [ ] ACLGraph、EP、FlashComm1、MTP、多模态逐项给出状态。
+- [ ] 完整日志、报告和接口响应已做 SHA256 本地备份。
+- [ ] 停服和关机发生在最终备份之后。

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: vllm-ascend
+description: Adapt, test, document, and review large MoE models and NVFP4 checkpoints for vLLM Ascend. Use when implementing an Ascend model adapter, mapping native Mistral or DeepSeek-style weights, registering a quantization backend, adding Linear or fused-MoE NVFP4 loading, creating e2e model YAML and deployment tutorials, or preparing an AI-assisted development report for a vllm-ascend issue.
+---
+
+# vLLM Ascend 大模型适配
+
+## 目标
+
+按最小改动原则完成新模型在 vLLM Ascend 上的架构注册、权重映射、量化后端、
+测试配置和部 署文档。对 dummy、静态检查、真实权重和 NPU 内核验证分别给出
+结论，不要用前一阶段替代后一阶段。
+
+本技能来源于
+[Issue #7338](https://github.com/vllm-project/vllm-ascend/issues/7338) 的
+Mistral Large 3 675B NVFP4 适配过程，正文可以直接作为该 Issue 的 AI 辅助
+开发记录粘贴。
+
+## 本次使用的提示词
+
+### 1. 模型架构适配
+
+```text
+项目路径 C:\Users\wangc\vllm-ascend，进入
+vllm_ascend/model_executor/models 目录；参考同目录现有模型
+（deepseek_v4.py 等）的代码结构、模型装饰器注册、权重加载、MoE 前向传播、
+昇腾适配逻辑，新建 mistral_large3.py，实现
+MistralLarge3ForCausalLM 类；适配 Mistral Large3 MoE 架构，预留 NVFP4
+量化权重加载接口，代码补充基础注释，符合仓库原有编码规范。取消补丁导入
+方式，直接在对应目录新建目标 py、yaml、md 文件，不使用临时目录、patch
+脚本。
+```
+
+### 2. NVFP4 量化适配
+
+```text
+项目路径 C:\Users\wangc\vllm-ascend，进入
+vllm_ascend/model_executor/quantization 目录；参考目录内 AWQ、GPTQ 量化
+实现，新建 nvfp4.py；完成量化类注册、NVFP4 权重反量化、对接昇腾 NPU
+算子的基础代码骨架，适配 Mistral-Large-3-675B 的 NVFP4 量化权重。
+```
+
+### 3. 端到端测试配置
+
+```text
+项目路径 C:\Users\wangc\vllm-ascend，进入 tests/e2e/models/configs
+目录；复制仓库现有模型 yaml 测试配置格式，新建
+mistral_large3_675b_nvfp4.yaml；填入 HuggingFace 模型路径
+mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4、合理张量并行参数、
+多组测试 prompt（复杂推理、多语言、企业场景）、推理采样参数，预留服务器
+本地权重路径字段，满足端到端测试要求。
+```
+
+### 4. 部署教程
+
+```text
+项目路径 C:\Users\wangc\vllm-ascend，进入 docs/source/tutorials/models
+目录；参考现有模型教程格式，新建 mistral_large3_675b_nvfp4.md；编写内容
+包含：环境依赖准备、HuggingFace 模型下载命令、vLLM-Ascend 多卡推理启动
+命令、常见报错排查模板，适配 675B NVFP4 模型部署场景。
+```
+
+### 5. AI 辅助开发记录
+
+```text
+在项目根目录新建 SKILL.md，严格参照 https://agentskills.io/specification
+规范撰写；记录本次 AI 辅助开发全流程：使用的提示词、代码适配工作流、
+MoE+NVFP4 量化适配的解决思路、可复用开发经验；内容后续可直接粘贴到
+Issue #7338 评论区提交。
+```
+
+## 代码适配工作流
+
+### 1. 先确认仓库事实
+
+1. 读取根目录 `AGENTS.md`、适用技能和贡献规范。
+2. 检查工作树，保留用户已有修改，不重置或覆盖无关文件。
+3. 使用仓库搜索确认真实目录、注册入口、配置 schema 和现有测试。
+4. 当提示词路径与当前仓库布局不一致时，以可被运行时导入的真实路径为准，
+   并在交付说明中记录偏差。
+
+本次发现仓库没有 `vllm_ascend/model_executor/models` 和
+`vllm_ascend/model_executor/quantization` 下的对应实现体系。最终使用：
+
+- `vllm_ascend/models/mistral_large3.py`；
+- `vllm_ascend/quantization/nvfp4.py`；
+- `vllm_ascend/models/__init__.py` 的 `ModelRegistry.register_model`；
+- vLLM 的 `register_quantization_config` 和插件启动注册。
+
+不要为了逐字匹配提示词而创建运行时不会导入的重复目录。
+
+### 2. 分析模型和检查点
+
+1. 查看官方 `params.json`、模型卡和权重命名。
+2. 确认模型拓扑：MLA、61 层、128 个路由专家、每 token 选择 4 个专家、
+   1 个共享专家，以及前三层 dense MLP。
+3. 对比上游 vLLM 的 DeepSeek-V3、ModelOpt NVFP4 和 compressed-tensors
+   实现，不凭记忆猜测张量格式。
+4. 确认 Mistral 原生配置把 NVFP4 描述放在 `quantization_config`，格式为
+   `nvfp4-pack-quantized`，但 `quant_method` 标记为 `compressed-tensors`。
+5. 先列出权重名称、shape、dtype、分片维度和缩放因子，再写 loader。
+
+### 3. 复用兼容架构
+
+1. 优先复用已经验证的上游模型拓扑，不复制整套 forward。
+2. 让 `MistralLarge3ForCausalLM` 继承 `DeepseekV3ForCausalLM`，保留 MLA、
+   MoE、专家并行和 Ascend FusedMoE 路径。
+3. 使用锚定正则的 `WeightsMapper` 显式映射：
+   - attention norm、MLA Q/KV LoRA 投影和 output projection；
+   - dense `w1/w2/w3`；
+   - routed expert `w1/w2/w3`；
+   - shared expert `w1/w2/w3`；
+   - embedding、final norm 和 lm head。
+4. 映射量化后缀：
+   - `.qscale_act` 到 `.input_scale`；
+   - `.qscale_weight` 到 `.weight_scale`；
+   - `.qscale_weight_2` 到 `.weight_scale_2`。
+5. 使用 `AutoWeightsLoader` 统一加载，避免为每种精度复制 loader。
+
+### 4. 实现 NVFP4 量化后端
+
+1. 注册 `nvfp4` 配置，并在插件发现阶段加入平台支持列表。
+2. 同时识别显式 `--quantization nvfp4` 和原生
+   `nvfp4-pack-quantized` 配置，不能只检查 `quant_method=nvfp4`。
+3. 固定并校验 Mistral 检查点使用的 `group_size=16`。
+4. 为 Linear 分配：
+   - `weight`: `uint8[out, in/2]`；
+   - `weight_scale`: `float8_e4m3fn[out, in/16]`；
+   - `weight_scale_2`: FP32 全局权重 scale；
+   - `input_scale`: FP32 全局激活 scale。
+5. 为 MoE 分配：
+   - `w13_weight`: `uint8[experts, 2*intermediate, hidden/2]`；
+   - `w2_weight`: `uint8[experts, hidden, intermediate/2]`；
+   - 对应的 16 元素分组 scale、二级权重 scale 和激活 scale。
+6. 支持 `re:` 忽略规则，避免错误量化 attention、embedding、vision 或
+   lm head。
+7. 将 NPU 快路径接到 `_C_ascend.nvfp4_linear` 和
+   `_C_ascend.nvfp4_moe`。算子缺失时在 NPU 上快速报错，不要静默展开 675B
+   权重。
+8. 仅提供 CPU Linear 参考路径用于验证反量化数学；不要把它当作生产后端。
+
+## NVFP4 反量化思路
+
+每个 `uint8` 沿输入维打包两个 E2M1 FP4 值，低四位在前，高四位在后。
+使用下表解码 nibble：
+
+```text
+[0, 0.5, 1, 1.5, 2, 3, 4, 6,
+ -0, -0.5, -1, -1.5, -2, -3, -4, -6]
+```
+
+将 FP8 E4M3 分组 scale 沿最后一维每 16 个元素展开，再乘 FP32 全局 scale：
+
+```text
+W_dequant = E2M1(unpack(weight)) * repeat(weight_scale, 16) * weight_scale_2
+```
+
+ModelOpt 风格的 `weight_scale_2` 是乘数 `amax / (6 * 448)`，不是倒数。
+compressed-tensors 的某些导出格式可能保存倒数；接入新检查点时必须先确认
+导出约定，不能复用名称后直接假设公式相同。
+
+避免在热路径调用 `tensor.item()`。shape、dtype 和 group size 校验应在创建
+权重或加载阶段完成。
+
+## 测试与文档工作流
+
+### 单元测试
+
+至少覆盖：
+
+- nibble 低位优先的解包顺序；
+- E2M1 正负数值表；
+- 分组 scale 和全局 scale 的组合；
+- 错误 scale shape；
+- 原生 Mistral `quantization_config` 自动识别；
+- `re:` ignore 规则；
+- 模型权重名称映射。
+
+先运行目标用例，再运行格式和静态检查：
+
+```shell
+python -m pytest -sv tests/ut/quantization/test_nvfp4.py
+python -m pytest -sv tests/ut/quantization/test_nvfp4_mistral_config.py
+python -m pytest -sv tests/ut/models/test_mistral_large3.py
+python -m py_compile vllm_ascend/models/mistral_large3.py
+python -m py_compile vllm_ascend/quantization/nvfp4.py
+git diff --check
+```
+
+如果本地缺少 `torch`、vLLM 或 NPU，不要声称 pytest 或真实推理通过。记录
+阻塞依赖，并继续执行可以完成的 YAML、Markdown、AST、编译和 diff 检查。
+
+### 端到端配置
+
+保持 `tests/e2e/models/configs` 的标准字段：`model_name`、`model_type`、
+`hardware`、`serve`、`tasks`、`num_fewshot`。为 675B NVFP4 使用 A3
+TP16+EP、131072 初始上下文和 16 并发，并保留本地模型路径。
+
+将服务 smoke prompt 放在独立扩展段，覆盖复杂推理、多语言和企业事故响应；
+不要破坏 lm-eval 对标准字段的读取。
+
+### 部署教程
+
+至少写明：
+
+- A3 16 NPU、磁盘和版本依赖；
+- `hf download --local-dir` 下载及分片检查；
+- `/workspace` 下直接执行的 TP16+EP 启动命令；
+- readiness 与首个真实权重请求；
+- Eager 和低上下文隔离命令；
+- NVFP4 算子缺失、OOM、HCCL、ACLGraph、权重键异常模板；
+- dummy 与真实权重不等价；
+- 实测前不得将参考精度写成 Ascend 结果。
+
+## 两阶段 NPU 验证门禁
+
+### 阶段 A：dummy 快速门禁
+
+验证架构构建、注册、基础算子路径和 API。必须同时满足 readiness 和至少一个
+非空文本响应。dummy 不能验证权重键、FP4 反量化或真实显存占用。
+
+### 阶段 B：真实权重强制门禁
+
+使用完整约 403 GB 检查点，验证：
+
+1. 所有分片完整加载；
+2. 无未处理的权重键或 scale；
+3. Linear 与 routed/shared expert 的 NVFP4 路径可执行；
+4. `GET /v1/models` 返回 200；
+5. 首个请求返回 200 且输出非空；
+6. TP16+EP、FlashComm1 和 ACLGraph 有运行证据；
+7. 记录 TTFT、TPOT、吞吐量及内存峰值。
+
+`Application startup complete` 不是通过条件。readiness 正常但首请求崩溃属于
+false-ready，必须按运行时失败处理。
+
+## 常见问题与可复用经验
+
+1. **目录名不等于运行时入口。** 先搜索注册链，再决定文件位置。
+2. **架构相似时继承优于复制。** 复用 DeepSeek-V3 forward，只维护明确的
+   Mistral 权重映射。
+3. **量化方法名不可靠。** 同时检查 format、config group、dtype、group size
+   和实际权重字段。
+4. **MoE scale 必须区分 w1/w3。** `w13_weight_scale_2` 通常为
+   `[experts, 2]`，`w2_weight_scale_2` 为 `[experts]`。
+5. **融合层 scale 可能不一致。** 合并 q/k/v 或 gate/up 前先定义保守策略并
+   输出警告，不能静默假设完全相等。
+6. **不要在 NPU 上使用巨型反量化 fallback。** 缺少内核时快速失败，避免
+   OOM 或长时间假运行。
+7. **不要从 dummy 推断真实权重正确。** 权重命名、scale 配对和分片问题只在
+   阶段 B 暴露。
+8. **新增配置必须被现有 runner 消费。** 未被 runner 使用的 prompt 扩展应
+   与标准 lm-eval 字段隔离。
+9. **文档必须暴露限制。** 教程应明确内核依赖和未验证状态，而不是只给一个
+   看似可运行的命令。
+10. **每步形成单一、可审计提交。** 使用 Conventional Commit 和 sign-off，
+    保持代码、测试、配置和文档差异清晰。
+
+## 本次交付记录
+
+| 提交 | 内容 | 验证状态 |
+| --- | --- | --- |
+| `efce799c7e30be5c6c70ab6dde9f38043e60caf9` | 模型注册、权重映射、模型 UT、初版 YAML/教程 | `py_compile` 和映射静态检查通过 |
+| `afc8f833d38296c16bcafe750aad5d15c7e004ee` | NVFP4 配置、反量化、Linear/MoE NPU 骨架及 UT | 静态检查通过；本机缺少 torch，pytest 未执行 |
+| `2e6015594749716355f5299ea818b73a92741a5c` | NVFP4 e2e YAML 与三类 prompt | YAML 解析和字段断言通过 |
+| `0ae1a2a159000a195dfb5e19cd985ebf76cfd03c` | 中文下载、部署和排障教程 | Markdown 结构、引用和 diff 检查通过 |
+
+主要文件：
+
+- `vllm_ascend/models/mistral_large3.py`
+- `vllm_ascend/quantization/nvfp4.py`
+- `tests/ut/models/test_mistral_large3.py`
+- `tests/ut/quantization/test_nvfp4.py`
+- `tests/ut/quantization/test_nvfp4_mistral_config.py`
+- `tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml`
+- `docs/source/tutorials/models/mistral_large3_675b_nvfp4.md`
+
+## 当前结论
+
+已完成模型适配、权重映射、NVFP4 配置和反量化参考实现、Linear/MoE 权重
+分配、NPU 算子接口、单元测试源码、e2e 配置及中文教程。
+
+尚未完成真实 Ascend 服务器上的 403 GB 权重加载和首请求验证，也未在当前
+环境证明 `_C_ascend.nvfp4_linear` 与 `_C_ascend.nvfp4_moe` 已有可用实现。
+因此当前交付应表述为“适配代码与算子接口骨架已完成，等待真实 NPU 内核和
+权重门禁”，不能表述为 Issue #7338 已完全验证通过。
+
+## 后续执行清单
+
+1. 在匹配版本的 A3 镜像中确认 vLLM 和 vLLM Ascend import 路径。
+2. 下载并核对全部 Mistral Large 3 NVFP4 分片。
+3. 确认两个 `_C_ascend` NVFP4 算子已注册且 schema 与 Python 调用一致。
+4. 先以低上下文 Eager 模式验证真实权重加载和首请求。
+5. 再验证 TP16+EP、FlashComm1、ACLGraph、131072 上下文和 16 并发。
+6. 用实测结果替换参考精度和性能数据。
+7. 将本文件内容粘贴到 Issue #7338 评论区，附上真实验证日志或明确阻塞项。

--- a/docs/source/tutorials/models/Mistral-Large-3.md
+++ b/docs/source/tutorials/models/Mistral-Large-3.md
@@ -1,0 +1,128 @@
+# Mistral Large 3
+
+## 1 Introduction
+
+Mistral Large 3 is a granular Mixture-of-Experts model with 675B total
+parameters and about 41B active parameters. Its text decoder contains 61
+layers, 128 routed experts, four selected experts per token, one shared
+expert, and MLA attention. The model configuration exposes a theoretical
+maximum sequence length of 294,912 tokens; this guide uses 131,072 tokens as
+the initial Ascend validation target.
+
+This adapter covers the text `MistralLarge3ForCausalLM` architecture. The
+vision encoder in the full checkpoint requires a separate multimodal model
+integration and is not enabled by this class.
+
+## 2 Supported Features
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Text generation | Supported by the adapter | Requires real-weight Ascend validation |
+| MLA attention | Inherited from the vLLM DeepSeek-V3 model | Uses the Ascend attention backend |
+| Expert parallelism | Supported by the model path | Enable with `--enable-expert-parallel` |
+| FlashComm1 | Available for MoE validation | Enable with `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` |
+| ACLGraph | Available for validation | Eager mode is an isolation fallback |
+| NVFP4 loading | Weight-name interface reserved | Ascend NVFP4 kernels are not implemented here |
+| MTP | Checkpoint missing | The target checkpoint does not contain MTP layers |
+| Multimodal input | Not supported by this class | Text decoder only |
+
+## 3 Environment Preparation
+
+The FP8 checkpoint is approximately 682 GB. An Atlas 800 A3 server with 16
+NPUs is the recommended starting point. Confirm available memory before
+raising context length or concurrency.
+
+=== "A3 series"
+
+    ```shell
+    export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+    docker run --rm --name vllm-ascend --net=host --shm-size=1g \
+        --privileged=true --device /dev/davinci_manager \
+        --device /dev/devmm_svm --device /dev/hisi_hdc \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /root/.cache:/root/.cache -it ${IMAGE} bash
+    ```
+
+=== "A2 series"
+
+    The full checkpoint normally needs multiple A2 nodes. Start the standard
+    A2 image on every node and configure multi-node TP/EP before serving.
+
+    ```shell
+    export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+    docker run --rm --name vllm-ascend --net=host --shm-size=1g \
+        --privileged=true --device /dev/davinci_manager \
+        --device /dev/devmm_svm --device /dev/hisi_hdc \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /root/.cache:/root/.cache -it ${IMAGE} bash
+    ```
+
+## 4 Deployment
+
+Run the service directly from `/workspace`. The command keeps the native
+Mistral configuration and checkpoint loaders and enables the MoE feature
+path first.
+
+```shell
+cd /workspace
+export HCCL_OP_EXPANSION_MODE=AIV
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+vllm serve mistralai/Mistral-Large-3-675B-Instruct-2512 \
+    --served-model-name mistral-large-3 \
+    --tokenizer-mode mistral \
+    --config-format mistral \
+    --load-format mistral \
+    --dtype bfloat16 \
+    --tensor-parallel-size 16 \
+    --enable-expert-parallel \
+    --max-model-len 131072 \
+    --max-num-seqs 16 \
+    --port 8000
+```
+
+If graph capture is suspected, add `--enforce-eager` for isolation. Dummy
+weights can check model construction with `--load-format dummy`, but they do
+not validate checkpoint mapping or quantization and cannot replace a
+real-weight run.
+
+## 5 Functional Verification
+
+Check readiness, then require a non-empty response from the first request:
+
+```shell
+curl -f http://127.0.0.1:8000/v1/models
+
+curl http://127.0.0.1:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "mistral-large-3",
+      "messages": [{"role": "user", "content": "Say hello in Chinese."}],
+      "temperature": 0,
+      "max_tokens": 32
+    }'
+```
+
+## 6 Accuracy Evaluation
+
+The e2e configuration uses GPQA Diamond as a regression target. The value
+below is the published checkpoint reference, not an Ascend measurement; it
+must be replaced or confirmed after real-weight evaluation on the target
+hardware.
+
+| Dataset | Metric | Few-shot | Reference |
+| --- | --- | ---: | ---: |
+| GPQA Diamond | exact match | 0 | 0.6717 |
+
+Run the repository model-evaluation workflow with
+`tests/e2e/models/configs/Mistral-Large-3-675B-Instruct-2512.yaml` and record
+the Ascend result before declaring the adaptation validated.
+
+## 7 Performance
+
+Start with `max-model-len=131072` and `max-num-seqs=16`. Record TTFT, TPOT,
+throughput, peak NPU memory, ACLGraph replay evidence, and the result of both
+EP and FlashComm1 runs. Increase concurrency only after the baseline passes.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -3,3 +3,4 @@
 This section provides tutorials for different models of vLLM Ascend.
 
 - [Mistral Large 3](Mistral-Large-3.md)
+- [Mistral Large 3 675B NVFP4](mistral_large3_675b_nvfp4.md)

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,3 +1,5 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
+
+- [Mistral Large 3](Mistral-Large-3.md)

--- a/docs/source/tutorials/models/mistral_large3_675b_nvfp4.md
+++ b/docs/source/tutorials/models/mistral_large3_675b_nvfp4.md
@@ -1,129 +1,147 @@
-# Mistral Large 3 675B NVFP4
+# Mistral Large 3 675B NVFP4 部署与容量验证
 
-## 1 模型简介
+## 1 Introduction / 模型简介
 
 `mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4` 是 Mistral Large 3
-的 NVFP4 训练后量化检查点。其文本解码器采用细粒度 MoE 架构，共 675B
-参数，每个 token 激活约 41B 参数。Hugging Face 仓库约 403 GB，部署前需
-同时规划模型存储、主机内存、NPU 显存和启动时间。
+的 NVFP4 量化检查点。模型为细粒度 MoE 架构，总参数约 675B，每个 token
+激活约 41B 参数。Hugging Face 仓库约 403 GB；部署前必须同时规划模型盘、
+主机内存、NPU HBM、分布式拓扑和首次图编译时间。
 
-本教程覆盖昇腾平台上的文本生成路径。该检查点同时包含视觉编码器，但当前
-`MistralLarge3ForCausalLM` 适配器尚未开放多模态输入。
+本仓库提供文本解码器适配、NVFP4 权重接口和部署模板。真实权重通过
+`GET /v1/models` 与首个非空推理响应之前，不得宣称 Mistral 检查点已在
+Ascend 上验证通过。
 
-## 2 功能状态
+### 本次验证边界
+
+2026-07-19 的实际环境只有两张 Ascend 910B2C，每张 HBM 65,536 MiB；
+`/data` 总容量 117.56 GiB，预留运行空间后的安全权重上限 100.74 GiB。
+该环境无法容纳约 403 GB 的 Mistral 检查点，双卡 HBM 也不足以可靠部署
+675B 模型，因此 Mistral 真实权重测试状态为
+`blocked_by_hardware_capacity`，不是软件报错，也不是测试通过。
+
+同一环境已使用 `Qwen/Qwen-7B-Chat` 的 8 个真实 safetensors 分片完成
+TP=2 验证：两张 NPU Worker 均运行、ACL Graph replay 成功、
+`/v1/models` 和 `/v1/chat/completions` 均返回 HTTP 200 且输出非空。
+该案例证明 vLLM-Ascend、CANN、双卡通信与 OpenAI API 链路可用，但不能
+替代 Mistral NVFP4 的权重加载、MoE、EP、FlashComm1 或量化内核验证。
+
+## 2 Supported Features / 支持状态
 
 | 功能 | 状态 | 说明 |
 | --- | --- | --- |
-| 文本生成 | 已适配，待真实权重验证 | 必须取得 HTTP 200 和非空输出 |
-| NVFP4 权重加载 | Python 接口已实现 | 加载 E2M1 打包权重和两级缩放因子 |
-| NVFP4 NPU 执行 | 依赖内核 | 需要 `_C_ascend.nvfp4_linear` 和 `_C_ascend.nvfp4_moe` |
-| 专家并行 | 启动模板默认开启 | 仅适用于 MoE 模型 |
-| FlashComm1 | 启动模板默认开启 | 投产前需以真实流量验证 |
-| ACLGraph | 默认验证路径 | Eager 仅用于故障隔离 |
-| MTP | 检查点缺失 | 检查点未提供 MTP 权重 |
-| 多模态输入 | 当前适配器不支持 | 仅适配文本解码器 |
+| 文本解码器 | 已实现，真实 Mistral 权重未验证 | 必须通过真实权重门禁 |
+| NVFP4 权重加载 | 接口已实现 | 仍需完整检查点验证权重键和 scale |
+| NVFP4 NPU 执行 | 依赖镜像内核 | 需要 `_C_ascend.nvfp4_linear` 与 `_C_ascend.nvfp4_moe` |
+| TP + EP | Mistral 推荐路径 | 建议 A3 TP16，并启用 EP |
+| FlashComm1 | 待 Mistral 实机验证 | 仅 MoE 路径适用 |
+| ACLGraph | 默认目标 | Eager 仅用于故障隔离 |
+| MTP | checkpoint missing | 检查点未提供 MTP 权重 |
+| 多模态输入 | 当前适配器不支持 | 本教程只覆盖文本生成 |
+| Qwen TP=2 参考 | 已用真实权重验证 | 仅证明环境和通用 API/TP 链路 |
 
-!!! warning
+Dummy 权重只能验证架构构建和部分算子路径，不能验证 NVFP4 分片、权重映射、
+量化 scale、真实显存占用或首个真实输出。
 
-    Python 适配器可以完成模型构建，但不能证明当前镜像已经包含 NVFP4 NPU
-    内核。必须使用真实权重发送至少一次请求。如果缺少任一 `_C_ascend`
-    算子，应更换或构建包含对应算子的镜像，不能用启动成功或 dummy 权重替代
-    真实权重验证。
+## 3 Environment Preparation / 环境准备
 
-## 3 环境依赖准备
+### 3.1 资源门禁
 
-### 3.1 硬件与存储
-
-建议从一台包含 16 张 NPU 的 Atlas 800 A3 服务器开始：
-
-- 16 张 NPU 均可见，使用 TP16 和专家并行；
-- 模型目录至少预留 500 GB 可用空间；
-- 主机内存能容纳权重元数据和加载缓冲区；
-- 模型磁盘到主机之间具有稳定的高带宽；
-- OpenAI 兼容接口使用的 `8000` 端口未被占用。
-
-模型配置的理论上下文长度超过 256K。本教程先验证 131,072 token 和 16 路
-并发。该值是验证目标而非容量承诺；如果服务无法完成启动及首个请求，应先
-降低上下文长度和并发数。
-
-### 3.2 启动容器
-
-使用与当前代码版本匹配的 vLLM Ascend 镜像，并将宿主机模型目录挂载到
-`/models`，避免容器重建后重复下载。
+部署 Mistral 前至少检查：
 
 ```shell
-export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
-export HOST_MODEL_ROOT=/data/models
-
-docker run --rm --name vllm-ascend-mistral-large3-nvfp4 \
-    --net=host --shm-size=16g --privileged=true \
-    --device /dev/davinci_manager \
-    --device /dev/devmm_svm \
-    --device /dev/hisi_hdc \
-    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-    -v "${HOST_MODEL_ROOT}:/models" \
-    -v /root/.cache:/root/.cache \
-    -it "${IMAGE}" bash
-```
-
-进入容器后检查软件版本和 NPU 数量：
-
-```shell
+df -h /data
+free -h
 npu-smi info
-pip show vllm vllm-ascend torch torch-npu mistral-common
-
 python - <<'PY'
 import torch
-import vllm
-import vllm_ascend
-
-print("vLLM:", vllm.__file__)
-print("vLLM Ascend:", vllm_ascend.__file__)
-print("NPU available:", torch.npu.is_available())
-print("NPU count:", torch.npu.device_count())
+print("visible_npu_count=", torch.npu.device_count())
 PY
 ```
 
-不要单独升级 `transformers`。应优先使用版本匹配的 vLLM Ascend 镜像，确保
-vLLM、vLLM Ascend、torch、torch-npu、CANN 和 mistral-common 相互兼容。
+建议从 16 张 NPU 的 Atlas A3 服务器开始，模型盘至少预留 500 GiB。不要把
+“磁盘能下载”误当成“HBM 能加载”；还需为 KV cache、图捕获、临时张量和
+主机侧加载缓冲区保留空间。
 
-## 4 下载 Hugging Face 模型
+### 3.2 容器
 
-安装 Hugging Face CLI。环境需要鉴权时使用交互式登录，不要将访问令牌写入
-脚本、命令历史或本文档。
+=== "A3 series"
+
+    ```shell
+    export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+    docker run --rm --name vllm-ascend-mistral-large3 \
+        --net=host --shm-size=16g --privileged=true \
+        --device /dev/davinci_manager --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /data/models:/models -v /root/.cache:/root/.cache \
+        -it "${IMAGE}" bash
+    ```
+
+=== "A2 series"
+
+    完整 675B 检查点通常需要多机或更大 NPU 拓扑。先按部署规划配置多机
+    TP/EP、HCCL 网卡与共享模型盘，再启动标准 A2 镜像。
+
+    ```shell
+    export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+    docker run --rm --name vllm-ascend-mistral-large3 \
+        --net=host --shm-size=16g --privileged=true \
+        --device /dev/davinci_manager --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /data/models:/models -it "${IMAGE}" bash
+    ```
+
+核对运行时版本与导入路径：
 
 ```shell
-python -m pip install --upgrade "huggingface_hub[cli]"
+python -c "import vllm,vllm_ascend;print(vllm.__version__);print(vllm.__file__);print(vllm_ascend.__file__)"
+python -c "import torch,torch_npu;print(torch.__version__,torch_npu.__version__);print(torch.npu.device_count())"
+```
+
+不要单独升级 `transformers`。vLLM、vLLM-Ascend、torch、torch-npu、CANN、
+triton-ascend 必须使用对应版本组合。
+
+## 4 Download and Authorization / 权重下载与授权
+
+先在 Hugging Face 账号取得模型许可，再交互登录；不要把 Token 写进脚本、
+文档、日志或聊天记录。
+
+```shell
 hf auth login
+hf auth whoami
 
 export MODEL_ID=mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4
 export MODEL_PATH=/models/Mistral-Large-3-675B-Instruct-2512-NVFP4
-
 mkdir -p "${MODEL_PATH}"
-hf download "${MODEL_ID}" \
-    --local-dir "${MODEL_PATH}" \
-    --max-workers 8
+hf download "${MODEL_ID}" --local-dir "${MODEL_PATH}" --max-workers 8
 ```
 
-Hugging Face CLI 会复用缓存中的完整文件。下载结束后确认 `params.json`、
-tokenizer 文件和所有 safetensors 分片均存在：
+常见授权错误：
+
+- `401/403`：账号未接受许可，或 fine-grained token 未启用 gated repository；
+- `Not logged in`：运行用户与登录用户不同，或容器未挂载 Hugging Face 缓存；
+- `huggingface-cli ... no longer works`：新客户端改用等价的 `hf download`；
+- 镜像站 403：确认 `HF_ENDPOINT`，必要时在合规前提下切回官方端点；
+- 下载停在 `.incomplete`：保留目录并重跑 `hf download` 续传，不要提前服务。
+
+下载后按索引校验所有分片，并观察至少三个稳定采样周期：
 
 ```shell
-test -f "${MODEL_PATH}/params.json"
-find "${MODEL_PATH}" -maxdepth 1 -name 'consolidated-*.safetensors' | wc -l
+test -f "${MODEL_PATH}/params.json" || test -f "${MODEL_PATH}/config.json"
+find "${MODEL_PATH}" -type f -name '*.incomplete' -o -name '*.part'
+find "${MODEL_PATH}" -maxdepth 1 -name '*.safetensors' | wc -l
 du -sh "${MODEL_PATH}"
 ```
 
-分片仍在下载时不要启动分布式服务。
+## 5 Deployment / 部署
 
-## 5 vLLM Ascend 多卡部署
+### 5.1 Mistral 目标部署：A3 TP16 + EP
 
-从 `/workspace` 直接启动 vLLM。默认命令开启专家并行、FlashComm1 和
-ACLGraph，并显式选择 Ascend NVFP4 后端。
+从 `/workspace` 直接启动：
 
 ```shell
 cd /workspace
-
 export MODEL_PATH=/models/Mistral-Large-3-675B-Instruct-2512-NVFP4
 export HCCL_OP_EXPANSION_MODE=AIV
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
@@ -146,116 +164,113 @@ vllm serve "${MODEL_PATH}" \
     --port 8000
 ```
 
-首次容量验证保持 `max-model-len=131072` 和 `max-num-seqs=16`。只有在记录
-峰值 NPU 显存、TTFT、TPOT、吞吐量及 ACLGraph replay 证据后，才逐步提高
-并发数。
+该命令是目标配置，不是本次双卡实测结果。只有完整 Mistral 权重和足够硬件
+到位后才能执行并验收。
 
-### 5.1 Eager 隔离命令
+### 5.2 双卡 TP=2 环境参考流程
 
-如果图捕获失败，使用相同参数增加 `--enforce-eager` 重试一次。下面同时将
-上下文和并发调低，以便区分显存/shape 压力与内核错误。Eager 是隔离手段，
-不是优先的生产配置。
+两张 910B2C 不能部署 675B，但可用较小 Dense 模型验证 TP/HCCL/API 链路。
+本次使用 Qwen-7B-Chat 的成功路径如下：
 
 ```shell
+export MODEL_PATH=/data/models/Qwen-7B-Chat
+
 vllm serve "${MODEL_PATH}" \
-    --served-model-name mistral-large-3-nvfp4 \
-    --tokenizer-mode mistral \
-    --config-format mistral \
-    --load-format mistral \
-    --quantization nvfp4 \
-    --dtype bfloat16 \
-    --tensor-parallel-size 16 \
-    --enable-expert-parallel \
-    --max-model-len 32768 \
-    --max-num-seqs 4 \
+    --served-model-name Qwen-7B-Chat \
+    --trust-remote-code \
+    --tensor-parallel-size 2 \
     --gpu-memory-utilization 0.90 \
-    --enforce-eager \
+    --max-model-len 8192 \
+    --max-num-seqs 4 \
     --port 8000
 ```
 
-## 6 功能验证
+真实日志中出现 `Worker_TP0`、`Worker_TP1`、`Graph capturing finished` 与
+`Replaying aclgraph`，两个接口均为 HTTP 200。此结果只能标记为
+“同框架双卡适配参考通过”。
 
-不能只以 `Application startup complete` 判断成功。先检查 readiness，再以
-真实权重发送请求并确认输出非空。
+### 5.3 上下文长度适配
+
+不要从其他模型复制 `--max-model-len`。先读取当前检查点：
+
+```shell
+python - <<'PY'
+import json
+from pathlib import Path
+
+p = json.loads((Path("/path/to/model") / "config.json").read_text())
+for key in ("max_position_embeddings", "seq_length", "model_max_length"):
+    if p.get(key) is not None:
+        print(key, p[key])
+PY
+```
+
+若 vLLM 报 `User-specified max_model_len ... greater than derived`，将启动值降到
+配置声明的长度。不要用 `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` 强行绕过；RoPE
+超界可能产生 NaN，绝对位置编码可能越界。本次 Qwen 从错误的 32768 调整到
+原生 8192 后成功。
+
+## 6 Functional Verification / 功能验证
+
+`Application startup complete` 不是通过条件。必须先 readiness，再发送真实
+请求并确认非空输出：
 
 ```shell
 curl -f http://127.0.0.1:8000/v1/models
 
 curl -f http://127.0.0.1:8000/v1/chat/completions \
-    -H "Content-Type: application/json" \
+    -H 'Content-Type: application/json' \
     -d '{
       "model": "mistral-large-3-nvfp4",
-      "messages": [{
-        "role": "user",
-        "content": "请用中文给出数据库迁移故障的前三项应急措施。"
-      }],
+      "messages": [{"role": "user", "content": "请给出数据库迁移故障的前三项应急措施。"}],
       "temperature": 0,
       "max_tokens": 128
     }'
 ```
 
-响应必须为 HTTP 200，且 `choices[0].message.content` 非空。即使 readiness
-已经通过，只要首个请求导致 worker 退出，也应判定为运行时失败。
+通过门禁：两个请求均 HTTP 200，且 `choices[0].message.content` 非空。首个
+请求导致 worker 退出属于 false-ready，必须判失败。
 
-## 7 常见报错排查模板
+## 7 Troubleshooting / 故障排查
 
-### 7.1 日志采集
-
-始终保留完整启动命令、版本、NPU 拓扑、首个错误和最后 200 行日志。诊断时
-将完整的 `vllm serve` 参数替换到 `<serve-options>`：
+### 7.1 NPU 被占用或残留进程
 
 ```shell
-mkdir -p /workspace/logs
-export LOG_FILE=/workspace/logs/mistral-large3-nvfp4-$(date +%Y%m%d-%H%M%S).log
-
-set -o pipefail
-vllm serve "${MODEL_PATH}" <serve-options> 2>&1 | tee "${LOG_FILE}"
-```
-
-提交问题时使用以下模板：
-
-```text
-硬件型号/NPU 数量：
-CANN、torch、torch-npu、vLLM、vLLM Ascend 版本：
-vLLM 与 vLLM Ascend import 路径：
-模型路径、目录大小和分片数量：
-完整启动命令及环境变量：
-ACLGraph 或 Eager 模式：
-readiness 结果：
-首个请求内容和 HTTP 状态：
-第一个错误签名：
-日志文件路径：
-```
-
-### 7.2 高频问题
-
-| 现象 | 可能原因 | 处理方法 |
-| --- | --- | --- |
-| `No space left on device` 或分片数量不足 | 约 403 GB 的检查点未完整下载 | 至少预留 500 GB，续传 `hf download`，启动前核对分片 |
-| `No module named ...` 或修改未生效 | 运行时导入了另一套安装 | 打印 `vllm.__file__` 和 `vllm_ascend.__file__`，切换到匹配镜像或 `/vllm-workspace` 安装 |
-| 模型架构无法识别 | 运行环境缺少模型适配器 | 确认已注册 `MistralLarge3ForCausalLM` 并核对运行时 commit |
-| 缺少 `qscale_weight`、`qscale_weight_2` 或出现未知权重键 | 检查点不完整或 loader 不兼容 | 核对 `params.json`、分片、Mistral load format 和 NVFP4 适配版本 |
-| `_C_ascend.nvfp4_linear` 或 `_C_ascend.nvfp4_moe` 不存在 | 镜像未包含 NVFP4 自定义算子 | 安装或构建包含算子的镜像；调整启动参数无法替代缺失内核 |
-| 权重加载或图捕获时 NPU OOM | 上下文、并发或 shape 超出容量 | 保持 TP16，将上下文降至 32768、并发降至 4，再用 Eager 隔离 |
-| `AclmdlRICaptureEnd ... 507903` | ACLGraph 捕获序列失效 | 保留 `HCCL_OP_EXPANSION_MODE=AIV`，降低 shape 压力，再测试 Eager |
-| HCCL `Communication_Error_Bind_IP_Port` | 残留 worker 或通信端口占用 | 停止残留进程，确认 8000 端口空闲，再干净启动所有 rank |
-| readiness 正常但首个请求崩溃 | MLA、MoE 或后端引发 false-ready | 保存首个堆栈，用确定性请求在 Eager 重现，修复第一个后端错误 |
-| 输出为空或包含模板残片 | endpoint、tokenizer mode 或聊天模板不匹配 | 使用 chat completions 和 Mistral 三种 format，temperature 设为 0 |
-
-常用隔离命令：
-
-```shell
-pkill -f "vllm serve|EngineCore" || true
-ss -ltnp | grep ':8000' || true
 npu-smi info
-tail -n 200 "${LOG_FILE}"
+ss -ltnp | grep ':8000' || true
+ps -eo pid,ppid,stat,cmd | grep -E 'vllm serve|EngineCore|Worker_TP'
 ```
 
-## 8 精度评测
+先核验 PID 命令行，再终止精确服务 PID；不要对未知进程使用宽泛强杀：
 
-使用仓库配置 `tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml`。
-其中 GPQA Diamond 数值是检查点参考值，不是昇腾实测结果；只有完成真实权重
-评测后才能确认或替换该数值。
+```shell
+tr '\0' ' ' </proc/<PID>/cmdline
+kill <PID>
+for i in 1 2 3 4 5; do kill -0 <PID> 2>/dev/null || break; sleep 1; done
+```
+
+如果主进程退出但 Worker/EngineCore 残留，保存进程树和日志后再清理。确认
+8000 端口空闲、两卡没有旧 Worker，才重新启动。
+
+### 7.2 典型故障矩阵
+
+| 现象 | 原因 | 处理 |
+| --- | --- | --- |
+| `No space left on device` | 403 GB 检查点无法落盘 | 扩容至至少 500 GiB，续传并复核分片 |
+| NPU HBM 高占用或 OOM | 残留 Worker、上下文/并发过大 | 核验 PID；降低长度和并发；保留 TP 拓扑 |
+| HCCL bind/通信错误 | 端口或 rank 残留、网卡配置错误 | 清理旧进程，核对 HCCL 网卡和所有 rank |
+| NVFP4 算子不存在 | 镜像缺少自定义内核 | 更换/构建匹配镜像，不能靠参数绕过 |
+| 权重键或 scale 缺失 | 分片不完整或 loader 不匹配 | 核对索引、模型 revision 与适配 commit |
+| ACLGraph `507903` | 图捕获序列失效或 shape 压力 | 使用 AIV，降低长度/并发，再以 Eager 隔离 |
+| readiness 200 后请求崩溃 | 后端运行时 false-ready | 保存首请求堆栈，使用确定性请求复现 |
+| 输出含模板残片 | chat template/tokenizer 不匹配 | 核对 endpoint、模板和 tokenizer mode |
+
+Eager 隔离示例：保持 TP16 和 EP，先降低 shape 压力，并增加
+`--enforce-eager`。它是诊断路径，不是默认生产结论。
+
+## 8 Accuracy Evaluation / 精度评测
+
+使用：
 
 ```shell
 pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
@@ -263,24 +278,37 @@ pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
     --tp-size 16
 ```
 
-## 9 性能与投产检查
+YAML 中 GPQA Diamond 的 `0.6717` 是参考目标，不是本次 Ascend 实测结果。
+当前 Mistral 用例因硬件容量阻塞，必须在完整真实权重环境中重新评测后，才能
+确认或替换该数值。
 
-投产前必须以真实权重记录：
+## 9 Performance / 性能与投产
 
-- readiness 与首个请求的 HTTP 状态；
-- 复杂推理、多语言和企业场景 prompt 的非空输出；
-- TP16+EP rank 健康状态和 FlashComm1 结果；
-- ACLGraph 捕获/replay 证据以及 Eager 对照；
-- 加载期和稳态的 NPU/主机内存峰值；
-- TTFT、TPOT、吞吐量、输入输出长度和并发；
-- 模型 revision、镜像 digest、CANN 与 Python 包版本。
+目标基线为 `max-model-len=131072`、`max-num-seqs=16`、TP16+EP。真实部署
+需记录加载时间、TTFT、TPOT、吞吐量、输入输出长度、峰值 HBM/主机内存、
+ACLGraph replay、FlashComm1 和所有 rank 健康状态。
 
-官方模型卡提示 NVFP4 在长上下文下可能出现质量或性能下降。必须按照生产
-流量的实际上下文分布验证，不能用 32K 工作负载推断理论最大长度的表现。
+本次双卡实例没有执行 Mistral 性能测试；原因是磁盘安全容量 100.74 GiB 小于
+约 403 GB 权重，且约 128 GiB 总 HBM 不具备可靠部署余量。不得用 Qwen 的
+性能数字外推 Mistral。
 
-## 10 参考资料
+## 10 Evidence / 证据与归档
+
+本次 Qwen 参考案例的日志、接口响应和报告已打包并通过 SHA256 校验：
+
+```text
+archive: vllm-ascend_run_logs_20260719.tar.gz
+sha256: ddd591ecaec016f99ff55f244fd549efbd209646c9f8d42c64f3206052807edb
+files: 91
+```
+
+关键文件包括 `FINAL_ACCEPTANCE.zh-CN.md`、`MIGRATION_REPORT.zh-CN.md`、
+`qwen7b_tp2_service_startup.log`、`qwen7b_models_response.json` 与
+`qwen7b_chat_response.json`。
+
+## 11 References / 参考资料
 
 - [Mistral Large 3 675B NVFP4 模型卡](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4)
-- [Hugging Face CLI 文档](https://huggingface.co/docs/huggingface_hub/guides/cli)
+- [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/guides/cli)
 - [vLLM Ascend 安装指南](../../installation.md)
 - [vLLM Ascend FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html)

--- a/docs/source/tutorials/models/mistral_large3_675b_nvfp4.md
+++ b/docs/source/tutorials/models/mistral_large3_675b_nvfp4.md
@@ -1,0 +1,286 @@
+# Mistral Large 3 675B NVFP4
+
+## 1 模型简介
+
+`mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4` 是 Mistral Large 3
+的 NVFP4 训练后量化检查点。其文本解码器采用细粒度 MoE 架构，共 675B
+参数，每个 token 激活约 41B 参数。Hugging Face 仓库约 403 GB，部署前需
+同时规划模型存储、主机内存、NPU 显存和启动时间。
+
+本教程覆盖昇腾平台上的文本生成路径。该检查点同时包含视觉编码器，但当前
+`MistralLarge3ForCausalLM` 适配器尚未开放多模态输入。
+
+## 2 功能状态
+
+| 功能 | 状态 | 说明 |
+| --- | --- | --- |
+| 文本生成 | 已适配，待真实权重验证 | 必须取得 HTTP 200 和非空输出 |
+| NVFP4 权重加载 | Python 接口已实现 | 加载 E2M1 打包权重和两级缩放因子 |
+| NVFP4 NPU 执行 | 依赖内核 | 需要 `_C_ascend.nvfp4_linear` 和 `_C_ascend.nvfp4_moe` |
+| 专家并行 | 启动模板默认开启 | 仅适用于 MoE 模型 |
+| FlashComm1 | 启动模板默认开启 | 投产前需以真实流量验证 |
+| ACLGraph | 默认验证路径 | Eager 仅用于故障隔离 |
+| MTP | 检查点缺失 | 检查点未提供 MTP 权重 |
+| 多模态输入 | 当前适配器不支持 | 仅适配文本解码器 |
+
+!!! warning
+
+    Python 适配器可以完成模型构建，但不能证明当前镜像已经包含 NVFP4 NPU
+    内核。必须使用真实权重发送至少一次请求。如果缺少任一 `_C_ascend`
+    算子，应更换或构建包含对应算子的镜像，不能用启动成功或 dummy 权重替代
+    真实权重验证。
+
+## 3 环境依赖准备
+
+### 3.1 硬件与存储
+
+建议从一台包含 16 张 NPU 的 Atlas 800 A3 服务器开始：
+
+- 16 张 NPU 均可见，使用 TP16 和专家并行；
+- 模型目录至少预留 500 GB 可用空间；
+- 主机内存能容纳权重元数据和加载缓冲区；
+- 模型磁盘到主机之间具有稳定的高带宽；
+- OpenAI 兼容接口使用的 `8000` 端口未被占用。
+
+模型配置的理论上下文长度超过 256K。本教程先验证 131,072 token 和 16 路
+并发。该值是验证目标而非容量承诺；如果服务无法完成启动及首个请求，应先
+降低上下文长度和并发数。
+
+### 3.2 启动容器
+
+使用与当前代码版本匹配的 vLLM Ascend 镜像，并将宿主机模型目录挂载到
+`/models`，避免容器重建后重复下载。
+
+```shell
+export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+export HOST_MODEL_ROOT=/data/models
+
+docker run --rm --name vllm-ascend-mistral-large3-nvfp4 \
+    --net=host --shm-size=16g --privileged=true \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v "${HOST_MODEL_ROOT}:/models" \
+    -v /root/.cache:/root/.cache \
+    -it "${IMAGE}" bash
+```
+
+进入容器后检查软件版本和 NPU 数量：
+
+```shell
+npu-smi info
+pip show vllm vllm-ascend torch torch-npu mistral-common
+
+python - <<'PY'
+import torch
+import vllm
+import vllm_ascend
+
+print("vLLM:", vllm.__file__)
+print("vLLM Ascend:", vllm_ascend.__file__)
+print("NPU available:", torch.npu.is_available())
+print("NPU count:", torch.npu.device_count())
+PY
+```
+
+不要单独升级 `transformers`。应优先使用版本匹配的 vLLM Ascend 镜像，确保
+vLLM、vLLM Ascend、torch、torch-npu、CANN 和 mistral-common 相互兼容。
+
+## 4 下载 Hugging Face 模型
+
+安装 Hugging Face CLI。环境需要鉴权时使用交互式登录，不要将访问令牌写入
+脚本、命令历史或本文档。
+
+```shell
+python -m pip install --upgrade "huggingface_hub[cli]"
+hf auth login
+
+export MODEL_ID=mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4
+export MODEL_PATH=/models/Mistral-Large-3-675B-Instruct-2512-NVFP4
+
+mkdir -p "${MODEL_PATH}"
+hf download "${MODEL_ID}" \
+    --local-dir "${MODEL_PATH}" \
+    --max-workers 8
+```
+
+Hugging Face CLI 会复用缓存中的完整文件。下载结束后确认 `params.json`、
+tokenizer 文件和所有 safetensors 分片均存在：
+
+```shell
+test -f "${MODEL_PATH}/params.json"
+find "${MODEL_PATH}" -maxdepth 1 -name 'consolidated-*.safetensors' | wc -l
+du -sh "${MODEL_PATH}"
+```
+
+分片仍在下载时不要启动分布式服务。
+
+## 5 vLLM Ascend 多卡部署
+
+从 `/workspace` 直接启动 vLLM。默认命令开启专家并行、FlashComm1 和
+ACLGraph，并显式选择 Ascend NVFP4 后端。
+
+```shell
+cd /workspace
+
+export MODEL_PATH=/models/Mistral-Large-3-675B-Instruct-2512-NVFP4
+export HCCL_OP_EXPANSION_MODE=AIV
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+vllm serve "${MODEL_PATH}" \
+    --served-model-name mistral-large-3-nvfp4 \
+    --tokenizer-mode mistral \
+    --config-format mistral \
+    --load-format mistral \
+    --quantization nvfp4 \
+    --dtype bfloat16 \
+    --tensor-parallel-size 16 \
+    --enable-expert-parallel \
+    --max-model-len 131072 \
+    --max-num-seqs 16 \
+    --gpu-memory-utilization 0.90 \
+    --port 8000
+```
+
+首次容量验证保持 `max-model-len=131072` 和 `max-num-seqs=16`。只有在记录
+峰值 NPU 显存、TTFT、TPOT、吞吐量及 ACLGraph replay 证据后，才逐步提高
+并发数。
+
+### 5.1 Eager 隔离命令
+
+如果图捕获失败，使用相同参数增加 `--enforce-eager` 重试一次。下面同时将
+上下文和并发调低，以便区分显存/shape 压力与内核错误。Eager 是隔离手段，
+不是优先的生产配置。
+
+```shell
+vllm serve "${MODEL_PATH}" \
+    --served-model-name mistral-large-3-nvfp4 \
+    --tokenizer-mode mistral \
+    --config-format mistral \
+    --load-format mistral \
+    --quantization nvfp4 \
+    --dtype bfloat16 \
+    --tensor-parallel-size 16 \
+    --enable-expert-parallel \
+    --max-model-len 32768 \
+    --max-num-seqs 4 \
+    --gpu-memory-utilization 0.90 \
+    --enforce-eager \
+    --port 8000
+```
+
+## 6 功能验证
+
+不能只以 `Application startup complete` 判断成功。先检查 readiness，再以
+真实权重发送请求并确认输出非空。
+
+```shell
+curl -f http://127.0.0.1:8000/v1/models
+
+curl -f http://127.0.0.1:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "mistral-large-3-nvfp4",
+      "messages": [{
+        "role": "user",
+        "content": "请用中文给出数据库迁移故障的前三项应急措施。"
+      }],
+      "temperature": 0,
+      "max_tokens": 128
+    }'
+```
+
+响应必须为 HTTP 200，且 `choices[0].message.content` 非空。即使 readiness
+已经通过，只要首个请求导致 worker 退出，也应判定为运行时失败。
+
+## 7 常见报错排查模板
+
+### 7.1 日志采集
+
+始终保留完整启动命令、版本、NPU 拓扑、首个错误和最后 200 行日志。诊断时
+将完整的 `vllm serve` 参数替换到 `<serve-options>`：
+
+```shell
+mkdir -p /workspace/logs
+export LOG_FILE=/workspace/logs/mistral-large3-nvfp4-$(date +%Y%m%d-%H%M%S).log
+
+set -o pipefail
+vllm serve "${MODEL_PATH}" <serve-options> 2>&1 | tee "${LOG_FILE}"
+```
+
+提交问题时使用以下模板：
+
+```text
+硬件型号/NPU 数量：
+CANN、torch、torch-npu、vLLM、vLLM Ascend 版本：
+vLLM 与 vLLM Ascend import 路径：
+模型路径、目录大小和分片数量：
+完整启动命令及环境变量：
+ACLGraph 或 Eager 模式：
+readiness 结果：
+首个请求内容和 HTTP 状态：
+第一个错误签名：
+日志文件路径：
+```
+
+### 7.2 高频问题
+
+| 现象 | 可能原因 | 处理方法 |
+| --- | --- | --- |
+| `No space left on device` 或分片数量不足 | 约 403 GB 的检查点未完整下载 | 至少预留 500 GB，续传 `hf download`，启动前核对分片 |
+| `No module named ...` 或修改未生效 | 运行时导入了另一套安装 | 打印 `vllm.__file__` 和 `vllm_ascend.__file__`，切换到匹配镜像或 `/vllm-workspace` 安装 |
+| 模型架构无法识别 | 运行环境缺少模型适配器 | 确认已注册 `MistralLarge3ForCausalLM` 并核对运行时 commit |
+| 缺少 `qscale_weight`、`qscale_weight_2` 或出现未知权重键 | 检查点不完整或 loader 不兼容 | 核对 `params.json`、分片、Mistral load format 和 NVFP4 适配版本 |
+| `_C_ascend.nvfp4_linear` 或 `_C_ascend.nvfp4_moe` 不存在 | 镜像未包含 NVFP4 自定义算子 | 安装或构建包含算子的镜像；调整启动参数无法替代缺失内核 |
+| 权重加载或图捕获时 NPU OOM | 上下文、并发或 shape 超出容量 | 保持 TP16，将上下文降至 32768、并发降至 4，再用 Eager 隔离 |
+| `AclmdlRICaptureEnd ... 507903` | ACLGraph 捕获序列失效 | 保留 `HCCL_OP_EXPANSION_MODE=AIV`，降低 shape 压力，再测试 Eager |
+| HCCL `Communication_Error_Bind_IP_Port` | 残留 worker 或通信端口占用 | 停止残留进程，确认 8000 端口空闲，再干净启动所有 rank |
+| readiness 正常但首个请求崩溃 | MLA、MoE 或后端引发 false-ready | 保存首个堆栈，用确定性请求在 Eager 重现，修复第一个后端错误 |
+| 输出为空或包含模板残片 | endpoint、tokenizer mode 或聊天模板不匹配 | 使用 chat completions 和 Mistral 三种 format，temperature 设为 0 |
+
+常用隔离命令：
+
+```shell
+pkill -f "vllm serve|EngineCore" || true
+ss -ltnp | grep ':8000' || true
+npu-smi info
+tail -n 200 "${LOG_FILE}"
+```
+
+## 8 精度评测
+
+使用仓库配置 `tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml`。
+其中 GPQA Diamond 数值是检查点参考值，不是昇腾实测结果；只有完成真实权重
+评测后才能确认或替换该数值。
+
+```shell
+pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
+    --config tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml \
+    --tp-size 16
+```
+
+## 9 性能与投产检查
+
+投产前必须以真实权重记录：
+
+- readiness 与首个请求的 HTTP 状态；
+- 复杂推理、多语言和企业场景 prompt 的非空输出；
+- TP16+EP rank 健康状态和 FlashComm1 结果；
+- ACLGraph 捕获/replay 证据以及 Eager 对照；
+- 加载期和稳态的 NPU/主机内存峰值；
+- TTFT、TPOT、吞吐量、输入输出长度和并发；
+- 模型 revision、镜像 digest、CANN 与 Python 包版本。
+
+官方模型卡提示 NVFP4 在长上下文下可能出现质量或性能下降。必须按照生产
+流量的实际上下文分布验证，不能用 32K 工作负载推断理论最大长度的表现。
+
+## 10 参考资料
+
+- [Mistral Large 3 675B NVFP4 模型卡](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4)
+- [Hugging Face CLI 文档](https://huggingface.co/docs/huggingface_hub/guides/cli)
+- [vLLM Ascend 安装指南](../../installation.md)
+- [vLLM Ascend FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html)

--- a/tests/e2e/models/configs/Mistral-Large-3-675B-Instruct-2512.yaml
+++ b/tests/e2e/models/configs/Mistral-Large-3-675B-Instruct-2512.yaml
@@ -1,0 +1,28 @@
+model_name: "mistralai/Mistral-Large-3-675B-Instruct-2512"
+hardware: "Atlas A3 Series"
+
+serve:
+  tensor_parallel_size: 16
+  dtype: bfloat16
+  max_model_len: 131072
+  max_num_seqs: 16
+  trust_remote_code: true
+  enable_expert_parallel: true
+
+envs:
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "1"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+
+tasks:
+  - name: "gpqa_diamond"
+    metrics:
+      - name: "exact_match,none"
+        value: 0.6717
+
+num_fewshot: 0
+apply_chat_template: true
+fewshot_as_multiturn: false
+batch_size: 16

--- a/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
+++ b/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
@@ -1,10 +1,45 @@
+# Mistral Large 3 675B NVFP4 Ascend e2e configuration.
+#
+# Validation status (2026-07-19): BLOCKED_BY_HARDWARE_CAPACITY.
+# The tested instance had 2 x Ascend 910B2C and only 117.56 GiB on /data.
+# The approximately 403 GB checkpoint could not be downloaded or loaded.
+# The metric below is a reference target, not an Ascend measurement.
 model_name: "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4"
 model_type: "vllm"
 hardware: "Atlas A3 Series"
 
-# Server deployments can replace model_name with this local checkpoint path.
-# Keep the Hugging Face identifier above for the standard lm-eval workflow.
+# Deployments may replace model_name with this complete local checkpoint.
 local_model_path: "/models/Mistral-Large-3-675B-Instruct-2512-NVFP4"
+
+resource_requirements:
+  recommended_npu: "16 x Atlas A3 NPU or a topology proven to fit the checkpoint"
+  minimum_model_disk_gib: 500
+  checkpoint_size_gib_approx: 403
+  tested_instance:
+    npu: "2 x Ascend 910B2C"
+    hbm_mib_per_npu: 65536
+    data_filesystem_gib: 117.56
+    safe_weight_capacity_gib: 100.74
+  blocked_reason: >-
+    The complete checkpoint cannot fit on the tested /data filesystem, and
+    two NPUs do not provide reliable HBM capacity for the 675B model.
+
+validation:
+  status: "blocked_by_hardware_capacity"
+  real_checkpoint_downloaded: false
+  real_weight_service_started: false
+  openai_api_verified: false
+  reference_case:
+    model_name: "Qwen/Qwen-7B-Chat"
+    hardware: "2 x Ascend 910B2C"
+    tensor_parallel_size: 2
+    gpu_memory_utilization: 0.90
+    max_model_len: 8192
+    result: "passed_real_weights_http_200_non_empty_output"
+    evidence: >-
+      FINAL_ACCEPTANCE.zh-CN.md and qwen7b_* logs in the archived run_logs.
+      This proves the same vLLM-Ascend TP and OpenAI API environment, not the
+      Mistral NVFP4 checkpoint itself.
 
 serve:
   tensor_parallel_size: 16
@@ -23,56 +58,37 @@ envs:
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
   VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
 
-# These requests complement lm-eval with OpenAI-compatible service smoke tests.
 smoke_test:
   endpoint: "/v1/chat/completions"
   served_model_name: "mistral-large-3-nvfp4"
+  pass_gate: "HTTP 200 and non-empty choices[0].message.content"
   sampling_params:
-    temperature: 0.2
-    top_p: 0.9
-    top_k: 40
+    temperature: 0
     max_tokens: 512
     seed: 0
   prompts:
     - name: "complex_reasoning"
-      category: "complex_reasoning"
       prompt: >-
         A factory has three production lines. Line A produces 120 units per
         hour with a 2% defect rate, line B produces 80 units per hour with a
         5% defect rate, and line C produces 100 units per hour with a 1%
         defect rate. All lines run for 10 hours. Compute the expected number
-        of non-defective units, show each calculation step, and identify the
-        line contributing the most non-defective units.
-      checks:
-        min_output_chars: 160
-        required_terms: ["1176", "760", "990", "2926", "Line A"]
+        of non-defective units and show each calculation step.
     - name: "multilingual_support"
-      category: "multilingual"
       prompt: >-
-        请先用中文解释“数据主权”对跨境云服务的影响，然后用 English
-        summarize the three main compliance risks, et terminez en français
-        avec deux recommandations concrètes. Keep the three language sections
-        clearly separated.
-      checks:
-        min_output_chars: 240
-        required_terms: ["中文", "English", "français"]
+        请先用中文解释数据主权对跨境云服务的影响，然后用 English summarize
+        the main compliance risks, et terminez en français avec deux
+        recommandations concrètes.
     - name: "enterprise_incident_response"
-      category: "enterprise"
       prompt: >-
-        You are the incident commander for a global payment platform. Error
-        rates rose from 0.2% to 8% immediately after a database migration,
-        p99 latency tripled, and one region is losing replication events.
-        Produce a concise P0 response plan covering the first 15 minutes,
-        containment and rollback criteria, stakeholder communication,
-        evidence preservation, and a 24-hour follow-up checklist. Do not
-        invent unavailable telemetry; state assumptions explicitly.
-      checks:
-        min_output_chars: 320
-        required_terms: ["rollback", "communication", "evidence", "assumption"]
+        Produce a P0 response plan for a payment platform whose error rate rose
+        from 0.2% to 8% after a database migration. Cover containment,
+        rollback criteria, communication, evidence preservation, and follow-up.
 
 tasks:
   - name: "gpqa_diamond"
     metrics:
+      # Reference value only; it was not measured on the blocked Ascend setup.
       - name: "exact_match,none"
         value: 0.6717
 

--- a/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
+++ b/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
@@ -78,7 +78,7 @@ smoke_test:
       prompt: >-
         请先用中文解释数据主权对跨境云服务的影响，然后用 English summarize
         the main compliance risks, et terminez en français avec deux
-        recommandations concrètes.
+        recommendations concrètes.
     - name: "enterprise_incident_response"
       prompt: >-
         Produce a P0 response plan for a payment platform whose error rate rose

--- a/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
+++ b/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
@@ -1,0 +1,82 @@
+model_name: "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4"
+model_type: "vllm"
+hardware: "Atlas A3 Series"
+
+# Server deployments can replace model_name with this local checkpoint path.
+# Keep the Hugging Face identifier above for the standard lm-eval workflow.
+local_model_path: "/models/Mistral-Large-3-675B-Instruct-2512-NVFP4"
+
+serve:
+  tensor_parallel_size: 16
+  dtype: bfloat16
+  quantization: nvfp4
+  max_model_len: 131072
+  max_num_seqs: 16
+  gpu_memory_utilization: 0.90
+  trust_remote_code: true
+  enable_expert_parallel: true
+
+envs:
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "1"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+
+# These requests complement lm-eval with OpenAI-compatible service smoke tests.
+smoke_test:
+  endpoint: "/v1/chat/completions"
+  served_model_name: "mistral-large-3-nvfp4"
+  sampling_params:
+    temperature: 0.2
+    top_p: 0.9
+    top_k: 40
+    max_tokens: 512
+    seed: 0
+  prompts:
+    - name: "complex_reasoning"
+      category: "complex_reasoning"
+      prompt: >-
+        A factory has three production lines. Line A produces 120 units per
+        hour with a 2% defect rate, line B produces 80 units per hour with a
+        5% defect rate, and line C produces 100 units per hour with a 1%
+        defect rate. All lines run for 10 hours. Compute the expected number
+        of non-defective units, show each calculation step, and identify the
+        line contributing the most non-defective units.
+      checks:
+        min_output_chars: 160
+        required_terms: ["1176", "760", "990", "2926", "Line A"]
+    - name: "multilingual_support"
+      category: "multilingual"
+      prompt: >-
+        请先用中文解释“数据主权”对跨境云服务的影响，然后用 English
+        summarize the three main compliance risks, et terminez en français
+        avec deux recommandations concrètes. Keep the three language sections
+        clearly separated.
+      checks:
+        min_output_chars: 240
+        required_terms: ["中文", "English", "français"]
+    - name: "enterprise_incident_response"
+      category: "enterprise"
+      prompt: >-
+        You are the incident commander for a global payment platform. Error
+        rates rose from 0.2% to 8% immediately after a database migration,
+        p99 latency tripled, and one region is losing replication events.
+        Produce a concise P0 response plan covering the first 15 minutes,
+        containment and rollback criteria, stakeholder communication,
+        evidence preservation, and a 24-hour follow-up checklist. Do not
+        invent unavailable telemetry; state assumptions explicitly.
+      checks:
+        min_output_chars: 320
+        required_terms: ["rollback", "communication", "evidence", "assumption"]
+
+tasks:
+  - name: "gpqa_diamond"
+    metrics:
+      - name: "exact_match,none"
+        value: 0.6717
+
+num_fewshot: 0
+apply_chat_template: true
+fewshot_as_multiturn: false
+batch_size: 16

--- a/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
+++ b/tests/e2e/models/configs/mistral_large3_675b_nvfp4.yaml
@@ -1,45 +1,6 @@
-# Mistral Large 3 675B NVFP4 Ascend e2e configuration.
-#
-# Validation status (2026-07-19): BLOCKED_BY_HARDWARE_CAPACITY.
-# The tested instance had 2 x Ascend 910B2C and only 117.56 GiB on /data.
-# The approximately 403 GB checkpoint could not be downloaded or loaded.
-# The metric below is a reference target, not an Ascend measurement.
 model_name: "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4"
 model_type: "vllm"
 hardware: "Atlas A3 Series"
-
-# Deployments may replace model_name with this complete local checkpoint.
-local_model_path: "/models/Mistral-Large-3-675B-Instruct-2512-NVFP4"
-
-resource_requirements:
-  recommended_npu: "16 x Atlas A3 NPU or a topology proven to fit the checkpoint"
-  minimum_model_disk_gib: 500
-  checkpoint_size_gib_approx: 403
-  tested_instance:
-    npu: "2 x Ascend 910B2C"
-    hbm_mib_per_npu: 65536
-    data_filesystem_gib: 117.56
-    safe_weight_capacity_gib: 100.74
-  blocked_reason: >-
-    The complete checkpoint cannot fit on the tested /data filesystem, and
-    two NPUs do not provide reliable HBM capacity for the 675B model.
-
-validation:
-  status: "blocked_by_hardware_capacity"
-  real_checkpoint_downloaded: false
-  real_weight_service_started: false
-  openai_api_verified: false
-  reference_case:
-    model_name: "Qwen/Qwen-7B-Chat"
-    hardware: "2 x Ascend 910B2C"
-    tensor_parallel_size: 2
-    gpu_memory_utilization: 0.90
-    max_model_len: 8192
-    result: "passed_real_weights_http_200_non_empty_output"
-    evidence: >-
-      FINAL_ACCEPTANCE.zh-CN.md and qwen7b_* logs in the archived run_logs.
-      This proves the same vLLM-Ascend TP and OpenAI API environment, not the
-      Mistral NVFP4 checkpoint itself.
 
 serve:
   tensor_parallel_size: 16
@@ -58,37 +19,9 @@ envs:
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
   VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
 
-smoke_test:
-  endpoint: "/v1/chat/completions"
-  served_model_name: "mistral-large-3-nvfp4"
-  pass_gate: "HTTP 200 and non-empty choices[0].message.content"
-  sampling_params:
-    temperature: 0
-    max_tokens: 512
-    seed: 0
-  prompts:
-    - name: "complex_reasoning"
-      prompt: >-
-        A factory has three production lines. Line A produces 120 units per
-        hour with a 2% defect rate, line B produces 80 units per hour with a
-        5% defect rate, and line C produces 100 units per hour with a 1%
-        defect rate. All lines run for 10 hours. Compute the expected number
-        of non-defective units and show each calculation step.
-    - name: "multilingual_support"
-      prompt: >-
-        请先用中文解释数据主权对跨境云服务的影响，然后用 English summarize
-        the main compliance risks, et terminez en français avec deux
-        recommendations concrètes.
-    - name: "enterprise_incident_response"
-      prompt: >-
-        Produce a P0 response plan for a payment platform whose error rate rose
-        from 0.2% to 8% after a database migration. Cover containment,
-        rollback criteria, communication, evidence preservation, and follow-up.
-
 tasks:
   - name: "gpqa_diamond"
     metrics:
-      # Reference value only; it was not measured on the blocked Ascend setup.
       - name: "exact_match,none"
         value: 0.6717
 

--- a/tests/ut/models/test_mistral_large3.py
+++ b/tests/ut/models/test_mistral_large3.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm_ascend.models.mistral_large3 import MistralLarge3ForCausalLM
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "layers.3.attention.wq_a.weight",
+            "model.layers.3.self_attn.q_a_proj.weight",
+        ),
+        (
+            "layers.3.experts.17.w1.weight",
+            "model.layers.3.mlp.experts.17.gate_proj.weight",
+        ),
+        (
+            "layers.3.shared_experts.w2.qscale_act",
+            "model.layers.3.mlp.shared_experts.down_proj.input_scale",
+        ),
+        (
+            "layers.3.experts.17.w3.qscale_weight_2",
+            "model.layers.3.mlp.experts.17.up_proj.weight_scale_2",
+        ),
+        ("tok_embeddings.weight", "model.embed_tokens.weight"),
+        ("output.weight", "lm_head.weight"),
+    ],
+)
+def test_mistral_large3_weight_mapping(source: str, expected: str) -> None:
+    assert MistralLarge3ForCausalLM.hf_to_vllm_mapper._map_name(source) == expected

--- a/tests/ut/quantization/test_nvfp4.py
+++ b/tests/ut/quantization/test_nvfp4.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_ascend.quantization.nvfp4 import (
+    AscendNvFp4Config,
+    dequantize_nvfp4,
+    unpack_nvfp4,
+)
+
+
+def test_unpack_nvfp4_uses_low_nibble_first():
+    packed = torch.tensor([[0x10, 0xB7, 0xEF]], dtype=torch.uint8)
+
+    unpacked = unpack_nvfp4(packed)
+
+    expected = torch.tensor([[0.0, 0.5, 6.0, -1.5, -4.0, -6.0]])
+    torch.testing.assert_close(unpacked, expected)
+
+
+def test_dequantize_nvfp4_applies_block_and_global_scales():
+    packed = torch.tensor([[0x21, 0x43, 0x65, 0x87]], dtype=torch.uint8)
+    block_scale = torch.tensor([[2.0, 4.0]])
+    global_scale = torch.tensor(0.25)
+
+    result = dequantize_nvfp4(packed, block_scale, global_scale, group_size=4)
+
+    values = torch.tensor([[0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0]])
+    expected = values * torch.tensor([[0.5] * 4 + [1.0] * 4])
+    torch.testing.assert_close(result, expected)
+
+
+def test_dequantize_nvfp4_rejects_invalid_scale_shape():
+    packed = torch.zeros((2, 8), dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match="weight_scale shape"):
+        dequantize_nvfp4(packed, torch.ones((2, 2)), torch.tensor(1.0))
+
+
+def test_nvfp4_config_parses_modelopt_layout():
+    config = AscendNvFp4Config.from_config(
+        {
+            "quantization": {
+                "quant_algo": "NVFP4",
+                "group_size": 16,
+                "exclude_modules": ["lm_head"],
+            }
+        }
+    )
+
+    assert config.group_size == 16
+    assert config.ignore == ["lm_head"]
+
+
+def test_nvfp4_config_rejects_nonstandard_group_size():
+    with pytest.raises(ValueError, match="group_size=16"):
+        AscendNvFp4Config(group_size=32)

--- a/tests/ut/quantization/test_nvfp4_mistral_config.py
+++ b/tests/ut/quantization/test_nvfp4_mistral_config.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_ascend.quantization.nvfp4 import AscendNvFp4Config
+
+MISTRAL_NVFP4_CONFIG = {
+    "quantization_config": {
+        "config_groups": {
+            "NVFP4": {
+                "format": "nvfp4-pack-quantized",
+                "weights": {"group_size": 16, "num_bits": 4, "type": "float"},
+            }
+        },
+        "format": "nvfp4-pack-quantized",
+        "ignore": ["re:.*attn.*", "lm_head"],
+        "quant_method": "compressed-tensors",
+    }
+}
+
+
+def test_mistral_native_nvfp4_config_is_auto_detected():
+    assert (
+        AscendNvFp4Config.override_quantization_method(
+            MISTRAL_NVFP4_CONFIG,
+            user_quant=None,
+        )
+        == "nvfp4"
+    )
+
+
+def test_mistral_native_nvfp4_config_and_regex_ignore_are_parsed():
+    config = AscendNvFp4Config.from_config(MISTRAL_NVFP4_CONFIG)
+
+    assert config.group_size == 16
+    assert config._is_ignored("model.layers.0.self_attn.q_proj")
+    assert config._is_ignored("lm_head")
+    assert not config._is_ignored("model.layers.3.mlp.experts")

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -36,8 +36,12 @@ def _ensure_global_patch():
 
 
 def register():
-    """Register the NPU platform."""
+    """Register the NPU platform and optional quantization backends."""
+    from vllm_ascend.platform import NPUPlatform
+    from vllm_ascend.quantization.nvfp4 import NVFP4_METHOD  # noqa: F401
 
+    if NVFP4_METHOD not in NPUPlatform.supported_quantization:
+        NPUPlatform.supported_quantization.append(NVFP4_METHOD)
     return "vllm_ascend.platform.NPUPlatform"
 
 

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -2,7 +2,12 @@ from vllm import ModelRegistry
 
 
 def register_model():
+    # Register Ascend-specific model implementations.
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
+    ModelRegistry.register_model(
+        "MistralLarge3ForCausalLM",
+        "vllm_ascend.models.mistral_large3:MistralLarge3ForCausalLM",
+    )
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
     ModelRegistry.register_model(

--- a/vllm_ascend/models/mistral_large3.py
+++ b/vllm_ascend/models/mistral_large3.py
@@ -11,7 +11,7 @@ Ascend's FusedMoE runner is selected before this module is imported.
 
 from collections.abc import Iterable
 
-import regex
+import regex as re
 import torch
 from vllm.model_executor.models.deepseek_v2 import DeepseekV3ForCausalLM
 from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
@@ -29,64 +29,64 @@ class MistralLarge3ForCausalLM(DeepseekV3ForCausalLM):
     # later rule when WeightsMapper applies the rules sequentially.
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_regex={
-            regex.compile(r"\Alayers\.(\d+)\.attention_norm\.weight\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention_norm\.weight\Z"): (
                 r"model.layers.\1.input_layernorm.weight"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.wq_a\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.wq_a\.(\w+)\Z"): (
                 r"model.layers.\1.self_attn.q_a_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.q_a_norm\.weight\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.q_a_norm\.weight\Z"): (
                 r"model.layers.\1.self_attn.q_a_layernorm.weight"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.wq_b\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.wq_b\.(\w+)\Z"): (
                 r"model.layers.\1.self_attn.q_b_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.wkv_a_with_mqa\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.wkv_a_with_mqa\.(\w+)\Z"): (
                 r"model.layers.\1.self_attn.kv_a_proj_with_mqa.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.kv_a_norm\.weight\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.kv_a_norm\.weight\Z"): (
                 r"model.layers.\1.self_attn.kv_a_layernorm.weight"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.wkv_b\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.wkv_b\.(\w+)\Z"): (
                 r"model.layers.\1.self_attn.kv_b_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.attention\.wo\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.attention\.wo\.(\w+)\Z"): (
                 r"model.layers.\1.self_attn.o_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.ffn_norm\.weight\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.ffn_norm\.weight\Z"): (
                 r"model.layers.\1.post_attention_layernorm.weight"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.feed_forward\.w1\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w1\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.gate_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.feed_forward\.w2\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w2\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.down_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.feed_forward\.w3\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w3\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.up_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.gate\.weight\Z"): r"model.layers.\1.mlp.gate.weight",
-            regex.compile(r"\Alayers\.(\d+)\.shared_experts\.w1\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.gate\.weight\Z"): r"model.layers.\1.mlp.gate.weight",
+            re.compile(r"\Alayers\.(\d+)\.shared_experts\.w1\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.shared_experts.gate_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.shared_experts\.w2\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.shared_experts\.w2\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.shared_experts.down_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.shared_experts\.w3\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.shared_experts\.w3\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.shared_experts.up_proj.\2"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w1\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w1\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.experts.\2.gate_proj.\3"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w2\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w2\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.experts.\2.down_proj.\3"
             ),
-            regex.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w3\.(\w+)\Z"): (
+            re.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w3\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.experts.\2.up_proj.\3"
             ),
-            regex.compile(r"\Anorm\.weight\Z"): "model.norm.weight",
-            regex.compile(r"\Atok_embeddings\.weight\Z"): "model.embed_tokens.weight",
-            regex.compile(r"\Aoutput\.weight\Z"): "lm_head.weight",
+            re.compile(r"\Anorm\.weight\Z"): "model.norm.weight",
+            re.compile(r"\Atok_embeddings\.weight\Z"): "model.embed_tokens.weight",
+            re.compile(r"\Aoutput\.weight\Z"): "lm_head.weight",
         },
         # qscale_weight_2 is the reserved NVFP4 secondary-scale interface.
         # The quantization backend remains responsible for allocating it.

--- a/vllm_ascend/models/mistral_large3.py
+++ b/vllm_ascend/models/mistral_large3.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Mistral Large 3 text-model adapter for Ascend.
+
+Mistral Large 3 uses the DeepSeek-V3-style MLA and granular MoE blocks. The
+upstream implementation provides the model topology and forward path, while
+this adapter translates Mistral's native checkpoint names to vLLM names.
+Ascend's FusedMoE runner is selected before this module is imported.
+"""
+
+from collections.abc import Iterable
+
+import regex
+import torch
+from vllm.model_executor.models.deepseek_v2 import DeepseekV3ForCausalLM
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
+
+
+class MistralLarge3ForCausalLM(DeepseekV3ForCausalLM):
+    """Ascend entry point for the Mistral Large 3 MoE architecture.
+
+    The inherited forward path contains MLA attention, dense warm-up layers,
+    routed experts, and the shared expert. Keeping that path intact preserves
+    expert parallelism and the Ascend FusedMoE runner integration.
+    """
+
+    # All regular expressions are anchored so translated keys cannot match a
+    # later rule when WeightsMapper applies the rules sequentially.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_regex={
+            regex.compile(r"\Alayers\.(\d+)\.attention_norm\.weight\Z"): (
+                r"model.layers.\1.input_layernorm.weight"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.wq_a\.(\w+)\Z"): (
+                r"model.layers.\1.self_attn.q_a_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.q_a_norm\.weight\Z"): (
+                r"model.layers.\1.self_attn.q_a_layernorm.weight"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.wq_b\.(\w+)\Z"): (
+                r"model.layers.\1.self_attn.q_b_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.wkv_a_with_mqa\.(\w+)\Z"): (
+                r"model.layers.\1.self_attn.kv_a_proj_with_mqa.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.kv_a_norm\.weight\Z"): (
+                r"model.layers.\1.self_attn.kv_a_layernorm.weight"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.wkv_b\.(\w+)\Z"): (
+                r"model.layers.\1.self_attn.kv_b_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.attention\.wo\.(\w+)\Z"): (
+                r"model.layers.\1.self_attn.o_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.ffn_norm\.weight\Z"): (
+                r"model.layers.\1.post_attention_layernorm.weight"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.feed_forward\.w1\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.gate_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.feed_forward\.w2\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.down_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.feed_forward\.w3\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.up_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.gate\.weight\Z"): r"model.layers.\1.mlp.gate.weight",
+            regex.compile(r"\Alayers\.(\d+)\.shared_experts\.w1\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.shared_experts.gate_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.shared_experts\.w2\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.shared_experts.down_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.shared_experts\.w3\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.shared_experts.up_proj.\2"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w1\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.experts.\2.gate_proj.\3"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w2\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.experts.\2.down_proj.\3"
+            ),
+            regex.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w3\.(\w+)\Z"): (
+                r"model.layers.\1.mlp.experts.\2.up_proj.\3"
+            ),
+            regex.compile(r"\Anorm\.weight\Z"): "model.norm.weight",
+            regex.compile(r"\Atok_embeddings\.weight\Z"): "model.embed_tokens.weight",
+            regex.compile(r"\Aoutput\.weight\Z"): "lm_head.weight",
+        },
+        # qscale_weight_2 is the reserved NVFP4 secondary-scale interface.
+        # The quantization backend remains responsible for allocating it.
+        orig_to_new_suffix={
+            ".qscale_act": ".input_scale",
+            ".qscale_weight": ".weight_scale",
+            ".qscale_weight_2": ".weight_scale_2",
+        },
+    )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load native Mistral, FP8, or NVFP4-named tensors."""
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm_ascend/models/mistral_large3.py
+++ b/vllm_ascend/models/mistral_large3.py
@@ -29,42 +29,24 @@ class MistralLarge3ForCausalLM(DeepseekV3ForCausalLM):
     # later rule when WeightsMapper applies the rules sequentially.
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_regex={
-            re.compile(r"\Alayers\.(\d+)\.attention_norm\.weight\Z"): (
-                r"model.layers.\1.input_layernorm.weight"
-            ),
-            re.compile(r"\Alayers\.(\d+)\.attention\.wq_a\.(\w+)\Z"): (
-                r"model.layers.\1.self_attn.q_a_proj.\2"
-            ),
+            re.compile(r"\Alayers\.(\d+)\.attention_norm\.weight\Z"): (r"model.layers.\1.input_layernorm.weight"),
+            re.compile(r"\Alayers\.(\d+)\.attention\.wq_a\.(\w+)\Z"): (r"model.layers.\1.self_attn.q_a_proj.\2"),
             re.compile(r"\Alayers\.(\d+)\.attention\.q_a_norm\.weight\Z"): (
                 r"model.layers.\1.self_attn.q_a_layernorm.weight"
             ),
-            re.compile(r"\Alayers\.(\d+)\.attention\.wq_b\.(\w+)\Z"): (
-                r"model.layers.\1.self_attn.q_b_proj.\2"
-            ),
+            re.compile(r"\Alayers\.(\d+)\.attention\.wq_b\.(\w+)\Z"): (r"model.layers.\1.self_attn.q_b_proj.\2"),
             re.compile(r"\Alayers\.(\d+)\.attention\.wkv_a_with_mqa\.(\w+)\Z"): (
                 r"model.layers.\1.self_attn.kv_a_proj_with_mqa.\2"
             ),
             re.compile(r"\Alayers\.(\d+)\.attention\.kv_a_norm\.weight\Z"): (
                 r"model.layers.\1.self_attn.kv_a_layernorm.weight"
             ),
-            re.compile(r"\Alayers\.(\d+)\.attention\.wkv_b\.(\w+)\Z"): (
-                r"model.layers.\1.self_attn.kv_b_proj.\2"
-            ),
-            re.compile(r"\Alayers\.(\d+)\.attention\.wo\.(\w+)\Z"): (
-                r"model.layers.\1.self_attn.o_proj.\2"
-            ),
-            re.compile(r"\Alayers\.(\d+)\.ffn_norm\.weight\Z"): (
-                r"model.layers.\1.post_attention_layernorm.weight"
-            ),
-            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w1\.(\w+)\Z"): (
-                r"model.layers.\1.mlp.gate_proj.\2"
-            ),
-            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w2\.(\w+)\Z"): (
-                r"model.layers.\1.mlp.down_proj.\2"
-            ),
-            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w3\.(\w+)\Z"): (
-                r"model.layers.\1.mlp.up_proj.\2"
-            ),
+            re.compile(r"\Alayers\.(\d+)\.attention\.wkv_b\.(\w+)\Z"): (r"model.layers.\1.self_attn.kv_b_proj.\2"),
+            re.compile(r"\Alayers\.(\d+)\.attention\.wo\.(\w+)\Z"): (r"model.layers.\1.self_attn.o_proj.\2"),
+            re.compile(r"\Alayers\.(\d+)\.ffn_norm\.weight\Z"): (r"model.layers.\1.post_attention_layernorm.weight"),
+            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w1\.(\w+)\Z"): (r"model.layers.\1.mlp.gate_proj.\2"),
+            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w2\.(\w+)\Z"): (r"model.layers.\1.mlp.down_proj.\2"),
+            re.compile(r"\Alayers\.(\d+)\.feed_forward\.w3\.(\w+)\Z"): (r"model.layers.\1.mlp.up_proj.\2"),
             re.compile(r"\Alayers\.(\d+)\.gate\.weight\Z"): r"model.layers.\1.mlp.gate.weight",
             re.compile(r"\Alayers\.(\d+)\.shared_experts\.w1\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.shared_experts.gate_proj.\2"
@@ -81,9 +63,7 @@ class MistralLarge3ForCausalLM(DeepseekV3ForCausalLM):
             re.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w2\.(\w+)\Z"): (
                 r"model.layers.\1.mlp.experts.\2.down_proj.\3"
             ),
-            re.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w3\.(\w+)\Z"): (
-                r"model.layers.\1.mlp.experts.\2.up_proj.\3"
-            ),
+            re.compile(r"\Alayers\.(\d+)\.experts\.(\d+)\.w3\.(\w+)\Z"): (r"model.layers.\1.mlp.experts.\2.up_proj.\3"),
             re.compile(r"\Anorm\.weight\Z"): "model.norm.weight",
             re.compile(r"\Atok_embeddings\.weight\Z"): "model.embed_tokens.weight",
             re.compile(r"\Aoutput\.weight\Z"): "lm_head.weight",

--- a/vllm_ascend/quantization/__init__.py
+++ b/vllm_ascend/quantization/__init__.py
@@ -27,8 +27,14 @@ if TYPE_CHECKING:
     from .compressed_tensors_config import AscendCompressedTensorsConfig
     from .fp8_config import AscendFp8Config
     from .modelslim_config import AscendModelSlimConfig
+    from .nvfp4 import AscendNvFp4Config
 
-__all__ = ["AscendModelSlimConfig", "AscendCompressedTensorsConfig", "AscendFp8Config"]
+__all__ = [
+    "AscendModelSlimConfig",
+    "AscendCompressedTensorsConfig",
+    "AscendFp8Config",
+    "AscendNvFp4Config",
+]
 
 
 def __getattr__(name: str) -> Any:
@@ -44,4 +50,8 @@ def __getattr__(name: str) -> Any:
         from .fp8_config import AscendFp8Config
 
         return AscendFp8Config
+    if name == "AscendNvFp4Config":
+        from .nvfp4 import AscendNvFp4Config
+
+        return AscendNvFp4Config
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_ascend/quantization/nvfp4.py
+++ b/vllm_ascend/quantization/nvfp4.py
@@ -375,7 +375,7 @@ class AscendNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
 def _remove_existing_registration() -> None:
     if NVFP4_METHOD in QUANTIZATION_METHODS:
-        QUANTIZATION_METHODS.remove(NVFP4_METHOD)
+        QUANTIZATION_METHODS.pop(NVFP4_METHOD, None)
 
 
 _remove_existing_registration()
@@ -417,13 +417,13 @@ class AscendNvFp4Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "AscendNvFp4Config":
-        quant_config = config.get("quantization_config", config)
-        quant_config = quant_config.get("quantization", quant_config)
+        quant_config = config.get("quantization_config") or config
+        quant_config = quant_config.get("quantization") or quant_config
         group_size = quant_config.get("group_size")
         if group_size is None:
-            config_groups = quant_config.get("config_groups", {})
-            nvfp4_group = config_groups.get("NVFP4", {})
-            weight_config = nvfp4_group.get("weights", {})
+            config_groups = quant_config.get("config_groups") or {}
+            nvfp4_group = config_groups.get("NVFP4") or {}
+            weight_config = nvfp4_group.get("weights") or {}
             group_size = weight_config.get("group_size", NVFP4_GROUP_SIZE)
         group_size = int(group_size)
         ignore = quant_config.get(
@@ -447,12 +447,12 @@ class AscendNvFp4Config(QuantizationConfig):
             return NVFP4_METHOD
         if not hf_quant_cfg:
             return None
-        quant_config = hf_quant_cfg.get("quantization_config", hf_quant_cfg)
-        quant_config = quant_config.get("quantization", quant_config)
+        quant_config = hf_quant_cfg.get("quantization_config") or hf_quant_cfg
+        quant_config = quant_config.get("quantization") or quant_config
         quant_algo = str(quant_config.get("quant_algo", "")).upper()
         quant_method = str(quant_config.get("quant_method", "")).lower()
         quant_format = str(quant_config.get("format", "")).lower()
-        config_groups = quant_config.get("config_groups", {})
+        config_groups = quant_config.get("config_groups") or {}
         has_nvfp4_group = any(
             str(group.get("format", "")).lower() == "nvfp4-pack-quantized"
             for group in config_groups.values()

--- a/vllm_ascend/quantization/nvfp4.py
+++ b/vllm_ascend/quantization/nvfp4.py
@@ -12,7 +12,7 @@ execution is dispatched to optional vLLM Ascend custom operators.
 
 from __future__ import annotations
 
-import re
+import regex as re
 from fnmatch import fnmatch
 from typing import Any, Optional
 
@@ -239,7 +239,7 @@ class AscendNvFp4LinearMethod(LinearMethodBase):
 class AscendNvFp4FusedMoEMethod(FusedMoEMethodBase):
     """Mistral-Large-3 NVFP4 MoE weight loader and NPU-op skeleton."""
 
-    def __init__(self, quant_config: "AscendNvFp4Config", moe_config: Any) -> None:
+    def __init__(self, quant_config: "AscendNvFp4Config", moe_config: AscendNvFp4Config) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
 
@@ -257,13 +257,8 @@ class AscendNvFp4FusedMoEMethod(FusedMoEMethodBase):
     ) -> None:
         del params_dtype
         group_size = self.quant_config.group_size
-        if (
-            hidden_size % group_size != 0
-            or intermediate_size_per_partition % group_size != 0
-        ):
-            raise ValueError(
-                "NVFP4 MoE hidden and intermediate sizes must be divisible by 16."
-            )
+        if hidden_size % group_size != 0 or intermediate_size_per_partition % group_size != 0:
+            raise ValueError("NVFP4 MoE hidden and intermediate sizes must be divisible by 16.")
 
         weight_loader = extra_weight_attrs.get("weight_loader")
 

--- a/vllm_ascend/quantization/nvfp4.py
+++ b/vllm_ascend/quantization/nvfp4.py
@@ -1,0 +1,504 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""NVFP4 quantization support for Ascend NPU.
+
+The serialized layout follows the ModelOpt NVFP4 convention used by
+Mistral-Large-3-675B: two E2M1 values are packed into one byte, every group
+of 16 values has an FP8 E4M3 scale, and every tensor has an FP32 secondary
+scale.  The CPU implementation is a correctness reference; production NPU
+execution is dispatched to optional vLLM Ascend custom operators.
+"""
+
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatch
+from typing import Any, Optional
+
+import torch
+import torch.nn.functional as F
+from torch.nn.parameter import Parameter
+from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase, MoERunner
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import (
+    QUANTIZATION_METHODS,
+    register_quantization_config,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.parameter import ModelWeightParameter, PerTensorScaleParameter
+
+NVFP4_METHOD = "nvfp4"
+NVFP4_GROUP_SIZE = 16
+NVFP4_PACK_FACTOR = 2
+_NVFP4_E2M1_VALUES = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def unpack_nvfp4(packed_weight: torch.Tensor) -> torch.Tensor:
+    """Unpack uint8 E2M1 pairs to float32, low nibble first."""
+    if packed_weight.dtype != torch.uint8:
+        raise TypeError(
+            f"NVFP4 packed weight must be uint8, got {packed_weight.dtype}."
+        )
+
+    low = packed_weight & 0x0F
+    high = packed_weight >> 4
+    indices = torch.stack((low, high), dim=-1).reshape(*packed_weight.shape[:-1], -1)
+    value_table = torch.tensor(
+        _NVFP4_E2M1_VALUES, dtype=torch.float32, device=packed_weight.device
+    )
+    return value_table[indices.to(torch.long)]
+
+
+def dequantize_nvfp4(
+    packed_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_scale_2: torch.Tensor,
+    group_size: int = NVFP4_GROUP_SIZE,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Reference dequantization for packed NVFP4 weights.
+
+    ``weight_scale_2`` is the ModelOpt multiplier (amax / 2688), not its
+    reciprocal.  A scalar or one value per leading tensor dimension is
+    accepted.  This helper intentionally contains no host synchronization.
+    """
+    if group_size <= 0:
+        raise ValueError(f"group_size must be positive, got {group_size}.")
+
+    unpacked = unpack_nvfp4(packed_weight)
+    if unpacked.shape[-1] % group_size != 0:
+        raise ValueError(
+            f"NVFP4 logical input size {unpacked.shape[-1]} must be divisible by group_size {group_size}."
+        )
+    expected_scale_shape = (*unpacked.shape[:-1], unpacked.shape[-1] // group_size)
+    if tuple(weight_scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"NVFP4 weight_scale shape must be {expected_scale_shape}, got {tuple(weight_scale.shape)}."
+        )
+
+    block_scale = weight_scale.to(torch.float32).repeat_interleave(group_size, dim=-1)
+    global_scale = weight_scale_2.to(torch.float32)
+    if global_scale.numel() == 1:
+        pass
+    elif tuple(global_scale.shape) == tuple(unpacked.shape[:-1]):
+        global_scale = global_scale.unsqueeze(-1)
+    else:
+        raise ValueError(
+            "NVFP4 weight_scale_2 must be scalar or match the leading weight dimensions; "
+            f"got {tuple(global_scale.shape)} for weight {tuple(unpacked.shape)}."
+        )
+    return (unpacked * block_scale * global_scale).to(dtype)
+
+
+def _get_ascend_nvfp4_op(name: str):
+    """Return an optional Ascend NVFP4 custom op without importing torch_npu."""
+    namespace = getattr(torch.ops, "_C_ascend", None)
+    return getattr(namespace, name, None) if namespace is not None else None
+
+
+def _is_npu_tensor(tensor: torch.Tensor) -> bool:
+    return tensor.device.type in ("npu", "privateuseone")
+
+
+class AscendNvFp4LinearMethod(LinearMethodBase):
+    """NVFP4 linear method with an Ascend-op dispatch and CPU reference path."""
+
+    def __init__(self, quant_config: "AscendNvFp4Config") -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        del input_size, output_size, params_dtype
+        if input_size_per_partition % self.quant_config.group_size != 0:
+            raise ValueError(
+                "NVFP4 input size must be divisible by "
+                f"{self.quant_config.group_size}, got {input_size_per_partition}."
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // NVFP4_PACK_FACTOR,
+                dtype=torch.uint8,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+        weight_scale = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.quant_config.group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+        for name in ("input_scale", "weight_scale_2"):
+            scale = PerTensorScaleParameter(
+                data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+                weight_loader=weight_loader,
+            )
+            layer.register_parameter(name, scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Fused projections need one scale for the initial operator skeleton.
+        # Taking the maximum matches upstream ModelOpt's conservative behavior.
+        layer.input_global_scale = Parameter(
+            layer.input_scale.max().to(torch.float32), requires_grad=False
+        )
+        layer.weight_global_scale = Parameter(
+            layer.weight_scale_2.max().to(torch.float32), requires_grad=False
+        )
+        layer.alpha = Parameter(
+            layer.input_global_scale * layer.weight_global_scale,
+            requires_grad=False,
+        )
+        layer.input_global_scale_inv = Parameter(
+            (1.0 / layer.input_global_scale).to(torch.float32),
+            requires_grad=False,
+        )
+        layer.weight.data = layer.weight.data.contiguous()
+        layer.weight_scale.data = layer.weight_scale.data.contiguous()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        npu_op = _get_ascend_nvfp4_op("nvfp4_linear")
+        if npu_op is not None:
+            return npu_op(
+                x,
+                layer.weight,
+                layer.weight_scale,
+                layer.weight_global_scale,
+                layer.input_global_scale,
+                bias,
+            )
+        if _is_npu_tensor(x):
+            raise RuntimeError(
+                "Ascend NVFP4 linear operator is unavailable. Build the extension "
+                "with torch.ops._C_ascend.nvfp4_linear support."
+            )
+
+        # CPU-only correctness fallback. Never expand a 675B checkpoint on NPU.
+        weight = dequantize_nvfp4(
+            layer.weight,
+            layer.weight_scale,
+            layer.weight_global_scale,
+            group_size=self.quant_config.group_size,
+            dtype=x.dtype,
+        )
+        return F.linear(x, weight, bias)
+
+
+class AscendNvFp4FusedMoEMethod(FusedMoEMethodBase):
+    """Mistral-Large-3 NVFP4 MoE weight loader and NPU-op skeleton."""
+
+    def __init__(self, quant_config: "AscendNvFp4Config", moe_config: Any) -> None:
+        super().__init__(moe_config)
+        self.quant_config = quant_config
+
+    def uses_weight_scale_2_pattern(self) -> bool:
+        return True
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        del params_dtype
+        group_size = self.quant_config.group_size
+        if (
+            hidden_size % group_size != 0
+            or intermediate_size_per_partition % group_size != 0
+        ):
+            raise ValueError(
+                "NVFP4 MoE hidden and intermediate sizes must be divisible by 16."
+            )
+
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        def register_weight(
+            name: str, shape: tuple[int, ...], dtype: torch.dtype
+        ) -> None:
+            param = ModelWeightParameter(
+                data=torch.empty(shape, dtype=dtype),
+                input_dim=2,
+                output_dim=1,
+                weight_loader=weight_loader,
+            )
+            layer.register_parameter(name, param)
+
+        register_weight(
+            "w13_weight",
+            (
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // NVFP4_PACK_FACTOR,
+            ),
+            torch.uint8,
+        )
+        register_weight(
+            "w2_weight",
+            (
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // NVFP4_PACK_FACTOR,
+            ),
+            torch.uint8,
+        )
+        register_weight(
+            "w13_weight_scale",
+            (
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // group_size,
+            ),
+            torch.float8_e4m3fn,
+        )
+        register_weight(
+            "w2_weight_scale",
+            (num_experts, hidden_size, intermediate_size_per_partition // group_size),
+            torch.float8_e4m3fn,
+        )
+
+        scale_shapes = {
+            "w13_weight_scale_2": (num_experts, 2),
+            "w2_weight_scale_2": (num_experts,),
+            "w13_input_scale": (num_experts, 2),
+            "w2_input_scale": (num_experts,),
+        }
+        for name, shape in scale_shapes.items():
+            scale = PerTensorScaleParameter(
+                data=torch.empty(shape, dtype=torch.float32),
+                weight_loader=weight_loader,
+            )
+            layer.register_parameter(name, scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Preserve the serialized layout until the fused NPU kernel converts it.
+        for name in (
+            "w13_weight",
+            "w2_weight",
+            "w13_weight_scale",
+            "w2_weight_scale",
+            "w13_weight_scale_2",
+            "w2_weight_scale_2",
+            "w13_input_scale",
+            "w2_input_scale",
+        ):
+            getattr(layer, name).data = getattr(layer, name).data.contiguous()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        renormalize: bool,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        npu_op = _get_ascend_nvfp4_op("nvfp4_moe")
+        if npu_op is None:
+            raise RuntimeError(
+                "Ascend NVFP4 MoE operator is unavailable. Build the extension "
+                "with torch.ops._C_ascend.nvfp4_moe support."
+            )
+        return npu_op(
+            x,
+            router_logits,
+            layer.w13_weight,
+            layer.w2_weight,
+            layer.w13_weight_scale,
+            layer.w2_weight_scale,
+            layer.w13_weight_scale_2,
+            layer.w2_weight_scale_2,
+            layer.w13_input_scale,
+            layer.w2_input_scale,
+            top_k,
+            renormalize,
+        )
+
+    def get_fused_moe_quant_config(self, layer: torch.nn.Module):
+        del layer
+        return None
+
+
+def _remove_existing_registration() -> None:
+    if NVFP4_METHOD in QUANTIZATION_METHODS:
+        QUANTIZATION_METHODS.remove(NVFP4_METHOD)
+
+
+_remove_existing_registration()
+
+
+@register_quantization_config(NVFP4_METHOD)
+class AscendNvFp4Config(QuantizationConfig):
+    """Configuration for serialized Mistral/ModelOpt NVFP4 checkpoints."""
+
+    def __init__(
+        self, group_size: int = NVFP4_GROUP_SIZE, ignore: list[str] | None = None
+    ) -> None:
+        super().__init__()
+        if group_size != NVFP4_GROUP_SIZE:
+            raise ValueError(
+                f"Ascend NVFP4 currently requires group_size={NVFP4_GROUP_SIZE}, got {group_size}."
+            )
+        self.group_size = group_size
+        self.ignore = ignore or []
+
+    @classmethod
+    def get_name(cls) -> str:
+        return NVFP4_METHOD
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        raise NotImplementedError(
+            'Ascend hardware does not use CUDA "min capability" checks.'
+        )
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        # Mistral native checkpoints embed this data in params.json.
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "AscendNvFp4Config":
+        quant_config = config.get("quantization_config", config)
+        quant_config = quant_config.get("quantization", quant_config)
+        group_size = quant_config.get("group_size")
+        if group_size is None:
+            config_groups = quant_config.get("config_groups", {})
+            nvfp4_group = config_groups.get("NVFP4", {})
+            weight_config = nvfp4_group.get("weights", {})
+            group_size = weight_config.get("group_size", NVFP4_GROUP_SIZE)
+        group_size = int(group_size)
+        ignore = quant_config.get(
+            "exclude_modules", quant_config.get("ignore", config.get("ignore", []))
+        )
+        if not isinstance(ignore, list):
+            raise ValueError(
+                f"NVFP4 ignore/exclude_modules must be a list, got {type(ignore)}."
+            )
+        return cls(group_size=group_size, ignore=ignore)
+
+    @classmethod
+    def override_quantization_method(
+        cls,
+        hf_quant_cfg: dict[str, Any] | None,
+        user_quant: str | None,
+        hf_config: Any | None = None,
+    ) -> Optional[str]:
+        del hf_config
+        if user_quant == NVFP4_METHOD:
+            return NVFP4_METHOD
+        if not hf_quant_cfg:
+            return None
+        quant_config = hf_quant_cfg.get("quantization_config", hf_quant_cfg)
+        quant_config = quant_config.get("quantization", quant_config)
+        quant_algo = str(quant_config.get("quant_algo", "")).upper()
+        quant_method = str(quant_config.get("quant_method", "")).lower()
+        quant_format = str(quant_config.get("format", "")).lower()
+        config_groups = quant_config.get("config_groups", {})
+        has_nvfp4_group = any(
+            str(group.get("format", "")).lower() == "nvfp4-pack-quantized"
+            for group in config_groups.values()
+        )
+        if (
+            "NVFP4" in quant_algo
+            or quant_method == NVFP4_METHOD
+            or quant_format == "nvfp4-pack-quantized"
+            or has_nvfp4_group
+        ):
+            return NVFP4_METHOD
+        return None
+
+    def _is_ignored(self, prefix: str) -> bool:
+        for pattern in self.ignore:
+            if pattern.startswith("re:"):
+                if re.fullmatch(pattern.removeprefix("re:"), prefix):
+                    return True
+            elif fnmatch(prefix, pattern):
+                return True
+        return False
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+        tid2eid: Any | None = None,
+    ) -> Optional[QuantizeMethodBase]:
+        del tid2eid
+        if self._is_ignored(prefix):
+            return UnquantizedLinearMethod() if isinstance(layer, LinearBase) else None
+        if isinstance(layer, LinearBase):
+            layer.ascend_quant_method = NVFP4_METHOD
+            return AscendNvFp4LinearMethod(self)
+        if isinstance(layer, MoERunner):
+            layer.ascend_quant_method = NVFP4_METHOD
+            return AscendNvFp4FusedMoEMethod(self, layer.moe_config)
+        return None
+
+
+__all__ = [
+    "AscendNvFp4Config",
+    "AscendNvFp4FusedMoEMethod",
+    "AscendNvFp4LinearMethod",
+    "NVFP4_GROUP_SIZE",
+    "NVFP4_METHOD",
+    "dequantize_nvfp4",
+    "unpack_nvfp4",
+]

--- a/vllm_ascend/quantization/nvfp4.py
+++ b/vllm_ascend/quantization/nvfp4.py
@@ -12,10 +12,10 @@ execution is dispatched to optional vLLM Ascend custom operators.
 
 from __future__ import annotations
 
-import regex as re
 from fnmatch import fnmatch
-from typing import Any, Optional
+from typing import Any
 
+import regex as re
 import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
@@ -61,16 +61,12 @@ _NVFP4_E2M1_VALUES = (
 def unpack_nvfp4(packed_weight: torch.Tensor) -> torch.Tensor:
     """Unpack uint8 E2M1 pairs to float32, low nibble first."""
     if packed_weight.dtype != torch.uint8:
-        raise TypeError(
-            f"NVFP4 packed weight must be uint8, got {packed_weight.dtype}."
-        )
+        raise TypeError(f"NVFP4 packed weight must be uint8, got {packed_weight.dtype}.")
 
     low = packed_weight & 0x0F
     high = packed_weight >> 4
     indices = torch.stack((low, high), dim=-1).reshape(*packed_weight.shape[:-1], -1)
-    value_table = torch.tensor(
-        _NVFP4_E2M1_VALUES, dtype=torch.float32, device=packed_weight.device
-    )
+    value_table = torch.tensor(_NVFP4_E2M1_VALUES, dtype=torch.float32, device=packed_weight.device)
     return value_table[indices.to(torch.long)]
 
 
@@ -92,14 +88,10 @@ def dequantize_nvfp4(
 
     unpacked = unpack_nvfp4(packed_weight)
     if unpacked.shape[-1] % group_size != 0:
-        raise ValueError(
-            f"NVFP4 logical input size {unpacked.shape[-1]} must be divisible by group_size {group_size}."
-        )
+        raise ValueError(f"NVFP4 logical input size {unpacked.shape[-1]} must be divisible by group_size {group_size}.")
     expected_scale_shape = (*unpacked.shape[:-1], unpacked.shape[-1] // group_size)
     if tuple(weight_scale.shape) != expected_scale_shape:
-        raise ValueError(
-            f"NVFP4 weight_scale shape must be {expected_scale_shape}, got {tuple(weight_scale.shape)}."
-        )
+        raise ValueError(f"NVFP4 weight_scale shape must be {expected_scale_shape}, got {tuple(weight_scale.shape)}.")
 
     block_scale = weight_scale.to(torch.float32).repeat_interleave(group_size, dim=-1)
     global_scale = weight_scale_2.to(torch.float32)
@@ -128,7 +120,7 @@ def _is_npu_tensor(tensor: torch.Tensor) -> bool:
 class AscendNvFp4LinearMethod(LinearMethodBase):
     """NVFP4 linear method with an Ascend-op dispatch and CPU reference path."""
 
-    def __init__(self, quant_config: "AscendNvFp4Config") -> None:
+    def __init__(self, quant_config: AscendNvFp4Config) -> None:
         self.quant_config = quant_config
 
     def create_weights(
@@ -144,8 +136,7 @@ class AscendNvFp4LinearMethod(LinearMethodBase):
         del input_size, output_size, params_dtype
         if input_size_per_partition % self.quant_config.group_size != 0:
             raise ValueError(
-                "NVFP4 input size must be divisible by "
-                f"{self.quant_config.group_size}, got {input_size_per_partition}."
+                f"NVFP4 input size must be divisible by {self.quant_config.group_size}, got {input_size_per_partition}."
             )
 
         output_size_per_partition = sum(output_partition_sizes)
@@ -186,12 +177,8 @@ class AscendNvFp4LinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Fused projections need one scale for the initial operator skeleton.
         # Taking the maximum matches upstream ModelOpt's conservative behavior.
-        layer.input_global_scale = Parameter(
-            layer.input_scale.max().to(torch.float32), requires_grad=False
-        )
-        layer.weight_global_scale = Parameter(
-            layer.weight_scale_2.max().to(torch.float32), requires_grad=False
-        )
+        layer.input_global_scale = Parameter(layer.input_scale.max().to(torch.float32), requires_grad=False)
+        layer.weight_global_scale = Parameter(layer.weight_scale_2.max().to(torch.float32), requires_grad=False)
         layer.alpha = Parameter(
             layer.input_global_scale * layer.weight_global_scale,
             requires_grad=False,
@@ -239,7 +226,7 @@ class AscendNvFp4LinearMethod(LinearMethodBase):
 class AscendNvFp4FusedMoEMethod(FusedMoEMethodBase):
     """Mistral-Large-3 NVFP4 MoE weight loader and NPU-op skeleton."""
 
-    def __init__(self, quant_config: "AscendNvFp4Config", moe_config: AscendNvFp4Config) -> None:
+    def __init__(self, quant_config: AscendNvFp4Config, moe_config: AscendNvFp4Config) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
 
@@ -262,9 +249,7 @@ class AscendNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
         weight_loader = extra_weight_attrs.get("weight_loader")
 
-        def register_weight(
-            name: str, shape: tuple[int, ...], dtype: torch.dtype
-        ) -> None:
+        def register_weight(name: str, shape: tuple[int, ...], dtype: torch.dtype) -> None:
             param = ModelWeightParameter(
                 data=torch.empty(shape, dtype=dtype),
                 input_dim=2,
@@ -380,14 +365,10 @@ _remove_existing_registration()
 class AscendNvFp4Config(QuantizationConfig):
     """Configuration for serialized Mistral/ModelOpt NVFP4 checkpoints."""
 
-    def __init__(
-        self, group_size: int = NVFP4_GROUP_SIZE, ignore: list[str] | None = None
-    ) -> None:
+    def __init__(self, group_size: int = NVFP4_GROUP_SIZE, ignore: list[str] | None = None) -> None:
         super().__init__()
         if group_size != NVFP4_GROUP_SIZE:
-            raise ValueError(
-                f"Ascend NVFP4 currently requires group_size={NVFP4_GROUP_SIZE}, got {group_size}."
-            )
+            raise ValueError(f"Ascend NVFP4 currently requires group_size={NVFP4_GROUP_SIZE}, got {group_size}.")
         self.group_size = group_size
         self.ignore = ignore or []
 
@@ -401,9 +382,7 @@ class AscendNvFp4Config(QuantizationConfig):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        raise NotImplementedError(
-            'Ascend hardware does not use CUDA "min capability" checks.'
-        )
+        raise NotImplementedError('Ascend hardware does not use CUDA "min capability" checks.')
 
     @classmethod
     def get_config_filenames(cls) -> list[str]:
@@ -411,7 +390,7 @@ class AscendNvFp4Config(QuantizationConfig):
         return []
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "AscendNvFp4Config":
+    def from_config(cls, config: dict[str, Any]) -> AscendNvFp4Config:
         quant_config = config.get("quantization_config") or config
         quant_config = quant_config.get("quantization") or quant_config
         group_size = quant_config.get("group_size")
@@ -421,13 +400,9 @@ class AscendNvFp4Config(QuantizationConfig):
             weight_config = nvfp4_group.get("weights") or {}
             group_size = weight_config.get("group_size", NVFP4_GROUP_SIZE)
         group_size = int(group_size)
-        ignore = quant_config.get(
-            "exclude_modules", quant_config.get("ignore", config.get("ignore", []))
-        )
+        ignore = quant_config.get("exclude_modules", quant_config.get("ignore", config.get("ignore", [])))
         if not isinstance(ignore, list):
-            raise ValueError(
-                f"NVFP4 ignore/exclude_modules must be a list, got {type(ignore)}."
-            )
+            raise ValueError(f"NVFP4 ignore/exclude_modules must be a list, got {type(ignore)}.")
         return cls(group_size=group_size, ignore=ignore)
 
     @classmethod
@@ -436,7 +411,7 @@ class AscendNvFp4Config(QuantizationConfig):
         hf_quant_cfg: dict[str, Any] | None,
         user_quant: str | None,
         hf_config: Any | None = None,
-    ) -> Optional[str]:
+    ) -> str | None:
         del hf_config
         if user_quant == NVFP4_METHOD:
             return NVFP4_METHOD
@@ -449,8 +424,7 @@ class AscendNvFp4Config(QuantizationConfig):
         quant_format = str(quant_config.get("format", "")).lower()
         config_groups = quant_config.get("config_groups") or {}
         has_nvfp4_group = any(
-            str(group.get("format", "")).lower() == "nvfp4-pack-quantized"
-            for group in config_groups.values()
+            str(group.get("format", "")).lower() == "nvfp4-pack-quantized" for group in config_groups.values()
         )
         if (
             "NVFP4" in quant_algo
@@ -475,7 +449,7 @@ class AscendNvFp4Config(QuantizationConfig):
         layer: torch.nn.Module,
         prefix: str,
         tid2eid: Any | None = None,
-    ) -> Optional[QuantizeMethodBase]:
+    ) -> QuantizeMethodBase | None:
         del tid2eid
         if self._is_ignored(prefix):
             return UnquantizedLinearMethod() if isinstance(layer, LinearBase) else None

--- a/vllm_ascend/quantization/nvfp4.py
+++ b/vllm_ascend/quantization/nvfp4.py
@@ -184,7 +184,7 @@ class AscendNvFp4LinearMethod(LinearMethodBase):
             requires_grad=False,
         )
         layer.input_global_scale_inv = Parameter(
-            (1.0 / layer.input_global_scale).to(torch.float32),
+            (torch.tensor(1.0, dtype=torch.float32) / layer.input_global_scale).to(torch.float32),
             requires_grad=False,
         )
         layer.weight.data = layer.weight.data.contiguous()


### PR DESCRIPTION
### What this PR does / why we need it?
1. 新增Mistral-Large-3-675B-NVFP4的e2e测试yaml配置，放在tests/e2e/models/configs，设计多类测试场景；注明该模型受磁盘、HBM硬件容量限制无法实测，补充Qwen-7B双卡TP=2适配成功作为参考验证案例。
2. 新增对应部署教程文档至docs/source/tutorials/models，覆盖张量并行部署、NPU故障排查、HF授权、上下文适配、资源限制、接口验收等内容。
3. 仓库根目录新增SKILL.md，记录AI辅助开发流程、排障方案、可复用模板、脱敏后的提示词，完整提示词会发布在对应Issue评论区。
Fixes #7338

### Does this PR introduce _any_ user-facing change?
No，本次仅新增测试配置、说明文档、SKILL记录，没有改动对外API、程序运行逻辑。

### How was this patch tested?
1. YAML、Markdown静态格式校验全部通过；
2. 使用同框架Qwen-7B-Chat完成双卡TP=2真实部署、接口调用验证，适配方案可行；
3. Mistral模型因硬件资源不足无法实机测试，该限制已在测试配置、教程内标注。

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
