### PR TITLE
[Ops][Feature] Implement memory pool and elastic KV cache for multi-model daemon on Ascend NPU 

### DIFF
--- a/daemon/daemon/README.md
+++ b/daemon/daemon/README.md
@@ -1,0 +1,43 @@
+# mdaemon
+
+Python package for the multimodel daemon monitor CLI.
+
+## Install
+
+From repo root:
+
+- `python3 -m pip install -e ./multimodel/daemon`
+
+## Run
+
+- `mdaemon --pool 0:16:4 --pool 1:16:4`
+- `mdaemon --pool 0:16:4 --control-enable`
+
+Pool format: `device_id:granularity_mb:total_gb`.
+
+## Control API (localhost)
+
+Monitor can expose a local HTTP API for external orchestrators:
+
+- `--control-enable`
+- `--control-host` (default `127.0.0.1`)
+- `--control-port` (default `18080`)
+
+Endpoints:
+
+- `GET /healthz`
+- `GET /v1/pools`
+- `POST /v1/pools/create`
+- `POST /v1/pools/extend`
+- `POST /v1/pools/remove`
+
+Write request body keys:
+
+- `create`: `device_id`, `granularity`, `total_bytes` (optional `cap_bytes`)
+- `extend/remove`: `device_id`, `granularity`, `target_bytes`
+
+`target_bytes` is translated to handle count inside monitor.
+
+Example:
+
+- `curl -s http://127.0.0.1:18080/v1/pools`

--- a/daemon/daemon/build_pybind.sh
+++ b/daemon/daemon/build_pybind.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN=${PYTHON_BIN:-python3}
+CXX=${CXX:-g++}
+ASCEND_HOME=${ASCEND_HOME:-/usr/local/Ascend/ascend-toolkit/latest}
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "PYTHON_BIN not found: $PYTHON_BIN" >&2
+  exit 1
+fi
+
+if ! "$PYTHON_BIN" -c "import pybind11" >/dev/null 2>&1; then
+  echo "pybind11 is not installed in $PYTHON_BIN environment. Try: $PYTHON_BIN -m pip install pybind11" >&2
+  exit 1
+fi
+
+EXT_SUFFIX=$($PYTHON_BIN-config --extension-suffix 2>/dev/null || true)
+if [[ -z "${EXT_SUFFIX}" ]]; then
+  EXT_SUFFIX=$($PYTHON_BIN -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or '.so')")
+fi
+
+PYBIND_INCLUDES=$($PYTHON_BIN -m pybind11 --includes)
+
+OUT="mdaemon_py${EXT_SUFFIX}"
+
+$CXX -O3 -shared -std=c++17 -fPIC \
+  $PYBIND_INCLUDES \
+  daemon_pybind.cpp daemon.cpp handle_pool.cpp model_management.cpp \
+  -I ./inc \
+  -I "${ASCEND_HOME}/include" \
+  -L "${ASCEND_HOME}/lib64" \
+  -lascendcl \
+  -o "$OUT"
+
+echo "Built: $OUT"

--- a/daemon/daemon/daemon.cpp
+++ b/daemon/daemon/daemon.cpp
@@ -1,0 +1,692 @@
+#include "inc/utils.h"
+#include "inc/daemon.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <thread>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <limits>
+#include <errno.h>
+#include <unistd.h>
+#include <semaphore.h>
+
+namespace mdaemon {
+
+namespace {
+constexpr int kDefaultLoopIntervalMs = 50;
+constexpr int64_t kDefaultLoopIntervalUs = static_cast<int64_t>(kDefaultLoopIntervalMs) * 1000;
+constexpr int64_t kHeartbeatTimeoutNs = 5LL * 1000LL * 1000LL * 1000LL;
+
+int64_t monotonicNowNs() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(
+		std::chrono::steady_clock::now().time_since_epoch())
+		.count();
+}
+
+bool heartbeatTimedOut(int64_t heartbeat_ns, int64_t now_ns) {
+	if (heartbeat_ns <= 0) {
+		return true;
+	}
+	if (heartbeat_ns > now_ns) {
+		return false;
+	}
+	return (now_ns - heartbeat_ns) > kHeartbeatTimeoutNs;
+}
+
+int64_t daemonLoopIntervalUs() {
+	const char* raw_us = std::getenv("MDAEMON_LOOP_INTERVAL_US");
+	if (raw_us && raw_us[0] != '\0') {
+		char* end = nullptr;
+		errno = 0;
+		long long value = std::strtoll(raw_us, &end, 10);
+		if (errno != 0 || end == raw_us || (end && *end != '\0') || value <= 0) {
+			daemonLogError(std::string("[Daemon] invalid MDAEMON_LOOP_INTERVAL_US='") + raw_us +
+				"', using default " + std::to_string(kDefaultLoopIntervalUs) + "us");
+			return kDefaultLoopIntervalUs;
+		}
+		return static_cast<int64_t>(value);
+	}
+
+	const char* raw = std::getenv("MDAEMON_LOOP_INTERVAL_MS");
+	if (!raw || raw[0] == '\0') {
+		return kDefaultLoopIntervalUs;
+	}
+
+	char* end = nullptr;
+	errno = 0;
+	long long value = std::strtoll(raw, &end, 10);
+	if (errno != 0 || end == raw || (end && *end != '\0') || value <= 0) {
+		daemonLogError(std::string("[Daemon] invalid MDAEMON_LOOP_INTERVAL_MS='") + raw +
+			"', using default " + std::to_string(kDefaultLoopIntervalMs) + "ms");
+		return kDefaultLoopIntervalUs;
+	}
+	if (value > static_cast<long long>(std::numeric_limits<int64_t>::max() / 1000LL)) {
+		daemonLogError(std::string("[Daemon] MDAEMON_LOOP_INTERVAL_MS too large='") + raw +
+			"', using default " + std::to_string(kDefaultLoopIntervalUs) + "us");
+		return kDefaultLoopIntervalUs;
+	}
+	return static_cast<int64_t>(value) * 1000LL;
+}
+
+bool mapCanonicalToLocalDeviceId(int32_t canonical_device_id,
+								 int32_t& local_device_id) {
+	if (canonical_device_id < 0) {
+		return false;
+	}
+	const char* raw = std::getenv("ASCEND_RT_VISIBLE_DEVICES");
+	if (!raw || raw[0] == '\0') {
+		raw = std::getenv("ASCEND_VISIBLE_DEVICES");
+	}
+	if (!raw || raw[0] == '\0') {
+		raw = std::getenv("CUDA_VISIBLE_DEVICES");
+	}
+	if (!raw || raw[0] == '\0') {
+		local_device_id = canonical_device_id;
+		return true;
+	}
+
+	const std::string visible(raw);
+	size_t start = 0;
+	int32_t idx = 0;
+	while (start < visible.size()) {
+		size_t end = visible.find(',', start);
+		if (end == std::string::npos) {
+			end = visible.size();
+		}
+		const std::string token = visible.substr(start, end - start);
+		if (!token.empty()) {
+			try {
+				if (static_cast<int32_t>(std::stoi(token)) == canonical_device_id) {
+					local_device_id = idx;
+					return true;
+				}
+				++idx;
+			} catch (...) {
+				return false;
+			}
+		}
+		start = end + 1;
+	}
+	return false;
+}
+} // namespace
+
+Daemon::~Daemon() {
+	stop();
+
+	// delete semaphore
+	::sem_unlink(MODEL_SEMAPHORE_NAME);
+}
+
+void Daemon::start() {
+	std::lock_guard<std::mutex> guard(daemon_mutex_);
+	if (running_.load()) {
+		return;
+	}
+	running_.store(true);
+	worker_ = std::thread(&Daemon::runLoop, this);
+}
+
+void Daemon::stop() {
+	{
+		std::lock_guard<std::mutex> guard(daemon_mutex_);
+		running_.store(false);
+	}
+	if (worker_.joinable()) {
+		worker_.join();
+	}
+}
+
+/* Handles pool manipulation */
+
+HandlePool* Daemon::findHandlePool(uint64_t granularity) {
+	std::lock_guard<std::mutex> guard(daemon_mutex_);
+	auto it = handle_pools_.find(granularity);
+	return it == handle_pools_.end() ? nullptr : it->second.get();
+}
+
+HandlePool* Daemon::ensureHandlePool(uint64_t granularity) {
+	std::lock_guard<std::mutex> guard(daemon_mutex_);
+	auto it = handle_pools_.find(granularity);
+	if (it != handle_pools_.end()) {
+		return it->second.get();
+	}
+	auto pool = std::make_unique<HandlePool>(granularity);
+	auto [insert_it, _] = handle_pools_.try_emplace(granularity, std::move(pool));
+	return insert_it->second.get();
+}
+
+void Daemon::initializeHandlePoolDevice(uint64_t granularity, int32_t device_id, uint64_t total_bytes) {
+	if (HandlePool* pool = ensureHandlePool(granularity)) {
+		const std::vector<int32_t> npuid_list = getCurrentModelNpuids();
+		pool->initializeDevice(device_id, total_bytes, npuid_list);
+	}
+}
+
+size_t Daemon::handlePoolAvailable(uint64_t granularity, int32_t device_id) const {
+	std::lock_guard<std::mutex> guard(daemon_mutex_);
+	if (auto it = handle_pools_.find(granularity); it != handle_pools_.end()) {
+		return it->second->available(device_id);
+	}
+	return 0;
+}
+
+bool Daemon::extendHandles(uint64_t granularity, int32_t device_id, size_t count) {
+	if (HandlePool* pool = findHandlePool(granularity)) {
+		const std::vector<int32_t> npuid_list = getCurrentModelNpuids();
+		return pool->extendHandles(device_id, count, npuid_list);
+	}
+	return false;
+}
+
+bool Daemon::removeHandles(uint64_t granularity, int32_t device_id, size_t count) {
+	if (HandlePool* pool = findHandlePool(granularity)) {
+		return pool->removeHandles(device_id, count);
+	}
+	return false;
+}
+
+std::vector<Daemon::HandlePoolDeviceSnapshot> Daemon::snapshotHandlePools() const {
+	std::vector<std::pair<uint64_t, HandlePool*>> pools;
+	{
+		std::lock_guard<std::mutex> guard(daemon_mutex_);
+		pools.reserve(handle_pools_.size());
+		for (const auto& kv : handle_pools_) {
+			pools.push_back({kv.first, kv.second.get()});
+		}
+	}
+
+	std::vector<HandlePoolDeviceSnapshot> out;
+	for (const auto& entry : pools) {
+		const uint64_t granularity = entry.first;
+		HandlePool* pool = entry.second;
+		if (!pool) {
+			continue;
+		}
+		for (int32_t device_id : pool->listDeviceIds()) {
+			HandlePoolDeviceSnapshot snap;
+			snap.granularity = granularity;
+			snap.device_id = device_id;
+			snap.available_handles = static_cast<uint64_t>(pool->available(device_id));
+			snap.total_handles = static_cast<uint64_t>(pool->total(device_id));
+			snap.used_handles = static_cast<uint64_t>(pool->used(device_id));
+			snap.total_bytes = snap.total_handles * granularity;
+			snap.available_bytes = snap.available_handles * granularity;
+			snap.used_bytes = snap.used_handles * granularity;
+			out.push_back(snap);
+		}
+	}
+	return out;
+}
+
+std::vector<Daemon::ModelSnapshot> Daemon::snapshotModels(bool sync_message_space_from_shm) {
+	std::vector<uint64_t> ids = model_manager_.listModelIds();
+	std::vector<ModelSnapshot> out;
+	out.reserve(ids.size());
+	for (uint64_t id : ids) {
+		ModelConfig* cfg = model_manager_.getModelConfig(id);
+		if (!cfg) {
+			continue;
+		}
+		if (sync_message_space_from_shm) {
+			cfg->syncMessageSpaceFromShm();
+		}
+		const ModelMessageSpace& space = cfg->messageSpace();
+		ModelSnapshot snap;
+		snap.model_id = id;
+		snap.state = cfg->getState();
+		snap.message_state = space.state;
+		snap.model_npuid = space.model_npuid;
+		snap.model_osid = space.model_osid;
+		snap.allocated_bytes = cfg->allocatedBytes();
+		snap.allocated_handles = static_cast<uint64_t>(cfg->allocatedHandleCount());
+		out.push_back(snap);
+	}
+	return out;
+}
+
+std::vector<std::string> Daemon::drainLogs() {
+	return daemonDrainLogs();
+}
+
+Daemon::ModelSnapshot Daemon::getModelSnapshot(uint64_t model_id, bool sync_message_space_from_shm) {
+	ModelSnapshot snap;
+	snap.model_id = model_id;
+	ModelConfig* cfg = model_manager_.getModelConfig(model_id);
+	if (!cfg) {
+		snap.state = ModelState::INVALID;
+		snap.message_state = MessageState::INVALID;
+		return snap;
+	}
+	if (sync_message_space_from_shm) {
+		cfg->syncMessageSpaceFromShm();
+	}
+	const ModelMessageSpace& space = cfg->messageSpace();
+	snap.state = cfg->getState();
+	snap.message_state = space.state;
+	snap.model_npuid = space.model_npuid;
+	snap.model_osid = space.model_osid;
+	snap.allocated_bytes = cfg->allocatedBytes();
+	snap.allocated_handles = static_cast<uint64_t>(cfg->allocatedHandleCount());
+	return snap;
+}
+
+/* Model manipulation */
+
+ModelConfig* Daemon::getModelConfig(uint64_t model_id) {
+	return model_manager_.getModelConfig(model_id);
+}
+
+bool Daemon::updateModelState(uint64_t model_id, ModelState new_state) {
+	return model_manager_.updateModelState(model_id, new_state);
+}
+
+ModelState Daemon::getModelState(uint64_t model_id) const {
+	return model_manager_.getModelState(model_id);
+}
+
+std::vector<uint64_t> Daemon::listModelIds() const {
+	return model_manager_.listModelIds();
+}
+
+std::vector<int32_t> Daemon::getCurrentModelNpuids() const {
+	return model_manager_.getCurrentModelNpuids();
+}
+
+ModelConfig* Daemon::registerModelFromMacro() {
+	ModelConfig* cfg = model_manager_.registerModelFromMacro();
+	if (cfg) {
+		SetPidToShare(getCurrentModelNpuids());
+		cfg->setState(ModelState::REGISTERED);
+		cfg->messageSpace().state = MessageState::REGISTERED;
+		cfg->messageSpace().heartbeat_ns = monotonicNowNs();
+		cfg->syncMessageSpaceToShm();
+	}
+	return cfg;
+}
+
+/* Interactive operations between models and handles */
+
+void Daemon::SetPidToShare(const std::vector<int32_t>& npuid_list) {
+	// update all handle pools with the new pid list to share
+	std::vector<HandlePool*> pools;
+	{
+		std::lock_guard<std::mutex> guard(daemon_mutex_);
+		pools.reserve(handle_pools_.size());
+		for (auto& pair : handle_pools_) {
+			pools.push_back(pair.second.get());
+		}
+	}
+	for (HandlePool* pool : pools) {
+		for (int32_t device_id : pool->listDeviceIds()) {
+			pool->memSetPidToShare(npuid_list, device_id);
+		}
+	}
+}
+
+bool Daemon::allocateHandlesForModel(ModelConfig& config) {
+	/* --- Mechanism --- */
+    /* req from handle_request_list -> get handle from pool -> put shareable_handle into handle_info_list
+	   -> put handle into allocated_handles -> offset_ed=offset_st+num -> clear handle_request_list */
+	// current logic is to allocate handles based on the handle_request_list in the model's message space;
+	// larger granularities are preferred, and if unavailable it falls back to smaller granularities.
+	ModelMessageSpace& space = config.messageSpace();
+	const std::vector<request_granularity> requests = collectHandleRequests(space);
+
+	std::vector<AllocatedHandle> allocated_handles;
+	for (const auto& req : requests) {
+		if (!allocateForRequest(req, allocated_handles)) {
+			releaseAllocatedHandles(allocated_handles);
+			space.offset_ed = space.offset_st;
+			return false;
+		}
+	}
+	space.offset_ed = space.offset_st + static_cast<int32_t>(allocated_handles.size());
+
+	writeHandlesToMessageSpace(space, allocated_handles);
+	// add in allocated_handles_ for later release when model is done
+	for (auto& entry : allocated_handles) {
+		config.addAllocatedHandle(entry.device_id, std::move(entry.handle));
+	}
+
+	// clear request list
+	for (auto& req : space.handle_request_list) {
+		if (req.request_num == 0 && req.granularity == 0 && req.device_id == -1) {
+			break; // end of requests
+		}
+		req.request_num = 0;
+		req.granularity = 0;
+		req.device_id = -1;
+	}
+	return true;
+}
+
+std::vector<request_granularity> Daemon::collectHandleRequests(const ModelMessageSpace& space) const {
+	std::vector<request_granularity> requests;
+	requests.reserve(space.handle_request_list.size());
+	for (const auto& req : space.handle_request_list) {
+		if (req.request_num == 0 && req.granularity == 0 && req.device_id == -1) {
+			break;
+		}
+		if (req.request_num > 0 && req.granularity > 0 && req.device_id >= 0) {
+			requests.push_back(req);
+		}
+	}
+	std::sort(requests.begin(), requests.end(), [](const request_granularity& a, const request_granularity& b) {
+		return a.granularity > b.granularity;
+	});
+	return requests;
+}
+
+bool Daemon::allocateForRequest(const request_granularity& req,
+										std::vector<AllocatedHandle>& allocated_handles) {
+	const int32_t canonical_device_id = req.device_id;
+	int32_t device_id = -1;
+	const uint64_t granularity = req.granularity;
+	if (!mapCanonicalToLocalDeviceId(canonical_device_id, device_id)) {
+		daemonLogError("[Daemon] unknown canonical device id from model request: " +
+			std::to_string(canonical_device_id) +
+			", request_num=" + std::to_string(req.request_num) +
+			", granularity=" + std::to_string(req.granularity));
+		return false;
+	}
+	if (granularity == 0 || req.request_num == 0) {
+		return false;
+	}
+	for (uint64_t idx = 0; idx < req.request_num; ++idx) {
+		Handle handle;
+		if (!tryAcquireHandleExact(granularity, device_id, handle)) {
+			return false;
+		}
+		AllocatedHandle entry;
+		entry.granularity = granularity;
+		entry.device_id = canonical_device_id;
+		entry.handle = std::move(handle);
+		allocated_handles.push_back(std::move(entry));
+	}
+	return true;
+}
+
+bool Daemon::tryAcquireHandleExact(uint64_t granularity, int32_t device_id, Handle& out_handle) {
+	HandlePool* pool = findHandlePool(granularity);
+	if (!pool) {
+		return false;
+	}
+	if (pool->available(device_id) == 0) {
+		return false;
+	}
+	Handle handle = pool->acquire(device_id);
+	if (!handle.valid()) {
+		return false;
+	}
+	out_handle = std::move(handle);
+	return true;
+}
+
+bool Daemon::tryAcquireHandle(uint64_t& granularity, int32_t device_id, Handle& out_handle) {
+	while (granularity > 0) {
+		HandlePool* pool = findHandlePool(granularity);
+		if (!pool) {
+			granularity /= 2;
+			continue;
+		}
+		if (pool->available(device_id) == 0) {
+			granularity /= 2;
+			continue;
+		}
+		Handle handle = pool->acquire(device_id);
+		if (!handle.valid()) {
+			granularity /= 2;
+			continue;
+		}
+		out_handle = std::move(handle);
+		return true;
+	}
+	return false;
+}
+
+void Daemon::releaseAllocatedHandles(std::vector<AllocatedHandle>& allocated_handles) {
+	for (auto& entry : allocated_handles) {
+		HandlePool* pool = findHandlePool(entry.granularity);
+		if (pool) {
+			pool->release(entry.handle.deviceId(), std::move(entry.handle));
+		}
+	}
+}
+
+void Daemon::writeHandlesToMessageSpace(ModelMessageSpace& space,
+										const std::vector<AllocatedHandle>& allocated_handles) {
+	std::vector<const AllocatedHandle*> sorted;
+	sorted.reserve(allocated_handles.size());
+	for (const auto& entry : allocated_handles) {
+		sorted.push_back(&entry);
+	}
+	std::sort(sorted.begin(), sorted.end(), [](const AllocatedHandle* a, const AllocatedHandle* b) {
+		return a->granularity > b->granularity;
+	});
+
+	size_t out = static_cast<size_t>(std::max<int32_t>(0, space.offset_st));
+	for (const auto* entry : sorted) {
+		if (out >= space.handle_info_list.size()) {
+			break;
+		}
+		space.handle_info_list[out].granularity = entry->granularity;
+		space.handle_info_list[out].shareable_handle = entry->handle.shareableHandle();
+		space.handle_info_list[out].device_id = entry->device_id;
+		++out;
+	}
+	space.offset_ed = static_cast<int32_t>(out);
+}
+
+void Daemon::returnHandlesFromModel(ModelConfig& config) {
+	/* Mechanism */
+	/* get shareable_handle from handle_info_list -> find handle from allocated_handles_
+	   -> release handle to pool -> erase from allocated_handles_ -> erase from handle_info_list 
+	   -> offset_ed --*/
+	// current logic is to return all handles from the model, and it relies on the model to correctly 
+	// fill in the handle_info_list with the handles to be returned and their granularities and device_ids;
+	ModelMessageSpace& space = config.messageSpace();
+	// remove handles from offset_st to offset_ed in the handle_info_list
+	const int32_t max_index = static_cast<int32_t>(space.handle_info_list.size());
+	int32_t start = std::max<int32_t>(0, space.offset_st);
+	int32_t end = std::max<int32_t>(start, space.offset_ed);
+	if (end > max_index) {
+		end = max_index;
+	}
+	for (int32_t idx = end - 1; idx > start - 1; --idx) {
+		const handle_granularity& handle_info = space.handle_info_list[idx];
+		const uint64_t shareable_handle = handle_info.shareable_handle;
+		const int32_t device_id = handle_info.device_id;
+		Handle handle;
+		if (!config.takeAllocatedHandle(device_id, shareable_handle, handle)) {
+			daemonLogError("[Daemon] returnHandlesFromModel miss: model_id=" +
+				std::to_string(config.getModelId()) +
+				", idx=" + std::to_string(idx) +
+				", device_id=" + std::to_string(device_id) +
+				", shareable_handle=" + std::to_string(shareable_handle));
+			continue;
+		}
+
+		if (!handle.valid()) {
+			daemonLogError("[Daemon] returnHandlesFromModel invalid handle: model_id=" +
+				std::to_string(config.getModelId()) +
+				", idx=" + std::to_string(idx) +
+				", device_id=" + std::to_string(device_id) +
+				", shareable_handle=" + std::to_string(shareable_handle));
+			continue;
+		}
+
+		HandlePool* pool = findHandlePool(handle.granularity());
+		if (!pool) {
+			daemonLogError("[Daemon] returnHandlesFromModel missing pool: model_id=" +
+				std::to_string(config.getModelId()) +
+				", granularity=" + std::to_string(handle.granularity()) +
+				", device_id=" + std::to_string(handle.deviceId()) +
+				", shareable_handle=" + std::to_string(handle.shareableHandle()));
+			continue;
+		}
+
+		pool->release(handle.deviceId(), std::move(handle));
+		// erase handle info
+		space.handle_info_list[idx].granularity = 0;
+		space.handle_info_list[idx].shareable_handle = std::numeric_limits<uint64_t>::max();
+		space.handle_info_list[idx].device_id = -1;
+		space.offset_ed = idx;
+	}
+}
+
+void Daemon::returnHandlesFromCfg(ModelConfig& config) {
+	std::vector<Handle> handles = config.drainAllocatedHandles();
+	for (auto& handle : handles) {
+		if (!handle.valid()) {
+			continue;
+		}
+		HandlePool* pool = findHandlePool(handle.granularity());
+		if (pool) {
+			pool->release(handle.deviceId(), std::move(handle));
+		}
+	}
+}
+
+void Daemon::runOnce() {
+	const auto now = std::chrono::steady_clock::now();
+	const bool should_check_liveness = now >= next_liveness_check_;
+	if (should_check_liveness) {
+		next_liveness_check_ = now + std::chrono::seconds(1);
+	}
+
+	const int64_t now_ns = monotonicNowNs();
+
+	auto model_ids = model_manager_.listModelIds();
+	std::vector<ModelConfig*> active_configs;
+	active_configs.reserve(model_ids.size() + 1);
+
+	// Sweep existing models for exit or completion
+	for (uint64_t id : model_ids) {
+		ModelConfig* cfg = model_manager_.getModelConfig(id);
+		if (!cfg) {
+			continue;
+		}
+
+		if (should_check_liveness) {
+			if (!cfg->tryLockMessageSpace()) {
+				active_configs.push_back(cfg);
+				continue;
+			}
+			cfg->syncMessageSpaceFromShm();
+			ModelMessageSpace& space = cfg->messageSpace();
+			const ModelState state = cfg->getState();
+			if (state == ModelState::DONE || state == ModelState::INVALID) {
+				daemonLogDebug("[Daemon] cleaning up model " + std::to_string(id) +
+					" with state " + std::to_string(static_cast<int>(state)));
+				cfg->unlockMessageSpace();
+				returnHandlesFromCfg(*cfg);
+				model_manager_.removeModelConfig(id);
+				if (daemonDebugLogsEnabled()) {
+					printAll();
+				}
+				continue;
+			}
+
+			if (heartbeatTimedOut(space.heartbeat_ns, now_ns)) {
+				const int64_t age_ns = (space.heartbeat_ns > 0 && now_ns > space.heartbeat_ns)
+					? (now_ns - space.heartbeat_ns)
+					: -1;
+				daemonLogInfo("[Daemon] heartbeat timeout for model " + std::to_string(id) +
+					" (npuid=" + std::to_string(space.model_npuid) +
+					", osid=" + std::to_string(space.model_osid) +
+					", age_ns=" + std::to_string(age_ns) + ")");
+				cfg->setState(ModelState::DONE);
+				cfg->unlockMessageSpace();
+				returnHandlesFromCfg(*cfg);
+				model_manager_.removeModelConfig(id);
+				if (daemonDebugLogsEnabled()) {
+					printAll();
+				}
+				continue;
+			}
+			cfg->unlockMessageSpace();
+		}
+
+		active_configs.push_back(cfg);
+	}
+
+	// Handle new registrations from the macro space
+	if (ModelConfig* cfg = registerModelFromMacro()) {
+		(void)cfg; // already handled inside registerModelFromMacro
+		daemonLogInfo("[Daemon] registered new model with id " + std::to_string(cfg->getModelId()) 
+			+ ", npuid " + std::to_string(cfg->messageSpace().model_npuid) + ", osid " 
+			+ std::to_string(cfg->messageSpace().model_osid));
+		active_configs.push_back(cfg);
+
+		if (daemonDebugLogsEnabled()) {
+			printAll();
+		}
+	}
+
+	// traverse the model MessageSpace for each model to check if there are requests from model
+	for (ModelConfig* cfg : active_configs) {
+		if (!cfg) {
+			continue;
+		}
+		if (!cfg->tryLockMessageSpace()) {
+			continue;
+		}
+		const uint64_t id = cfg->getModelId();
+		cfg->syncMessageSpaceFromShm();
+		ModelMessageSpace& space = cfg->messageSpace();
+		bool changed = false;
+		if (space.state == MessageState::REQUEST_GET_HANDLES) {
+			// model is requesting handles
+			// daemonLogDebug("[Daemon] model " + std::to_string(id) + " REQUEST_GET_HANDLES");
+			try {
+				if (allocateHandlesForModel(*cfg)) {
+					space.state = MessageState::HANDLES_READY;
+					changed = true;
+					daemonLogDebug("[Daemon] allocated handles for model " + std::to_string(id));
+				}
+			} catch (const std::exception& ex) {
+				daemonLogError("[Daemon] exception during REQUEST_GET_HANDLES for model " +
+					std::to_string(id) + ": " + ex.what());
+			} catch (...) {
+				daemonLogError("[Daemon] unknown exception during REQUEST_GET_HANDLES for model " +
+					std::to_string(id));
+			}
+		} else if (space.state == MessageState::REQUEST_RETURN_HANDLES) {
+			// model is returning handles
+			// daemonLogDebug("[Daemon] model " + std::to_string(id) + " REQUEST_RETURN_HANDLES");
+			try {
+				returnHandlesFromModel(*cfg);
+				space.state = MessageState::HANDLES_RETURNED;
+				changed = true;
+				daemonLogDebug("[Daemon] returned handles for model " + std::to_string(id));
+			} catch (const std::exception& ex) {
+				daemonLogError("[Daemon] exception during REQUEST_RETURN_HANDLES for model " +
+					std::to_string(id) + ": " + ex.what());
+			} catch (...) {
+				daemonLogError("[Daemon] unknown exception during REQUEST_RETURN_HANDLES for model " +
+					std::to_string(id));
+			}
+		}
+		if (changed) {
+			cfg->syncMessageSpaceToShm();
+			if (daemonDebugLogsEnabled()) {
+				printAll();
+			}
+		}
+		cfg->unlockMessageSpace();
+	}
+}
+
+void Daemon::runLoop() {
+	const int64_t loop_interval_us = daemonLoopIntervalUs();
+	while (running_.load()) {
+		runOnce();
+		std::this_thread::sleep_for(std::chrono::microseconds(loop_interval_us));
+	}
+}
+
+} // namespace mdaemon

--- a/daemon/daemon/daemon.sh
+++ b/daemon/daemon/daemon.sh
@@ -1,0 +1,16 @@
+export PYTHONPATH=/vllm-workspace/bifrost/daemon/:$PYTHONPATH
+export ASCEND_RT_VISIBLE_DEVICES="3,4"
+
+# daemon setup script
+# export MDAEMON_LOOP_INTERVAL_MS='1'
+export MDAEMON_LOOP_INTERVAL_US='2'
+export MDAEMON_DEBUG_LOG='0'
+export MDAEMON_EXTEND_THRESHOLD_inGiB='1'
+export MDAEMON_REMOVE_THRESHOLD_inGiB='20'
+export MDAEMON_EXTEND_BYTES_inMiB='256'
+export MDAEMON_REMOVE_BYTES_inMiB='256'
+export MDAEMON_DEVICE_TOTAL_CAP_GB='35'
+
+mdaemon --pool 0:16:1.2:12.5 --pool 0:8:1 --pool 0:4:2 --pool 0:2:1 \
+        --pool 1:16:1 --pool 1:8:1 --pool 1:4:2 --pool 1:2:1 \
+        --refresh-ms 50 --control-enable --control-host 127.0.0.1 --control-port 18080

--- a/daemon/daemon/daemon_pybind.cpp
+++ b/daemon/daemon/daemon_pybind.cpp
@@ -1,0 +1,82 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "inc/daemon.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(mdaemon_py, m) {
+    m.doc() = "Python bindings for the multimodel daemon (handle pools + model management)";
+
+    py::enum_<mdaemon::ModelState>(m, "ModelState")
+        .value("UNINITIALIZED", mdaemon::ModelState::UNINITIALIZED)
+        .value("INITIALIZED", mdaemon::ModelState::INITIALIZED)
+        .value("REGISTERED", mdaemon::ModelState::REGISTERED)
+        .value("DONE", mdaemon::ModelState::DONE)
+        .value("INVALID", mdaemon::ModelState::INVALID)
+        .export_values();
+
+    py::enum_<mdaemon::MessageState>(m, "MessageState")
+        .value("NONE", mdaemon::MessageState::NONE)
+        .value("REQUEST_REGISTER", mdaemon::MessageState::REQUEST_REGISTER)
+        .value("REGISTERED", mdaemon::MessageState::REGISTERED)
+        .value("REQUEST_GET_HANDLES", mdaemon::MessageState::REQUEST_GET_HANDLES)
+        .value("HANDLES_READY", mdaemon::MessageState::HANDLES_READY)
+        .value("REQUEST_RETURN_HANDLES", mdaemon::MessageState::REQUEST_RETURN_HANDLES)
+        .value("HANDLES_RETURNED", mdaemon::MessageState::HANDLES_RETURNED)
+        .value("DONE", mdaemon::MessageState::DONE)
+        .value("INVALID", mdaemon::MessageState::INVALID)
+        .export_values();
+
+    py::class_<mdaemon::Daemon::HandlePoolDeviceSnapshot>(m, "HandlePoolDeviceSnapshot")
+        .def_readonly("granularity", &mdaemon::Daemon::HandlePoolDeviceSnapshot::granularity)
+        .def_readonly("device_id", &mdaemon::Daemon::HandlePoolDeviceSnapshot::device_id)
+        .def_readonly("total_handles", &mdaemon::Daemon::HandlePoolDeviceSnapshot::total_handles)
+        .def_readonly("used_handles", &mdaemon::Daemon::HandlePoolDeviceSnapshot::used_handles)
+        .def_readonly("available_handles", &mdaemon::Daemon::HandlePoolDeviceSnapshot::available_handles)
+        .def_readonly("total_bytes", &mdaemon::Daemon::HandlePoolDeviceSnapshot::total_bytes)
+        .def_readonly("used_bytes", &mdaemon::Daemon::HandlePoolDeviceSnapshot::used_bytes)
+        .def_readonly("available_bytes", &mdaemon::Daemon::HandlePoolDeviceSnapshot::available_bytes);
+
+    py::class_<mdaemon::Daemon::ModelSnapshot>(m, "ModelSnapshot")
+        .def_readonly("model_id", &mdaemon::Daemon::ModelSnapshot::model_id)
+        .def_readonly("state", &mdaemon::Daemon::ModelSnapshot::state)
+        .def_readonly("message_state", &mdaemon::Daemon::ModelSnapshot::message_state)
+        .def_readonly("model_npuid", &mdaemon::Daemon::ModelSnapshot::model_npuid)
+        .def_readonly("model_osid", &mdaemon::Daemon::ModelSnapshot::model_osid)
+        .def_readonly("allocated_bytes", &mdaemon::Daemon::ModelSnapshot::allocated_bytes)
+        .def_readonly("allocated_handles", &mdaemon::Daemon::ModelSnapshot::allocated_handles);
+
+    py::class_<mdaemon::Daemon>(m, "Daemon")
+        .def(py::init<>())
+        .def("start", &mdaemon::Daemon::start)
+        .def("stop", &mdaemon::Daemon::stop)
+        .def("is_running", &mdaemon::Daemon::isRunning)
+        // .def("run_once", &mdaemon::Daemon::runOnce)
+        // .def("register_model_from_macro",
+        //      [](mdaemon::Daemon& d) -> py::object {
+        //          mdaemon::ModelConfig* cfg = d.registerModelFromMacro();
+        //          if (!cfg) {
+        //              return py::none();
+        //          }
+        //          return py::int_(cfg->getModelId());
+        //      })
+        .def("get_model_snapshot", &mdaemon::Daemon::getModelSnapshot,
+             py::arg("model_id"), py::arg("sync_message_space_from_shm") = false)
+        .def("get_model_state", &mdaemon::Daemon::getModelState)
+        // .def("update_model_state", &mdaemon::Daemon::updateModelState)
+        // .def("list_model_ids", &mdaemon::Daemon::listModelIds)
+        // .def("get_current_model_npuids", &mdaemon::Daemon::getCurrentModelNpuids)
+        .def("initialize_handle_pool_device", &mdaemon::Daemon::initializeHandlePoolDevice,
+             py::arg("granularity"), py::arg("device_id"), py::arg("total_bytes"))
+        .def("handle_pool_available", &mdaemon::Daemon::handlePoolAvailable,
+             py::arg("granularity"), py::arg("device_id"))
+        .def("extend_handles", &mdaemon::Daemon::extendHandles,
+             py::arg("granularity"), py::arg("device_id"), py::arg("count"))
+        .def("remove_handles", &mdaemon::Daemon::removeHandles,
+             py::arg("granularity"), py::arg("device_id"), py::arg("count"))
+        .def("snapshot_handle_pools", &mdaemon::Daemon::snapshotHandlePools)
+        .def("snapshot_models", &mdaemon::Daemon::snapshotModels,
+             py::arg("sync_message_space_from_shm") = false)
+        .def("drain_logs", &mdaemon::Daemon::drainLogs);
+}

