### PR TITLE
[Feature][GLM-5.2][SpecDecode] DSpark full-graph path with context KV bucketing

### DIFF
--- a/tests/ut/patch/worker/test_draft_quarot.py
+++ b/tests/ut/patch/worker/test_draft_quarot.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.patch.worker import patch_draft_quarot
+from vllm_ascend.patch.worker.patch_draft_quarot import (
+    get_rotation_path,
+    make_qwen3_dspark_load_weights,
+    transform_quarot_linear_weight,
+)
+
+
+def test_get_rotation_path_falls_back_to_model_description(tmp_path):
+    description_path = tmp_path / "quant_model_description.json"
+    description_path.write_text(
+        '{"is_rot_used": true, "optional": {"quarot": {"rotation_map": '
+        '{"global_rotation": "optional/quarot.safetensors"}}}}',
+        encoding="utf-8",
+    )
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(model=str(tmp_path)),
+        quant_config=None,
+    )
+
+    assert get_rotation_path(config) == tmp_path / "optional/quarot.safetensors"
+
+
+def test_transform_quarot_linear_weight_rotates_each_input_block():
+    weight = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+        ],
+        dtype=torch.float32,
+    )
+    rotation = torch.tensor(
+        [
+            [0.0, 1.0],
+            [1.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    actual = transform_quarot_linear_weight(weight, rotation)
+    expected = torch.tensor(
+        [
+            [2.0, 1.0, 4.0, 3.0],
+            [6.0, 5.0, 8.0, 7.0],
+        ],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_transform_quarot_linear_weight_rejects_invalid_input_width():
+    weight = torch.ones((2, 3), dtype=torch.float32)
+    rotation = torch.eye(2, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="multiple of the QuaRot hidden size"):
+        transform_quarot_linear_weight(weight, rotation)
+
+
+def test_transform_quarot_linear_weight_preserves_dtype():
+    weight = torch.arange(8, dtype=torch.bfloat16).reshape(2, 4)
+    rotation = torch.eye(2, dtype=torch.float32)
+
+    actual = transform_quarot_linear_weight(weight, rotation)
+
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual, weight)
+
+
+def test_qwen3_dspark_wrapper_rotates_only_fc_weight(monkeypatch):
+    captured_weights = {}
+    rotation = torch.tensor([[0.0, 1.0], [1.0, 0.0]], dtype=torch.float32)
+
+    def original_load_weights(_self, weights):
+        captured_weights.update(dict(weights))
+        return "loaded"
+
+    monkeypatch.setattr(
+        patch_draft_quarot,
+        "get_rotataion_matrix",
+        lambda _path: rotation,
+    )
+
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            fc=SimpleNamespace(weight=torch.empty(0)),
+        )
+    )
+    fc_weight = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32)
+    lm_head_weight = torch.tensor([[5.0, 6.0]], dtype=torch.float32)
+
+    result = make_qwen3_dspark_load_weights(
+        "rotation.safetensors",
+        original_load_weights,
+    )(
+        model,
+        [
+            ("fc.weight", fc_weight),
+            ("lm_head.weight", lm_head_weight),
+        ],
+    )
+
+    assert result == "loaded"
+    torch.testing.assert_close(
+        captured_weights["fc.weight"],
+        torch.tensor([[2.0, 1.0, 4.0, 3.0]], dtype=torch.float32),
+    )
+    assert captured_weights["lm_head.weight"] is lm_head_weight

--- a/tests/ut/spec_decode/test_dspark_graph_gate.py
+++ b/tests/ut/spec_decode/test_dspark_graph_gate.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from vllm_ascend.spec_decode.llm_base_proposer import _is_dspark_draft_model
+
+
+def _model_config(**hf_fields):
+    return SimpleNamespace(hf_config=SimpleNamespace(**hf_fields))
+
+
+def test_dspark_draft_model_detects_native_architecture():
+    config = _model_config(architectures=["Qwen3DSparkModel"])
+
+    assert _is_dspark_draft_model(config)
+
+
+def test_dspark_draft_model_detects_speculators_metadata():
+    config = _model_config(
+        architectures=["UnknownDraftModel"],
+        speculators_model_type="dspark",
+    )
+
+    assert _is_dspark_draft_model(config)
+
+
+def test_dspark_draft_model_rejects_other_drafters():
+    config = _model_config(architectures=["Eagle3LlamaForCausalLM"])
+
+    assert not _is_dspark_draft_model(config)

--- a/tests/ut/spec_decode/test_dspark_graph_inputs.py
+++ b/tests/ut/spec_decode/test_dspark_graph_inputs.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import torch
+from vllm.config import CUDAGraphMode
+
+import vllm_ascend.spec_decode.dspark_proposer as dspark_module
+from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
+
+
+class _ContextRecorder:
+    def precompute_and_store_context_kv(self, hidden_states, positions, slot_mapping):
+        self.hidden_states = hidden_states
+        self.positions = positions
+        self.slot_mapping = slot_mapping
+
+
+def _make_proposer():
+    return SimpleNamespace(
+        _dflash_num_context=3,
+        _dflash_hidden_states=torch.zeros(16, 4),
+        _context_positions_buffer=torch.zeros(16, dtype=torch.int32),
+        _context_slot_mapping_buffer=torch.zeros(16, dtype=torch.int32),
+        input_ids=torch.zeros(16, dtype=torch.int32),
+        positions=torch.zeros(16, dtype=torch.int32),
+        model=_ContextRecorder(),
+    )
+
+
+def test_dspark_eager_precomputes_live_context(monkeypatch):
+    proposer = _make_proposer()
+    monkeypatch.setattr(
+        dspark_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE),
+    )
+
+    model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
+        proposer,
+        num_input_tokens=8,
+    )
+
+    assert proposer.model.hidden_states.shape[0] == 3
+    assert proposer.model.positions.shape[0] == 3
+    assert proposer.model.slot_mapping.shape[0] == 3
+    assert model_inputs["input_ids"].shape[0] == 8
+
+
+def test_dspark_graph_precomputes_padded_context(monkeypatch):
+    proposer = _make_proposer()
+    monkeypatch.setattr(
+        dspark_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL),
+    )
+
+    model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
+        proposer,
+        num_input_tokens=8,
+    )
+
+    assert proposer.model.hidden_states.shape[0] == 8
+    assert proposer.model.positions.shape[0] == 8
+    assert proposer.model.slot_mapping.shape[0] == 8
+    assert model_inputs["positions"].shape[0] == 8

--- a/tests/ut/spec_decode/test_dspark_graph_inputs.py
+++ b/tests/ut/spec_decode/test_dspark_graph_inputs.py
@@ -41,9 +41,7 @@ def _make_proposer():
         _context_positions_buffer=positions,
         _context_slot_mapping_buffers=[slots],
         _per_group_context_slot_mapping_buffers={0: slots},
-        _per_group_query_slot_mapping_buffers={
-            0: torch.ones(16, dtype=torch.int32)
-        },
+        _per_group_query_slot_mapping_buffers={0: torch.ones(16, dtype=torch.int32)},
         input_ids=torch.zeros(16, dtype=torch.int32),
         positions=torch.zeros(16, dtype=torch.int32),
         model=_ContextRecorder(),
@@ -54,9 +52,7 @@ def _make_proposer():
         _dspark_context_kv_precomputed=False,
         _precompute_live_context_kv=lambda: None,
     )
