### PR TITLE
[Performance][310p]support multi-stream-shared-experts

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -29,13 +29,19 @@ def _build_weight_layer():
     )
 
 
-def test_runner_310_installs_specialized_unquantized_method_and_comm():
+@pytest.mark.parametrize("multistream_overlap_shared_expert", [False, True])
+def test_runner_310_installs_specialized_unquantized_method_and_comm(
+    multistream_overlap_shared_expert,
+):
     runner = _build_runner()
     moe_config = MagicMock()
     runner.moe_config = moe_config
     runner._get_quant_type = MagicMock(return_value=QuantType.NONE)
+    runner.multistream_overlap_shared_expert = multistream_overlap_shared_expert
+    runner._validate_shared_expert_consistency = MagicMock()
     routed_experts = SimpleNamespace(quant_config=None, quant_method=None)
-    quant_method = object()
+    quant_method = MagicMock()
+    original_process_weights = quant_method.process_weights_after_loading
     comm_method = object()
 
     with (
@@ -54,9 +60,16 @@ def test_runner_310_installs_specialized_unquantized_method_and_comm():
 
         assert routed_experts.quant_method is quant_method
         assert runner.quant_type == QuantType.NONE
-        assert runner.multistream_overlap_shared_expert is False
+        assert runner.multistream_overlap_shared_expert is multistream_overlap_shared_expert
         assert fused_moe_310_module._MoECommMethods[MoECommType.ALLGATHER] is comm_method
         parent_init.assert_called_once()
+
+        routed_experts.quant_method.process_weights_after_loading("layer")
+        original_process_weights.assert_called_once_with("layer")
+        if multistream_overlap_shared_expert:
+            runner._validate_shared_expert_consistency.assert_called_once_with()
+        else:
+            runner._validate_shared_expert_consistency.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 from collections.abc import Callable
+from functools import wraps
 
 import torch
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
@@ -169,5 +170,22 @@ class AscendMoERunner310(AscendMoERunner):
             routed_experts.quant_method = AscendUnquantizedFusedMoEMethod310(self.moe_config)
             self.quant_type = self._get_quant_type()
 
-        self.multistream_overlap_shared_expert = False
+            # AscendMoERunner installs this validation hook before the 310P
+            # unquantized method replaces its generic method. Reinstall it on
+            # the method that will actually process the routed-expert weights.
+            if self.multistream_overlap_shared_expert:
+                original_process_weights = routed_experts.quant_method.process_weights_after_loading
+
+                @wraps(original_process_weights)
+                def wrapped_process_weights(*args, **kwargs):
+                    result = original_process_weights(*args, **kwargs)
+                    self._validate_shared_expert_consistency()
+                    return result
+
+                routed_experts.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
+
+        # Keep the FlashCommV3 switch initialized by AscendMoERunner. Its
+        # event-driven shared-expert path overlaps gate/up with dispatch and
+        # down projection with combine instead of running the whole shared
+        # expert independently from the routed experts.
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl310(self.moe_config)


### PR DESCRIPTION
### What this PR does / why we need it?

Implemented support for multi-stream shared experts by adding a validation hook to the weight processing method.

### Does this PR introduce _any_ user-facing change?

Can open the `multi-stream-shared-experts` on 310P

### How was this patch tested?

localtest and CI

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