--- a/daemon/daemon/handle_pool.cpp
+++ b/daemon/daemon/handle_pool.cpp
@@ -1,0 +1,367 @@
+#include "inc/handle_pool.hpp"
+#include "inc/utils.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace mdaemon {
+
+namespace {
+std::atomic_bool g_acl_initialized{false};
+std::mutex g_acl_init_mutex;
+
+void ensureAclInitialized() {
+    if (g_acl_initialized.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> guard(g_acl_init_mutex);
+    if (!g_acl_initialized.load(std::memory_order_relaxed)) {
+        CHECK_ERROR(aclInit(nullptr));
+        g_acl_initialized.store(true, std::memory_order_release);
+    }
+}
+} // namespace
+
+Handle::Handle(Handle&& other) noexcept
+    : handle_(other.handle_),
+      device_id_(other.device_id_),
+      granularity_(other.granularity_),
+      owns_handle_(other.owns_handle_),
+      shareable_handle_(other.shareable_handle_) {
+    other.handle_ = aclrtDrvMemHandle{};
+    other.device_id_ = -1;
+    other.granularity_ = 0;
+    other.owns_handle_ = false;
+    other.shareable_handle_ = std::numeric_limits<uint64_t>::max();
+}
+
+Handle& Handle::operator=(Handle&& other) noexcept {
+    if (this != &other) {
+        cleanup();
+        handle_ = other.handle_;
+        device_id_ = other.device_id_;
+        granularity_ = other.granularity_;
+        owns_handle_ = other.owns_handle_;
+        shareable_handle_ = other.shareable_handle_;
+
+        other.handle_ = aclrtDrvMemHandle{};
+        other.device_id_ = -1;
+        other.granularity_ = 0;
+        other.owns_handle_ = false;
+        other.shareable_handle_ = std::numeric_limits<uint64_t>::max();
+    }
+    return *this;
+}
+
+Handle::~Handle() {
+    cleanup();
+}
+
+bool Handle::allocate(int32_t device_id, uint64_t size) {
+    if (owns_handle_) {
+        throw std::logic_error("Handle already owns a physical resource");
+    }
+    if (size == 0) {
+        throw std::invalid_argument("Handle size must be positive");
+    }
+
+    ensure_context(device_id);
+
+    aclrtPhysicalMemProp prop = {};
+    prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
+    prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
+    prop.memAttr = ACL_HBM_MEM_HUGE;
+    prop.location.id = device_id;
+    prop.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
+    prop.reserve = 0;
+
+    // Check if the allocation is supported
+    size_t granularity;
+    CHECK_ERROR(aclrtMemGetAllocationGranularity(&prop,
+                                ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM,
+                                &granularity));
+    size = ((size + granularity - 1) / granularity) * granularity; // align size to granularity
+
+    aclrtDrvMemHandle raw_handle;
+    CHECK_ERROR(aclrtMallocPhysical(&raw_handle, static_cast<size_t>(size), &prop, 0));
+    handle_ = raw_handle;
+    device_id_ = device_id;
+    granularity_ = size;
+    owns_handle_ = true;
+    return true;
+}
+
+void Handle::release() {
+    cleanup();
+}
+
+void Handle::reset(int32_t device_id, aclrtDrvMemHandle handle, uint64_t granularity, uint64_t shareable_handle) noexcept {
+    cleanup();
+    handle_ = handle;
+    device_id_ = device_id;
+    granularity_ = granularity;
+    owns_handle_ = true;
+    shareable_handle_ = shareable_handle;
+}
+
+bool Handle::valid() const noexcept {
+    return owns_handle_;
+}
+
+int32_t Handle::deviceId() const noexcept {
+    return device_id_;
+}
+
+uint64_t Handle::granularity() const noexcept {
+    return granularity_;
+}
+
+aclrtDrvMemHandle Handle::rawHandle() const noexcept {
+    return handle_;
+}
+
+uint64_t Handle::shareableHandle() const noexcept {
+    return shareable_handle_;
+}
+
+uint64_t Handle::exportShareableHandle() {
+    if (!owns_handle_) {
+        throw std::runtime_error("Cannot export an invalid handle");
+    }
+    uint64_t shareable = 0;
+    CHECK_ERROR(aclrtMemExportToShareableHandle(handle_, ACL_MEM_HANDLE_TYPE_NONE, 0, &shareable));
+    shareable_handle_ = shareable;
+    return shareable_handle_;
+}
+
+void Handle::cleanup() noexcept {
+    if (!owns_handle_) {
+        return;
+    }
+    ensure_context(device_id_);
+    CHECK_ERROR(aclrtFreePhysical(handle_));
+    handle_ = aclrtDrvMemHandle{};
+    device_id_ = -1;
+    granularity_ = 0;
+    owns_handle_ = false;
+    shareable_handle_ = std::numeric_limits<uint64_t>::max();
+}
+
+HandlePool::HandlePool(uint64_t page_size)
+    // page_size is 2MB by default
+    : page_size_(page_size), running_(true) {
+    if (page_size_ == 0) {
+        throw std::invalid_argument("page_size must be positive");
+    }
+}
+
+HandlePool::~HandlePool() {
+    shutdown();
+}
+
+void HandlePool::ensureInitialized(int32_t device_id) {
+    if (!running_) {
+        throw std::runtime_error("HandlePool is no longer running");
+    }
+    ensureAclInitialized();
+    ensure_context(device_id);
+}
+
+void HandlePool::allocateHandles(int32_t device_id,
+                                 size_t count,
+                                 const std::vector<int32_t>& npuid_list) {
+    if (count == 0) {
+        return;
+    }
+    ensureInitialized(device_id);
+    auto& bucket = device_handle_map_[device_id];
+    std::vector<int32_t> mutable_npuid_list = npuid_list;
+    for (size_t idx = 0; idx < count; ++idx) {
+        Handle handle;
+        handle.allocate(device_id, page_size_);
+        // by default, we set handle to share
+        uint64_t shareable_handle = handle.exportShareableHandle();
+        if (!mutable_npuid_list.empty()) {
+            CHECK_ERROR(aclrtMemSetPidToShareableHandle(shareable_handle,
+                                                       mutable_npuid_list.data(),
+                                                       mutable_npuid_list.size()));
+        }
+        device_shareable_handle_map_[device_id].push_back(shareable_handle);
+        bucket.emplace_back(std::move(handle));
+        device_total_handle_map_[device_id] += 1;
+    }
+}
+
+void HandlePool::initializeDevice(int32_t device_id,
+                                  uint64_t total_bytes,
+                                  const std::vector<int32_t>& npuid_list) {
+    if (total_bytes == 0) {
+        throw std::invalid_argument("total_bytes must be positive");
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (device_handle_map_.count(device_id)) {
+        return;
+    }
+    auto handle_count = static_cast<size_t>((total_bytes + page_size_ - 1) / page_size_);
+    allocateHandles(device_id, std::max<size_t>(1, handle_count), npuid_list);
+}
+
+Handle HandlePool::acquire(int32_t device_id) {
+    // this function will always return a Handle, if no available handle, return an invalid one
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = device_handle_map_.find(device_id);
+    if (it == device_handle_map_.end() || it->second.empty()) {
+        // no enough handles, return invalid Handle. Keep warning only in debug mode.
+        if (daemonDebugLogsEnabled()) {
+            daemonLogDebug("[HandlePool] no available handles for device " + std::to_string(device_id));
+        }
+        return Handle{};
+    }
+    Handle handle = std::move(it->second.front());
+    it->second.pop_front();
+    return handle;
+}
+
+void HandlePool::release(int32_t device_id, Handle handle) {
+    if (!handle.valid()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    device_handle_map_[device_id].emplace_back(std::move(handle));
+}
+
+// void HandlePool::exportShareableHandles(int32_t device_id) {
+//     std::cout << "[WARNING] exportShareableHandles is deprecated and will be removed in future versions.\n"
+//                   "ShareableHandle is set by default when create the physical handle" << std::endl;
+//     std::lock_guard<std::mutex> lock(mutex_);
+//     auto it = device_handle_map_.find(device_id);
+//     if (it == device_handle_map_.end()) {
+//         return;
+//     }
+//     for (auto& handle : it->second) {
+//         handle.exportShareableHandle();
+//     }
+//     return;
+// }
+
+bool HandlePool::extendHandles(int32_t device_id,
+                               size_t additional_count,
+                               const std::vector<int32_t>& npuid_list) {
+    if (additional_count == 0) {
+        return true;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    try {
+        allocateHandles(device_id, additional_count, npuid_list);
+    } catch (const std::exception& ex) {
+        daemonLogError("Failed to extend handles for device " + std::to_string(device_id)
+                  + ": " + ex.what());
+        return false;
+    }
+    return true;
+}
+
+bool HandlePool::removeHandles(int32_t device_id, size_t remove_count) {
+    if (remove_count == 0) {
+        return true;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = device_handle_map_.find(device_id);
+    if (it == device_handle_map_.end()) {
+        return false;
+    }
+    auto& bucket = it->second;
+    if (remove_count > bucket.size()) {
+        return false;
+    }
+    for (size_t idx = 0; idx < remove_count; ++idx) {
+        uint64_t shareable_handle = bucket.back().shareableHandle();
+        auto& shareable_handles = device_shareable_handle_map_[device_id];
+        auto pos = std::find(shareable_handles.begin(), shareable_handles.end(), shareable_handle);
+        if (pos != shareable_handles.end()) {
+            shareable_handles.erase(pos);
+        }
+        bucket.back().release();
+        bucket.pop_back();
+    }
+    auto total_it = device_total_handle_map_.find(device_id);
+    if (total_it != device_total_handle_map_.end()) {
+        total_it->second -= remove_count;
+    }
+    return true;
+}
+
+void HandlePool::memSetPidToShare(const std::vector<int32_t>& npuid_list, int32_t device_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = device_shareable_handle_map_.find(device_id);
+    if (it == device_shareable_handle_map_.end()) {
+        return;
+    }
+    std::vector<int32_t> mutable_npuid_list = npuid_list;
+    for (auto& shareable_handle : it->second) {
+        CHECK_ERROR(aclrtMemSetPidToShareableHandle(shareable_handle,
+                                                   mutable_npuid_list.data(),
+                                                   mutable_npuid_list.size()));
+    }
+}
+
+size_t HandlePool::available(int32_t device_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = device_handle_map_.find(device_id);
+    if (it == device_handle_map_.end()) {
+        return 0;
+    }
+    return it->second.size();
+}
+
+size_t HandlePool::total(int32_t device_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = device_total_handle_map_.find(device_id);
+    if (it == device_total_handle_map_.end()) {
+        return 0;
+    }
+    return it->second;
+}
+
+size_t HandlePool::used(int32_t device_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const size_t available_count = device_handle_map_.count(device_id) ? device_handle_map_.at(device_id).size() : 0;
+    const size_t total_count = device_total_handle_map_.count(device_id) ? device_total_handle_map_.at(device_id) : 0;
+    return total_count >= available_count ? (total_count - available_count) : 0;
+}
+
+std::vector<int32_t> HandlePool::listDeviceIds() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<int32_t> device_ids;
+    device_ids.reserve(device_handle_map_.size());
+    for (const auto& pair : device_handle_map_) {
+        device_ids.push_back(pair.first);
+    }
+    return device_ids;
+}
+
+void HandlePool::shutdown() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!running_) {
+        return;
+    }
+    for (auto& pair : device_handle_map_) {
+        for (auto& handle : pair.second) {
+            handle.release();
+        }
+        pair.second.clear();
+    }
+    device_handle_map_.clear();
+    device_shareable_handle_map_.clear();
+    device_total_handle_map_.clear();
+    running_ = false;
+}
+
+} // namespace mdaemon

--- a/daemon/daemon/inc/daemon.hpp
+++ b/daemon/daemon/inc/daemon.hpp
@@ -1,0 +1,119 @@
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "utils.h"
+#include "model_management.hpp"
+#include "handle_pool.hpp"
+
+namespace mdaemon {
+
+// Provided by user later to share PIDs with external components (e.g., python side).
+void SetPidToShare(const std::vector<int32_t>& npuid_list);
+
+class Daemon {
+public:
+    Daemon() noexcept = default;
+    ~Daemon();
+
+    // Lifecycle controls
+    void start();
+    void stop();
+    bool isRunning() const noexcept { return running_.load(); }
+    // Single-iteration runner for driving from python/bindings without a thread
+    void runOnce();
+
+    // Model management bindings
+    ModelConfig* registerModelFromMacro();
+    ModelConfig* getModelConfig(uint64_t model_id);
+    bool updateModelState(uint64_t model_id, ModelState new_state);
+    ModelState getModelState(uint64_t model_id) const;
+    std::vector<uint64_t> listModelIds() const;
+    std::vector<int32_t> getCurrentModelNpuids() const;
+
+    // HandlePool bindings
+    HandlePool* ensureHandlePool(uint64_t granularity);
+    void initializeHandlePoolDevice(uint64_t granularity, int32_t device_id, uint64_t total_bytes);
+    size_t handlePoolAvailable(uint64_t granularity, int32_t device_id) const;
+    bool extendHandles(uint64_t granularity, int32_t device_id, size_t count);
+    bool removeHandles(uint64_t granularity, int32_t device_id, size_t count);
+
+    struct HandlePoolDeviceSnapshot {
+        uint64_t granularity{0};
+        int32_t device_id{-1};
+        uint64_t total_handles{0};
+        uint64_t used_handles{0};
+        uint64_t available_handles{0};
+        uint64_t total_bytes{0};
+        uint64_t used_bytes{0};
+        uint64_t available_bytes{0};
+    };
+
+    struct ModelSnapshot {
+        uint64_t model_id{0};
+        ModelState state{ModelState::INVALID};
+        MessageState message_state{MessageState::INVALID};
+        int32_t model_npuid{-1};
+        int32_t model_osid{-1};
+        uint64_t allocated_bytes{0};
+        uint64_t allocated_handles{0};
+    };
+
+    std::vector<HandlePoolDeviceSnapshot> snapshotHandlePools() const;
+    std::vector<ModelSnapshot> snapshotModels(bool sync_message_space_from_shm = false);
+    ModelSnapshot getModelSnapshot(uint64_t model_id, bool sync_message_space_from_shm = false);
+    std::vector<std::string> drainLogs();
+
+    // interactive operations between models and handles
+    void SetPidToShare(const std::vector<int32_t>& npuid_list);
+    bool allocateHandlesForModel(ModelConfig& config);
+    void returnHandlesFromModel(ModelConfig& config);
+
+    // for debug
+    void printAll() const noexcept {
+        std::lock_guard<std::mutex> guard(daemon_mutex_);
+        std::cout << "=== Daemon State ===\n";
+        model_manager_.printAll();
+        for (const auto& pair : handle_pools_) {
+            uint64_t granularity = pair.first;
+            const HandlePool& pool = *pair.second;
+            printf("HandlePool Granularity: %lu\n", granularity);
+            pool.printStatus();
+        };
+
+    }
+private:
+    struct AllocatedHandle {
+        uint64_t granularity{0};
+        int32_t device_id{-1};
+        Handle handle{};
+    };
+
+    void runLoop();
+    HandlePool* findHandlePool(uint64_t granularity);
+
+    std::vector<request_granularity> collectHandleRequests(const ModelMessageSpace& space) const;
+    bool allocateForRequest(const request_granularity& req,
+                            std::vector<AllocatedHandle>& allocated_handles);
+    bool tryAcquireHandleExact(uint64_t granularity, int32_t device_id, Handle& out_handle);
+    bool tryAcquireHandle(uint64_t& granularity, int32_t device_id, Handle& out_handle);
+    void releaseAllocatedHandles(std::vector<AllocatedHandle>& allocated_handles);
+    void writeHandlesToMessageSpace(ModelMessageSpace& space,
+                                    const std::vector<AllocatedHandle>& allocated_handles);
+    void returnHandlesFromCfg(ModelConfig& config);
+
+    ModelConfigManager model_manager_;
+    // granularity to HandlePool map
+    std::unordered_map<uint64_t, std::unique_ptr<HandlePool>> handle_pools_;
+    std::atomic<bool> running_{false};
+    std::thread worker_;
+    std::chrono::steady_clock::time_point next_liveness_check_{std::chrono::steady_clock::time_point::min()};
+    mutable std::mutex daemon_mutex_;
+
+};
+
+} // namespace mdaemon

--- a/daemon/daemon/inc/handle_pool.hpp
+++ b/daemon/daemon/inc/handle_pool.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+/*
+This header file is used to define the handle class and handle pool for the daemon process.
+It includes necessary libraries and declares the daemon namespace.
+*/
+
+#include <cstdint>
+#include <limits>
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "utils.h"
+
+namespace mdaemon {
+
+class Handle{
+public:
+    Handle() noexcept = default;
+    ~Handle();
+
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+
+    Handle(Handle&& other) noexcept;
+    Handle& operator=(Handle&& other) noexcept;
+
+    bool allocate(int32_t device_id, uint64_t size);
+    void release();
+    void reset(int32_t device_id, aclrtDrvMemHandle handle, uint64_t granularity, uint64_t shareable_handle) noexcept;
+
+    [[nodiscard]] bool valid() const noexcept;
+    [[nodiscard]] int32_t deviceId() const noexcept;
+    [[nodiscard]] uint64_t granularity() const noexcept;
+    [[nodiscard]] aclrtDrvMemHandle rawHandle() const noexcept;
+    [[nodiscard]] uint64_t shareableHandle() const noexcept;
+
+    uint64_t exportShareableHandle();
+
+private:
+    void cleanup() noexcept;
+
+    aclrtDrvMemHandle handle_{};
+    int32_t device_id_{-1};
+    uint64_t granularity_{0};
+    bool owns_handle_{false};
+    uint64_t shareable_handle_{std::numeric_limits<uint64_t>::max()};
+};
+
+
+class HandlePool {
+public:
+    explicit HandlePool(uint64_t page_size = 2ULL * 1024 * 1024);
+    ~HandlePool();
+    
+    HandlePool(const HandlePool&) = delete;
+    HandlePool& operator=(const HandlePool&) = delete;
+
+    void initializeDevice(int32_t device_id,
+                         uint64_t total_bytes,
+                         const std::vector<int32_t>& npuid_list = {});
+    Handle acquire(int32_t device_id);
+    void release(int32_t device_id, Handle handle);
+    // void exportShareableHandles(int32_t device_id);
+    size_t available(int32_t device_id) const;
+    size_t total(int32_t device_id) const;
+    size_t used(int32_t device_id) const;
+    uint64_t pageSize() const noexcept { return page_size_; }
+    void shutdown();
+
+    bool extendHandles(int32_t device_id,
+                      size_t additional_count,
+                      const std::vector<int32_t>& npuid_list = {});
+    bool removeHandles(int32_t device_id, size_t remove_count);
+
+    void memSetPidToShare(const std::vector<int32_t>& npuid_list, int32_t device_id);
+
+    // Returns all device ids that have been initialized in this pool.
+    std::vector<int32_t> listDeviceIds() const;
+
+    // for debug
+    void printStatus() const noexcept {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& pair : device_handle_map_) {
+            int32_t device_id = pair.first;
+            size_t handle_count = pair.second.size();
+            printf("Device ID: %d, Available Handles: %zu\n", device_id, handle_count);
+        }
+    }
+
+private:
+    // Map from device_id to a list of handles
+    std::unordered_map<int32_t, std::deque<Handle>> device_handle_map_;
+
+    // Map from device_id to total number of handles allocated for this pool.
+    // Invariants (when initialized): total = available + used.
+    std::unordered_map<int32_t, size_t> device_total_handle_map_;
+
+    // Map from device_id to shareable handles, this is used to quickly set pid to 
+    // shareable handles when new model comes in
+    std::unordered_map<int32_t, std::vector<uint64_t>> device_shareable_handle_map_;
+
+    uint64_t page_size_;
+    mutable std::mutex mutex_;
+    bool running_;
+
+    void allocateHandles(int32_t device_id,
+                        size_t count,
+                        const std::vector<int32_t>& npuid_list = {});
+    void ensureInitialized(int32_t device_id);
+};
+
+} // namespace mdaemon
+

--- a/daemon/daemon/inc/model_management.hpp
+++ b/daemon/daemon/inc/model_management.hpp
@@ -1,0 +1,334 @@
+#pragma once
+
+/*
+This header file is used to define the model configuration for each model
+in the daemon process. 
+[NOTE(shijin)]: Current version only supports single-npu service, so this is
+a placeholder for future multi-npu support.
+*/
+
+/*
+ * model_management hierarchy
+ *
+ * ModelMacroSpace (shared macro region for semaphore-driven registration)
+ * ├─ fields: shm_name, current_model_npuid, current_model_osid
+ * ├─ helpers: reset(), hasCandidate(), get/set shm_name
+ *
+ * ModelMessageSpace (per-model message sync area)
+ * ├─ fields: shm_name, state, model identifiers, handle list
+ * ├─ helpers: get/set shm_name
+ *
+ * ModelConfig
+ * ├─ Fields: model_id, state, ModelMessageSpace, mutex
+ * ├─ Methods: setModelConfig(), get/set state, messageSpace accessors
+ * └─ Static helpers: generateModelId(), buildShmName()
+ *
+ * ModelMacroRegistry (encapsulates MODEL_REG_SHM shared memory)
+ * ├─ Opens/Mmaps FILE /dev/shm/vllm-model-registry
+ * ├─ Exposes: data(), hasPendingRegistration(), writeShmName()
+ * └─ Cleans up mapping and descriptor in cleanup()
+ *
+ * ModelConfigManager
+ * ├─ Manages unordered_map<model_id, ModelConfig>
+ * ├─ Guarded by map_mutex_
+ * ├─ Operations: add/remove/get/update/isDone
+ * ├─ Macro features: macroSpace(), registerModelFromMacro()
+ * └─ Tracks total_models_ and holds ModelMacroRegistry instance
+ */
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <semaphore.h>
+
+#include "utils.h"
+#include "handle_pool.hpp"
+
+namespace mdaemon {
+
+namespace {
+constexpr size_t kModelShmNameLength = 256;
+constexpr int32_t kInvalidModelHandle = std::numeric_limits<int32_t>::max();
+
+inline std::string_view defaultShmName() noexcept {
+    static const std::string value = std::string(getShmPrefix()) + "null";
+    return std::string_view(value);
+}
+
+inline std::string_view readShmName(const std::array<char, kModelShmNameLength>& buffer) noexcept {
+    return std::string_view(buffer.data(), std::strlen(buffer.data()));
+}
+
+inline void writeShmName(std::array<char, kModelShmNameLength>& buffer, std::string_view value) noexcept {
+    std::fill(buffer.begin(), buffer.end(), '\0');
+    if (value.empty()) {
+        return;
+    }
+    const size_t copy_count = std::min(value.size(), buffer.size() - 1);
+    std::memcpy(buffer.data(), value.data(), copy_count);
+}
+
+inline bool isDefaultShmName(std::string_view value) noexcept {
+    const std::string_view null_name = defaultShmName();
+    return value.empty() || value == null_name;
+}
+} // namespace
+
+
+// Model state class
+enum class ModelState : uint8_t {
+    UNINITIALIZED = 0, // model is not initialized
+    INITIALIZED = 1, // model is initialized
+    REGISTERED = 2, // model is registered with daemon
+    // LOADING = 3, // model is loading weights
+    // READY = 4, // model is ready to run
+    // RUNNING = 5, // model is running
+    // OFFLOADED = 6, // model is offloaded to CPU
+    DONE = 7, // model has finished execution or killed by force
+    INVALID = 8 // invalid state
+};
+
+// Model message space between daemon and model process
+enum class MessageState : uint8_t {
+    NONE = 0,
+    REQUEST_REGISTER = 1, // model process requests registration
+    REGISTERED = 2, // daemon acknowledges registration
+    REQUEST_GET_HANDLES = 3, // model process requests handles
+    HANDLES_READY = 4, // daemon acknowledges handles are ready
+    REQUEST_RETURN_HANDLES = 5, // model process requests to return handles
+    HANDLES_RETURNED = 6, // daemon acknowledges handles are returned
+    DONE = 7, // model has finished execution
+    INVALID = 8 // invalid state
+};
+
+struct pair_hash {
+    size_t operator()(const std::pair<int32_t, uint64_t>& value) const noexcept {
+        const size_t h1 = std::hash<int32_t>{}(value.first);
+        const size_t h2 = std::hash<uint64_t>{}(value.second);
+        return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+    }
+};
+
+struct handle_granularity {
+    uint64_t shareable_handle{std::numeric_limits<uint64_t>::max()};
+    uint64_t granularity{0};
+    int32_t device_id{ -1 };
+};
+
+struct request_granularity {
+    uint64_t request_num{0};
+    uint64_t granularity{0};
+    int32_t device_id{ -1 };
+};
+
+struct ModelMacroSpace {
+    ModelMacroSpace() noexcept {
+        reset();
+    }
+
+    std::string_view getShmName() const noexcept {
+        return readShmName(shm_name);
+    }
+
+    void setShmName(std::string_view value = defaultShmName()) noexcept {
+        writeShmName(shm_name, value);
+    }
+
+    void reset() noexcept {
+        setShmName();
+        current_model_npuid = kInvalidModelHandle;
+        current_model_osid = kInvalidModelHandle;
+    }
+
+    bool hasCandidate() const noexcept {
+        return current_model_npuid != kInvalidModelHandle &&
+               current_model_osid != kInvalidModelHandle;
+    }
+
+    std::array<char, kModelShmNameLength> shm_name{};
+    int32_t current_model_npuid{kInvalidModelHandle};
+    int32_t current_model_osid{kInvalidModelHandle};
+};
+
+struct ModelMessageSpace {
+    ModelMessageSpace() noexcept {
+        setShmName();
+    }
+
+    std::string_view getShmName() const noexcept {
+        return readShmName(shm_name);
+    }
+
+    void setShmName(std::string_view value = defaultShmName()) noexcept {
+        writeShmName(shm_name, value);
+    }
+
+    std::array<char, kModelShmNameLength> shm_name{};
+    MessageState state{MessageState::NONE};
+    int32_t model_npuid{kInvalidModelHandle};
+    int32_t model_osid{kInvalidModelHandle};
+    int64_t heartbeat_ns{0};
+    // handle_info_list containing all the handles in exchange between model and daemon
+    std::array<handle_granularity, MAX_HANDLES_PER_MODEL> handle_info_list{};
+    // active area in handle_info_list is [offset_st, offset_ed)
+    int32_t offset_st{0}; // offset start for handle access, usually 0
+    int32_t offset_ed{0}; // current total handles in the list
+    // request list for model to request handles with specific granularity and device_id
+    std::array<request_granularity, MAX_HANDLES_PER_MODEL> handle_request_list{};
+};
+
+class ModelMacroRegistry;
+
+class ModelConfig {
+public:
+    ModelConfig() noexcept = default;
+    ~ModelConfig();
+
+    bool setModelConfig() noexcept;
+    uint64_t getModelId() const noexcept;
+    ModelState getState() const noexcept;
+    void setState(ModelState new_state) noexcept;
+
+    ModelMessageSpace& messageSpace();
+    const ModelMessageSpace& messageSpace() const;
+    bool syncMessageSpaceFromShm() noexcept;
+    bool syncMessageSpaceToShm() noexcept;
+    bool tryLockMessageSpace() noexcept;
+    void unlockMessageSpace() noexcept;
+
+    void addAllocatedHandle(int32_t canonical_device_id, Handle&& handle);
+    void setPidToShareForAllocated(const std::vector<int32_t>& npuid_list);
+    bool takeAllocatedHandle(int32_t device_id, uint64_t shareable_handle, Handle& out_handle);
+    std::vector<Handle> drainAllocatedHandles();
+
+    size_t allocatedHandleCount() const noexcept;
+    uint64_t allocatedBytes() const noexcept;
+    void unlinkMessageShm() noexcept;
+
+private:
+    // model id : a generated hash value
+    uint64_t model_id_{std::numeric_limits<uint64_t>::max()};
+    // model state
+    ModelState state_{ModelState::UNINITIALIZED};
+    // add shm space between model and daemon to sync information (direct mmap region)
+    ModelMessageSpace* message_space_{nullptr};
+    int message_fd_{-1};
+    std::string message_shm_name_;
+    sem_t* message_sem_{nullptr};
+    std::string message_sem_name_;
+    mutable std::mutex state_mutex_;
+    // allocated handles for this model, to be released when model is done
+    // member in allocated_handles_: key -- (device_id, shareable_handle), value -- Handle
+    std::unordered_map<std::pair<int32_t, uint64_t>, Handle, pair_hash> allocated_handles_;
+    mutable std::mutex allocated_mutex_;
+
+    bool openAndMapMessageShm(bool create) noexcept;
+    void closeMessageShmMapping() noexcept;
+    bool openMessageSemaphore(bool create) noexcept;
+    void closeMessageSemaphore() noexcept;
+
+    static uint64_t generateModelId() noexcept;
+    static std::string buildShmName(uint64_t model_id);
+
+    friend class ModelConfigManager;
+};
+
+class ModelConfigManager {
+public:
+    ModelConfigManager() noexcept;
+    ~ModelConfigManager();
+
+    ModelConfig* addModelConfig();
+    void removeModelConfig(uint64_t model_id);
+    ModelConfig* getModelConfig(uint64_t model_id);
+
+    ModelMacroSpace* macroSpace() const noexcept;
+    ModelConfig* registerModelFromMacro();
+    std::vector<uint64_t> listModelIds() const;
+
+    bool isModelDone(uint64_t model_id);
+    bool updateModelState(uint64_t model_id, ModelState new_state);
+    ModelState getModelState(uint64_t model_id) const noexcept;
+
+    int32_t getTotalModels() const noexcept {
+        std::lock_guard<std::mutex> guard(map_mutex_);
+        return total_models_;
+    }
+    std::vector<int32_t> getCurrentModelNpuids() const noexcept {
+        std::lock_guard<std::mutex> guard(map_mutex_);
+        return current_model_npuids_;
+    }
+
+    // for debug
+    void printModelConfigs() const noexcept {
+        std::lock_guard<std::mutex> guard(map_mutex_);
+        printModelConfigsLocked();
+    }
+
+    void printAll() const noexcept {
+        std::lock_guard<std::mutex> guard(map_mutex_);
+        printf("Total Models: %d\n", total_models_);
+        printModelConfigsLocked();
+        ModelMacroSpace* macro_space = macroSpace();
+        if (macro_space) {
+            std::string_view shm_name = macro_space->getShmName();
+                 printf("Macro Space Shm Name: %.*s\n",
+                     static_cast<int>(shm_name.size()),
+                     shm_name.data());
+                 printf("  Current Model NPU ID: %d, Current Model OS ID: %d\n",
+                     macro_space->current_model_npuid,
+                     macro_space->current_model_osid);
+        } else {
+            printf("Macro Space is null.\n");
+        }
+    }
+private:
+    void printModelConfigsLocked() const noexcept {
+        for (const auto& kv : model_config_map_) {
+            const ModelConfig& config = *kv.second;
+            const ModelMessageSpace& msg_space = config.messageSpace();
+            std::string_view shm_name = msg_space.getShmName();
+            ModelState state = config.getState();
+            printf("Model ID: %lu, State: %d, Shm Name: %.*s\n",
+                   config.getModelId(),
+                   static_cast<int>(state),
+                   static_cast<int>(shm_name.size()),
+                   shm_name.data());
+            // print message space info
+                 printf("  Message State: %d, Model NPU ID: %d, Model OS ID: %d\n",
+                     static_cast<int>(msg_space.state),
+                     msg_space.model_npuid,
+                     msg_space.model_osid);
+            printf("  first 3 Handles:\n");
+            for (size_t i = 0; i < 3; ++i) {
+                const handle_granularity& handle_info = msg_space.handle_info_list[i];
+                printf("    Handle %zu: Shareable Handle: %lu, Granularity: %lu, Device ID: %d\n",
+                       i,
+                       handle_info.shareable_handle,
+                       handle_info.granularity,
+                       handle_info.device_id);
+            }
+        }
+    }
+
+    // hash to ModelConfig map
+    std::unordered_map<uint64_t, std::unique_ptr<ModelConfig>> model_config_map_; 
+    mutable std::mutex map_mutex_;
+    int32_t total_models_{0};
+    std::unique_ptr<ModelMacroRegistry> macro_registry_;
+    std::vector<int32_t> current_model_npuids_{};
+
+};
+
+} // namespace mdaemon

--- a/daemon/daemon/inc/utils.h
+++ b/daemon/daemon/inc/utils.h
@@ -1,0 +1,185 @@
+// source: kvcached(https://github.com/ovg-project/kvcached)
+
+#ifndef __SSHAREUTILS_H__
+#define __SSHAREUTILS_H__
+
+#include <cstddef>
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <cstdlib>
+#include <deque>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <stdexcept>
+#include <vector>
+#include <assert.h>
+#include <stdio.h>
+
+extern "C" {
+#include "acl/acl.h"
+}
+
+// meta function: get from env; otherwise default string
+inline std::string getEnvOrDefault(const char* env_name, const std::string& default_value) {
+    const char* env_value = std::getenv(env_name);
+    if (env_value && env_value[0] != '\0') {
+        return std::string(env_value);
+    }
+    return default_value;
+}
+
+inline int getEnvOrDefault(const char* env_name, int default_value) {
+    const char* env_value = std::getenv(env_name);
+    if (env_value && env_value[0] != '\0') {
+        try {
+            return std::stoi(env_value);
+        } catch (const std::exception& e) {
+            std::cerr << "Warning: invalid integer in env " << env_name
+                      << "='" << env_value << "', using default " << default_value << "\n";
+        }
+    }
+    return default_value;
+}
+
+inline bool daemonDebugLogsEnabled() {
+    static const bool enabled = []() {
+        const char* flag = std::getenv("MDAEMON_DEBUG_LOG");
+        return flag && std::string_view(flag) == "1";
+    }();
+    return enabled;
+}
+
+inline size_t daemonLogBufferCapacity() {
+    const int cap = getEnvOrDefault("MDAEMON_LOG_BUFFER_SIZE", 2000);
+    return static_cast<size_t>(cap > 0 ? cap : 2000);
+}
+
+inline std::mutex& daemonLogMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+inline std::deque<std::string>& daemonLogBuffer() {
+    static std::deque<std::string> buffer;
+    return buffer;
+}
+
+inline std::string daemonLogNow() {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::tm tmv{};
+#if defined(_WIN32)
+    localtime_s(&tmv, &t);
+#else
+    localtime_r(&t, &tmv);
+#endif
+    std::ostringstream oss;
+    oss << std::put_time(&tmv, "%H:%M:%S");
+    return oss.str();
+}
+
+inline void daemonLogPushLine(const std::string& line) {
+    std::lock_guard<std::mutex> guard(daemonLogMutex());
+    auto& buffer = daemonLogBuffer();
+    buffer.push_back(line);
+    const size_t cap = daemonLogBufferCapacity();
+    while (buffer.size() > cap) {
+        buffer.pop_front();
+    }
+}
+
+inline void daemonLogError(const std::string& message) {
+    const std::string line = daemonLogNow() + " [ERROR] " + message;
+    daemonLogPushLine(line);
+    std::cerr << "\033[31m" << line << "\033[0m" << std::endl;
+}
+
+inline void daemonLogInfo(const std::string& message) {
+    const std::string line = daemonLogNow() + " [INFO ] " + message;
+    daemonLogPushLine(line);
+    if (daemonDebugLogsEnabled()) {
+        std::cout << line << std::endl;
+    }
+}
+
+inline void daemonLogDebug(const std::string& message) {
+    if (!daemonDebugLogsEnabled()) {
+        return;
+    }
+    const std::string line = daemonLogNow() + " [DEBUG] " + message;
+    daemonLogPushLine(line);
+    std::cout << line << std::endl;
+}
+
+inline std::vector<std::string> daemonDrainLogs() {
+    std::vector<std::string> out;
+    std::lock_guard<std::mutex> guard(daemonLogMutex());
+    auto& buffer = daemonLogBuffer();
+    out.assign(buffer.begin(), buffer.end());
+    buffer.clear();
+    return out;
+}
+
+// ------------------------------------------------------------------------------
+// Constants:
+
+inline const char* getShmPrefix() {
+    static const std::string value = getEnvOrDefault("MDAEMON_SHM_PREFIX", std::string("/vllm-model-"));
+    return value.c_str();
+}
+
+inline const char* getModelSemaphoreName() {
+    static const std::string value =
+        getEnvOrDefault("MDAEMON_SEMAPHORE_NAME", std::string("/vllm-model-semaphore"));
+    return value.c_str();
+}
+
+inline const char* getModelRegShm() {
+    static const std::string value =
+        getEnvOrDefault("MDAEMON_MODEL_REG_SHM", std::string("/vllm-model-registry"));
+    return value.c_str();
+}
+
+#define SHM_PREFIX getShmPrefix()
+#define MAX_HANDLES_PER_MODEL 30720
+                                    // Maximum number of handles per model. assuming 
+                                    // each handle is at least 2MB, this allows up to 
+                                    // 60GB per model upon all devices.
+                                    // [TODO(shijin)]: This is currently for single-npu service,
+                                    // need to reconsider for multi-npu service.
+#define MODEL_SEMAPHORE_NAME getModelSemaphoreName()
+#define MODEL_REG_SHM getModelRegShm()
+
+// ------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------
+// Helper functions:
+inline void showError(aclError error_code, const std::string& file, int line) {
+    if (error_code != 0) {
+        std::string message = "acl Error, code: " + std::to_string(error_code) +
+                              " at " + file + ":" + std::to_string(line);
+        daemonLogError(message);
+        throw std::runtime_error(message);
+    }
+}
+
+#define CHECK_ERROR(error_code) showError(error_code, __FILE__, __LINE__)
+
+inline void ensure_context(int32_t device) {
+    CHECK_ERROR(aclrtSetDevice(device));
+    aclrtContext pctx;
+    CHECK_ERROR(aclrtGetCurrentContext(&pctx));
+    if (!pctx) {
+        // Ensure device context.
+        CHECK_ERROR(aclrtCreateContext(&pctx, device));
+        CHECK_ERROR(aclrtSetCurrentContext(pctx));
+    }
+}
+// ------------------------------------------------------------------------------
+
+#endif

--- a/daemon/daemon/main.sh
+++ b/daemon/daemon/main.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <source_file>"
+    exit 1
+fi
+
+SOURCE_FILE=$1
+OUTPUT_FILE=$2
+
+HANDLE_POOL_FILE="$(pwd)/handle_pool.cpp"
+MODEL_MGMT_FILE="$(pwd)/model_management.cpp"
+DAEMON_FILE="$(pwd)/daemon.cpp"
+
+g++ "$SOURCE_FILE" $HANDLE_POOL_FILE $MODEL_MGMT_FILE $DAEMON_FILE -std=c++17 \
+    -I /usr/local/Ascend/ascend-toolkit/latest/include \
+    -I $(pwd)/inc \
+    -L /usr/local/Ascend/ascend-toolkit/latest/lib64 \
+    -lascendcl \
+    -o "$OUTPUT_FILE"
+
+if [ $? -eq 0 ]; then
+    echo "Compilation successful. Output file: $OUTPUT_FILE"
+else
+    echo "Compilation failed!"
+    exit 1
+fi

--- a/daemon/daemon/mdaemon/__init__.py
+++ b/daemon/daemon/mdaemon/__init__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+__all__ = ["main"]

--- a/daemon/daemon/mdaemon/__main__.py
+++ b/daemon/daemon/mdaemon/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/daemon/daemon/mdaemon/cli.py
+++ b/daemon/daemon/mdaemon/cli.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from py_monitor.daemon_monitor import main as monitor_main
+
+
+def main() -> int:
+    return monitor_main()