-    proposer._primary_context_slot_mapping = lambda: (
-        AscendDSparkProposer._primary_context_slot_mapping(proposer)
-    )
+    proposer._primary_context_slot_mapping = lambda: (AscendDSparkProposer._primary_context_slot_mapping(proposer))
     proposer._use_dspark_context_kv_bucket_graph = lambda _: False
     proposer._get_dspark_context_kv_bucket = lambda num_context: (
         AscendDSparkProposer._get_dspark_context_kv_bucket(
@@ -68,9 +64,7 @@ def _make_proposer():
 
 
 def _bind_live_context_precompute(proposer):
-    proposer._precompute_live_context_kv = lambda: (
-        AscendDSparkProposer._precompute_live_context_kv(proposer)
-    )
+    proposer._precompute_live_context_kv = lambda: (AscendDSparkProposer._precompute_live_context_kv(proposer))
 
 
 def test_dspark_precompute_filters_rejected_context_rows():
@@ -188,9 +182,7 @@ def test_dspark_graph_initializes_only_graph_visible_padding(monkeypatch):
     proposer.input_ids.fill_(1)
     proposer.positions.fill_(1)
     proposer._slot_mapping_buffer = torch.ones(16, dtype=torch.int32)
-    proposer._per_group_query_slot_mapping_buffers = {
-        0: proposer._slot_mapping_buffer
-    }
+    proposer._per_group_query_slot_mapping_buffers = {0: proposer._slot_mapping_buffer}
 
     AscendDSparkProposer._initialize_graph_padding(
         proposer,

--- a/tests/ut/spec_decode/test_dspark_graph_inputs.py
+++ b/tests/ut/spec_decode/test_dspark_graph_inputs.py
@@ -3,62 +3,151 @@ from types import SimpleNamespace
 import torch
 from vllm.config import CUDAGraphMode
 
-import vllm_ascend.spec_decode.dspark_proposer as dspark_module
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
 
 
 class _ContextRecorder:
     def precompute_and_store_context_kv(self, hidden_states, positions, slot_mapping):
-        self.hidden_states = hidden_states
-        self.positions = positions
-        self.slot_mapping = slot_mapping
+        self.hidden_states = hidden_states.clone()
+        self.positions = positions.clone()
+        self.slot_mapping = slot_mapping.clone()
 
 
 def _make_proposer():
+    hidden_states = torch.arange(64, dtype=torch.float32).reshape(16, 4)
+    positions = torch.zeros(16, dtype=torch.int32)
+    positions[:3] = torch.tensor([10, 11, 12], dtype=torch.int32)
+    slots = torch.zeros(16, dtype=torch.int32)
+    slots[:3] = torch.tensor([110, -1, 112], dtype=torch.int32)
     return SimpleNamespace(
         _dflash_num_context=3,
-        _dflash_hidden_states=torch.zeros(16, 4),
-        _context_positions_buffer=torch.zeros(16, dtype=torch.int32),
-        _context_slot_mapping_buffer=torch.zeros(16, dtype=torch.int32),
+        _dflash_hidden_states=hidden_states,
+        _context_positions_buffer=positions,
+        _context_slot_mapping_buffer=slots,
         input_ids=torch.zeros(16, dtype=torch.int32),
         positions=torch.zeros(16, dtype=torch.int32),
         model=_ContextRecorder(),
+        use_cuda_graph=True,
+        _dspark_context_kv_precomputed=False,
+        _precompute_live_context_kv=lambda: None,
     )
 
 
-def test_dspark_eager_precomputes_live_context(monkeypatch):
+def _bind_live_context_precompute(proposer):
+    proposer._precompute_live_context_kv = lambda: AscendDsparkProposer._precompute_live_context_kv(proposer)
+
+
+def test_dspark_precompute_filters_rejected_context_rows():
     proposer = _make_proposer()
-    monkeypatch.setattr(
-        dspark_module,
-        "get_forward_context",
-        lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE),
+    _bind_live_context_precompute(proposer)
+
+    AscendDsparkProposer._precompute_live_context_kv(proposer)
+
+    torch.testing.assert_close(
+        proposer.model.hidden_states,
+        proposer._dflash_hidden_states[torch.tensor([0, 2])],
     )
+    torch.testing.assert_close(
+        proposer.model.positions,
+        torch.tensor([10, 12], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        proposer.model.slot_mapping,
+        torch.tensor([110, 112], dtype=torch.int32),
+    )
+
+
+def test_dspark_eager_build_precomputes_live_context():
+    proposer = _make_proposer()
+    _bind_live_context_precompute(proposer)
 
     model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
         proposer,
         num_input_tokens=8,
     )
 
-    assert proposer.model.hidden_states.shape[0] == 3
-    assert proposer.model.positions.shape[0] == 3
-    assert proposer.model.slot_mapping.shape[0] == 3
+    assert proposer.model.hidden_states.shape[0] == 2
+    assert model_inputs["input_ids"].shape[0] == 8
+    assert model_inputs["positions"].shape[0] == 8
+
+
+def test_dspark_query_graph_skips_precomputed_context():
+    proposer = _make_proposer()
+    _bind_live_context_precompute(proposer)
+    proposer._dspark_context_kv_precomputed = True
+
+    model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
+        proposer,
+        num_input_tokens=8,
+    )
+
+    assert not hasattr(proposer.model, "hidden_states")
     assert model_inputs["input_ids"].shape[0] == 8
 
 
-def test_dspark_graph_precomputes_padded_context(monkeypatch):
+def test_dspark_graph_precomputes_context_before_query_replay():
     proposer = _make_proposer()
-    monkeypatch.setattr(
-        dspark_module,
-        "get_forward_context",
-        lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL),
-    )
+    _bind_live_context_precompute(proposer)
+    forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL)
 
-    model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
+    assert AscendDsparkProposer.prepare_dspark_context_kv_for_graph(
         proposer,
-        num_input_tokens=8,
+        forward_context,
+    )
+    assert proposer._dspark_context_kv_precomputed
+    assert proposer.model.hidden_states.shape[0] == 2
+
+
+def test_dspark_context_precompute_is_not_split_from_eager_query():
+    proposer = _make_proposer()
+    _bind_live_context_precompute(proposer)
+    forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE)
+
+    assert not AscendDsparkProposer.prepare_dspark_context_kv_for_graph(
+        proposer,
+        forward_context,
+    )
+    assert not proposer._dspark_context_kv_precomputed
+    assert not hasattr(proposer.model, "hidden_states")
+
+
+def test_dspark_stabilizes_graph_padding_metadata():
+    proposer = SimpleNamespace(
+        _dspark_query_tokens_per_req=8,
+        _adjust_tensor=lambda tensor, size: torch.nn.functional.pad(
+            tensor,
+            (0, size - tensor.shape[0]),
+        ),
+    )
+    metadata = SimpleNamespace(
+        seq_lens=torch.tensor([1010, 1012, 0, 0], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([1010, 1012], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([1010, 1012], dtype=torch.int32),
+        actual_seq_lengths_q=[8, 8],
     )
 
-    assert proposer.model.hidden_states.shape[0] == 8
-    assert proposer.model.positions.shape[0] == 8
-    assert proposer.model.slot_mapping.shape[0] == 8
-    assert model_inputs["positions"].shape[0] == 8
+    AscendDsparkProposer._stabilize_padded_graph_metadata(
+        proposer,
+        metadata,
+        actual_num_reqs=2,
+        padded_num_reqs=4,
+    )
+
+    torch.testing.assert_close(
+        metadata.seq_lens,
+        torch.tensor([1010, 1012, 1, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        metadata._seq_lens_cpu,
+        torch.tensor([1010, 1012, 1, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        metadata.seq_lens_cpu,
+        torch.tensor([1010, 1012, 1, 1], dtype=torch.int32),
+    )
+    assert metadata.actual_seq_lengths_q == [8, 8, 8, 8]
+
+
+def test_dspark_uses_dflash_graph_capture_metadata_path():
+    assert AscendDsparkProposer.dummy_run is AscendDflashProposer.dummy_run

--- a/tests/ut/spec_decode/test_dspark_graph_inputs.py
+++ b/tests/ut/spec_decode/test_dspark_graph_inputs.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import torch
+from vllm.compilation import monitor as cudagraph_monitor
 from vllm.config import CUDAGraphMode
 
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
@@ -147,7 +148,14 @@ def test_dspark_context_kv_bucket_rejects_unsupported_shape():
     assert AscendDSparkProposer._get_dspark_context_kv_bucket(proposer, 17) is None
 
 
-def test_dspark_bucket_graph_uses_bucket_and_restores_query_descriptor():
+def test_dspark_bucket_graph_restores_descriptor_and_capture_monitor(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        cudagraph_monitor,
+        "cudagraph_capturing_enabled",
+        False,
+    )
     proposer = _make_proposer()
     graph = _GraphRecorder()
     query_descriptor = object()
@@ -163,6 +171,7 @@ def test_dspark_bucket_graph_uses_bucket_and_restores_query_descriptor():
     assert graph.positions.shape[0] == 8
     assert graph.slot_mapping.shape[0] == 8
     assert forward_context.batch_descriptor is query_descriptor
+    assert not cudagraph_monitor.cudagraph_capturing_enabled
     assert proposer._dspark_context_kv_precomputed
 
 

--- a/tests/ut/spec_decode/test_dspark_graph_inputs.py
+++ b/tests/ut/spec_decode/test_dspark_graph_inputs.py
@@ -14,13 +14,25 @@ class _ContextRecorder:
         self.slot_mapping = slot_mapping.clone()
 
 
+class _GraphRecorder:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, hidden_states, positions, slot_mapping):
+        self.calls += 1
+        self.hidden_states = hidden_states
+        self.positions = positions
+        self.slot_mapping = slot_mapping
+        return hidden_states
+
+
 def _make_proposer():
     hidden_states = torch.arange(64, dtype=torch.float32).reshape(16, 4)
     positions = torch.zeros(16, dtype=torch.int32)
     positions[:3] = torch.tensor([10, 11, 12], dtype=torch.int32)
     slots = torch.zeros(16, dtype=torch.int32)
     slots[:3] = torch.tensor([110, -1, 112], dtype=torch.int32)
-    return SimpleNamespace(
+    proposer = SimpleNamespace(
         _dflash_num_context=3,
         _dflash_hidden_states=hidden_states,
         _context_positions_buffer=positions,
@@ -29,9 +41,20 @@ def _make_proposer():
         positions=torch.zeros(16, dtype=torch.int32),
         model=_ContextRecorder(),
         use_cuda_graph=True,
+        max_query_tokens=16,
+        _dspark_query_tokens_per_req=8,
+        _dspark_context_kv_graph=None,
         _dspark_context_kv_precomputed=False,
         _precompute_live_context_kv=lambda: None,
     )
+    proposer._use_dspark_context_kv_bucket_graph = lambda _: False
+    proposer._get_dspark_context_kv_bucket = lambda num_context: (
+        AscendDsparkProposer._get_dspark_context_kv_bucket(
+            proposer,
+            num_context,
+        )
+    )
+    return proposer
 
 
 def _bind_live_context_precompute(proposer):
@@ -97,6 +120,73 @@ def test_dspark_graph_precomputes_context_before_query_replay():
     )
     assert proposer._dspark_context_kv_precomputed
     assert proposer.model.hidden_states.shape[0] == 2
+
+
+def test_dspark_context_kv_bucket_uses_query_block_width():
+    proposer = _make_proposer()
+
+    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 1) == 8
+    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 9) == 16
+    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 16) == 16
+
+
+def test_dspark_context_kv_bucket_rejects_unsupported_shape():
+    proposer = _make_proposer()
+
+    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 0) is None
+    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 17) is None
+
+
+def test_dspark_bucket_graph_uses_bucket_and_restores_query_descriptor():
+    proposer = _make_proposer()
+    graph = _GraphRecorder()
+    query_descriptor = object()
+    proposer._dspark_context_kv_graph = graph
+    forward_context = SimpleNamespace(batch_descriptor=query_descriptor)
+
+    assert AscendDsparkProposer._precompute_context_kv_bucket_graph(
+        proposer,
+        forward_context,
+    )
+    assert graph.calls == 1
+    assert graph.hidden_states.shape[0] == 8
+    assert graph.positions.shape[0] == 8
+    assert graph.slot_mapping.shape[0] == 8
+    assert forward_context.batch_descriptor is query_descriptor
+    assert proposer._dspark_context_kv_precomputed
+
+
+def test_dspark_graph_initializes_only_graph_visible_padding(monkeypatch):
+    monkeypatch.setenv(
+        "VLLM_ASCEND_ENABLE_GLM_DSPARK_CONTEXT_KV_BUCKET_GRAPH",
+        "1",
+    )
+    proposer = _make_proposer()
+    proposer.parallel_drafting_token_id = 99
+    proposer._dflash_hidden_states.fill_(1)
+    proposer._context_positions_buffer.fill_(1)
+    proposer._context_slot_mapping_buffer.fill_(1)
+    proposer.input_ids.fill_(1)
+    proposer.positions.fill_(1)
+    proposer._slot_mapping_buffer = torch.ones(16, dtype=torch.int32)
+
+    AscendDsparkProposer._initialize_graph_padding(
+        proposer,
+        num_context=3,
+        num_query_total=8,
+    )
+
+    assert torch.all(proposer._dflash_hidden_states[:3] == 1)
+    assert torch.all(proposer._dflash_hidden_states[3:8] == 0)
+    assert torch.all(proposer._dflash_hidden_states[8:] == 1)
+    assert torch.all(proposer._context_positions_buffer[3:8] == 0)
+    assert torch.all(proposer._context_slot_mapping_buffer[3:8] == -1)
+    assert torch.all(proposer.input_ids[:8] == 1)
+    assert torch.all(proposer.input_ids[8:] == 99)
+    assert torch.all(proposer.positions[:8] == 1)
+    assert torch.all(proposer.positions[8:] == 0)
+    assert torch.all(proposer._slot_mapping_buffer[:8] == 1)
+    assert torch.all(proposer._slot_mapping_buffer[8:] == -1)
 
 
 def test_dspark_context_precompute_is_not_split_from_eager_query():

