### PR TITLE
[Cherry-pick][releases/v0.24.0rc][Refactor][Ops] Refactor multi-modal encoder attention sequence length handling (from #12084)

### DIFF
--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -105,6 +105,8 @@ if not _npu_available:
     sys.modules["torch_npu"]._npu_flash_attention = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"]._npu_paged_attention_splitfuse = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"]._npu_reshape_and_cache = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_fused_infer_attention_score = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"]._npu_fused_infer_attention_score_get_max_workspace = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_moe_gating_top_k_softmax = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_quant_matmul = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_rms_norm = MagicMock()  # type: ignore[attr-defined]

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -1,0 +1,195 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import torch
+from vllm.config import CompilationConfig, VllmConfig
+from vllm.config.vllm import get_cached_compilation_config
+
+from tests.ut.base import TestBase
+from vllm_ascend.ops.mm_encoder_attention import (
+    MAX_PAD_SIZE,
+    AscendMMEncoderAttention,
+)
+from vllm_ascend.worker import encoder_acl_graph
+from vllm_ascend.worker.encoder_acl_graph import (
+    get_encoder_graph_params,
+    set_encoder_forward_context,
+    set_encoder_graph_params,
+)
+
+
+class FIAMockMixin(TestBase):
+    captured: dict[str, Any]
+
+    def _install_vllm_config_mock(self):
+        mock_vllm_config = MagicMock(spec=VllmConfig)
+        mock_vllm_config.compilation_config = CompilationConfig()
+        patcher = patch(
+            "vllm.config.vllm.get_current_vllm_config",
+            return_value=mock_vllm_config,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        get_cached_compilation_config.cache_clear()
+        self.addCleanup(get_cached_compilation_config.cache_clear)
+
+    def _make_layer(self, num_heads=4, num_kv_heads=4, head_size=72, scale=None):
+        return AscendMMEncoderAttention(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+        )
+
+    def _fake_fia(self, **kwargs):
+        self.captured = {
+            "mode": "functional",
+            "q_shape": kwargs["query"].shape,
+            "input_layout": kwargs["input_layout"],
+            "actual_seq_lengths": kwargs["actual_seq_lengths"],
+        }
+        return torch.zeros_like(kwargs["query"]), None
+
+    def _fake_fia_out(self, *, workspace, out, **kwargs):
+        self.captured = {"mode": "out", "softmax_lse": out[1]}
+        out[0].zero_()
+
+    def _install_fia_mocks(self, *, capture: bool):
+        self.captured = {}
+        mock_fia = MagicMock(side_effect=self._fake_fia)
+        mock_fia.out = self._fake_fia_out
+
+        patch_targets: list[tuple[str, Any]] = [
+            (
+                "vllm_ascend.ops.mm_encoder_attention.torch_npu.npu_fused_infer_attention_score",
+                mock_fia,
+            ),
+            (
+                "vllm_ascend.ops.mm_encoder_attention.torch_npu._npu_fused_infer_attention_score_get_max_workspace",
+                MagicMock(return_value=torch.zeros(1)),
+            ),
+        ]
+        if capture:
+            self.mock_graph_begin = MagicMock()
+            self.mock_graph_end = MagicMock(return_value=42)
+            mock_event = MagicMock()
+            patch_targets.extend(
+                [
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.weak_ref_tensors",
+                        lambda tensors: tensors,
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch_npu.npu.current_stream",
+                        MagicMock(return_value=MagicMock()),
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch.npu.ExternalEvent",
+                        MagicMock(return_value=mock_event),
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch.npu.graph_task_group_begin",
+                        self.mock_graph_begin,
+                    ),
+                    (
+                        "vllm_ascend.ops.mm_encoder_attention.torch.npu.graph_task_group_end",
+                        self.mock_graph_end,
+                    ),
+                ]
+            )
+
+        for target, replacement in patch_targets:
+            patcher = patch(target, replacement)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+
+class TestAscendMMEncoderAttentionEager(FIAMockMixin):
+    def setUp(self):
+        self._install_vllm_config_mock()
+        self._install_fia_mocks(capture=False)
+
+    def test_forward_oot_basic(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=128)
+        bsz, q_len = 2, 4
+        query = torch.randn(bsz, q_len, layer.num_heads * layer.head_size)
+        key = query.clone()
+        value = query.clone()
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+        out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(out.shape, (bsz, q_len, layer.num_heads * layer.head_size))
+        self.assertEqual(self.captured["mode"], "functional")
+        self.assertEqual(self.captured["input_layout"], "TND")
+
+    def test_forward_oot_seqlens(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        seq_lens = [3, 7, 2]
+        cu_seqlens = torch.tensor([0, 3, 10, 12], dtype=torch.int32, device="cpu")
+        max_q_len = max(seq_lens)
+        query = torch.randn(len(seq_lens), max_q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+
+        out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(out.shape, query.shape)
+        self.assertEqual(self.captured["actual_seq_lengths"], [3, 10, 12])
+        self.assertEqual(self.captured["q_shape"], (len(seq_lens) * max_q_len, 4, MAX_PAD_SIZE))
+
+
+class TestAscendMMEncoderAttentionCapture(FIAMockMixin):
+    def setUp(self):
+        self._install_vllm_config_mock()
+        set_encoder_graph_params([2048])
+        self._install_fia_mocks(capture=True)
+
+    def tearDown(self):
+        encoder_acl_graph._encoder_graph_params = None
+        encoder_acl_graph._reset_encoder_forward_context()
+
+    def test_forward_oot_basic(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        bsz, q_len = 2, 4
+        query = torch.randn(bsz, q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+        with set_encoder_forward_context(2048, True):
+            layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        params = get_encoder_graph_params()
+        self.assertIsNotNone(params)
+        self.assertEqual(len(params.attn_params[2048]), 1)
+        self.assertEqual(len(params.handles[2048]), 1)
+        self.assertEqual(self.captured["mode"], "out")
+        self.mock_graph_begin.assert_called_once()
+        self.mock_graph_end.assert_called_once()
+
+    def test_forward_oot_seqlens(self):
+        layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        seq_lens = [3, 7, 2]
+        cu_seqlens = torch.tensor([0, 3, 10, 12], dtype=torch.int32, device="cpu")
+        max_q_len = max(seq_lens)
+        query = torch.randn(len(seq_lens), max_q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+
+        captured_lengths: list[Any] = []
+
+        def capture_workspace(**kwargs):
+            captured_lengths.append(kwargs.get("actual_seq_lengths"))
+            return torch.zeros(1)
+
+        with (
+            patch(
+                "vllm_ascend.ops.mm_encoder_attention.torch_npu._npu_fused_infer_attention_score_get_max_workspace",
+                side_effect=capture_workspace,
+            ),
+            set_encoder_forward_context(2048, True),
+        ):
+            layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(captured_lengths[-1], [7, 14, 21])

--- a/tests/ut/worker/test_encoder_acl_graph.py
+++ b/tests/ut/worker/test_encoder_acl_graph.py
@@ -1,0 +1,186 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.config import CompilationConfig, VllmConfig
+
+from vllm_ascend.worker import encoder_acl_graph
+from vllm_ascend.worker.encoder_acl_graph import (
+    EncoderAclGraphManager,
+    get_encoder_forward_context,
+    get_encoder_graph_params,
+    maybe_compute_actual_seq_lengths,
+    set_encoder_graph_params,
+    update_encoder_graph_params,
+)
+
+
+def _reset_encoder_acl_graph_state() -> None:
+    encoder_acl_graph._encoder_graph_params = None
+    encoder_acl_graph._reset_encoder_forward_context()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    _reset_encoder_acl_graph_state()
+    yield
+    _reset_encoder_acl_graph_state()
+
+
+@pytest.mark.parametrize(
+    "cu_seqlens, num_tokens, expected",
+    [
+        (torch.tensor([0, 4, 16], dtype=torch.int32), 8, [4, 16]),
+    ],
+)
+def test_maybe_compute_actual_seq_lengths_eager(cu_seqlens, num_tokens, expected):
+    actual_q, actual_kv = maybe_compute_actual_seq_lengths(
+        cu_seqlens,
+        num_tokens,
+        num_tokens,
+        cudagraph_mm_encoder=False,
+    )
+    assert actual_q == expected
+    assert actual_kv == expected
+
+
+def test_maybe_compute_actual_seq_lengths_eager_unequal_q_kv():
+    """Molmo-style uniform cross-attention: scale KV endpoints by kv/q ratio."""
+    cu_seqlens = torch.tensor([0, 1, 2], dtype=torch.int32)
+    actual_q, actual_kv = maybe_compute_actual_seq_lengths(
+        cu_seqlens,
+        2,
+        8,
+        cudagraph_mm_encoder=False,
+    )
+    assert actual_q == [1, 2]
+    assert actual_kv == [4, 8]
+
+
+@pytest.mark.parametrize(
+    "cu_seqlens, num_tokens, expected",
+    [
+        (torch.tensor([0, 4, 8], dtype=torch.int32), 8, [4, 8]),
+        (torch.tensor([0, 4, 16], dtype=torch.int32), 8, [4, 8]),
+    ],
+)
+def test_maybe_compute_actual_seq_lengths_graph(cu_seqlens, num_tokens, expected):
+    actual_q, actual_kv = maybe_compute_actual_seq_lengths(
+        cu_seqlens,
+        num_tokens,
+        num_tokens,
+        cudagraph_mm_encoder=True,
+    )
+    assert actual_q == expected
+    assert actual_kv == expected
+
+
+def test_update_encoder_graph_params_cu_seqlens():
+    set_encoder_graph_params([2048])
+    params = get_encoder_graph_params()
+    query = MagicMock()
+    query.shape = [8, 4, 72]
+    key = MagicMock()
+    key.shape = [8, 4, 72]
+    packed = (
+        query,
+        key,
+        MagicMock(),
+        None,
+        None,
+        128,
+        4,
+        4,
+        0.125,
+        MagicMock(),
+        MagicMock(),
+    )
+    params.handles[2048] = [1]
+    params.events[2048] = [MagicMock()]
+    params.attn_params[2048] = [packed]
+    params.workspaces[2048] = MagicMock()
+
+    ctx = get_encoder_forward_context()
+    ctx.cu_seqlens_cpu = torch.tensor([0, 4, 8], dtype=torch.int32)
+
+    captured = {}
+
+    def fake_out(**kwargs):
+        captured["actual_seq_lengths"] = kwargs["actual_seq_lengths"]
+
+    fake_fia = SimpleNamespace(out=fake_out)
+    with (
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.stream"),
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph_task_update_begin"),
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph_task_update_end"),
+        patch(
+            "vllm_ascend.worker.encoder_acl_graph.torch_npu.npu_fused_infer_attention_score",
+            fake_fia,
+        ),
+    ):
+        update_encoder_graph_params(MagicMock(), 2048)
+
+    assert captured["actual_seq_lengths"] == [4, 8]
+
+
+def _make_manager():
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.compilation_config = CompilationConfig()
+    mm_config = MagicMock()
+    mm_config.get_limit_per_prompt.return_value = 0
+    mm_config.mm_encoder_tp_mode = "tensor"
+    vllm_config.model_config = MagicMock()
+    vllm_config.model_config.multimodal_config = mm_config
+    vllm_config.parallel_config = MagicMock()
+    vllm_config.parallel_config.tensor_parallel_size = 1
+
+    model = MagicMock()
+    model.get_encoder_cudagraph_config.return_value = MagicMock(
+        modalities=["image"],
+        buffer_keys=["cu_seqlens"],
+        out_hidden_size=64,
+        enable_dual_path_graph=False,
+        padding_logics={},
+        max_frames_per_video=1,
+    )
+    model.get_encoder_cudagraph_budget_range.return_value = (64, 2048)
+    return EncoderAclGraphManager(vllm_config, "npu", "bfloat16", model), model
+
+
+def test_capture_graph_params():
+    mgr, _ = _make_manager()
+    mgr.token_budgets = [2048]
+
+    with patch("vllm.v1.worker.encoder_cudagraph.EncoderCudaGraphManager.capture", return_value=None):
+        mgr.capture()
+
+    params = get_encoder_graph_params()
+    assert params is not None
+    assert 2048 in params.events
+
+
+def test_capture_budget_graph_npu():
+    mgr, model = _make_manager()
+    mgr.max_batch_size = 2
+    mgr.max_frames_per_batch = 0
+    capture_values = {"cu_seqlens": torch.zeros(3, dtype=torch.int32)}
+    model.prepare_encoder_cudagraph_capture_inputs.return_value = MagicMock(
+        values=capture_values,
+    )
+    model.encoder_cudagraph_forward.return_value = torch.zeros(2, 64)
+
+    fake_graph = MagicMock()
+    with (
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.NPUGraph", return_value=fake_graph),
+        patch("vllm_ascend.worker.encoder_acl_graph.torch.npu.graph"),
+        patch(
+            "vllm_ascend.worker.encoder_acl_graph.weak_ref_tensors",
+            side_effect=lambda tensors: tensors,
+        ),
+    ):
+        mgr._capture_budget_graph(2048)
+
+    graph_meta = mgr._get_graph_set("default")[2048]
+    assert graph_meta.graph is fake_graph
+    assert graph_meta.input_buffers is capture_values

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -25,17 +25,16 @@ matching the LLM full-graph pattern in :mod:`vllm_ascend.attention.attention_v1`
 from __future__ import annotations
 
 import einops
-import numpy as np
 import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.utils import weak_ref_tensors
 from vllm_ascend.worker.encoder_acl_graph import (
     get_encoder_forward_context,
     get_encoder_graph_params,
+    maybe_compute_actual_seq_lengths,
     update_encoder_graph_workspace,
 )
 
@@ -73,43 +72,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         )
 
         self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
-        self.scale_value = self.head_size**-0.5
-
-    @classmethod
-    def maybe_compute_seq_lens(
-        cls,
-        attn_backend: AttentionBackendEnum,
-        cu_seqlens: np.ndarray,
-        device: torch.device,
-    ) -> np.ndarray | None:
-        if cu_seqlens is None:
-            return None
-
-        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-        seq_lens = torch.from_numpy(seq_lens).to("cpu", non_blocking=True)
-
-        return seq_lens
-
-    def _maybe_compute_actual_seq_lengths(
-        self,
-        bsz: int,
-        q_len: int,
-        cu_seqlens: torch.Tensor | None,
-        sequence_lengths: torch.Tensor | None,
-    ) -> tuple[list[int], list[int]]:
-        """Build FIA ``actual_seq_lengths`` as cumulative host-side ``list[int]``."""
-        if sequence_lengths is not None:
-            seq_lens_cpu = sequence_lengths
-            if seq_lens_cpu.device.type != "cpu":
-                seq_lens_cpu = seq_lens_cpu.to("cpu")
-            actual = seq_lens_cpu.cumsum(0).to(torch.int64).tolist()
-        else:
-            cu = self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens)
-            if cu.device.type != "cpu":
-                cu = cu.to("cpu")
-            actual = cu[1:].to(torch.int64).tolist()
-
-        return actual, actual
 
     def _reshape_qkv_to_3d(
         self,
@@ -135,21 +97,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
 
         return query, key, value
 
-    def _maybe_compute_cu_seqlens(
-        self,
-        bsz: int,
-        q_len: int,
-        cu_seqlens: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        if cu_seqlens is not None:
-            return cu_seqlens
-
-        # If cu_seqlens is not provided, we create a default one assuming all sequences have the same length.
-        # This is used by models such as Hunyuan-OCR, which always pass None as cu_seqlens and rely on the operator to
-        # compute it internally.
-        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
-        return cu_seqlens
-
     def _maybe_pad_qkv(
         self,
         q: torch.Tensor,
@@ -164,6 +111,25 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         k = F.pad(k, (0, pad_len), mode="constant", value=0)
         v = F.pad(v, (0, pad_len), mode="constant", value=0)
         return q, k, v, origin_head_dim
+
+    def _maybe_compute_cu_seqlens(
+        self,
+        bsz: int,
+        q_len: int,
+        cu_seqlens: torch.Tensor | None,
+        *,
+        is_capturing: bool = False,
+    ) -> torch.Tensor:
+        # In the eager path, if cu_seqlens is provided by the model we use it; if it is not provided, we create a
+        # default one assuming all sequences have the same length. This is used by models such as Hunyuan-OCR, which
+        # always pass None as cu_seqlens and rely on the operator to compute it internally.
+        # In the capture path, we always create the default cu_seqlens on CPU instead of using the model tensor, to
+        # avoid a device-to-host sync (.cpu()).
+        if is_capturing or cu_seqlens is None:
+            cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32, device="cpu")
+            return cu_seqlens
+
+        return cu_seqlens.cpu()
 
     @staticmethod
     def _maybe_unpad_output(
@@ -210,7 +176,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             actual_seq_lengths_kv=actual_seq_lengths_kv,
             num_key_value_heads=self.num_kv_heads,
             num_heads=self.num_heads,
-            scale=self.scale_value,
+            scale=self.scale,
             sparse_mode=0,
             pre_tokens=SWA_INT_MAX,
             next_tokens=SWA_INT_MAX,
@@ -235,17 +201,16 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        seq_lens: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
     ) -> torch.Tensor:
-        actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(  # TODO
-            bsz,
-            q_len,
-            cu_seqlens,
-            seq_lens,
+        actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
+            self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens),
+            query.shape[0],
+            key.shape[0],
+            cudagraph_mm_encoder=False,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
         context_layer = self._run_vit_fia(q, k, v, actual_seq_lengths_q, actual_seq_lengths_kv)
@@ -263,24 +228,23 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         *,
-        cu_seqlens: torch.Tensor | None,
-        sequence_lengths: torch.Tensor | None,
+        cu_seqlens: torch.Tensor | None = None,
         is_reshaped: bool,
         bsz: int,
         q_len: int,
-        kv_len: int,
     ) -> torch.Tensor:
         context = get_encoder_forward_context()
         token_budget = context.token_budget
+        is_capturing = context.capturing
         params = get_encoder_graph_params()
         if token_budget is None or params is None:
             raise RuntimeError("Encoder graph capture state was not initialized (missing token_budget).")
 
-        actual_seq_lengths_q, actual_seq_lengths_kv = self._maybe_compute_actual_seq_lengths(
-            bsz,
-            q_len,
-            cu_seqlens,
-            sequence_lengths,
+        actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
+            self._maybe_compute_cu_seqlens(bsz, q_len, cu_seqlens, is_capturing=is_capturing),
+            query.shape[0],
+            key.shape[0],
+            cudagraph_mm_encoder=True,
         )
         q, k, v, origin_head_dim = self._maybe_pad_qkv(query, key, value)
 
@@ -302,7 +266,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
                 num_key_value_heads=self.num_kv_heads,
                 num_heads=self.num_heads,
                 sparse_mode=0,
-                scale=self.scale_value,
+                scale=self.scale,
                 pre_tokens=SWA_INT_MAX,
                 next_tokens=SWA_INT_MAX,
             )
@@ -326,9 +290,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         )
         handle = torch.npu.graph_task_group_end(stream)
 
-        vit_layer_idx = context.capture_layer_cursor
-        context.capture_layer_cursor = vit_layer_idx + 1
-        uses_sequence_lengths_host = sequence_lengths is not None
         packed = (
             weak_ref_tensors(q),
             weak_ref_tensors(k),
@@ -336,11 +297,9 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             None,
             None,
             FIA_BLOCK_SIZE,
-            uses_sequence_lengths_host,
-            vit_layer_idx,
             self.num_kv_heads,
             self.num_heads,
-            self.scale_value,
+            self.scale,
             weak_ref_tensors(out),
             weak_ref_tensors(softmax_lse),
         )
@@ -362,7 +321,7 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Unused on Ascend (upstream API compat)
+        max_seqlen: torch.Tensor | None = None,
         sequence_lengths: torch.Tensor | None = None,
     ):
         bsz, q_len = query.size()[:2]
@@ -377,13 +336,17 @@ class AscendMMEncoderAttention(MMEncoderAttention):
                 k,
                 v,
                 cu_seqlens=cu_seqlens,
-                sequence_lengths=sequence_lengths,
                 is_reshaped=is_reshaped,
                 bsz=bsz,
                 q_len=q_len,
-                kv_len=kv_len,
             )
 
         return self._forward_eager_fia(
-            q, k, v, seq_lens=sequence_lengths, cu_seqlens=cu_seqlens, is_reshaped=is_reshaped, bsz=bsz, q_len=q_len
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            is_reshaped=is_reshaped,
+            bsz=bsz,
+            q_len=q_len,
         )