--- a/daemon/daemon/model_management.cpp
+++ b/daemon/daemon/model_management.cpp
@@ -1,0 +1,537 @@
+#include "inc/model_management.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <random>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace mdaemon {
+
+namespace {
+
+std::mt19937_64& modelIdEngine() {
+    static std::mt19937_64 engine(std::random_device{}());
+    return engine;
+}
+
+uint64_t drawModelId() noexcept {
+    static std::uniform_int_distribution<uint64_t> dist(1, std::numeric_limits<uint64_t>::max() - 1);
+    return dist(modelIdEngine());
+}
+
+void logShmError(const char* op, std::string_view shm_name) {
+    std::cerr << "\033[31m[ModelConfig] " << op << " failed for shm '" << shm_name
+              << "' errno=" << errno << " (" << std::strerror(errno) << ")\033[0m\n";
+}
+
+std::string buildMessageSemName(std::string_view shm_name) {
+    return std::string(shm_name) + "-sem";
+}
+
+} // namespace
+
+class ModelMacroRegistry {
+public:
+    ModelMacroRegistry() {
+        fd_ = ::shm_open(MODEL_REG_SHM, O_RDWR | O_CREAT, 0666);
+        if (fd_ == -1) {
+            return;
+        }
+        struct stat file_state{};
+        if (::fstat(fd_, &file_state) == -1) {
+            cleanup();
+            return;
+        }
+        const bool needs_init = file_state.st_size == 0;
+        if (::ftruncate(fd_, sizeof(ModelMacroSpace)) == -1) {
+            cleanup();
+            return;
+        }
+        void* region = ::mmap(nullptr,
+                              sizeof(ModelMacroSpace),
+                              PROT_READ | PROT_WRITE,
+                              MAP_SHARED,
+                              fd_,
+                              0);
+        if (region == MAP_FAILED) {
+            cleanup();
+            return;
+        }
+        data_ = static_cast<ModelMacroSpace*>(region);
+        if (needs_init && data_) {
+            data_->reset();
+        }
+    }
+
+    ~ModelMacroRegistry() {
+        cleanup();
+    }
+
+    ModelMacroSpace* data() const noexcept {
+        return data_;
+    }
+
+    bool hasPendingRegistration() const noexcept {
+        if (!data_) {
+            return false;
+        }
+        return data_->hasCandidate() && isDefaultShmName(data_->getShmName());
+    }
+
+    void writeShmName(std::string_view new_name) {
+        if (!data_) {
+            return;
+        }
+        data_->setShmName(new_name);
+    }
+
+private:
+    void cleanup() noexcept {
+        if (data_) {
+            ::msync(data_, sizeof(ModelMacroSpace), MS_SYNC);
+            ::munmap(data_, sizeof(ModelMacroSpace));
+            data_ = nullptr;
+        }
+        if (fd_ != -1) {
+            ::close(fd_);
+            fd_ = -1;
+        }
+        ::shm_unlink(MODEL_REG_SHM);
+    }
+
+    int fd_{-1};
+    ModelMacroSpace* data_{nullptr};
+};
+
+ModelConfig::~ModelConfig() {
+    closeMessageSemaphore();
+    closeMessageShmMapping();
+    // Shared memory unlink is managed by ModelConfigManager::removeModelConfig
+    // so that shm lifetime is tied to explicit model removal.
+}
+
+bool ModelConfig::setModelConfig() noexcept {
+    std::lock_guard<std::mutex> guard(state_mutex_);
+    if (model_id_ != std::numeric_limits<uint64_t>::max()) {
+        return true;
+    }
+    model_id_ = generateModelId();
+    state_ = ModelState::INITIALIZED;
+    message_shm_name_ = buildShmName(model_id_);
+    // message_space_.model_npuid = model_id_;
+    // message_space_.model_osid = model_id_;
+    return true;
+}
+
+uint64_t ModelConfig::getModelId() const noexcept {
+    return model_id_;
+}
+
+ModelState ModelConfig::getState() const noexcept {
+    std::lock_guard<std::mutex> guard(state_mutex_);
+    return state_;
+}
+
+void ModelConfig::setState(ModelState new_state) noexcept {
+    std::lock_guard<std::mutex> guard(state_mutex_);
+    state_ = new_state;
+}
+
+ModelMessageSpace& ModelConfig::messageSpace() {
+    if (!message_space_) {
+        throw std::runtime_error("message space is not mapped");
+    }
+    return *message_space_;
+}
+
+const ModelMessageSpace& ModelConfig::messageSpace() const {
+    if (!message_space_) {
+        throw std::runtime_error("message space is not mapped");
+    }
+    return *message_space_;
+}
+
+bool ModelConfig::syncMessageSpaceFromShm() noexcept {
+    if (!message_space_) {
+        std::cerr << "\033[31m[ModelConfig] syncMessageSpaceFromShm skipped: shm not mapped for '"
+                  << message_shm_name_ << "'\033[0m\n";
+        return false;
+    }
+    // message_space_ is already the mapped shared memory region.
+    return true;
+}
+
+bool ModelConfig::syncMessageSpaceToShm() noexcept {
+    if (!message_space_) {
+        std::cerr << "\033[31m[ModelConfig] syncMessageSpaceToShm skipped: shm not mapped for '"
+                  << message_shm_name_ << "'\033[0m\n";
+        return false;
+    }
+    // message_space_ is already the mapped shared memory region.
+    return true;
+}
+
+bool ModelConfig::tryLockMessageSpace() noexcept {
+    if (!message_sem_) {
+        return false;
+    }
+    if (::sem_trywait(message_sem_) == 0) {
+        return true;
+    }
+    if (errno == EAGAIN) {
+        return false;
+    }
+    std::cerr << "\033[31m[ModelConfig] sem_trywait failed for '"
+              << message_sem_name_ << "' errno=" << errno << " (" << std::strerror(errno)
+              << ")\033[0m\n";
+    return false;
+}
+
+void ModelConfig::unlockMessageSpace() noexcept {
+    if (!message_sem_) {
+        return;
+    }
+    if (::sem_post(message_sem_) == -1) {
+        std::cerr << "\033[31m[ModelConfig] sem_post failed for '"
+                  << message_sem_name_ << "' errno=" << errno << " (" << std::strerror(errno)
+                  << ")\033[0m\n";
+    }
+}
+
+bool ModelConfig::openAndMapMessageShm(bool create) noexcept {
+    const std::string shm_name(message_shm_name_);
+    if (shm_name.empty() || isDefaultShmName(shm_name)) {
+        std::cerr << "\033[31m[ModelConfig] openAndMapMessageShm skipped: invalid shm name\033[0m\n";
+        return false;
+    }
+
+    closeMessageSemaphore();
+    closeMessageShmMapping();
+
+    int flags = O_RDWR;
+    if (create) {
+        flags |= O_CREAT;
+    }
+
+    const int fd = ::shm_open(shm_name.c_str(), flags, 0666);
+    if (fd == -1) {
+        logShmError("shm_open", shm_name);
+        return false;
+    }
+
+    if (create && ::ftruncate(fd, sizeof(ModelMessageSpace)) == -1) {
+        logShmError("ftruncate", shm_name);
+        ::close(fd);
+        return false;
+    }
+
+    void* region = ::mmap(nullptr,
+                          sizeof(ModelMessageSpace),
+                          PROT_READ | PROT_WRITE,
+                          MAP_SHARED,
+                          fd,
+                          0);
+    if (region == MAP_FAILED) {
+        logShmError("mmap", shm_name);
+        ::close(fd);
+        return false;
+    }
+
+    message_fd_ = fd;
+    message_space_ = static_cast<ModelMessageSpace*>(region);
+
+    if (!openMessageSemaphore(create)) {
+        closeMessageSemaphore();
+        closeMessageShmMapping();
+        return false;
+    }
+    return true;
+}
+
+void ModelConfig::closeMessageShmMapping() noexcept {
+    if (message_space_) {
+        ::munmap(message_space_, sizeof(ModelMessageSpace));
+        message_space_ = nullptr;
+    }
+    if (message_fd_ != -1) {
+        ::close(message_fd_);
+        message_fd_ = -1;
+    }
+}
+
+bool ModelConfig::openMessageSemaphore(bool create) noexcept {
+    message_sem_name_ = buildMessageSemName(message_shm_name_);
+    if (message_sem_name_.empty()) {
+        return false;
+    }
+
+    int flags = 0;
+    if (create) {
+        flags |= O_CREAT;
+    }
+
+    message_sem_ = ::sem_open(message_sem_name_.c_str(), flags, 0666, 1);
+    if (message_sem_ == SEM_FAILED) {
+        message_sem_ = nullptr;
+        std::cerr << "\033[31m[ModelConfig] sem_open failed for '"
+                  << message_sem_name_ << "' errno=" << errno << " (" << std::strerror(errno)
+                  << ")\033[0m\n";
+        return false;
+    }
+    return true;
+}
+
+void ModelConfig::closeMessageSemaphore() noexcept {
+    if (message_sem_) {
+        ::sem_close(message_sem_);
+        message_sem_ = nullptr;
+    }
+}
+
+void ModelConfig::addAllocatedHandle(int32_t canonical_device_id, Handle&& handle) {
+    const auto key = std::make_pair(canonical_device_id, handle.shareableHandle());
+    std::lock_guard<std::mutex> guard(allocated_mutex_);
+    if (allocated_handles_.find(key) != allocated_handles_.end()) {
+        throw std::runtime_error("duplicate allocated handle key detected");
+    }
+    allocated_handles_.emplace(key, std::move(handle));
+}
+
+void ModelConfig::setPidToShareForAllocated(const std::vector<int32_t>& npuid_list) {
+    if (npuid_list.empty()) {
+        return;
+    }
+    std::vector<int32_t> mutable_npuid_list = npuid_list;
+    std::lock_guard<std::mutex> guard(allocated_mutex_);
+    for (const auto& kv : allocated_handles_) {
+        const uint64_t shareable_handle = kv.first.second;
+        CHECK_ERROR(aclrtMemSetPidToShareableHandle(shareable_handle,
+                                                    mutable_npuid_list.data(),
+                                                    mutable_npuid_list.size()));
+    }
+}
+
+bool ModelConfig::takeAllocatedHandle(int32_t device_id, uint64_t shareable_handle, Handle& out_handle) {
+    std::lock_guard<std::mutex> guard(allocated_mutex_);
+    auto it = allocated_handles_.find({device_id, shareable_handle});
+    if (it == allocated_handles_.end()) {
+        return false;
+    }
+    out_handle = std::move(it->second);
+    allocated_handles_.erase(it);
+    return true;
+}
+
+std::vector<Handle> ModelConfig::drainAllocatedHandles() {
+    std::lock_guard<std::mutex> guard(allocated_mutex_);
+    std::vector<Handle> handles;
+    handles.reserve(allocated_handles_.size());
+    for (auto& kv : allocated_handles_) {
+        handles.push_back(std::move(kv.second));
+    }
+    allocated_handles_.clear();
+    return handles;
+}
+
+size_t ModelConfig::allocatedHandleCount() const noexcept {
+    std::lock_guard<std::mutex> guard(allocated_mutex_);
+    return allocated_handles_.size();
+}
+
+uint64_t ModelConfig::allocatedBytes() const noexcept {
+    std::lock_guard<std::mutex> guard(allocated_mutex_);
+    uint64_t total = 0;
+    for (const auto& kv : allocated_handles_) {
+        total += kv.second.granularity();
+    }
+    return total;
+}
+
+void ModelConfig::unlinkMessageShm() noexcept {
+    const std::string shm_name(message_shm_name_);
+    if (shm_name.empty() || isDefaultShmName(shm_name)) {
+        return;
+    }
+    closeMessageSemaphore();
+    closeMessageShmMapping();
+    if (!message_sem_name_.empty()) {
+        if (::sem_unlink(message_sem_name_.c_str()) == -1 && errno != ENOENT) {
+            std::cerr << "\033[31m[ModelConfig] sem_unlink failed for '"
+                      << message_sem_name_ << "' errno=" << errno << " (" << std::strerror(errno)
+                      << ")\033[0m\n";
+        }
+    }
+    if (::shm_unlink(shm_name.c_str()) == -1 && errno != ENOENT) {
+        logShmError("shm_unlink", shm_name);
+    }
+}
+
+uint64_t ModelConfig::generateModelId() noexcept {
+    return drawModelId();
+}
+
+std::string ModelConfig::buildShmName(uint64_t model_id) {
+    return std::string(SHM_PREFIX) + std::to_string(model_id);
+}
+
+ModelConfigManager::ModelConfigManager() noexcept
+    : macro_registry_(new ModelMacroRegistry()) {}
+
+ModelConfigManager::~ModelConfigManager() {
+    std::vector<uint64_t> ids = listModelIds();
+    for (uint64_t id : ids) {
+        removeModelConfig(id);
+    }
+    // remove macro_registry_ shm file
+    macro_registry_.reset();
+}
+
+ModelConfig* ModelConfigManager::addModelConfig() {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    constexpr int kMaxAttempts = 5;
+    for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
+        auto config = std::make_unique<ModelConfig>();
+        if (!config->setModelConfig()) {
+            return nullptr;
+        }
+        const uint64_t id = config->getModelId();
+        auto [it, inserted] = model_config_map_.try_emplace(id, std::move(config));
+        if (inserted) {
+            ++total_models_;
+            return it->second.get();
+        }
+    }
+    return nullptr;
+}
+
+void ModelConfigManager::removeModelConfig(uint64_t model_id) {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = model_config_map_.find(model_id);
+    if (it != model_config_map_.end()) {
+        const int32_t npuid = it->second->messageSpace().model_npuid;
+        it->second->unlinkMessageShm();
+        model_config_map_.erase(it);
+        if (total_models_ > 0) {
+            --total_models_;
+        }
+        if (npuid != kInvalidModelHandle) {
+            current_model_npuids_.erase(
+                std::remove(current_model_npuids_.begin(), current_model_npuids_.end(), npuid),
+                current_model_npuids_.end());
+        }
+    }
+}
+
+ModelConfig* ModelConfigManager::getModelConfig(uint64_t model_id) {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = model_config_map_.find(model_id);
+    return it != model_config_map_.end() ? it->second.get() : nullptr;
+}
+
+bool ModelConfigManager::isModelDone(uint64_t model_id) {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = model_config_map_.find(model_id);
+    if (it == model_config_map_.end()) {
+        return false;
+    }
+    it->second->syncMessageSpaceFromShm();
+    ModelMessageSpace& space = it->second->messageSpace();
+    if (space.state != MessageState::DONE) {
+        return false;
+    }
+    it->second->setState(ModelState::DONE);
+    return true;
+}
+
+bool ModelConfigManager::updateModelState(uint64_t model_id, ModelState new_state) {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = model_config_map_.find(model_id);
+    if (it == model_config_map_.end()) {
+        return false;
+    }
+    it->second->setState(new_state);
+    return true;
+}
+
+ModelState ModelConfigManager::getModelState(uint64_t model_id) const noexcept {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = model_config_map_.find(model_id);
+    if (it == model_config_map_.end()) {
+        return ModelState::INVALID;
+    }
+    return it->second->getState();
+}
+
+ModelMacroSpace* ModelConfigManager::macroSpace() const noexcept {
+    return macro_registry_ ? macro_registry_->data() : nullptr;
+}
+
+std::vector<uint64_t> ModelConfigManager::listModelIds() const {
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    std::vector<uint64_t> ids;
+    ids.reserve(model_config_map_.size());
+    for (const auto& kv : model_config_map_) {
+        ids.push_back(kv.first);
+    }
+    return ids;
+}
+
+
+ModelConfig* ModelConfigManager::registerModelFromMacro() {
+    if (!macro_registry_ || !macro_registry_->hasPendingRegistration()) {
+        return nullptr;
+    }
+    ModelMacroSpace* macro_space = macro_registry_->data();
+    if (!macro_space) {
+        return nullptr;
+    }
+    ModelConfig* config = addModelConfig();
+    if (!config) {
+        return nullptr;
+    }
+    const uint64_t model_id = config->getModelId();
+    bool setup_ok = config->openAndMapMessageShm(true);
+    if (setup_ok) {
+        ModelMessageSpace& space = config->messageSpace();
+        space = ModelMessageSpace{};
+        space.setShmName(config->message_shm_name_);
+        space.model_npuid = macro_space->current_model_npuid;
+        space.model_osid = macro_space->current_model_osid;
+        space.state = MessageState::REQUEST_REGISTER;
+        setup_ok = config->syncMessageSpaceToShm();
+    }
+
+    if (!setup_ok) {
+        if (macro_registry_) {
+            macro_registry_->writeShmName(defaultShmName());
+        }
+        removeModelConfig(model_id);
+        return nullptr;
+    }
+
+    macro_registry_->writeShmName(config->message_shm_name_);
+
+    // update current npu id list; set all to pidShare
+    {
+        std::lock_guard<std::mutex> guard(map_mutex_);
+        ModelMessageSpace& space = config->messageSpace();
+        if (space.model_npuid != kInvalidModelHandle) {
+            auto pos = std::find(current_model_npuids_.begin(), current_model_npuids_.end(), space.model_npuid);
+            if (pos == current_model_npuids_.end()) {
+                current_model_npuids_.push_back(space.model_npuid);
+            }
+        }
+    }
+    
+    return config;
+}
+
+} // namespace mdaemon

--- a/daemon/daemon/py_monitor/command_queue.py
+++ b/daemon/daemon/py_monitor/command_queue.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import queue
+
+from py_monitor.control_api import ControlCommand
+
+
+class MonitorCommandQueue:
+    def __init__(self) -> None:
+        self._q: "queue.Queue[ControlCommand]" = queue.Queue()
+
+    @property
+    def queue(self) -> "queue.Queue[ControlCommand]":
+        return self._q

