### PR TITLE
[BugFix][KV Pool] Chunk oversized Mooncake SSD objects

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -29,6 +29,13 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_b
     _parse_global_segment_size,
     _ssd_setup_kwargs,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.ssd_chunking import (
+    DEFAULT_SSD_OBJECT_CHUNK_BYTES,
+    aggregate_chunk_results,
+    iter_ssd_read_batches,
+    split_ssd_batch,
+    ssd_chunk_head_keys,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.yuanrong_backend import (
     YuanrongConfig,
     YuanrongHelper,
@@ -173,6 +180,20 @@ class TestMooncakeStoreConfig(unittest.TestCase):
             },
         )
 
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend."
+        "mooncake_backend._mooncake_setup_supports_ssd_offload",
+        return_value=True,
+    )
+    def test_ssd_setup_kwargs_scheduler_does_not_mount_ssd(self, _mock_supports):
+        ssd_path = TestMooncakeStoreConfig._writable_ssd_path()
+        self.addCleanup(lambda: os.rmdir(ssd_path))
+        cfg = _make_mooncake_store_config(
+            enable_ssd_offload=True,
+            ssd_offload_path=ssd_path,
+        )
+        self.assertEqual(_ssd_setup_kwargs(cfg, contribute_memory=False), {})
+
     def test_load_from_env_missing(self):
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("MOONCAKE_CONFIG_PATH", None)
@@ -240,6 +261,69 @@ class TestConvertToBytes(unittest.TestCase):
     def test_invalid_number(self):
         with self.assertRaises(ValueError):
             _convert_to_bytes("abc", 1, "abc")
+
+
+# =========================================================================
+# Mooncake SSD object chunking
+# =========================================================================
+class TestMooncakeSSDChunking(unittest.TestCase):
+    def test_split_hybrid_kv_group(self):
+        layer_bytes = 1536 * 2 * 256 * 2
+        keys, addrs, sizes, ranges = split_ssd_batch(
+            ["hybrid-group"],
+            [[1000 + index * layer_bytes for index in range(16)]],
+            [[layer_bytes] * 16],
+        )
+
+        self.assertEqual(len(keys), 8)
+        self.assertEqual(ranges, [(0, 8)])
+        self.assertEqual(keys[0], "hybrid-group@mcssd1:0")
+        self.assertEqual(keys[-1], "hybrid-group@mcssd1:7")
+        self.assertTrue(all(sum(chunk) <= DEFAULT_SSD_OBJECT_CHUNK_BYTES for chunk in sizes))
+        self.assertEqual(sum(map(sum, sizes)), 16 * layer_bytes)
+        self.assertEqual(len(addrs), len(sizes))
+
+    def test_split_single_large_buffer_preserves_offsets(self):
+        mib = 1024**2
+        keys, addrs, sizes, ranges = split_ssd_batch(
+            ["large"],
+            [[100]],
+            [[7 * mib]],
+        )
+
+        self.assertEqual(keys, ["large@mcssd1:0", "large@mcssd1:1", "large@mcssd1:2"])
+        self.assertEqual(addrs, [[100], [100 + 3 * mib], [100 + 6 * mib]])
+        self.assertEqual(sizes, [[3 * mib], [3 * mib], [mib]])
+        self.assertEqual(ranges, [(0, 3)])
+
+    def test_read_batches_bound_bytes_and_object_count(self):
+        mib = 1024**2
+        self.assertEqual(
+            list(iter_ssd_read_batches([[3 * mib], [3 * mib], [mib]], 3 * mib)),
+            [(0, 1), (1, 2), (2, 3)],
+        )
+        self.assertEqual(
+            list(iter_ssd_read_batches([[1], [1], [1]], 10, max_batch_objects=2)),
+            [(0, 2), (2, 3)],
+        )
+
+    def test_aggregate_chunk_results(self):
+        self.assertEqual(
+            aggregate_chunk_results([1, 1, -7, 0, 4], [(0, 2), (2, 5)]),
+            [0, -7],
+        )
+
+    def test_chunking_rejects_mismatched_shapes(self):
+        with self.assertRaises(ValueError):
+            split_ssd_batch(["key"], [[100]], [])
+        with self.assertRaises(ValueError):
+            split_ssd_batch(["key"], [[100]], [[1, 2]])
+
+    def test_chunk_head_keys(self):
+        self.assertEqual(
+            ssd_chunk_head_keys(["k1", "k2"]),
+            ["k1@mcssd1:0", "k2@mcssd1:0"],
+        )
 
 
 # =========================================================================