--- a/vllm_ascend/worker/encoder_acl_graph.py
+++ b/vllm_ascend/worker/encoder_acl_graph.py
@@ -87,10 +87,7 @@ class EncoderForwardContext:
 
     token_budget: int | None = None
     capturing: bool = False
-    capture_layer_cursor: int = 0
     cu_seqlens_cpu: torch.Tensor | None = None
-    cu_window_seqlens_cpu: torch.Tensor | None = None
-    sequence_lengths_cpu: torch.Tensor | None = None
 
 
 _context = EncoderForwardContext()
@@ -106,8 +103,6 @@ def _reset_encoder_forward_context() -> None:
     _context.token_budget = None
     _context.capturing = False
     _context.cu_seqlens_cpu = None
-    _context.cu_window_seqlens_cpu = None
-    _context.sequence_lengths_cpu = None
 
 
 @contextmanager
@@ -116,8 +111,6 @@ def set_encoder_forward_context(
     capturing: bool,
     *,
     cu_seqlens_cpu: torch.Tensor | None = None,
-    cu_window_seqlens_cpu: torch.Tensor | None = None,
-    sequence_lengths_cpu: torch.Tensor | None = None,
 ):
     """Enter encoder graph replay (FIA host args): callers must pass lengths each time.
 
@@ -128,9 +121,6 @@ def set_encoder_forward_context(
     _context.token_budget = token_budget
     _context.capturing = capturing
     _context.cu_seqlens_cpu = cu_seqlens_cpu
-    _context.cu_window_seqlens_cpu = cu_window_seqlens_cpu
-    _context.sequence_lengths_cpu = sequence_lengths_cpu
-    _context.capture_layer_cursor = 0
     try:
         yield _context
     finally:
@@ -138,57 +128,57 @@ def set_encoder_forward_context(
 
 
 # ---------------------------------------------------------------------------
-# Replay-time FIA task updates
+# FIA actual_seq_lengths (cu_seqlens -> list[int])
 # ---------------------------------------------------------------------------
 
 
-def _pad_actual_seq_lengths_for_fia(actual_seq_lengths: list[int], num_tokens: int) -> list[int]:
-    """TND FIA requires ``query.shape[0] == actual_seq_lengths[-1]``."""
-    if not actual_seq_lengths or actual_seq_lengths[-1] != num_tokens:
-        actual_seq_lengths.append(num_tokens)
-    return actual_seq_lengths
-
-
-def _maybe_compute_actual_seq_lengths(
-    *,
+def maybe_compute_actual_seq_lengths(
+    cu_seqlens: torch.Tensor,
     num_query_tokens: int,
-    uses_seq_len_host: bool,
-    vit_layer_idx: int,
-    fullatt_block_indexes: set[int] | frozenset[int] | None,
+    num_kv_tokens: int,
+    *,
+    cudagraph_mm_encoder: bool = False,
 ) -> tuple[list[int], list[int]]:
-    context = get_encoder_forward_context()
-    if uses_seq_len_host:
-        if context.sequence_lengths_cpu is None:
-            raise RuntimeError("context.sequence_lengths_cpu is None during encoder replay.")
-        actual = context.sequence_lengths_cpu.cumsum(0).to(torch.int64).tolist()
-    elif fullatt_block_indexes is not None:
-        if vit_layer_idx in fullatt_block_indexes:
-            if context.cu_seqlens_cpu is None:
-                raise RuntimeError("context.cu_seqlens_cpu is None during encoder replay.")
-            actual = context.cu_seqlens_cpu[1:].to(torch.int64).tolist()
-        else:
-            if context.cu_window_seqlens_cpu is None:
-                raise RuntimeError("context.cu_window_seqlens_cpu is None during encoder replay.")
-            actual = context.cu_window_seqlens_cpu[1:].to(torch.int64).tolist()
-    else:
-        if context.cu_seqlens_cpu is None:
-            raise RuntimeError("context.cu_seqlens_cpu is None during encoder replay.")
-        actual = context.cu_seqlens_cpu[1:].to(torch.int64).tolist()
+    """Convert ``cu_seqlens`` to FIA host ``actual_seq_lengths``.
 