--- a/daemon/daemon/py_monitor/control_api.py
+++ b/daemon/daemon/py_monitor/control_api.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable, Dict, Optional
+
+
+@dataclass
+class ControlCommand:
+    action: str
+    payload: Dict[str, Any]
+    response_queue: "queue.Queue[Dict[str, Any]]"
+
+
+class ControlApiServer:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        command_queue: "queue.Queue[ControlCommand]",
+        snapshot_provider: Callable[[], list],
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._command_queue = command_queue
+        self._snapshot_provider = snapshot_provider
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._server is not None:
+            return
+
+        command_queue = self._command_queue
+        snapshot_provider = self._snapshot_provider
+
+        class Handler(BaseHTTPRequestHandler):
+            def _json(self, code: int, body: Dict[str, Any]) -> None:
+                raw = json.dumps(body).encode("utf-8")
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def _read_json(self) -> Dict[str, Any]:
+                length = int(self.headers.get("Content-Length", "0"))
+                if length <= 0:
+                    raise ValueError("empty request body")
+                raw = self.rfile.read(length)
+                data = json.loads(raw.decode("utf-8"))
+                if not isinstance(data, dict):
+                    raise ValueError("request body must be a JSON object")
+                return data
+
+            def _enqueue(self, action: str, payload: Dict[str, Any]) -> None:
+                resp_q: "queue.Queue[Dict[str, Any]]" = queue.Queue(maxsize=1)
+                command_queue.put(ControlCommand(action=action, payload=payload, response_queue=resp_q))
+                try:
+                    result = resp_q.get(timeout=5.0)
+                except queue.Empty:
+                    self._json(504, {"ok": False, "error": "command timeout"})
+                    return
+                status = int(result.get("status", 200))
+                self._json(status, result)
+
+            def do_GET(self) -> None:  # noqa: N802
+                if self.path == "/healthz":
+                    self._json(200, {"ok": True, "ts": int(time.time())})
+                    return
+                if self.path == "/v1/pools":
+                    pools = []
+                    for snap in snapshot_provider():
+                        pools.append(
+                            {
+                                "device_id": int(snap.device_id),
+                                "granularity": int(snap.granularity),
+                                "total_handles": int(snap.total_handles),
+                                "used_handles": int(snap.used_handles),
+                                "available_handles": int(snap.available_handles),
+                                "total_bytes": int(snap.total_bytes),
+                                "used_bytes": int(snap.used_bytes),
+                                "available_bytes": int(snap.available_bytes),
+                            }
+                        )
+                    self._json(200, {"ok": True, "pools": pools})
+                    return
+                self._json(404, {"ok": False, "error": "not found"})
+
+            def do_POST(self) -> None:  # noqa: N802
+                try:
+                    payload = self._read_json()
+                except Exception as exc:
+                    self._json(400, {"ok": False, "error": str(exc)})
+                    return
+
+                if self.path == "/v1/pools/create":
+                    self._enqueue("create", payload)
+                    return
+                if self.path == "/v1/pools/extend":
+                    self._enqueue("extend", payload)
+                    return
+                if self.path == "/v1/pools/remove":
+                    self._enqueue("remove", payload)
+                    return
+
+                self._json(404, {"ok": False, "error": "not found"})
+
+            def log_message(self, format: str, *args: Any) -> None:
+                return
+
+        self._server = ThreadingHTTPServer((self._host, self._port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._server = None
+        self._thread = None
+
+
+def parse_int_field(payload: Dict[str, Any], key: str, minimum: int = 0) -> int:
+    if key not in payload:
+        raise ValueError(f"missing field: {key}")
+    value = int(payload[key])
+    if value < minimum:
+        raise ValueError(f"{key} must be >= {minimum}")
+    return value

--- a/daemon/daemon/py_monitor/daemon_monitor.py
+++ b/daemon/daemon/py_monitor/daemon_monitor.py
@@ -1,0 +1,1078 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import collections
+import math
+import queue
+import time
+from typing import Callable, Deque, Dict, Iterable, List, Optional, Tuple
+
+from rich.table import Table
+from rich.text import Text
+
+from py_monitor.control_api import ControlApiServer, ControlCommand, parse_int_field
+from py_monitor.env_config import env_float, env_scaled_size
+from py_monitor.models import PoolSpec, PoolTuneOverride
+from py_monitor.parsing import parse_gb_to_bytes, parse_mb_to_bytes, parse_pool_key, parse_pool_spec
+from py_monitor.units import GB, MB, fmt_bytes
+
+
+def _safe_enum_name(value) -> str:
+    # pybind enums stringify inconsistently across versions; be defensive.
+    if hasattr(value, "name"):
+        return str(value.name)
+    text = str(value)
+    # textual prints like 'ModelState.REGISTERED'
+    if "." in text:
+        return text.split(".")[-1]
+    return text
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="mdaemon monitor (nvitop-like TUI for multimodel daemon)")
+    parser.add_argument(
+        "--pool",
+        action="append",
+        type=parse_pool_spec,
+        default=[],
+        help=(
+            "Initial pool spec device:granularity_mb:total_gb[:cap_gb] (repeatable). "
+            "Examples: --pool 0:16:4 --pool 1:16:4:12. "
+            "If cap_gb is omitted, only MDAEMON_DEVICE_TOTAL_CAP_GB is applied."
+        ),
+    )
+    parser.add_argument("--refresh-ms", type=int, default=500, help="UI refresh interval in milliseconds. Default: 500ms")
+    parser.add_argument(
+        "--sync-model-shm",
+        action="store_true",
+        help="If set, calls snapshot_models(sync=True) to sync from shared memory each refresh",
+    )
+    parser.add_argument(
+        "--control-enable",
+        action="store_true",
+        help="Enable localhost HTTP control API for pool operations",
+    )
+    parser.add_argument(
+        "--control-host",
+        type=str,
+        default="127.0.0.1",
+        help="Control API bind host (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--control-port",
+        type=int,
+        default=18080,
+        help="Control API bind port (default: 18080)",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    if not args.pool:
+        raise SystemExit("At least one --pool is required. Example: --pool 0:16:4 or --pool 0:16:4:10")
+
+    try:
+        import mdaemon_py  # type: ignore
+    except Exception as exc:
+        raise SystemExit(
+            "Failed to import mdaemon_py. Build it first in multimodel/daemon via ./build_pybind.sh\n"
+            f"Import error: {exc}"
+        )
+
+    from textual.app import App, ComposeResult, SystemCommand
+    from textual.containers import Horizontal, Vertical, VerticalScroll
+    from textual.screen import ModalScreen
+    from textual.widgets import DataTable, Header, Input, Label, RichLog, Static
+
+    class PromptInputScreen(ModalScreen[Optional[str]]):
+        def __init__(self, title: str, help_text: str,
+                     placeholder: str) -> None:
+            super().__init__()
+            self._title = title
+            self._help_text = help_text
+            self._placeholder = placeholder
+
+        CSS = """
+        PromptInputScreen {
+            align: center middle;
+            background: rgba(0, 0, 0, 0.55);
+        }
+        #prompt_box {
+            width: 84;
+            height: auto;
+            border: round #4ea1ff;
+            padding: 1 2;
+            background: #111a2e;
+        }
+        #prompt_title {
+            color: #7be3ff;
+            text-style: bold;
+        }
+        #prompt_help {
+            color: #b6c7ff;
+            margin: 1 0;
+        }
+        #prompt_input {
+            margin-top: 1;
+        }
+        """
+
+        def compose(self) -> ComposeResult:
+            with Vertical(id="prompt_box"):
+                yield Static(self._title, id="prompt_title")
+                yield Static(self._help_text, id="prompt_help")
+                yield Input(placeholder=self._placeholder, id="prompt_input")
+
+        def on_mount(self) -> None:
+            self.query_one("#prompt_input", Input).focus()
+
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            self.dismiss(event.value)
+
+        def on_key(self, event) -> None:
+            if event.key == "escape":
+                self.dismiss(None)
+
+    class PoolRow(Static):
+        def __init__(self, key: Tuple[int, int]):
+            super().__init__(classes="pool-row")
+            self.key = key
+            self.label = Label("")
+            self.bar = Static("", classes="pool-bar")
+            self.right = Label("")
+
+        @staticmethod
+        def _render_bar(used_h: int, total_h: int, width: int, height: int = 2) -> Text:
+            total = max(1, total_h)
+            ratio = max(0.0, min(1.0, used_h / total))
+            filled = int(round(ratio * width))
+            empty = max(0, width - filled)
+
+            bar_text = Text()
+            for row in range(height):
+                row_text = Text()
+                if filled > 0:
+                    row_text.append("█" * filled, style="bold #3ad47a")
+                if empty > 0:
+                    row_text.append("░" * empty, style="#3b4f78")
+                bar_text.append_text(row_text)
+                if row < height - 1:
+                    bar_text.append("\n")
+            return bar_text
+
+        def compose(self) -> ComposeResult:
+            yield Horizontal(self.label, self.bar, self.right)
+
+        def update_from_snapshot(self, snap) -> None:
+            gran = int(snap.granularity)
+            dev = int(snap.device_id)
+            total_h = int(snap.total_handles)
+            used_h = int(snap.used_handles)
+            avail_b = int(snap.available_bytes)
+            total_b = int(snap.total_bytes)
+
+            self.label.update(f"dev{dev}  {gran // MB:>4}MB")
+
+            # Responsive width: use current rendered bar widget width.
+            # Fallback keeps first paint stable before layout finalizes.
+            bar_width = max(10, int(getattr(self.bar.size, "width", 0) or 34) - 1)
+            self.bar.update(
+                self._render_bar(used_h=used_h, total_h=total_h, width=bar_width)
+            )
+
+            used_b = int(snap.used_bytes)
+            ratio = (used_h / max(1, total_h)) * 100.0
+            self.right.update(
+                f"{ratio:5.1f}%  |  used {fmt_bytes(used_b):>8} / total {fmt_bytes(total_b):>8}  |  avail {fmt_bytes(avail_b):>8}"
+            )
+
+    class DaemonMonitor(App):
+        BINDINGS = [
+            ("q", "quit", "Quit"),
+            ("ctrl+p", "open_palette", "Palette"),
+            ("ctrl+shift+1", "pool_set_cap", "Set Pool Cap (local)"),
+            ("ctrl+shift+2", "pool_set_tuning", "Set Pool Auto-Tuning (local)"),
+            ("ctrl+shift+3", "pool_create", "Create Pool (local)"),
+            ("ctrl+shift+4", "pool_show_info", "Show Pool Runtime Info (local)"),
+        ]
+        CSS = """
+        Screen {
+            background: #0b1020;
+            color: #d7e3ff;
+        }
+
+        #pools {
+            width: 58%;
+            border: round #4ea1ff;
+            padding: 0 1;
+            margin: 0 1 0 0;
+            background: #121a33;
+        }
+
+        #right_col {
+            width: 42%;
+            height: 1fr;
+        }
+
+        #models {
+            border: round #67d17a;
+            background: #111a2e;
+            height: 58%;
+            margin: 0 0 1 0;
+        }
+
+        #messages {
+            border: round #ffb454;
+            background: #111a2e;
+            height: 42%;
+            padding: 0 1;
+        }
+
+        #status_bar {
+            dock: bottom;
+            height: 1;
+            background: #1b2440;
+            padding: 0 1;
+        }
+
+        #status {
+            width: 1fr;
+            color: #7be3ff;
+            text-style: bold;
+        }
+
+        #help {
+            width: auto;
+            color: #b6c7ff;
+            content-align: right middle;
+        }
+
+        .pool-row {
+            height: 3;
+            border: round #3f5d8f;
+            padding: 0 1;
+            margin: 0 0 1 0;
+            background: #192544;
+        }
+
+        .pool-bar {
+            width: 1fr;
+            margin: 0 1;
+        }
+        """
+
+        def __init__(
+            self,
+            daemon,
+            pool_specs: List[PoolSpec],
+            refresh_ms: int,
+            sync_model_shm: bool,
+            control_enable: bool,
+            control_host: str,
+            control_port: int,
+        ):
+            super().__init__()
+            self.daemon = daemon
+            self.pool_specs = pool_specs
+            self.refresh_ms = refresh_ms
+            self.sync_model_shm = sync_model_shm
+            self.control_enable = control_enable
+            self.control_host = control_host
+            self.control_port = control_port
+            self.pool_caps: Dict[Tuple[int, int], int] = {
+                (int(spec.device_id), int(spec.granularity_bytes)): int(spec.cap_bytes)
+                for spec in pool_specs
+            }
+            self.pool_tune_overrides: Dict[Tuple[int, int], PoolTuneOverride] = {}
+            self._known_pools: set[Tuple[int, int]] = set(self.pool_caps.keys())
+            self._pending_cap_pool: Optional[Tuple[int, int]] = None
+            self._pending_tune_pool: Optional[Tuple[int, int]] = None
+            self._pending_create_pool: Optional[Tuple[int, int]] = None
+
+            self.pool_rows: Dict[Tuple[int, int], PoolRow] = {}
+            self.prev_model_msg_states: Dict[int, str] = {}
+            self.message_lines: Deque[Tuple[str, str]] = collections.deque(maxlen=400)
+            self.last_action = ""
+            self.control_cmd_q: "queue.Queue[ControlCommand]" = queue.Queue()
+            self.control_api: Optional[ControlApiServer] = None
+
+        def compose(self) -> ComposeResult:
+            yield Header()
+            with Horizontal():
+                self.pools_view = VerticalScroll(id="pools")
+                yield self.pools_view
+                with Vertical(id="right_col"):
+                    self.models_table = DataTable(id="models")
+                    self.messages_log = RichLog(id="messages", wrap=True, auto_scroll=True)
+                    yield self.models_table
+                    yield self.messages_log
+            with Horizontal(id="status_bar"):
+                self.status = Label("", id="status")
+                self.help = Label("Palette: Ctrl+P | Quit: Q", id="help")
+                yield self.status
+                yield self.help
+
+        def on_mount(self) -> None:
+            for spec in self.pool_specs:
+                self.daemon.initialize_handle_pool_device(
+                    int(spec.granularity_bytes), int(spec.device_id), int(spec.total_bytes)
+                )
+            self.daemon.start()
+
+            self.pools_view.border_title = " Handle Pools "
+            self.models_table.border_title = " Models "
+            self.messages_log.border_title = " Messages "
+            self.models_table.zebra_stripes = True
+
+            self.models_table.add_columns(
+                "model_id",
+                "state",
+                "msg",
+                "npuid",
+                "osid",
+                "alloc",
+                "handles",
+            )
+            self._append_message("info", "monitor started")
+            if self.control_enable:
+                self.control_api = ControlApiServer(
+                    host=self.control_host,
+                    port=self.control_port,
+                    command_queue=self.control_cmd_q,
+                    snapshot_provider=self.daemon.snapshot_handle_pools,
+                )
+                self.control_api.start()
+                self._append_message(
+                    "info",
+                    f"control API enabled at http://{self.control_host}:{self.control_port}",
+                )
+            self._set_status("initializing monitor...")
+            self.set_interval(self.refresh_ms / 1000.0, self._refresh)
+
+        def on_unmount(self) -> None:
+            if self.control_api is not None:
+                try:
+                    self.control_api.stop()
+                except Exception:
+                    pass
+            try:
+                self.daemon.stop()
+            except Exception:
+                pass
+
+        def _drain_control_commands(self) -> None:
+            while True:
+                try:
+                    cmd = self.control_cmd_q.get_nowait()
+                except queue.Empty:
+                    break
+
+                try:
+                    def _find_pool_snapshot(dev: int, gran: int):
+                        for snap in self.daemon.snapshot_handle_pools():
+                            if int(snap.device_id) == dev and int(snap.granularity) == gran:
+                                return snap
+                        return None
+
+                    if cmd.action == "create":
+                        dev = parse_int_field(cmd.payload, "device_id", 0)
+                        gran = parse_int_field(cmd.payload, "granularity", 1)
+                        total_bytes = parse_int_field(cmd.payload, "total_bytes", 1)
+                        cap_bytes = int(cmd.payload.get("cap_bytes", 0))
+                        if cap_bytes < 0:
+                            raise ValueError("cap_bytes must be >= 0")
+                        if cap_bytes > 0 and cap_bytes < total_bytes:
+                            raise ValueError("cap_bytes must be >= total_bytes")
+                        pool_key = (dev, gran)
+                        if self._pool_exists(pool_key):
+                            cmd.response_queue.put({"ok": False, "status": 409, "error": "pool already exists"})
+                            continue
+                        self.daemon.initialize_handle_pool_device(int(gran), int(dev), int(total_bytes))
+                        self._known_pools.add(pool_key)
+                        if cap_bytes > 0:
+                            self.pool_caps[pool_key] = cap_bytes
+                        self._append_message("info", f"api create pool {self._pool_text(pool_key)} total={fmt_bytes(total_bytes)}")
+                        cmd.response_queue.put({
+                            "ok": True,
+                            "status": 200,
+                            "device_id": dev,
+                            "granularity": gran,
+                            "total_bytes": total_bytes,
+                            "cap_bytes": cap_bytes,
+                        })
+                        continue
+
+                    if cmd.action in ("extend", "remove"):
+                        dev = parse_int_field(cmd.payload, "device_id", 0)
+                        gran = parse_int_field(cmd.payload, "granularity", 1)
+                        target_bytes = parse_int_field(cmd.payload, "target_bytes", 1)
+                        pool_key = (dev, gran)
+                        if not self._pool_exists(pool_key):
+                            cmd.response_queue.put({"ok": False, "status": 404, "error": "pool not found"})
+                            continue
+                        snap = _find_pool_snapshot(dev, gran)
+                        if snap is None:
+                            cmd.response_queue.put({"ok": False, "status": 404, "error": "pool snapshot not found"})
+                            continue
+                        current_total_bytes = int(snap.total_bytes)
+                        if cmd.action == "extend" and target_bytes <= current_total_bytes:
+                            cmd.response_queue.put(
+                                {
+                                    "ok": False,
+                                    "status": 409,
+                                    "error": (
+                                        f"extend target_bytes {target_bytes} is not above current total "
+                                        f"{current_total_bytes}"
+                                    ),
+                                }
+                            )
+                            continue
+                        if cmd.action == "remove" and target_bytes >= current_total_bytes:
+                            cmd.response_queue.put(
+                                {
+                                    "ok": False,
+                                    "status": 409,
+                                    "error": (
+                                        f"remove target_bytes {target_bytes} is not below current total "
+                                        f"{current_total_bytes}"
+                                    ),
+                                }
+                            )
+                            continue
+
+                        delta_bytes = abs(target_bytes - current_total_bytes)
+                        count = int(math.ceil(delta_bytes / max(1, gran)))
+                        if count <= 0:
+                            cmd.response_queue.put(
+                                {
+                                    "ok": False,
+                                    "status": 200,
+                                    "message": "no-op: target does not require handle change",
+                                    "current_total_bytes": current_total_bytes,
+                                    "target_bytes": target_bytes,
+                                }
+                            )
+                            continue
+
+                        if cmd.action == "extend":
+                            ok = bool(self.daemon.extend_handles(gran, dev, count))
+                        else:
+                            ok = bool(self.daemon.remove_handles(gran, dev, count))
+                        self._append_message(
+                            "info",
+                            f"api {cmd.action} {self._pool_text(pool_key)} target={fmt_bytes(target_bytes)} count={count} -> {ok}",
+                        )
+                        cmd.response_queue.put(
+                            {
+                                "ok": bool(ok),
+                                "status": 200 if ok else 409,
+                                "device_id": dev,
+                                "granularity": gran,
+                                "count": count,
+                                "current_total_bytes": current_total_bytes,
+                                "target_bytes": target_bytes,
+                                "action": cmd.action,
+                            }
+                        )
+                        continue
+
+                    cmd.response_queue.put({"ok": False, "status": 400, "error": f"unknown action: {cmd.action}"})
+                except Exception as exc:
+                    cmd.response_queue.put({"ok": False, "status": 400, "error": str(exc)})
+
+        def action_open_palette(self) -> None:
+            if hasattr(self, "action_command_palette"):
+                self.action_command_palette()
+                return
+            self._set_status(
+                "error: command palette is not available in this Textual version; update textual and retry"
+                ,
+                is_error=True,
+            )
+
+        def action_pool_set_cap(self) -> None:
+            """Set Pool Cap (local): dev:gran:new_cap or guided dev:gran then cap."""
+            self._pending_cap_pool = None
+            self._prompt_for_pool_cap_first()
+
+        def action_pool_set_tuning(self) -> None:
+            """Set Pool Auto-Tuning (local): dev:gran:extend:ex_step:remove:rm_step or guided."""
+            self._pending_tune_pool = None
+            self._prompt_for_pool_tuning_first()
+
+        def action_pool_create(self) -> None:
+            """Create Pool (local): dev:gran:init:cap or guided dev:gran then init:cap."""
+            self._pending_create_pool = None
+            self._prompt_for_pool_create_first()
+
+        def action_pool_show_info(self) -> None:
+            """Show Pool Runtime Info (local): cap and tuning overrides/effective values."""
+            extend_threshold = env_scaled_size("MDAEMON_EXTEND_THRESHOLD_inGB", 1, GB)
+            remove_threshold = env_scaled_size("MDAEMON_REMOVE_THRESHOLD_inGB", 2, GB)
+            extend_bytes = env_scaled_size("MDAEMON_EXTEND_BYTES_inMB", 256, MB)
+            remove_bytes = env_scaled_size("MDAEMON_REMOVE_BYTES_inMB", 512, MB)
+
+            pools = sorted(self._known_pools, key=lambda x: (x[0], x[1]))
+            if not pools:
+                self._set_status("no known pools yet", is_error=False)
+                self._append_message("info", "pool info: no known pools yet")
+                return
+
+            table = Table(title="Pool Runtime Info", header_style="bold #7be3ff")
+            table.add_column("Pool", style="#d7e3ff")
+            table.add_column("Cap(local)", style="#d7e3ff")
+            table.add_column("Override(local)", style="#d7e3ff")
+            table.add_column("Effective Tuning", style="#d7e3ff")
+
+            for dev, gran in pools:
+                pool_key = (dev, gran)
+                cap_bytes = int(self.pool_caps.get(pool_key, 0))
+                cap_text = "none" if cap_bytes <= 0 else fmt_bytes(cap_bytes)
+
+                override = self.pool_tune_overrides.get(pool_key)
+                if override is None:
+                    ov_text = "none"
+                    eff_extend = extend_threshold
+                    eff_ex_step = extend_bytes
+                    eff_remove = remove_threshold
+                    eff_rm_step = remove_bytes
+                else:
+                    ov_text = (
+                        f"extend={fmt_bytes(override.extend_threshold_bytes)} "
+                        f"step={fmt_bytes(override.extend_step_bytes)} "
+                        f"remove={fmt_bytes(override.remove_threshold_bytes)} "
+                        f"step={fmt_bytes(override.remove_step_bytes)}"
+                    )
+                    eff_extend = override.extend_threshold_bytes
+                    eff_ex_step = override.extend_step_bytes
+                    eff_remove = override.remove_threshold_bytes
+                    eff_rm_step = override.remove_step_bytes
+
+                eff_text = (
+                    f"extend={fmt_bytes(eff_extend)} "
+                    f"step={fmt_bytes(eff_ex_step)} "
+                    f"remove={fmt_bytes(eff_remove)} "
+                    f"step={fmt_bytes(eff_rm_step)}"
+                )
+
+                table.add_row(f"dev{dev}:{gran // MB}MB", cap_text, ov_text, eff_text)
+
+            self.messages_log.write(table)
+
+            self.last_action = f"listed {len(pools)} pool runtime configs"
+
+        def get_system_commands(self, screen) -> Iterable[SystemCommand]:
+            # Register pool management actions so they are discoverable in Ctrl+P.
+            yield from super().get_system_commands(screen)
+            yield SystemCommand(
+                "Set Pool Cap (local)",
+                "Set per-pool cap override used only by this monitor process",
+                self.action_pool_set_cap,
+            )
+            yield SystemCommand(
+                "Set Pool Auto-Tuning (local)",
+                "Set per-pool extend/remove thresholds and steps for this monitor",
+                self.action_pool_set_tuning,
+            )
+            yield SystemCommand(
+                "Create Pool (local)",
+                "Create a pool via monitor and attach local cap metadata",
+                self.action_pool_create,
+            )
+            yield SystemCommand(
+                "Show Pool Runtime Info (local)",
+                "Show local cap/tuning overrides and effective runtime values",
+                self.action_pool_show_info,
+            )
+
+        def _prompt(self, title: str, help_text: str, placeholder: str,
+                    callback: Callable[[Optional[str]], None]) -> None:
+            self.push_screen(PromptInputScreen(title, help_text, placeholder), callback)
+
+        def _pool_exists(self, pool_key: Tuple[int, int]) -> bool:
+            return pool_key in self._known_pools
+
+        def _pool_text(self, pool_key: Tuple[int, int]) -> str:
+            dev, gran = pool_key
+            return f"dev{dev}:{gran // MB}MB"
+
+        def _parse_tuning_values(self, text: str) -> PoolTuneOverride:
+            parts = [p.strip() for p in text.split(":")]
+            if len(parts) != 4:
+                raise ValueError("expected extend:extend_step:remove:remove_step")
+            extend_threshold = parse_gb_to_bytes(parts[0])
+            extend_step = parse_mb_to_bytes(parts[1])
+            remove_threshold = parse_gb_to_bytes(parts[2])
+            remove_step = parse_mb_to_bytes(parts[3])
+            return PoolTuneOverride(
+                extend_threshold_bytes=extend_threshold,
+                extend_step_bytes=extend_step,
+                remove_threshold_bytes=remove_threshold,
+                remove_step_bytes=remove_step,
+            )
+
+        def _prompt_for_pool_cap_first(self) -> None:
+            self._prompt(
+                "Set Pool Cap (local override)",
+                "Input full: dev:gran_mb:new_cap_gb\n"
+                "or input pool: dev:gran_mb then next step input cap.\n"
+                "Examples: 0:4:5 , 0:4:5GB",
+                "dev:gran[:cap]",
+                self._on_pool_cap_first,
+            )
+
+        def _on_pool_cap_first(self, value: Optional[str]) -> None:
+            if value is None:
+                return
+            text = value.strip()
+            if not text:
+                self._set_status("empty input for pool cap", is_error=True)
+                return
+            try:
+                parts = [p.strip() for p in text.split(":")]
+                if len(parts) == 3:
+                    pool_key = parse_pool_key(":".join(parts[:2]))
+                    if not self._pool_exists(pool_key):
+                        self._set_status(f"unknown pool {parts[0]}:{parts[1]}", is_error=True)
+                        return
+                    cap_bytes = parse_gb_to_bytes(parts[2])
+                    self.pool_caps[pool_key] = cap_bytes
+                    self.last_action = (
+                        f"set cap {self._pool_text(pool_key)} -> {fmt_bytes(cap_bytes)} (local)"
+                    )
+                    self._append_message("info", self.last_action)
+                    return
+
+                if len(parts) == 2:
+                    pool_key = parse_pool_key(text)
+                    if not self._pool_exists(pool_key):
+                        self._set_status(f"unknown pool {parts[0]}:{parts[1]}", is_error=True)
+                        return
+                    self._pending_cap_pool = pool_key
+                    self._prompt(
+                        f"Set Cap for {self._pool_text(pool_key)}",
+                        "Input cap in GB. If no unit, GB is assumed.\n"
+                        "Examples: 5, 5GB, 4.5GB",
+                        "new_cap",
+                        self._on_pool_cap_second,
+                    )
+                    return
+                raise ValueError("expected dev:gran or dev:gran:cap")
+            except Exception as exc:
+                self._set_status(f"invalid pool cap input: {exc}", is_error=True)
+
+        def _on_pool_cap_second(self, value: Optional[str]) -> None:
+            if value is None:
+                self._pending_cap_pool = None
+                return
+            pool_key = self._pending_cap_pool
+            self._pending_cap_pool = None
+            if pool_key is None:
+                self._set_status("missing selected pool for cap update", is_error=True)
+                return
+            try:
+                cap_bytes = parse_gb_to_bytes(value.strip())
+                self.pool_caps[pool_key] = cap_bytes
+                self.last_action = (
+                    f"set cap {self._pool_text(pool_key)} -> {fmt_bytes(cap_bytes)} (local)"
+                )
+                self._append_message("info", self.last_action)
+            except Exception as exc:
+                self._set_status(f"invalid cap value: {exc}", is_error=True)
+
+        def _prompt_for_pool_tuning_first(self) -> None:
+            self._prompt(
+                "Set Pool Auto-Tuning (local override)",
+                "Input full: dev:gran_mb:extend:extend_step:remove:remove_step\n"
+                "or input pool: dev:gran_mb then next step tuning values.\n"
+                "Defaults when no unit: extend/remove in GB, steps in MB.\n"
+                "Examples: 0:4:1GB:200MB:2GB:200MB or 0:4:1:200:2:200",
+                "dev:gran[:extend:step:remove:step]",
+                self._on_pool_tuning_first,
+            )
+
+        def _on_pool_tuning_first(self, value: Optional[str]) -> None:
+            if value is None:
+                return
+            text = value.strip()
+            if not text:
+                self._set_status("empty input for pool tuning", is_error=True)
+                return
+            try:
+                parts = [p.strip() for p in text.split(":")]
+                if len(parts) == 6:
+                    pool_key = parse_pool_key(":".join(parts[:2]))
+                    if not self._pool_exists(pool_key):
+                        self._set_status(f"unknown pool {parts[0]}:{parts[1]}", is_error=True)
+                        return
+                    override = self._parse_tuning_values(":".join(parts[2:]))
+                    self.pool_tune_overrides[pool_key] = override
+                    self.last_action = (
+                        "set tuning "
+                        f"{self._pool_text(pool_key)} -> "
+                        f"extend={fmt_bytes(override.extend_threshold_bytes)} "
+                        f"step={fmt_bytes(override.extend_step_bytes)} "
+                        f"remove={fmt_bytes(override.remove_threshold_bytes)} "
+                        f"step={fmt_bytes(override.remove_step_bytes)} (local)"
+                    )
+                    self._append_message("info", self.last_action)
+                    return
+
+                if len(parts) == 2:
+                    pool_key = parse_pool_key(text)
+                    if not self._pool_exists(pool_key):
+                        self._set_status(f"unknown pool {parts[0]}:{parts[1]}", is_error=True)
+                        return
+                    self._pending_tune_pool = pool_key
+                    self._prompt(
+                        f"Set Tuning for {self._pool_text(pool_key)}",
+                        "Input extend:extend_step:remove:remove_step\n"
+                        "Defaults when no unit: GB:MB:GB:MB\n"
+                        "Examples: 1GB:200MB:2GB:200MB or 1:200:2:200",
+                        "extend:step:remove:step",
+                        self._on_pool_tuning_second,
+                    )
+                    return
+                raise ValueError("expected dev:gran or dev:gran:extend:step:remove:step")
+            except Exception as exc:
+                self._set_status(f"invalid pool tuning input: {exc}", is_error=True)
+
+        def _on_pool_tuning_second(self, value: Optional[str]) -> None:
+            if value is None:
+                self._pending_tune_pool = None
+                return
+            pool_key = self._pending_tune_pool
+            self._pending_tune_pool = None
+            if pool_key is None:
+                self._set_status("missing selected pool for tuning update", is_error=True)
+                return
+            try:
+                override = self._parse_tuning_values(value.strip())
+                self.pool_tune_overrides[pool_key] = override
+                self.last_action = (
+                    "set tuning "
+                    f"{self._pool_text(pool_key)} -> "
+                    f"extend={fmt_bytes(override.extend_threshold_bytes)} "
+                    f"step={fmt_bytes(override.extend_step_bytes)} "
+                    f"remove={fmt_bytes(override.remove_threshold_bytes)} "
+                    f"step={fmt_bytes(override.remove_step_bytes)} (local)"
+                )
+                self._append_message("info", self.last_action)
+            except Exception as exc:
+                self._set_status(f"invalid tuning value: {exc}", is_error=True)
+
+        def _prompt_for_pool_create_first(self) -> None:
+            self._prompt(
+                "Create Pool (local monitor setup)",
+                "Input full: dev:gran_mb:init_gb:cap_gb\n"
+                "or input pool: dev:gran_mb then next step init:cap.\n"
+                "Examples: 0:4:2:10 or 0:4:2GB:10GB",
+                "dev:gran:init:cap",
+                self._on_pool_create_first,
+            )
+
+        def _apply_create_pool(self, pool_key: Tuple[int, int], init_bytes: int,
+                               cap_bytes: int) -> bool:
+            if self._pool_exists(pool_key):
+                self._set_status(f"pool already exists: {self._pool_text(pool_key)}", is_error=True)
+                return False
+            dev, gran = pool_key
+            self.daemon.initialize_handle_pool_device(int(gran), int(dev), int(init_bytes))
+            self.pool_caps[pool_key] = cap_bytes
+            self._known_pools.add(pool_key)
+            self.last_action = (
+                f"create pool {self._pool_text(pool_key)} init={fmt_bytes(init_bytes)} "
+                f"cap={fmt_bytes(cap_bytes)} (local)"
+            )
+            self._append_message("info", self.last_action)
+            return True
+
+        def _on_pool_create_first(self, value: Optional[str]) -> None:
+            if value is None:
+                return
+            text = value.strip()
+            if not text:
+                self._set_status("empty input for create pool", is_error=True)
+                return
+            try:
+                parts = [p.strip() for p in text.split(":")]
+                if len(parts) == 4:
+                    pool_key = parse_pool_key(":".join(parts[:2]))
+                    init_bytes = parse_gb_to_bytes(parts[2])
+                    cap_bytes = parse_gb_to_bytes(parts[3])
+                    if cap_bytes < init_bytes:
+                        raise ValueError("cap must be >= init")
+                    self._apply_create_pool(pool_key, init_bytes, cap_bytes)
+                    return
+
+                if len(parts) == 2:
+                    pool_key = parse_pool_key(text)
+                    if self._pool_exists(pool_key):
+                        self._set_status(f"pool already exists: {self._pool_text(pool_key)}", is_error=True)
+                        return
+                    self._pending_create_pool = pool_key
+                    self._prompt(
+                        f"Create {self._pool_text(pool_key)}",
+                        "Input init:cap in GB. If no unit, GB is assumed.\n"
+                        "Examples: 2:10 or 2GB:10GB",
+                        "init:cap",
+                        self._on_pool_create_second,
+                    )
+                    return
+                raise ValueError("expected dev:gran or dev:gran:init:cap")
+            except Exception as exc:
+                self._set_status(f"invalid create input: {exc}", is_error=True)
+
+        def _on_pool_create_second(self, value: Optional[str]) -> None:
+            if value is None:
+                self._pending_create_pool = None
+                return
+            pool_key = self._pending_create_pool
+            self._pending_create_pool = None
+            if pool_key is None:
+                self._set_status("missing selected pool for create", is_error=True)
+                return
+            try:
+                parts = [p.strip() for p in value.strip().split(":")]
+                if len(parts) != 2:
+                    raise ValueError("expected init:cap")
+                init_bytes = parse_gb_to_bytes(parts[0])
+                cap_bytes = parse_gb_to_bytes(parts[1])
+                if cap_bytes < init_bytes:
+                    raise ValueError("cap must be >= init")
+                self._apply_create_pool(pool_key, init_bytes, cap_bytes)
+            except Exception as exc:
+                self._set_status(f"invalid init/cap value: {exc}", is_error=True)
+
+        def _append_message(self, level: str, message: str) -> None:
+            lvl = level.lower().strip() or "info"
+            ts = time.strftime("%H:%M:%S")
+            self.message_lines.append((lvl, f"{ts} [{lvl.upper():5}] {message}"))
+
+            if not self.is_mounted:
+                return
+
+            if lvl == "error":
+                style = "bold #ff5f7a"
+            elif lvl == "debug":
+                style = "#8ba0d6"
+            else:
+                style = "#d7e3ff"
+            self.messages_log.write(Text(self.message_lines[-1][1], style=style))
+
+        def _append_daemon_line(self, line: str) -> None:
+            if "[ERROR]" in line:
+                lvl = "error"
+                style = "bold #ff5f7a"
+            elif "[DEBUG]" in line:
+                lvl = "debug"
+                style = "#8ba0d6"
+            else:
+                lvl = "info"
+                style = "#d7e3ff"
+
+            self.message_lines.append((lvl, line))
+            if self.is_mounted:
+                self.messages_log.write(Text(line, style=style))
+
+        def _set_status(self, message: str, is_error: bool = False) -> None:
+            status = self.query_one("#status", Label)
+            status.styles.color = "#ff5f7a" if is_error else "#7be3ff"
+            status.update(message)
+            if is_error:
+                self._append_message("error", message)
+
+        def _auto_tune(self, pool_snaps: Iterable) -> None:
+            extend_threshold = env_scaled_size("MDAEMON_EXTEND_THRESHOLD_inGB", 1, GB)
+            remove_threshold = env_scaled_size("MDAEMON_REMOVE_THRESHOLD_inGB", 2, GB)
+            extend_bytes = env_scaled_size("MDAEMON_EXTEND_BYTES_inMB", 256, MB)
+            remove_bytes = env_scaled_size("MDAEMON_REMOVE_BYTES_inMB", 512, MB)
+            # Optional hard cap in GB from env. 0 means unlimited.
+            per_device_total_cap_gb = env_float("MDAEMON_DEVICE_TOTAL_CAP_GB", 0.0)
+            per_device_total_cap = int(per_device_total_cap_gb * GB)
+
+            snaps = list(pool_snaps)
+            per_device_total: Dict[int, int] = collections.defaultdict(int)
+            for snap in snaps:
+                per_device_total[int(snap.device_id)] += int(snap.total_bytes)
+
+            for snap in snaps:
+                gran = int(snap.granularity)
+                dev = int(snap.device_id)
+                avail_b = int(snap.available_bytes)
+                avail_h = int(snap.available_handles)
+                self._known_pools.add((dev, gran))
+
+                tuning_override = self.pool_tune_overrides.get((dev, gran))
+                pool_extend_threshold = (
+                    tuning_override.extend_threshold_bytes
+                    if tuning_override is not None
+                    else extend_threshold
+                )
+                pool_extend_step = (
+                    tuning_override.extend_step_bytes
+                    if tuning_override is not None
+                    else extend_bytes
+                )
+                pool_remove_threshold = (
+                    tuning_override.remove_threshold_bytes
+                    if tuning_override is not None
+                    else remove_threshold
+                )
+                pool_remove_step = (
+                    tuning_override.remove_step_bytes
+                    if tuning_override is not None
+                    else remove_bytes
+                )
+
+                if avail_b < pool_extend_threshold:
+                    count = int(math.ceil(pool_extend_step / max(1, gran)))
+
+                    pool_cap = int(self.pool_caps.get((dev, gran), 0))
+                    effective_pool_cap = pool_cap
+                    if per_device_total_cap > 0:
+                        effective_pool_cap = (
+                            min(pool_cap, per_device_total_cap)
+                            if pool_cap > 0
+                            else per_device_total_cap
+                        )
+
+                    pool_total = int(snap.total_bytes)
+                    if effective_pool_cap > 0:
+                        if pool_total >= effective_pool_cap:
+                            self.last_action = (
+                                f"extend skipped dev{dev} {gran // MB}MB: "
+                                f"pool total {fmt_bytes(pool_total)} >= cap {fmt_bytes(effective_pool_cap)}"
+                            )
+                            self._append_message("debug", self.last_action)
+                            continue
+
+                        pool_remaining = effective_pool_cap - pool_total
+                        max_count_by_pool_cap = int(pool_remaining // max(1, gran))
+                        if max_count_by_pool_cap <= 0:
+                            self.last_action = (
+                                f"extend skipped dev{dev} {gran // MB}MB: "
+                                f"remaining pool cap {fmt_bytes(pool_remaining)} < one handle {fmt_bytes(gran)}"
+                            )
+                            self._append_message("debug", self.last_action)
+                            continue
+                        if count > max_count_by_pool_cap:
+                            count = max_count_by_pool_cap
+
+                    if per_device_total_cap > 0:
+                        used_total = int(per_device_total.get(dev, 0))
+                        if used_total >= per_device_total_cap:
+                            self.last_action = (
+                                f"extend skipped dev{dev} {gran // MB}MB: "
+                                f"device total {fmt_bytes(used_total)} >= cap {fmt_bytes(per_device_total_cap)}"
+                            )
+                            self._append_message("debug", self.last_action)
+                            continue
+
+                        remaining = per_device_total_cap - used_total
+                        max_count_by_cap = int(remaining // max(1, gran))
+                        if max_count_by_cap <= 0:
+                            self.last_action = (
+                                f"extend skipped dev{dev} {gran // MB}MB: "
+                                f"remaining cap {fmt_bytes(remaining)} < one handle {fmt_bytes(gran)}"
+                            )
+                            self._append_message("debug", self.last_action)
+                            continue
+                        if count > max_count_by_cap:
+                            count = max_count_by_cap
+
+                    if count > 0:
+                        ok = bool(self.daemon.extend_handles(gran, dev, count))
+                        if ok:
+                            per_device_total[dev] = int(per_device_total.get(dev, 0)) + count * gran
+                        self.last_action = (
+                            f"extend dev{dev} {gran // MB}MB +{count} ({pool_extend_step // MB}MB) -> {ok}"
+                        )
+                        self._append_message("info", self.last_action)
+
+                elif avail_b > pool_remove_threshold:
+                    count = int(pool_remove_step // max(1, gran))
+                    count = min(count, avail_h)
+                    if count > 0:
+                        ok = bool(self.daemon.remove_handles(gran, dev, count))
+                        self.last_action = (
+                            f"remove dev{dev} {gran // MB}MB -{count} ({pool_remove_step // MB}MB) -> {ok}"
+                        )
+                        self._append_message("info", self.last_action)
+
+        def _refresh(self) -> None:
+            try:
+                self._drain_control_commands()
+
+                if hasattr(self.daemon, "drain_logs"):
+                    for line in self.daemon.drain_logs():
+                        self._append_daemon_line(str(line))
+
+                pool_snaps = self.daemon.snapshot_handle_pools()
+                self._auto_tune(pool_snaps)
+
+                # Pools (progress bars)
+                seen_keys = set()
+                for snap in sorted(pool_snaps, key=lambda s: (int(s.device_id), int(s.granularity))):
+                    key = (int(snap.device_id), int(snap.granularity))
+                    seen_keys.add(key)
+                    row = self.pool_rows.get(key)
+                    if row is None:
+                        row = PoolRow(key)
+                        self.pool_rows[key] = row
+                        self.pools_view.mount(row)
+                    row.update_from_snapshot(snap)
+
+                # Models (table)
+                model_snaps = self.daemon.snapshot_models(self.sync_model_shm)
+                self.models_table.clear()
+                for snap in sorted(model_snaps, key=lambda s: int(s.model_id)):
+                    model_id = int(snap.model_id)
+                    msg_state = _safe_enum_name(snap.message_state)
+                    prev = self.prev_model_msg_states.get(model_id)
+                    if prev is not None and prev != msg_state:
+                        self._append_message("debug", f"model {model_id} message_state: {prev} -> {msg_state}")
+                    self.prev_model_msg_states[model_id] = msg_state
+
+                    self.models_table.add_row(
+                        str(model_id),
+                        _safe_enum_name(snap.state),
+                        msg_state,
+                        str(int(snap.model_npuid)),
+                        str(int(snap.model_osid)),
+                        fmt_bytes(int(snap.allocated_bytes)),
+                        str(int(snap.allocated_handles)),
+                    )
+
+                now = time.strftime("%H:%M:%S")
+                self._set_status(
+                    "daemon running="
+                    f"{bool(self.daemon.is_running())}"
+                    f" | refresh={self.refresh_ms}ms"
+                    f" | tune(thr<={fmt_bytes(env_scaled_size('MDAEMON_EXTEND_THRESHOLD_inGB', 1, GB))}/>={fmt_bytes(env_scaled_size('MDAEMON_REMOVE_THRESHOLD_inGB', 2, GB))}"
+                    f", add={fmt_bytes(env_scaled_size('MDAEMON_EXTEND_BYTES_inMB', 256, MB))}"
+                    f", drop={fmt_bytes(env_scaled_size('MDAEMON_REMOVE_BYTES_inMB', 512, MB))}"
+                    f" | {now} | {self.last_action}"
+                )
+            except Exception as exc:
+                self._set_status(f"error: {exc}", is_error=True)
+
+    daemon = mdaemon_py.Daemon()
+    app = DaemonMonitor(
+        daemon,
+        args.pool,
+        args.refresh_ms,
+        args.sync_model_shm,
+        args.control_enable,
+        args.control_host,
+        args.control_port,
+    )
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/daemon/daemon/py_monitor/env_config.py
+++ b/daemon/daemon/py_monitor/env_config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+from py_monitor.parsing import parse_unit_or_default_to_bytes
+
+
+def env_scaled_size(name: str, default_value: float, default_unit_bytes: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return int(default_value * default_unit_bytes)
+    try:
+        return parse_unit_or_default_to_bytes(raw, default_unit_bytes)
+    except Exception as exc:
+        raise SystemExit(f"Invalid env {name}='{raw}': {exc}")
+
+
+def env_float(name: str, default_value: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default_value
+    try:
+        value = float(raw)
+    except Exception as exc:
+        raise SystemExit(f"Invalid env {name}='{raw}': {exc}")
+    if value < 0:
+        raise SystemExit(f"Invalid env {name}='{raw}': value must be >= 0")
+    return value

--- a/daemon/daemon/py_monitor/models.py
+++ b/daemon/daemon/py_monitor/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PoolSpec:
+    device_id: int
+    granularity_bytes: int
+    total_bytes: int
+    cap_bytes: int
+
+
+@dataclass(frozen=True)
+class PoolTuneOverride:
+    extend_threshold_bytes: int
+    extend_step_bytes: int
+    remove_threshold_bytes: int
+    remove_step_bytes: int

--- a/daemon/daemon/py_monitor/parsing.py
+++ b/daemon/daemon/py_monitor/parsing.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+from typing import Tuple
+
+from py_monitor.models import PoolSpec
+from py_monitor.units import GB, MB
+
+
+def parse_size_bytes(text: str) -> int:
+    """Parse a human-readable size into bytes.
+
+    Supported examples: "1073741824", "2GB", "512MB", "64KB".
+    KB/MB/GB are interpreted with 1024-based multipliers.
+    """
+    value = text.strip()
+    if not value:
+        raise ValueError("empty size")
+
+    if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
+        return int(value)
+
+    value_up = value.upper()
+
+    units = [
+        ("TB", 1024**4),
+        ("GB", 1024**3),
+        ("MB", 1024**2),
+        ("KB", 1024),
+        ("B", 1),
+    ]
+
+    for unit, mult in units:
+        if value_up.endswith(unit):
+            number = value_up[: -len(unit)].strip()
+            if not number:
+                raise ValueError(f"missing number for unit {unit}")
+            return int(float(number) * mult)
+
+    try:
+        return int(float(value_up))
+    except ValueError as exc:
+        raise ValueError(f"unrecognized size suffix in '{text}'") from exc
+
+
+def parse_unit_or_default_to_bytes(text: str, default_unit_bytes: int) -> int:
+    raw = text.strip()
+    if not raw:
+        raise ValueError("empty value")
+    if any(c.isalpha() for c in raw):
+        size = parse_size_bytes(raw)
+    else:
+        size = int(float(raw) * default_unit_bytes)
+    if size <= 0:
+        raise ValueError("value must be > 0")
+    return size
+
+
+def parse_gb_to_bytes(text: str) -> int:
+    return parse_unit_or_default_to_bytes(text, GB)
+
+
+def parse_mb_to_bytes(text: str) -> int:
+    return parse_unit_or_default_to_bytes(text, MB)
+
+
+def parse_pool_key(text: str) -> Tuple[int, int]:
+    parts = text.split(":")
+    if len(parts) != 2:
+        raise ValueError("expected dev:gran format")
+    dev = int(parts[0].strip())
+    gran_mb = int(parts[1].strip())
+    if dev < 0:
+        raise ValueError("dev must be >= 0")
+    if gran_mb <= 0:
+        raise ValueError("gran must be > 0")
+    return dev, gran_mb * MB
+
+
+def parse_pool_spec(text: str) -> PoolSpec:
+    """Parse: device_id:granularity_mb:total_gb[:cap_gb]"""
+    parts = text.split(":")
+    if len(parts) not in (3, 4):
+        raise argparse.ArgumentTypeError(
+            f"Invalid --pool '{text}'. Expected format device:granularity_mb:total_gb[:cap_gb] (e.g. 0:16:4 or 0:16:4:10)."
+        )
+    try:
+        device_id = int(parts[0])
+        gran_mb = int(parts[1])
+        total_bytes = parse_gb_to_bytes(parts[2])
+        cap_bytes = parse_gb_to_bytes(parts[3]) if len(parts) == 4 else 0
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Invalid --pool '{text}': {exc}") from exc
+    if device_id < 0:
+        raise argparse.ArgumentTypeError("device_id must be >= 0")
+    if gran_mb <= 0:
+        raise argparse.ArgumentTypeError("granularity_mb must be > 0")
+    if total_bytes <= 0:
+        raise argparse.ArgumentTypeError("total_gb must be > 0")
+    if len(parts) == 4 and cap_bytes <= 0:
+        raise argparse.ArgumentTypeError("cap_gb must be > 0 when provided")
+    if len(parts) == 4 and cap_bytes < total_bytes:
+        raise argparse.ArgumentTypeError("cap_gb must be >= total_gb")
+
+    granularity_bytes = gran_mb * MB
+    return PoolSpec(
+        device_id=device_id,
+        granularity_bytes=granularity_bytes,
+        total_bytes=total_bytes,
+        cap_bytes=cap_bytes,
+    )

--- a/daemon/daemon/py_monitor/units.py
+++ b/daemon/daemon/py_monitor/units.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+GB = 1024**3
+MB = 1024**2
+KB = 1024
+
+
+def fmt_bytes(num: int) -> str:
+    if num < MB:
+        return f"{num / KB:.0f}KB"
+    if num < GB:
+        return f"{num / MB:.0f}MB"
+    return f"{num / GB:.2f}GB"

--- a/daemon/daemon/pyproject.toml
+++ b/daemon/daemon/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mdaemon"
+version = "0.1.0"
+description = "Textual monitor CLI for multimodel mdaemon_py daemon"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "textual>=0.58.0",
+    "rich>=13.0.0",
+]
+
+[project.scripts]
+mdaemon = "mdaemon.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mdaemon", "mdaemon.*", "py_monitor", "py_monitor.*"]

--- a/daemon/daemon/test_daemon.cpp
+++ b/daemon/daemon/test_daemon.cpp
@@ -1,0 +1,108 @@
+#include "inc/daemon.hpp"
+#include "inc/handle_pool.hpp"
+#include "inc/model_management.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+// define colors for better visibility in test output
+#define COLOR_RESET "\033[0m"
+#define COLOR_RED "\033[31m"
+#define COLOR_GREEN "\033[32m"
+#define COLOR_YELLOW "\033[33m"
+#define COLOR_BLUE "\033[34m"
+#define COLOR_MAGENTA "\033[35m"
+
+using namespace mdaemon;
+
+namespace {
+
+void test_handle_pool(Daemon& d, uint64_t granularity, int device_id) {
+    constexpr int kCount = 10;
+    HandlePool* pool = d.ensureHandlePool(granularity);
+    d.initializeHandlePoolDevice(granularity, device_id, granularity * kCount); // allocate a bit extra
+    std::vector<Handle> handles;
+    handles.reserve(kCount);
+    for (int i = 0; i < kCount; ++i) {
+        Handle h = pool->acquire(device_id);
+        handles.push_back(std::move(h));
+    }
+    std::cout << "[HandlePool] acquired " << kCount << " handles at granularity=" << granularity
+              << " device=" << device_id << " available(after acquire)=" << pool->available(device_id) << "\n";
+    // release back
+    for (auto& h : handles) {
+        pool->release(device_id, std::move(h));
+    }
+    std::cout << "[HandlePool] released " << kCount << " handles at granularity=" << granularity
+              << " device=" << device_id << " available(after release)=" << pool->available(device_id) << "\n";
+
+    const size_t available_before = pool->available(device_id);
+    const size_t extend_count = 3;
+    if (d.extendHandles(granularity, device_id, extend_count)) {
+        const size_t available_extended = pool->available(device_id);
+        std::cout << "[HandlePool] extended " << extend_count << " handles at granularity=" << granularity
+                  << " device=" << device_id << " available(after extend)=" << available_extended << "\n";
+    } else {
+        std::cerr << "[HandlePool] extendHandles failed for granularity=" << granularity
+                  << " device=" << device_id << "\n";
+    }
+
+    const size_t remove_count = 2;
+    if (d.removeHandles(granularity, device_id, remove_count)) {
+        const size_t available_removed = pool->available(device_id);
+        std::cout << "[HandlePool] removed " << remove_count << " handles at granularity=" << granularity
+                  << " device=" << device_id << " available(after remove)=" << available_removed << "\n";
+    } else {
+        std::cerr << "[HandlePool] removeHandles failed for granularity=" << granularity
+                  << " device=" << device_id << "\n";
+    }
+}
+
+} // namespace
+
+int main() {
+    std::cout << "[DaemonTest] starting daemon...\n";
+    Daemon daemon;
+    daemon.start();
+
+    // HandlePool tests on device 0 and 1 for 2/4/8/16MB granularity
+    const std::array<uint64_t, 4> granularities = {
+        2ULL * 1024 * 1024,
+        4ULL * 1024 * 1024,
+        8ULL * 1024 * 1024,
+        16ULL * 1024 * 1024
+    };
+    for (uint64_t granularity : granularities) {
+        test_handle_pool(daemon, granularity, 0);
+        test_handle_pool(daemon, granularity, 1);
+    }
+    daemon.printAll();
+
+    std::atomic<bool> stop_requested{false};
+    std::thread input_thread([&stop_requested]() {
+        std::cout << COLOR_GREEN << "\n[DaemonTest] press 'q' then ENTER to stop." << COLOR_RESET << std::endl;
+        for (char ch; std::cin >> ch;) {
+            if (ch == 'q' || ch == 'Q') {
+                stop_requested.store(true);
+                break;
+            }
+        }
+    });
+
+    std::cout << "[DaemonTest] daemon loop running; launch model processes separately." << std::endl;
+    while (!stop_requested.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+    if (input_thread.joinable()) {
+        input_thread.join();
+    }
+
+    std::cout << "[DaemonTest] stopping daemon...\n";
+    daemon.stop();
+
+    std::cout << "[DaemonTest] remaining models: " << daemon.listModelIds().size() << "\n";
+    return 0;
+}

--- a/daemon/daemon/test_handle_pool.cpp
+++ b/daemon/daemon/test_handle_pool.cpp
@@ -1,0 +1,115 @@
+#include "inc/handle_pool.hpp"
+
+#include <array>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+using mdaemon::HandlePool;
+
+int main() {
+    std::array<uint64_t, 3> page_sizes = {4ULL * 1024 * 1024, 8ULL * 1024 * 1024, 2ULL * 1024 * 1024};
+    std::array<int32_t, 4> devices = {0, 1, 2, 3};
+
+    for (uint64_t page_size : page_sizes) {
+        HandlePool pool(page_size);
+        uint64_t total_bytes = page_size * 8; // keep a few handles available per device
+
+        std::cout << "Testing page size " << page_size / (1024 * 1024) << " MB" << std::endl;
+        for (int32_t device_id : devices) {
+            try {
+                pool.initializeDevice(device_id, total_bytes);
+                std::cout << "  Initialized device " << device_id << std::endl;
+            } catch (const std::exception& ex) {
+                std::cerr << "Failed to initialize device " << device_id << ": " << ex.what() << std::endl;
+                return 1;
+            }
+
+            size_t available_before = pool.available(device_id);
+            std::cout << "    Available handles: " << available_before << std::endl;
+            if (available_before == 0) {
+                std::cerr << "No handles available after initialization for device " << device_id << std::endl;
+                return 1;
+            }
+
+            auto handle = pool.acquire(device_id);
+            if (!handle.valid()) {
+                std::cerr << "Failed to acquire a valid handle for device " << device_id << std::endl;
+                return 1;
+            }
+            else {
+                std::cout << "    Acquired handle with granularity " << handle.granularity() / (1024 * 1024) << " MB" << std::endl;
+            }
+
+            uint64_t shareable = handle.shareableHandle();
+            if (shareable == std::numeric_limits<uint64_t>::max()) {
+                std::cerr << "shareable handle was not updated for device " << device_id << std::endl;
+                return 1;
+            }
+
+            pool.release(device_id, std::move(handle));
+            std::cout << "    Released handle back to pool" << std::endl;
+
+            size_t available_after = pool.available(device_id);
+            if (available_after != available_before) {
+                std::cerr << "Handle count mismatch for device " << device_id
+                          << " (before=" << available_before << " after=" << available_after << ")"
+                          << std::endl;
+                return 1;
+            }
+
+            std::cout << "  device " << device_id << " passed" << std::endl;
+        }
+
+        // additional extend/remove verification on a subset of chips
+        std::array<int32_t, 2> extend_devices = {0, 2};
+        for (int32_t device_id : extend_devices) {
+            size_t available_before = pool.available(device_id);
+            size_t extend_count = 3;
+            if (!pool.extendHandles(device_id, extend_count)) {
+                std::cerr << "extendHandles failed for device " << device_id << std::endl;
+                return 1;
+            }
+            size_t available_extended = pool.available(device_id);
+            if (available_extended != available_before + extend_count) {
+                std::cerr << "extendHandles did not add the expected handles for device " << device_id << std::endl;
+                return 1;
+            }
+
+            size_t remove_count = 2;
+            if (!pool.removeHandles(device_id, remove_count)) {
+                std::cerr << "removeHandles failed for device " << device_id << std::endl;
+                return 1;
+            }
+            size_t available_removed = pool.available(device_id);
+            if (available_removed != available_extended - remove_count) {
+                std::cerr << "removeHandles did not drop the expected handles for device " << device_id << std::endl;
+                return 1;
+            }
+
+            std::cout << "  extend/remove pair succeeded for device " << device_id << std::endl;
+        }
+
+        // print the handle pool items
+        for (int32_t device_id : devices) {
+            size_t available = pool.available(device_id);
+            std::cout << "  Final available handles for device " << device_id << ": " << available << std::endl;
+            
+            // handles print
+            for (size_t i = 0; i < available; ++i) {
+                auto handle = pool.acquire(device_id);
+                std::cout << "    Handle " << i << ": granularity " << handle.granularity() / (1024 * 1024)
+                          << " MB, shareable handle " << handle.shareableHandle() << std::endl;
+                pool.release(device_id, std::move(handle));
+            }
+        }
+
+        // shutdown pool
+        pool.shutdown();
+        std::cout << "  Shutdown pool for page size " << page_size / (1024 * 1024) << " MB" << std::endl;
+    }
+
+    std::cout << "test_handle_pool: all configurations succeed" << std::endl;
+    return 0;
+}

--- a/daemon/daemon/test_model1.cpp
+++ b/daemon/daemon/test_model1.cpp
@@ -1,0 +1,258 @@
+#include "inc/model_management.hpp"
+#include "inc/utils.h"
+
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <random>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+// define colors for better visibility in test output
+#define COLOR_RESET "\033[0m"
+#define COLOR_RED "\033[31m"
+#define COLOR_GREEN "\033[32m"
+#define COLOR_YELLOW "\033[33m"
+#define COLOR_BLUE "\033[34m"
+#define COLOR_MAGENTA "\033[35m"
+
+using namespace mdaemon;
+
+static void write_macro(ModelMacroSpace* macro, int32_t npuid) {
+    macro->current_model_npuid = npuid;
+    macro->current_model_osid = static_cast<int32_t>(::getpid());
+    macro->setShmName(defaultShmName());
+    ::msync(macro, sizeof(ModelMacroSpace), MS_SYNC);
+    std::cout << "[Model1] wrote npuid=" << npuid << " osid=" << macro->current_model_osid << "\n";
+}
+
+static void print_message_space(const ModelMessageSpace& space, const char* tag) {
+    std::cout << COLOR_BLUE << "[Model1] " << tag << COLOR_RESET
+              << " state=" << static_cast<int>(space.state)
+              << " npuid=" << space.model_npuid << " osid=" << space.model_osid
+              << " offset_st=" << space.offset_st << " offset_ed=" << space.offset_ed << "\n";
+    const int32_t end = std::min<int32_t>(space.offset_ed,
+                                          static_cast<int32_t>(space.handle_info_list.size()));
+    for (int32_t i = space.offset_st; i < end; ++i) {
+        const handle_granularity& info = space.handle_info_list[i];
+        std::cout << "  handle[" << i << "] shareable=" << info.shareable_handle
+                  << " granularity=" << (info.granularity / (1024 * 1024))
+                  << "MB device=" << info.device_id << "\n";
+    }
+    std::cout << "------------------------------------------------\n";
+}
+
+static bool wait_for_state(ModelMessageSpace* space, MessageState target, int timeout_ms) {
+    const int step_ms = 50;
+    int waited = 0;
+    while (space->state != target && waited < timeout_ms) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(step_ms));
+        waited += step_ms;
+    }
+    return space->state == target;
+}
+
+static void clear_requests(ModelMessageSpace* space) {
+    for (auto& req : space->handle_request_list) {
+        if (req.request_num == 0 && req.granularity == 0 && req.device_id == -1) {
+            break; // end of requests
+        }
+        req.request_num = 0;
+        req.granularity = 0;
+        req.device_id = -1;
+    }
+}
+
+static void clear_handles(ModelMessageSpace* space) {
+    for (auto& info : space->handle_info_list) {
+        if (info.shareable_handle == std::numeric_limits<uint64_t>::max() &&
+            info.granularity == 0 &&
+            info.device_id == -1) {
+            break; // end of handles
+        }
+        info.shareable_handle = std::numeric_limits<uint64_t>::max();
+        info.granularity = 0;
+        info.device_id = -1;
+    }
+    space->offset_st = 0;
+    space->offset_ed = 0;
+}
+
+int main() {
+    int32_t device_id = 0; // for testing we just use device 0
+    aclInit(nullptr);
+    ensure_context(device_id);
+    int32_t kNpuid;
+    CHECK_ERROR(aclrtDeviceGetBareTgid(&kNpuid));
+
+    sem_t* sem = ::sem_open(MODEL_SEMAPHORE_NAME, O_CREAT, 0666, 1);
+    if (sem == SEM_FAILED) {
+        std::cerr << COLOR_RED << "[Model1] sem_open failed\n" << COLOR_RESET;
+        return 1;
+    }
+    if (::sem_wait(sem) == -1) {
+        std::cerr << COLOR_RED << "[Model1] sem_wait failed\n" << COLOR_RESET;
+        ::sem_close(sem);
+        return 1;
+    }
+
+    int fd = ::shm_open(MODEL_REG_SHM, O_RDWR | O_CREAT, 0666);
+    if (fd == -1) {
+        std::cerr << COLOR_RED << "[Model1] failed to open MODEL_REG_SHM\n" << COLOR_RESET;
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    if (::ftruncate(fd, sizeof(ModelMacroSpace)) == -1) {
+        std::cerr << COLOR_RED << "[Model1] ftruncate failed\n" << COLOR_RESET;
+        ::close(fd);
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    void* region = ::mmap(nullptr, sizeof(ModelMacroSpace), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (region == MAP_FAILED) {
+        std::cerr << COLOR_RED << "[Model1] mmap failed\n" << COLOR_RESET;
+        ::close(fd);
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    auto* macro = static_cast<ModelMacroSpace*>(region);
+    if (isDefaultShmName(macro->getShmName())) {
+        write_macro(macro, kNpuid);
+    }
+
+    // wait for daemon to fill shm_name
+    while (isDefaultShmName(macro->getShmName())) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::string shm_name(macro->getShmName());
+    std::cout << "[Model1] got shm_name=" << shm_name << "\n";
+
+    macro->reset();
+    ::msync(macro, sizeof(ModelMacroSpace), MS_SYNC);
+    ::munmap(region, sizeof(ModelMacroSpace));
+    ::close(fd);
+    ::sem_post(sem);
+    ::sem_close(sem);
+
+
+    // open per-model message space
+    int msg_fd = ::shm_open(shm_name.c_str(), O_RDWR, 0666);
+    if (msg_fd == -1) {
+        std::cerr << COLOR_RED << "[Model1] failed to open model shm: " << shm_name << "\n" << COLOR_RESET;
+        return 1;
+    }
+    void* msg_region = ::mmap(nullptr, sizeof(ModelMessageSpace), PROT_READ | PROT_WRITE, MAP_SHARED, msg_fd, 0);
+    if (msg_region == MAP_FAILED) {
+        std::cerr << COLOR_RED << "[Model1] mmap failed for model shm\n" << COLOR_RESET;
+        ::close(msg_fd);
+        return 1;
+    }
+    auto* space = static_cast<ModelMessageSpace*>(msg_region);
+    print_message_space(*space, "after registration");
+    while (space->state != MessageState::REGISTERED) {
+        std::cerr << COLOR_RED << "[Model1] expected REGISTERED state, got " << static_cast<int>(space->state) << "\n" << COLOR_RESET;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    // request small handle set: 3x16MB, 4x8MB, 2x4MB, 1x2MB
+    clear_requests(space);
+    clear_handles(space);
+    space->handle_request_list[0] = {3, 16ULL * 1024 * 1024, device_id};
+    space->handle_request_list[1] = {4, 8ULL * 1024 * 1024, device_id};
+    space->handle_request_list[2] = {2, 4ULL * 1024 * 1024, device_id};
+    space->handle_request_list[3] = {1, 2ULL * 1024 * 1024, device_id};
+    space->state = MessageState::REQUEST_GET_HANDLES;
+    print_message_space(*space, "request handles (small)");
+    if (!wait_for_state(space, MessageState::HANDLES_READY, 10000)) {
+        std::cerr << COLOR_RED << "[Model1] timed out waiting for HANDLES_READY\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles ready (small)");
+
+    std::vector<handle_granularity> allocated_handles;
+    int32_t end = std::min<int32_t>(space->offset_ed,
+                                          static_cast<int32_t>(space->handle_info_list.size()));
+    for (int32_t i = space->offset_st; i < end; ++i) {
+        allocated_handles.push_back(space->handle_info_list[i]);
+    }
+    space->offset_ed = space->offset_st; // reset offset_ed after reading
+    std::cout << "[Model1] allocated handles:\n";
+    for (const auto& info : allocated_handles) {
+        std::cout << "  shareable=" << info.shareable_handle
+                  << " granularity=" << (info.granularity / (1024 * 1024))
+                  << "MB device=" << info.device_id << "\n";
+    }
+
+    // request large handles: 20x16MB
+    clear_requests(space);
+    clear_handles(space);
+    space->handle_request_list[0] = {20, 16ULL * 1024 * 1024, device_id};
+    space->state = MessageState::REQUEST_GET_HANDLES;
+    print_message_space(*space, "request handles (large)");
+    if (!wait_for_state(space, MessageState::HANDLES_READY, 10000)) {
+        std::cerr << COLOR_RED << "[Model1] timed out waiting for HANDLES_READY (large)\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles ready (large)");
+
+    end = std::min<int32_t>(space->offset_ed, static_cast<int32_t>(space->handle_info_list.size()));
+    for (int32_t i = space->offset_st; i < end; ++i) {
+        allocated_handles.push_back(space->handle_info_list[i]);
+    }
+    space->offset_ed = space->offset_st; // reset offset_ed after reading
+    std::cout << "[Model1] allocated handles (small + large):\n";
+    for (const auto& info : allocated_handles) {
+        std::cout << "  shareable=" << info.shareable_handle
+                  << " granularity=" << (info.granularity / (1024 * 1024))
+                  << "MB device=" << info.device_id << "\n";
+    }
+
+    // return first 15 handles
+    clear_requests(space);
+    clear_handles(space);
+    for (size_t i = 0; i < 15 && i < allocated_handles.size(); ++i) {
+        const auto& info = allocated_handles[i];
+        space->handle_info_list[space->offset_ed] = info;
+        ++space->offset_ed;
+    }
+    allocated_handles.erase(allocated_handles.begin(), allocated_handles.begin() + std::min<size_t>(15, allocated_handles.size()));
+    space->state = MessageState::REQUEST_RETURN_HANDLES;
+    print_message_space(*space, "return handles (first 15)");
+    if (!wait_for_state(space, MessageState::HANDLES_RETURNED, 10000)) {
+        std::cerr << COLOR_RED << "[Model1] timed out waiting for HANDLES_RETURNED\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles returned (first 15)");
+
+    // return the rest of handles
+    clear_requests(space);
+    clear_handles(space);
+    for (const auto& info : allocated_handles) {
+        space->handle_info_list[space->offset_ed] = info;
+        ++space->offset_ed;
+    }
+    space->state = MessageState::REQUEST_RETURN_HANDLES;
+    print_message_space(*space, "return handles (all the rest)");
+    if (!wait_for_state(space, MessageState::HANDLES_RETURNED, 10000)) {
+        std::cerr << COLOR_RED << "[Model1] timed out waiting for HANDLES_RETURNED (all the rest)\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles returned (all the rest)");
+
+
+    ::munmap(msg_region, sizeof(ModelMessageSpace));
+    ::close(msg_fd);
+
+    // random sleep 5-10s before exit
+    std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<int> dist(5, 10);
+    int wait_s = dist(rng);
+    std::cout << COLOR_GREEN << "[Model1] exiting after " << wait_s << "s\n" << COLOR_RESET;
+    std::this_thread::sleep_for(std::chrono::seconds(wait_s));
+    return 0;
+}

--- a/daemon/daemon/test_model2.cpp
+++ b/daemon/daemon/test_model2.cpp
@@ -1,0 +1,255 @@
+#include "inc/model_management.hpp"
+#include "inc/utils.h"
+
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <random>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+// define colors for better visibility in test output
+#define COLOR_RESET "\033[0m"
+#define COLOR_RED "\033[31m"
+#define COLOR_GREEN "\033[32m"
+#define COLOR_YELLOW "\033[33m"
+#define COLOR_BLUE "\033[34m"
+#define COLOR_MAGENTA "\033[35m"
+
+using namespace mdaemon;
+
+static void write_macro(ModelMacroSpace* macro, int32_t npuid) {
+    macro->current_model_npuid = npuid;
+    macro->current_model_osid = static_cast<int32_t>(::getpid());
+    macro->setShmName(defaultShmName());
+    ::msync(macro, sizeof(ModelMacroSpace), MS_SYNC);
+    std::cout << "[Model2] wrote npuid=" << npuid << " osid=" << macro->current_model_osid << "\n";
+}
+
+static void print_message_space(const ModelMessageSpace& space, const char* tag) {
+    std::cout << COLOR_BLUE << "[Model2] " << tag << COLOR_RESET
+              << " state=" << static_cast<int>(space.state)
+              << " npuid=" << space.model_npuid << " osid=" << space.model_osid
+              << " offset_st=" << space.offset_st << " offset_ed=" << space.offset_ed << "\n";
+    const int32_t end = std::min<int32_t>(space.offset_ed,
+                                          static_cast<int32_t>(space.handle_info_list.size()));
+    for (int32_t i = space.offset_st; i < end; ++i) {
+        const handle_granularity& info = space.handle_info_list[i];
+        std::cout << "  handle[" << i << "] shareable=" << info.shareable_handle
+                  << " granularity=" << (info.granularity / (1024 * 1024))
+                  << "MB device=" << info.device_id << "\n";
+    }
+    std::cout << "------------------------------------------------\n";
+}
+
+static bool wait_for_state(ModelMessageSpace* space, MessageState target, int timeout_ms) {
+    const int step_ms = 50;
+    int waited = 0;
+    while (space->state != target && waited < timeout_ms) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(step_ms));
+        waited += step_ms;
+    }
+    return space->state == target;
+}
+
+static void clear_requests(ModelMessageSpace* space) {
+    for (auto& req : space->handle_request_list) {
+        if (req.request_num == 0 && req.granularity == 0 && req.device_id == -1) {
+            break; // end of requests
+        }
+        req.request_num = 0;
+        req.granularity = 0;
+        req.device_id = -1;
+    }
+}
+
+static void clear_handles(ModelMessageSpace* space) {
+    for (auto& info : space->handle_info_list) {
+        if (info.shareable_handle == std::numeric_limits<uint64_t>::max() &&
+            info.granularity == 0 &&
+            info.device_id == -1) {
+            break; // end of handles
+        }
+        info.shareable_handle = std::numeric_limits<uint64_t>::max();
+        info.granularity = 0;
+        info.device_id = -1;
+    }
+    space->offset_st = 0;
+    space->offset_ed = 0;
+}
+
+int main() {
+    int32_t device_id = 1; // model2 runs on device 1
+    aclInit(nullptr);
+    ensure_context(device_id);
+    int32_t kNpuid;
+    CHECK_ERROR(aclrtDeviceGetBareTgid(&kNpuid));
+    sem_t* sem = ::sem_open(MODEL_SEMAPHORE_NAME, O_CREAT, 0666, 1);
+    if (sem == SEM_FAILED) {
+        std::cerr << COLOR_RED << "[Model2] sem_open failed\n" << COLOR_RESET;
+        return 1;
+    }
+    if (::sem_wait(sem) == -1) {
+        std::cerr << COLOR_RED << "[Model2] sem_wait failed\n" << COLOR_RESET;
+        ::sem_close(sem);
+        return 1;
+    }
+
+    int fd = ::shm_open(MODEL_REG_SHM, O_RDWR | O_CREAT, 0666);
+    if (fd == -1) {
+        std::cerr << COLOR_RED << "[Model2] failed to open MODEL_REG_SHM\n" << COLOR_RESET;
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    if (::ftruncate(fd, sizeof(ModelMacroSpace)) == -1) {
+        std::cerr << COLOR_RED << "[Model2] ftruncate failed\n" << COLOR_RESET;
+        ::close(fd);
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    void* region = ::mmap(nullptr, sizeof(ModelMacroSpace), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (region == MAP_FAILED) {
+        std::cerr << COLOR_RED << "[Model2] mmap failed\n" << COLOR_RESET;
+        ::close(fd);
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    auto* macro = static_cast<ModelMacroSpace*>(region);
+    if (isDefaultShmName(macro->getShmName())) {
+        write_macro(macro, kNpuid);
+    }
+
+    while (isDefaultShmName(macro->getShmName())) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::string shm_name(macro->getShmName());
+    std::cout << "[Model2] got shm_name=" << shm_name << "\n";
+
+    macro->reset();
+    ::msync(macro, sizeof(ModelMacroSpace), MS_SYNC);
+    ::munmap(region, sizeof(ModelMacroSpace));
+    ::close(fd);
+    ::sem_post(sem);
+    ::sem_close(sem);
+
+    // open per-model message space
+    int msg_fd = ::shm_open(shm_name.c_str(), O_RDWR, 0666);
+    if (msg_fd == -1) {
+        std::cerr << COLOR_RED << "[Model2] failed to open model shm: " << shm_name << "\n" << COLOR_RESET;
+        return 1;
+    }
+    void* msg_region = ::mmap(nullptr, sizeof(ModelMessageSpace), PROT_READ | PROT_WRITE, MAP_SHARED, msg_fd, 0);
+    if (msg_region == MAP_FAILED) {
+        std::cerr << COLOR_RED << "[Model2] mmap failed for model shm\n" << COLOR_RESET;
+        ::close(msg_fd);
+        return 1;
+    }
+    auto* space = static_cast<ModelMessageSpace*>(msg_region);
+    print_message_space(*space, "after registration");
+    if (space->state != MessageState::REGISTERED) {
+        std::cerr << COLOR_RED << "[Model2] expected REGISTERED state, got "
+                  << static_cast<int>(space->state) << "\n" << COLOR_RESET;
+    }
+
+    // request small handle set: 3x16MB, 4x8MB, 2x4MB, 1x2MB
+    clear_requests(space);
+    clear_handles(space);
+    space->handle_request_list[0] = {3, 16ULL * 1024 * 1024, device_id};
+    space->handle_request_list[1] = {4, 8ULL * 1024 * 1024, device_id};
+    space->handle_request_list[2] = {2, 4ULL * 1024 * 1024, device_id};
+    space->handle_request_list[3] = {1, 2ULL * 1024 * 1024, device_id};
+    space->state = MessageState::REQUEST_GET_HANDLES;
+    print_message_space(*space, "request handles (small)");
+    if (!wait_for_state(space, MessageState::HANDLES_READY, 10000)) {
+        std::cerr << COLOR_RED << "[Model2] timed out waiting for HANDLES_READY\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles ready (small)");
+
+    std::vector<handle_granularity> allocated_handles;
+    int32_t end = std::min<int32_t>(space->offset_ed,
+                                    static_cast<int32_t>(space->handle_info_list.size()));
+    for (int32_t i = space->offset_st; i < end; ++i) {
+        allocated_handles.push_back(space->handle_info_list[i]);
+    }
+    space->offset_ed = space->offset_st; // reset offset_ed after reading
+    std::cout << "[Model2] allocated handles:\n";
+    for (const auto& info : allocated_handles) {
+        std::cout << "  shareable=" << info.shareable_handle
+                  << " granularity=" << (info.granularity / (1024 * 1024))
+                  << "MB device=" << info.device_id << "\n";
+    }
+
+    // request overclaimed handles: 13x16MB
+    clear_requests(space);
+    clear_handles(space);
+    space->handle_request_list[0] = {13, 16ULL * 1024 * 1024, device_id};
+    space->state = MessageState::REQUEST_GET_HANDLES;
+    print_message_space(*space, "request handles (overclaim)");
+    if (!wait_for_state(space, MessageState::HANDLES_READY, 10000)) {
+        std::cerr << COLOR_RED << "[Model2] timed out waiting for HANDLES_READY (overclaim)\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles ready (overclaim)");
+
+    end = std::min<int32_t>(space->offset_ed, static_cast<int32_t>(space->handle_info_list.size()));
+    for (int32_t i = space->offset_st; i < end; ++i) {
+        allocated_handles.push_back(space->handle_info_list[i]);
+    }
+    space->offset_ed = space->offset_st; // reset offset_ed after reading
+    std::cout << "[Model2] allocated handles (small + overclaim):\n";
+    for (const auto& info : allocated_handles) {
+        std::cout << "  shareable=" << info.shareable_handle
+                  << " granularity=" << (info.granularity / (1024 * 1024))
+                  << "MB device=" << info.device_id << "\n";
+    }
+
+    // return first 15 handles
+    clear_requests(space);
+    clear_handles(space);
+    for (size_t i = 0; i < 15 && i < allocated_handles.size(); ++i) {
+        const auto& info = allocated_handles[i];
+        space->handle_info_list[space->offset_ed] = info;
+        ++space->offset_ed;
+    }
+    allocated_handles.erase(allocated_handles.begin(),
+                            allocated_handles.begin() + std::min<size_t>(15, allocated_handles.size()));
+    space->state = MessageState::REQUEST_RETURN_HANDLES;
+    print_message_space(*space, "return handles (first 15)");
+    if (!wait_for_state(space, MessageState::HANDLES_RETURNED, 10000)) {
+        std::cerr << COLOR_RED << "[Model2] timed out waiting for HANDLES_RETURNED\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles returned (first 15)");
+
+    // return the rest of handles
+    clear_requests(space);
+    clear_handles(space);
+    for (const auto& info : allocated_handles) {
+        space->handle_info_list[space->offset_ed] = info;
+        ++space->offset_ed;
+    }
+    space->state = MessageState::REQUEST_RETURN_HANDLES;
+    print_message_space(*space, "return handles (all the rest)");
+    if (!wait_for_state(space, MessageState::HANDLES_RETURNED, 10000)) {
+        std::cerr << COLOR_RED << "[Model2] timed out waiting for HANDLES_RETURNED (all the rest)\n" << COLOR_RESET;
+    }
+    print_message_space(*space, "handles returned (all the rest)");
+
+    ::munmap(msg_region, sizeof(ModelMessageSpace));
+    ::close(msg_fd);
+
+    // random sleep 5-10s before exit
+    std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<int> dist(5, 10);
+    int wait_s = dist(rng);
+    std::cout << COLOR_GREEN << "[Model2] exiting after " << wait_s << "s\n" << COLOR_RESET;
+    std::this_thread::sleep_for(std::chrono::seconds(wait_s));
+    return 0;
+}

--- a/daemon/daemon/test_model3.cpp
+++ b/daemon/daemon/test_model3.cpp
@@ -1,0 +1,84 @@
+#include "inc/model_management.hpp"
+#include "inc/utils.h"
+
+#include <chrono>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <random>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+
+using namespace mdaemon;
+
+static void write_macro(ModelMacroSpace* macro, int32_t npuid) {
+    macro->current_model_npuid = npuid;
+    macro->current_model_osid = static_cast<int32_t>(::getpid());
+    macro->setShmName(defaultShmName());
+    ::msync(macro, sizeof(ModelMacroSpace), MS_SYNC);
+    std::cout << "[Model3] wrote npuid=" << npuid << " osid=" << macro->current_model_osid << "\n";
+}
+
+int main() {
+    constexpr int32_t kNpuid = 3003;
+    sem_t* sem = ::sem_open(MODEL_SEMAPHORE_NAME, O_CREAT, 0666, 1);
+    if (sem == SEM_FAILED) {
+        std::cerr << "[Model3] sem_open failed\n";
+        return 1;
+    }
+    if (::sem_wait(sem) == -1) {
+        std::cerr << "[Model3] sem_wait failed\n";
+        ::sem_close(sem);
+        return 1;
+    }
+
+    int fd = ::shm_open(MODEL_REG_SHM, O_RDWR | O_CREAT, 0666);
+    if (fd == -1) {
+        std::cerr << "[Model3] failed to open MODEL_REG_SHM\n";
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    if (::ftruncate(fd, sizeof(ModelMacroSpace)) == -1) {
+        std::cerr << "[Model3] ftruncate failed\n";
+        ::close(fd);
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    void* region = ::mmap(nullptr, sizeof(ModelMacroSpace), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (region == MAP_FAILED) {
+        std::cerr << "[Model3] mmap failed\n";
+        ::close(fd);
+        ::sem_post(sem);
+        ::sem_close(sem);
+        return 1;
+    }
+    auto* macro = static_cast<ModelMacroSpace*>(region);
+    if (isDefaultShmName(macro->getShmName())) {
+        write_macro(macro, kNpuid);
+    }
+
+    while (isDefaultShmName(macro->getShmName())) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::string shm_name(macro->getShmName());
+    std::cout << "[Model3] got shm_name=" << shm_name << "\n";
+
+    macro->reset();
+    ::msync(macro, sizeof(ModelMacroSpace), MS_SYNC);
+    ::munmap(region, sizeof(ModelMacroSpace));
+    ::close(fd);
+    ::sem_post(sem);
+    ::sem_close(sem);
+
+    std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<int> dist(5, 10);
+    int wait_s = dist(rng);
+    std::cout << "[Model3] exiting after " << wait_s << "s\n";
+    std::this_thread::sleep_for(std::chrono::seconds(wait_s));
+    return 0;
+}

--- a/daemon/vllm_bifrost/CMakeLists.txt
+++ b/daemon/vllm_bifrost/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.16)
+project(bifrost_ascend_C LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+# User can pass -DASCEND_HOME_PATH=... at configure time.
+if(NOT DEFINED ASCEND_HOME_PATH)
+  set(ASCEND_HOME_PATH "/usr/local/Ascend/ascend-toolkit/latest" CACHE PATH "Ascend toolkit root")
+endif()
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
+add_library(bifrost_ascend_C MODULE
+  ${CMAKE_CURRENT_SOURCE_DIR}/camem_allocator.cpp
+)
+
+target_include_directories(bifrost_ascend_C
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${Python3_INCLUDE_DIRS}
+  ${ASCEND_HOME_PATH}/include
+  ${ASCEND_HOME_PATH}/aarch64-linux/include/experiment/platform
+  ${ASCEND_HOME_PATH}/x86_64-linux/include/experiment/platform
+)
+
+target_link_directories(bifrost_ascend_C
+  PRIVATE
+  ${ASCEND_HOME_PATH}/lib64
+)
+
+target_link_libraries(bifrost_ascend_C
+  PRIVATE
+  Python3::Python
+  ascendcl
+  pthread
+  dl
+  rt
+)
+
+# Emit exact filename requested by user.
+set_target_properties(bifrost_ascend_C PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "bifrost_ascend_C"
+  SUFFIX ".cpython-311-aarch64-linux-gnu.so"
+)
+
+# Keep local run/import simple.
+set_target_properties(bifrost_ascend_C PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+install(TARGETS bifrost_ascend_C DESTINATION .)

--- a/daemon/vllm_bifrost/build.sh
+++ b/daemon/vllm_bifrost/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-/usr/local/Ascend/ascend-toolkit/latest}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+JOBS="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+
+cmake -S "${SCRIPT_DIR}" -B "${BUILD_DIR}" \
+  -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+  -DASCEND_HOME_PATH="${ASCEND_HOME_PATH}"
+
+cmake --build "${BUILD_DIR}" -j "${JOBS}"
+
+echo "Built: ${BUILD_DIR}/bifrost_ascend_C.cpython-311-aarch64-linux-gnu.so"

--- a/daemon/vllm_bifrost/camem_allocator.cpp
+++ b/daemon/vllm_bifrost/camem_allocator.cpp
@@ -1,0 +1,1423 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <array>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fcntl.h>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "camem_utils.hpp"
+
+extern "C" {
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "acl/acl.h"
+
+static PyObject* g_python_malloc_callback = nullptr;
+static PyObject* g_python_free_callback = nullptr;
+
+namespace {
+
+using Byte = uint8_t;
+
+constexpr uint64_t kMB = 1024ULL * 1024ULL;
+constexpr int kDefaultWaitTimeoutMs = 10000;
+constexpr int kDefaultPollIntervalUs = 1000;
+constexpr int kMacroWaitTimeoutMs = 10000;
+constexpr std::chrono::milliseconds kHeartbeatInterval(500);
+
+int64_t monotonicNowNs() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+int pollIntervalUs() {
+    static const int interval_us = []() {
+        const char* raw = std::getenv("MDAEMON_POLL_INTERVAL_US");
+        if (!raw || raw[0] == '\0') {
+            return kDefaultPollIntervalUs;
+        }
+        char* end = nullptr;
+        errno = 0;
+        long value = std::strtol(raw, &end, 10);
+        if (errno != 0 || end == raw || (end && *end != '\0') || value <= 0) {
+            return kDefaultPollIntervalUs;
+        }
+        return static_cast<int>(value);
+    }();
+    return interval_us;
+}
+
+const std::array<uint64_t, 4> kSupportedGranularities = {
+    16ULL * kMB, 8ULL * kMB, 4ULL * kMB, 2ULL * kMB
+};
+
+/* allocation mapping structure
+d_mem_base -> Allocated by aclrtMalloc, with reserved_size
+    | requested_size (<= reserved_size)
+    |---> slot 0: virt_addr, granularity, device_id, state, handle
+    |---> slot 1: virt_addr, granularity, device_id, state, handle
+    ...
+*/
+
+struct ImportedHandle {
+    uint64_t shareable_handle{std::numeric_limits<uint64_t>::max()};
+    uint64_t granularity{0};
+    int32_t device_id{-1};
+    aclrtDrvMemHandle raw{};
+    bool valid{false};
+};
+
+enum class SlotState : uint8_t {
+    UNMAPPED = 0,
+    NULL_MAPPED = 1,
+    REAL_MAPPED = 2,
+};
+
+struct MappingSlot {
+    void* virt_addr{nullptr};
+    uint64_t granularity{0};
+    int32_t device_id{-1};
+    SlotState state{SlotState::UNMAPPED};
+    ImportedHandle handle{};
+};
+
+struct AllocationRecord {
+    void* base{nullptr};
+    void* raw_base{nullptr};
+    size_t requested_size{0};
+    size_t reserved_size{0};
+    int32_t device_id{-1};
+    bool is_kvcache{false};
+    uint64_t kvcache_granularity{0};
+    size_t mapped_weight_bytes{0};
+    std::vector<MappingSlot> slots;
+};
+
+struct RuntimeState {
+    std::mutex mutex;
+    bool initialized{false};
+    std::atomic<bool> heartbeat_running{false};
+    std::thread heartbeat_thread;
+    int macro_fd{-1};
+    int message_fd{-1};
+    sem_t* message_sem{nullptr};
+    ModelMacroSpace* macro_space{nullptr};
+    ModelMessageSpace* message_space{nullptr};
+    std::string model_shm_name;
+    std::string message_sem_name;
+    int32_t device_id{-1};
+    int32_t model_npuid{kInvalidModelHandle};
+    int32_t model_osid{kInvalidModelHandle};
+    std::unordered_map<void*, AllocationRecord> allocations;
+    std::unordered_map<uint64_t, ImportedHandle> null_pages;
+};
+
+RuntimeState g_state;
+
+std::string buildMessageSemName(const std::string& shm_name) {
+    return shm_name + "-sem";
+}
+
+void lockMessageSemaphore() {
+    if (!g_state.message_sem) {
+        throw std::runtime_error("message semaphore is not initialized");
+    }
+    while (::sem_wait(g_state.message_sem) == -1) {
+        if (errno == EINTR) {
+            continue;
+        }
+        throw std::runtime_error("sem_wait failed for message semaphore");
+    }
+}
+
+void unlockMessageSemaphore() {
+    if (!g_state.message_sem) {
+        return;
+    }
+    if (::sem_post(g_state.message_sem) == -1) {
+        throw std::runtime_error("sem_post failed for message semaphore");
+    }
+}
+
+struct MessageSemaphoreGuard {
+    MessageSemaphoreGuard() {
+        lockMessageSemaphore();
+    }
+    ~MessageSemaphoreGuard() {
+        if (g_state.message_sem) {
+            (void)::sem_post(g_state.message_sem);
+        }
+    }
+};
+
+[[noreturn]] void throwAcl(aclError code, const char* op, const char* file, int line) {
+    throw std::runtime_error(std::string(op) + " failed with acl error code: " +
+                             std::to_string(code) + " at " + file + ":" +
+                             std::to_string(line));
+}
+
+void checkAcl(aclError code, const char* op, const char* file, int line) {
+    if (code != 0) {
+        throwAcl(code, op, file, line);
+    }
+}
+
+#define CHECK_ACL(op, expr) checkAcl((expr), (op), __FILE__, __LINE__)
+
+bool daemonDebugLogsEnabled() {
+    const char* flag = std::getenv("MDAEMON_DEBUG_LOG");
+    return flag && std::string(flag) == "1";
+}
+
+void ensureContext(int32_t device) {
+    CHECK_ACL("aclrtSetDevice", aclrtSetDevice(device));
+    aclrtContext context;
+    CHECK_ACL("aclrtGetCurrentContext", aclrtGetCurrentContext(&context));
+    if (!context) {
+        CHECK_ACL("aclrtCreateContext", aclrtCreateContext(&context, device));
+        CHECK_ACL("aclrtSetCurrentContext", aclrtSetCurrentContext(context));
+    }
+}
+
+uint64_t alignUp(uint64_t value, uint64_t align) {
+    if (align == 0) {
+        throw std::invalid_argument("align must be positive");
+    }
+    return ((value + align - 1) / align) * align;
+}
+
+uint64_t alignDown(uint64_t value, uint64_t align) {
+    if (align == 0) {
+        throw std::invalid_argument("align must be positive");
+    }
+    return (value / align) * align;
+}
+
+uintptr_t alignUpPtr(uintptr_t value, uint64_t align) {
+    return static_cast<uintptr_t>(alignUp(static_cast<uint64_t>(value), align));
+}
+
+int readIntEnv(const char* name, int default_value) {
+    const char* raw = std::getenv(name);
+    if (!raw || raw[0] == '\0') {
+        return default_value;
+    }
+    try {
+        return std::stoi(raw);
+    } catch (...) {
+        return default_value;
+    }
+}
+
+std::vector<int32_t> parseVisibleDeviceList() {
+    const char* raw = std::getenv("ASCEND_RT_VISIBLE_DEVICES");
+    if (!raw || raw[0] == '\0') {
+        raw = std::getenv("ASCEND_VISIBLE_DEVICES");
+    }
+    if (!raw || raw[0] == '\0') {
+        raw = std::getenv("CUDA_VISIBLE_DEVICES");
+    }
+    if (!raw || raw[0] == '\0') {
+        return {};
+    }
+
+    std::vector<int32_t> ids;
+    const std::string visible(raw);
+    size_t start = 0;
+    while (start < visible.size()) {
+        size_t end = visible.find(',', start);
+        if (end == std::string::npos) {
+            end = visible.size();
+        }
+        std::string token = visible.substr(start, end - start);
+        token.erase(std::remove_if(token.begin(), token.end(), [](unsigned char c) {
+                        return std::isspace(c) != 0;
+                    }),
+                    token.end());
+        if (!token.empty()) {
+            ids.push_back(static_cast<int32_t>(std::stoi(token)));
+        }
+        start = end + 1;
+    }
+    return ids;
+}
+
+int32_t localToCanonicalDeviceId(int32_t local_device_id) {
+    if (local_device_id < 0) {
+        return local_device_id;
+    }
+    const auto ids = parseVisibleDeviceList();
+    if (ids.empty() || static_cast<size_t>(local_device_id) >= ids.size()) {
+        return local_device_id;
+    }
+    return ids[local_device_id];
+}
+
+int32_t canonicalToLocalDeviceId(int32_t canonical_device_id) {
+    if (canonical_device_id < 0) {
+        return canonical_device_id;
+    }
+    const auto ids = parseVisibleDeviceList();
+    if (ids.empty()) {
+        return canonical_device_id;
+    }
+    for (size_t i = 0; i < ids.size(); ++i) {
+        if (ids[i] == canonical_device_id) {
+            return static_cast<int32_t>(i);
+        }
+    }
+    return canonical_device_id;
+}
+
+uint64_t getKvcacheGranularity() {
+    const int mb = readIntEnv("MDAEMON_KV_GRAN_MB", 4);
+    const uint64_t bytes = static_cast<uint64_t>(mb) * kMB;
+    for (uint64_t g : kSupportedGranularities) {
+        if (g == bytes) {
+            return bytes;
+        }
+    }
+    return 4ULL * kMB;
+}
+
+void callPythonMallocCallback(int device, uint64_t aligned_size, void* d_mem) {
+    if (!g_python_malloc_callback) {
+        return;
+    }
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    PyObject* arg_tuple = PyTuple_New(4);
+    if (!arg_tuple) {
+        PyGILState_Release(gstate);
+        return;
+    }
+    PyTuple_SetItem(arg_tuple, 0, PyLong_FromUnsignedLongLong(static_cast<unsigned long long>(device)));
+    PyTuple_SetItem(arg_tuple, 1, PyLong_FromUnsignedLongLong(static_cast<unsigned long long>(aligned_size)));
+    PyTuple_SetItem(arg_tuple, 2, PyLong_FromUnsignedLongLong(reinterpret_cast<unsigned long long>(d_mem)));
+    PyTuple_SetItem(arg_tuple, 3, PyLong_FromUnsignedLongLong(0ULL));
+    PyObject* py_result = PyObject_CallFunctionObjArgs(g_python_malloc_callback, arg_tuple, NULL);
+    Py_DECREF(arg_tuple);
+    if (!py_result) {
+        PyErr_Print();
+    } else {
+        Py_DECREF(py_result);
+    }
+    PyGILState_Release(gstate);
+}
+
+void callPythonFreeCallback(void* ptr) {
+    if (!g_python_free_callback) {
+        return;
+    }
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    PyObject* py_ptr = PyLong_FromUnsignedLongLong(reinterpret_cast<unsigned long long>(ptr));
+    PyObject* py_result = PyObject_CallFunctionObjArgs(g_python_free_callback, py_ptr, NULL);
+    Py_DECREF(py_ptr);
+    if (!py_result) {
+        PyErr_Print();
+    } else {
+        Py_DECREF(py_result);
+    }
+    PyGILState_Release(gstate);
+}
+
+void clearRequestList(ModelMessageSpace& space) {
+    for (auto& req : space.handle_request_list) {
+        if (req.request_num == 0 && req.granularity == 0 && req.device_id == -1) {
+            // already cleared, skip to save some time
+            break;
+        }
+        req.request_num = 0;
+        req.granularity = 0;
+        req.device_id = -1;
+    }
+}
+
+void clearHandleInfoList(ModelMessageSpace& space) {
+    for (auto& info : space.handle_info_list) {
+        if (info.shareable_handle == std::numeric_limits<uint64_t>::max() &&
+            info.granularity == 0 &&
+            info.device_id == -1) {
+            // already cleared, skip to save some time
+            break;
+        }
+        info.shareable_handle = std::numeric_limits<uint64_t>::max();
+        info.granularity = 0;
+        info.device_id = -1;
+    }
+    space.offset_st = 0;
+    space.offset_ed = 0;
+}
+
+void syncMessageToShm() {
+    if (!g_state.message_space) {
+        throw std::runtime_error("message space is not initialized");
+    }
+    std::atomic_thread_fence(std::memory_order_release);
+}
+
+void syncMessageFromShm() {
+    if (!g_state.message_space) {
+        throw std::runtime_error("message space is not initialized");
+    }
+    std::atomic_thread_fence(std::memory_order_acquire);
+}
+
+void touchHeartbeat() {
+    if (!g_state.message_space || !g_state.message_sem) {
+        return;
+    }
+    MessageSemaphoreGuard guard;
+    syncMessageFromShm();
+    g_state.message_space->heartbeat_ns = monotonicNowNs();
+    syncMessageToShm();
+}
+
+void heartbeatLoop() {
+    while (g_state.heartbeat_running.load(std::memory_order_relaxed)) {
+        try {
+            touchHeartbeat();
+        } catch (...) {
+            // Keep heartbeat best-effort and non-fatal.
+        }
+        std::this_thread::sleep_for(kHeartbeatInterval);
+    }
+}
+
+void startHeartbeatThread() {
+    if (g_state.heartbeat_running.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+    g_state.heartbeat_thread = std::thread(heartbeatLoop);
+}
+
+void stopHeartbeatThread() {
+    if (!g_state.heartbeat_running.exchange(false, std::memory_order_acq_rel)) {
+        return;
+    }
+    if (g_state.heartbeat_thread.joinable()) {
+        g_state.heartbeat_thread.join();
+    }
+}
+
+bool waitForMessageState(MessageState target, int timeout_ms) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+        bool reached = false;
+        {
+            MessageSemaphoreGuard guard;
+            syncMessageFromShm();
+            reached = (g_state.message_space->state == target);
+        }
+        if (reached) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::microseconds(pollIntervalUs()));
+    }
+    return false;
+}
+
+ImportedHandle importShareableHandle(const handle_granularity& info) {
+    ImportedHandle imported;
+    imported.shareable_handle = info.shareable_handle;
+    imported.granularity = info.granularity;
+    imported.device_id = info.device_id;
+    const int32_t local_device_id = canonicalToLocalDeviceId(info.device_id);
+    aclrtDrvMemHandle raw{};
+    CHECK_ACL("aclrtMemImportFromShareableHandle",
+              aclrtMemImportFromShareableHandle(info.shareable_handle, local_device_id, &raw));
+    imported.raw = raw;
+    imported.valid = true;
+    return imported;
+}
+
+void releaseImportedHandle(ImportedHandle& imported) {
+    if (!imported.valid) {
+        return;
+    }
+    CHECK_ACL("aclrtFreePhysical", aclrtFreePhysical(imported.raw));
+    imported = ImportedHandle{};
+}
+
+void mapSlot(MappingSlot& slot, const ImportedHandle& imported, SlotState state) {
+    if (!imported.valid) {
+        throw std::runtime_error("cannot map invalid imported handle");
+    }
+    const uintptr_t vaddr = reinterpret_cast<uintptr_t>(slot.virt_addr);
+    if (slot.granularity == 0 || (vaddr % slot.granularity) != 0) {
+        throw std::runtime_error("virtual address is not aligned to mapping granularity");
+    }
+    CHECK_ACL("aclrtMapMem", aclrtMapMem(slot.virt_addr, slot.granularity, 0, imported.raw, 0));
+    slot.handle = imported;
+    slot.state = state;
+}
+
+void unmapSlot(MappingSlot& slot) {
+    if (slot.state == SlotState::UNMAPPED) {
+        return;
+    }
+    const SlotState old_state = slot.state;
+    CHECK_ACL("aclrtUnmapMem", aclrtUnmapMem(slot.virt_addr));
+    if (old_state == SlotState::REAL_MAPPED) {
+        releaseImportedHandle(slot.handle);
+    }
+    slot.state = SlotState::UNMAPPED;
+    slot.handle = ImportedHandle{};
+}
+
+std::vector<request_granularity> buildLargeFirstRequests(uint64_t bytes, int32_t device_id) {
+    std::vector<request_granularity> requests;
+    uint64_t remaining = bytes;
+    for (uint64_t granularity : kSupportedGranularities) {
+        const uint64_t num = remaining / granularity;
+        if (num > 0) {
+            requests.push_back({num, granularity, device_id});
+            remaining -= num * granularity;
+        }
+    }
+    if (remaining > 0) {
+        const uint64_t smallest = kSupportedGranularities.back();
+        requests.push_back({1, smallest, device_id});
+    }
+    return requests;
+}
+
+std::vector<request_granularity> buildSingleGranularityRequests(uint64_t bytes,
+                                                                uint64_t granularity,
+                                                                int32_t device_id) {
+    const uint64_t aligned = alignUp(bytes, granularity);
+    const uint64_t num = aligned / granularity;
+    if (num == 0) {
+        return {};
+    }
+    return {{num, granularity, device_id}};
+}
+
+std::vector<handle_granularity> requestHandlesFromDaemon(const std::vector<request_granularity>& requests,
+                                                         int timeout_ms) {
+    if (requests.empty()) {
+        return {};
+    }
+    if (!g_state.message_space) {
+        throw std::runtime_error("init_space must be called before requesting handles");
+    }
+    if (requests.size() > g_state.message_space->handle_request_list.size()) {
+        throw std::runtime_error("too many handle requests for message space");
+    }
+
+    ModelMessageSpace& space = *g_state.message_space;
+    {
+        MessageSemaphoreGuard guard;
+        clearRequestList(space);
+        clearHandleInfoList(space);
+
+        for (size_t i = 0; i < requests.size(); ++i) {
+            space.handle_request_list[i] = requests[i];
+        }
+
+        space.state = MessageState::REQUEST_GET_HANDLES;
+        syncMessageToShm();
+    }
+
+    if (!waitForMessageState(MessageState::HANDLES_READY, timeout_ms)) {
+        throw std::runtime_error("timed out waiting for HANDLES_READY");
+    }
+
+    std::vector<handle_granularity> handles;
+    {
+        MessageSemaphoreGuard guard;
+        syncMessageFromShm();
+        const int32_t start = std::max<int32_t>(0, space.offset_st);
+        const int32_t end = std::min<int32_t>(space.offset_ed,
+                                              static_cast<int32_t>(space.handle_info_list.size()));
+        for (int32_t i = start; i < end; ++i) {
+            const handle_granularity& info = space.handle_info_list[i];
+            if (info.granularity == 0 || info.device_id < 0 ||
+                info.shareable_handle == std::numeric_limits<uint64_t>::max()) {
+                continue;
+            }
+            handles.push_back(info);
+        }
+
+        clearRequestList(space);
+        clearHandleInfoList(space);
+        space.state = MessageState::NONE;
+        syncMessageToShm();
+    }
+
+    return handles;
+}
+
+void returnHandlesToDaemon(const std::vector<handle_granularity>& handles,
+                           int timeout_ms = kDefaultWaitTimeoutMs) {
+    if (handles.empty()) {
+        return;
+    }
+    if (!g_state.message_space) {
+        throw std::runtime_error("init_space must be called before returning handles");
+    }
+    if (handles.size() > g_state.message_space->handle_info_list.size()) {
+        throw std::runtime_error("too many handles to return for message space");
+    }
+
+    ModelMessageSpace& space = *g_state.message_space;
+    {
+        MessageSemaphoreGuard guard;
+        clearRequestList(space);
+        clearHandleInfoList(space);
+
+        for (size_t i = 0; i < handles.size(); ++i) {
+            space.handle_info_list[i] = handles[i];
+        }
+        space.offset_st = 0;
+        space.offset_ed = static_cast<int32_t>(handles.size());
+        space.state = MessageState::REQUEST_RETURN_HANDLES;
+        syncMessageToShm();
+    }
+
+    if (!waitForMessageState(MessageState::HANDLES_RETURNED, timeout_ms)) {
+        throw std::runtime_error("timed out waiting for HANDLES_RETURNED");
+    }
+
+    {
+        MessageSemaphoreGuard guard;
+        clearRequestList(space);
+        clearHandleInfoList(space);
+        space.state = MessageState::NONE;
+        syncMessageToShm();
+    }
+}
+
+struct ReservedAddress {
+    void* raw_base{nullptr};
+    void* aligned_base{nullptr};
+    size_t raw_reserved_size{0};
+    size_t usable_size{0};
+};
+
+ReservedAddress reserveVirtualAddress(size_t requested_usable_size, uint64_t align_granularity) {
+    const uint64_t headroom = align_granularity - 1;
+    const uint64_t raw_reserved =
+        alignUp(static_cast<uint64_t>(requested_usable_size) + headroom, align_granularity);
+    void* raw_base = nullptr;
+    CHECK_ACL("aclrtReserveMemAddress",
+              aclrtReserveMemAddress(&raw_base, static_cast<size_t>(raw_reserved), 0, nullptr, 0));
+
+    const uintptr_t raw_addr = reinterpret_cast<uintptr_t>(raw_base);
+    const uintptr_t aligned_addr = alignUpPtr(raw_addr, align_granularity);
+    const size_t offset = static_cast<size_t>(aligned_addr - raw_addr);
+    const size_t usable = static_cast<size_t>(raw_reserved) - offset;
+    if (usable < requested_usable_size) {
+        CHECK_ACL("aclrtReleaseMemAddress", aclrtReleaseMemAddress(raw_base));
+        throw std::runtime_error("reserved virtual address usable range is smaller than requested");
+    }
+
+    return ReservedAddress{
+        raw_base,
+        reinterpret_cast<void*>(aligned_addr),
+        static_cast<size_t>(raw_reserved),
+        usable,
+    };
+}
+
+AllocationRecord& findAllocationOrThrow(void* ptr) {
+    auto it = g_state.allocations.find(ptr);
+    if (it == g_state.allocations.end()) {
+        throw std::runtime_error("allocation not found for pointer");
+    }
+    return it->second;
+}
+
+size_t currentKvcacheMappedRealSlots(const AllocationRecord& record) {
+    size_t count = 0;
+    while (count < record.slots.size() && record.slots[count].state == SlotState::REAL_MAPPED) {
+        ++count;
+    }
+    return count;
+}
+
+void registerToDaemonAndOpenMessageSpace(int32_t local_device_id,
+                                         int32_t canonical_device_id) {
+    ensureContext(local_device_id);
+
+    int32_t npuid = kInvalidModelHandle;
+    CHECK_ACL("aclrtDeviceGetBareTgid", aclrtDeviceGetBareTgid(&npuid));
+    const int32_t osid = static_cast<int32_t>(::getpid());
+
+    sem_t* sem = ::sem_open(MODEL_SEMAPHORE_NAME, O_CREAT, 0666, 1);
+    if (sem == SEM_FAILED) {
+        throw std::runtime_error("sem_open failed for model semaphore");
+    }
+    if (::sem_wait(sem) == -1) {
+        ::sem_close(sem);
+        throw std::runtime_error("sem_wait failed for model semaphore");
+    }
+
+    auto sem_guard = [&]() {
+        ::sem_post(sem);
+        ::sem_close(sem);
+    };
+
+    int macro_fd = ::shm_open(MODEL_REG_SHM, O_RDWR | O_CREAT, 0666);
+    if (macro_fd == -1) {
+        sem_guard();
+        throw std::runtime_error("shm_open failed for MODEL_REG_SHM");
+    }
+    if (::ftruncate(macro_fd, sizeof(ModelMacroSpace)) == -1) {
+        ::close(macro_fd);
+        sem_guard();
+        throw std::runtime_error("ftruncate failed for MODEL_REG_SHM");
+    }
+
+    void* macro_region = ::mmap(nullptr,
+                                sizeof(ModelMacroSpace),
+                                PROT_READ | PROT_WRITE,
+                                MAP_SHARED,
+                                macro_fd,
+                                0);
+    if (macro_region == MAP_FAILED) {
+        ::close(macro_fd);
+        sem_guard();
+        throw std::runtime_error("mmap failed for MODEL_REG_SHM");
+    }
+
+    ModelMacroSpace* macro_space = static_cast<ModelMacroSpace*>(macro_region);
+    if (isDefaultShmName(macro_space->getShmName())) {
+        macro_space->current_model_npuid = npuid;
+        macro_space->current_model_osid = osid;
+        macro_space->setShmName(defaultShmName());
+        ::msync(macro_space, sizeof(ModelMacroSpace), MS_SYNC);
+    }
+    else {
+        ::munmap(macro_space, sizeof(ModelMacroSpace));
+        ::close(macro_fd);
+        sem_guard();
+        throw std::runtime_error("ModelMacroSpace is dirty, please check");
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(kMacroWaitTimeoutMs);
+    while (std::chrono::steady_clock::now() < deadline && isDefaultShmName(macro_space->getShmName())) {
+        std::this_thread::sleep_for(std::chrono::microseconds(pollIntervalUs()));
+        ::msync(macro_space, sizeof(ModelMacroSpace), MS_SYNC);
+    }
+    if (isDefaultShmName(macro_space->getShmName())) {
+        ::munmap(macro_space, sizeof(ModelMacroSpace));
+        ::close(macro_fd);
+        sem_guard();
+        throw std::runtime_error("timed out waiting daemon registration response");
+    }
+
+    const std::string model_shm_name(macro_space->getShmName());
+    macro_space->reset();
+    ::msync(macro_space, sizeof(ModelMacroSpace), MS_SYNC);
+
+    ::munmap(macro_space, sizeof(ModelMacroSpace));
+    ::close(macro_fd);
+    sem_guard();
+
+    const int message_fd = ::shm_open(model_shm_name.c_str(), O_RDWR, 0666);
+    if (message_fd == -1) {
+        throw std::runtime_error("shm_open failed for model message shm");
+    }
+
+    void* message_region = ::mmap(nullptr,
+                                  sizeof(ModelMessageSpace),
+                                  PROT_READ | PROT_WRITE,
+                                  MAP_SHARED,
+                                  message_fd,
+                                  0);
+    if (message_region == MAP_FAILED) {
+        ::close(message_fd);
+        throw std::runtime_error("mmap failed for model message shm");
+    }
+
+    g_state.device_id = canonical_device_id;
+    g_state.model_npuid = npuid;
+    g_state.model_osid = osid;
+    g_state.model_shm_name = model_shm_name;
+    g_state.message_sem_name = buildMessageSemName(model_shm_name);
+    g_state.message_sem = ::sem_open(g_state.message_sem_name.c_str(), O_CREAT, 0666, 1);
+    if (g_state.message_sem == SEM_FAILED) {
+        g_state.message_sem = nullptr;
+        ::munmap(message_region, sizeof(ModelMessageSpace));
+        ::close(message_fd);
+        throw std::runtime_error("sem_open failed for model message semaphore");
+    }
+    g_state.message_fd = message_fd;
+    g_state.message_space = static_cast<ModelMessageSpace*>(message_region);
+
+    // check if messasge state becomes REGISTERED by daemon within timeout, otherwise consider it as registration failure
+    if (!waitForMessageState(MessageState::REGISTERED, kMacroWaitTimeoutMs)) {
+        ::sem_close(g_state.message_sem);
+        ::munmap(message_region, sizeof(ModelMessageSpace));
+        ::close(message_fd);
+        throw std::runtime_error("timed out waiting for message space registration");
+    }
+}
+
+void initializeNullPages() {
+    if (daemonDebugLogsEnabled()) {
+        std::cout << "\033[34m[CamemAllocator] Initializing null pages for all supported granularities\033[0m\n";
+        std::cout << "model shm name: \033[32m" << g_state.model_shm_name << "\033[0m\n";
+        std::cout << "device id: " << g_state.device_id << ", support granularities: ";
+        for (uint64_t granularity : kSupportedGranularities) {
+            std::cout << granularity << " ";
+        }
+        std::cout << "\n";
+    }
+    std::vector<request_granularity> requests;
+    requests.reserve(kSupportedGranularities.size());
+    for (uint64_t granularity : kSupportedGranularities) {
+        requests.push_back({1, granularity, g_state.device_id});
+    }
+
+    const std::vector<handle_granularity> granted =
+        requestHandlesFromDaemon(requests, kDefaultWaitTimeoutMs);
+    if (granted.size() != kSupportedGranularities.size()) {
+        throw std::runtime_error("failed to initialize null pages for all granularities");
+    }
+
+    g_state.null_pages.clear();
+    for (const auto& info : granted) {
+        g_state.null_pages[info.granularity] = importShareableHandle(info);
+    }
+
+    for (uint64_t granularity : kSupportedGranularities) {
+        if (g_state.null_pages.find(granularity) == g_state.null_pages.end()) {
+            throw std::runtime_error("missing null page for granularity");
+        }
+    }
+}
+
+void maybeFinalizeState() {
+    stopHeartbeatThread();
+    if (g_state.message_sem) {
+        ::sem_close(g_state.message_sem);
+        g_state.message_sem = nullptr;
+    }
+    if (g_state.message_space) {
+        g_state.message_space->state = MessageState::DONE;
+        ::munmap(g_state.message_space, sizeof(ModelMessageSpace));
+        g_state.message_space = nullptr;
+    }
+    if (g_state.message_fd != -1) {
+        ::close(g_state.message_fd);
+        g_state.message_fd = -1;
+    }
+    g_state.model_shm_name.clear();
+    g_state.message_sem_name.clear();
+    g_state.initialized = false;
+}
+
+void requireInitialized() {
+    if (!g_state.initialized || !g_state.message_space) {
+        throw std::runtime_error("allocator message space is not initialized; call python_init_space first");
+    }
+}
+
+void mapWeightRange(AllocationRecord& record, size_t final_size, int timeout_ms) {
+    if (record.is_kvcache) {
+        throw std::runtime_error("mapWeightRange called for kvcache allocation");
+    }
+    const uint64_t min_gran = kSupportedGranularities.back();
+    const size_t target_bytes = static_cast<size_t>(
+        std::min<uint64_t>(alignUp(static_cast<uint64_t>(final_size), min_gran),
+                           static_cast<uint64_t>(record.reserved_size)));
+    if (target_bytes <= record.mapped_weight_bytes) {
+        return;
+    }
+
+    const size_t delta_bytes = target_bytes - record.mapped_weight_bytes;
+    const std::vector<request_granularity> requests =
+        buildLargeFirstRequests(delta_bytes, g_state.device_id);
+    std::vector<handle_granularity> granted = requestHandlesFromDaemon(requests, timeout_ms);
+
+    std::vector<handle_granularity> accepted_for_return;
+    Byte* base = static_cast<Byte*>(record.base);
+    for (const auto& info : granted) {
+        if (record.mapped_weight_bytes + info.granularity > record.reserved_size) {
+            accepted_for_return.push_back(info);
+            continue;
+        }
+
+        ImportedHandle imported = importShareableHandle(info);
+        MappingSlot slot;
+        slot.virt_addr = base + record.mapped_weight_bytes;
+        slot.granularity = info.granularity;
+        slot.device_id = info.device_id;
+        mapSlot(slot, imported, SlotState::REAL_MAPPED);
+
+        record.slots.push_back(slot);
+        record.mapped_weight_bytes += info.granularity;
+
+        if (record.mapped_weight_bytes >= target_bytes) {
+            break;
+        }
+    }
+
+    if (!accepted_for_return.empty()) {
+        returnHandlesToDaemon(accepted_for_return, timeout_ms);
+    }
+
+    if (record.mapped_weight_bytes < target_bytes) {
+        throw std::runtime_error("daemon returned insufficient handles to satisfy weight mapping");
+    }
+}
+
+void unmapWeightAll(AllocationRecord& record, int timeout_ms) {
+    std::vector<handle_granularity> to_return;
+    for (auto& slot : record.slots) {
+        if (slot.state == SlotState::REAL_MAPPED) {
+            ImportedHandle old = slot.handle;
+            unmapSlot(slot);
+            to_return.push_back({old.shareable_handle, old.granularity, old.device_id});
+        } else if (slot.state == SlotState::NULL_MAPPED) {
+            unmapSlot(slot);
+        }
+    }
+    record.slots.clear();
+    record.mapped_weight_bytes = 0;
+    returnHandlesToDaemon(to_return, timeout_ms);
+}
+
+void mapKvcacheUntil(AllocationRecord& record, size_t final_size, int timeout_ms) {
+    if (!record.is_kvcache) {
+        throw std::runtime_error("mapKvcacheUntil called for weight allocation");
+    }
+    const uint64_t gran = record.kvcache_granularity;
+    const uint64_t ceil_bytes = alignUp(static_cast<uint64_t>(final_size), gran);
+    const size_t target_slots = static_cast<size_t>(
+        std::min<uint64_t>(ceil_bytes / gran, static_cast<uint64_t>(record.slots.size())));
+
+    const size_t current_real = currentKvcacheMappedRealSlots(record);
+    if (target_slots <= current_real) {
+        return;
+    }
+
+    const size_t need_slots = target_slots - current_real;
+    const uint64_t need_bytes = static_cast<uint64_t>(need_slots) * gran;
+    const std::vector<request_granularity> requests =
+        buildSingleGranularityRequests(need_bytes, gran, g_state.device_id);
+    const std::vector<handle_granularity> granted = requestHandlesFromDaemon(requests, timeout_ms);
+
+    size_t mapped = 0;
+    for (const auto& info : granted) {
+        if (info.granularity != gran) {
+            throw std::runtime_error("kvcache mapping received unexpected handle granularity" 
+                + std::to_string(info.granularity) + " expected " + std::to_string(gran));
+        }
+        if (current_real + mapped >= record.slots.size()) {
+            break;
+        }
+        MappingSlot& slot = record.slots[current_real + mapped];
+        if (slot.state != SlotState::NULL_MAPPED) {
+            throw std::runtime_error("kvcache slot is not null-mapped before real mapping");
+        }
+        unmapSlot(slot);
+
+        ImportedHandle imported = importShareableHandle(info);
+        mapSlot(slot, imported, SlotState::REAL_MAPPED);
+        ++mapped;
+        if (mapped == need_slots) {
+            break;
+        }
+    }
+
+    if (mapped != need_slots) {
+        throw std::runtime_error("daemon returned insufficient handles for kvcache mapping");
+    }
+}
+
+void unmapKvcacheUntil(AllocationRecord& record, size_t final_size, int timeout_ms) {
+    if (!record.is_kvcache) {
+        throw std::runtime_error("unmapKvcacheUntil called for weight allocation");
+    }
+    const uint64_t gran = record.kvcache_granularity;
+    const uint64_t ceil_bytes = alignUp(static_cast<uint64_t>(final_size), gran);
+    const size_t keep_slots = static_cast<size_t>(
+        std::min<uint64_t>(ceil_bytes / gran, static_cast<uint64_t>(record.slots.size())));
+
+    size_t current_real = currentKvcacheMappedRealSlots(record);
+    if (keep_slots >= current_real) {
+        return;
+    }
+
+    std::vector<handle_granularity> to_return;
+    for (size_t idx = current_real; idx > keep_slots; --idx) {
+        MappingSlot& slot = record.slots[idx - 1];
+        if (slot.state != SlotState::REAL_MAPPED) {
+            throw std::runtime_error("kvcache real-mapped slots must be a prefix");
+        }
+        ImportedHandle old_real = slot.handle;
+        unmapSlot(slot);
+
+        auto null_it = g_state.null_pages.find(gran);
+        if (null_it == g_state.null_pages.end()) {
+            throw std::runtime_error("null page handle missing for kvcache granularity");
+        }
+        mapSlot(slot, null_it->second, SlotState::NULL_MAPPED);
+
+        to_return.push_back({old_real.shareable_handle, old_real.granularity, old_real.device_id});
+    }
+
+    returnHandlesToDaemon(to_return, timeout_ms);
+}
+
+void releaseAllocation(void* ptr, int timeout_ms) {
+    AllocationRecord& record = findAllocationOrThrow(ptr);
+    if (record.is_kvcache) {
+        std::vector<handle_granularity> to_return;
+        for (auto& slot : record.slots) {
+            if (slot.state == SlotState::REAL_MAPPED) {
+                ImportedHandle old = slot.handle;
+                unmapSlot(slot);
+                to_return.push_back({old.shareable_handle, old.granularity, old.device_id});
+            } else if (slot.state == SlotState::NULL_MAPPED) {
+                unmapSlot(slot);
+            }
+        }
+        returnHandlesToDaemon(to_return, timeout_ms);
+    } else {
+        unmapWeightAll(record, timeout_ms);
+    }
+
+    void* release_base = record.raw_base ? record.raw_base : record.base;
+    CHECK_ACL("aclrtReleaseMemAddress", aclrtReleaseMemAddress(release_base));
+    g_state.allocations.erase(ptr);
+}
+
+void unmapNullPagesBeforeFinalize() {
+    for (auto& allocation_kv : g_state.allocations) {
+        AllocationRecord& record = allocation_kv.second;
+        for (auto& slot : record.slots) {
+            if (slot.state == SlotState::NULL_MAPPED) {
+                unmapSlot(slot);
+            }
+        }
+    }
+}
+
+} // namespace
+
+__attribute__((visibility("default"))) void* my_malloc_weight(ssize_t size,
+                                                               int device,
+                                                               aclrtStream stream) {
+    (void)stream;
+    std::unique_lock<std::mutex> guard(g_state.mutex);
+    requireInitialized();
+    ensureContext(device);
+
+    const uint64_t map_granularity = kSupportedGranularities.back();
+    const uint64_t reserve_granularity = kSupportedGranularities.front();
+    const uint64_t aligned_size = alignUp(static_cast<uint64_t>(size), map_granularity);
+    const ReservedAddress reserved =
+        reserveVirtualAddress(static_cast<size_t>(aligned_size), reserve_granularity);
+    void* d_mem = reserved.aligned_base;
+    
+    if(daemonDebugLogsEnabled()) {
+        fprintf(stderr,
+                "my_malloc_weight: requested size=%zd, aligned size=%zu, reserve_gran=%zu, raw_reserved=%zu, raw_base=%p, aligned_base=%p\n",
+                size,
+                static_cast<size_t>(aligned_size),
+                static_cast<size_t>(reserve_granularity),
+                reserved.raw_reserved_size,
+                reserved.raw_base,
+                d_mem);
+    }
+
+    AllocationRecord record;
+    record.base = d_mem;
+    record.raw_base = reserved.raw_base;
+    record.requested_size = static_cast<size_t>(size);
+    record.reserved_size = static_cast<size_t>(aligned_size);
+    record.device_id = device;
+    record.is_kvcache = false;
+    g_state.allocations[d_mem] = std::move(record);
+
+    guard.unlock();
+    callPythonMallocCallback(device, aligned_size, d_mem);
+    return d_mem;
+}
+
+__attribute__((visibility("default"))) void my_free_weight(void* ptr,
+                                                             ssize_t size,
+                                                             int device,
+                                                             aclrtStream stream) {
+    (void)size;
+    (void)device;
+    (void)stream;
+    std::unique_lock<std::mutex> guard(g_state.mutex);
+    requireInitialized();
+    releaseAllocation(ptr, kDefaultWaitTimeoutMs);
+    guard.unlock();
+    callPythonFreeCallback(ptr);
+}
+
+__attribute__((visibility("default"))) void* my_malloc_kvcache(ssize_t size,
+                                                                int device,
+                                                                aclrtStream stream) {
+    (void)stream;
+    std::unique_lock<std::mutex> guard(g_state.mutex);
+    requireInitialized();
+    ensureContext(device);
+
+    const uint64_t granularity = getKvcacheGranularity();
+    const uint64_t aligned_size = alignUp(static_cast<uint64_t>(size), granularity);
+    const ReservedAddress reserved =
+        reserveVirtualAddress(static_cast<size_t>(aligned_size), granularity);
+    void* d_mem = reserved.aligned_base;
+
+    auto null_it = g_state.null_pages.find(granularity);
+    if (null_it == g_state.null_pages.end()) {
+        throw std::runtime_error("null page for selected kvcache granularity is not initialized");
+    }
+
+    AllocationRecord record;
+    record.base = d_mem;
+    record.raw_base = reserved.raw_base;
+    record.requested_size = static_cast<size_t>(size);
+    record.reserved_size = static_cast<size_t>(aligned_size);
+    record.device_id = device;
+    record.is_kvcache = true;
+    record.kvcache_granularity = granularity;
+
+    const size_t slot_count = static_cast<size_t>(aligned_size / granularity);
+    record.slots.reserve(slot_count);
+    Byte* base = static_cast<Byte*>(d_mem);
+    for (size_t i = 0; i < slot_count; ++i) {
+        MappingSlot slot;
+        slot.virt_addr = base + i * granularity;
+        slot.granularity = granularity;
+        slot.device_id = device;
+        mapSlot(slot, null_it->second, SlotState::NULL_MAPPED);
+        record.slots.push_back(slot);
+    }
+
+    if(daemonDebugLogsEnabled()) {
+        fprintf(stderr,
+            "my_malloc_kvcache: requested size=%zd, aligned size=%zu, granularity=%zu, raw_reserved=%zu, raw_base=%p, aligned_base=%p, slot count=%zu\n",
+            size,
+            static_cast<size_t>(aligned_size),
+            granularity,
+            reserved.raw_reserved_size,
+            reserved.raw_base,
+            d_mem,
+            slot_count);
+    }
+
+    g_state.allocations[d_mem] = std::move(record);
+    guard.unlock();
+    callPythonMallocCallback(device, aligned_size, d_mem);
+    return d_mem;
+}
+
+__attribute__((visibility("default"))) void my_free_kvcache(void* ptr,
+                                                              ssize_t size,
+                                                              int device,
+                                                              aclrtStream stream) {
+    (void)size;
+    (void)device;
+    (void)stream;
+    std::unique_lock<std::mutex> guard(g_state.mutex);
+    requireInitialized();
+    releaseAllocation(ptr, kDefaultWaitTimeoutMs);
+    guard.unlock();
+    callPythonFreeCallback(ptr);
+}
+
+static PyObject* py_init_module(PyObject* self, PyObject* args) {
+    (void)self;
+    PyObject* malloc_callback = nullptr;
+    PyObject* free_callback = nullptr;
+
+    if (!PyArg_ParseTuple(args, "OO", &malloc_callback, &free_callback)) {
+        return nullptr;
+    }
+
+    if (!PyCallable_Check(malloc_callback) || !PyCallable_Check(free_callback)) {
+        PyErr_SetString(PyExc_TypeError, "Both arguments must be callables");
+        return nullptr;
+    }
+
+    Py_XINCREF(malloc_callback);
+    Py_XINCREF(free_callback);
+    Py_XDECREF(g_python_malloc_callback);
+    Py_XDECREF(g_python_free_callback);
+    g_python_malloc_callback = malloc_callback;
+    g_python_free_callback = free_callback;
+    Py_RETURN_NONE;
+}
+
+static PyObject* python_init_space(PyObject* self, PyObject* args) {
+    (void)self;
+    unsigned long long device_id_ull;
+    unsigned long long canonical_device_id_ull = 0;
+    if (!PyArg_ParseTuple(args, "K|K", &device_id_ull, &canonical_device_id_ull)) {
+        PyErr_SetString(PyExc_TypeError, "Expected (local_device_id[, canonical_device_id])");
+        return nullptr;
+    }
+
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        if (g_state.initialized) {
+            Py_RETURN_TRUE;
+        }
+        const int32_t local_device_id = static_cast<int32_t>(device_id_ull);
+        const int32_t canonical_device_id =
+            (PyTuple_Size(args) >= 2)
+                ? static_cast<int32_t>(canonical_device_id_ull)
+                : localToCanonicalDeviceId(local_device_id);
+        registerToDaemonAndOpenMessageSpace(local_device_id,
+                            canonical_device_id);
+        initializeNullPages();
+        touchHeartbeat();
+        startHeartbeatThread();
+        g_state.initialized = true;
+        Py_RETURN_TRUE;
+    } catch (const std::exception& ex) {
+        maybeFinalizeState();
+        PySys_WriteStderr("python_init_space failed: %s\n", ex.what());
+        Py_RETURN_FALSE;
+    }
+}
+
+static PyObject* python_finalize_space(PyObject* self, PyObject* args) {
+    (void)self;
+    (void)args;
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        if (!g_state.initialized) {
+            Py_RETURN_NONE;
+        }
+
+        stopHeartbeatThread();
+
+        unmapNullPagesBeforeFinalize();
+
+        std::vector<handle_granularity> to_return;
+        for (auto& kv : g_state.null_pages) {
+            ImportedHandle& h = kv.second;
+            to_return.push_back({h.shareable_handle, h.granularity, h.device_id});
+            releaseImportedHandle(h);
+        }
+        returnHandlesToDaemon(to_return, kDefaultWaitTimeoutMs);
+        g_state.null_pages.clear();
+
+        maybeFinalizeState();
+        Py_RETURN_NONE;
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return nullptr;
+    }
+}
+
+static PyObject* python_map_weight(PyObject* self, PyObject* args) {
+    (void)self;
+    unsigned long long device_ull;
+    unsigned long long d_mem_ull;
+    unsigned long long final_size_ull;
+    int timeout_ms = kDefaultWaitTimeoutMs;
+    if (!PyArg_ParseTuple(args, "KKK|i", &device_ull, &d_mem_ull, &final_size_ull, &timeout_ms)) {
+        PyErr_SetString(PyExc_TypeError, "Expected (device_id, d_mem, final_size[, timeout_ms])");
+        return nullptr;
+    }
+
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        requireInitialized();
+        ensureContext(static_cast<int32_t>(device_ull));
+        AllocationRecord& record = findAllocationOrThrow(reinterpret_cast<void*>(d_mem_ull));
+        mapWeightRange(record, static_cast<size_t>(final_size_ull), timeout_ms);
+        Py_RETURN_NONE;
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return nullptr;
+    }
+}
+
+static PyObject* python_unmap_weight(PyObject* self, PyObject* args) {
+    (void)self;
+    unsigned long long device_ull;
+    unsigned long long d_mem_ull;
+    int timeout_ms = kDefaultWaitTimeoutMs;
+    if (!PyArg_ParseTuple(args, "KK|i", &device_ull, &d_mem_ull, &timeout_ms)) {
+        PyErr_SetString(PyExc_TypeError, "Expected (device_id, d_mem[, timeout_ms])");
+        return nullptr;
+    }
+
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        requireInitialized();
+        ensureContext(static_cast<int32_t>(device_ull));
+        AllocationRecord& record = findAllocationOrThrow(reinterpret_cast<void*>(d_mem_ull));
+        unmapWeightAll(record, timeout_ms);
+        Py_RETURN_NONE;
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return nullptr;
+    }
+}
+
+static PyObject* python_map_kvcache_until(PyObject* self, PyObject* args) {
+    (void)self;
+    unsigned long long device_ull;
+    unsigned long long d_mem_ull;
+    unsigned long long final_size_ull;
+    int timeout_ms = kDefaultWaitTimeoutMs;
+    if (!PyArg_ParseTuple(args, "KKK|i", &device_ull, &d_mem_ull, &final_size_ull, &timeout_ms)) {
+        PyErr_SetString(PyExc_TypeError, "Expected (device_id, d_mem, final_size[, timeout_ms])");
+        return nullptr;
+    }
+
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        requireInitialized();
+        ensureContext(static_cast<int32_t>(device_ull));
+        AllocationRecord& record = findAllocationOrThrow(reinterpret_cast<void*>(d_mem_ull));
+        mapKvcacheUntil(record, static_cast<size_t>(final_size_ull), timeout_ms);
+        Py_RETURN_NONE;
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return nullptr;
+    }
+}
+
+static PyObject* python_unmap_kvcache_until(PyObject* self, PyObject* args) {
+    (void)self;
+    unsigned long long device_ull;
+    unsigned long long d_mem_ull;
+    unsigned long long final_size_ull;
+    int timeout_ms = kDefaultWaitTimeoutMs;
+    if (!PyArg_ParseTuple(args, "KKK|i", &device_ull, &d_mem_ull, &final_size_ull, &timeout_ms)) {
+        PyErr_SetString(PyExc_TypeError, "Expected (device_id, d_mem, final_size[, timeout_ms])");
+        return nullptr;
+    }
+
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        requireInitialized();
+        ensureContext(static_cast<int32_t>(device_ull));
+        AllocationRecord& record = findAllocationOrThrow(reinterpret_cast<void*>(d_mem_ull));
+        unmapKvcacheUntil(record, static_cast<size_t>(final_size_ull), timeout_ms);
+        Py_RETURN_NONE;
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return nullptr;
+    }
+}
+
+static PyObject* python_debug_allocations(PyObject* self, PyObject* args) {
+    (void)self;
+    (void)args;
+    try {
+        std::lock_guard<std::mutex> guard(g_state.mutex);
+        PyObject* out = PyList_New(0);
+        if (!out) {
+            return nullptr;
+        }
+        for (const auto& kv : g_state.allocations) {
+            const AllocationRecord& rec = kv.second;
+            PyObject* item = Py_BuildValue("{s:K,s:K,s:K,s:i,s:i,s:K,s:K}",
+                                           "d_mem",
+                                           static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(rec.base)),
+                                           "requested_size",
+                                           static_cast<unsigned long long>(rec.requested_size),
+                                           "reserved_size",
+                                           static_cast<unsigned long long>(rec.reserved_size),
+                                           "device_id",
+                                           rec.device_id,
+                                           "is_kvcache",
+                                           rec.is_kvcache ? 1 : 0,
+                                           "slots",
+                                           static_cast<unsigned long long>(rec.slots.size()),
+                                           "mapped_weight_bytes",
+                                           static_cast<unsigned long long>(rec.mapped_weight_bytes));
+            if (!item) {
+                Py_DECREF(out);
+                return nullptr;
+            }
+            PyList_Append(out, item);
+            Py_DECREF(item);
+        }
+        return out;
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return nullptr;
+    }
+}
+
+static PyMethodDef module_methods[] = {
+    {"init_module", (PyCFunction)py_init_module, METH_VARARGS,
+     "Initialize module with python_malloc and python_free callables."},
+    {"python_init_space", (PyCFunction)python_init_space, METH_VARARGS,
+     "Register to daemon and initialize per-model message space + null pages."},
+    {"python_finalize_space", (PyCFunction)python_finalize_space, METH_NOARGS,
+     "Return held null pages and close model message space."},
+    {"python_map_weight", (PyCFunction)python_map_weight, METH_VARARGS,
+     "Map weight range by requesting handles from daemon."},
+    {"python_unmap_weight", (PyCFunction)python_unmap_weight, METH_VARARGS,
+     "Unmap all weight handles and return them to daemon."},
+    {"python_map_kvcache_until", (PyCFunction)python_map_kvcache_until, METH_VARARGS,
+     "Map kvcache slots until target size (ceil policy)."},
+    {"python_unmap_kvcache_until", (PyCFunction)python_unmap_kvcache_until, METH_VARARGS,
+     "Unmap kvcache slots until target size (ceil policy)."},
+    {"python_debug_allocations", (PyCFunction)python_debug_allocations, METH_NOARGS,
+     "Return current allocation metadata for debugging."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef camem_allocator_module = {
+    PyModuleDef_HEAD_INIT,
+    "bifrost_ascend_C",
+    "CANN-mem-based allocator for NPUPluggableAllocator",
+    -1,
+    module_methods
+};
+
+PyMODINIT_FUNC PyInit_bifrost_ascend_C(void) {
+    PyObject* module = PyModule_Create(&camem_allocator_module);
+    if (!module) {
+        return NULL;
+    }
+    return module;
+}
+
+PyMODINIT_FUNC PyInit_vllm_ascend_C(void) {
+    return PyInit_bifrost_ascend_C();
+}
+
+} // extern "C"

--- a/daemon/vllm_bifrost/camem_utils.hpp
+++ b/daemon/vllm_bifrost/camem_utils.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string_view>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <assert.h>
+#include <stdio.h>
+
+extern "C" {
+#include "acl/acl.h"
+}
+
+// meta function: get from env; otherwise default string
+inline std::string getEnvOrDefault(const char* env_name, const std::string& default_value) {
+    const char* env_value = std::getenv(env_name);
+    if (env_value && env_value[0] != '\0') {
+        return std::string(env_value);
+    }
+    return default_value;
+}
+
+inline int getEnvOrDefault(const char* env_name, int default_value) {
+    const char* env_value = std::getenv(env_name);
+    if (env_value && env_value[0] != '\0') {
+        try {
+            return std::stoi(env_value);
+        } catch (const std::exception& e) {
+            std::cerr << "Warning: invalid integer in env " << env_name
+                      << "='" << env_value << "', using default " << default_value << "\n";
+        }
+    }
+    return default_value;
+}
+
+// ------------------------------------------------------------------------------
+// Constants:
+
+inline const char* getShmPrefix() {
+    static const std::string value = getEnvOrDefault("MDAEMON_SHM_PREFIX", std::string("/vllm-model-"));
+    return value.c_str();
+}
+
+inline const char* getModelSemaphoreName() {
+    static const std::string value =
+        getEnvOrDefault("MDAEMON_SEMAPHORE_NAME", std::string("/vllm-model-semaphore"));
+    return value.c_str();
+}
+
+inline const char* getModelRegShm() {
+    static const std::string value =
+        getEnvOrDefault("MDAEMON_MODEL_REG_SHM", std::string("/vllm-model-registry"));
+    return value.c_str();
+}
+
+#define SHM_PREFIX getShmPrefix()
+#define MAX_HANDLES_PER_MODEL 30720
+                                    // Maximum number of handles per model. assuming 
+                                    // each handle is at least 2MB, this allows up to 
+                                    // 60GB per model upon all devices.
+                                    // [TODO(shijin)]: This is currently for single-npu service,
+                                    // need to reconsider for multi-npu service.
+#define MODEL_SEMAPHORE_NAME getModelSemaphoreName()
+#define MODEL_REG_SHM getModelRegShm()
+
+constexpr size_t kModelShmNameLength = 256;
+constexpr int32_t kInvalidModelHandle = std::numeric_limits<int32_t>::max();
+
+// ------------------------------------------------------------------------------
+
+
+inline std::string_view defaultShmName() noexcept {
+    static const std::string value = std::string(getShmPrefix()) + "null";
+    return std::string_view(value);
+}
+
+inline std::string_view readShmName(const std::array<char, kModelShmNameLength>& buffer) noexcept {
+    return std::string_view(buffer.data(), std::strlen(buffer.data()));
+}
+
+inline void writeShmName(std::array<char, kModelShmNameLength>& buffer, std::string_view value) noexcept {
+    std::fill(buffer.begin(), buffer.end(), '\0');
+    if (value.empty()) {
+        return;
+    }
+    const size_t copy_count = std::min(value.size(), buffer.size() - 1);
+    std::memcpy(buffer.data(), value.data(), copy_count);
+}
+
+inline bool isDefaultShmName(std::string_view value) noexcept {
+    const std::string_view null_name = defaultShmName();
+    return value.empty() || value == null_name;
+}
+
+// Model message space between daemon and model process
+enum class MessageState : uint8_t {
+    NONE = 0,
+    REQUEST_REGISTER = 1, // model process requests registration
+    REGISTERED = 2, // daemon acknowledges registration
+    REQUEST_GET_HANDLES = 3, // model process requests handles
+    HANDLES_READY = 4, // daemon acknowledges handles are ready
+    REQUEST_RETURN_HANDLES = 5, // model process requests to return handles
+    HANDLES_RETURNED = 6, // daemon acknowledges handles are returned
+    DONE = 7, // model has finished execution
+    INVALID = 8 // invalid state
+};
+
+struct handle_granularity {
+    uint64_t shareable_handle{std::numeric_limits<uint64_t>::max()};
+    uint64_t granularity{0};
+    int32_t device_id{ -1 };
+};
+
+struct request_granularity {
+    uint64_t request_num{0};
+    uint64_t granularity{0};
+    int32_t device_id{ -1 };
+};
+
+struct ModelMacroSpace {
+    ModelMacroSpace() noexcept {
+        reset();
+    }
+
+    std::string_view getShmName() const noexcept {
+        return readShmName(shm_name);
+    }
+
+    void setShmName(std::string_view value = defaultShmName()) noexcept {
+        writeShmName(shm_name, value);
+    }
+
+    void reset() noexcept {
+        setShmName();
+        current_model_npuid = kInvalidModelHandle;
+        current_model_osid = kInvalidModelHandle;
+    }
+
+    bool hasCandidate() const noexcept {
+        return current_model_npuid != kInvalidModelHandle &&
+               current_model_osid != kInvalidModelHandle;
+    }
+
+    std::array<char, kModelShmNameLength> shm_name{};
+    int32_t current_model_npuid{kInvalidModelHandle};
+    int32_t current_model_osid{kInvalidModelHandle};
+};
+
+struct ModelMessageSpace {
+    ModelMessageSpace() noexcept {
+        setShmName();
+    }
+
+    std::string_view getShmName() const noexcept {
+        return readShmName(shm_name);
+    }
+
+    void setShmName(std::string_view value = defaultShmName()) noexcept {
+        writeShmName(shm_name, value);
+    }
+
+    std::array<char, kModelShmNameLength> shm_name{};
+    MessageState state{MessageState::NONE};
+    int32_t model_npuid{kInvalidModelHandle};
+    int32_t model_osid{kInvalidModelHandle};
+    int64_t heartbeat_ns{0};
+    // handle_info_list containing all the handles in exchange between model and daemon
+    std::array<handle_granularity, MAX_HANDLES_PER_MODEL> handle_info_list{};
+    // active area in handle_info_list is [offset_st, offset_ed)
+    int32_t offset_st{0}; // offset start for handle access, usually 0
+    int32_t offset_ed{0}; // current total handles in the list
+    // request list for model to request handles with specific granularity and device_id
+    std::array<request_granularity, MAX_HANDLES_PER_MODEL> handle_request_list{};
+};

--- a/daemon/vllm_bifrost/test_camem_allocator.py
+++ b/daemon/vllm_bifrost/test_camem_allocator.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import faulthandler
+import os
+import sys
+import unittest
+from pathlib import Path
+import time
+
+import torch
+
+
+MODEL_DIR = Path(__file__).resolve().parent
+DAEMON_DIR = MODEL_DIR.parent / "daemon"
+if str(MODEL_DIR) not in sys.path:
+    sys.path.insert(0, str(MODEL_DIR))
+if str(DAEMON_DIR) not in sys.path:
+    sys.path.insert(0, str(DAEMON_DIR))
+
+from camem import CaMemAllocator, camem_available  # noqa: E402
+
+
+MiB = 1024 * 1024
+GiB = 1024 * 1024 * 1024
+
+faulthandler.enable(all_threads=True)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except Exception:
+        return default
+
+
+def _log(msg: str) -> None:
+    print(f"[test_camem_allocator] {msg}", flush=True)
+
+
+def _safe_sync(where: str) -> None:
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        _log(f"sync enter: {where}")
+        torch.npu.synchronize()
+        _log(f"sync done : {where}")
+
+
+class TestCaMemAllocator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _log("setUpClass enter")
+        if not camem_available:
+            raise unittest.SkipTest("camem extension is unavailable")
+        if not hasattr(torch, "npu") or not torch.npu.is_available():
+            raise unittest.SkipTest("torch.npu is unavailable")
+
+        os.environ.setdefault("MDAEMON_KV_INIT_MB", "64")
+
+        default_device = int(torch.npu.current_device())
+        cls.device_id = _env_int("TEST_NPU_DEVICE_ID", default_device)
+        device_count = int(torch.npu.device_count()) if hasattr(torch.npu, "device_count") else 1
+        if cls.device_id < 0 or cls.device_id >= device_count:
+            raise unittest.SkipTest(
+                f"Invalid TEST_NPU_DEVICE_ID={cls.device_id}, available range is [0, {device_count - 1}]"
+            )
+        torch.npu.set_device(cls.device_id)
+        cls.device = f"npu:{cls.device_id}"
+        _log(
+            f"current device={cls.device_id}, device={cls.device}, "
+            f"MDAEMON_KV_INIT_MB={os.environ.get('MDAEMON_KV_INIT_MB')}"
+        )
+
+        CaMemAllocator.instance = None
+        try:
+            cls.alloc = CaMemAllocator.get_instance()
+            _log("CaMemAllocator.get_instance done")
+        except Exception as exc:
+            raise unittest.SkipTest(
+                "Failed to initialize CaMemAllocator. Ensure daemon is launched "
+                "externally and model-side shm/semaphore envs are configured. "
+                f"Root error: {exc}"
+            )
+        _log("setUpClass done")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        _log("tearDownClass enter")
+        try:
+            if hasattr(cls, "alloc") and cls.alloc is not None:
+                _log("allocator close begin")
+                cls.alloc.close()
+                _log("allocator close done")
+        finally:
+            CaMemAllocator.instance = None
+            _log("tearDownClass done")
+
+    def _dump_pointer_state(self, where: str) -> None:
+        size = len(self.alloc.pointer_to_data)
+        _log(f"{where}: pointer_to_data size={size}")
+        for ptr, data in list(self.alloc.pointer_to_data.items()):
+            _log(
+                f"  ptr=0x{ptr:x} kind={data.kind} tag={data.tag} "
+                f"mapped={data.mapped_bytes} handle_size={data.handle[1]} "
+                f"cpu_backup={'yes' if data.cpu_backup_tensor is not None else 'no'}"
+            )
+
+    def _alloc_weight_tensor(self, size_bytes: int, tag: str) -> torch.Tensor:
+        with self.alloc.use_weight_memory_pool(tag=tag):
+            tensor = torch.empty(size_bytes, dtype=torch.bfloat16, device=self.device)
+        return tensor
+
+    def _alloc_kvcache_tensor(self, size_bytes: int, tag: str) -> torch.Tensor:
+        with self.alloc.use_kvcache_memory_pool(tag=tag):
+            tensor = torch.empty(size_bytes, dtype=torch.bfloat16, device=self.device)
+        return tensor
+
+    # def test_weight_kvcache_data_integrity_after_sleep_wakeup(self) -> None:
+    #     _log("test_weight_kvcache_data_integrity_after_sleep_wakeup enter")
+    #     weight_tag = "weight_integrity"
+    #     kv_tag = "kv_integrity"
+
+    #     with self.alloc.use_weight_memory_pool(tag=weight_tag):
+    #         weight_tensor = torch.arange(4 * MiB,
+    #                                      dtype=torch.bfloat16,
+    #                                      device=self.device)
+    #     with self.alloc.use_kvcache_memory_pool(tag=kv_tag):
+    #         kvcache_tensor = torch.arange(6 * MiB,
+    #                                       dtype=torch.bfloat16,
+    #                                       device=self.device)
+
+    #     _safe_sync("after integrity tensor alloc+write")
+
+    #     expected_weight = weight_tensor.cpu().clone()
+    #     expected_kv = kvcache_tensor.cpu().clone()
+
+    #     _log("sleep for 10 seconds to allow manual inspection if needed")
+    #     time.sleep(10)
+
+    #     self.alloc.sleep(offload_tags=(weight_tag, kv_tag))
+    #     _safe_sync("after integrity sleep")
+
+    #     _log("sleep for 10 seconds to allow manual inspection if needed")
+    #     time.sleep(10)
+
+    #     self.alloc.wake_up(tags=[weight_tag, kv_tag])
+    #     _safe_sync("after integrity wake_up")
+
+    #     got_weight = weight_tensor.cpu()
+    #     got_kv = kvcache_tensor.cpu()
+
+    #     self.assertTrue(torch.equal(got_weight, expected_weight),
+    #                     "weight tensor data mismatch after sleep/wake")
+    #     self.assertTrue(torch.equal(got_kv, expected_kv),
+    #                     "kvcache tensor data mismatch after sleep/wake")
+    #     _log("test_weight_kvcache_data_integrity_after_sleep_wakeup done")
+
+    def test_weight_kvcache_sleep_wakeup_and_free(self) -> None:
+        _log("test_weight_kvcache_sleep_wakeup_and_free enter")
+        weight_tag = "weight_tag"
+        kv_tag = "kv_tag"
+
+        _log("alloc weight tensor begin")
+        weight_tensor = self._alloc_weight_tensor(2411 * MiB, tag=weight_tag)
+        _log("alloc weight tensor done")
+        _safe_sync("after weight alloc")
+
+        _log("alloc kvcache tensor begin")
+        kvcache_tensor = self._alloc_kvcache_tensor(1963 * MiB, tag=kv_tag)
+        _log("alloc kvcache tensor done")
+        _safe_sync("after kvcache alloc")
+
+        weight_ptr = int(weight_tensor.data_ptr())
+        kv_ptr = int(kvcache_tensor.data_ptr())
+        _log(f"weight_ptr=0x{weight_ptr:x}, kv_ptr=0x{kv_ptr:x}")
+        self._dump_pointer_state("after allocations")
+
+        self.assertIn(weight_ptr, self.alloc.pointer_to_data)
+        self.assertIn(kv_ptr, self.alloc.pointer_to_data)
+
+        weight_data = self.alloc.pointer_to_data[weight_ptr]
+        kv_data = self.alloc.pointer_to_data[kv_ptr]
+
+        self.assertEqual(weight_data.kind, "weight")
+        self.assertEqual(kv_data.kind, "kvcache")
+        self.assertGreater(weight_data.mapped_bytes, 0)
+        self.assertGreaterEqual(weight_data.mapped_bytes, weight_data.handle[1])
+
+        kv_expected_mapped = min(kv_data.handle[1], _env_int("MDAEMON_KV_INIT_MB", 128) * MiB)
+        self.assertEqual(kv_data.mapped_bytes, kv_expected_mapped)
+        _log(f"kv_expected_mapped={kv_expected_mapped}")
+
+        _log("sleep for 10 seconds to allow manual inspection if needed")
+        time.sleep(10)
+
+        _log("sleep begin")
+        self.alloc.sleep(offload_tags=(weight_tag,))
+        _log("sleep done")
+        _safe_sync("after sleep")
+        self._dump_pointer_state("after sleep")
+
+        weight_data = self.alloc.pointer_to_data[weight_ptr]
+        kv_data = self.alloc.pointer_to_data[kv_ptr]
+
+        self.assertIsNotNone(weight_data.cpu_backup_tensor)
+        self.assertIsNone(kv_data.cpu_backup_tensor)
+        self.assertEqual(weight_data.mapped_bytes, 0)
+        self.assertEqual(kv_data.mapped_bytes, 0)
+
+        _log("sleep for 10 seconds to allow manual inspection if needed")
+        time.sleep(10)
+
+        _log("wake_up begin")
+        self.alloc.wake_up(tags=[weight_tag, kv_tag])
+        _log("wake_up done")
+        _safe_sync("after wake_up")
+        self._dump_pointer_state("after wake_up")
+
+        weight_data = self.alloc.pointer_to_data[weight_ptr]
+        kv_data = self.alloc.pointer_to_data[kv_ptr]
+
+        self.assertIsNone(weight_data.cpu_backup_tensor)
+        self.assertGreater(weight_data.mapped_bytes, 0)
+        self.assertEqual(kv_data.mapped_bytes, kv_expected_mapped)
+
+        _log("test_weight_kvcache_sleep_wakeup_and_free done")
+
+    def test_double_pool_contexts_exist(self) -> None:
+        self.assertTrue(hasattr(self.alloc, "use_weight_memory_pool"))
+        self.assertTrue(hasattr(self.alloc, "use_kvcache_memory_pool"))
+        self.assertTrue(hasattr(self.alloc, "use_memory_pool"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/daemon/vllm_kvcache/kv_cache_manager.py
+++ b/daemon/vllm_kvcache/kv_cache_manager.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Optional
+
+from vllm.logger import logger
+
+from vllm_ascend.device_allocator.camem_bifrost import CaMemAllocator
+from .elastic_config import ElasticPolicyConfig
+
+
+class KVCacheManager:
+
+    def __init__(
+        self,
+        num_blocks: int,
+        block_size: int,
+        cell_size: int,
+        num_layers: int,
+        policy: Optional[ElasticPolicyConfig] = None,
+    ) -> None:
+        if num_blocks <= 0:
+            raise ValueError("num_blocks must be > 0")
+        if block_size <= 0:
+            raise ValueError("block_size must be > 0")
+        if cell_size <= 0:
+            raise ValueError("cell_size must be > 0")
+        if num_layers <= 0:
+            raise ValueError("num_layers must be > 0")
+
+        self.num_blocks = num_blocks
+        self.block_size = block_size
+        self.cell_size = cell_size
+        self.num_layers = num_layers
+
+        self.block_mem_size = block_size * cell_size
+        logger.info(f"Initializing KVCacheManager with num_blocks={num_blocks}, block_mem_size=" +
+                    f"{self.block_mem_size/1024/1024:.4f} MB, num_layers={num_layers}")
+
+        allocator = CaMemAllocator.get_instance()
+        self.page_size = allocator.get_kvcache_page_bytes()
+        self.blocks_per_page = max(1, self.page_size // self.block_mem_size)
+        if self.page_size % self.block_mem_size != 0:
+            logger.warning(
+                "KV page size (%d) is not a multiple of block bytes (%d); "
+                "tail bytes in each page are unused.",
+                self.page_size,
+                self.block_mem_size,
+            )
+
+        self.mem_size = self.num_blocks * self.block_mem_size
+
+        existing = allocator.get_elastic_page_allocator()
+        if existing is None:
+            self.page_allocator = allocator.build_elastic_page_allocator(
+                policy=policy or ElasticPolicyConfig.from_env(),
+                autostart=True,
+            )
+        else:
+            self.page_allocator = existing
+            self.page_allocator.start()
+
+        self._lock = threading.RLock()
+
+        self._active_pages: set[int] = set()
+        self._page_free_blocks: dict[int, set[int]] = {}
+        self._free_block_queue: deque[int] = deque()
+        self._allocated_blocks: set[int] = set()
+        allocator.register_kvcache_manager(self)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._active_pages.clear()
+            self._page_free_blocks.clear()
+            self._free_block_queue.clear()
+            self._allocated_blocks.clear()
+
+    def alloc(self, need_size: int) -> Optional[list[int]]:
+        if need_size <= 0:
+            return []
+        with self._lock:
+            if not self._ensure_free_blocks_locked(need_size):
+                logger.warning(
+                    "Failed to allocate %d blocks: not enough free blocks available",
+                    need_size,
+                )
+                return None
+
+            block_ids: list[int] = []
+            while len(block_ids) < need_size and self._free_block_queue:
+                block_id = self._free_block_queue.popleft()
+                page_id = self._block_to_page_id(block_id)
+                page_free = self._page_free_blocks.get(page_id)
+                if page_free is None or block_id not in page_free:
+                    continue
+                page_free.remove(block_id)
+                self._allocated_blocks.add(block_id)
+                block_ids.append(block_id)
+
+            if len(block_ids) != need_size:
+                logger.error(
+                    "KVCacheManager internal inconsistency during alloc: need=%d got=%d",
+                    need_size,
+                    len(block_ids),
+                )
+                self._rollback_alloc_locked(block_ids)
+                return None
+
+            return block_ids
+
+    def free(self, indices: list[int]) -> None:
+        if not indices:
+            return
+        with self._lock:
+            pages_to_try_release: set[int] = set()
+            for block_id in indices:
+                if block_id < 0 or block_id >= self.num_blocks:
+                    logger.warning("Ignoring invalid block_id=%d in free", block_id)
+                    continue
+                if block_id not in self._allocated_blocks:
+                    continue
+
+                self._allocated_blocks.remove(block_id)
+                page_id = self._block_to_page_id(block_id)
+                page_free = self._page_free_blocks.get(page_id)
+                if page_free is None:
+                    continue
+                page_free.add(block_id)
+                self._free_block_queue.append(block_id)
+                pages_to_try_release.add(page_id)
+
+            for page_id in pages_to_try_release:
+                self._try_release_page_locked(page_id)
+
+    def resize(self, new_mem_size: int) -> bool:
+        if new_mem_size <= 0:
+            raise ValueError("new_mem_size must be positive")
+        with self._lock:
+            target_blocks = max(1, min(self.num_blocks,
+                                       new_mem_size // self.block_mem_size))
+            target_pages = self._blocks_to_pages(target_blocks)
+            return self.page_allocator.resize(target_pages)
+
+    def get_kv_size(self) -> int:
+        return self.page_allocator.snapshot()["mapped_pages"] * self.page_size
+
+    def available_size(self) -> int:
+        with self._lock:
+            local_free = sum(len(v) for v in self._page_free_blocks.values())
+            snapshot = self.page_allocator.snapshot()
+            latent_free_pages = snapshot["free_pages"] + snapshot["unmapped_pages"]
+            latent_free = latent_free_pages * self.blocks_per_page
+            alloced = len(self._allocated_blocks)
+            approx = local_free + latent_free
+            capacity_left = max(0, self.num_blocks - alloced)
+            return max(0, min(capacity_left, approx))
+
+    def get_mapped_memory_size(self, unit: str = "bytes") -> float:
+        memory_bytes = self.get_kv_size() * self.num_layers * 2
+        if unit == "bytes":
+            return float(memory_bytes)
+        if unit == "kb":
+            return float(memory_bytes / 1024)
+        if unit == "mb":
+            return float(memory_bytes / (1024**2))
+        if unit == "gb":
+            return float(memory_bytes / (1024**3))
+        raise ValueError(f"Unknown unit: {unit}")
+
+    def trim(self) -> None:
+        return
+
+    def clear(self) -> None:
+        raise NotImplementedError("clear() is not supported")
+
+    def _ensure_free_blocks_locked(self, need_size: int) -> bool:
+        if self._count_effective_free_blocks_locked() >= need_size:
+            return True
+
+        still_need = need_size - self._count_effective_free_blocks_locked()
+        pages_needed = self._blocks_to_pages(still_need)
+        page_ids = self.page_allocator.alloc(pages_needed)
+        if page_ids is None:
+            return False
+
+        for page_id in page_ids:
+            self._activate_page_locked(page_id)
+
+        return self._count_effective_free_blocks_locked() >= need_size
+
+    def _activate_page_locked(self, page_id: int) -> None:
+        if page_id in self._active_pages:
+            return
+
+        block_ids = self._all_block_ids_of_page(page_id)
+        if not block_ids:
+            self.page_allocator.free([page_id])
+            return
+
+        self._active_pages.add(page_id)
+        free_set = set(block_ids)
+        self._page_free_blocks[page_id] = free_set
+        for block_id in block_ids:
+            if block_id in free_set:
+                self._free_block_queue.append(block_id)
+
+    def _try_release_page_locked(self, page_id: int) -> None:
+        if page_id not in self._active_pages:
+            return
+        page_free = self._page_free_blocks.get(page_id)
+        if page_free is None:
+            return
+
+        all_blocks = self._all_block_ids_of_page(page_id)
+        fully_free = all(block_id in page_free for block_id in all_blocks)
+        if not fully_free:
+            return
+
+        self.page_allocator.free([page_id])
+        self._active_pages.remove(page_id)
+        del self._page_free_blocks[page_id]
+
+    def _count_effective_free_blocks_locked(self) -> int:
+        return sum(len(v) for v in self._page_free_blocks.values())
+
+    def _rollback_alloc_locked(self, block_ids: list[int]) -> None:
+        if not block_ids:
+            return
+
+        for block_id in block_ids:
+            page_id = self._block_to_page_id(block_id)
+            page_free = self._page_free_blocks.get(page_id)
+            if page_free is None:
+                continue
+
+            self._allocated_blocks.discard(block_id)
+            if block_id not in page_free:
+                page_free.add(block_id)
+            self._free_block_queue.appendleft(block_id)
+
+    def _blocks_to_pages(self, blocks: int) -> int:
+        return (blocks + self.blocks_per_page - 1) // self.blocks_per_page
+
+    def _block_to_page_id(self, block_id: int) -> int:
+        return block_id // self.blocks_per_page
+
+    def _all_block_ids_of_page(self, page_id: int) -> list[int]:
+        start = page_id * self.blocks_per_page
+        end = min(start + self.blocks_per_page, self.num_blocks)
+        if start >= end:
+            return []
+        return list(range(start, end))

--- a/daemon/vllm_kvcache/patch.sh
+++ b/daemon/vllm_kvcache/patch.sh
@@ -1,0 +1,3 @@
+cp -f kv_cache_coordinator.py /vllm-workspace/vllm/vllm/v1/core/kv_cache_coordinator.py
+
+echo "Patch for kvcache applied successfully."

--- a/vllm_ascend/core/kvcache/__init__.py
+++ b/vllm_ascend/core/kvcache/__init__.py
@@ -1,0 +1,17 @@
+from .elastic_config import ElasticPolicyConfig
+from .page_allocator import ElasticPageAllocator
+from .dispatcher import KVCacheResizeDispatcher
+from .kv_cache_manager import KVCacheManager
+from .elastic_block_pool import (build_elastic_block_pool_class,
+                                 inject_elastic_block_pool,
+                                 inject_elastic_block_pool_by_import)
+
+__all__ = [
+    "ElasticPolicyConfig",
+    "ElasticPageAllocator",
+    "KVCacheResizeDispatcher",
+    "KVCacheManager",
+    "build_elastic_block_pool_class",
+    "inject_elastic_block_pool",
+    "inject_elastic_block_pool_by_import",
+]

--- a/vllm_ascend/core/kvcache/dispatcher.py
+++ b/vllm_ascend/core/kvcache/dispatcher.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from vllm_ascend.core.kvcache.page_allocator import ElasticPageAllocator
+
+
+class KVCacheResizeDispatcher:
+
+    def __init__(self, allocator: ElasticPageAllocator, page_bytes: int) -> None:
+        if page_bytes <= 0:
+            raise ValueError("page_bytes must be > 0")
+        self.allocator = allocator
+        self.page_bytes = page_bytes
+
+    def resize_pages(self, target_pages: int) -> bool:
+        return self.allocator.resize(target_pages)
+
+    def resize_bytes(self, target_bytes: int) -> bool:
+        target_pages = max(0, target_bytes // self.page_bytes)
+        return self.allocator.resize(target_pages)
+
+    def snapshot(self) -> dict[str, int]:
+        state = self.allocator.snapshot()
+        state["page_bytes"] = self.page_bytes
+        state["mapped_bytes"] = state["mapped_pages"] * self.page_bytes
+        return state

--- a/vllm_ascend/core/kvcache/elastic_block_pool.py
+++ b/vllm_ascend/core/kvcache/elastic_block_pool.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Iterable
+from typing import Any, Optional, Type
+
+from .kv_cache_manager import KVCacheManager
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_elastic_block_pool_class(block_pool_mod: Any,
+                                   manager_cls: Type[KVCacheManager] =
+                                   KVCacheManager) -> type:
+    if hasattr(block_pool_mod, "ElasticBlockPool"):
+        return getattr(block_pool_mod, "ElasticBlockPool")
+
+    BlockPool = getattr(block_pool_mod, "BlockPool")
+    KVCacheBlock = getattr(block_pool_mod, "KVCacheBlock")
+
+    class ElasticBlockPool(BlockPool):  # type: ignore[misc]
+
+        def __init__(
+            self,
+            num_gpu_blocks: int,
+            block_size: int,
+            cell_size: int,
+            num_layers: int,
+            enable_caching: bool,
+            enable_kv_cache_events: bool = False,
+        ) -> None:
+            assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
+            assert not enable_caching, "Caching is not supported in ElasticBlockPool"
+            assert not enable_kv_cache_events, (
+                "KV cache events are not supported in ElasticBlockPool")
+
+            self.num_gpu_blocks = num_gpu_blocks
+            self.enable_kv_cache_events = enable_kv_cache_events
+            self.kv_event_queue: list[Any] = []
+
+            self.kv_cache_manager = manager_cls(
+                num_blocks=num_gpu_blocks,
+                block_size=block_size,
+                cell_size=cell_size,
+                num_layers=num_layers,
+            )
+
+            self.null_block = None
+
+        def get_cached_block(self, *args: Any,
+                             **kwargs: Any) -> Optional[list[Any]]:
+            return None
+
+        def cache_full_blocks(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError(
+                "Caching is not supported in ElasticBlockPool")
+
+        def get_new_blocks(self, num_blocks: int) -> list[Any]:
+            if num_blocks > self.get_num_free_blocks():
+                raise ValueError(
+                    f"Cannot get {num_blocks} free blocks from the pool")
+
+            block_ids = self.kv_cache_manager.alloc(num_blocks)
+            if block_ids is None or len(block_ids) != num_blocks:
+                # logger.error("Failed to allocate blocks: need=%d, got=%s",
+                #              num_blocks, block_ids)
+                return []
+
+            return [KVCacheBlock(bid) for bid in block_ids]
+
+        def kv_resize(self, size: int) -> bool:
+            if size == 0:
+                return True
+            return self.kv_cache_manager.resize(size)
+
+        def get_kv_size(self) -> int:
+            return self.kv_cache_manager.get_kv_size()
+
+        def touch(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError("Prefix caching is not supported in ElasticBlockPool")
+
+        def free_blocks(self, ordered_blocks: Iterable[Any]) -> None:
+            block_ids = [
+                block.block_id  # type: ignore[attr-defined]
+                for block in ordered_blocks
+            ]
+            if block_ids:
+                self.kv_cache_manager.free(block_ids)
+
+        def reset_prefix_cache(self) -> bool:
+            logger.error(f"Prefix caching is not supported in ElasticBlockPool")
+            return False
+        
+        def get_num_free_blocks(self) -> int:
+            return self.kv_cache_manager.available_size()
+
+        def get_usage(self) -> float:
+            return 1.0 - (self.get_num_free_blocks() / self.num_gpu_blocks)
+
+        def take_events(self) -> list[Any]:
+            return []
+
+    setattr(block_pool_mod, "ElasticBlockPool", ElasticBlockPool)
+    return ElasticBlockPool
+
+
+def inject_elastic_block_pool(block_pool_mod: Any) -> type:
+    return build_elastic_block_pool_class(block_pool_mod)
+
+
+def inject_elastic_block_pool_by_import(
+    module_name: str = "vllm.v1.core.block_pool",
+) -> type:
+    block_pool_mod = importlib.import_module(module_name)
+    return inject_elastic_block_pool(block_pool_mod)

--- a/vllm_ascend/core/kvcache/elastic_config.py
+++ b/vllm_ascend/core/kvcache/elastic_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env_int(name: str, default: int, min_value: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except Exception:
+        return default
+    return max(min_value, value)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class ElasticPolicyConfig:
+    min_free_pages: int = 3
+    grow_step_pages: int = 1
+    shrink_step_pages: int = 1
+    max_free_pages: int = 5
+    control_interval_ms: int = 100
+    auto_grow: bool = True
+    auto_shrink: bool = True
+
+    @staticmethod
+    def from_env() -> "ElasticPolicyConfig":
+        min_free_pages = _env_int("KVCACHE_MIN_FREE_PAGES", 3, min_value=0)
+        grow_step_pages = _env_int("KVCACHE_GROW_STEP_PAGES", 1, min_value=1)
+        shrink_step_pages = _env_int("KVCACHE_SHRINK_STEP_PAGES", 1, min_value=1)
+
+        default_max_free = min_free_pages + max(grow_step_pages, shrink_step_pages) * 2
+        max_free_pages = _env_int("KVCACHE_MAX_FREE_PAGES", default_max_free, min_value=min_free_pages)
+
+        control_interval_ms = _env_int("KVCACHE_CONTROL_INTERVAL_MS", 100, min_value=10)
+        auto_grow = _env_bool("KVCACHE_AUTO_GROW", True)
+        auto_shrink = _env_bool("KVCACHE_AUTO_SHRINK", True)
+
+        return ElasticPolicyConfig(
+            min_free_pages=min_free_pages,
+            grow_step_pages=grow_step_pages,
+            shrink_step_pages=shrink_step_pages,
+            max_free_pages=max_free_pages,
+            control_interval_ms=control_interval_ms,
+            auto_grow=auto_grow,
+            auto_shrink=auto_shrink,
+        )

--- a/vllm_ascend/core/kvcache/kv_cache_manager.py
+++ b/vllm_ascend/core/kvcache/kv_cache_manager.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Optional
+
+from vllm.logger import logger
+
+from vllm_ascend.device_allocator.camem_bifrost import CaMemAllocator
+from .elastic_config import ElasticPolicyConfig
+
+
+class KVCacheManager:
+
+    def __init__(
+        self,
+        num_blocks: int,
+        block_size: int,
+        cell_size: int,
+        num_layers: int,
+        policy: Optional[ElasticPolicyConfig] = None,
+    ) -> None:
+        if num_blocks <= 0:
+            raise ValueError("num_blocks must be > 0")
+        if block_size <= 0:
+            raise ValueError("block_size must be > 0")
+        if cell_size <= 0:
+            raise ValueError("cell_size must be > 0")
+        if num_layers <= 0:
+            raise ValueError("num_layers must be > 0")
+
+        self.num_blocks = num_blocks
+        self.block_size = block_size
+        self.cell_size = cell_size
+        self.num_layers = num_layers
+
+        self.block_mem_size = block_size * cell_size
+        logger.info(f"Initializing KVCacheManager with num_blocks={num_blocks}, block_mem_size=" +
+                    f"{self.block_mem_size/1024/1024:.4f} MB, num_layers={num_layers}")
+
+        allocator = CaMemAllocator.get_instance()
+        self.page_size = allocator.get_kvcache_page_bytes()
+        self.blocks_per_page = max(1, self.page_size // self.block_mem_size)
+        if self.page_size % self.block_mem_size != 0:
+            logger.warning(
+                "KV page size (%d) is not a multiple of block bytes (%d); "
+                "tail bytes in each page are unused.",
+                self.page_size,
+                self.block_mem_size,
+            )
+
+        self.mem_size = self.num_blocks * self.block_mem_size
+
+        existing = allocator.get_elastic_page_allocator()
+        if existing is None:
+            self.page_allocator = allocator.build_elastic_page_allocator(
+                policy=policy or ElasticPolicyConfig.from_env(),
+                autostart=True,
+            )
+        else:
+            self.page_allocator = existing
+            self.page_allocator.start()
+
+        self._lock = threading.RLock()
+
+        self._active_pages: set[int] = set()
+        self._page_free_blocks: dict[int, set[int]] = {}
+        self._free_block_queue: deque[int] = deque()
+        self._allocated_blocks: set[int] = set()
+        allocator.register_kvcache_manager(self)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._active_pages.clear()
+            self._page_free_blocks.clear()
+            self._free_block_queue.clear()
+            self._allocated_blocks.clear()
+
+    def alloc(self, need_size: int) -> Optional[list[int]]:
+        if need_size <= 0:
+            return []
+        with self._lock:
+            if not self._ensure_free_blocks_locked(need_size):
+                logger.warning(
+                    "Failed to allocate %d blocks: not enough free blocks available",
+                    need_size,
+                )
+                return None
+
+            block_ids: list[int] = []
+            while len(block_ids) < need_size and self._free_block_queue:
+                block_id = self._free_block_queue.popleft()
+                page_id = self._block_to_page_id(block_id)
+                page_free = self._page_free_blocks.get(page_id)
+                if page_free is None or block_id not in page_free:
+                    continue
+                page_free.remove(block_id)
+                self._allocated_blocks.add(block_id)
+                block_ids.append(block_id)
+
+            if len(block_ids) != need_size:
+                logger.error(
+                    "KVCacheManager internal inconsistency during alloc: need=%d got=%d",
+                    need_size,
+                    len(block_ids),
+                )
+                self._rollback_alloc_locked(block_ids)
+                return None
+
+            return block_ids
+
+    def free(self, indices: list[int]) -> None:
+        if not indices:
+            return
+        with self._lock:
+            pages_to_try_release: set[int] = set()
+            for block_id in indices:
+                if block_id < 0 or block_id >= self.num_blocks:
+                    logger.warning("Ignoring invalid block_id=%d in free", block_id)
+                    continue
+                if block_id not in self._allocated_blocks:
+                    continue
+
+                self._allocated_blocks.remove(block_id)
+                page_id = self._block_to_page_id(block_id)
+                page_free = self._page_free_blocks.get(page_id)
+                if page_free is None:
+                    continue
+                page_free.add(block_id)
+                self._free_block_queue.append(block_id)
+                pages_to_try_release.add(page_id)
+
+            for page_id in pages_to_try_release:
+                self._try_release_page_locked(page_id)
+
+    def resize(self, new_mem_size: int) -> bool:
+        if new_mem_size <= 0:
+            raise ValueError("new_mem_size must be positive")
+        with self._lock:
+            target_blocks = max(1, min(self.num_blocks,
+                                       new_mem_size // self.block_mem_size))
+            target_pages = self._blocks_to_pages(target_blocks)
+            return self.page_allocator.resize(target_pages)
+
+    def get_kv_size(self) -> int:
+        return self.page_allocator.snapshot()["mapped_pages"] * self.page_size
+
+    def available_size(self) -> int:
+        with self._lock:
+            local_free = sum(len(v) for v in self._page_free_blocks.values())
+            snapshot = self.page_allocator.snapshot()
+            latent_free_pages = snapshot["free_pages"] + snapshot["unmapped_pages"]
+            latent_free = latent_free_pages * self.blocks_per_page
+            alloced = len(self._allocated_blocks)
+            approx = local_free + latent_free
+            capacity_left = max(0, self.num_blocks - alloced)
+            return max(0, min(capacity_left, approx))
+
+    def get_mapped_memory_size(self, unit: str = "bytes") -> float:
+        memory_bytes = self.get_kv_size() * self.num_layers * 2
+        if unit == "bytes":
+            return float(memory_bytes)
+        if unit == "kb":
+            return float(memory_bytes / 1024)
+        if unit == "mb":
+            return float(memory_bytes / (1024**2))
+        if unit == "gb":
+            return float(memory_bytes / (1024**3))
+        raise ValueError(f"Unknown unit: {unit}")
+
+    def trim(self) -> None:
+        return
+
+    def clear(self) -> None:
+        raise NotImplementedError("clear() is not supported")
+
+    def _ensure_free_blocks_locked(self, need_size: int) -> bool:
+        if self._count_effective_free_blocks_locked() >= need_size:
+            return True
+
+        still_need = need_size - self._count_effective_free_blocks_locked()
+        pages_needed = self._blocks_to_pages(still_need)
+        page_ids = self.page_allocator.alloc(pages_needed)
+        if page_ids is None:
+            return False
+
+        for page_id in page_ids:
+            self._activate_page_locked(page_id)
+
+        return self._count_effective_free_blocks_locked() >= need_size
+
+    def _activate_page_locked(self, page_id: int) -> None:
+        if page_id in self._active_pages:
+            return
+
+        block_ids = self._all_block_ids_of_page(page_id)
+        if not block_ids:
+            self.page_allocator.free([page_id])
+            return
+
+        self._active_pages.add(page_id)
+        free_set = set(block_ids)
+        self._page_free_blocks[page_id] = free_set
+        for block_id in block_ids:
+            if block_id in free_set:
+                self._free_block_queue.append(block_id)
+
+    def _try_release_page_locked(self, page_id: int) -> None:
+        if page_id not in self._active_pages:
+            return
+        page_free = self._page_free_blocks.get(page_id)
+        if page_free is None:
+            return
+
+        all_blocks = self._all_block_ids_of_page(page_id)
+        fully_free = all(block_id in page_free for block_id in all_blocks)
+        if not fully_free:
+            return
+
+        self.page_allocator.free([page_id])
+        self._active_pages.remove(page_id)
+        del self._page_free_blocks[page_id]
+
+    def _count_effective_free_blocks_locked(self) -> int:
+        return sum(len(v) for v in self._page_free_blocks.values())
+
+    def _rollback_alloc_locked(self, block_ids: list[int]) -> None:
+        if not block_ids:
+            return
+
+        for block_id in block_ids:
+            page_id = self._block_to_page_id(block_id)
+            page_free = self._page_free_blocks.get(page_id)
+            if page_free is None:
+                continue
+
+            self._allocated_blocks.discard(block_id)
+            if block_id not in page_free:
+                page_free.add(block_id)
+            self._free_block_queue.appendleft(block_id)
+
+    def _blocks_to_pages(self, blocks: int) -> int:
+        return (blocks + self.blocks_per_page - 1) // self.blocks_per_page
+
+    def _block_to_page_id(self, block_id: int) -> int:
+        return block_id // self.blocks_per_page
+
+    def _all_block_ids_of_page(self, page_id: int) -> list[int]:
+        start = page_id * self.blocks_per_page
+        end = min(start + self.blocks_per_page, self.num_blocks)
+        if start >= end:
+            return []
+        return list(range(start, end))

--- a/vllm_ascend/core/kvcache/page_allocator.py
+++ b/vllm_ascend/core/kvcache/page_allocator.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Callable, Optional
+
+from .elastic_config import ElasticPolicyConfig
+
+
+class ElasticPageAllocator:
+
+    def __init__(
+        self,
+        total_pages: int,
+        mapped_pages: int,
+        resize_callback: Callable[[int], int],
+        policy: Optional[ElasticPolicyConfig] = None,
+    ) -> None:
+        if total_pages < 0:
+            raise ValueError("total_pages must be >= 0")
+        if mapped_pages < 0:
+            raise ValueError("mapped_pages must be >= 0")
+        if mapped_pages > total_pages:
+            raise ValueError("mapped_pages must be <= total_pages")
+
+        self.total_pages = total_pages
+        self._mapped_pages = mapped_pages
+        self._resize_callback = resize_callback
+        self.policy = policy or ElasticPolicyConfig.from_env()
+
+        self._free_page_list = deque(range(mapped_pages))
+        self._in_use_pages: set[int] = set()
+        self._unmapped_page_ids = deque(range(mapped_pages, total_pages))
+
+        self._lock = threading.RLock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._control_loop, daemon=True)
+            self._thread.start()
+
+    def stop(self, timeout_s: float = 2.0) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout_s)
+
+    def alloc(self, num_pages: int = 1) -> Optional[list[int]]:
+        if num_pages <= 0:
+            return []
+        with self._lock:
+            if len(self._free_page_list) < num_pages and self.policy.auto_grow:
+                need = num_pages - len(self._free_page_list)
+                grow_pages = max(need, self.policy.grow_step_pages)
+                self._grow_locked(grow_pages)
+
+            if len(self._free_page_list) < num_pages:
+                return None
+
+            page_ids = [self._free_page_list.popleft() for _ in range(num_pages)]
+            self._in_use_pages.update(page_ids)
+            return page_ids
+
+    def free(self, page_ids: list[int]) -> None:
+        if not page_ids:
+            return
+        with self._lock:
+            for page_id in page_ids:
+                if page_id in self._in_use_pages:
+                    self._in_use_pages.remove(page_id)
+                    self._free_page_list.append(page_id)
+
+    def resize(self, target_pages: int) -> bool:
+        with self._lock:
+            target_pages = max(0, min(target_pages, self.total_pages))
+            if target_pages == self._mapped_pages:
+                return True
+            if target_pages > self._mapped_pages:
+                return self._grow_locked(target_pages - self._mapped_pages)
+            return self._shrink_locked(self._mapped_pages - target_pages)
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "total_pages": self.total_pages,
+                "mapped_pages": self._mapped_pages,
+                "free_pages": len(self._free_page_list),
+                "in_use_pages": len(self._in_use_pages),
+                "unmapped_pages": len(self._unmapped_page_ids),
+            }
+
+    def reset(self, mapped_pages: int) -> None:
+        with self._lock:
+            mapped_pages = max(0, min(mapped_pages, self.total_pages))
+            self._mapped_pages = mapped_pages
+            self._free_page_list = deque(range(mapped_pages))
+            self._in_use_pages.clear()
+            self._unmapped_page_ids = deque(range(mapped_pages, self.total_pages))
+
+    def _control_loop(self) -> None:
+        interval_s = self.policy.control_interval_ms / 1000.0
+        while not self._stop_event.is_set():
+            with self._lock:
+                free_pages = len(self._free_page_list)
+                if self.policy.auto_grow and free_pages < self.policy.min_free_pages:
+                    self._grow_locked(self.policy.grow_step_pages)
+
+                free_pages = len(self._free_page_list)
+                if self.policy.auto_shrink and free_pages > self.policy.max_free_pages:
+                    self._shrink_locked(self.policy.shrink_step_pages)
+
+            self._stop_event.wait(interval_s)
+
+    def _grow_locked(self, pages: int) -> bool:
+        if pages <= 0:
+            return True
+        grow = min(pages, len(self._unmapped_page_ids))
+        if grow <= 0:
+            return False
+
+        target = self._mapped_pages + grow
+        applied = self._resize_callback(target)
+        if applied < target:
+            return False
+
+        for _ in range(grow):
+            self._free_page_list.append(self._unmapped_page_ids.popleft())
+        self._mapped_pages += grow
+        return True
+
+    def _shrink_locked(self, pages: int) -> bool:
+        if pages <= 0:
+            return True
+        shrink_ids = self._collect_shrinkable_tail_pages_locked(pages)
+        shrink = len(shrink_ids)
+        if shrink <= 0:
+            return False
+
+        target = self._mapped_pages - shrink
+        if target < len(self._in_use_pages):
+            return False
+
+        applied = self._resize_callback(target)
+        if applied > target:
+            return False
+
+        shrink_id_set = set(shrink_ids)
+        self._free_page_list = deque(
+            page_id for page_id in self._free_page_list
+            if page_id not in shrink_id_set)
+
+        for page_id in reversed(shrink_ids):
+            self._unmapped_page_ids.appendleft(page_id)
+        self._mapped_pages -= shrink
+        return True
+
+    def _collect_shrinkable_tail_pages_locked(self, pages: int) -> list[int]:
+        if pages <= 0 or self._mapped_pages <= 0:
+            return []
+
+        free_set = set(self._free_page_list)
+        max_candidate = min(pages, self._mapped_pages)
+        shrink_ids: list[int] = []
+
+        for page_id in range(self._mapped_pages - 1,
+                             self._mapped_pages - max_candidate - 1, -1):
+            if page_id in self._in_use_pages:
+                break
+            if page_id not in free_set:
+                break
+            shrink_ids.append(page_id)
+
+        shrink_ids.reverse()
+        return shrink_ids

--- a/vllm_ascend/device_allocator/camem_bifrost.py
+++ b/vllm_ascend/device_allocator/camem_bifrost.py
@@ -1,0 +1,449 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CANN-mem-based pytorch pluggable allocator to implement sleep mode.
+#
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional, Tuple, Union
+
+import torch
+from acl.rt import memcpy  # type: ignore # noqa: F401
+from vllm.logger import logger
+
+from vllm_ascend.platform import NPUPlatform
+
+from vllm_ascend.core.kvcache.elastic_config import ElasticPolicyConfig
+from vllm_ascend.core.kvcache.page_allocator import ElasticPageAllocator
+
+
+GiB = 1024**3
+MiB = 1024**2
+
+
+def find_loaded_library(lib_name: str) -> Optional[str]:
+    found_line = None
+    with open("/proc/self/maps") as f:
+        for line in f:
+            if lib_name in line:
+                found_line = line
+                break
+    if found_line is None:
+        return None
+    start = found_line.index("/")
+    path = found_line[start:].strip()
+    filename = path.split("/")[-1]
+    assert filename.rpartition(".so")[0].startswith(lib_name), (
+        f"Unexpected filename: {filename} for library {lib_name}")
+    return path
+
+
+camem_available = False
+try:
+    from vllm_ascend.bifrost_ascend_C import (  # type: ignore # noqa: F401
+        init_module,
+        python_finalize_space,
+        python_init_space,
+        python_map_kvcache_until,
+        python_map_weight,
+        python_unmap_kvcache_until,
+        python_unmap_weight,
+    )
+
+    lib_name = find_loaded_library("bifrost_ascend_C")
+    camem_available = True
+except ImportError as e:
+    logger.warning(
+        "Failed to import bifrost_ascend_C:%s. Sleep mode will be disabled. ", e)
+    init_module = None
+    python_init_space = None
+    python_finalize_space = None
+    python_map_weight = None
+    python_unmap_weight = None
+    python_map_kvcache_until = None
+    python_unmap_kvcache_until = None
+    lib_name = None
+
+
+HandleType = Tuple[int, int, int, int]
+
+
+@dataclasses.dataclass
+class AllocationData:
+    handle: HandleType
+    tag: str
+    kind: str
+    mapped_bytes: int
+    cpu_backup_tensor: Optional[torch.Tensor] = None
+
+
+def _to_env_mb(name: str, default_mb: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default_mb
+    try:
+        value = int(raw)
+        return max(0, value)
+    except Exception:
+        logger.warning("Invalid env %s=%s, fallback to %d", name, raw,
+                       default_mb)
+        return default_mb
+
+
+def _build_allocator(lib_path: str, malloc_symbol: str,
+                     free_symbol: str) -> torch.npu.memory.NPUPluggableAllocator:
+    return torch.npu.memory.NPUPluggableAllocator(lib_path, malloc_symbol,
+                                                  free_symbol)
+
+
+def _parse_visible_devices() -> Optional[list[int]]:
+    raw = (os.environ.get("ASCEND_RT_VISIBLE_DEVICES")
+           or os.environ.get("ASCEND_VISIBLE_DEVICES")
+           or os.environ.get("CUDA_VISIBLE_DEVICES"))
+    if raw is None or raw.strip() == "":
+        return None
+    out: list[int] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            out.append(int(token))
+        except Exception:
+            return None
+    return out or None
+
+
+def _resolve_local_device_id(device_id: Optional[int]) -> int:
+    if device_id is not None:
+        return int(device_id)
+    try:
+        return int(torch.npu.current_device())
+    except Exception:
+        return 0
+
+
+def _resolve_canonical_device_id(local_device_id: int) -> int:
+    visible = _parse_visible_devices()
+    if not visible:
+        return local_device_id
+    if local_device_id < 0 or local_device_id >= len(visible):
+        return local_device_id
+    return int(visible[local_device_id])
+
+
+class CaMemAllocator:
+    instance = None
+    default_tag: str = "default"
+
+    @staticmethod
+    def get_instance() -> "CaMemAllocator":
+        if CaMemAllocator.instance is None:
+            CaMemAllocator.instance = CaMemAllocator()
+        return CaMemAllocator.instance
+
+    def __init__(self, device_id: Optional[int] = None) -> None:
+        conf = os.environ.get("PYTORCH_NPU_ALLOC_CONF", "")
+        assert "expandable_segments:True" not in conf, (
+            "Expandable segments are not compatible with memory pool. "
+            "Please track https://github.com/pytorch/pytorch/issues/147851 "
+            "for the latest updates.")
+
+        if not camem_available or init_module is None or python_init_space is None:
+            raise RuntimeError("bifrost_ascend_C is unavailable; cannot initialize CaMemAllocator")
+
+        self.pointer_to_data: Dict[int, AllocationData] = {}
+        self.current_tag: str = CaMemAllocator.default_tag
+        self._active_kind: str = "weight"
+        self._device_id: int = _resolve_local_device_id(device_id)
+        self._canonical_device_id: int = _resolve_canonical_device_id(
+            self._device_id)
+        self._kvcache_init_map_mb: int = _to_env_mb("MDAEMON_KV_INIT_MB", 128)
+        self._kvcache_init_map_bytes: int = self._kvcache_init_map_mb * MiB
+        self._kvcache_page_mb: int = _to_env_mb("MDAEMON_KV_GRAN_MB", 4)
+        self._kvcache_page_bytes: int = self._kvcache_page_mb * MiB
+        self._elastic_allocator: Optional[ElasticPageAllocator] = None
+        self._kvcache_managers: list[Any] = []
+
+        ok = python_init_space(self._device_id, self._canonical_device_id)
+        if not ok:
+            raise RuntimeError(
+                f"python_init_space failed (local_device_id={self._device_id}, "
+                f"canonical_device_id={self._canonical_device_id})")
+        print(f"[SD-DEBUG] Initialized CaMemAllocator with local_device_id={self._device_id}, "
+              f"canonical_device_id={self._canonical_device_id}, "
+              f"kvcache_init_map_mb={self._kvcache_init_map_mb} MiB")
+        init_module(self.python_malloc_callback, self.python_free_callback)
+
+        if lib_name is None:
+            raise RuntimeError("Failed to locate bifrost_ascend_C shared library")
+
+        self._weight_allocator = _build_allocator(lib_name, "my_malloc_weight",
+                                                  "my_free_weight")
+        self._kvcache_allocator = _build_allocator(lib_name,
+                                                   "my_malloc_kvcache",
+                                                   "my_free_kvcache")
+        self._weight_pool = torch.npu.memory.MemPool(self._weight_allocator._allocator)
+        self._kvcache_pool = torch.npu.memory.MemPool(
+            self._kvcache_allocator._allocator)
+
+        self.allocator_and_pools: Dict[str, Any] = {
+            "weight": (self._weight_pool, self._weight_allocator),
+            "kvcache": (self._kvcache_pool, self._kvcache_allocator),
+        }
+
+    def _map_on_malloc(self, kind: str, device: int, d_mem: int,
+                       aligned_size: int) -> int:
+        if kind == "weight":
+            python_map_weight(device, d_mem, aligned_size)
+            return aligned_size
+
+        init_map = min(aligned_size, self._kvcache_init_map_bytes)
+        python_map_kvcache_until(device, d_mem, init_map)
+        return init_map
+
+    def _remap_on_wakeup(self, data: AllocationData) -> int:
+        device, aligned_size, d_mem, _ = data.handle
+        if data.kind == "weight":
+            python_map_weight(device, d_mem, aligned_size)
+            return aligned_size
+
+        init_map = min(aligned_size, self._kvcache_init_map_bytes)
+        python_map_kvcache_until(device, d_mem, init_map)
+        return init_map
+
+    def _unmap_for_entry(self, data: AllocationData) -> None:
+        device, _, d_mem, _ = data.handle
+        if data.kind == "weight":
+            python_unmap_weight(device, d_mem)
+        else:
+            python_unmap_kvcache_until(device, d_mem, 0)
+
+    def python_malloc_callback(self, allocation_handle: HandleType) -> None:
+        device, aligned_size, d_mem, _ = allocation_handle
+        mapped_bytes = self._map_on_malloc(self._active_kind, device, d_mem,
+                                           aligned_size)
+        self.pointer_to_data[d_mem] = AllocationData(
+            handle=allocation_handle,
+            tag=self.current_tag,
+            kind=self._active_kind,
+            mapped_bytes=mapped_bytes,
+        )
+
+    def python_free_callback(self, ptr: int) -> HandleType:
+        data = self.pointer_to_data.pop(ptr)
+        # C++ my_free_* already performs unmap/return and address release.
+        # Keep python callback as bookkeeping only to avoid duplicate unmap.
+        data.cpu_backup_tensor = None
+        return data.handle
+
+    def register_kvcache_manager(self, manager: Any) -> None:
+        self._kvcache_managers.append(manager)
+
+    def sleep(self,
+              offload_tags: Optional[Union[Tuple[str, ...], str]] = None) -> None:
+        if offload_tags is None:
+            offload_tags = (CaMemAllocator.default_tag, )
+        elif isinstance(offload_tags, str):
+            offload_tags = (offload_tags, )
+
+        assert isinstance(offload_tags, tuple)
+
+        if self._elastic_allocator is not None:
+            self._elastic_allocator.stop()
+            self._elastic_allocator.reset(0)
+
+        for manager in self._kvcache_managers:
+            manager.reset()
+
+        for ptr, data in self.pointer_to_data.items():
+            should_offload = data.kind != "kvcache" and data.tag in offload_tags
+            mapped_size = int(data.mapped_bytes)
+            if should_offload and mapped_size > 0:
+                cpu_backup_tensor = torch.empty(
+                    mapped_size,
+                    dtype=torch.uint8,
+                    device="cpu",
+                    pin_memory=NPUPlatform.is_pin_memory_available(),
+                )
+                cpu_ptr = cpu_backup_tensor.data_ptr()
+                ACL_MEMCPY_DEVICE_TO_HOST = 2
+                dest_max = cpu_ptr + mapped_size * 2
+                memcpy(cpu_ptr, dest_max, ptr, mapped_size,
+                       ACL_MEMCPY_DEVICE_TO_HOST)
+                data.cpu_backup_tensor = cpu_backup_tensor
+
+            self._unmap_for_entry(data)
+            data.mapped_bytes = 0
+
+    def wake_up(self, tags: Optional[list[str]] = None) -> None:
+        for ptr, data in self.pointer_to_data.items():
+            if tags is not None and data.tag not in tags:
+                continue
+
+            if data.cpu_backup_tensor is not None:
+                data.mapped_bytes = self._remap_on_wakeup(data)
+                cpu_backup_tensor = data.cpu_backup_tensor
+                size_in_bytes = min(
+                    data.mapped_bytes,
+                    cpu_backup_tensor.numel() * cpu_backup_tensor.element_size(),
+                )
+                cpu_ptr = cpu_backup_tensor.data_ptr()
+                ACL_MEMCPY_HOST_TO_DEVICE = 1
+                dest_max = ptr + size_in_bytes * 2
+                memcpy(ptr, dest_max, cpu_ptr, size_in_bytes,
+                       ACL_MEMCPY_HOST_TO_DEVICE)
+                data.cpu_backup_tensor = None
+
+        if self._elastic_allocator is not None:
+            self._elastic_allocator.reset(self.get_kvcache_mapped_pages())
+            self._elastic_allocator.start()
+
+    @contextmanager
+    def use_weight_memory_pool(self, tag: Optional[str] = None) -> Iterator[None]:
+        if tag is None:
+            tag = CaMemAllocator.default_tag
+
+        old_tag = self.current_tag
+        old_kind = self._active_kind
+        self.current_tag = tag
+        self._active_kind = "weight"
+        with torch.npu.memory.use_mem_pool(self._weight_pool):
+            yield
+        self.current_tag = old_tag
+        self._active_kind = old_kind
+
+    @contextmanager
+    def use_kvcache_memory_pool(self, tag: Optional[str] = None) -> Iterator[None]:
+        if tag is None:
+            tag = CaMemAllocator.default_tag
+
+        old_tag = self.current_tag
+        old_kind = self._active_kind
+        self.current_tag = tag
+        self._active_kind = "kvcache"
+        with torch.npu.memory.use_mem_pool(self._kvcache_pool):
+            yield
+        self.current_tag = old_tag
+        self._active_kind = old_kind
+
+    @contextmanager
+    def use_memory_pool(self, tag: Optional[str] = None) -> Iterator[None]:
+        # Backward-compatible route: default `use_memory_pool` means weight pool.
+        with self.use_weight_memory_pool(tag=tag):
+            yield
+
+    def close(self) -> None:
+        if self._elastic_allocator is not None:
+            self._elastic_allocator.stop()
+            self._elastic_allocator = None
+        if python_finalize_space is not None:
+            python_finalize_space()
+
+    def get_current_usage(self) -> int:
+        total = 0
+        for data in self.pointer_to_data.values():
+            total += data.mapped_bytes
+        return total
+
+    def _iter_kvcache_data(self) -> list[AllocationData]:
+        return [data for data in self.pointer_to_data.values() if data.kind == "kvcache"]
+
+    def get_kvcache_page_bytes(self) -> int:
+        return self._kvcache_page_bytes
+
+    def get_kvcache_capacity_pages(self) -> int:
+        entries = self._iter_kvcache_data()
+        if not entries:
+            return 0
+        return min(int(data.handle[1] // self._kvcache_page_bytes) for data in entries)
+
+    def get_kvcache_mapped_pages(self) -> int:
+        entries = self._iter_kvcache_data()
+        if not entries:
+            return 0
+        return min(int(data.mapped_bytes // self._kvcache_page_bytes) for data in entries)
+
+    def resize_kvcache_mapped_pages(self, target_pages: int) -> int:
+        entries = self._iter_kvcache_data()
+        if not entries:
+            return 0
+
+        capacity_pages = self.get_kvcache_capacity_pages()
+        clamped_pages = max(0, min(target_pages, capacity_pages))
+        target_bytes = clamped_pages * self._kvcache_page_bytes
+        original_mapped_bytes = {
+            id(data): int(data.mapped_bytes) for data in entries
+        }
+        resized_entries: list[AllocationData] = []
+
+        for data in entries:
+            device, aligned_size, d_mem, _ = data.handle
+            bounded_target = min(target_bytes, aligned_size)
+            if bounded_target > data.mapped_bytes:
+                try:
+                    python_map_kvcache_until(device, d_mem, bounded_target)
+                except RuntimeError as exc:
+                    rollback_target = original_mapped_bytes[id(data)]
+                    for resized in resized_entries:
+                        rollback_device, _, rollback_d_mem, _ = resized.handle
+                        python_unmap_kvcache_until(
+                            rollback_device,
+                            rollback_d_mem,
+                            original_mapped_bytes[id(resized)],
+                        )
+                        resized.mapped_bytes = original_mapped_bytes[id(resized)]
+                    logger.warning(
+                        "resize_kvcache_mapped_pages rollback after map failure: "
+                        "target_pages=%d, target_bytes=%d, rollback_target=%d, error=%s",
+                        clamped_pages,
+                        target_bytes,
+                        rollback_target,
+                        exc,
+                    )
+                    return self.get_kvcache_mapped_pages()
+            elif bounded_target < data.mapped_bytes:
+                python_unmap_kvcache_until(device, d_mem, bounded_target)
+            data.mapped_bytes = bounded_target
+            resized_entries.append(data)
+
+        return self.get_kvcache_mapped_pages()
+
+    def build_elastic_page_allocator(
+        self,
+        policy: Optional[ElasticPolicyConfig] = None,
+        autostart: bool = True,
+    ) -> ElasticPageAllocator:
+        total_pages = self.get_kvcache_capacity_pages()
+        mapped_pages = self.get_kvcache_mapped_pages()
+
+        allocator = ElasticPageAllocator(
+            total_pages=total_pages,
+            mapped_pages=mapped_pages,
+            resize_callback=self.resize_kvcache_mapped_pages,
+            policy=policy or ElasticPolicyConfig.from_env(),
+        )
+        if autostart:
+            allocator.start()
+        self._elastic_allocator = allocator
+        return allocator
+
+    def get_elastic_page_allocator(self) -> Optional[ElasticPageAllocator]:
+        return self._elastic_allocator

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -18,6 +18,7 @@
 #
 
 import copy
+import os
 from typing import Optional, Union
 
 import torch
@@ -45,7 +46,6 @@ from vllm.v1.worker.worker_base import WorkerBase
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.cpu_binding import bind_cpus
-from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.platform import NPUPlatform
 from vllm_ascend.utils import (init_ascend_soc_version, is_enable_nz,
@@ -65,6 +65,16 @@ torch_non_c_binding_in_graph_functions_npu[
 torch._dynamo.trace_rules.torch_name_rule_map.append(
     torch_non_c_binding_in_graph_functions_npu)  # noqa: E402
 
+import os
+enable_bifrost = os.getenv("ENABLE_BIFROST", "0").lower() in {
+  "1", "true", "yes", "on"
+}
+if enable_bifrost:
+    from vllm_ascend.device_allocator.camem_bifrost import CaMemAllocator
+    import vllm_ascend.vllm_ascend_C # this is to ensure the custom ops in 
+                    # vllm_ascend_C are registered when Bifrost is enabled
+else:
+    from vllm_ascend.device_allocator.camem import CaMemAllocator
 
 class NPUWorker(WorkerBase):
 
@@ -165,14 +175,16 @@ class NPUWorker(WorkerBase):
             }
         allocator = CaMemAllocator.get_instance()
         allocator.sleep(offload_tags=("weights", ) if level == 1 else tuple())
-        free_bytes_after_sleep, total = NPUPlatform.mem_get_info()
-        freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
-        used_bytes = total - free_bytes_after_sleep
-        assert freed_bytes >= 0, "Memory usage increased after sleeping."
-        logger.info(
-            "Sleep mode freed %.2f GiB memory, "
-            "%.2f GiB memory is still in use.", freed_bytes / GiB_bytes,
-            used_bytes / GiB_bytes)
+
+        if not enable_bifrost:
+            free_bytes_after_sleep, total = NPUPlatform.mem_get_info()
+            freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
+            used_bytes = total - free_bytes_after_sleep
+            assert freed_bytes >= 0, "Memory usage increased after sleeping."
+            logger.info(
+                "Sleep mode freed %.2f GiB memory, "
+                "%.2f GiB memory is still in use.", freed_bytes / GiB_bytes,
+                used_bytes / GiB_bytes)
 
     def wake_up(self, tags: Optional[list[str]] = None) -> None:
         if not sleep_mode_enabled():
@@ -226,33 +238,38 @@ class NPUWorker(WorkerBase):
         _, total_npu_memory = NPUPlatform.mem_get_info()
         self.model_runner.profile_run()
 
-        # Calculate the number of blocks that can be allocated with the
-        # profiled peak memory.
-        free_npu_memory, _ = NPUPlatform.mem_get_info()
-        # NOTE(woosuk): Here we assume that the other processes using the same
-        # GPU did not change their memory usage during the profiling.
-        assert self.init_npu_memory > free_npu_memory, (
-            "Error in memory profiling. "
-            f"Initial free memory {self.init_npu_memory}, current free memory"
-            f" {free_npu_memory}. This happens when the NPU memory was "
-            "not properly cleaned up before initializing the vLLM instance.")
+        if not enable_bifrost:
+            # Calculate the number of blocks that can be allocated with the
+            # profiled peak memory.
+            free_npu_memory, _ = NPUPlatform.mem_get_info()
+            # NOTE(woosuk): Here we assume that the other processes using the same
+            # GPU did not change their memory usage during the profiling.
+            assert self.init_npu_memory > free_npu_memory, (
+                "Error in memory profiling. "
+                f"Initial free memory {self.init_npu_memory}, current free memory"
+                f" {free_npu_memory}. This happens when the NPU memory was "
+                "not properly cleaned up before initializing the vLLM instance.")
 
-        # Get the peak memory allocation recorded by torch
-        peak_memory = torch_npu.npu.memory_stats()["allocated_bytes.all.peak"]
-        # TODO: don`t need impl this func after empty_cache in
-        # Worker.determine_num_available_blocks() unified`
-        NPUPlatform.empty_cache()
-        torch_allocated_bytes = torch_npu.npu.memory_stats(
-        )["allocated_bytes.all.current"]
-        total_allocated_bytes = torch_npu.npu.mem_get_info(
-        )[1] - torch_npu.npu.mem_get_info()[0]
-        non_torch_allocations = total_allocated_bytes - torch_allocated_bytes
-        if non_torch_allocations > 0:
-            peak_memory += non_torch_allocations
-        available_kv_cache_memory = int(
-            total_npu_memory * self.cache_config.gpu_memory_utilization -
-            peak_memory)
-        available_kv_cache_memory = int(max(available_kv_cache_memory, 0))
+            # Get the peak memory allocation recorded by torch
+            peak_memory = torch_npu.npu.memory_stats()["allocated_bytes.all.peak"]
+            # TODO: don`t need impl this func after empty_cache in
+            # Worker.determine_num_available_blocks() unified`
+            NPUPlatform.empty_cache()
+            torch_allocated_bytes = torch_npu.npu.memory_stats(
+            )["allocated_bytes.all.current"]
+            total_allocated_bytes = torch_npu.npu.mem_get_info(
+            )[1] - torch_npu.npu.mem_get_info()[0]
+            non_torch_allocations = total_allocated_bytes - torch_allocated_bytes
+            if non_torch_allocations > 0:
+                peak_memory += non_torch_allocations
+            available_kv_cache_memory = int(
+                total_npu_memory * self.cache_config.gpu_memory_utilization -
+                peak_memory)
+            available_kv_cache_memory = int(max(available_kv_cache_memory, 0))
+        else:
+            NPUPlatform.empty_cache()
+            available_kv_cache_memory = os.environ.get("MODEL_KV_MAX_GB", '40')
+            available_kv_cache_memory = int(float(available_kv_cache_memory) * GiB_bytes)
         logger.info(
             f"Available memory: {available_kv_cache_memory}, total memory: {total_npu_memory}"
         )
@@ -305,7 +322,10 @@ class NPUWorker(WorkerBase):
             assert allocator.get_current_usage() == 0, (
                 "Sleep mode can only be "
                 "used for one instance per process.")
-            context = allocator.use_memory_pool(tag="weights")
+            if enable_bifrost:
+                context = allocator.use_weight_memory_pool(tag="weights")
+            else:
+                context = allocator.use_memory_pool(tag="weights")
         else:
             from contextlib import nullcontext
             context = nullcontext()  # type: ignore
@@ -350,7 +370,10 @@ class NPUWorker(WorkerBase):
         """Allocate NPU KV cache with the specified kv_cache_config."""
         if self.vllm_config.model_config.enable_sleep_mode:
             allocator = CaMemAllocator.get_instance()
-            context = allocator.use_memory_pool(tag="kv_cache")
+            if enable_bifrost:
+                context = allocator.use_kvcache_memory_pool(tag="kv_cache")
+            else:
+                context = allocator.use_memory_pool(tag="kv_cache")
         else:
             from contextlib import nullcontext
             context = nullcontext()  # type: ignore


### PR DESCRIPTION
> > ### What this PR does / why we need it?
> 
> This PR introduces the Bifrost memory management architecture for vLLM on Ascend NPU, enabling multi-model memory sharing via a daemon-coordinated approach. It consists of three major components:
> 
> mdaemon (C++ daemon process) — A shared-memory-based daemon that coordinates NPU memory allocation across multiple vLLM model instances. It manages handle pools with configurable granularity (2/4/8/16MB), model registration via POSIX shared memory & semaphores, and per-model message spaces for handle request/return lifecycle. Includes a Python monitor CLI (mdaemon) with Textual TUI and HTTP control API for pool management. bifrost_ascend_C (C++ extension) — A PyTorch pluggable allocator bridge that splits memory into separate weight and kvcache pools. It communicates with the daemon to acquire/shareable memory handles, and supports map_weight/unmap_weight and map_kvcache_until/unmap_kvcache_until operations for fine-grained memory visibility control, enabling proper sleep/wake mode with CPU backup tensors. Elastic KV cache management (Python) — A new vllm_ascend.core.kvcache module providing: ElasticPageAllocator — Thread-safe page allocator with auto-grow/shrink control loop KVCacheManager — Block-level allocator mapping blocks to daemon-managed pages ElasticBlockPool — Monkey-patched BlockPool that replaces vLLM's default with elastic resizing ElasticPolicyConfig — Configurable policy (min/max free pages, grow/shrink steps) via env vars The worker (worker_v1.py) is modified to conditionally activate Bifrost via ENABLE_BIFROST env var, routing to camem_bifrost.CaMemAllocator with separate weight/kvcache pools, and using MODEL_KV_MAX_GB for KV cache sizing instead of profiling-based estimation.
> 
> Why needed: In multi-model scenarios on Ascend NPUs, the existing camem allocator cannot coordinate memory between concurrent model instances, leading to OOM or inefficient utilization. Bifrost solves this by centralizing allocation through a daemon, enabling elastic KV cache resizing and proper weight offloading across models.
> 
> > ### Does this PR introduce _any_ user-facing change?
> 
> Yes. New environment variables are introduced:
> 
> ENABLE_BIFROST — Enable/disable Bifrost mode (default: disabled, fully backward-compatible) MODEL_KV_MAX_GB — Specify KV cache memory size in GiB (replaces profiling-based estimation when Bifrost enabled) MDAEMON_KV_INIT_MB / MDAEMON_KV_GRAN_MB — KV cache initial mapping and granularity KVCACHE_MIN_FREE_PAGES, KVCACHE_GROW_STEP_PAGES, etc. — Elastic policy tuning When ENABLE_BIFROST=1, sleep mode memory reporting is suppressed (no freed/used GiB log), and weight/kvcache use separate pool context managers (use_weight_memory_pool / use_kvcache_memory_pool). All changes are gated behind the env var — no impact when disabled.
> 
> > ### How was this patch tested?
> 
> C++ unit tests: test_handle_pool.cpp validates handle pool acquire/release/extend/remove across multiple devices and granularities; test_daemon.cpp tests daemon lifecycle with handle pool operations; test_model1/2/3.cpp test multi-model registration, handle request/return, and overclaim scenarios via shared memory IPC. Python test: test_camem_allocator.py validates the bifrost C extension allocator (weight/kvcache malloc/free, map/unmap operations). Integration: The mdaemon monitor CLI (mdaemon) can be launched with pool configurations for runtime validation. Manual testing on Ascend NPU hardware with multi-model sleep/wake cycles is recommended before merge. vLLM version: v0.11.0 vLLM main: https://github.com/vllm-project/vllm/commit/ (to be filled by author)