--- a/tests/ut/spec_decode/test_dspark_graph_inputs.py
+++ b/tests/ut/spec_decode/test_dspark_graph_inputs.py
@@ -4,11 +4,13 @@ import torch
 from vllm.config import CUDAGraphMode
 
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
-from vllm_ascend.spec_decode.dspark_proposer import AscendDsparkProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 
 
 class _ContextRecorder:
     def precompute_and_store_context_kv(self, hidden_states, positions, slot_mapping):
+        if isinstance(slot_mapping, list):
+            slot_mapping = slot_mapping[0]
         self.hidden_states = hidden_states.clone()
         self.positions = positions.clone()
         self.slot_mapping = slot_mapping.clone()
@@ -36,7 +38,11 @@ def _make_proposer():
         _dflash_num_context=3,
         _dflash_hidden_states=hidden_states,
         _context_positions_buffer=positions,
-        _context_slot_mapping_buffer=slots,
+        _context_slot_mapping_buffers=[slots],
+        _per_group_context_slot_mapping_buffers={0: slots},
+        _per_group_query_slot_mapping_buffers={
+            0: torch.ones(16, dtype=torch.int32)
+        },
         input_ids=torch.zeros(16, dtype=torch.int32),
         positions=torch.zeros(16, dtype=torch.int32),
         model=_ContextRecorder(),
@@ -47,9 +53,12 @@ def _make_proposer():
         _dspark_context_kv_precomputed=False,
         _precompute_live_context_kv=lambda: None,
     )
+    proposer._primary_context_slot_mapping = lambda: (
+        AscendDSparkProposer._primary_context_slot_mapping(proposer)
+    )
     proposer._use_dspark_context_kv_bucket_graph = lambda _: False
     proposer._get_dspark_context_kv_bucket = lambda num_context: (
-        AscendDsparkProposer._get_dspark_context_kv_bucket(
+        AscendDSparkProposer._get_dspark_context_kv_bucket(
             proposer,
             num_context,
         )
@@ -58,14 +67,16 @@ def _make_proposer():
 
 
 def _bind_live_context_precompute(proposer):
-    proposer._precompute_live_context_kv = lambda: AscendDsparkProposer._precompute_live_context_kv(proposer)
+    proposer._precompute_live_context_kv = lambda: (
+        AscendDSparkProposer._precompute_live_context_kv(proposer)
+    )
 
 
 def test_dspark_precompute_filters_rejected_context_rows():
     proposer = _make_proposer()
     _bind_live_context_precompute(proposer)
 
-    AscendDsparkProposer._precompute_live_context_kv(proposer)
+    AscendDSparkProposer._precompute_live_context_kv(proposer)
 
     torch.testing.assert_close(
         proposer.model.hidden_states,
@@ -85,14 +96,13 @@ def test_dspark_eager_build_precomputes_live_context():
     proposer = _make_proposer()
     _bind_live_context_precompute(proposer)
 
-    model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
+    AscendDSparkProposer.build_model_inputs_first_pass(
         proposer,
         num_input_tokens=8,
+        context_slots=proposer._context_slot_mapping_buffers,
     )
 
     assert proposer.model.hidden_states.shape[0] == 2
-    assert model_inputs["input_ids"].shape[0] == 8
-    assert model_inputs["positions"].shape[0] == 8
 
 
 def test_dspark_query_graph_skips_precomputed_context():
@@ -100,13 +110,13 @@ def test_dspark_query_graph_skips_precomputed_context():
     _bind_live_context_precompute(proposer)
     proposer._dspark_context_kv_precomputed = True
 
-    model_inputs = AscendDsparkProposer.build_model_inputs_first_pass(
+    AscendDSparkProposer.build_model_inputs_first_pass(
         proposer,
         num_input_tokens=8,
+        context_slots=proposer._context_slot_mapping_buffers,
     )
 
     assert not hasattr(proposer.model, "hidden_states")
-    assert model_inputs["input_ids"].shape[0] == 8
 
 
 def test_dspark_graph_precomputes_context_before_query_replay():
@@ -114,7 +124,7 @@ def test_dspark_graph_precomputes_context_before_query_replay():
     _bind_live_context_precompute(proposer)
     forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL)
 
-    assert AscendDsparkProposer.prepare_dspark_context_kv_for_graph(
+    assert AscendDSparkProposer.prepare_dspark_context_kv_for_graph(
         proposer,
         forward_context,
     )
@@ -125,16 +135,16 @@ def test_dspark_graph_precomputes_context_before_query_replay():
 def test_dspark_context_kv_bucket_uses_query_block_width():
     proposer = _make_proposer()
 
-    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 1) == 8
-    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 9) == 16
-    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 16) == 16
+    assert AscendDSparkProposer._get_dspark_context_kv_bucket(proposer, 1) == 8
+    assert AscendDSparkProposer._get_dspark_context_kv_bucket(proposer, 9) == 16
+    assert AscendDSparkProposer._get_dspark_context_kv_bucket(proposer, 16) == 16
 
 
 def test_dspark_context_kv_bucket_rejects_unsupported_shape():
     proposer = _make_proposer()
 
-    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 0) is None
-    assert AscendDsparkProposer._get_dspark_context_kv_bucket(proposer, 17) is None
+    assert AscendDSparkProposer._get_dspark_context_kv_bucket(proposer, 0) is None
+    assert AscendDSparkProposer._get_dspark_context_kv_bucket(proposer, 17) is None
 
 
 def test_dspark_bucket_graph_uses_bucket_and_restores_query_descriptor():
@@ -144,7 +154,7 @@ def test_dspark_bucket_graph_uses_bucket_and_restores_query_descriptor():
     proposer._dspark_context_kv_graph = graph
     forward_context = SimpleNamespace(batch_descriptor=query_descriptor)
 