@@ -353,6 +437,9 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             backend._use_fabric_mem = False
             backend._store_init_lock = MagicMock()
             backend.local_seg = None
+            backend.config.enable_ssd_offload = False
+            backend._ssd_chunk_bytes = DEFAULT_SSD_OBJECT_CHUNK_BYTES
+            backend._ssd_read_batch_bytes = 512 * 1024**2
             return backend
 
     def test_exists(self):
@@ -360,6 +447,15 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         b.store.batch_is_exist.return_value = [1, 0]
         result = b.exists(["k1", "k2"])
         self.assertEqual(result, [1, 0])
+        b.store.batch_is_exist.assert_called_once_with(["k1", "k2"])
+
+    def test_exists_ssd_uses_chunk_head(self):
+        b = self._make_backend()
+        b.config.enable_ssd_offload = True
+        b.store.batch_is_exist.return_value = [1]
+        result = b.exists(["k1"])
+        self.assertEqual(result, [1])
+        b.store.batch_is_exist.assert_called_once_with(["k1@mcssd1:0"])
 
     def test_put(self):
         b = self._make_backend()
@@ -377,6 +473,19 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         b.store.batch_put_from_multi_buffers.side_effect = Exception("fail")
         b.put(["k1"], [[100]], [[10]])  # Should log error but not raise
 
+    def test_put_ssd_splits_large_object(self):
+        b = self._make_backend()
+        b.config.enable_ssd_offload = True
+        b.store.batch_put_from_multi_buffers.return_value = [0, 0, 0]
+        mib = 1024**2
+
+        b.put(["large"], [[100]], [[7 * mib]])
+
+        keys, addrs, sizes, _config = b.store.batch_put_from_multi_buffers.call_args.args
+        self.assertEqual(keys, ["large@mcssd1:0", "large@mcssd1:1", "large@mcssd1:2"])
+        self.assertEqual(addrs, [[100], [100 + 3 * mib], [100 + 6 * mib]])
+        self.assertEqual(sizes, [[3 * mib], [3 * mib], [mib]])
+
     def test_get(self):
         b = self._make_backend()
         b.store.batch_get_into_multi_buffers.return_value = [0]
@@ -392,6 +501,22 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         b = self._make_backend()
         b.store.batch_get_into_multi_buffers.side_effect = Exception("fail")
         b.get(["k1"], [[100]], [[10]])
