### PR TITLE
[CI] Switch A3 single-node and multi-card tests to 560T runners with parallel execution

### DIFF
--- a/.github/workflows/_e2e_nightly_single_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_560t.yaml
@@ -259,6 +259,35 @@ jobs:
           pytest -sv tests/e2e/nightly/single_node/models/scripts/test_single_node.py \
             2>&1 | tee /tmp/test-logs/yaml-test.log
 
+      - name: Update good_table.csv on success
+        if: >-
+          ${{ always() &&
+          inputs.request_id == '' &&
+          (steps.pytest-driven.outcome == 'success' || steps.pytest-driven.outcome == 'skipped') &&
+          (steps.yaml-test.outcome == 'success' || steps.yaml-test.outcome == 'skipped') &&
+          (steps.pytest-driven.outcome == 'success' || steps.yaml-test.outcome == 'success') }}
+        working-directory: /vllm-workspace/vllm-ascend
+        env:
+          TEST_NAME: ${{ inputs.name || inputs.config_file_path || inputs.tests }}
+          TEST_PATH: ${{ inputs.config_file_path || inputs.tests }}
+          CONFIG_BASE_PATH: ${{ inputs.config_base_path }}
+          RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VLLM_ASCEND_VERSION: ${{ env.VLLM_ASCEND_VERSION }}
+        run: |
+          python3 tests/e2e/nightly/scripts/update_good_table.py \
+            --cache-csv "/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch }}/nightly/good_table.csv" \
+            --test-name "$TEST_NAME" \
+            --test-path "$TEST_PATH" \
+            --config-base-path "$CONFIG_BASE_PATH" \
+            --run-link  "$RUN_LINK" \
+            --vllm-dir  "/vllm-workspace/vllm" \
+            --vllm-ascend-dir "/vllm-workspace/vllm-ascend" \
+            --vllm-ascend-version "$VLLM_ASCEND_VERSION"
+
+      # ============================================
+      # AOP hooks: intercept test results uniformly
+      # ============================================
+
       - name: Capture test result
         id: test-result
         if: ${{ always() && inputs.aop_single_enabled && (inputs.config_file_path != '' || inputs.tests != '') }}
@@ -275,6 +304,12 @@ jobs:
         run: |
           bash tests/e2e/nightly/scripts/aop_classify.sh \
             "${{ steps.test-result.outputs.failed_test }}"
+
+      # ============================================================
+      # Decision gate:
+      #   env_failure     → Skip directly (no need to check age)
+      #   not_env_failure → Check commit age → old? Skip : Process
+      # ============================================================
 
       - name: Skip - env issue
         if: >-
@@ -338,6 +373,8 @@ jobs:
         if: ${{ always() && inputs.aop_single_enabled && steps.test-result.outputs.result == 'success' }}
         run: |
           echo ">>> All tests passed!"
+
+      # ============================================
 
       - name: Set benchmark artifact timestamp
         if: ${{ always() && inputs.config_file_path != '' }}

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -125,77 +125,77 @@ a3:
   single_node:
     test_config:
       - name: mtpx-deepseek-r1-0528-w8a8
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: MTPX-DeepSeek-R1-0528-W8A8.yaml
       - name: deepseek-r1-0528-w8a8
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: DeepSeek-R1-0528-W8A8.yaml
       - name: MiniMax-M2.5-w8a8-QuaRot-A3
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3.yaml
       - name: DeepSeek-V4-Flash-W8A8-A3
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
       - name: kimi-k2-thinking
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Kimi-K2-Thinking.yaml
       - name: kimi-k2.5
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Kimi-K2.5.yaml
       - name: Qwen3.5-122B-A10B-W8A8-A3
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
       - name: Qwen3.5-397B-A17B-w8a8-mtp-longseq
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3.5-397B-A17B-w8a8-mtp-longseq-A3.yaml
       - name: deepseek-v3-2-w8a8
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: DeepSeek-V3.2-W8A8.yaml
       - name: glm-5.1-w8a8-prefill-mc2
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: GLM-5.1-W8A8-PrefillMC2.yaml
       - name: qwen3-235b-a22b-w8a8
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3-235B-A22B-W8A8.yaml
       - name: Qwen3.5-397B-A17B-w8a8-mtp
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
       - name: deepseek-r1-0528-w8a8-prefix-cache
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
       - name: glm-4.7-w8a8
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: GLM-4.7.yaml
       - name: qwen3-vl-235b-a22b-instruct-w8a8
-        os: linux-aarch64-nightly-a3-16
+        os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
   multi_card:
     test_config:
       # pytest-driven tests
       - name: qwen3-30b-acc
-        os: linux-aarch64-nightly-a3-4
+        os: linux-aarch64-a3-4-cn12-001
         tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
       # YAML-driven tests
       - name: Qwen3.5-27B-w8a8-A3
-        os: linux-aarch64-nightly-a3-2
+        os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3.5-27B-w8a8-A3.yaml
       - name: qwen3-32b-int8
-        os: linux-aarch64-nightly-a3-4
+        os: linux-aarch64-a3-4-cn12-001
         config_file_path: Qwen3-32B-Int8.yaml
       - name: Qwen3-32B-QuaRot
-        os: linux-aarch64-nightly-a3-2
+        os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3-32B-QuaRot-eagle3.yaml
       - name: qwen3-30b-a3b-w8a8
-        os: linux-aarch64-nightly-a3-4
+        os: linux-aarch64-a3-4-cn12-001
         config_file_path: Qwen3-30B-A3B-W8A8.yaml
       - name: qwen3-32b-int8-prefix-cache
-        os: linux-aarch64-nightly-a3-4
+        os: linux-aarch64-a3-4-cn12-001
         config_file_path: Prefix-Cache-Qwen3-32B-Int8.yaml
       - name: Qwen3-30B-A3B-W4A8-llm-compressor
-        os: linux-aarch64-nightly-a3-2
+        os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3-30B-A3B-W4A8-llm-compressor.yaml
       - name: Qwen3-30B-QuaRot
-        os: linux-aarch64-nightly-a3-2
+        os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
 
 a3-560t:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -216,7 +216,7 @@ jobs:
 
   double-node-tests:
     name: double-node
-    needs: [setup-vars, parse-trigger, build-image, multi-node-tests]
+    needs: [setup-vars, parse-trigger, build-image]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -255,7 +255,7 @@ jobs:
 
   single-node-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
+    needs: [setup-vars, parse-trigger, build-image]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -266,7 +266,7 @@ jobs:
       matrix:
         vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
         test_config: ${{ fromJson(needs.setup-vars.outputs.single_node) }}
-    uses: ./.github/workflows/_e2e_nightly_single_node.yaml
+    uses: ./.github/workflows/_e2e_nightly_single_node_560t.yaml
     with:
       runner: ${{ matrix.test_config.os }}
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
@@ -285,7 +285,7 @@ jobs:
 
   multi-card-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
+    needs: [setup-vars, parse-trigger, build-image]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -295,7 +295,7 @@ jobs:
       matrix:
         vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
         test_config: ${{ fromJson(needs.setup-vars.outputs.multi_card) }}
-    uses: ./.github/workflows/_e2e_nightly_single_node.yaml
+    uses: ./.github/workflows/_e2e_nightly_single_node_560t.yaml
     with:
       runner: ${{ matrix.test_config.os }}
       image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'


### PR DESCRIPTION
### What this PR does / why we need it?

Switch A3 single-node and multi-card tests to 560T runners with parallel execution

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