-    assert AscendDsparkProposer._precompute_context_kv_bucket_graph(
+    assert AscendDSparkProposer._precompute_context_kv_bucket_graph(
         proposer,
         forward_context,
     )
@@ -165,12 +175,15 @@ def test_dspark_graph_initializes_only_graph_visible_padding(monkeypatch):
     proposer.parallel_drafting_token_id = 99
     proposer._dflash_hidden_states.fill_(1)
     proposer._context_positions_buffer.fill_(1)
-    proposer._context_slot_mapping_buffer.fill_(1)
+    proposer._context_slot_mapping_buffers[0].fill_(1)
     proposer.input_ids.fill_(1)
     proposer.positions.fill_(1)
     proposer._slot_mapping_buffer = torch.ones(16, dtype=torch.int32)
+    proposer._per_group_query_slot_mapping_buffers = {
+        0: proposer._slot_mapping_buffer
+    }
 
-    AscendDsparkProposer._initialize_graph_padding(
+    AscendDSparkProposer._initialize_graph_padding(
         proposer,
         num_context=3,
         num_query_total=8,
@@ -180,7 +193,7 @@ def test_dspark_graph_initializes_only_graph_visible_padding(monkeypatch):
     assert torch.all(proposer._dflash_hidden_states[3:8] == 0)
     assert torch.all(proposer._dflash_hidden_states[8:] == 1)
     assert torch.all(proposer._context_positions_buffer[3:8] == 0)
-    assert torch.all(proposer._context_slot_mapping_buffer[3:8] == -1)
+    assert torch.all(proposer._context_slot_mapping_buffers[0][3:8] == -1)
     assert torch.all(proposer.input_ids[:8] == 1)
     assert torch.all(proposer.input_ids[8:] == 99)
     assert torch.all(proposer.positions[:8] == 1)
@@ -194,7 +207,7 @@ def test_dspark_context_precompute_is_not_split_from_eager_query():
     _bind_live_context_precompute(proposer)
     forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE)
 
-    assert not AscendDsparkProposer.prepare_dspark_context_kv_for_graph(
+    assert not AscendDSparkProposer.prepare_dspark_context_kv_for_graph(
         proposer,
         forward_context,
     )
@@ -217,7 +230,7 @@ def test_dspark_stabilizes_graph_padding_metadata():
         actual_seq_lengths_q=[8, 8],
     )
 
-    AscendDsparkProposer._stabilize_padded_graph_metadata(
+    AscendDSparkProposer._stabilize_padded_graph_metadata(
         proposer,
         metadata,
         actual_num_reqs=2,
@@ -239,5 +252,15 @@ def test_dspark_stabilizes_graph_padding_metadata():
     assert metadata.actual_seq_lengths_q == [8, 8, 8, 8]
 
 
-def test_dspark_uses_dflash_graph_capture_metadata_path():
-    assert AscendDsparkProposer.dummy_run is AscendDflashProposer.dummy_run
+def test_glm_dspark_uses_dflash_graph_capture_metadata_path(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(
+        AscendDflashProposer,
+        "dummy_run",
+        lambda *args, **kwargs: sentinel,
+    )
+    proposer = SimpleNamespace(_dspark_sample_from_anchor=False)
+
+    result = AscendDSparkProposer.dummy_run(proposer, num_tokens=8)
+
+    assert result is sentinel

--- a/tests/ut/worker/test_dspark_aux_layers.py
+++ b/tests/ut/worker/test_dspark_aux_layers.py
@@ -6,10 +6,7 @@ from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 def _runner_with_draft_config(**hf_config_fields):
     runner = object.__new__(NPUModelRunner)
     runner.speculative_config = SimpleNamespace(
-        use_dspark=lambda: True,
-        draft_model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(**hf_config_fields)
-        )
+        use_dspark=lambda: True, draft_model_config=SimpleNamespace(hf_config=SimpleNamespace(**hf_config_fields))
     )
     return runner
 

--- a/tests/ut/worker/test_dspark_aux_layers.py
+++ b/tests/ut/worker/test_dspark_aux_layers.py
@@ -6,6 +6,7 @@ from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 def _runner_with_draft_config(**hf_config_fields):
     runner = object.__new__(NPUModelRunner)
     runner.speculative_config = SimpleNamespace(
+        use_dspark=lambda: True,
         draft_model_config=SimpleNamespace(
             hf_config=SimpleNamespace(**hf_config_fields)
         )

--- a/tests/ut/worker/test_dspark_aux_layers.py
+++ b/tests/ut/worker/test_dspark_aux_layers.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+def _runner_with_draft_config(**hf_config_fields):
+    runner = object.__new__(NPUModelRunner)
+    runner.speculative_config = SimpleNamespace(
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(**hf_config_fields)
+        )
+    )
+    return runner
+
+
+def test_dspark_aux_layers_prefer_capture_layer_ids():
+    runner = _runner_with_draft_config(
+        eagle_aux_hidden_state_layer_ids=[8, 23, 39, 55, 70],
+        target_layer_ids=[7, 22, 38, 54, 69],
+    )
+
+    assert runner._get_eagle3_aux_layers_from_config() == (8, 23, 39, 55, 70)
+
+
+def test_dspark_aux_layers_convert_legacy_target_layer_ids():
+    runner = _runner_with_draft_config(
+        target_layer_ids=[7, 22, 38, 54, 69],
+    )
+
+    assert runner._get_eagle3_aux_layers_from_config() == (8, 23, 39, 55, 70)
+
+
+def test_dspark_aux_layers_missing_config_returns_none():
+    runner = _runner_with_draft_config()
+
+    assert runner._get_eagle3_aux_layers_from_config() is None

--- a/tests/ut/worker/test_dspark_aux_layers.py
+++ b/tests/ut/worker/test_dspark_aux_layers.py
@@ -22,6 +22,14 @@ def test_dspark_aux_layers_prefer_capture_layer_ids():
     assert runner._get_eagle3_aux_layers_from_config() == (8, 23, 39, 55, 70)
 
 
+def test_dspark_aux_layers_accept_speculators_field():
+    runner = _runner_with_draft_config(
+        aux_hidden_state_layer_ids=[8, 23, 39, 55, 70],
+    )
+
+    assert runner._get_eagle3_aux_layers_from_config() == (8, 23, 39, 55, 70)
+
+
 def test_dspark_aux_layers_convert_legacy_target_layer_ids():
     runner = _runner_with_draft_config(
         target_layer_ids=[7, 22, 38, 54, 69],

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -94,19 +94,13 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
+    RECOMPUTE_CONTEXT_SLOTS: tl.constexpr = False,
+    MASK_REJECTED_CONTEXT_SLOTS: tl.constexpr = True,
 ):
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
         ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
         num_ctx = ctx_end - ctx_start
-
-        for j in range(0, num_ctx):
-            ctx_pos_idx = ctx_start + j
-            pos = tl.load(target_positions_ptr + ctx_pos_idx)
-            tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
-
-            slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
-            tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
 
         if HAS_NUM_REJECTED:
             num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
@@ -115,9 +109,34 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
             num_rejected = 0
             valid_ctx_end = ctx_end
 
+        for j in range(0, num_ctx):
+            ctx_pos_idx = ctx_start + j
+            pos = tl.load(target_positions_ptr + ctx_pos_idx)
+            tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
+
+            if RECOMPUTE_CONTEXT_SLOTS:
+                block_num_ctx = tl.maximum(
+                    0,
+                    tl.minimum(pos // block_size, block_table_stride - 1),
+                )
+                block_id_ctx = tl.load(
+                    block_table_ptr
+                    + req_idx * block_table_stride
+                    + block_num_ctx
+                ).to(tl.int64)
+                slot = block_id_ctx * block_size + (pos % block_size)
+                if MASK_REJECTED_CONTEXT_SLOTS:
+                    slot = tl.where(ctx_pos_idx < valid_ctx_end, slot, -1)
+            else:
+                slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
+            tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
+
         seq_len = tl.load(seq_lens_ptr + req_idx)
         effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+        last_pos_idx = valid_ctx_end - 1
+        if RECOMPUTE_CONTEXT_SLOTS:
+            last_pos_idx = tl.maximum(ctx_start, last_pos_idx)
+        last_pos = tl.load(target_positions_ptr + last_pos_idx)
 
         for q_idx in range(0, num_query_per_req):
             query_pos = last_pos + 1 + q_idx
@@ -125,8 +144,16 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
 
             tl.store(out_query_positions_ptr + query_out_idx, query_pos)
 
-            query_cache_pos = effective_seq_len + q_idx
+            if RECOMPUTE_CONTEXT_SLOTS:
+                query_cache_pos = query_pos
+            else:
+                query_cache_pos = effective_seq_len + q_idx
             block_num_q = query_cache_pos // block_size
+            if RECOMPUTE_CONTEXT_SLOTS:
+                block_num_q = tl.maximum(
+                    0,
+                    tl.minimum(block_num_q, block_table_stride - 1),
+                )
             block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
             slot_q = block_id_q * block_size + (query_cache_pos % block_size)
             tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -95,7 +95,6 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
     RECOMPUTE_CONTEXT_SLOTS: tl.constexpr = False,
-    MASK_REJECTED_CONTEXT_SLOTS: tl.constexpr = True,
 ):
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
@@ -125,8 +124,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
                     + block_num_ctx
                 ).to(tl.int64)
                 slot = block_id_ctx * block_size + (pos % block_size)
-                if MASK_REJECTED_CONTEXT_SLOTS:
-                    slot = tl.where(ctx_pos_idx < valid_ctx_end, slot, -1)
+                slot = tl.where(ctx_pos_idx < valid_ctx_end, slot, -1)
             else:
                 slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
             tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -118,11 +118,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
                     0,
                     tl.minimum(pos // block_size, block_table_stride - 1),
                 )
-                block_id_ctx = tl.load(
-                    block_table_ptr
-                    + req_idx * block_table_stride
-                    + block_num_ctx
-                ).to(tl.int64)
+                block_id_ctx = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_ctx).to(tl.int64)
                 slot = block_id_ctx * block_size + (pos % block_size)
                 slot = tl.where(ctx_pos_idx < valid_ctx_end, slot, -1)
             else:

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -1,18 +1,16 @@
-import logging
+import json
 import os
 from collections.abc import Iterable
 from pathlib import Path
 
 import torch
 from safetensors.torch import load_file
+from vllm.logger import logger
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     process_eagle_weight,
 )
-
-logger = logging.getLogger(__name__)
-
 
 def get_embedding_tensor(directory_path):
     """
@@ -43,14 +41,26 @@ def get_rotation_path(target_vllm_config):
     """
     Gets the path of the rotation matrix, returns None if the target model is not a quarot model.
     """
-    target_model_path = target_vllm_config.model_config.model
-    try:
-        quant_description = target_vllm_config.quant_config.quant_description
-        rotation_relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
-    except KeyError:
+    target_model_path = Path(target_vllm_config.model_config.model)
+    quant_config = getattr(target_vllm_config, "quant_config", None)
+    quant_description = getattr(quant_config, "quant_description", None)
+
+    if quant_description is None:
+        description_path = target_model_path / "quant_model_description.json"
+        if not description_path.is_file():
+            return None
+        with description_path.open(encoding="utf-8") as description_file:
+            quant_description = json.load(description_file)
+
+    if not quant_description.get("is_rot_used", True):
         return None
 
-    return Path(target_model_path) / rotation_relative_path
+    try:
+        rotation_relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
+    except (KeyError, TypeError):
+        return None
+
+    return target_model_path / rotation_relative_path
 
 
 def get_rotataion_matrix(rotation_path):
@@ -70,6 +80,39 @@ def get_rotataion_matrix(rotation_path):
         raise e
 
 
+@torch.inference_mode()
+def transform_quarot_linear_weight(
+    weight: torch.Tensor,
+    rotation: torch.Tensor,
+    target_device: torch.device | str | None = None,
+):
+    """Rotate each hidden-size input block of a draft linear weight."""
+    if weight.ndim != 2:
+        raise ValueError(f"Expected a 2-D weight, got shape={tuple(weight.shape)}")
+    if rotation.ndim != 2 or rotation.shape[0] != rotation.shape[1]:
+        raise ValueError(f"Expected a square rotation matrix, got shape={tuple(rotation.shape)}")
+
+    hidden_size = rotation.shape[0]
+    if weight.shape[1] % hidden_size != 0:
+        raise ValueError(
+            "Linear input width must be a multiple of the QuaRot hidden size: "
+            f"weight={tuple(weight.shape)}, rotation={tuple(rotation.shape)}"
+        )
+
+    device = torch.device(target_device) if target_device is not None else weight.device
+    transformed = torch.empty(weight.shape, dtype=weight.dtype, device=device)
+    rotation_device = rotation.to(device=device, dtype=torch.float32)
+    for start in range(0, weight.shape[1], hidden_size):
+        weight_chunk = weight[:, start : start + hidden_size].to(
+            device=device,
+            dtype=torch.float32,
+        )
+        transformed[:, start : start + hidden_size].copy_(
+            torch.matmul(weight_chunk, rotation_device).to(dtype=weight.dtype)
+        )
+    return transformed
+
+
 def compute_rotataion_matrix3(Q):
     """
     Anti-rotate matrix for 3 layers of hidden_states.
@@ -83,9 +126,29 @@ def patch_load_weights(target_vllm_config):
 
     # if rotation path is not found, then quarot is not in use.
     if rotation_path is None:
+        logger.info("Target model does not use QuaRot; draft weight patch is not needed")
         return
 
     Eagle3LlamaForCausalLM.load_weights = make_load_weights(target_model_path, rotation_path)
+    try:
+        from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
+    except ImportError:
+        logger.info("Qwen3 DSpark model is unavailable; only Eagle3 QuaRot loading was patched")
+        return
+
+    current_load_weights = Qwen3DSparkForCausalLM.load_weights
+    if getattr(current_load_weights, "_vllm_ascend_quarot_wrapper", False):
+        logger.info("Qwen3 DSpark QuaRot weight loader is already patched")
+        return
+
+    Qwen3DSparkForCausalLM.load_weights = make_qwen3_dspark_load_weights(
+        rotation_path,
+        current_load_weights,
+    )
+    logger.warning(
+        "Patched Qwen3 DSpark weight loading for target QuaRot rotation: %s",
+        rotation_path,
+    )
 
 
 def make_load_weights(target_model_path, rotation_path):
@@ -142,4 +205,40 @@ def make_load_weights(target_model_path, rotation_path):
         )
         loader.load_weights(model_weights.items())
 