+
+    def test_get_ssd_splits_and_batches_large_object(self):
+        b = self._make_backend()
+        b.config.enable_ssd_offload = True
+        b._ssd_read_batch_bytes = DEFAULT_SSD_OBJECT_CHUNK_BYTES
+        b.store.batch_get_into_multi_buffers.side_effect = [[1], [1], [1]]
+        mib = 1024**2
+
+        result = b.get(["large"], [[100]], [[7 * mib]])
+
+        self.assertEqual(result, [0])
+        self.assertEqual(b.store.batch_get_into_multi_buffers.call_count, 3)
+        calls = b.store.batch_get_into_multi_buffers.call_args_list
+        self.assertEqual(calls[0].args[0], ["large@mcssd1:0"])
+        self.assertEqual(calls[1].args[0], ["large@mcssd1:1"])
+        self.assertEqual(calls[2].args[0], ["large@mcssd1:2"])
 
     def test_register_buffer(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -17,6 +17,14 @@ from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.ssd_chunking import (
+    DEFAULT_SSD_OBJECT_CHUNK_BYTES,
+    DEFAULT_SSD_READ_BATCH_BYTES,
+    aggregate_chunk_results,
+    iter_ssd_read_batches,
+    split_ssd_batch,
+    ssd_chunk_head_keys,
+)
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.parallel_state import get_global_rank
 
@@ -41,9 +49,13 @@ def _mooncake_setup_supports_ssd_offload() -> bool:
         return "enable_ssd_offload" in doc
 
 
-def _ssd_setup_kwargs(config: "MooncakeStoreConfig") -> dict[str, object]:
+def _ssd_setup_kwargs(
+    config: "MooncakeStoreConfig",
+    *,
+    contribute_memory: bool = True,
+) -> dict[str, object]:
     """Keyword args for store.setup(); empty on old Mooncake or when SSD is off."""
-    if not config.enable_ssd_offload:
+    if not contribute_memory or not config.enable_ssd_offload:
         return {}
     if not _mooncake_setup_supports_ssd_offload():
         raise RuntimeError(
@@ -63,6 +75,15 @@ class MooncakeBackend(Backend):
     def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False, contribute_memory: bool = True):
         self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
+        self._ssd_chunk_bytes = DEFAULT_SSD_OBJECT_CHUNK_BYTES
+        self._ssd_read_batch_bytes = min(
+            self.config.local_buffer_size,
+            DEFAULT_SSD_READ_BATCH_BYTES,
+        )
+        if self.config.enable_ssd_offload and self._ssd_read_batch_bytes < self._ssd_chunk_bytes:
+            raise ValueError(
+                f"Mooncake local_buffer_size must be at least {self._ssd_chunk_bytes} bytes when SSD offload is enabled"
+            )
         if self.config.protocol != "ascend":
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
 
@@ -102,7 +123,12 @@ class MooncakeBackend(Backend):
 
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
-        ssd_kwargs = _ssd_setup_kwargs(self.config)
+        # The scheduler only performs metadata lookup. Mounting FileStorage on
+        # it advertises capacity that cannot serve worker KV transfers.
+        ssd_kwargs = _ssd_setup_kwargs(
+            self.config,
+            contribute_memory=self._contribute_memory,
+        )
         # Each rank that contributes memory to the pool uses its own SSD
         # directory to avoid bucket file collisions. Key by the globally unique
         # rank so that DP/TP/PP/CP replicas never share a directory (dense and
@@ -184,39 +210,65 @@ class MooncakeBackend(Backend):
             )
             return [0] * len(keys)
         assert self.store is not None
-        return self.store.batch_is_exist(keys)
+        query_keys = ssd_chunk_head_keys(keys) if self.config.enable_ssd_offload else keys
+        return self.store.batch_is_exist(query_keys)
 
     def put(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         self.ensure_initialized()
         assert self.store is not None
+        logical_keys = keys
+        result_ranges = None
+        if self.config.enable_ssd_offload:
+            keys, addrs, sizes, result_ranges = split_ssd_batch(
+                keys,
+                addrs,
+                sizes,
+                self._ssd_chunk_bytes,
+            )
+            logger.debug(
+                "Mooncake SSD put split logical_keys=%d physical_keys=%d max_object_bytes=%d",
+                len(logical_keys),
+                len(keys),
+                self._ssd_chunk_bytes,
+            )
         try:
             config = ReplicateConfig()
             if self.config.preferred_segment:
                 config.preferred_segment = self.local_seg
             config.prefer_alloc_in_same_node = self.config.prefer_alloc_in_same_node
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes, config)
-            failed_codes = [int(value) for value in res if value < 0]
+            expanded_results = [int(value) for value in res]
+            res_list = (
+                aggregate_chunk_results(expanded_results, result_ranges)
+                if result_ranges is not None
+                else expanded_results
+            )
+            failed_codes = [value for value in res_list if value < 0]
             failed_count = len(failed_codes)
             if failed_count:
                 error_codes = sorted(set(failed_codes))
                 logger.error(
                     "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
                     failed_count,
-                    len(keys),
+                    len(logical_keys),
                     error_codes,
                 )