-    aligned = _pad_actual_seq_lengths_for_fia(actual, num_query_tokens)
-    return aligned, aligned
+    Drops the leading-zero marker; with ``cudagraph_mm_encoder`` filters endpoints and
+    aligns the terminal to ``num_query_tokens``; when Q≠KV, scales Q endpoints by
+    ``num_kv_tokens // num_query_tokens`` for the KV list.
+    """
+    flat = cu_seqlens.detach().cpu().view(-1).tolist()
+    actual = flat[1:] if flat else flat
+
+    if not cudagraph_mm_encoder:
+        pass
+    elif num_query_tokens <= 0:
+        actual = [0]
+    else:
+        filtered: list[int] = []
+        for end in actual:
+            if end <= 0:
+                continue
+            if end > num_query_tokens:
+                break
+            if not filtered or end > filtered[-1]:
+                filtered.append(end)
+
+        if not filtered or filtered[-1] != num_query_tokens:
+            filtered.append(num_query_tokens)
+        actual = filtered
+
+    if num_kv_tokens == num_query_tokens:
+        return actual, actual
+
+    assert num_kv_tokens % num_query_tokens == 0
+    ratio = num_kv_tokens // num_query_tokens
+    return actual, [end * ratio for end in actual]
 
 
 def update_encoder_graph_params(
     update_stream: torch.npu.Stream,
     token_budget: int,
-    *,
-    fullatt_block_indexes: set[int] | frozenset[int] | None = None,
 ) -> None:
     """Re-bind fused infer attention host tensors inside the encoder NPUGraph (parallel to LLM path).
