### PR TITLE
[BugFix][KV Cache] Return per-group hybrid cache hit lengths

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -308,6 +308,33 @@ def test_get_kv_cache_coordinator_uses_ascend_for_deepseek_v4(monkeypatch) -> No
     assert coordinator is sentinel
 
 
+def test_find_longest_cache_hit_per_group_returns_hit_length_per_group() -> None:
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        full_block_size=16,
+        mamba_block_size=16,
+    )
+    coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=kv_cache_config,
+        max_model_len=128,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=16,
+        max_num_batched_tokens=128,
+    )
+
+    hit_blocks, hit_lengths = coordinator.find_longest_cache_hit_per_group(
+        block_hashes=[],
+        max_cache_hit_length=0,
+    )
+
+    assert hit_blocks == ([], [])
+    assert hit_lengths == (0, 0)
+    assert max(hit_lengths) == 0
+
+
 class _FakeEagleManager:
     def __init__(self) -> None:
         self.use_eagle = False

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -535,12 +535,13 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
                             HybridKVCacheCoordinator,
                         )
                     ):
-                        computed_blocks, num_new_local_computed_tokens = (
+                        computed_blocks, per_group_hits = (
                             self.kv_cache_manager.coordinator.find_longest_cache_hit_per_group(
                                 request.block_hashes,
                                 request.num_tokens - 1,
                             )
                         )
+                        num_new_local_computed_tokens = max(per_group_hits)
                         new_computed_blocks = self.kv_cache_manager.create_kv_cache_blocks(computed_blocks)
                         if self.kv_cache_manager.log_stats:
                             assert self.kv_cache_manager.prefix_cache_stats is not None

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -366,7 +366,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         self,
         block_hashes: list[BlockHash],
         max_cache_hit_length: int,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], tuple[int, ...]]:
         def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
             target_block_size = kv_cache_spec.block_size
             if not isinstance(kv_cache_spec, MambaSpec) and self.dcp_world_size * self.pcp_world_size > 1:
@@ -462,7 +462,12 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
 
-        return tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group), hit_length
+        hit_lengths_by_group = tuple(
+            len(blocks or [])
+            * self._get_effective_block_size(self.kv_cache_config.kv_cache_groups[group_id].kv_cache_spec)
+            for group_id, blocks in enumerate(hit_blocks_by_group)
+        )
+        return tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group), hit_lengths_by_group
 
 
 def get_kv_cache_coordinator(


### PR DESCRIPTION
### What this PR does / why we need it?

The Ascend hybrid KV cache coordinator still returned one scalar cache-hit
length. In vLLM 0.24, `find_longest_cache_hit_per_group()` returns one length
per KV cache group, and scheduler call sites reduce those values with `max()`.
The scalar override therefore crashes hybrid models such as Qwen3.6 with
`TypeError: 'int' object is not iterable` when prefix-cache lookup runs.

This PR:

- returns the per-group cache-hit lengths from the Ascend coordinator patch;
- keeps the existing minimum-hit alignment across groups;
- reduces the tuple at the recompute scheduler call site, matching the balance
  scheduler and upstream vLLM contract;
- adds a regression test that exercises the hybrid coordinator result.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Hybrid models using the Ascend KV pool no
longer crash during prefix-cache lookup.

### How was this patch tested?

```bash
PYTHONPATH=. python3 -m pytest -q \
  tests/ut/patch/platform/test_prefix_cache_cp_patches.py
# 14 passed

PYTHONPATH=. python3 -m pytest -q \
  tests/ut/core/test_recompute_scheduler.py \
  tests/ut/patch/platform/test_patch_balance_schedule.py
# 12 passed

ruff check \
  vllm_ascend/patch/platform/patch_kv_cache_coordinator.py \
  vllm_ascend/core/recompute_scheduler.py \
  tests/ut/patch/platform/test_prefix_cache_cp_patches.py

ruff format --check \
  vllm_ascend/patch/platform/patch_kv_cache_coordinator.py \
  vllm_ascend/core/recompute_scheduler.py \
  tests/ut/patch/platform/test_prefix_cache_cp_patches.py
```

Also validated with Qwen3.6-27B on two Ascend NPUs using a Mooncake KV pool:
prefix-hit requests completed with HTTP 200 and the previous iterable type
error did not recur.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