-                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
+                logger.debug(
+                    "Failed to put key details. keys=%s, result=%s",
+                    logical_keys,
+                    res_list,
+                )
                 if self._lazy_init:
                     logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
                 "Failed to put %d keys out of %d. Check store state and memory.",
-                len(keys),
-                len(keys),
+                len(logical_keys),
+                len(logical_keys),
             )
             logger.debug(
                 "Failed to put key details. keys=%s, type=%s, error=%s",
-                keys,
+                logical_keys,
                 type(e).__name__,
                 e,
             )
@@ -224,6 +276,8 @@ class MooncakeBackend(Backend):
                 logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
+        logical_keys = keys
+        result_ranges = None
         if self._lazy_init and not self._store_initialized:
             logger.error(
                 "Failed to get %d keys out of %d. Store is not initialized; "
@@ -234,14 +288,49 @@ class MooncakeBackend(Backend):
             logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
+        if self.config.enable_ssd_offload:
+            keys, addrs, sizes, result_ranges = split_ssd_batch(
+                keys,
+                addrs,
+                sizes,
+                self._ssd_chunk_bytes,
+            )
+            read_batches = list(
+                iter_ssd_read_batches(
+                    sizes,
+                    self._ssd_read_batch_bytes,
+                )
+            )
+            logger.debug(
+                "Mooncake SSD get split logical_keys=%d physical_keys=%d "
+                "read_batches=%d max_object_bytes=%d max_batch_bytes=%d",
+                len(logical_keys),
+                len(keys),
+                len(read_batches),
+                self._ssd_chunk_bytes,
+                self._ssd_read_batch_bytes,
+            )
+        else:
+            read_batches = [(0, len(keys))] if keys else []
         logger.debug(
             "MooncakeBackend.get enter keys=%d sample_keys=%s",
-            len(keys),
-            keys[:3],
+            len(logical_keys),
+            logical_keys[:3],
         )
         try:
-            res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
-            res_list = list(res)
+            expanded_results: list[int] = []
+            for start, end in read_batches:
+                res = self.store.batch_get_into_multi_buffers(
+                    keys[start:end],
+                    addrs[start:end],
+                    sizes[start:end],
+                )
+                expanded_results.extend(int(value) for value in res)
+            res_list = (
+                aggregate_chunk_results(expanded_results, result_ranges)
+                if result_ranges is not None
+                else [0 if value > 0 else value for value in expanded_results]
+            )
             failed_codes = [int(value) for value in res_list if value < 0]
             failed_count = len(failed_codes)
             error_codes = sorted(set(failed_codes))
@@ -249,23 +338,24 @@ class MooncakeBackend(Backend):
                 logger.error(
                     "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
                     failed_count,
-                    len(keys),
+                    len(logical_keys),
                     error_codes,
                 )
-                logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
-            for i, value in enumerate(res_list):
-                if value > 0:
-                    res_list[i] = 0
+                logger.debug(
+                    "Failed to get key details. keys=%s, result=%s",
+                    logical_keys,
+                    res_list,
+                )
             return res_list
         except Exception as e:
             logger.error(
                 "Failed to get %d keys out of %d. Check store state and network.",
-                len(keys),
-                len(keys),
+                len(logical_keys),
+                len(logical_keys),
             )
             logger.debug(
                 "Failed to get key details. keys=%s, type=%s, error=%s",
-                keys,
+                logical_keys,
                 type(e).__name__,
                 e,
             )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/ssd_chunking.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/ssd_chunking.py
@@ -1,0 +1,166 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+"""Transparent object chunking for Mooncake's local SSD path.
+
+Mooncake stages each SSD object in a contiguous CacheLib allocation. Hybrid
+models can aggregate multiple layers into one logical KV object that is larger
+than a CacheLib slab, so keep scheduler-facing keys logical and split only the
+backend representation.
+"""
+
+from collections.abc import Iterable
+
+DEFAULT_SSD_OBJECT_CHUNK_BYTES = 3 * 1024 * 1024
+DEFAULT_SSD_READ_BATCH_BYTES = 512 * 1024 * 1024
+DEFAULT_SSD_READ_BATCH_OBJECTS = 256
+SSD_CHUNK_KEY_SUFFIX = "@mcssd1:"
+
+
+def _split_ssd_object(
+    key: str,
+    addrs: list[int],
+    sizes: list[int],
+    max_chunk_bytes: int,
+) -> list[tuple[str, list[int], list[int]]]:
+    if max_chunk_bytes <= 0:
+        raise ValueError("max_chunk_bytes must be positive")
+    if len(addrs) != len(sizes):
+        raise ValueError("Mooncake buffer address and size counts differ")
+
+    chunks: list[tuple[list[int], list[int]]] = []
+    chunk_addrs: list[int] = []
+    chunk_sizes: list[int] = []
+    chunk_bytes = 0
+
+    def flush() -> None:
+        nonlocal chunk_addrs, chunk_sizes, chunk_bytes
+        if chunk_sizes:
+            chunks.append((chunk_addrs, chunk_sizes))
+            chunk_addrs = []
+            chunk_sizes = []
+            chunk_bytes = 0
+
+    for raw_addr, raw_size in zip(addrs, sizes, strict=True):
+        addr = int(raw_addr)
+        size = int(raw_size)
+        if size < 0:
+            raise ValueError("Mooncake buffer size must not be negative")
+        offset = 0
+        while offset < size:
+            if chunk_bytes == max_chunk_bytes:
+                flush()
+            take = min(size - offset, max_chunk_bytes - chunk_bytes)
+            chunk_addrs.append(addr + offset)
+            chunk_sizes.append(take)
+            chunk_bytes += take
+            offset += take
+        if chunk_bytes == max_chunk_bytes:
+            flush()
+
+    flush()
+    if not chunks:
+        chunks.append(([], []))
+    return [
+        (
+            f"{key}{SSD_CHUNK_KEY_SUFFIX}{index}",
+            chunk_addrs,
+            chunk_sizes,
+        )
+        for index, (chunk_addrs, chunk_sizes) in enumerate(chunks)
+    ]
+
+
+def split_ssd_batch(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+    max_chunk_bytes: int = DEFAULT_SSD_OBJECT_CHUNK_BYTES,
+) -> tuple[list[str], list[list[int]], list[list[int]], list[tuple[int, int]]]:
+    """Expand logical objects into deterministic SSD-sized objects."""
+    if not (len(keys) == len(addrs) == len(sizes)):
+        raise ValueError("Mooncake key, address, and size counts differ")
+
+    expanded_keys: list[str] = []
+    expanded_addrs: list[list[int]] = []
+    expanded_sizes: list[list[int]] = []
+    result_ranges: list[tuple[int, int]] = []
+
+    for key, object_addrs, object_sizes in zip(keys, addrs, sizes, strict=True):
+        start = len(expanded_keys)
+        for chunk_key, chunk_addrs, chunk_sizes in _split_ssd_object(
+            key,
+            object_addrs,
+            object_sizes,
+            max_chunk_bytes,
+        ):
+            expanded_keys.append(chunk_key)
+            expanded_addrs.append(chunk_addrs)
+            expanded_sizes.append(chunk_sizes)
+        result_ranges.append((start, len(expanded_keys)))
+
+    return expanded_keys, expanded_addrs, expanded_sizes, result_ranges
+
+
+def ssd_chunk_head_keys(keys: list[str]) -> list[str]:
+    """Return logical existence markers for SSD-chunked objects."""
+    return [f"{key}{SSD_CHUNK_KEY_SUFFIX}0" for key in keys]
+
+
+def iter_ssd_read_batches(
+    sizes: list[list[int]],
+    max_batch_bytes: int,
+    max_batch_objects: int = DEFAULT_SSD_READ_BATCH_OBJECTS,
+) -> Iterable[tuple[int, int]]:
+    """Bound each native BatchGet below the registered staging buffer."""
+    if max_batch_bytes <= 0 or max_batch_objects <= 0:
+        raise ValueError("SSD read batch limits must be positive")
+
+    start = 0
+    batch_bytes = 0
+    for index, object_sizes in enumerate(sizes):
+        object_bytes = sum(int(size) for size in object_sizes)
+        if object_bytes > max_batch_bytes:
+            raise ValueError(
+                f"SSD object chunk ({object_bytes} bytes) exceeds read batch limit ({max_batch_bytes} bytes)"
+            )
+        if index > start and (batch_bytes + object_bytes > max_batch_bytes or index - start >= max_batch_objects):
+            yield start, index
+            start = index
+            batch_bytes = 0
+        batch_bytes += object_bytes
+
+    if start < len(sizes):
+        yield start, len(sizes)
+
+
+def aggregate_chunk_results(
+    expanded_results: list[int],
+    result_ranges: list[tuple[int, int]],
+) -> list[int]:
+    """Collapse physical chunk statuses to one status per logical object."""
+    logical_results: list[int] = []
+    for start, end in result_ranges:
+        if start < 0 or end <= start or end > len(expanded_results):
+            raise ValueError("Invalid Mooncake SSD chunk result range")
+        chunk_results = expanded_results[start:end]
+        first_failure = next(
+            (int(value) for value in chunk_results if value < 0),
+            None,
+        )
+        logical_results.append(first_failure if first_failure is not None else 0)
+    return logical_results


### PR DESCRIPTION
### What this PR does / why we need it?

With Mooncake SSD offload enabled, a hybrid model can aggregate many layer
buffers into one logical KV object. On an SSD cache hit, Mooncake stages that
object in a contiguous CacheLib allocation. Objects larger than CacheLib's slab
allocation limit trigger a native allocation assertion and terminate the vLLM
service.

This PR keeps scheduler-facing KV keys unchanged while transparently mapping
each logical object to deterministic SSD-safe physical chunks. It also:

- checks the first physical chunk for scheduler existence queries;
- bounds native `BatchGet` calls by bytes and object count so reads fit the
  registered staging buffer;
- collapses physical chunk statuses back to one logical result;
- prevents the metadata-only scheduler client from mounting FileStorage and
  advertising SSD capacity that cannot serve worker KV transfers;
- adds unit coverage for hybrid KV groups, address offsets, read batching,
  result aggregation, existence checks, and backend put/get behavior.

This addresses a different failure mode from #11037: that PR prefetches SSD
objects during existence checks, while this change prevents oversized
FileStorage objects and oversized batch reads.

### Does this PR introduce _any_ user-facing change?

Only Mooncake deployments with `enable_ssd_offload=true` are affected. There is
no new configuration. The internal SSD key representation changes, so
short-lived cache entries written by an older process will be treated as
misses after upgrading.

### How was this patch tested?

```bash
PYTHONPATH=. python3 -m pytest -q \
  tests/ut/distributed/ascend_store/test_backend.py
# 80 passed

ruff check \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/ssd_chunking.py \
  tests/ut/distributed/ascend_store/test_backend.py

ruff format --check \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/ssd_chunking.py \
  tests/ut/distributed/ascend_store/test_backend.py
```

Manual validation used Qwen3.6-27B on two Ascend NPUs with Mooncake SSD
offload. A 100k-token cold request populated the cache, pressure requests
evicted about 19.4 GiB to SSD, and replay reported a 99,840-token cache hit.
All requests returned HTTP 200 and the native allocation assertion did not
recur.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
