### PR TITLE
[Doc][BugFix] Fix vllm start instruction v0.23.0

### DIFF
--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -246,9 +246,9 @@ vllm serve Eco-Tech/Qwen3.6-35B-A3B-w8a8 \
   --served-model-name qwen3.6 \
   --dtype float16 \
   --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
   --quantization ascend \
-  --max-model-len 16384 \
+  --max-model-len 20480 \
   --no-enable-prefix-caching
 ```
 
@@ -256,7 +256,6 @@ vllm serve Eco-Tech/Qwen3.6-35B-A3B-w8a8 \
 
 - `--tensor-parallel-size 2` maps the model across two Atlas inference devices. Adjust it together with `ASCEND_RT_VISIBLE_DEVICES` according to the available devices and memory.
 - `--dtype float16` is used for Atlas inference products to match the Atlas inference execution path.
-- `--max-model-len 16384` is intentionally conservative. On Atlas inference products, large context lengths allocate large attention masks, so do not rely on automatic max-model-len detection.
 - `--max-num-seqs 16` limits concurrent active requests to reduce KV cache and graph capture pressure on Atlas inference products.
 - `--gpu-memory-utilization` controls KV cache capacity. Reduce it if startup or runtime requests report OOM.
 - `--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'` disables norm-quant fusion for the Atlas inference products serving path.


### PR DESCRIPTION

### What this PR does / why we need it?
qwen3.6B 310p VLLM start instruction was wrong, this PR fixed it.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local test

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