+    return load_weights
+
+
+def make_qwen3_dspark_load_weights(rotation_path, original_load_weights):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        rotation = get_rotataion_matrix(rotation_path)
+        transformed_fc = False
+
+        def transformed_weights():
+            nonlocal transformed_fc
+            for name, loaded_weight in weights:
+                if name == "fc.weight":
+                    loaded_weight = transform_quarot_linear_weight(
+                        loaded_weight,
+                        rotation,
+                        target_device=self.model.fc.weight.device,
+                    )
+                    transformed_fc = True
+                yield name, loaded_weight
+
+        result = original_load_weights(self, transformed_weights())
+        if transformed_fc:
+            logger.warning(
+                "Applied target QuaRot rotation to Qwen3 DSpark fc.weight: "
+                "shape=%s, rotation=%s",
+                tuple(self.model.fc.weight.shape),
+                rotation_path,
+            )
+        else:
+            logger.warning(
+                "Qwen3 DSpark checkpoint did not provide the expected fc.weight; "
+                "target QuaRot rotation was not applied"
+            )
+        return result
+
+    load_weights._vllm_ascend_quarot_wrapper = True
     return load_weights

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -12,6 +12,7 @@ from vllm.model_executor.models.utils import (
     process_eagle_weight,
 )
 
+
 def get_embedding_tensor(directory_path):
     """
     Scans the directory and returns the first tensor found that contains 'embed' in its key.
@@ -228,15 +229,13 @@ def make_qwen3_dspark_load_weights(rotation_path, original_load_weights):
         result = original_load_weights(self, transformed_weights())
         if transformed_fc:
             logger.warning(
-                "Applied target QuaRot rotation to Qwen3 DSpark fc.weight: "
-                "shape=%s, rotation=%s",
+                "Applied target QuaRot rotation to Qwen3 DSpark fc.weight: shape=%s, rotation=%s",
                 tuple(self.model.fc.weight.shape),
                 rotation_path,
             )
         else:
             logger.warning(
-                "Qwen3 DSpark checkpoint did not provide the expected fc.weight; "
-                "target QuaRot rotation was not applied"
+                "Qwen3 DSpark checkpoint did not provide the expected fc.weight; target QuaRot rotation was not applied"
             )
         return result
 

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -239,5 +239,5 @@ def make_qwen3_dspark_load_weights(rotation_path, original_load_weights):
             )
         return result
 
-    load_weights._vllm_ascend_quarot_wrapper = True
+    load_weights._vllm_ascend_quarot_wrapper = True  # type: ignore[attr-defined]
     return load_weights

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -242,17 +242,13 @@ class AscendDflashProposer(AscendEagleProposer):
                     None,
                 )
                 context_kv_precomputed = (
-                    prepare_context_kv(get_forward_context())
-                    if callable(prepare_context_kv)
-                    else False
+                    prepare_context_kv(get_forward_context()) if callable(prepare_context_kv) else False
                 )
                 try:
                     self._runnable(
                         num_input_tokens=num_input_tokens,
                         batch_size=num_reqs,
-                        token_indices_to_sample=self.token_indices_to_sample[
-                            : num_reqs * self.num_speculative_tokens
-                        ],
+                        token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                         target_positions=self._get_positions(num_input_tokens),
                         inputs_embeds=None,
                         multi_steps_attn_metadata=multi_steps_attn_metadata,

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -236,15 +236,31 @@ class AscendDflashProposer(AscendEagleProposer):
 
             else:
                 self._dflash_num_context = num_input_tokens
-                self._runnable(
-                    num_input_tokens=num_input_tokens,
-                    batch_size=num_reqs,
-                    token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
-                    target_positions=self._get_positions(num_input_tokens),
-                    inputs_embeds=None,
-                    multi_steps_attn_metadata=multi_steps_attn_metadata,
-                    num_tokens=num_input_tokens,
+                prepare_context_kv = getattr(
+                    self,
+                    "prepare_dspark_context_kv_for_graph",
+                    None,
                 )
+                context_kv_precomputed = (
+                    prepare_context_kv(get_forward_context())
+                    if callable(prepare_context_kv)
+                    else False
+                )
+                try:
+                    self._runnable(
+                        num_input_tokens=num_input_tokens,
+                        batch_size=num_reqs,
+                        token_indices_to_sample=self.token_indices_to_sample[
+                            : num_reqs * self.num_speculative_tokens
+                        ],
+                        target_positions=self._get_positions(num_input_tokens),
+                        inputs_embeds=None,
+                        multi_steps_attn_metadata=multi_steps_attn_metadata,
+                        num_tokens=num_input_tokens,
+                    )
+                finally:
+                    if context_kv_precomputed:
+                        self._dspark_context_kv_precomputed = False
 
             forward_context = get_forward_context()
             if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -57,9 +57,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 f"num_speculative_tokens={self.num_speculative_tokens}"
             )
         self._dspark_query_tokens_per_req = int(checkpoint_block_size)
-        self._dspark_sample_from_anchor = (
-            self._dspark_query_tokens_per_req == self.num_speculative_tokens
-        )
+        self._dspark_sample_from_anchor = self._dspark_query_tokens_per_req == self.num_speculative_tokens
         self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
         self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
         # DSpark is not supported in vllm v1, so related property needs to be reset here.
@@ -191,9 +189,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 context_slots[:bucket],
             )
         finally:
-            cudagraph_monitor.set_cudagraph_capturing_enabled(
-                capture_was_enabled
-            )
+            cudagraph_monitor.set_cudagraph_capturing_enabled(capture_was_enabled)
             forward_context.batch_descriptor = query_batch_descriptor
 
         self._dspark_context_kv_precomputed = True
@@ -215,21 +211,11 @@ class AscendDSparkProposer(AscendDflashProposer):
         filtered_slots: torch.Tensor | list[torch.Tensor | None]
         if isinstance(context_slots, list):
             filtered_slots = [
-                (
-                    slots[:num_context][valid_context]
-                    .to(torch.int32)
-                    .contiguous()
-                    if slots is not None
-                    else None
-                )
+                (slots[:num_context][valid_context].to(torch.int32).contiguous() if slots is not None else None)
                 for slots in context_slots
             ]
         else:
-            filtered_slots = (
-                primary_slots[:num_context][valid_context]
-                .to(torch.int32)
-                .contiguous()
-            )
+            filtered_slots = primary_slots[:num_context][valid_context].to(torch.int32).contiguous()
 
         self.model.precompute_and_store_context_kv(
             self._dflash_hidden_states[:num_context][valid_context].contiguous(),
@@ -259,9 +245,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 slots[num_context:context_bucket].fill_(-1)
 
         if self.max_query_tokens > num_query_total:
-            self.input_ids[num_query_total : self.max_query_tokens].fill_(
-                self.parallel_drafting_token_id
-            )
+            self.input_ids[num_query_total : self.max_query_tokens].fill_(self.parallel_drafting_token_id)
             self.positions[num_query_total : self.max_query_tokens].zero_()
             for slots in self._per_group_query_slot_mapping_buffers.values():
                 slots[num_query_total : self.max_query_tokens].fill_(-1)
@@ -270,10 +254,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         self,
         forward_context: ForwardContext,
     ) -> bool:
-        if (
-            not self.use_cuda_graph
-            or forward_context.cudagraph_runtime_mode != CUDAGraphMode.FULL
-        ):
+        if not self.use_cuda_graph or forward_context.cudagraph_runtime_mode != CUDAGraphMode.FULL:
             return False
         if self._use_dspark_context_kv_bucket_graph(forward_context):
             if self._precompute_context_kv_bucket_graph(forward_context):
@@ -299,9 +280,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             seq_lens_cpu[actual_num_reqs:padded_num_reqs].fill_(1)
             setattr(common_attn_metadata, attr_name, seq_lens_cpu)
         if hasattr(common_attn_metadata, "actual_seq_lengths_q"):
-            common_attn_metadata.actual_seq_lengths_q = [
-                self._dspark_query_tokens_per_req
-            ] * padded_num_reqs
+            common_attn_metadata.actual_seq_lengths_q = [self._dspark_query_tokens_per_req] * padded_num_reqs
 
     def build_model_inputs_first_pass(
         self,
@@ -389,9 +368,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             attn_group.kv_cache_group_id: torch.zeros(self.max_num_tokens, dtype=torch.int32, device=self.device)
             for attn_group in self.draft_attn_groups
         }
-        self._slot_mapping_buffer = self._per_group_query_slot_mapping_buffers[
-            self.kv_cache_gid
-        ]
+        self._slot_mapping_buffer = self._per_group_query_slot_mapping_buffers[self.kv_cache_gid]
 
     def set_per_group_attn_metadata(
         self,
@@ -498,9 +475,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         else:
             last_position_indices = old_query_start_loc[1:] - 1
             if has_num_rejected:
-                last_position_indices = (
-                    last_position_indices - num_rejected_tokens_gpu
-                )
+                last_position_indices = last_position_indices - num_rejected_tokens_gpu
             last_position_indices = torch.maximum(
                 last_position_indices,
                 old_query_start_loc[:-1],
@@ -511,13 +486,10 @@ class AscendDSparkProposer(AscendDflashProposer):
             ).to(torch.int32)
             new_seq_lens = last_valid_positions + num_query_per_req + 1
 
-        cad.query_start_loc = (
-            self.arange_dflash[: batch_size + 1] * num_query_per_req
-        )
+        cad.query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
         cad.seq_lens = new_seq_lens
         cad.query_start_loc_cpu = (
-            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone()
-            * num_query_per_req
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * num_query_per_req
         ).to(torch.int32)
         if getattr(cad, "_seq_lens_cpu", None) is not None:
             cad._seq_lens_cpu = new_seq_lens.detach().cpu()

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import BatchDescriptor, ForwardContext
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
@@ -12,6 +14,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 
@@ -38,6 +41,24 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "model runner; use greedy (the default) instead."
             )
         blk = 1 + self.num_speculative_tokens
+        checkpoint_block_size = getattr(
+            self.speculative_config.draft_model_config.hf_config,
+            "block_size",
+            None,
+        )
+        if checkpoint_block_size is None:
+            checkpoint_block_size = self.num_speculative_tokens
+        if checkpoint_block_size not in (self.num_speculative_tokens, blk):
+            raise ValueError(
+                "DSpark checkpoint block_size must equal num_speculative_tokens "
+                "or one anchor plus all speculative tokens: "
+                f"checkpoint block_size={checkpoint_block_size}, "
+                f"num_speculative_tokens={self.num_speculative_tokens}"
+            )
+        self._dspark_query_tokens_per_req = int(checkpoint_block_size)
+        self._dspark_sample_from_anchor = (
+            self._dspark_query_tokens_per_req == self.num_speculative_tokens
+        )
         self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
         self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
         # DSpark is not supported in vllm v1, so related property needs to be reset here.
@@ -53,12 +74,10 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=self.dtype,
             device=self.device,
         )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
-        # Max query tokens = max_batch_size * num_speculative_tokens
-        # (anchor-first: N query tokens per request, no bonus token, unlike
-        # DFlash's 1+N). Overrides dflash:28; v2 derives via num_query_per_req.
-        self.max_query_tokens = self.max_batch_size * self.num_speculative_tokens
+        # The v1 graph path is validated only for the GLM/Qwen checkpoint
+        # contract that carries one anchor plus N supervised query positions.
+        self.use_cuda_graph = self.use_cuda_graph and not self._dspark_sample_from_anchor
+        self.max_query_tokens = self.max_batch_size * self._dspark_query_tokens_per_req
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -97,6 +116,194 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         # per-layer context slot mappings as a flat list
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
+        self._dspark_context_kv_graph: ACLGraphWrapper | None = None
+        self._dspark_context_kv_precomputed = False
+
+    def _primary_context_slot_mapping(self) -> torch.Tensor | None:
+        context_slots = self._context_slot_mapping_buffers
+        if isinstance(context_slots, list):
+            return next((slots for slots in context_slots if slots is not None), None)
+        return context_slots
+
+    def _use_dspark_context_kv_bucket_graph(
+        self,
+        forward_context: ForwardContext,
+    ) -> bool:
+        return (
+            self.use_cuda_graph
+            and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+            and os.getenv(
+                "VLLM_ASCEND_ENABLE_GLM_DSPARK_CONTEXT_KV_BUCKET_GRAPH",
+                "0",
+            ).lower()
+            in ("1", "true", "yes", "on")
+        )
+
+    def _get_dspark_context_kv_bucket(self, num_context: int) -> int | None:
+        if num_context <= 0 or num_context > self.max_query_tokens:
+            return None
+        width = self._dspark_query_tokens_per_req
+        return min(
+            self.max_query_tokens,
+            ((num_context + width - 1) // width) * width,
+        )
+
+    def _precompute_padded_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor,
+    ) -> torch.Tensor:
+        self.model.precompute_and_store_context_kv(
+            context_states,
+            context_positions,
+            context_slot_mapping,
+        )
+        return context_states
+
+    def _precompute_context_kv_bucket_graph(
+        self,
+        forward_context: ForwardContext,
+    ) -> bool:
+        bucket = self._get_dspark_context_kv_bucket(self._dflash_num_context)
+        context_slots = self._primary_context_slot_mapping()
+        if bucket is None or context_slots is None:
+            return False
+
+        if self._dspark_context_kv_graph is None:
+            self._dspark_context_kv_graph = ACLGraphWrapper(
+                self._precompute_padded_context_kv,
+                self.vllm_config,
+                runtime_mode=CUDAGraphMode.FULL,
+                use_eagle=self.use_eagle,
+                enable_enpu=self.enable_enpu,
+            )
+
+        query_batch_descriptor = forward_context.batch_descriptor
+        forward_context.batch_descriptor = BatchDescriptor(num_tokens=bucket)
+        try:
+            self._dspark_context_kv_graph(
+                self._dflash_hidden_states[:bucket],
+                self._context_positions_buffer[:bucket],
+                context_slots[:bucket],
+            )
+        finally:
+            forward_context.batch_descriptor = query_batch_descriptor
+
+        self._dspark_context_kv_precomputed = True
+        return True
+
+    def _precompute_live_context_kv(self) -> None:
+        num_context = self._dflash_num_context
+        context_slots = self._context_slot_mapping_buffers
+        primary_slots = self._primary_context_slot_mapping()
+        if primary_slots is None:
+            self.model.precompute_and_store_context_kv(
+                self._dflash_hidden_states[:num_context],
+                self._context_positions_buffer[:num_context],
+                None,
+            )
+            return
+
+        valid_context = primary_slots[:num_context] >= 0
+        filtered_slots: torch.Tensor | list[torch.Tensor | None]
+        if isinstance(context_slots, list):
+            filtered_slots = [
+                (
+                    slots[:num_context][valid_context]
+                    .to(torch.int32)
+                    .contiguous()
+                    if slots is not None
+                    else None
+                )
+                for slots in context_slots
+            ]
+        else:
+            filtered_slots = (
+                primary_slots[:num_context][valid_context]
+                .to(torch.int32)
+                .contiguous()
+            )
+
+        self.model.precompute_and_store_context_kv(
+            self._dflash_hidden_states[:num_context][valid_context].contiguous(),
+            self._context_positions_buffer[:num_context][valid_context].contiguous(),
+            filtered_slots,
+        )
+
+    def _initialize_graph_padding(
+        self,
+        num_context: int,
+        num_query_total: int,
+    ) -> None:
+        context_bucket = (
+            self._get_dspark_context_kv_bucket(num_context)
+            if os.getenv(
+                "VLLM_ASCEND_ENABLE_GLM_DSPARK_CONTEXT_KV_BUCKET_GRAPH",
+                "0",
+            ).lower()
+            in ("1", "true", "yes", "on")
+            else None
+        ) or num_context
+
+        if context_bucket > num_context:
+            self._dflash_hidden_states[num_context:context_bucket].zero_()
+            self._context_positions_buffer[num_context:context_bucket].zero_()
+            for slots in self._per_group_context_slot_mapping_buffers.values():
+                slots[num_context:context_bucket].fill_(-1)
+
+        if self.max_query_tokens > num_query_total:
+            self.input_ids[num_query_total : self.max_query_tokens].fill_(
+                self.parallel_drafting_token_id
+            )
+            self.positions[num_query_total : self.max_query_tokens].zero_()
+            for slots in self._per_group_query_slot_mapping_buffers.values():
+                slots[num_query_total : self.max_query_tokens].fill_(-1)
+
+    def prepare_dspark_context_kv_for_graph(
+        self,
+        forward_context: ForwardContext,
+    ) -> bool:
+        if (
+            not self.use_cuda_graph
+            or forward_context.cudagraph_runtime_mode != CUDAGraphMode.FULL
+        ):
+            return False
+        if self._use_dspark_context_kv_bucket_graph(forward_context):
+            if self._precompute_context_kv_bucket_graph(forward_context):
+                return True
+        self._precompute_live_context_kv()
+        self._dspark_context_kv_precomputed = True
+        return True
+
+    def _stabilize_padded_graph_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        actual_num_reqs: int,
+        padded_num_reqs: int,
+    ) -> None:
+        if padded_num_reqs <= actual_num_reqs:
+            return
+        common_attn_metadata.seq_lens[actual_num_reqs:padded_num_reqs].fill_(1)
+        for attr_name in ("_seq_lens_cpu", "seq_lens_cpu"):
+            seq_lens_cpu = getattr(common_attn_metadata, attr_name, None)
+            if seq_lens_cpu is None:
+                continue
+            seq_lens_cpu = self._adjust_tensor(seq_lens_cpu, padded_num_reqs)
+            seq_lens_cpu[actual_num_reqs:padded_num_reqs].fill_(1)
+            setattr(common_attn_metadata, attr_name, seq_lens_cpu)
+        if hasattr(common_attn_metadata, "actual_seq_lengths_q"):
+            common_attn_metadata.actual_seq_lengths_q = [
+                self._dspark_query_tokens_per_req
+            ] * padded_num_reqs
+
+    def build_model_inputs_first_pass(
+        self,
+        num_input_tokens: int,
+        context_slots: torch.Tensor | list[torch.Tensor | None] | None,
+    ) -> None:
+        if not self._dspark_context_kv_precomputed:
+            self._precompute_live_context_kv()
 
     def initialize_attn_backend(self, kv_cache_config, kernel_block_sizes=None) -> None:
         # Find draft layers (attention layers added by draft model)
@@ -176,6 +383,9 @@ class AscendDSparkProposer(AscendDflashProposer):
             attn_group.kv_cache_group_id: torch.zeros(self.max_num_tokens, dtype=torch.int32, device=self.device)
             for attn_group in self.draft_attn_groups
         }
+        self._slot_mapping_buffer = self._per_group_query_slot_mapping_buffers[
+            self.kv_cache_gid
+        ]
 
     def set_per_group_attn_metadata(
         self,
@@ -205,10 +415,11 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._dspark_seed_buffer[:n].copy_(next_token_ids)
         self._dspark_seed_buffer[n:].fill_(0)
         batch_size = cad.num_reqs
-        block_size = self.num_speculative_tokens
-        num_query_total = batch_size * block_size
+        num_query_per_req = self._dspark_query_tokens_per_req
+        num_query_total = batch_size * num_query_per_req
         has_num_rejected = num_rejected_tokens_gpu is not None
         primary_gid = getattr(self, "kv_cache_gid", 0)
+        old_query_start_loc = cad.query_start_loc
         self._per_group_block_table_buffers = {
             attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
             for attn_group in self.draft_attn_groups
@@ -219,14 +430,13 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         # below (SAMPLE_FROM_ANCHOR=True, anchor included) -- not arange here.
         token_indices_to_sample = torch.empty(
-            num_query_total,
+            batch_size * self.num_speculative_tokens,
             dtype=torch.int32,
             device=self.device,
         )
 
-        # Query block: reuse the DFlash inputs kernel logic (host-side ref)
-        # per kv-cache-group to fill positions / input_ids / query slot_mapping
-        # / token_indices (SAMPLE_FROM_ANCHOR: anchor at q_idx=0 is sampled too).
+        # Fill each KV group's context/query slots while sharing query tokens,
+        # positions, and sample indices across groups.
         draft_attn_groups = getattr(self, "draft_attn_groups", [])
         for attn_group in draft_attn_groups:
             gid = attn_group.kv_cache_group_id
@@ -250,45 +460,77 @@ class AscendDSparkProposer(AscendDflashProposer):
                 block_table_ptr=gid_block_table,
                 block_table_stride=gid_block_table.stride(0),
                 # Metadata
-                query_start_loc_ptr=cad.query_start_loc,
+                query_start_loc_ptr=old_query_start_loc,
                 seq_lens_ptr=cad.seq_lens,
                 num_rejected_tokens_ptr=num_rejected_tokens_gpu,
                 # Scalars
                 parallel_drafting_token_id=self.parallel_drafting_token_id,
                 block_size=kv_block_size,
-                num_query_per_req=block_size,
-                num_speculative_tokens=block_size,
+                num_query_per_req=num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
                 total_input_tokens=self._dflash_num_context,
                 batch_size=batch_size,
                 HAS_NUM_REJECTED=has_num_rejected,
-                SAMPLE_FROM_ANCHOR=True,
+                SAMPLE_FROM_ANCHOR=self._dspark_sample_from_anchor,
+                RECOMPUTE_CONTEXT_SLOTS=not self._dspark_sample_from_anchor,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
             self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx
         ]
+        if self.use_cuda_graph:
+            self._initialize_graph_padding(
+                self._dflash_num_context,
+                num_query_total,
+            )
 
-        effective_seq_lens = cad.seq_lens
-        if has_num_rejected:
-            effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
+        if self._dspark_sample_from_anchor:
+            new_seq_lens = cad.seq_lens
+            if has_num_rejected:
+                new_seq_lens = new_seq_lens - num_rejected_tokens_gpu
+            new_seq_lens = new_seq_lens + num_query_per_req
+        else:
+            last_position_indices = old_query_start_loc[1:] - 1
+            if has_num_rejected:
+                last_position_indices = (
+                    last_position_indices - num_rejected_tokens_gpu
+                )
+            last_position_indices = torch.maximum(
+                last_position_indices,
+                old_query_start_loc[:-1],
+            )
+            last_valid_positions = target_positions.index_select(
+                0,
+                last_position_indices.long(),
+            ).to(torch.int32)
+            new_seq_lens = last_valid_positions + num_query_per_req + 1
 
-        cad.query_start_loc = self.arange_dflash[: batch_size + 1] * block_size
-        cad.seq_lens = effective_seq_lens + block_size
-        cad.query_start_loc_cpu = (torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * block_size).to(
-            torch.int32
+        cad.query_start_loc = (
+            self.arange_dflash[: batch_size + 1] * num_query_per_req
         )
+        cad.seq_lens = new_seq_lens
+        cad.query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone()
+            * num_query_per_req
+        ).to(torch.int32)
+        if getattr(cad, "_seq_lens_cpu", None) is not None:
+            cad._seq_lens_cpu = new_seq_lens.detach().cpu()
+        if getattr(cad, "seq_lens_cpu", None) is not None:
+            cad.seq_lens_cpu = new_seq_lens.detach().cpu()
 
         if hasattr(cad, "actual_seq_lengths_q"):
-            cad.actual_seq_lengths_q = [block_size] * batch_size
+            cad.actual_seq_lengths_q = [num_query_per_req] * batch_size
         if hasattr(cad, "decode_token_per_req"):
-            cad.decode_token_per_req = block_size
+            cad.decode_token_per_req = num_query_per_req
 
         cad.num_actual_tokens = num_query_total
         cad.num_input_tokens = num_query_total
-        cad.max_query_len = block_size
-        cad.max_seq_len = cad.max_seq_len + block_size
+        cad.max_query_len = num_query_per_req
+        cad.max_seq_len = cad.max_seq_len + num_query_per_req
         cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
         cad.positions = self.positions[:num_query_total]
+        if getattr(cad, "positions_cpu", None) is not None:
+            cad.positions_cpu = cad.positions.detach().cpu()
         cad.causal = False
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
@@ -307,10 +549,23 @@ class AscendDSparkProposer(AscendDflashProposer):
         is_profile=False,
         **kwargs,
     ) -> None:
-        # Run dummy_run at full load: the query length of each request is self.num_speculative_tokens
-        # Unlike DFlash, where the query length is self.num_speculative_tokens + 1.
+        if not self._dspark_sample_from_anchor:
+            return AscendDflashProposer.dummy_run(
+                self,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                num_tokens_across_dp=num_tokens_across_dp,
+                aclgraph_runtime_mode=aclgraph_runtime_mode,
+                batch_descriptor=batch_descriptor,
+                dummy_compute_logits=dummy_compute_logits,
+                is_profile=is_profile,
+                **kwargs,
+            )
+
+        # The DSv4 contract samples the anchor query itself and therefore uses
+        # exactly num_speculative_tokens query rows per request.
         # Ensure that the maximum batch token is within the limit of self.max_query_tokens.
-        num_query_per_req = self.num_speculative_tokens
+        num_query_per_req = self._dspark_query_tokens_per_req
         num_query_total = num_reqs * num_query_per_req
         num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
 

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 
 import torch
+from vllm.compilation import monitor as cudagraph_monitor
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.forward_context import BatchDescriptor, ForwardContext
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -181,6 +182,8 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         query_batch_descriptor = forward_context.batch_descriptor
         forward_context.batch_descriptor = BatchDescriptor(num_tokens=bucket)
+        capture_was_enabled = cudagraph_monitor.cudagraph_capturing_enabled
+        cudagraph_monitor.set_cudagraph_capturing_enabled(True)
         try:
             self._dspark_context_kv_graph(
                 self._dflash_hidden_states[:bucket],
@@ -188,6 +191,9 @@ class AscendDSparkProposer(AscendDflashProposer):
                 context_slots[:bucket],
             )
         finally:
+            cudagraph_monitor.set_cudagraph_capturing_enabled(
+                capture_was_enabled
+            )
             forward_context.batch_descriptor = query_batch_descriptor
 
         self._dspark_context_kv_precomputed = True

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
+import os
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
@@ -142,6 +143,20 @@ def _is_glm_model(model_config) -> bool:
     return "glm" in str(model_type).lower()
 
 
+def _is_dspark_draft_model(model_config) -> bool:
+    if model_config is None:
+        return False
+    hf_config = getattr(model_config, "hf_config", None)
+    if hf_config is None:
+        return False
+    architectures = getattr(hf_config, "architectures", []) or []
+    return (
+        "Qwen3DSparkModel" in architectures
+        or "DSparkDraftModel" in architectures
+        or getattr(hf_config, "speculators_model_type", None) == "dspark"
+    )
+
+
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
@@ -208,14 +223,19 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.use_cuda_graph = self.runner._use_aclgraph() and not self.speculative_config.enforce_eager
         self._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
 
-        # GLM series models: speculative decoding does not yet support running
-        # the draft model in graph mode. Force the draft model to always use
-        # eager mode. This is equivalent to the user adding
-        # `"enforce_eager": true` to the `--speculative-config`, and keeps
-        # the target model's graph-mode setting untouched.
-        # TODO(lilinsiman): Remove this code segment after future versions of the GLM
-        # series models support graph input for speculative inference.
-        if _is_glm_model(self.vllm_config.model_config):
+        # Keep the GLM force-eager default. The validated DSpark path can opt
+        # into draft graph capture explicitly without changing other GLM
+        # speculative methods.
+        enable_glm_dspark_draft_graph = (
+            self.method == "dspark"
+            and _is_dspark_draft_model(draft_model_config)
+            and os.getenv("VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH", "0").lower()
+            in ("1", "true", "yes", "on")
+        )
+        if (
+            _is_glm_model(self.vllm_config.model_config)
+            and not enable_glm_dspark_draft_graph
+        ):
             if self.use_cuda_graph:
                 logger.warning(
                     "GLM series models with speculative decoding currently do "
@@ -225,6 +245,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     "speculative decoding will be added in a future release. "
                 )
             self.use_cuda_graph = False
+        elif enable_glm_dspark_draft_graph and self.use_cuda_graph:
+            logger.warning(
+                "VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH is enabled; "
+                "attempting ACL graph capture for the DSpark draft model."
+            )
 
         # TODO: Remove it when the bug of fx-graph is solved
         self.maybe_eager_context: AbstractContextManager[Any] = nullcontext()
@@ -1175,7 +1200,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
                 # The MarkovHead performs bias correction on logits.
                 # The ConfidenceHead predicts the expected acceptance length of tokens(Not yet achieved).
-                raw_logits = self.model.compute_logits(last_hidden_states)
+                raw_logits = self.model.compute_logits(sample_hidden_states)
                 logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
                 num_blk = logits.shape[0]
                 draft_token_ids = self._dspark_draft_buffer[:num_blk]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -229,13 +229,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         enable_glm_dspark_draft_graph = (
             self.method == "dspark"
             and _is_dspark_draft_model(draft_model_config)
-            and os.getenv("VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH", "0").lower()
-            in ("1", "true", "yes", "on")
+            and os.getenv("VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH", "0").lower() in ("1", "true", "yes", "on")
         )
-        if (
-            _is_glm_model(self.vllm_config.model_config)
-            and not enable_glm_dspark_draft_graph
-        ):
+        if _is_glm_model(self.vllm_config.model_config) and not enable_glm_dspark_draft_graph:
             if self.use_cuda_graph:
                 logger.warning(
                     "GLM series models with speculative decoding currently do "
@@ -1077,11 +1073,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "prepare_dspark_context_kv_for_graph",
                 None,
             )
-            context_kv_precomputed = (
-                prepare_context_kv(forward_context)
-                if callable(prepare_context_kv)
-                else False
-            )
+            context_kv_precomputed = prepare_context_kv(forward_context) if callable(prepare_context_kv) else False
 
             try:
                 # DSpark rewrites cross-attention sequence lengths and slots
@@ -1089,8 +1081,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # replay so the draft query observes the current rollback
                 # state instead of the previous iteration's metadata.
                 update_graph_params_before_run = self.enable_enpu or (
-                    self.method == "dspark"
-                    and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+                    self.method == "dspark" and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
                 )
                 if update_graph_params_before_run:
                     self._update_full_graph_params_if_needed(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -866,6 +866,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # is run in eager mode currently, which means `_pad_query_start_loc_for_fia` is not called,
             # while draft model is run in graph model, which means we should pad the `query_start_loc`.
             # Need to be fixed in the future.
+            actual_num_reqs = common_attn_metadata.num_reqs
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
@@ -886,8 +887,19 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
-            if self.method == "dflash":
+            if self.method in ("dflash", "dspark"):
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+                stabilize_padded_metadata = getattr(
+                    self,
+                    "_stabilize_padded_graph_metadata",
+                    None,
+                )
+                if callable(stabilize_padded_metadata):
+                    stabilize_padded_metadata(
+                        common_attn_metadata,
+                        actual_num_reqs,
+                        num_reqs_padded,
+                    )
             else:
                 common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
@@ -1060,13 +1072,43 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             }
             runnable = cast(Callable[..., Any], self._runnable)
             run_draft: Callable[[], Any] = partial(runnable, **model_inputs)
+            prepare_context_kv = getattr(
+                self,
+                "prepare_dspark_context_kv_for_graph",
+                None,
+            )
+            context_kv_precomputed = (
+                prepare_context_kv(forward_context)
+                if callable(prepare_context_kv)
+                else False
+            )
 
-            if self.enable_enpu:
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
-                draft_token_ids = run_draft()
-            else:
-                draft_token_ids = run_draft()
-                self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
+            try:
+                # DSpark rewrites cross-attention sequence lengths and slots
+                # every verifier iteration. Update graph parameters before
+                # replay so the draft query observes the current rollback
+                # state instead of the previous iteration's metadata.
+                update_graph_params_before_run = self.enable_enpu or (
+                    self.method == "dspark"
+                    and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+                )
+                if update_graph_params_before_run:
+                    self._update_full_graph_params_if_needed(
+                        forward_context,
+                        num_input_tokens,
+                        multi_steps_attn_metadata,
+                    )
+                    draft_token_ids = run_draft()
+                else:
+                    draft_token_ids = run_draft()
+                    self._update_full_graph_params_if_needed(
+                        forward_context,
+                        num_input_tokens,
+                        multi_steps_attn_metadata,
+                    )
+            finally:
+                if context_kv_precomputed:
+                    self._dspark_context_kv_precomputed = False
         return draft_token_ids
 
     def compute_draft_token_ids(self, hidden_states: torch.Tensor):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -642,6 +642,9 @@ class NPUModelRunner(GPUModelRunner):
             return layer_ids
         if self.speculative_config.use_dspark():
             hf_config = self.speculative_config.draft_model_config.hf_config
+            layer_ids = getattr(hf_config, "aux_hidden_state_layer_ids", None)
+            if layer_ids:
+                return tuple(int(i) for i in layer_ids)
             # deepseek v4 dspark
             dspark_layer_ids = getattr(hf_config, "dspark_target_layer_ids", None)
             if dspark_layer_ids:


### PR DESCRIPTION
### What

Enable GLM-5.2 DSpark **ACLGraph (full-graph)** path and bucket the context-KV precompute:

- Opt DSpark into ACLGraph capture (main currently force-eager on the whole GLM family, `use_cuda_graph = False`), gated by env so other GLM speculative methods are untouched.
- Fix bugs surfaced by graph replay: rejected-row filter kept outside the graph, padded metadata stabilization, DP-padding fix, context-KV precompute moved out of the query graph.
- Wrap the context-KV precompute in `ACLGraphWrapper` and bucket input length up to `1 + num_speculative_tokens` boundaries to cut capture count on long contexts.

### Data (AISBench · GLM-5.2 W8A8 · DP2/TP8/EP)

**Acceptance parity vs eager (1k / 300 / c16)**:

| | Mode | Acceptance | Accepted length |
|---|---|---:|---:|
| Eager reference (#12262) | eager | 56.45% | 4.952 |
| **This PR** | Graph | **55.31%** | 4.872 |

Graph-mode acceptance lands within ~1 pp of the eager reference — well within run-to-run noise on this W8A8/EP topology.

**Throughput (1k / 1k / c16, same code, eager vs Graph)**:

| Metric | eager | Graph | Δ |
|---|---:|---:|---:|
| Output TPS | 170.0 | **578.6** | **+240.27%** |
| TPOT | 63.5 ms | **20.2 ms** | **−68.19%** |
| Acceptance | 52.78% | 52.03% | −0.75 pp |

Baseline: `vllm-ascend@9c5826eaf1`.

### User-facing

Two opt-in env, both **default off**:
- `VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH` — allow DSpark draft into ACLGraph.
- `VLLM_ASCEND_ENABLE_GLM_DSPARK_CONTEXT_KV_BUCKET_GRAPH` — bucket the context-KV precompute (requires the first).

### Test

New UT: `test_dspark_graph_gate.py` · `test_dspark_graph_inputs.py` · `test_draft_quarot.py` · `test_dspark_aux_layers.py`.

### Scope

- MarkovHead path only. **ConfidenceHead-driven scheduling is not in this PR** (marked `Not yet achieved` in `llm_base_proposer.py`); a follow-up.
- A2 / A3 covered; 310P out of scope.

### Related

Complements **#12262** (eager acceptance fix). Recommended merge order: #12262 → this PR.

Co-authored-by: QwertyJack <QwertyJack@users.noreply.github.com>
Co-authored-by: wangzhao-11a <73340653+wangzhao-11a@users.noreply.github.com>

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