-
-    Qwen2.5-VL: layers listed in ``fullatt_block_indexes`` use ``cu_seqlens`` host endpoints;
-    others use ``cu_window_seqlens``. Those layouts are **not** baked at capture — only here.
 
     This deliberately bypasses :class:`AttentionBackend` — ViT attention is not registered there — but reuses
     the same ``graph_task_update_{begin,end}`` + ``ExternalEvent`` ordering pattern as
@@ -220,8 +210,6 @@ def update_encoder_graph_params(
                 block_table,
                 attn_mask,
                 block_size,
-                uses_sequence_lengths_host,
-                vit_layer_idx,
                 num_kv_heads,
                 num_heads,
                 scale,
@@ -230,11 +218,14 @@ def update_encoder_graph_params(
             ) = packed
 
             num_query_tokens = query.shape[0]
-            actual_seq_lengths_q, actual_seq_lengths_kv = _maybe_compute_actual_seq_lengths(
-                num_query_tokens=num_query_tokens,
-                uses_seq_len_host=uses_sequence_lengths_host,
-                vit_layer_idx=vit_layer_idx,
-                fullatt_block_indexes=fullatt_block_indexes,
+            num_kv_tokens = key.shape[0]
+            cu_seqlens_cpu = get_encoder_forward_context().cu_seqlens_cpu
+
+            actual_seq_lengths_q, actual_seq_lengths_kv = maybe_compute_actual_seq_lengths(
+                cu_seqlens_cpu,
+                num_query_tokens,
+                num_kv_tokens,
+                cudagraph_mm_encoder=True,
             )
 
             torch.npu.graph_task_update_begin(update_stream, handle)
@@ -269,9 +260,6 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
         super().__init__(*args, **kwargs)
         self.graph_pool = current_platform.get_global_graph_pool()
         self.update_stream: torch.npu.Stream | None = None
-        visual = getattr(self.model, "visual", None)
-        fa_raw = getattr(visual, "fullatt_block_indexes", None) if visual is not None else None
-        self.fullatt = frozenset(fa_raw) if fa_raw is not None else None
 
     def capture(self, graph_pool: Any | None = None):
         encoder_graph_pool = graph_pool if graph_pool is not None else self.graph_pool
@@ -356,13 +344,8 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
                 padding_logic = self.config.padding_logics.get(key, self._copy_padded_buffer)
                 padding_logic(buf, src)
 
-        meta = graph_meta.input_buffers
-        cu_seqlens = meta.get("cu_seqlens")
+        cu_seqlens = graph_meta.input_buffers.get("cu_seqlens")
         cu_seqlens_cpu = None if cu_seqlens is None else cu_seqlens.cpu()
-        cu_window_seqlens = meta.get("cu_window_seqlens")
-        cu_window_seqlens_cpu = None if cu_window_seqlens is None else cu_window_seqlens.cpu()
-        seq_lens = meta.get("sequence_lengths")
-        seq_lens_cpu = None if seq_lens is None else seq_lens.cpu()
 
         update_stream = self.update_stream
         if update_stream is None:
@@ -374,10 +357,8 @@ class EncoderAclGraphManager(EncoderCudaGraphManager):
             token_budget,
             False,
             cu_seqlens_cpu=cu_seqlens_cpu,
-            cu_window_seqlens_cpu=cu_window_seqlens_cpu,
-            sequence_lengths_cpu=seq_lens_cpu,
         ):
-            update_encoder_graph_params(update_stream, token_budget, fullatt_block_indexes=self.fullatt)
+            update_encoder_graph_params(update_stream, token_budget)
 
         self.graph_hits += num_items
         return graph_meta.output_buffer


### PR DESCRIPTION
Cherry-pick of PR #12084 onto `releases/v0.24.0rc`.

Original PR: #12084
Original author: @zhoux77899

---
### What this PR does / why we need it?

This PR unifies FIA `actual_seq_lengths` handling for ViT encoder ACL graph across eager, capture, and replay. Previously, `AscendMMEncoderAttention` and `encoder_acl_graph` built sequence lengths independently, which could produce incorrect results for padded `cu_seqlens` and budget-padding trailing zeros.

Fix #10549 and #10824

Key changes:
- Introduce shared helper `maybe_compute_actual_seq_lengths()` in `encoder_acl_graph.py` to convert `cu_seqlens` → host `list[int]`; in graph mode filter invalid endpoints and align `actual_seq_lengths[-1] == num_query_tokens`; when Q≠KV, scale KV endpoints by `kv/q`.
- Update `_maybe_compute_cu_seqlens()` for `None` fallback, CPU normalization, and capture-time uniform `cu_seqlens`.
- Route eager/capture/replay through the shared helper; simplify replay context to only `cu_seqlens_cpu`.
- Remove redundant per-layer metadata (`vit_layer_idx`, `fullatt_block_indexes`, `sequence_lengths`, `cu_window_seqlens`) and use `self.scale` instead of `scale_value`.

```mermaid
flowchart TB
    direction TB
    Before["Before: duplicated paths"] --> E1[cu_seqlens / sequence_lengths / cu_window_seqlens]
    E1 --> E2[AscendMMEncoderAttention<br/>local convert + per-layer metadata]
    E2 --> E3[_pad_actual_seq_lengths_for_fia]
    Before --> R1[cu_seqlens_cpu / cu_window_seqlens_cpu<br/>sequence_lengths_cpu + fullatt_block_indexes]
    R1 --> R2[encoder_acl_graph<br/>_maybe_compute_actual_seq_lengths]
    R2 --> R3[_pad_actual_seq_lengths_for_fia]
    E3 --> FIA1[FIA]
    R3 --> FIA1
    After["After: shared pipeline"] --> IN[cu_seqlens]
    IN --> BUILD[maybe_compute_actual_seq_lengths<br/>filter + budget align]
    BUILD --> EAGER[eager / capture]
    BUILD --> REPLAY[replay via cu_seqlens_cpu context]
    EAGER --> FIA2[FIA actual_seq_lengths]
    REPLAY --> FIA2
```

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

- The following UT added to verify the eager and capture paths as well as the sequence length computation.
  - `tests/ut/worker/test_encoder_acl_graph.py`
  - `tests/ut/ops/test_mm_encoder_attention.py`
- Also test on `Qwen/Qwen3.6-27B`.
```diff
| dataset | version | metric | mode | vllm-api-stream-chat |
|----- | ----- | ----- | ----- | -----|
- | videomme | 2f2602 | [Overall][overall] | gen | 67.78 |
+ | videomme | 2f2602 | [Overall][overall] | gen | 68.85 |
```

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
