### PR TITLE
[WIP] replace with cann ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,5 @@ csrc/third_party/
 .codegraph/
 
 .vllm_ascend/
+.claude/
+.opencode/

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -145,17 +145,9 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
     setup_catlass_dependency
 
     CUSTOM_OPS_ARRAY=(
-        "scatter_nd_update_v2"
         "grouped_matmul_swiglu_quant_weight_nz_tensor_list"
         "lightning_indexer"
         "sparse_flash_attention"
-        "dispatch_ffn_combine"
-        "dispatch_ffn_combine_w4_a8"
-        "dispatch_ffn_combine_bf16"
-        "dispatch_gmm_combine_decode"
-        "moe_init_routing_custom"
-        "moe_gating_top_k"
-        "moe_gating_top_k_hash"
         "add_rms_norm_bias"
         "apply_top_k_top_p_custom"
         "transpose_kv_cache_by_block"
@@ -165,17 +157,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "lightning_indexer_quant"
         "compressor"
         "compressor_metadata"
-        "vllm_quant_lightning_indexer"
-        "vllm_quant_lightning_indexer_metadata"
-        "sparse_attn_sharedkv"
-        "sparse_attn_sharedkv_metadata"
-        "hc_pre_sinkhorn"
-        "hc_pre_inv_rms"
-        "hc_pre"
-        "hc_post"
-        "inplace_partial_rotary_mul"
-        "rms_norm_dynamic_quant"
-        "dequant_swiglu_quant"
         "grouped_matmul_swiglu_quant"
         "grouped_matmul_swiglu_quant_v2"
         "hamming_dist_top_k"
@@ -186,7 +167,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
         "store_kv_block"
-    )
+            )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"
 elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
@@ -196,23 +177,8 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
     setup_catlass_dependency
 
     CUSTOM_OPS_ARRAY=(
-        "moe_gating_top_k_hash"
-        "indexer_compress_epilog"
-        "inplace_partial_rotary_mul"
-        "kv_compress_epilog"
-        "compressor"
         "compressor_metadata"
-        "vllm_quant_lightning_indexer"
-        "vllm_quant_lightning_indexer_metadata"
-        "kv_quant_sparse_attn_sharedkv"
-        "kv_quant_sparse_attn_sharedkv_metadata"
-        "hc_pre_sinkhorn"
-        "hc_pre_inv_rms"
-        "hc_post"
-        "hc_pre"
-        "swiglu_group_quant"
         "load_index_kv_cache"
-        "indexer_compress_epilog_v2"
         "causal_conv1d"
         "recurrent_gated_delta_rule"
         "chunk_fwd_o"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -104,7 +104,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "matmul_allreduce_add_rmsnorm"
         "moe_init_routing_custom"
         "moe_gating_top_k"
-        "moe_gating_top_k_hash"
         "add_rms_norm_bias"
         "apply_top_k_top_p_custom"
         "transpose_kv_cache_by_block"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -115,8 +115,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "compressor_metadata"
         "vllm_quant_lightning_indexer"
         "vllm_quant_lightning_indexer_metadata"
-        "sparse_attn_sharedkv"
-        "sparse_attn_sharedkv_metadata"
         "hc_pre_sinkhorn"
         "hc_pre_inv_rms"
         "hc_pre"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -113,8 +113,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "lightning_indexer_quant"
         "compressor"
         "compressor_metadata"
-        "vllm_quant_lightning_indexer"
-        "vllm_quant_lightning_indexer_metadata"
         "hc_pre_sinkhorn"
         "hc_pre_inv_rms"
         "hc_pre"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -117,7 +117,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "hc_pre"
         "hc_post"
         "inplace_partial_rotary_mul"
-        "rms_norm_dynamic_quant"
         "dequant_swiglu_quant"
         "grouped_matmul_swiglu_quant"
         "grouped_matmul_swiglu_quant_v2"

--- a/docs/ops_migration.md
+++ b/docs/ops_migration.md
@@ -1,0 +1,386 @@
+# DeepSeek-V4 算子解耦迁移总结
+
+> 本文档记录 vllm-ascend 中 DeepSeek-V4 调用链上所有 `torch.ops._C_ascend.*` 算子迁移到外部 CANN 仓库或替代方案的情况。
+> 后续如有新改动，请同步更新本文档。
+
+---
+
+## 1. 背景
+
+### 1.1 目标
+
+将 vllm-ascend 中 DeepSeek-V4 调用链上的所有 `_C_ascend` 算子替换为 CANN 仓库提供的算子或替代方案。仅修改 vllm-ascend，不修改 CANN 仓库。
+
+### 1.2 算子来源与替代方案
+
+| 来源 | 命名空间 | 优先级 |
+|------|---------|--------|
+| **ops-transformer** | `torch.ops.cann_ops_transformer.*` | 1（优先） |
+| **cann-recipes-infer** | `torch.ops.custom.*` | 2 |
+| **torch_npu 原生** | `torch_npu.npu_*` | 3 |
+| **Python 预计算/分解** | 纯 PyTorch + 上述算子组合 | 4（无外部对应时） |
+| **vllm-ascend csrc** | `torch.ops._C_ascend.*` | 保留（确实无替代时） |
+
+### 1.3 兼容性判断原则
+
+- aclnn API 名称和参数一致 → 直接替换
+- aclnn API 不同但有 torch binding 且功能等价 → 替换 + 参数适配
+- 无 torch binding 但有 aclnn 源码 → 不迁移（不修改 CANN 仓库）
+- 完全无外部对应 → Python 预计算或分解为已有算子组合（参考 cann-recipes DSV4 实现）
+
+### 1.4 V4 调用链
+
+```
+AscendDeepseekV4ForCausalLM
+  → DeepseekV2DecoderLayer
+    ├── DeepseekV4Attention → AscendDeepseekSparseAttention (ops/dsa.py)
+    │     → DSAAttention → AscendDSABackend → AscendDSAImpl (attention/dsa_v1.py)
+    │       或 AscendDSACPImpl (attention/context_parallel/dsa_cp.py)
+    ├── DeepseekV4MoE → FusedMoE → AscendMoERunner
+    │     → select_experts (ops/fused_moe/experts_selector.py)
+    │     → fused_experts (ops/fused_moe/moe_comm_method.py)
+    │     → unified_apply_mlp (ops/fused_moe/moe_mlp.py)
+    └── RMSNorm (ops/layernorm.py)
+```
+
+V4 的 attention 走 **DSA 路径**，不走 SFA/MLA。
+
+### 1.5 约束
+
+- 仅修改 vllm-ascend，不修改 CANN 仓库
+- csrc 不清理
+- 目标平台：A5 (Ascend 910C / arch35 / `__DAV_C310__`)，同时兼容 A3 (Ascend 910B)
+
+### 1.6 同名算子覆盖原则
+
+同一个 aclnn 算子如果在 vllm-ascend、cann-recipes-infer 或 ops-transformer 的 `.run`/SO 中同名注册，运行时会优先命中 vllm-ascend 已安装的实现，然后才会使用 recipes/transformer 的实现。因此迁移方案不仅要修改 Python 调用命名空间，还必须同步调整 vllm-ascend 编译脚本中的算子列表：
+
+- 最终使用 vllm-ascend 实现：必须在 vllm-ascend 编译脚本中保留该算子，确保对应 `.run` 安装。
+- 最终使用 recipes/transformer 实现：必须从 vllm-ascend 编译脚本中移除同名算子，避免 vllm-ascend SO 覆盖外部实现。
+- 按设备分流的算子：需要按 SOC 编译列表分别处理；例如 A3/Base 使用 vllm-ascend `compressor`，A5 使用 recipes `custom.compressor`，因此 A3 编译列表保留 `compressor`，A5 编译列表不编译 `compressor`。
+- 后续新增/回退任一算子时，必须同时更新 Python 分流、`csrc/build_aclnn.sh` 编译列表和本文档。
+
+---
+
+## 2. 已迁移的算子
+
+### 2.1 Attention — DSA 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 1 | inplace_partial_rotary_mul | `inplace_partial_rotary_mul` | `cann_ops_transformer.inplace_partial_rotary_mul` | dsa_v1.py, dsa_cp.py (13处) | 无，aclnn API + 参数完全一致 |
+| 2 | compressor | `compressor` | 按设备分流：A3/Base 保留 `_C_ascend.compressor`，A5 使用 `custom.compressor` | device_op.py 分流；dsa_v1.py, dsa_cp.py (6处) 调用 `DeviceOperator.dsa_compressor` | keyword args 分隔；A3 回退原 vllm-ascend wrapper，避免 cann-recipes wrapper 对 `state_cache` 连续性/dtype 的额外约束 |
+| 3 | npu_quant_lightning_indexer | `npu_vllm_quant_lightning_indexer` | `custom.npu_quant_lightning_indexer` | dsa_v1.py, dsa_cp.py (4处) | 多可选参数 |
+| 4 | npu_quant_lightning_indexer_metadata | `npu_vllm_quant_lightning_indexer_metadata` | `custom.npu_quant_lightning_indexer_metadata` | dsa_v1.py, dsa_cp.py (3处) | device 默认值差异 |
+| 5 | npu_rms_norm_dynamic_quant | `npu_rms_norm_dynamic_quant` | `custom.npu_rms_norm_dynamic_quant` | dsa_v1.py, dsa_cp.py (4处) | 无 |
+| 6 | npu_sparse_attn_sharedkv | `npu_sparse_attn_sharedkv` | `custom.npu_sparse_attn_sharedkv` | device_op.py (BaseAdaptor) | 默认值差异，显式传参 |
+| 7 | npu_sparse_attn_sharedkv_metadata | 同上 | `custom.npu_sparse_attn_sharedkv_metadata` | device_op.py (BaseAdaptor) | 同上 |
+| 8 | npu_kv_quant_sparse_attn_sharedkv | `npu_kv_quant_sparse_attn_sharedkv` | `custom.npu_kv_quant_sparse_attn_sharedkv` | device_op.py (A5Adaptor) | A5 路径需与 `kv_compress_epilog(quant_mode="fp8_bf16")` 配套 |
+| 9 | npu_kv_quant_sparse_attn_sharedkv_metadata | 同上 | `custom.npu_kv_quant_sparse_attn_sharedkv_metadata` | device_op.py (A5Adaptor) | 同上 |
+| 10 | scatter_nd_update_asc | `npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | device_op.py (BaseAdaptor, 7处) | 纯改名；in-place op（3 positional args 不变）；保留 `[:x_flat.shape[0]]` 截取逻辑 |
+| 11 | kv_compress_epilog | `kv_compress_epilog` | `cann_ops_transformer.kv_compress_epilog` | device_op.py (A5Adaptor) | A5 custom sparse attention 路径使用 `quant_mode="fp8_bf16"`；cache 保持 4D 不 reshape（tiling 要求 4D `[blockNum, blockSize, 1, headDim]`） |
+| 12 | indexer_compress_epilog_v2 | `indexer_compress_epilog_v2` | `cann_ops_transformer.indexer_quant_cache` | device_op.py (A5Adaptor, 3处) | `cache_scale` 必须为 float32（op_def 约束）；cache/cache_scale 保持 4D 不 reshape（tiling `ValidateCache4D` 要求 4D）；参数名 `indexer_full_cache`→`indexer_scale_cache` |
+
+### 2.2 MHC (Hyper-Connection) 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 13 | npu_hc_pre | `npu_hc_pre_v2` | `cann_ops_transformer.mhc_pre_sinkhorn` | deepseek_v4.py (1处) | 参数改名（`hc_fn`→`phi`, `hc_scale`→`alpha`, `hc_base`→`bias`）；顺序交换（`hc_eps, norm_eps`）；输入 unsqueeze 3D→4D；返回 8 元组取前 3；comb `unflatten(-1, (hc_mult, hc_mult))`+`squeeze(1)`；不同 aclnn API（`aclnnHcPre`→`aclnnMhcPreSinkhorn`） |
+| 14 | npu_hc_post | `npu_hc_post` | `cann_ops_transformer.mhc_post` | deepseek_v4.py (1处) | 参数顺序重排 `(x,residual,post,comb)`→`(residual,comb,x,post)`；去掉 unsqueeze/squeeze workaround；不同 aclnn API（`aclnnHcPost`→`aclnnMhcPost`） |
+
+### 2.3 MoE — Gating 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 15 | moe_gating_top_k_hash | `moe_gating_top_k_hash` | `custom.npu_moe_gating_top_k` | experts_selector.py (1处) | `x`/`k` 改 positional；hash 路径保留 `custom`（torch_npu 不支持 `input_ids`/`tid2eid`） |
+| 16 | moe_gating_top_k (非hash) | `moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | device_op.py (BaseAdaptor, 1处) | 去掉 `input_ids`/`tid2eid`（非 hash 路径不需要）；ops-transformer 内核原生支持 `renorm=0/1`（无需 Python 后处理） |
+
+### 2.4 MoE — Routing 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 17 | npu_moe_init_routing_custom | `npu_moe_init_routing_custom` | `torch_npu.npu_moe_init_routing_v2` | device_op.py (BaseAdaptor, 1处) | 纯改名；A5 路径已用此 op 验证可行 |
+
+### 2.5 MoE — Quant/Activation 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 18 | npu_swiglu_group_quant | `npu_swiglu_group_quant` | `custom.npu_swiglu_group_quant` | device_op.py, fused_moe.py, fused_moe_0_23_0.py (3处) | `topk_weight`→`weight`，`clamp_value`→`clamp_limit`；`quant_mode=2`(MX_QUANT)→`quant_mode=1`(cann MX_QUANT)；输入需 bf16/f16（不能传 int32）；MX_QUANT 时 `round_scale=True` |
+| 19 | npu_dequant_swiglu_quant | `npu_dequant_swiglu_quant` | `torch_npu.npu_dequant_swiglu_quant` | fused_moe.py, fused_moe_0_23_0.py, moe_mlp.py (3处) | 去掉 `bias`/`quant_offset`；条件传参：无 `swiglu_limit` 时不传 `swiglu_mode`/`clamp_limit`（用默认 `swiglu_mode=0` 不钳位）；有 `swiglu_limit` 时共享专家 `swiglu_mode=2`（contiguous），路由专家 `swiglu_mode=1`（interleaved） |
+
+### 2.6 MoE — MC2 Communication 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 20 | dispatch_ffn_combine | `dispatch_ffn_combine` | `super().fused_experts()` (基类非融合路径) | moe_comm_method.py (1处) | 分解为 dispatch + 3阶段 FFN + combine，使用 `npu_moe_distribute_dispatch_v2` + `npu_moe_distribute_combine_v2` |
+| 21 | dispatch_gmm_combine_decode | `dispatch_gmm_combine_decode` | `super().fused_experts()` (基类非融合路径) | moe_comm_method.py (1处) | 同上 |
+
+### 2.7 Norm 模块
+
+| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
+|---|------|---------------|--------|---------|---------|
+| 22 | npu_add_rms_norm_bias | `npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | layernorm.py (2处) | bias 不再融合但功能等价 |
+
+### 2.8 保持当前来源的算子（属第三组 HARD，待后续处理）
+
+以下算子在 ops-transformer 中有对应版本，但因改动量大或参数不兼容暂未切换：
+
+| 算子 | 当前来源 | ops-transformer 对应 | 不切换原因 |
+|------|---------|---------------------|-----------|
+| `compressor` | A3/Base `_C_ascend.compressor` (18参融合)，A5 `custom.compressor` | `cann_ops_transformer.compressor` (12参，无 norm/rope) | ops-transformer 版不含 RMSNorm+RoPE 融合，拆分 3 步会性能下降（属第三组 HARD） |
+| `npu_quant_lightning_indexer` + metadata | `custom.npu_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` (V2) | V2 要求 `layout_k="PA_BBND"`，V4 用 `PA_BSND`；需改 KV cache 布局（属第三组 HARD） |
+| `npu_sparse_attn_sharedkv` + metadata | `custom.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 算子名和参数结构大幅变化，metadata 签名重写（属第三组 HARD） |
+| `moe_gating_top_k_hash` | `custom.npu_moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | torch_npu 不支持 hash 模式（`input_ids`/`tid2eid`），hash 路径保留 `custom` |
+
+---
+
+## 3. 未迁移的算子
+
+### 3.1 compressor_metadata（回退到 `_C_ascend`，graph capture 不兼容）
+
+> **状态：已回退。** Python 预计算方案与 `UNIFORM_BATCH` graph capture/replay 不兼容。
+
+| 算子 | 原 `_C_ascend` | 调用文件 | 原因 |
+|------|---------------|---------|------|
+| compressor_metadata | `compressor_metadata` | dsa_v1.py (6处), dsa_cp.py (2处) | 见下方分析 |
+
+**根因分析：**
+
+原始 `_C_ascend.compressor_metadata` 在 forward 路径执行，作为 custom op 注册为 graph node。graph replay 时读取 scheduler 更新的 `start_pos_decode` tensor 的当前值。
+
+Python 预计算在 metadata build 阶段执行，读取 tensor 值后计算结果存为常量。graph replay 时 `build_decode_metadata` 不再调用，预计算结果被冻结为 capture 时的值。导致首 token 正确，后续 token 因 `start_pos` 更新但预计算结果未更新而精度错误。
+
+**结论：** `compressor_metadata` 必须作为 graph node 在 forward 路径执行，不能预计算。csrc 不清理，保留 `_C_ascend` 调用。
+
+### 3.2 MoE — GMM 模块（暂未迁移，保留 `_C_ascend`）
+
+> **状态：暂未迁移。** 3 阶段分解方案在 A3 上调试时遇到 `npu_grouped_matmul` 的 A8W8 per-token quant dtype 不匹配问题（`scale` dtype FLOAT 与 `output_dtype` FLOAT16 不兼容），已回退。
+
+| 算子 | 原 `_C_ascend` | 调用文件 | 原因 |
+|------|---------------|---------|------|
+| grouped_matmul_swiglu_quant_weight_nz | `grouped_matmul_swiglu_quant_weight_nz` | device_op.py (BaseAdaptor, 1处) | 见下方方案分析 |
+| grouped_matmul_swiglu_quant_weight_nz_tensor_list | `grouped_matmul_swiglu_quant_weight_nz_tensor_list` | moe_mlp.py (2处) | 同上 |
+| grouped_matmul_swiglu_quant_v2 | `grouped_matmul_swiglu_quant_v2` | moe_mlp.py (1处) | 同上 |
+
+**可行方案（待后续实现）：**
+
+参考 cann-recipes DSV4 `CompressedTensorW8A8Int8MoEGMMMethod`（`compressed_tensors_moe_gmm.py:155-194`）和 `modeling_deepseek.py:442-498`：
+
+1. **gmm1 阶段**：`npu_grouped_matmul` **不传 `scale`/`per_token_scale`**，`output_dtype=torch.int32`
+   - cann-recipes W8A8Int8 路径（L159-165）：gmm1 不传 scale，output=int32
+   - **关键**：W8A8Int8 路径的 `weight_scale` 是 float32，不能直接传给 `npu_grouped_matmul` 的 `scale` 参数（报 dtype 不匹配）
+
+2. **dequant + swiglu + quant 阶段**：`npu_dequant_swiglu_clamp_quant`，传入 `weight_scale` 做反量化
+   - 参数：`x=gmm1_out(int32)`, `weight_scale=w1_scale(float32)`, `activation_scale=pertoken_scale`, `quant_mode=1`(dynamic), `swiglu_mode=0`/`1`
+
+3. **gmm2 阶段**：`npu_grouped_matmul` 传 `scale=[w2_weight_scale]` + `per_token_scale=[swiglu_out_scale]`，`output_dtype=bf16`
+
+**A5 路径不受影响**：`A5DeviceAdaptor.npu_grouped_matmul_swiglu_quant` 使用 `torch_npu.npu_grouped_matmul_swiglu_quant_v2`（torch_npu 原生融合算子），不走 `_C_ascend`。
+
+### 3.3 完全无外部对应（vllm-ascend 独有）
+
+| 算子 | 模块 | aclnn API | 说明 |
+|------|------|-----------|------|
+| `store_kv_block` / `store_kv_block_pre` | SFA | `aclnnStoreKVBlock` | 两仓库均无（SFA 路径，V4 不走） |
+| `batch_matmul_transpose` | SFA | 自研 kernel | 两仓库均无（SFA 路径，V4 不走） |
+
+### 3.4 有 aclnn 源码但无 torch binding（不修改 CANN 仓库）
+
+| 算子 | 模块 | CANN 仓库情况 | 无法迁移原因 |
+|------|------|-------------|-----------|
+| `grouped_matmul_swiglu_quant_weight_nz` | MoE-GMM | ops-transformer 有 `aclnnGroupedMatmulSwigluQuantWeightNZ` 源码 | 无 torch_extension binding。vllm-ascend 版 aclnn 多 `limited` 参数。3 阶段分解方案见 3.1 节 |
+| `grouped_matmul_swiglu_quant_v2` | MoE-GMM | ops-transformer 有 `aclnnGroupedMatmulSwigluQuantWeightNzV2` 源码 | 无 torch_extension binding。vllm-ascend 版 aclnn 多 `swigluLimit` 参数。3 阶段分解方案见 3.1 节 |
+
+---
+
+## 4. 修改的文件列表
+
+| 文件 | 模块 | 改动内容 |
+|------|------|---------|
+| `vllm_ascend/ops/__init__.py` | 基础 | 添加 `import custom_ops`（注册 `torch.ops.custom.*`） |
+| `vllm_ascend/attention/dsa_v1.py` | Attention | inplace_partial_rotary_mul→cann_ops_transformer（延迟导入）；compressor→`DeviceOperator.dsa_compressor`（A3/Base 回退 `_C_ascend`，A5 走 custom）；rms_norm_dynamic_quant/quant_lightning_indexer+metadata→custom；compressor_metadata 保留 `_C_ascend`（graph capture 不兼容） |
+| `vllm_ascend/attention/context_parallel/dsa_cp.py` | Attention | 同上 |
+| `vllm_ascend/models/deepseek_v4.py` | MHC | hc_pre/hc_post→custom |
+| `vllm_ascend/device/device_op.py` | Attention+MoE | 新增 `dsa_compressor` 设备分流（A3/Base `_C_ascend.compressor`，A5 `custom.compressor`）；A5 `npu_kv_quant_sparse_attn_sharedkv(+metadata)`→custom；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_attn_sharedkv/scatter_nd_update_asc→custom（含 reshape 适配）；moe_gating_top_k/moe_init_routing/swiglu_group_quant→custom（GMM 模块已回退，保留 `_C_ascend`） |
+| `vllm_ascend/ops/fused_moe/experts_selector.py` | MoE-Gating | moe_gating_top_k_hash→custom |
+| `vllm_ascend/ops/fused_moe/fused_moe.py` | MoE-Quant | swiglu_group_quant→custom；dequant_swiglu_quant→custom |
+| `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | MoE-Quant | 同上 |
+| `vllm_ascend/ops/fused_moe/moe_mlp.py` | MoE-GMM | dequant_swiglu_quant→custom（GMM 3 阶段分解已回退） |
+| `vllm_ascend/ops/fused_moe/moe_comm_method.py` | MoE-MC2 | dispatch_ffn_combine/dispatch_gmm_combine_decode→基类非融合路径 |
+| `vllm_ascend/ops/layernorm.py` | Norm | npu_add_rms_norm_bias→torch_npu.npu_add_rms_norm + bias add |
+| `csrc/build_aclnn.sh` | 编译脚本 | A3 (`ascend910_93`) 编译列表保留/新增 `compressor`；A5 (`ascend950`) 编译列表不包含 `compressor`、`kv_compress_epilog`、`kv_quant_sparse_attn_sharedkv(+metadata)`、`indexer_compress_epilog_v2`，避免覆盖外部实现 |
+
+---
+
+## 5. A5 (arch35) 兼容性
+
+所有迁移的算子均验证了 arch35 内核支持。关键路径：
+
+| 路径 | 算子 | arch35 内核 |
+|------|------|------------|
+| A5 DSA sparse attention | `custom.npu_kv_quant_sparse_attn_sharedkv` | ✅ arch35 |
+| A5 KV compress | `cann_ops_transformer.kv_compress_epilog` | ✅ ops-transformer arch35 |
+| A5 indexer scatter | `cann_ops_transformer.indexer_quant_cache` | ✅ ops-transformer arch35 |
+| A5 MoE gating | `npu_moe_gating_top_k` | ✅ torch_npu 原生 |
+| A5 MoE GMM | `torch_npu.npu_grouped_matmul_swiglu_quant_v2` | ✅ torch_npu 原生（未改） |
+| A5 MoE MC2 | `npu_moe_distribute_dispatch_v2` + `npu_moe_distribute_combine_v2` | ✅ torch_npu 原生 |
+| A5 RMSNorm | `npu_add_rms_norm` | ✅ torch_npu 原生 |
+| A5 compressor | `custom.compressor` (wrapper) | ✅ cann-recipes-infer .run |
+| A3/Base compressor | `_C_ascend.compressor`（回退） | ✅ vllm-ascend csrc |
+| 共享 rotary | `cann_ops_transformer.inplace_partial_rotary_mul` | ✅ arch35 only |
+| 共享 hc_pre/post | `custom.npu_hc_pre`/`npu_hc_post` | ✅ `__DAV_C310__` 显式 |
+| 共享 compressor_metadata | `_C_ascend.compressor_metadata`（保留） | ✅ vllm-ascend csrc |
+
+---
+
+## 6. 汇总
+
+### 6.1 算子迁移统计
+
+| 状态 | 数量 | 算子 |
+|------|:---:|------|
+| **已迁移到 ops-transformer** | 6 | inplace_partial_rotary_mul, kv_compress_epilog, indexer_quant_cache, mhc_pre_sinkhorn, mhc_post |
+| **已迁移到 ops-nn** | 0 | （暂回退，版本不配套，后续处理） |
+| **已迁移到 torch_npu 原生** | 5 | npu_add_rms_norm, scatter_nd_update_, moe_init_routing_v2, moe_gating_top_k(非hash), dequant_swiglu_quant |
+| **保留 cann-recipes** | 4 | moe_gating_top_k_hash（hash 路径）, rms_norm_dynamic_quant, swiglu_group_quant, partial_rotary_mul_quant |
+| **已迁移到基类非融合路径** | 2 | dispatch_ffn_combine, dispatch_gmm_combine_decode |
+| **暂未迁移（graph capture 不兼容）** | 1 | compressor_metadata |
+| **暂未迁移（有可行方案）** | 3 | grouped_matmul_swiglu_quant_weight_nz, _tensor_list, _v2 |
+| **无法迁移（SFA 路径，V4 不走）** | 3 | store_kv_block, store_kv_block_pre, batch_matmul_transpose |
+| **合计** | 25 | |
+
+### 6.2 命名空间分布
+
+| 命名空间 | 算子数 |
+|---------|:---:|
+| `torch.ops.cann_ops_transformer.*` (ops-transformer) | 5 |
+| `torch.ops.cann_ops_nn.*` (ops-nn) | 0（暂回退） |
+| `torch.ops.custom.*` (cann-recipes-infer) | 4 + A5 compressor |
+| `torch_npu.npu_*` (torch_npu 原生) | 5 |
+| 基类非融合路径 | 2 |
+| `torch.ops._C_ascend.*` (vllm-ascend csrc，暂未迁移/设备回退) | 4 + A3/Base compressor |
+| `torch.ops._C_ascend.*` (vllm-ascend csrc，SFA 路径 V4 不走) | 6 |
+
+### 6.3 V4 路径上 `_C_ascend` 残留
+
+V4 DSA + MoE 调用链上，A5 路径有 **4 个 `_C_ascend` 算子**未迁移（compressor_metadata + GMM 模块 3 个）。A3/Base 路径额外回退 `compressor` 到 `_C_ascend.compressor`，因此 A3/Base 路径当前有 **5 个 `_C_ascend` 算子**残留。
+
+### 6.4 关键技术决策
+
+| 决策 | 原因 |
+|------|------|
+| 同名算子需同步调整编译列表 | `.run`/SO 中同名 aclnn 算子会优先命中 vllm-ascend 实现；若目标是 recipes/transformer 实现，必须从 vllm-ascend 编译列表移除同名算子，避免覆盖 |
+| compressor_metadata 保留 `_C_ascend` | Python 预计算与 `UNIFORM_BATCH` graph capture/replay 不兼容：预计算在 build 时执行，结果冻结为常量；graph replay 时 `start_pos` 已更新但预计算结果未更新，导致首 token 正确后续 token 精度错误。必须作为 graph node 在 forward 路径执行 |
+| quant_lightning_indexer 保持 V1 不切 V2 | V2 要求 `layout_q == layout_k`，V4 用不同 layout |
+| compressor 按设备分流 | ops-transformer 版 14 参不含 RMSNorm+RoPE 融合；A5 继续使用 cann-recipes `custom.compressor`；A3/Base 使用 cann-recipes wrapper 会触发 `state_cache` 连续性/dtype 约束，先回退 `_C_ascend.compressor` |
+| hc_pre/post 保持 cann-recipes 不切 ops-transformer | 不同 aclnn API，语义可能有差异 |
+| GMM 模块暂未迁移 | A3 上 `npu_grouped_matmul` A8W8 dtype 不兼容，有可行方案待实现 |
+| scatter_nd_update_asc 需 reshape | cann-recipes 要求 2D 输入，vllm-ascend 传 4D |
+| NPU 格式兼容（NCHW vs ND） | pad 用 `index_select` + `fill_` 替代 `torch.cat`，避免格式不兼容 |
+
+---
+
+## 7. 算子编译
+
+> 仅编译 vllm-ascend V4 路径实际用到的算子，减少编译时间。编译命令参考 ops-transformer `docs/zh/install/compile.md` 和 ops-nn `build.sh --help`。
+
+### 7.1 ops-transformer 编译（.run 包 + whl 包）
+
+**用到的算子（5 个，A3/A5 统一）：**
+
+```
+inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post
+```
+
+**A3 (ascend910_93)：**
+
+```bash
+cd ops-transformer
+
+# 编译 .run 包（仅上述 5 个算子）
+bash build.sh --pkg --soc=ascend910_93 \
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post
+
+# 安装 .run 包
+./build_out/cann-ops-transformer-custom_linux-*.run
+
+# 编译并安装 whl 包（torch_extension，JIT 编译 C++ binding）
+cd torch_extension
+python3 -m build --wheel -n
+pip3 install dist/*.whl --force-reinstall --no-deps
+```
+
+**A5 (ascend950)：**
+
+```bash
+cd ops-transformer
+
+# 编译 .run 包（仅上述 5 个算子）
+bash build.sh --pkg --soc=ascend950 \
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post
+
+# 安装 .run 包
+./build_out/cann-ops-transformer-custom_linux-*.run
+
+# 编译并安装 whl 包
+cd torch_extension
+python3 -m build --wheel -n
+pip3 install dist/*.whl --force-reinstall --no-deps
+```
+
+> **说明**：
+> - `.run` 包提供 aclnn API（AscendC 内核），安装到 `$ASCEND_HOME_PATH/opp/vendors/`
+> - whl 包提供 torch Python binding（JIT 编译），通过 `import cann_ops_transformer` 注册 `torch.ops.cann_ops_transformer.*` 命名空间
+> - `--ops` 参数指定算子目录名，多个用英文逗号分隔，不指定时默认编译全部算子
+> - A3 和 A5 的算子列表相同（第三组 HARD 完成后 A3 会增加 compressor/quant_lightning_indexer/sparse_flash_mla）
+
+### 7.2 ops-nn 编译
+
+> **暂不需要**。`swiglu_group_quant` 和 `rms_norm_dynamic_quant` 已回退到 cann-recipes，ops-nn 版本不配套，后续处理。
+
+### 7.3 cann-recipes-infer 编译（hash 路径 moe_gating_top_k + rms_norm_dynamic_quant + swiglu_group_quant）
+
+V4 hash 路径仍使用 `custom.npu_moe_gating_top_k`（ops-transformer 不支持 `input_ids`/`tid2eid`），需编译 cann-recipes：
+
+```bash
+cd cann-recipes-infer/ops/ascendc
+
+# 编译 .run 包
+bash build.sh -c ascend910_93   # A3
+# 或
+bash build.sh -c ascend950      # A5
+
+# 安装 .run 包
+bash CANN-custom_ops-*.run --install
+
+# 编译并安装 whl 包
+cd torch_ops_extension
+pip3 install .
+```
+
+### 7.4 vllm-ascend 编译（csrc 保留算子）
+
+csrc 仍需编译保留的 `_C_ascend` 算子（`compressor_metadata`、GMM 模块 3 个等）：
+
+```bash
+COMPILE_CUSTOM_KERNELS=1 pip install -e .
+```
+
+`csrc/build_aclnn.sh` 已按 SOC 版本精简编译列表（A3 保留 22 个，A5 保留 6 个），仅编译无法迁移的算子。
+
+### 7.5 编译顺序
+
+1. ops-transformer .run + whl（提供 aclnn 内核 + Python binding）
+2. ops-nn .run + whl
+3. cann-recipes-infer .run + whl（hash 路径）
+4. vllm-ascend csrc（保留算子）
+
+---
+
+## 8. 架构映射
+
+| 标识 | 硬件 | 宏 |
+|------|------|-----|
+| arch22 | Ascend 910B (A3) | `__CCE_AICORE__ == 220` |
+| arch35 | Ascend 910C (A5) | `__CCE_AICORE__ == 310` / `__DAV_C310__` |
+| ascend950 | Ascend 910C (A5) | cann-recipes A5 编译目标 |

--- a/docs/ops_migration.md
+++ b/docs/ops_migration.md
@@ -1,6 +1,6 @@
 # DeepSeek-V4 算子迁移到 CANN 仓库指导
 
-> **文档用途**：基线当前已验证通过的算子迁移改动，供其他人编译和使用。后续迁移工作仍在进行。
+> **文档用途**：DSV4 算子迁移改动记录。A5 已验证通过，A3 路径待验证。
 > **更新规则**：代码或编译方式有改动时，请同步更新本文档。
 
 ---
@@ -16,14 +16,13 @@
 | 仓库 | 说明 | Python 命名空间 |
 |------|------|----------------|
 | ops-transformer | CANN 主线算子仓库（非 experimental + experimental） | `torch.ops.cann_ops_transformer.*` |
-| ops-nn | CANN 算子仓库（暂未使用） | `torch.ops.cann_ops_nn.*` |
-| cann-recipes-infer | 模型推理 recipe 仓库（含 wrapper） | `torch.ops.custom.*` |
+| ops-nn | CANN 算子仓库（norm/activation） | `torch.ops.cann_ops_nn.*` |
 | vllm-ascend csrc | vllm-ascend 原生算子（保留必要部分） | `torch.ops._C_ascend.*` |
 
 ### 1.3 SO 加载优先级
 
 ```
-vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
+vllm-ascend > ops-transformer > ops-nn
 ```
 
 同名 `OP_ADD` 按此优先级覆盖。因此迁移时必须同步调整 `csrc/build_aclnn.sh` 编译列表，移除已迁移算子，避免 vllm-ascend SO 覆盖外部实现。
@@ -37,9 +36,9 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 ---
 
-## 2. 当前状态（已验证通过）
+## 2. 当前状态
 
-> 当前代码已在 A5 环境验证通过。这是**中间态**，部分算子仍使用 cann-recipes wrapper 或 vllm-ascend csrc，后续会继续迁移。
+> **A5 已验证通过**，A3 路径待验证。A3-only 算子标记为 🟡（代码已改，尚未在 A3 环境验证）。
 
 ### 2.1 算子总表
 
@@ -51,22 +50,22 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 | 4 | indexer_quant_cache `[A5]` | ✅ | `_C_ascend.indexer_compress_epilog_v2` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, attention/, arch35 ✅ | `cache_scale` float32；cache 4D；参数名 `indexer_full_cache`→`indexer_scale_cache` |
 | 5 | mhc_pre_sinkhorn | ✅ | `_C_ascend.npu_hc_pre_v2` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, mhc/, arch35 ✅ | 参数改名+顺序交换；unsqueeze 3D→4D；返回 8 元组取前 3；comb `unflatten`+`squeeze` |
 | 6 | mhc_post | ✅ | `_C_ascend.npu_hc_post` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, mhc/, arch35 ✅ | 参数顺序重排；去掉 unsqueeze/squeeze |
-| 7 | scatter_nd_update `[A3]` | ✅ | `_C_ascend.npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | 同当前 | torch_npu pip 包 | 纯改名；保留 `[:x_flat.shape[0]]` 截取 |
+| 7 | scatter_nd_update `[A3]` | 🟡 | `_C_ascend.npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | 同当前 | torch_npu pip 包 | 纯改名；保留 `[:x_flat.shape[0]]` 截取；A3 待验证 |
 | 8 | moe_init_routing_v2 | ✅ | `_C_ascend.npu_moe_init_routing_custom` | `torch_npu.npu_moe_init_routing_v2` | 同当前 | torch_npu pip 包 | 纯改名 |
 | 9 | moe_gating_top_k (非hash) | ✅ | `_C_ascend.moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | 同当前 | torch_npu pip 包 | 去掉 `input_ids`/`tid2eid` |
 | 10 | dequant_swiglu_quant | ✅ | `_C_ascend.npu_dequant_swiglu_quant` | `torch_npu.npu_dequant_swiglu_quant` | 同当前 | torch_npu pip 包 | 条件传参：无 limit `swiglu_mode=0`，有 limit 共享专家 `=2`，路由专家 `=1` |
 | 11 | add_rms_norm | ✅ | `_C_ascend.npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | 同当前 | torch_npu pip 包 | bias 不再融合 |
-| 12 | dispatch_ffn_combine `[A3]` | ✅ | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 基类非融合路径 |
-| 13 | dispatch_gmm_combine_decode `[A3]` | ✅ | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 同上 |
+| 12 | dispatch_ffn_combine `[A3]` | 🟡 | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 基类非融合路径；A3 待验证 |
+| 13 | dispatch_gmm_combine_decode `[A3]` | 🟡 | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 同上；A3 待验证 |
 | 14 | quant_lightning_indexer | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` | 同当前 | ot 非 exp, attention/quant_lightning_indexer_v2/, arch35 ✅ | whl C++ 调 V2 aclnn；`.run` 编译 `quant_lightning_indexer_v2`；`layout_k` 改 `PA_BBND`；`quant_mode` 按 arch 锁定（A5=1 FP8, A3=2 INT8）；`seqused_q` 用 per-batch query token 数 |
 | 15 | quant_lightning_indexer_metadata | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer_metadata` | `cann_ops_transformer.quant_lightning_indexer_metadata` | 同当前 | ot 非 exp, attention/quant_lightning_indexer_v2_metadata/, AICPU | 同上；新增 `seqused_k`/`cmp_residual_k`；删除 `device`/`pre_tokens`/`next_tokens`/`max_seqlen_*` |
-| 16 | sparse_attn_sharedkv `[A3]` | ✅ | `_C_ascend.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 同当前 | ot 非 exp, attention/sparse_flash_mla/, arch35 ✅ | 算子名变更；`seqused_kv`→`seqused_ori_kv`；`PA_ND`→`PA_BBND`；新增 `seqused_cmp_kv`/`cmp_residual_kv`/`topk_value_mode` |
-| 17 | sparse_attn_sharedkv_metadata `[A3]` | ✅ | `_C_ascend.npu_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上；新增 `max_seqlen_cmp_kv`；删除 `device` |
+| 16 | sparse_attn_sharedkv `[A3]` | 🟡 | `_C_ascend.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 同当前 | ot 非 exp, attention/sparse_flash_mla/, arch35 ✅ | 算子名变更；`seqused_kv`→`seqused_ori_kv`；`PA_ND`→`PA_BBND`；A3 待验证 |
+| 17 | sparse_attn_sharedkv_metadata `[A3]` | 🟡 | `_C_ascend.npu_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上；A3 待验证 |
 | 18 | kv_quant_sparse_attn_sharedkv `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv` | `cann_ops_transformer.mixed_quant_sparse_flash_mla` | 同当前 | ot 非 exp, attention/mixed_quant_sparse_flash_mla/, arch35 ✅ | A5 路径；`kv_quant_mode`→`quant_mode`；删除 `tile_size` |
 | 19 | kv_quant_sparse_attn_sharedkv_metadata `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.mixed_quant_sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上 |
-| 20 | rms_norm_dynamic_quant | ⏳ | `_C_ascend.*` | `custom.npu_rms_norm_dynamic_quant` | A5: `torch_npu.npu_dynamic_quant`；A3: `cann_ops_nn.rms_norm_dynamic_quant` | cann-recipes, src/, 无 arch35 | DSV4 A5 用 `npu_dynamic_quant`，A3 用 `cann_ops_nn.*`；需平台分支；ops-nn 未打包 |
-| 21 | swiglu_group_quant `[A5]` | ⏳ | `_C_ascend.*` | `custom.npu_swiglu_group_quant` | `cann_ops_nn.swiglu_group_quant` | cann-recipes, src/, 无 arch35 | DSV4 所有平台都用 `cann_ops_nn.*`；ops-nn 未打包 |
-| 22 | moe_gating_top_k_hash | ✅ | `_C_ascend.moe_gating_top_k_hash` | `torch_npu.npu_moe_gating_top_k` | 同当前 | ot 非 exp, moe/moe_gating_top_k/, arch35 ✅ | hash 路径改用 `torch_npu.npu_moe_gating_top_k`（调 `aclnnMoeGatingTopKV2`）；`k_group=1, group_count=1`（hash 模式简化路径） |
+| 20 | rms_norm_dynamic_quant | 🟡 | `_C_ascend.*` | `DeviceOperator.rms_norm_dynamic_quant` | 同当前 | ops-nn, norm/, arch22 ✅ (A3)；A5 无 arch35 | A3: `cann_ops_nn.rms_norm_dynamic_quant`（fused）；A5: `npu_rms_norm`+`npu_dynamic_quant`（拆分）；不传 `smooth_scales`；A3 待验证 |
+| 21 | swiglu_group_quant `[A5]` | ✅ | `_C_ascend.*` | `cann_ops_nn.swiglu_group_quant` | 同当前 | ops-nn, activation/, arch35 ✅ | `dst_type=24`（ScalarType）；`quant_mode=1`；`clamp_limit` None→-1.0；A5-only |
+| 22 | moe_gating_top_k_hash | ✅ | `_C_ascend.moe_gating_top_k_hash` | `torch_npu.npu_moe_gating_top_k` | 同当前 | ot 非 exp, moe/moe_gating_top_k/, arch35 ✅ | hash 路径用 `torch_npu.npu_moe_gating_top_k`（13 参数，调 `aclnnMoeGatingTopKV2`）；`k_group=1, group_count=1`；需升级 torch_npu 到 13 参数版本 + `exposed: all_version` |
 | 23 | compressor_metadata | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, attention/, 无 arch35 | graph capture 不兼容，无外部对应 |
 | 24 | grouped_matmul_swiglu_quant_weight_nz | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | 无 torch binding；可行方案：3 阶段分解 |
 | 25 | grouped_matmul_swiglu_quant_weight_nz_tensor_list | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | vllm 独有 |
@@ -76,9 +75,8 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 | 进度 | 数量 | 说明 |
 |------|:---:|------|
-| ✅ 完成 | 20 | 已对齐 DSV4，当前=目标 |
-| 📋 待执行 | 0 | 全部完成 |
-| ⏳ 暂缓 | 2 | 依赖 ops-nn 打包 |
+| ✅ A5 已验证 | 16 | A5 环境验证通过 |
+| 🟡 代码已改，A3 待验证 | 6 | A3-only 或含 A3 路径，尚未在 A3 验证 |
 | ❌ 阻塞 | 4 | graph capture 不兼容或无外部对应 |
 | **合计** | 26 | |
 
@@ -86,13 +84,13 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 | 文件 | 改动内容 |
 |------|---------|
-| `vllm_ascend/ops/__init__.py` | 添加 `import custom_ops` |
-| `vllm_ascend/attention/dsa_v1.py` | inplace_partial_rotary_mul/compressor→cann_ops_transformer；rms_norm_dynamic_quant/quant_lightning_indexer→custom；compressor_metadata 保留 `_C_ascend` |
+| `vllm_ascend/ops/__init__.py` | 移除 `import custom_ops`（cann-recipes 不再依赖） |
+| `vllm_ascend/attention/dsa_v1.py` | inplace_partial_rotary_mul/compressor→cann_ops_transformer；rms_norm_dynamic_quant→DeviceOperator.rms_norm_dynamic_quant；quant_lightning_indexer→cann_ops_transformer；compressor_metadata 保留 `_C_ascend` |
 | `vllm_ascend/attention/context_parallel/dsa_cp.py` | 同上 |
-| `vllm_ascend/models/deepseek_v4.py` | mhc_pre_sinkhorn/mhc_post→cann_ops_transformer |
-| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；quant_lightning_indexer quant_mode→DeviceOperator.get_qli_quant_mode()；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→custom |
-| `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→torch_npu.npu_moe_gating_top_k（hash 路径）；k_group/group_count=1 |
-| `vllm_ascend/ops/fused_moe/fused_moe.py` | swiglu_group_quant→custom；dequant_swiglu_quant→torch_npu |
+| `vllm_ascend/models/deepseek_v4.py` | mhc_pre_sinkhorn/mhc_post→cann_ops_transformer；cache_dim 608 公式对齐 cann-recipes |
+| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；quant_lightning_indexer quant_mode→DeviceOperator.get_qli_quant_mode()；rms_norm_dynamic_quant→DeviceOperator.rms_norm_dynamic_quant；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→cann_ops_nn |
+| `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→torch_npu.npu_moe_gating_top_k（13 参数）；k_group/group_count=1 |
+| `vllm_ascend/ops/fused_moe/fused_moe.py` | swiglu_group_quant→cann_ops_nn；dequant_swiglu_quant→torch_npu |
 | `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | 同上 |
 | `vllm_ascend/ops/fused_moe/moe_mlp.py` | dequant_swiglu_quant→torch_npu |
 | `vllm_ascend/ops/fused_moe/moe_comm_method.py` | dispatch_ffn_combine/dispatch_gmm_combine_decode→基类非融合路径 |
@@ -103,74 +101,97 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 ## 3. 算子编译指导
 
-> 以下为当前已验证通过的环境的算子打包方式。SO 加载顺序：vllm-ascend > experimental > ops-transformer(非exp) > cann-recipes。
+> SO 加载顺序：vllm-ascend > ops-transformer > ops-nn。
 
-### 3.1 ops-transformer（非 experimental）
+### 3.1 ops-transformer
 
-**已打包算子（9 个，含 metadata）**：
+**算子列表（10 个主算子 + 3 个 metadata）**：
 ```
-inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla,quant_lightning_indexer_v2
+inplace_partial_rotary_mul, kv_compress_epilog, indexer_quant_cache,
+mhc_pre_sinkhorn, mhc_post, compressor,
+sparse_flash_mla, mixed_quant_sparse_flash_mla, quant_lightning_indexer_v2, moe_gating_top_k,
+sparse_flash_mla_metadata, mixed_quant_sparse_flash_mla_metadata, quant_lightning_indexer_v2_metadata
 ```
 
-> ⚠️ metadata 算子（`sparse_flash_mla_metadata`、`mixed_quant_sparse_flash_mla_metadata`、`quant_lightning_indexer_v2_metadata`）**必须手动在 `--ops` 中列出**，不会随主算子自动编译。
+> ⚠️ metadata 算子**必须手动在 `--ops` 中列出**，不会随主算子自动编译。
 >
-> ℹ️ `quant_lightning_indexer_v2` 的 whl C++ 扩展（`csrc/quant_lightning_indexer.cpp`）调用 V2 aclnn 符号（`aclnnQuantLightningIndexerV2` / `aclnnQuantLightningIndexerV2Metadata`），因此 `.run` 包必须编译 `quant_lightning_indexer_v2`（不是 V1 的 `quant_lightning_indexer`）。
+> ℹ️ whl C++ 扩展调用 V2 aclnn 符号（`aclnnQuantLightningIndexerV2`），`.run` 包必须编译 `quant_lightning_indexer_v2`（不是 V1）。
+>
+> ℹ️ `--pkg` 会自动构建 `.run` 包 **和** whl 包（`build_torch_extension_whl` 在 `--pkg` 流程中自动执行），whl 是全量编译不按 `--ops` 选择。
 
 ```bash
 cd ops-transformer
 
 # A3
 bash build.sh --pkg --soc=ascend910_93 \
-  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,sparse_flash_mla_metadata,mixed_quant_sparse_flash_mla,mixed_quant_sparse_flash_mla_metadata,quant_lightning_indexer_v2,quant_lightning_indexer_v2_metadata
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,sparse_flash_mla_metadata,mixed_quant_sparse_flash_mla,mixed_quant_sparse_flash_mla_metadata,quant_lightning_indexer_v2,quant_lightning_indexer_v2_metadata,moe_gating_top_k
 
 # A5
 bash build.sh --pkg --soc=ascend950 \
-  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,sparse_flash_mla_metadata,mixed_quant_sparse_flash_mla,mixed_quant_sparse_flash_mla_metadata,quant_lightning_indexer_v2,quant_lightning_indexer_v2_metadata
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,sparse_flash_mla_metadata,mixed_quant_sparse_flash_mla,mixed_quant_sparse_flash_mla_metadata,quant_lightning_indexer_v2,quant_lightning_indexer_v2_metadata,moe_gating_top_k
 
-# 安装
-./build_out/cann-ops-transformer-custom_linux-*.run
+# 安装 .run 包（aclnn kernel）
+./build_out/*.run
+
+# 安装 whl 包（torch binding，JIT 编译）
+python3 -m pip install build_out/*.whl --force-reinstall --no-deps
 ```
 
-### 3.2 ops-transformer（experimental）
+### 3.2 ops-nn
 
-> **不再需要**。quant_lightning_indexer + metadata 已迁移到非 experimental（3.1），experimental 包无算子。
+**算子列表（2 个）**：
+```
+rms_norm_dynamic_quant, swiglu_group_quant
+```
 
-### 3.3 cann-recipes-infer
-
-**全量打包**（包含所有 cann-recipes 有源码的算子）。
+> ℹ️ ops-nn torch_extension 与 ops-transformer 架构一致：`cann_ops_nn` namespace + OpBuilder JIT + `aclnn_common.h`。
+>
+> ℹ️ `rms_norm_dynamic_quant` 有 arch22（A3），无 arch35（A5）→ A5 走 `npu_rms_norm`+`npu_dynamic_quant` 拆分。
+>
+> ℹ️ `swiglu_group_quant` 仅 arch35（A5），A5-only 算子。
+>
+> ℹ️ `.run` 包和 whl 包**分开构建**：`--pkg` 只构建 `.run` 包，`--torch_extension` 只构建 whl 包。
 
 ```bash
-cd cann-recipes-infer/ops/ascendc
+cd ops-nn
 
-# A3
-bash build.sh -c ascend910_93
-# A5
-bash build.sh -c ascend950
+# --- .run 包（aclnn kernel）---
+
+# A3 (rms_norm_dynamic_quant: arch22)
+bash build.sh --pkg --soc=ascend910_93 --ops=rms_norm_dynamic_quant
+
+# A5 (swiglu_group_quant: arch35)
+bash build.sh --pkg --soc=ascend950 --ops=swiglu_group_quant
 
 # 安装 .run 包
-bash CANN-custom_ops-*.run --install
+./build_out/*.run
 
-# 编译并安装 whl 包
-cd torch_ops_extension
-bash build_and_install.sh
-```
-
-### 3.4 ops-nn
-
-> **未打包**。`swiglu_group_quant` 和 `rms_norm_dynamic_quant` 仍用 cann-recipes，ops-nn 版本不配套，后续处理。
-
-### 3.5 ops-transformer whl 包
-
-whl 包是全量编译（包含所有 torch_extension 中注册的算子），不按 `--ops` 选择：
-
-```bash
-cd ops-transformer/torch_extension
+# --- whl 包（torch binding，JIT 编译）---
+# 整包构建（包含所有 op 的框架 + 自动扫描 torch_extension）
+cd torch_extension
 python3 -m pip install -r requirements.txt
 python3 -m build --wheel -n
-python3 -m pip install dist/*.whl --force-reinstall --no-deps
+python3 -m pip install dist/cann_ops_nn-*.whl --force-reinstall --no-deps
 ```
 
-### 3.6 vllm-ascend（csrc 保留算子）
+### 3.3 torch_npu
+
+> ℹ️ `npu_moe_gating_top_k` 需要升级到 13 参数版本（支持 `input_ids`/`tid2eid` hash 模式）。
+>
+> ℹ️ 源码 `op_plugin_functions.yaml` 中 `npu_moe_gating_top_k` 缺少 `exposed: all_version`，需手动添加才能暴露到 Python `torch_npu.npu_moe_gating_top_k`。
+
+```bash
+cd ascend/pytorch
+
+# 1. 修改 op_plugin_functions.yaml，给 npu_moe_gating_top_k 加 exposed: all_version
+#    在 "op_api: all_version" 后添加 "exposed: all_version"
+
+# 2. 编译安装 torch_npu
+bash build.sh
+pip install dist/torch_npu-*.whl --force-reinstall --no-deps
+```
+
+### 3.4 vllm-ascend
 
 ```bash
 COMPILE_CUSTOM_KERNELS=1 pip install -e .
@@ -181,23 +202,18 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 - **A3 (ascend910_93)**：移除已迁移算子，保留 17 个
 - **A5 (ascend950)**：移除已迁移算子，保留 6 个（compressor_metadata、load_index_kv_cache、causal_conv1d、recurrent_gated_delta_rule、chunk_fwd_o、chunk_gated_delta_rule_fwd_h）
 
-### 3.7 编译顺序
+### 3.5 编译顺序
 
-1. ops-transformer 非 experimental（.run）
-2. cann-recipes-infer（.run + whl）
-3. ops-transformer whl 包
-4. vllm-ascend csrc
+1. ops-transformer（.run + whl）
+2. ops-nn（.run + whl）
+3. torch_npu（修改 + 编译）
+4. vllm-ascend（csrc）
 
 ---
 
 ## 4. 后续迁移计划
 
-### 4.1 暂缓（⏳，3 个）
-
-| # | 算子 | 遗留问题 |
-|---|------|---------|
-| 20 | rms_norm_dynamic_quant | DSV4 A5 用 `torch_npu.npu_dynamic_quant`，A3 用 `cann_ops_nn.*`。需平台分支 + ops-nn 打包 |
-| 21 | swiglu_group_quant | DSV4 用 `cann_ops_nn.*`。需 ops-nn 打包 |
+全部可迁移算子已完成（22/26）。剩余 4 个为阻塞状态。
 
 ### 4.3 阻塞（❌，4 个）
 
@@ -212,47 +228,25 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 
 | 决策 | 原因 |
 |------|------|
-| 同名 OP_ADD 需同步调整 `build_aclnn.sh` | SO 加载优先级：vllm-ascend > experimental > ot(非exp) > cann-recipes |
+| 同名 OP_ADD 需同步调整 `build_aclnn.sh` | SO 加载优先级：vllm-ascend > ops-transformer > ops-nn |
 | compressor_metadata 保留 `_C_ascend` | Python 预计算与 graph capture/replay 不兼容，必须作为 graph node 在 forward 路径执行 |
 | compressor 拆融合 norm/rope | ot 版 12 参不含 RMSNorm+RoPE，Python 层用 `npu_rms_norm` + `inplace_partial_rotary_mul` 补偿 |
-| experimental `.run` 包需 `--vendor_name=experimental` | 安装到独立目录，避免与非 experimental 同名 OP_ADD 冲突 |
-| experimental 编译列表需精确指定 | 不能包含 compressor/mhc_post 等与非 experimental 同名且参数不兼容的算子 |
 | dequant_swiglu_quant 条件传参 | 无 `swiglu_limit` 时用默认 `swiglu_mode=0`（不钳位），避免输出错误 |
+| `rms_norm_dynamic_quant` A5 拆分 | ops-nn 无 arch35 kernel，A5 走 `npu_rms_norm` + `npu_dynamic_quant`，对齐 cann-recipes |
+| `swiglu_group_quant` `dst_type=24` | ops-nn `GetAclDataType` 同时支持 ScalarType(24) 和 DType enum(291)，用 24 对齐 cann-recipes |
+| `quant_lightning_indexer_v2` 而非 v1 | whl C++ 扩展调 V2 aclnn 符号，`.run` 包必须编译 v2 目录 |
+| `sparse_flash_mla` metadata 手动编译 | metadata 不会随主算子自动编译，必须在 `--ops` 中显式列出 |
+| torch_npu `npu_moe_gating_top_k` 需升级 | 源码有 13 参数版本（支持 hash），但缺 `exposed: all_version`；需手动添加并重新编译安装 |
+| ops-nn whl 整包构建 | `--torch_extension --ops=` 子包方式依赖整包先安装；直接整包构建最简单 |
 
 ---
 
-## 6. OP_DEF 冲突审计表
+## 6. OP_ADD 冲突注意事项
 
-> SO 加载优先级：vllm-ascend > experimental > ops-transformer(非exp) > cann-recipes
+迁移后大部分同名 OP_ADD 冲突已消除（vllm-ascend csrc 编译列表已移除已迁移算子）。新增/回退算子时仍需检查：
 
-| OP_ADD 类名 | vllm | exp | ot | rc | 冲突 | 生效 | 说明 |
-|---|:---:|:---:|:---:|:---:|:---:|---|---|
-| Compressor | ✅ | ✅18参 | ✅12参 | ❌ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
-| InplacePartialRotaryMul | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
-| MhcPost | ❌ | ✅ | ✅ | ❌ | ⚠️ | exp / ot | exp 编译列表不含 mhc_post |
-| KvCompressEpilog | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
-| QuantLightningIndexerV2 | ❌ | ✅(已打包) | ✅(已打包) | ❌ | ⚠️ | ot 非 exp | whl C++ 调 V2 aclnn；`.run` 编译 `quant_lightning_indexer_v2`；A2A3 vllm csrc 需移除 |
-| QuantLightningIndexerV2Metadata | ❌ | ✅(已打包) | ✅(已打包) | ❌ | 无 | ot 非 exp | 同上 |
-| RmsNormDynamicQuant | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
-| SparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | 新增非 exp 算子，无同名冲突 |
-| MixedQuantSparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | A5 only (arch35)；A3 无 kernel 但 op_def 注册无害 |
-| SparseAttnSharedkv | ✅ | ✅(未打包) | ❌ | ❌ | ⚠️ | A2A3: vllm | A5 已移除；exp 已移除；A2/A3 需移除 |
-| KvQuantSparseAttnSharedkv | ✅ | ✅(未打包) | ❌ | ❌ | ⚠️ | A2A3: vllm | A5 已移除；exp 已移除；A2/A3 需移除 |
-| MoeGatingTopKHash | ✅ | ❌ | ❌ | ✅ | ⚠️ | A2A3: vllm | A3 已移除；hash 路径改用 `torch_npu.npu_moe_gating_top_k`（调 `aclnnMoeGatingTopKV2`） |
-| MoeGatingTopK | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
-| SwigluGroupQuant | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
-| ScatterNdUpdate | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除；A2/A3 需移除 |
-| CompressorMetadata | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
-| IndexerQuantCache | ❌ | ❌ | ✅ | ❌ | 无 | ot | |
-| MhcPreSinkhorn | ❌ | ❌ | ✅ | ❌ | 无 | ot | |
-| DequantSwigluQuant | ✅ | ❌ | ❌ | ❌ | 无 | vllm | torch_npu 原生，不依赖 OP_ADD |
-| AddRmsNormBias | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
-| MoeInitRoutingCustom | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留（A2/A3） |
-| MoeInitRoutingV2 | ❌ | ❌ | ✅ | ❌ | 无 | ot | torch_npu 原生调用 |
-| GroupedMatmulSwigluQuantWeightNz | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
-| GroupedMatmulSwigluQuantWeightNzTensorList | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
-
-**⚠️ 后续改动检查清单**：新增/回退算子时 → 检查上表冲突 → 确保 `build_aclnn.sh` 移除冲突算子 → 确保 experimental 编译列表不含同名且参数不兼容的算子。
+1. 同名 `OP_ADD` 按 SO 加载优先级覆盖（见 1.3 节），vllm-ascend csrc 优先级最高
+2. 确保 `csrc/build_aclnn.sh` 不再编译已迁移算子（否则会覆盖外部实现）
 
 ---
 

--- a/docs/ops_migration.md
+++ b/docs/ops_migration.md
@@ -1,383 +1,286 @@
-# DeepSeek-V4 算子解耦迁移总结
+# DeepSeek-V4 算子迁移到 CANN 仓库指导
 
-> 本文档记录 vllm-ascend 中 DeepSeek-V4 调用链上所有 `torch.ops._C_ascend.*` 算子迁移到外部 CANN 仓库或替代方案的情况。
-> 后续如有新改动，请同步更新本文档。
+> **文档用途**：基线当前已验证通过的算子迁移改动，供其他人编译和使用。后续迁移工作仍在进行。
+> **更新规则**：代码或编译方式有改动时，请同步更新本文档。
 
 ---
 
-## 1. 背景
+## 1. 背景与目标
 
-### 1.1 目标
+### 1.1 任务
 
-将 vllm-ascend 中 DeepSeek-V4 调用链上的所有 `_C_ascend` 算子替换为 CANN 仓库提供的算子或替代方案。仅修改 vllm-ascend，不修改 CANN 仓库。
+将 vllm-ascend 中 DeepSeek-V4 原生算子（`torch.ops._C_ascend.*`，由 `csrc/` 编译）切换到 CANN 主线算子仓库（ops-transformer、ops-nn），对齐 cann-recipes-infer 仓库中 DeepSeek-V4 的实现。cann-recipes 已基本完成迁移，vllm-ascend 参考其实现进行迁移。
 
-### 1.2 算子来源与替代方案
+### 1.2 仓库
 
-| 来源 | 命名空间 | 优先级 |
-|------|---------|--------|
-| **ops-transformer** | `torch.ops.cann_ops_transformer.*` | 1（优先） |
-| **cann-recipes-infer** | `torch.ops.custom.*` | 2 |
-| **torch_npu 原生** | `torch_npu.npu_*` | 3 |
-| **Python 预计算/分解** | 纯 PyTorch + 上述算子组合 | 4（无外部对应时） |
-| **vllm-ascend csrc** | `torch.ops._C_ascend.*` | 保留（确实无替代时） |
+| 仓库 | 说明 | Python 命名空间 |
+|------|------|----------------|
+| ops-transformer | CANN 主线算子仓库（非 experimental + experimental） | `torch.ops.cann_ops_transformer.*` |
+| ops-nn | CANN 算子仓库（暂未使用） | `torch.ops.cann_ops_nn.*` |
+| cann-recipes-infer | 模型推理 recipe 仓库（含 wrapper） | `torch.ops.custom.*` |
+| vllm-ascend csrc | vllm-ascend 原生算子（保留必要部分） | `torch.ops._C_ascend.*` |
 
-### 1.3 兼容性判断原则
-
-- aclnn API 名称和参数一致 → 直接替换
-- aclnn API 不同但有 torch binding 且功能等价 → 替换 + 参数适配
-- 无 torch binding 但有 aclnn 源码 → 不迁移（不修改 CANN 仓库）
-- 完全无外部对应 → Python 预计算或分解为已有算子组合（参考 cann-recipes DSV4 实现）
-
-### 1.4 V4 调用链
+### 1.3 SO 加载优先级
 
 ```
-AscendDeepseekV4ForCausalLM
-  → DeepseekV2DecoderLayer
-    ├── DeepseekV4Attention → AscendDeepseekSparseAttention (ops/dsa.py)
-    │     → DSAAttention → AscendDSABackend → AscendDSAImpl (attention/dsa_v1.py)
-    │       或 AscendDSACPImpl (attention/context_parallel/dsa_cp.py)
-    ├── DeepseekV4MoE → FusedMoE → AscendMoERunner
-    │     → select_experts (ops/fused_moe/experts_selector.py)
-    │     → fused_experts (ops/fused_moe/moe_comm_method.py)
-    │     → unified_apply_mlp (ops/fused_moe/moe_mlp.py)
-    └── RMSNorm (ops/layernorm.py)
+vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 ```
 
-V4 的 attention 走 **DSA 路径**，不走 SFA/MLA。
+同名 `OP_ADD` 按此优先级覆盖。因此迁移时必须同步调整 `csrc/build_aclnn.sh` 编译列表，移除已迁移算子，避免 vllm-ascend SO 覆盖外部实现。
 
-### 1.5 约束
+### 1.4 约束
 
 - 仅修改 vllm-ascend，不修改 CANN 仓库
-- csrc 不清理
-- 目标平台：A5 (Ascend 910C / arch35 / `__DAV_C310__`)，同时兼容 A3 (Ascend 910B)
-
-### 1.6 同名算子覆盖原则
-
-同一个 aclnn 算子如果在 vllm-ascend、cann-recipes-infer 或 ops-transformer 的 `.run`/SO 中同名注册，运行时会优先命中 vllm-ascend 已安装的实现，然后才会使用 recipes/transformer 的实现。因此迁移方案不仅要修改 Python 调用命名空间，还必须同步调整 vllm-ascend 编译脚本中的算子列表：
-
-- 最终使用 vllm-ascend 实现：必须在 vllm-ascend 编译脚本中保留该算子，确保对应 `.run` 安装。
-- 最终使用 recipes/transformer 实现：必须从 vllm-ascend 编译脚本中移除同名算子，避免 vllm-ascend SO 覆盖外部实现。
-- 按设备分流的算子：需要按 SOC 编译列表分别处理；例如 A3/Base 使用 vllm-ascend `compressor`，A5 使用 recipes `custom.compressor`，因此 A3 编译列表保留 `compressor`，A5 编译列表不编译 `compressor`。
-- 后续新增/回退任一算子时，必须同时更新 Python 分流、`csrc/build_aclnn.sh` 编译列表和本文档。
+- csrc 不清理（保留无法迁移的算子）
+- 目标平台 A5 (Ascend 910C / arch35)，兼容 A3 (Ascend 910B / arch22)
+- `csrc/build_aclnn.sh` A2 (ascend910b) 列表不动
 
 ---
 
-## 2. 已迁移的算子
+## 2. 当前状态（已验证通过）
 
-### 2.1 Attention — DSA 模块
+> 当前代码已在 A5 环境验证通过。这是**中间态**，部分算子仍使用 cann-recipes wrapper 或 vllm-ascend csrc，后续会继续迁移。
 
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 1 | inplace_partial_rotary_mul | `inplace_partial_rotary_mul` | `cann_ops_transformer.inplace_partial_rotary_mul` | dsa_v1.py, dsa_cp.py (13处) | 无，aclnn API + 参数完全一致 |
-| 2 | compressor | `compressor` | 按设备分流：A3/Base 保留 `_C_ascend.compressor`，A5 使用 `custom.compressor` | device_op.py 分流；dsa_v1.py, dsa_cp.py (6处) 调用 `DeviceOperator.dsa_compressor` | keyword args 分隔；A3 回退原 vllm-ascend wrapper，避免 cann-recipes wrapper 对 `state_cache` 连续性/dtype 的额外约束 |
-| 3 | npu_quant_lightning_indexer | `npu_vllm_quant_lightning_indexer` | `custom.npu_quant_lightning_indexer` | dsa_v1.py, dsa_cp.py (4处) | 多可选参数 |
-| 4 | npu_quant_lightning_indexer_metadata | `npu_vllm_quant_lightning_indexer_metadata` | `custom.npu_quant_lightning_indexer_metadata` | dsa_v1.py, dsa_cp.py (3处) | device 默认值差异 |
-| 5 | npu_rms_norm_dynamic_quant | `npu_rms_norm_dynamic_quant` | `custom.npu_rms_norm_dynamic_quant` | dsa_v1.py, dsa_cp.py (4处) | 无 |
-| 6 | npu_sparse_attn_sharedkv | `npu_sparse_attn_sharedkv` | `custom.npu_sparse_attn_sharedkv` | device_op.py (BaseAdaptor) | 默认值差异，显式传参 |
-| 7 | npu_sparse_attn_sharedkv_metadata | 同上 | `custom.npu_sparse_attn_sharedkv_metadata` | device_op.py (BaseAdaptor) | 同上 |
-| 8 | npu_kv_quant_sparse_attn_sharedkv | `npu_kv_quant_sparse_attn_sharedkv` | `custom.npu_kv_quant_sparse_attn_sharedkv` | device_op.py (A5Adaptor) | A5 路径需与 `kv_compress_epilog(quant_mode="fp8_bf16")` 配套 |
-| 9 | npu_kv_quant_sparse_attn_sharedkv_metadata | 同上 | `custom.npu_kv_quant_sparse_attn_sharedkv_metadata` | device_op.py (A5Adaptor) | 同上 |
-| 10 | scatter_nd_update_asc | `npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | device_op.py (BaseAdaptor, 7处) | 纯改名；in-place op（3 positional args 不变）；保留 `[:x_flat.shape[0]]` 截取逻辑 |
-| 11 | kv_compress_epilog | `kv_compress_epilog` | `cann_ops_transformer.kv_compress_epilog` | device_op.py (A5Adaptor) | A5 custom sparse attention 路径使用 `quant_mode="fp8_bf16"`；cache 保持 4D 不 reshape（tiling 要求 4D `[blockNum, blockSize, 1, headDim]`） |
-| 12 | indexer_compress_epilog_v2 | `indexer_compress_epilog_v2` | `cann_ops_transformer.indexer_quant_cache` | device_op.py (A5Adaptor, 3处) | `cache_scale` 必须为 float32（op_def 约束）；cache/cache_scale 保持 4D 不 reshape（tiling `ValidateCache4D` 要求 4D）；参数名 `indexer_full_cache`→`indexer_scale_cache` |
+### 2.1 算子总表
 
-### 2.2 MHC (Hyper-Connection) 模块
+| # | 算子 | 进度 | 原 torch API | 当前 torch API | 目标 torch API | kernel 位置 | 关键信息 |
+|---|------|:---:|---|---|---|---|---|
+| 1 | inplace_partial_rotary_mul | ✅ | `_C_ascend.*` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, posembedding/, arch35 ✅ | 无参数变化 |
+| 2 | compressor | ✅ | `_C_ascend.*` (18参融合) | `cann_ops_transformer.*` (12参) + Python `npu_rms_norm` + `inplace_partial_rotary_mul` | 同当前 | ot 非 exp, attention/, arch35 ✅ (op_api 来自 base 包) | 拆融合；需 `kv[..., :head_dim]` 截断；RoPE view 4D；indexer 用 `indexcom_head_dim` |
+| 3 | kv_compress_epilog `[A5]` | ✅ | `_C_ascend.*` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, attention/, arch35 ✅ | `quant_mode="fp8_bf16"`；cache 保持 4D |
+| 4 | indexer_quant_cache `[A5]` | ✅ | `_C_ascend.indexer_compress_epilog_v2` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, attention/, arch35 ✅ | `cache_scale` float32；cache 4D；参数名 `indexer_full_cache`→`indexer_scale_cache` |
+| 5 | mhc_pre_sinkhorn | ✅ | `_C_ascend.npu_hc_pre_v2` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, mhc/, arch35 ✅ | 参数改名+顺序交换；unsqueeze 3D→4D；返回 8 元组取前 3；comb `unflatten`+`squeeze` |
+| 6 | mhc_post | ✅ | `_C_ascend.npu_hc_post` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, mhc/, arch35 ✅ | 参数顺序重排；去掉 unsqueeze/squeeze |
+| 7 | scatter_nd_update `[A3]` | ✅ | `_C_ascend.npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | 同当前 | torch_npu pip 包 | 纯改名；保留 `[:x_flat.shape[0]]` 截取 |
+| 8 | moe_init_routing_v2 | ✅ | `_C_ascend.npu_moe_init_routing_custom` | `torch_npu.npu_moe_init_routing_v2` | 同当前 | torch_npu pip 包 | 纯改名 |
+| 9 | moe_gating_top_k (非hash) | ✅ | `_C_ascend.moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | 同当前 | torch_npu pip 包 | 去掉 `input_ids`/`tid2eid` |
+| 10 | dequant_swiglu_quant | ✅ | `_C_ascend.npu_dequant_swiglu_quant` | `torch_npu.npu_dequant_swiglu_quant` | 同当前 | torch_npu pip 包 | 条件传参：无 limit `swiglu_mode=0`，有 limit 共享专家 `=2`，路由专家 `=1` |
+| 11 | add_rms_norm | ✅ | `_C_ascend.npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | 同当前 | torch_npu pip 包 | bias 不再融合 |
+| 12 | dispatch_ffn_combine `[A3]` | ✅ | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 基类非融合路径 |
+| 13 | dispatch_gmm_combine_decode `[A3]` | ✅ | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 同上 |
+| 14 | quant_lightning_indexer | 📋 | `_C_ascend.npu_vllm_quant_lightning_indexer` | `custom.npu_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` | ot exp, attention/quant_lightning_indexer/, arch35 ✅ | `layout_k` 改 `PA_BBND`；参数改名；`quant_mode` 按 arch 锁定 |
+| 15 | quant_lightning_indexer_metadata | 📋 | `_C_ascend.npu_vllm_quant_lightning_indexer_metadata` | `custom.npu_quant_lightning_indexer_metadata` | `cann_ops_transformer.quant_lightning_indexer_metadata` | ot exp, AICPU | 新增 `seqused_k`/`cmp_residual_k`；删除 `device`/`pre_tokens`/`next_tokens` |
+| 16 | sparse_attn_sharedkv `[A3]` | ✅ | `_C_ascend.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 同当前 | ot 非 exp, attention/sparse_flash_mla/, arch35 ✅ | 算子名变更；`seqused_kv`→`seqused_ori_kv`；`PA_ND`→`PA_BBND`；新增 `seqused_cmp_kv`/`cmp_residual_kv`/`topk_value_mode` |
+| 17 | sparse_attn_sharedkv_metadata `[A3]` | ✅ | `_C_ascend.npu_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上；新增 `max_seqlen_cmp_kv`；删除 `device` |
+| 18 | kv_quant_sparse_attn_sharedkv `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv` | `cann_ops_transformer.mixed_quant_sparse_flash_mla` | 同当前 | ot 非 exp, attention/mixed_quant_sparse_flash_mla/, arch35 ✅ | A5 路径；`kv_quant_mode`→`quant_mode`；删除 `tile_size` |
+| 19 | kv_quant_sparse_attn_sharedkv_metadata `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.mixed_quant_sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上 |
+| 20 | rms_norm_dynamic_quant | ⏳ | `_C_ascend.*` | `custom.npu_rms_norm_dynamic_quant` | A5: `torch_npu.npu_dynamic_quant`；A3: `cann_ops_nn.rms_norm_dynamic_quant` | cann-recipes, src/, 无 arch35 | DSV4 A5 用 `npu_dynamic_quant`，A3 用 `cann_ops_nn.*`；需平台分支；ops-nn 未打包 |
+| 21 | swiglu_group_quant `[A5]` | ⏳ | `_C_ascend.*` | `custom.npu_swiglu_group_quant` | `cann_ops_nn.swiglu_group_quant` | cann-recipes, src/, 无 arch35 | DSV4 所有平台都用 `cann_ops_nn.*`；ops-nn 未打包 |
+| 22 | moe_gating_top_k_hash | ⏳ | `_C_ascend.moe_gating_top_k_hash` | `custom.npu_moe_gating_top_k` | PyTorch native fallback | cann-recipes, src/, arch35 ✅ | DSV4 hash 路径用纯 PyTorch 实现；需改 vllm hash 路径为 native fallback |
+| 23 | compressor_metadata | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, attention/, 无 arch35 | graph capture 不兼容，无外部对应 |
+| 24 | grouped_matmul_swiglu_quant_weight_nz | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | 无 torch binding；可行方案：3 阶段分解 |
+| 25 | grouped_matmul_swiglu_quant_weight_nz_tensor_list | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | vllm 独有 |
+| 26 | grouped_matmul_swiglu_quant_v2 | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, arch35 ✅ | vllm 版多 `swigluLimit` 参数 |
 
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 13 | npu_hc_pre | `npu_hc_pre_v2` | `cann_ops_transformer.mhc_pre_sinkhorn` | deepseek_v4.py (1处) | 参数改名（`hc_fn`→`phi`, `hc_scale`→`alpha`, `hc_base`→`bias`）；顺序交换（`hc_eps, norm_eps`）；输入 unsqueeze 3D→4D；返回 8 元组取前 3；comb `unflatten(-1, (hc_mult, hc_mult))`+`squeeze(1)`；不同 aclnn API（`aclnnHcPre`→`aclnnMhcPreSinkhorn`） |
-| 14 | npu_hc_post | `npu_hc_post` | `cann_ops_transformer.mhc_post` | deepseek_v4.py (1处) | 参数顺序重排 `(x,residual,post,comb)`→`(residual,comb,x,post)`；去掉 unsqueeze/squeeze workaround；不同 aclnn API（`aclnnHcPost`→`aclnnMhcPost`） |
+### 2.2 迁移统计
 
-### 2.3 MoE — Gating 模块
-
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 15 | moe_gating_top_k_hash | `moe_gating_top_k_hash` | `custom.npu_moe_gating_top_k` | experts_selector.py (1处) | `x`/`k` 改 positional；hash 路径保留 `custom`（torch_npu 不支持 `input_ids`/`tid2eid`） |
-| 16 | moe_gating_top_k (非hash) | `moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | device_op.py (BaseAdaptor, 1处) | 去掉 `input_ids`/`tid2eid`（非 hash 路径不需要）；ops-transformer 内核原生支持 `renorm=0/1`（无需 Python 后处理） |
-
-### 2.4 MoE — Routing 模块
-
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 17 | npu_moe_init_routing_custom | `npu_moe_init_routing_custom` | `torch_npu.npu_moe_init_routing_v2` | device_op.py (BaseAdaptor, 1处) | 纯改名；A5 路径已用此 op 验证可行 |
-
-### 2.5 MoE — Quant/Activation 模块
-
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 18 | npu_swiglu_group_quant | `npu_swiglu_group_quant` | `custom.npu_swiglu_group_quant` | device_op.py, fused_moe.py, fused_moe_0_23_0.py (3处) | `topk_weight`→`weight`，`clamp_value`→`clamp_limit`；`quant_mode=2`(MX_QUANT)→`quant_mode=1`(cann MX_QUANT)；输入需 bf16/f16（不能传 int32）；MX_QUANT 时 `round_scale=True` |
-| 19 | npu_dequant_swiglu_quant | `npu_dequant_swiglu_quant` | `torch_npu.npu_dequant_swiglu_quant` | fused_moe.py, fused_moe_0_23_0.py, moe_mlp.py (3处) | 去掉 `bias`/`quant_offset`；条件传参：无 `swiglu_limit` 时不传 `swiglu_mode`/`clamp_limit`（用默认 `swiglu_mode=0` 不钳位）；有 `swiglu_limit` 时共享专家 `swiglu_mode=2`（contiguous），路由专家 `swiglu_mode=1`（interleaved） |
-
-### 2.6 MoE — MC2 Communication 模块
-
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 20 | dispatch_ffn_combine | `dispatch_ffn_combine` | `super().fused_experts()` (基类非融合路径) | moe_comm_method.py (1处) | 分解为 dispatch + 3阶段 FFN + combine，使用 `npu_moe_distribute_dispatch_v2` + `npu_moe_distribute_combine_v2` |
-| 21 | dispatch_gmm_combine_decode | `dispatch_gmm_combine_decode` | `super().fused_experts()` (基类非融合路径) | moe_comm_method.py (1处) | 同上 |
-
-### 2.7 Norm 模块
-
-| # | 算子 | 原 `_C_ascend` | 迁移到 | 调用文件 | 签名调整 |
-|---|------|---------------|--------|---------|---------|
-| 22 | npu_add_rms_norm_bias | `npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | layernorm.py (2处) | bias 不再融合但功能等价 |
-
-### 2.8 保持当前来源的算子（属第三组 HARD，待后续处理）
-
-以下算子在 ops-transformer 中有对应版本，但因改动量大或参数不兼容暂未切换：
-
-| 算子 | 当前来源 | ops-transformer 对应 | 不切换原因 |
-|------|---------|---------------------|-----------|
-| `compressor` | A3/Base `_C_ascend.compressor` (18参融合)，A5 `custom.compressor` | `cann_ops_transformer.compressor` (12参，无 norm/rope) | ops-transformer 版不含 RMSNorm+RoPE 融合，拆分 3 步会性能下降（属第三组 HARD） |
-| `npu_quant_lightning_indexer` + metadata | `custom.npu_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` (V2) | V2 要求 `layout_k="PA_BBND"`，V4 用 `PA_BSND`；需改 KV cache 布局（属第三组 HARD） |
-| `npu_sparse_attn_sharedkv` + metadata | `custom.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 算子名和参数结构大幅变化，metadata 签名重写（属第三组 HARD） |
-| `moe_gating_top_k_hash` | `custom.npu_moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | torch_npu 不支持 hash 模式（`input_ids`/`tid2eid`），hash 路径保留 `custom` |
-
----
-
-## 3. 未迁移的算子
-
-### 3.1 compressor_metadata（回退到 `_C_ascend`，graph capture 不兼容）
-
-> **状态：已回退。** Python 预计算方案与 `UNIFORM_BATCH` graph capture/replay 不兼容。
-
-| 算子 | 原 `_C_ascend` | 调用文件 | 原因 |
-|------|---------------|---------|------|
-| compressor_metadata | `compressor_metadata` | dsa_v1.py (6处), dsa_cp.py (2处) | 见下方分析 |
-
-**根因分析：**
-
-原始 `_C_ascend.compressor_metadata` 在 forward 路径执行，作为 custom op 注册为 graph node。graph replay 时读取 scheduler 更新的 `start_pos_decode` tensor 的当前值。
-
-Python 预计算在 metadata build 阶段执行，读取 tensor 值后计算结果存为常量。graph replay 时 `build_decode_metadata` 不再调用，预计算结果被冻结为 capture 时的值。导致首 token 正确，后续 token 因 `start_pos` 更新但预计算结果未更新而精度错误。
-
-**结论：** `compressor_metadata` 必须作为 graph node 在 forward 路径执行，不能预计算。csrc 不清理，保留 `_C_ascend` 调用。
-
-### 3.2 MoE — GMM 模块（暂未迁移，保留 `_C_ascend`）
-
-> **状态：暂未迁移。** 3 阶段分解方案在 A3 上调试时遇到 `npu_grouped_matmul` 的 A8W8 per-token quant dtype 不匹配问题（`scale` dtype FLOAT 与 `output_dtype` FLOAT16 不兼容），已回退。
-
-| 算子 | 原 `_C_ascend` | 调用文件 | 原因 |
-|------|---------------|---------|------|
-| grouped_matmul_swiglu_quant_weight_nz | `grouped_matmul_swiglu_quant_weight_nz` | device_op.py (BaseAdaptor, 1处) | 见下方方案分析 |
-| grouped_matmul_swiglu_quant_weight_nz_tensor_list | `grouped_matmul_swiglu_quant_weight_nz_tensor_list` | moe_mlp.py (2处) | 同上 |
-| grouped_matmul_swiglu_quant_v2 | `grouped_matmul_swiglu_quant_v2` | moe_mlp.py (1处) | 同上 |
-
-**可行方案（待后续实现）：**
-
-参考 cann-recipes DSV4 `CompressedTensorW8A8Int8MoEGMMMethod`（`compressed_tensors_moe_gmm.py:155-194`）和 `modeling_deepseek.py:442-498`：
-
-1. **gmm1 阶段**：`npu_grouped_matmul` **不传 `scale`/`per_token_scale`**，`output_dtype=torch.int32`
-   - cann-recipes W8A8Int8 路径（L159-165）：gmm1 不传 scale，output=int32
-   - **关键**：W8A8Int8 路径的 `weight_scale` 是 float32，不能直接传给 `npu_grouped_matmul` 的 `scale` 参数（报 dtype 不匹配）
-
-2. **dequant + swiglu + quant 阶段**：`npu_dequant_swiglu_clamp_quant`，传入 `weight_scale` 做反量化
-   - 参数：`x=gmm1_out(int32)`, `weight_scale=w1_scale(float32)`, `activation_scale=pertoken_scale`, `quant_mode=1`(dynamic), `swiglu_mode=0`/`1`
-
-3. **gmm2 阶段**：`npu_grouped_matmul` 传 `scale=[w2_weight_scale]` + `per_token_scale=[swiglu_out_scale]`，`output_dtype=bf16`
-
-**A5 路径不受影响**：`A5DeviceAdaptor.npu_grouped_matmul_swiglu_quant` 使用 `torch_npu.npu_grouped_matmul_swiglu_quant_v2`（torch_npu 原生融合算子），不走 `_C_ascend`。
-
-### 3.3 完全无外部对应（vllm-ascend 独有）
-
-| 算子 | 模块 | aclnn API | 说明 |
-|------|------|-----------|------|
-| `store_kv_block` / `store_kv_block_pre` | SFA | `aclnnStoreKVBlock` | 两仓库均无（SFA 路径，V4 不走） |
-| `batch_matmul_transpose` | SFA | 自研 kernel | 两仓库均无（SFA 路径，V4 不走） |
-
-### 3.4 有 aclnn 源码但无 torch binding（不修改 CANN 仓库）
-
-| 算子 | 模块 | CANN 仓库情况 | 无法迁移原因 |
-|------|------|-------------|-----------|
-| `grouped_matmul_swiglu_quant_weight_nz` | MoE-GMM | ops-transformer 有 `aclnnGroupedMatmulSwigluQuantWeightNZ` 源码 | 无 torch_extension binding。vllm-ascend 版 aclnn 多 `limited` 参数。3 阶段分解方案见 3.1 节 |
-| `grouped_matmul_swiglu_quant_v2` | MoE-GMM | ops-transformer 有 `aclnnGroupedMatmulSwigluQuantWeightNzV2` 源码 | 无 torch_extension binding。vllm-ascend 版 aclnn 多 `swigluLimit` 参数。3 阶段分解方案见 3.1 节 |
-
----
-
-## 4. 修改的文件列表
-
-| 文件 | 模块 | 改动内容 |
-|------|------|---------|
-| `vllm_ascend/ops/__init__.py` | 基础 | 添加 `import custom_ops`（注册 `torch.ops.custom.*`） |
-| `vllm_ascend/attention/dsa_v1.py` | Attention | inplace_partial_rotary_mul→cann_ops_transformer（延迟导入）；compressor→`DeviceOperator.dsa_compressor`（A3/Base 回退 `_C_ascend`，A5 走 custom）；rms_norm_dynamic_quant/quant_lightning_indexer+metadata→custom；compressor_metadata 保留 `_C_ascend`（graph capture 不兼容） |
-| `vllm_ascend/attention/context_parallel/dsa_cp.py` | Attention | 同上 |
-| `vllm_ascend/models/deepseek_v4.py` | MHC | hc_pre/hc_post→custom |
-| `vllm_ascend/device/device_op.py` | Attention+MoE | 新增 `dsa_compressor` 设备分流（A3/Base `_C_ascend.compressor`，A5 `custom.compressor`）；A5 `npu_kv_quant_sparse_attn_sharedkv(+metadata)`→custom；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_attn_sharedkv/scatter_nd_update_asc→custom（含 reshape 适配）；moe_gating_top_k/moe_init_routing/swiglu_group_quant→custom（GMM 模块已回退，保留 `_C_ascend`） |
-| `vllm_ascend/ops/fused_moe/experts_selector.py` | MoE-Gating | moe_gating_top_k_hash→custom |
-| `vllm_ascend/ops/fused_moe/fused_moe.py` | MoE-Quant | swiglu_group_quant→custom；dequant_swiglu_quant→custom |
-| `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | MoE-Quant | 同上 |
-| `vllm_ascend/ops/fused_moe/moe_mlp.py` | MoE-GMM | dequant_swiglu_quant→custom（GMM 3 阶段分解已回退） |
-| `vllm_ascend/ops/fused_moe/moe_comm_method.py` | MoE-MC2 | dispatch_ffn_combine/dispatch_gmm_combine_decode→基类非融合路径 |
-| `vllm_ascend/ops/layernorm.py` | Norm | npu_add_rms_norm_bias→torch_npu.npu_add_rms_norm + bias add |
-| `csrc/build_aclnn.sh` | 编译脚本 | A3 (`ascend910_93`) 编译列表保留/新增 `compressor`；A5 (`ascend950`) 编译列表不包含 `compressor`、`kv_compress_epilog`、`kv_quant_sparse_attn_sharedkv(+metadata)`、`indexer_compress_epilog_v2`，避免覆盖外部实现 |
-
----
-
-## 5. A5 (arch35) 兼容性
-
-所有迁移的算子均验证了 arch35 内核支持。关键路径：
-
-| 路径 | 算子 | arch35 内核 |
-|------|------|------------|
-| A5 DSA sparse attention | `custom.npu_kv_quant_sparse_attn_sharedkv` | ✅ arch35 |
-| A5 KV compress | `cann_ops_transformer.kv_compress_epilog` | ✅ ops-transformer arch35 |
-| A5 indexer scatter | `cann_ops_transformer.indexer_quant_cache` | ✅ ops-transformer arch35 |
-| A5 MoE gating | `npu_moe_gating_top_k` | ✅ torch_npu 原生 |
-| A5 MoE GMM | `torch_npu.npu_grouped_matmul_swiglu_quant_v2` | ✅ torch_npu 原生（未改） |
-| A5 MoE MC2 | `npu_moe_distribute_dispatch_v2` + `npu_moe_distribute_combine_v2` | ✅ torch_npu 原生 |
-| A5 RMSNorm | `npu_add_rms_norm` | ✅ torch_npu 原生 |
-| A5 compressor | `custom.compressor` (wrapper) | ✅ cann-recipes-infer .run |
-| A3/Base compressor | `_C_ascend.compressor`（回退） | ✅ vllm-ascend csrc |
-| 共享 rotary | `cann_ops_transformer.inplace_partial_rotary_mul` | ✅ arch35 only |
-| 共享 hc_pre/post | `custom.npu_hc_pre`/`npu_hc_post` | ✅ `__DAV_C310__` 显式 |
-| 共享 compressor_metadata | `_C_ascend.compressor_metadata`（保留） | ✅ vllm-ascend csrc |
-
----
-
-## 6. 汇总
-
-### 6.1 算子迁移统计
-
-| 状态 | 数量 | 算子 |
+| 进度 | 数量 | 说明 |
 |------|:---:|------|
-| **已迁移到 ops-transformer** | 6 | inplace_partial_rotary_mul, kv_compress_epilog, indexer_quant_cache, mhc_pre_sinkhorn, mhc_post |
-| **已迁移到 ops-nn** | 0 | （暂回退，版本不配套，后续处理） |
-| **已迁移到 torch_npu 原生** | 5 | npu_add_rms_norm, scatter_nd_update_, moe_init_routing_v2, moe_gating_top_k(非hash), dequant_swiglu_quant |
-| **保留 cann-recipes** | 4 | moe_gating_top_k_hash（hash 路径）, rms_norm_dynamic_quant, swiglu_group_quant, partial_rotary_mul_quant |
-| **已迁移到基类非融合路径** | 2 | dispatch_ffn_combine, dispatch_gmm_combine_decode |
-| **暂未迁移（graph capture 不兼容）** | 1 | compressor_metadata |
-| **暂未迁移（有可行方案）** | 3 | grouped_matmul_swiglu_quant_weight_nz, _tensor_list, _v2 |
-| **无法迁移（SFA 路径，V4 不走）** | 3 | store_kv_block, store_kv_block_pre, batch_matmul_transpose |
-| **合计** | 25 | |
+| ✅ 完成 | 17 | 已对齐 DSV4，当前=目标 |
+| 📋 待执行 | 2 | 当前用 cann-recipes wrapper，目标切到 ops-transformer |
+| ⏳ 暂缓 | 3 | 依赖 ops-nn 打包或需改 hash 路径为 native fallback |
+| ❌ 阻塞 | 4 | graph capture 不兼容或无外部对应 |
+| **合计** | 26 | |
 
-### 6.2 命名空间分布
+### 2.3 修改的文件
 
-| 命名空间 | 算子数 |
-|---------|:---:|
-| `torch.ops.cann_ops_transformer.*` (ops-transformer) | 5 |
-| `torch.ops.cann_ops_nn.*` (ops-nn) | 0（暂回退） |
-| `torch.ops.custom.*` (cann-recipes-infer) | 4 + A5 compressor |
-| `torch_npu.npu_*` (torch_npu 原生) | 5 |
-| 基类非融合路径 | 2 |
-| `torch.ops._C_ascend.*` (vllm-ascend csrc，暂未迁移/设备回退) | 4 + A3/Base compressor |
-| `torch.ops._C_ascend.*` (vllm-ascend csrc，SFA 路径 V4 不走) | 6 |
-
-### 6.3 V4 路径上 `_C_ascend` 残留
-
-V4 DSA + MoE 调用链上，A5 路径有 **4 个 `_C_ascend` 算子**未迁移（compressor_metadata + GMM 模块 3 个）。A3/Base 路径额外回退 `compressor` 到 `_C_ascend.compressor`，因此 A3/Base 路径当前有 **5 个 `_C_ascend` 算子**残留。
-
-### 6.4 关键技术决策
-
-| 决策 | 原因 |
-|------|------|
-| 同名算子需同步调整编译列表 | `.run`/SO 中同名 aclnn 算子会优先命中 vllm-ascend 实现；若目标是 recipes/transformer 实现，必须从 vllm-ascend 编译列表移除同名算子，避免覆盖 |
-| compressor_metadata 保留 `_C_ascend` | Python 预计算与 `UNIFORM_BATCH` graph capture/replay 不兼容：预计算在 build 时执行，结果冻结为常量；graph replay 时 `start_pos` 已更新但预计算结果未更新，导致首 token 正确后续 token 精度错误。必须作为 graph node 在 forward 路径执行 |
-| quant_lightning_indexer 保持 V1 不切 V2 | V2 要求 `layout_q == layout_k`，V4 用不同 layout |
-| compressor 按设备分流 | ops-transformer 版 14 参不含 RMSNorm+RoPE 融合；A5 继续使用 cann-recipes `custom.compressor`；A3/Base 使用 cann-recipes wrapper 会触发 `state_cache` 连续性/dtype 约束，先回退 `_C_ascend.compressor` |
-| hc_pre/post 保持 cann-recipes 不切 ops-transformer | 不同 aclnn API，语义可能有差异 |
-| GMM 模块暂未迁移 | A3 上 `npu_grouped_matmul` A8W8 dtype 不兼容，有可行方案待实现 |
-| scatter_nd_update_asc 需 reshape | cann-recipes 要求 2D 输入，vllm-ascend 传 4D |
-| NPU 格式兼容（NCHW vs ND） | pad 用 `index_select` + `fill_` 替代 `torch.cat`，避免格式不兼容 |
+| 文件 | 改动内容 |
+|------|---------|
+| `vllm_ascend/ops/__init__.py` | 添加 `import custom_ops` |
+| `vllm_ascend/attention/dsa_v1.py` | inplace_partial_rotary_mul/compressor→cann_ops_transformer；rms_norm_dynamic_quant/quant_lightning_indexer→custom；compressor_metadata 保留 `_C_ascend` |
+| `vllm_ascend/attention/context_parallel/dsa_cp.py` | 同上 |
+| `vllm_ascend/models/deepseek_v4.py` | mhc_pre_sinkhorn/mhc_post→cann_ops_transformer |
+| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→custom |
+| `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→custom |
+| `vllm_ascend/ops/fused_moe/fused_moe.py` | swiglu_group_quant→custom；dequant_swiglu_quant→torch_npu |
+| `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | 同上 |
+| `vllm_ascend/ops/fused_moe/moe_mlp.py` | dequant_swiglu_quant→torch_npu |
+| `vllm_ascend/ops/fused_moe/moe_comm_method.py` | dispatch_ffn_combine/dispatch_gmm_combine_decode→基类非融合路径 |
+| `vllm_ascend/ops/layernorm.py` | npu_add_rms_norm_bias→torch_npu.npu_add_rms_norm + bias add |
+| `csrc/build_aclnn.sh` | A3 编译列表移除已迁移算子；A5 编译列表移除已迁移算子 |
 
 ---
 
-## 7. 算子编译
+## 3. 算子编译指导
 
-> 仅编译 vllm-ascend V4 路径实际用到的算子，减少编译时间。编译命令参考 ops-transformer `docs/zh/install/compile.md` 和 ops-nn `build.sh --help`。
+> 以下为当前已验证通过的环境的算子打包方式。SO 加载顺序：vllm-ascend > experimental > ops-transformer(非exp) > cann-recipes。
 
-### 7.1 ops-transformer 编译（.run 包 + whl 包）
+### 3.1 ops-transformer（非 experimental）
 
-**用到的算子（5 个，A3/A5 统一）：**
-
+**已打包算子（8 个）**：
 ```
-inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post
+inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla
 ```
-
-**A3 (ascend910_93)：**
 
 ```bash
 cd ops-transformer
 
-# 编译 .run 包（仅上述 5 个算子）
+# A3
 bash build.sh --pkg --soc=ascend910_93 \
-  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla
 
-# 安装 .run 包
+# A5
+bash build.sh --pkg --soc=ascend950 \
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla
+
+# 安装
 ./build_out/cann-ops-transformer-custom_linux-*.run
-
-# 编译并安装 whl 包（torch_extension，JIT 编译 C++ binding）
-cd torch_extension
-python3 -m build --wheel -n
-pip3 install dist/*.whl --force-reinstall --no-deps
 ```
 
-**A5 (ascend950)：**
+### 3.2 ops-transformer（experimental）
+
+**已打包算子（2 个）**：
+```
+quant_lightning_indexer,quant_lightning_indexer_metadata
+```
 
 ```bash
 cd ops-transformer
 
-# 编译 .run 包（仅上述 5 个算子）
-bash build.sh --pkg --soc=ascend950 \
-  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post
+# A3
+bash build.sh --pkg --experimental --vendor_name=experimental --soc=ascend910_93 \
+  --ops=quant_lightning_indexer,quant_lightning_indexer_metadata
 
-# 安装 .run 包
-./build_out/cann-ops-transformer-custom_linux-*.run
+# A5
+bash build.sh --pkg --experimental --vendor_name=experimental --soc=ascend950 \
+  --ops=quant_lightning_indexer,quant_lightning_indexer_metadata
 
-# 编译并安装 whl 包
-cd torch_extension
-python3 -m build --wheel -n
-pip3 install dist/*.whl --force-reinstall --no-deps
+# 安装
+./build_out/cann-ops-transformer-experimental_linux-*.run
 ```
 
-> **说明**：
-> - `.run` 包提供 aclnn API（AscendC 内核），安装到 `$ASCEND_HOME_PATH/opp/vendors/`
-> - whl 包提供 torch Python binding（JIT 编译），通过 `import cann_ops_transformer` 注册 `torch.ops.cann_ops_transformer.*` 命名空间
-> - `--ops` 参数指定算子目录名，多个用英文逗号分隔，不指定时默认编译全部算子
-> - A3 和 A5 的算子列表相同（第三组 HARD 完成后 A3 会增加 compressor/quant_lightning_indexer/sparse_flash_mla）
+> ⚠️ experimental 编译列表**不能**包含 compressor/mhc_post 等与非 experimental 同名 OP_ADD 且参数不兼容的算子。
 
-### 7.2 ops-nn 编译
+### 3.3 cann-recipes-infer
 
-> **暂不需要**。`swiglu_group_quant` 和 `rms_norm_dynamic_quant` 已回退到 cann-recipes，ops-nn 版本不配套，后续处理。
-
-### 7.3 cann-recipes-infer 编译（hash 路径 moe_gating_top_k + rms_norm_dynamic_quant + swiglu_group_quant）
-
-V4 hash 路径仍使用 `custom.npu_moe_gating_top_k`（ops-transformer 不支持 `input_ids`/`tid2eid`），需编译 cann-recipes：
+**全量打包**（包含所有 cann-recipes 有源码的算子）。
 
 ```bash
 cd cann-recipes-infer/ops/ascendc
 
-# 编译 .run 包
-bash build.sh -c ascend910_93   # A3
-# 或
-bash build.sh -c ascend950      # A5
+# A3
+bash build.sh -c ascend910_93
+# A5
+bash build.sh -c ascend950
 
 # 安装 .run 包
 bash CANN-custom_ops-*.run --install
 
 # 编译并安装 whl 包
 cd torch_ops_extension
-pip3 install .
+bash build_and_install.sh
 ```
 
-### 7.4 vllm-ascend 编译（csrc 保留算子）
+### 3.4 ops-nn
 
-csrc 仍需编译保留的 `_C_ascend` 算子（`compressor_metadata`、GMM 模块 3 个等）：
+> **未打包**。`swiglu_group_quant` 和 `rms_norm_dynamic_quant` 仍用 cann-recipes，ops-nn 版本不配套，后续处理。
+
+### 3.5 ops-transformer whl 包
+
+whl 包是全量编译（包含所有 torch_extension 中注册的算子），不按 `--ops` 选择：
+
+```bash
+cd ops-transformer/torch_extension
+python3 -m pip install -r requirements.txt
+python3 -m build --wheel -n
+python3 -m pip install dist/*.whl --force-reinstall --no-deps
+```
+
+### 3.6 vllm-ascend（csrc 保留算子）
 
 ```bash
 COMPILE_CUSTOM_KERNELS=1 pip install -e .
 ```
 
-`csrc/build_aclnn.sh` 已按 SOC 版本精简编译列表（A3 保留 22 个，A5 保留 6 个），仅编译无法迁移的算子。
+`csrc/build_aclnn.sh` 已按 SOC 版本精简编译列表：
+- **A2 (ascend910b)**：不动，保留全部原始算子
+- **A3 (ascend910_93)**：移除已迁移算子，保留 20 个
+- **A5 (ascend950)**：移除已迁移算子，保留 6 个（compressor_metadata、load_index_kv_cache、causal_conv1d、recurrent_gated_delta_rule、chunk_fwd_o、chunk_gated_delta_rule_fwd_h）
 
-### 7.5 编译顺序
+### 3.7 编译顺序
 
-1. ops-transformer .run + whl（提供 aclnn 内核 + Python binding）
-2. ops-nn .run + whl
-3. cann-recipes-infer .run + whl（hash 路径）
-4. vllm-ascend csrc（保留算子）
+1. ops-transformer 非 experimental（.run）
+2. ops-transformer experimental（.run，--vendor_name=experimental）
+3. cann-recipes-infer（.run + whl）
+4. ops-transformer whl 包
+5. vllm-ascend csrc
 
 ---
 
-## 8. 架构映射
+## 4. 后续迁移计划
+
+### 4.1 待执行（📋，2 个）
+
+| # | 算子 | 当前 | 目标 | 方案 |
+|---|------|------|------|------|
+| 14-15 | quant_lightning_indexer + metadata | `custom.*` (wrapper, ot exp kernel) | `cann_ops_transformer.*` | 切换 Python API；`layout_k` 改 `PA_BBND`；参数改名 |
+
+### 4.2 暂缓（⏳，3 个）
+
+| # | 算子 | 遗留问题 |
+|---|------|---------|
+| 20 | rms_norm_dynamic_quant | DSV4 A5 用 `torch_npu.npu_dynamic_quant`，A3 用 `cann_ops_nn.*`。需平台分支 + ops-nn 打包 |
+| 21 | swiglu_group_quant | DSV4 用 `cann_ops_nn.*`。需 ops-nn 打包 |
+| 22 | moe_gating_top_k_hash | DSV4 hash 路径用纯 PyTorch 实现。需改 vllm hash 路径为 native fallback |
+
+### 4.3 阻塞（❌，4 个）
+
+| # | 算子 | 原因 |
+|---|------|------|
+| 23 | compressor_metadata | graph capture 不兼容，无外部对应 |
+| 24-26 | GMM 模块 3 个 | 无 torch binding 或 vllm 独有；可行方案：3 阶段分解 |
+
+---
+
+## 5. 关键技术决策
+
+| 决策 | 原因 |
+|------|------|
+| 同名 OP_ADD 需同步调整 `build_aclnn.sh` | SO 加载优先级：vllm-ascend > experimental > ot(非exp) > cann-recipes |
+| compressor_metadata 保留 `_C_ascend` | Python 预计算与 graph capture/replay 不兼容，必须作为 graph node 在 forward 路径执行 |
+| compressor 拆融合 norm/rope | ot 版 12 参不含 RMSNorm+RoPE，Python 层用 `npu_rms_norm` + `inplace_partial_rotary_mul` 补偿 |
+| experimental `.run` 包需 `--vendor_name=experimental` | 安装到独立目录，避免与非 experimental 同名 OP_ADD 冲突 |
+| experimental 编译列表需精确指定 | 不能包含 compressor/mhc_post 等与非 experimental 同名且参数不兼容的算子 |
+| dequant_swiglu_quant 条件传参 | 无 `swiglu_limit` 时用默认 `swiglu_mode=0`（不钳位），避免输出错误 |
+
+---
+
+## 6. OP_DEF 冲突审计表
+
+> SO 加载优先级：vllm-ascend > experimental > ops-transformer(非exp) > cann-recipes
+
+| OP_ADD 类名 | vllm | exp | ot | rc | 冲突 | 生效 | 说明 |
+|---|:---:|:---:|:---:|:---:|:---:|---|---|
+| Compressor | ✅ | ✅18参 | ✅12参 | ❌ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
+| InplacePartialRotaryMul | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
+| MhcPost | ❌ | ✅ | ✅ | ❌ | ⚠️ | exp / ot | exp 编译列表不含 mhc_post |
+| KvCompressEpilog | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
+| QuantLightningIndexer | ❌ | ✅(已打包) | ✅(有源码未打包) | ❌ | ⚠️ | exp | exp 优先；非 exp 有完整源码但未打包 |
+| QuantLightningIndexerMetadata | ❌ | ✅(已打包) | ❌ | ❌ | 无 | exp | 仅 exp 有 |
+| RmsNormDynamicQuant | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
+| SparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | 新增非 exp 算子，无同名冲突 |
+| MixedQuantSparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | A5 only (arch35)；A3 无 kernel 但 op_def 注册无害 |
+| SparseAttnSharedkv | ✅ | ✅(未打包) | ❌ | ❌ | ⚠️ | A2A3: vllm | A5 已移除；exp 已移除；A2/A3 需移除 |
+| KvQuantSparseAttnSharedkv | ✅ | ✅(未打包) | ❌ | ❌ | ⚠️ | A2A3: vllm | A5 已移除；exp 已移除；A2/A3 需移除 |
+| MoeGatingTopKHash | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
+| MoeGatingTopK | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
+| SwigluGroupQuant | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
+| ScatterNdUpdate | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除；A2/A3 需移除 |
+| CompressorMetadata | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
+| IndexerQuantCache | ❌ | ❌ | ✅ | ❌ | 无 | ot | |
+| MhcPreSinkhorn | ❌ | ❌ | ✅ | ❌ | 无 | ot | |
+| DequantSwigluQuant | ✅ | ❌ | ❌ | ❌ | 无 | vllm | torch_npu 原生，不依赖 OP_ADD |
+| AddRmsNormBias | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
+| MoeInitRoutingCustom | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留（A2/A3） |
+| MoeInitRoutingV2 | ❌ | ❌ | ✅ | ❌ | 无 | ot | torch_npu 原生调用 |
+| GroupedMatmulSwigluQuantWeightNz | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
+| GroupedMatmulSwigluQuantWeightNzTensorList | ✅ | ❌ | ❌ | ❌ | 无 | vllm | 保留 |
+
+**⚠️ 后续改动检查清单**：新增/回退算子时 → 检查上表冲突 → 确保 `build_aclnn.sh` 移除冲突算子 → 确保 experimental 编译列表不含同名且参数不兼容的算子。
+
+---
+
+## 7. 架构映射
 
 | 标识 | 硬件 | 宏 |
 |------|------|-----|

--- a/docs/ops_migration.md
+++ b/docs/ops_migration.md
@@ -7,29 +7,28 @@
 
 ## 1. 背景与目标
 
-### 1.1 任务
+将 vllm-ascend 中 DeepSeek-V4 原生算子（`torch.ops._C_ascend.*`，由 `csrc/` 编译）切换到 CANN 主线算子仓库（ops-transformer、ops-nn、torch_npu），不再依赖 cann-recipes-infer。
 
-将 vllm-ascend 中 DeepSeek-V4 原生算子（`torch.ops._C_ascend.*`，由 `csrc/` 编译）切换到 CANN 主线算子仓库（ops-transformer、ops-nn），对齐 cann-recipes-infer 仓库中 DeepSeek-V4 的实现。cann-recipes 已基本完成迁移，vllm-ascend 参考其实现进行迁移。
-
-### 1.2 仓库
+### 1.1 仓库
 
 | 仓库 | 说明 | Python 命名空间 |
 |------|------|----------------|
-| ops-transformer | CANN 主线算子仓库（非 experimental + experimental） | `torch.ops.cann_ops_transformer.*` |
+| ops-transformer | CANN 主线算子仓库 | `torch.ops.cann_ops_transformer.*` |
 | ops-nn | CANN 算子仓库（norm/activation） | `torch.ops.cann_ops_nn.*` |
+| torch_npu | torch_npu op-plugin | `torch_npu.npu_*` |
 | vllm-ascend csrc | vllm-ascend 原生算子（保留必要部分） | `torch.ops._C_ascend.*` |
 
-### 1.3 SO 加载优先级
+### 1.2 SO 加载优先级
 
 ```
 vllm-ascend > ops-transformer > ops-nn
 ```
 
-同名 `OP_ADD` 按此优先级覆盖。因此迁移时必须同步调整 `csrc/build_aclnn.sh` 编译列表，移除已迁移算子，避免 vllm-ascend SO 覆盖外部实现。
+同名 `OP_ADD` 按此优先级覆盖。因此迁移时必须同步调整 `csrc/build_aclnn.sh` 编译列表，移除已迁移算子。
 
-### 1.4 约束
+### 1.3 约束
 
-- 仅修改 vllm-ascend，不修改 CANN 仓库
+- 仅修改 vllm-ascend 和 torch_npu（`op_plugin_functions.yaml`），不修改 ops-transformer / ops-nn 仓库
 - csrc 不清理（保留无法迁移的算子）
 - 目标平台 A5 (Ascend 910C / arch35)，兼容 A3 (Ascend 910B / arch22)
 - `csrc/build_aclnn.sh` A2 (ascend910b) 列表不动
@@ -42,34 +41,34 @@ vllm-ascend > ops-transformer > ops-nn
 
 ### 2.1 算子总表
 
-| # | 算子 | 进度 | 原 torch API | 当前 torch API | 目标 torch API | kernel 位置 | 关键信息 |
-|---|------|:---:|---|---|---|---|---|
-| 1 | inplace_partial_rotary_mul | ✅ | `_C_ascend.*` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, posembedding/, arch35 ✅ | 无参数变化 |
-| 2 | compressor | ✅ | `_C_ascend.*` (18参融合) | `cann_ops_transformer.*` (12参) + Python `npu_rms_norm` + `inplace_partial_rotary_mul` | 同当前 | ot 非 exp, attention/, arch35 ✅ (op_api 来自 base 包) | 拆融合；需 `kv[..., :head_dim]` 截断；RoPE view 4D；indexer 用 `indexcom_head_dim` |
-| 3 | kv_compress_epilog `[A5]` | ✅ | `_C_ascend.*` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, attention/, arch35 ✅ | `quant_mode="fp8_bf16"`；cache 保持 4D |
-| 4 | indexer_quant_cache `[A5]` | ✅ | `_C_ascend.indexer_compress_epilog_v2` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, attention/, arch35 ✅ | `cache_scale` float32；cache 4D；参数名 `indexer_full_cache`→`indexer_scale_cache` |
-| 5 | mhc_pre_sinkhorn | ✅ | `_C_ascend.npu_hc_pre_v2` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, mhc/, arch35 ✅ | 参数改名+顺序交换；unsqueeze 3D→4D；返回 8 元组取前 3；comb `unflatten`+`squeeze` |
-| 6 | mhc_post | ✅ | `_C_ascend.npu_hc_post` | `cann_ops_transformer.*` | 同当前 | ot 非 exp, mhc/, arch35 ✅ | 参数顺序重排；去掉 unsqueeze/squeeze |
-| 7 | scatter_nd_update `[A3]` | 🟡 | `_C_ascend.npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | 同当前 | torch_npu pip 包 | 纯改名；保留 `[:x_flat.shape[0]]` 截取；A3 待验证 |
-| 8 | moe_init_routing_v2 | ✅ | `_C_ascend.npu_moe_init_routing_custom` | `torch_npu.npu_moe_init_routing_v2` | 同当前 | torch_npu pip 包 | 纯改名 |
-| 9 | moe_gating_top_k (非hash) | ✅ | `_C_ascend.moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | 同当前 | torch_npu pip 包 | 去掉 `input_ids`/`tid2eid` |
-| 10 | dequant_swiglu_quant | ✅ | `_C_ascend.npu_dequant_swiglu_quant` | `torch_npu.npu_dequant_swiglu_quant` | 同当前 | torch_npu pip 包 | 条件传参：无 limit `swiglu_mode=0`，有 limit 共享专家 `=2`，路由专家 `=1` |
-| 11 | add_rms_norm | ✅ | `_C_ascend.npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | 同当前 | torch_npu pip 包 | bias 不再融合 |
-| 12 | dispatch_ffn_combine `[A3]` | 🟡 | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 基类非融合路径；A3 待验证 |
-| 13 | dispatch_gmm_combine_decode `[A3]` | 🟡 | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 同上；A3 待验证 |
-| 14 | quant_lightning_indexer | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` | 同当前 | ot 非 exp, attention/quant_lightning_indexer_v2/, arch35 ✅ | whl C++ 调 V2 aclnn；`.run` 编译 `quant_lightning_indexer_v2`；`layout_k` 改 `PA_BBND`；`quant_mode` 按 arch 锁定（A5=1 FP8, A3=2 INT8）；`seqused_q` 用 per-batch query token 数 |
-| 15 | quant_lightning_indexer_metadata | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer_metadata` | `cann_ops_transformer.quant_lightning_indexer_metadata` | 同当前 | ot 非 exp, attention/quant_lightning_indexer_v2_metadata/, AICPU | 同上；新增 `seqused_k`/`cmp_residual_k`；删除 `device`/`pre_tokens`/`next_tokens`/`max_seqlen_*` |
-| 16 | sparse_attn_sharedkv `[A3]` | 🟡 | `_C_ascend.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 同当前 | ot 非 exp, attention/sparse_flash_mla/, arch35 ✅ | 算子名变更；`seqused_kv`→`seqused_ori_kv`；`PA_ND`→`PA_BBND`；A3 待验证 |
-| 17 | sparse_attn_sharedkv_metadata `[A3]` | 🟡 | `_C_ascend.npu_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上；A3 待验证 |
-| 18 | kv_quant_sparse_attn_sharedkv `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv` | `cann_ops_transformer.mixed_quant_sparse_flash_mla` | 同当前 | ot 非 exp, attention/mixed_quant_sparse_flash_mla/, arch35 ✅ | A5 路径；`kv_quant_mode`→`quant_mode`；删除 `tile_size` |
-| 19 | kv_quant_sparse_attn_sharedkv_metadata `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.mixed_quant_sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上 |
-| 20 | rms_norm_dynamic_quant | 🟡 | `_C_ascend.*` | `DeviceOperator.rms_norm_dynamic_quant` | 同当前 | ops-nn, norm/, arch22 ✅ (A3)；A5 无 arch35 | A3: `cann_ops_nn.rms_norm_dynamic_quant`（fused）；A5: `npu_rms_norm`+`npu_dynamic_quant`（拆分）；不传 `smooth_scales`；A3 待验证 |
-| 21 | swiglu_group_quant `[A5]` | ✅ | `_C_ascend.*` | `cann_ops_nn.swiglu_group_quant` | 同当前 | ops-nn, activation/, arch35 ✅ | `dst_type=24`（ScalarType）；`quant_mode=1`；`clamp_limit` None→-1.0；A5-only |
-| 22 | moe_gating_top_k_hash | ✅ | `_C_ascend.moe_gating_top_k_hash` | `torch_npu.npu_moe_gating_top_k` | 同当前 | ot 非 exp, moe/moe_gating_top_k/, arch35 ✅ | hash 路径用 `torch_npu.npu_moe_gating_top_k`（13 参数，调 `aclnnMoeGatingTopKV2`）；`k_group=1, group_count=1`；需升级 torch_npu 到 13 参数版本 + `exposed: all_version` |
-| 23 | compressor_metadata | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, attention/, 无 arch35 | graph capture 不兼容，无外部对应 |
-| 24 | grouped_matmul_swiglu_quant_weight_nz | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | 无 torch binding；可行方案：3 阶段分解 |
-| 25 | grouped_matmul_swiglu_quant_weight_nz_tensor_list | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | vllm 独有 |
-| 26 | grouped_matmul_swiglu_quant_v2 | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, arch35 ✅ | vllm 版多 `swigluLimit` 参数 |
+| # | 算子 | 进度 | 原 torch API | 当前 torch API | 关键信息 |
+|---|------|:---:|---|---|---|
+| 1 | inplace_partial_rotary_mul | ✅ | `_C_ascend.*` | `cann_ops_transformer.*` | 无参数变化 |
+| 2 | compressor | ✅ | `_C_ascend.*` (18参融合) | `cann_ops_transformer.*` (12参) + Python `npu_rms_norm` + `inplace_partial_rotary_mul` | 拆融合；需 `kv[..., :head_dim]` 截断；RoPE view 4D；indexer 用 `indexcom_head_dim` |
+| 3 | kv_compress_epilog `[A5]` | ✅ | `_C_ascend.*` | `cann_ops_transformer.*` | 融合 scatter+FP8 quant；A3 对等：`scatter_nd_update`（非融合，先 scatter 再单独 quant） |
+| 4 | indexer_quant_cache `[A5]` | ✅ | `_C_ascend.indexer_compress_epilog_v2` | `cann_ops_transformer.*` | 融合 scatter+FP8 quant；A3 对等：`scatter_nd_update`（非融合） |
+| 5 | mhc_pre_sinkhorn | ✅ | `_C_ascend.npu_hc_pre_v2` | `cann_ops_transformer.*` | 参数改名+顺序交换；unsqueeze 3D→4D；返回 8 元组取前 3；comb `unflatten`+`squeeze` |
+| 6 | mhc_post | ✅ | `_C_ascend.npu_hc_post` | `cann_ops_transformer.*` | 参数顺序重排；去掉 unsqueeze/squeeze |
+| 7 | scatter_nd_update `[A3]` | 🟡 | `_C_ascend.npu_scatter_nd_update_v2` | `torch_npu.npu_scatter_nd_update_` | 非融合 scatter；A5 对等：`kv_compress_epilog` + `indexer_quant_cache`（融合 scatter+quant）；A3 待验证 |
+| 8 | moe_init_routing_v2 | ✅ | `_C_ascend.npu_moe_init_routing_custom` | `torch_npu.npu_moe_init_routing_v2` | 纯改名 |
+| 9 | moe_gating_top_k (非hash) | ✅ | `_C_ascend.moe_gating_top_k` | `torch_npu.npu_moe_gating_top_k` | 去掉 `input_ids`/`tid2eid` |
+| 10 | dequant_swiglu_quant | ✅ | `_C_ascend.npu_dequant_swiglu_quant` | `torch_npu.npu_dequant_swiglu_quant` | 条件传参：无 limit `swiglu_mode=0`，有 limit 共享专家 `=2`，路由专家 `=1` |
+| 11 | add_rms_norm | ✅ | `_C_ascend.npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | bias 不再融合 |
+| 12 | dispatch_ffn_combine `[A3]` | 🟡 | `_C_ascend.*` | `super().fused_experts()` | `FusedMC2CommImpl` 拆分 dispatch+FFN+combine；A5 不执行，走 `MC2CommImpl`（MC2 融合通信+GMM 不拆分）；A3 待验证 |
+| 13 | dispatch_gmm_combine_decode `[A3]` | 🟡 | `_C_ascend.*` | `super().fused_experts()` | 同 #12；A3 待验证 |
+| 14 | quant_lightning_indexer | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` | `.run` 编译 `quant_lightning_indexer_v2`；`layout_k` 改 `PA_BBND`；`quant_mode` 按 arch 锁定（A5=1 FP8, A3=2 INT8）；`seqused_q` 用 per-batch query token 数；`cu_seqlens_q` 传完整 `[B+1]` |
+| 15 | quant_lightning_indexer_metadata | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer_metadata` | `cann_ops_transformer.quant_lightning_indexer_metadata` | 新增 `seqused_k`/`cmp_residual_k`；删除 `device`/`pre_tokens`/`next_tokens`/`max_seqlen_*` |
+| 16 | sparse_attn_sharedkv `[A3]` | 🟡 | `_C_ascend.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 非量化 bf16 KV cache；A5 对等：`mixed_quant_sparse_flash_mla`（FP8 量化 KV cache）；`seqused_kv`→`seqused_ori_kv`；`PA_ND`→`PA_BBND`；A3 待验证 |
+| 17 | sparse_attn_sharedkv_metadata `[A3]` | 🟡 | `_C_ascend.npu_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.sparse_flash_mla_metadata` | A5 对等：`mixed_quant_sparse_flash_mla_metadata`；A3 待验证 |
+| 18 | kv_quant_sparse_attn_sharedkv `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv` | `cann_ops_transformer.mixed_quant_sparse_flash_mla` | FP8 量化 KV cache；A3 对等：`sparse_flash_mla`（非量化 bf16）；`kv_quant_mode`→`quant_mode`；删除 `tile_size` |
+| 19 | kv_quant_sparse_attn_sharedkv_metadata `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.mixed_quant_sparse_flash_mla_metadata` | A3 对等：`sparse_flash_mla_metadata` |
+| 20 | rms_norm_dynamic_quant | 🟡 | `_C_ascend.*` | `DeviceOperator.rms_norm_dynamic_quant` | A3: `cann_ops_nn.rms_norm_dynamic_quant`（fused）；A5: `npu_rms_norm`+`npu_dynamic_quant`（拆分）；不传 `smooth_scales`；A3 待验证 |
+| 21 | swiglu_group_quant `[A5]` | ✅ | `_C_ascend.*` | `cann_ops_nn.swiglu_group_quant` | A3 不执行（W4A8MXFP 路径不存在）；`dst_type=24`；`quant_mode=1`；`clamp_limit` None→-1.0 |
+| 22 | moe_gating_top_k_hash | ✅ | `_C_ascend.moe_gating_top_k_hash` | `torch_npu.npu_moe_gating_top_k` | 13 参数（调 `aclnnMoeGatingTopKV2`）；`k_group=1, group_count=1`；需升级 torch_npu 到 13 参数版本 + `exposed: all_version` |
+| 23 | compressor_metadata | ❌ | `_C_ascend.*` | 同原 | graph capture 不兼容，无外部对应 |
+| 24 | grouped_matmul_swiglu_quant_weight_nz | ❌ | `_C_ascend.*` | 同原 | 无 torch binding；可行方案：3 阶段分解 |
+| 25 | grouped_matmul_swiglu_quant_weight_nz_tensor_list | ❌ | `_C_ascend.*` | 同原 | vllm 独有 |
+| 26 | grouped_matmul_swiglu_quant_v2 | ❌ | `_C_ascend.*` | 同原 | vllm 版多 `swigluLimit` 参数 |
 
 ### 2.2 迁移统计
 
@@ -88,7 +87,8 @@ vllm-ascend > ops-transformer > ops-nn
 | `vllm_ascend/attention/dsa_v1.py` | inplace_partial_rotary_mul/compressor→cann_ops_transformer；rms_norm_dynamic_quant→DeviceOperator.rms_norm_dynamic_quant；quant_lightning_indexer→cann_ops_transformer；compressor_metadata 保留 `_C_ascend` |
 | `vllm_ascend/attention/context_parallel/dsa_cp.py` | 同上 |
 | `vllm_ascend/models/deepseek_v4.py` | mhc_pre_sinkhorn/mhc_post→cann_ops_transformer；cache_dim 608 公式对齐 cann-recipes |
-| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；quant_lightning_indexer quant_mode→DeviceOperator.get_qli_quant_mode()；rms_norm_dynamic_quant→DeviceOperator.rms_norm_dynamic_quant；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→cann_ops_nn |
+| `vllm_ascend/models/layer/attention/layer.py` | cache_dim 608 公式 + `_DSV4_BLOCK_SIZES_A5` pads[1] 更新 |
+| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；quant_lightning_indexer quant_mode→DeviceOperator.get_qli_quant_mode()；rms_norm_dynamic_quant→DeviceOperator.rms_norm_dynamic_quant；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→cann_ops_nn；`index_fill` 空 indices 保护 |
 | `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→torch_npu.npu_moe_gating_top_k（13 参数）；k_group/group_count=1 |
 | `vllm_ascend/ops/fused_moe/fused_moe.py` | swiglu_group_quant→cann_ops_nn；dequant_swiglu_quant→torch_npu |
 | `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | 同上 |
@@ -117,7 +117,7 @@ sparse_flash_mla_metadata, mixed_quant_sparse_flash_mla_metadata, quant_lightnin
 >
 > ℹ️ whl C++ 扩展调用 V2 aclnn 符号（`aclnnQuantLightningIndexerV2`），`.run` 包必须编译 `quant_lightning_indexer_v2`（不是 V1）。
 >
-> ℹ️ `--pkg` 会自动构建 `.run` 包 **和** whl 包（`build_torch_extension_whl` 在 `--pkg` 流程中自动执行），whl 是全量编译不按 `--ops` 选择。
+> ℹ️ `--pkg` 会自动构建 `.run` 包 **和** whl 包，whl 是全量编译不按 `--ops` 选择。
 
 ```bash
 cd ops-transformer
@@ -144,13 +144,11 @@ python3 -m pip install build_out/*.whl --force-reinstall --no-deps
 rms_norm_dynamic_quant, swiglu_group_quant
 ```
 
-> ℹ️ ops-nn torch_extension 与 ops-transformer 架构一致：`cann_ops_nn` namespace + OpBuilder JIT + `aclnn_common.h`。
->
 > ℹ️ `rms_norm_dynamic_quant` 有 arch22（A3），无 arch35（A5）→ A5 走 `npu_rms_norm`+`npu_dynamic_quant` 拆分。
 >
 > ℹ️ `swiglu_group_quant` 仅 arch35（A5），A5-only 算子。
 >
-> ℹ️ `.run` 包和 whl 包**分开构建**：`--pkg` 只构建 `.run` 包，`--torch_extension` 只构建 whl 包。
+> ℹ️ `.run` 包和 whl 包**分开构建**：`--pkg` 只构建 `.run` 包，whl 整包构建。
 
 ```bash
 cd ops-nn
@@ -167,7 +165,6 @@ bash build.sh --pkg --soc=ascend950 --ops=swiglu_group_quant
 ./build_out/*.run
 
 # --- whl 包（torch binding，JIT 编译）---
-# 整包构建（包含所有 op 的框架 + 自动扫描 torch_extension）
 cd torch_extension
 python3 -m pip install -r requirements.txt
 python3 -m build --wheel -n
@@ -178,7 +175,7 @@ python3 -m pip install dist/cann_ops_nn-*.whl --force-reinstall --no-deps
 
 > ℹ️ `npu_moe_gating_top_k` 需要升级到 13 参数版本（支持 `input_ids`/`tid2eid` hash 模式）。
 >
-> ℹ️ 源码 `op_plugin_functions.yaml` 中 `npu_moe_gating_top_k` 缺少 `exposed: all_version`，需手动添加才能暴露到 Python `torch_npu.npu_moe_gating_top_k`。
+> ℹ️ 源码 `op_plugin_functions.yaml` 中 `npu_moe_gating_top_k` 缺少 `exposed: all_version`，需手动添加才能暴露到 Python。
 
 ```bash
 cd ascend/pytorch
@@ -211,11 +208,7 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 
 ---
 
-## 4. 后续迁移计划
-
-全部可迁移算子已完成（22/26）。剩余 4 个为阻塞状态。
-
-### 4.3 阻塞（❌，4 个）
+## 4. 阻塞算子（❌，4 个）
 
 | # | 算子 | 原因 |
 |---|------|------|
@@ -232,28 +225,20 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 | compressor_metadata 保留 `_C_ascend` | Python 预计算与 graph capture/replay 不兼容，必须作为 graph node 在 forward 路径执行 |
 | compressor 拆融合 norm/rope | ot 版 12 参不含 RMSNorm+RoPE，Python 层用 `npu_rms_norm` + `inplace_partial_rotary_mul` 补偿 |
 | dequant_swiglu_quant 条件传参 | 无 `swiglu_limit` 时用默认 `swiglu_mode=0`（不钳位），避免输出错误 |
-| `rms_norm_dynamic_quant` A5 拆分 | ops-nn 无 arch35 kernel，A5 走 `npu_rms_norm` + `npu_dynamic_quant`，对齐 cann-recipes |
-| `swiglu_group_quant` `dst_type=24` | ops-nn `GetAclDataType` 同时支持 ScalarType(24) 和 DType enum(291)，用 24 对齐 cann-recipes |
+| `rms_norm_dynamic_quant` A5 拆分 | ops-nn 无 arch35 kernel，A5 走 `npu_rms_norm` + `npu_dynamic_quant` |
+| `swiglu_group_quant` `dst_type=24` | ops-nn `GetAclDataType` 同时支持 ScalarType(24) 和 DType enum(291) |
 | `quant_lightning_indexer_v2` 而非 v1 | whl C++ 扩展调 V2 aclnn 符号，`.run` 包必须编译 v2 目录 |
 | `sparse_flash_mla` metadata 手动编译 | metadata 不会随主算子自动编译，必须在 `--ops` 中显式列出 |
-| torch_npu `npu_moe_gating_top_k` 需升级 | 源码有 13 参数版本（支持 hash），但缺 `exposed: all_version`；需手动添加并重新编译安装 |
-| ops-nn whl 整包构建 | `--torch_extension --ops=` 子包方式依赖整包先安装；直接整包构建最简单 |
+| torch_npu `npu_moe_gating_top_k` 需升级 | 源码有 13 参数版本（支持 hash），但缺 `exposed: all_version`；需手动添加并重新编译 |
+| ops-nn whl 整包构建 | 子包方式依赖整包先安装；直接整包构建最简单 |
+| `index_fill` 空 indices 保护 | NPU `InplaceIndexFill` 不接受空 tensor，需 `if indices.numel() > 0` 跳过 |
 
 ---
 
-## 6. OP_ADD 冲突注意事项
-
-迁移后大部分同名 OP_ADD 冲突已消除（vllm-ascend csrc 编译列表已移除已迁移算子）。新增/回退算子时仍需检查：
-
-1. 同名 `OP_ADD` 按 SO 加载优先级覆盖（见 1.3 节），vllm-ascend csrc 优先级最高
-2. 确保 `csrc/build_aclnn.sh` 不再编译已迁移算子（否则会覆盖外部实现）
-
----
-
-## 7. 架构映射
+## 6. 架构映射
 
 | 标识 | 硬件 | 宏 |
 |------|------|-----|
 | arch22 | Ascend 910B (A3) | `__CCE_AICORE__ == 220` |
 | arch35 | Ascend 910C (A5) | `__CCE_AICORE__ == 310` / `__DAV_C310__` |
-| ascend950 | Ascend 910C (A5) | cann-recipes A5 编译目标 |
+| ascend950 | Ascend 910C (A5) | A5 编译目标 |

--- a/docs/ops_migration.md
+++ b/docs/ops_migration.md
@@ -66,7 +66,7 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 | 19 | kv_quant_sparse_attn_sharedkv_metadata `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.mixed_quant_sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上 |
 | 20 | rms_norm_dynamic_quant | ⏳ | `_C_ascend.*` | `custom.npu_rms_norm_dynamic_quant` | A5: `torch_npu.npu_dynamic_quant`；A3: `cann_ops_nn.rms_norm_dynamic_quant` | cann-recipes, src/, 无 arch35 | DSV4 A5 用 `npu_dynamic_quant`，A3 用 `cann_ops_nn.*`；需平台分支；ops-nn 未打包 |
 | 21 | swiglu_group_quant `[A5]` | ⏳ | `_C_ascend.*` | `custom.npu_swiglu_group_quant` | `cann_ops_nn.swiglu_group_quant` | cann-recipes, src/, 无 arch35 | DSV4 所有平台都用 `cann_ops_nn.*`；ops-nn 未打包 |
-| 22 | moe_gating_top_k_hash | ⏳ | `_C_ascend.moe_gating_top_k_hash` | `custom.npu_moe_gating_top_k` | PyTorch native fallback | cann-recipes, src/, arch35 ✅ | DSV4 hash 路径用纯 PyTorch 实现；需改 vllm hash 路径为 native fallback |
+| 22 | moe_gating_top_k_hash | ✅ | `_C_ascend.moe_gating_top_k_hash` | `torch_npu.npu_moe_gating_top_k` | 同当前 | ot 非 exp, moe/moe_gating_top_k/, arch35 ✅ | hash 路径改用 `torch_npu.npu_moe_gating_top_k`（调 `aclnnMoeGatingTopKV2`）；`k_group=1, group_count=1`（hash 模式简化路径） |
 | 23 | compressor_metadata | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, attention/, 无 arch35 | graph capture 不兼容，无外部对应 |
 | 24 | grouped_matmul_swiglu_quant_weight_nz | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | 无 torch binding；可行方案：3 阶段分解 |
 | 25 | grouped_matmul_swiglu_quant_weight_nz_tensor_list | ❌ | `_C_ascend.*` | 同原 | 同原 | vllm csrc, gmm/, 无 arch35 | vllm 独有 |
@@ -76,9 +76,9 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 | 进度 | 数量 | 说明 |
 |------|:---:|------|
-| ✅ 完成 | 19 | 已对齐 DSV4，当前=目标 |
+| ✅ 完成 | 20 | 已对齐 DSV4，当前=目标 |
 | 📋 待执行 | 0 | 全部完成 |
-| ⏳ 暂缓 | 3 | 依赖 ops-nn 打包或需改 hash 路径为 native fallback |
+| ⏳ 暂缓 | 2 | 依赖 ops-nn 打包 |
 | ❌ 阻塞 | 4 | graph capture 不兼容或无外部对应 |
 | **合计** | 26 | |
 
@@ -91,7 +91,7 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 | `vllm_ascend/attention/context_parallel/dsa_cp.py` | 同上 |
 | `vllm_ascend/models/deepseek_v4.py` | mhc_pre_sinkhorn/mhc_post→cann_ops_transformer |
 | `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；quant_lightning_indexer quant_mode→DeviceOperator.get_qli_quant_mode()；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→custom |
-| `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→custom |
+| `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→torch_npu.npu_moe_gating_top_k（hash 路径）；k_group/group_count=1 |
 | `vllm_ascend/ops/fused_moe/fused_moe.py` | swiglu_group_quant→custom；dequant_swiglu_quant→torch_npu |
 | `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | 同上 |
 | `vllm_ascend/ops/fused_moe/moe_mlp.py` | dequant_swiglu_quant→torch_npu |
@@ -178,7 +178,7 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 
 `csrc/build_aclnn.sh` 已按 SOC 版本精简编译列表：
 - **A2 (ascend910b)**：不动，保留全部原始算子
-- **A3 (ascend910_93)**：移除已迁移算子，保留 18 个
+- **A3 (ascend910_93)**：移除已迁移算子，保留 17 个
 - **A5 (ascend950)**：移除已迁移算子，保留 6 个（compressor_metadata、load_index_kv_cache、causal_conv1d、recurrent_gated_delta_rule、chunk_fwd_o、chunk_gated_delta_rule_fwd_h）
 
 ### 3.7 编译顺序
@@ -198,7 +198,6 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 |---|------|---------|
 | 20 | rms_norm_dynamic_quant | DSV4 A5 用 `torch_npu.npu_dynamic_quant`，A3 用 `cann_ops_nn.*`。需平台分支 + ops-nn 打包 |
 | 21 | swiglu_group_quant | DSV4 用 `cann_ops_nn.*`。需 ops-nn 打包 |
-| 22 | moe_gating_top_k_hash | DSV4 hash 路径用纯 PyTorch 实现。需改 vllm hash 路径为 native fallback |
 
 ### 4.3 阻塞（❌，4 个）
 
@@ -239,7 +238,7 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 | MixedQuantSparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | A5 only (arch35)；A3 无 kernel 但 op_def 注册无害 |
 | SparseAttnSharedkv | ✅ | ✅(未打包) | ❌ | ❌ | ⚠️ | A2A3: vllm | A5 已移除；exp 已移除；A2/A3 需移除 |
 | KvQuantSparseAttnSharedkv | ✅ | ✅(未打包) | ❌ | ❌ | ⚠️ | A2A3: vllm | A5 已移除；exp 已移除；A2/A3 需移除 |
-| MoeGatingTopKHash | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
+| MoeGatingTopKHash | ✅ | ❌ | ❌ | ✅ | ⚠️ | A2A3: vllm | A3 已移除；hash 路径改用 `torch_npu.npu_moe_gating_top_k`（调 `aclnnMoeGatingTopKV2`） |
 | MoeGatingTopK | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
 | SwigluGroupQuant | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
 | ScatterNdUpdate | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除；A2/A3 需移除 |

--- a/docs/ops_migration.md
+++ b/docs/ops_migration.md
@@ -58,8 +58,8 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 | 11 | add_rms_norm | ✅ | `_C_ascend.npu_add_rms_norm_bias` | `torch_npu.npu_add_rms_norm` + `x.add_(bias)` | 同当前 | torch_npu pip 包 | bias 不再融合 |
 | 12 | dispatch_ffn_combine `[A3]` | ✅ | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 基类非融合路径 |
 | 13 | dispatch_gmm_combine_decode `[A3]` | ✅ | `_C_ascend.*` | `super().fused_experts()` | 同当前 | 无独立内核 | 同上 |
-| 14 | quant_lightning_indexer | 📋 | `_C_ascend.npu_vllm_quant_lightning_indexer` | `custom.npu_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` | ot exp, attention/quant_lightning_indexer/, arch35 ✅ | `layout_k` 改 `PA_BBND`；参数改名；`quant_mode` 按 arch 锁定 |
-| 15 | quant_lightning_indexer_metadata | 📋 | `_C_ascend.npu_vllm_quant_lightning_indexer_metadata` | `custom.npu_quant_lightning_indexer_metadata` | `cann_ops_transformer.quant_lightning_indexer_metadata` | ot exp, AICPU | 新增 `seqused_k`/`cmp_residual_k`；删除 `device`/`pre_tokens`/`next_tokens` |
+| 14 | quant_lightning_indexer | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer` | `cann_ops_transformer.quant_lightning_indexer` | 同当前 | ot 非 exp, attention/quant_lightning_indexer_v2/, arch35 ✅ | whl C++ 调 V2 aclnn；`.run` 编译 `quant_lightning_indexer_v2`；`layout_k` 改 `PA_BBND`；`quant_mode` 按 arch 锁定（A5=1 FP8, A3=2 INT8）；`seqused_q` 用 per-batch query token 数 |
+| 15 | quant_lightning_indexer_metadata | ✅ | `_C_ascend.npu_vllm_quant_lightning_indexer_metadata` | `cann_ops_transformer.quant_lightning_indexer_metadata` | 同当前 | ot 非 exp, attention/quant_lightning_indexer_v2_metadata/, AICPU | 同上；新增 `seqused_k`/`cmp_residual_k`；删除 `device`/`pre_tokens`/`next_tokens`/`max_seqlen_*` |
 | 16 | sparse_attn_sharedkv `[A3]` | ✅ | `_C_ascend.npu_sparse_attn_sharedkv` | `cann_ops_transformer.sparse_flash_mla` | 同当前 | ot 非 exp, attention/sparse_flash_mla/, arch35 ✅ | 算子名变更；`seqused_kv`→`seqused_ori_kv`；`PA_ND`→`PA_BBND`；新增 `seqused_cmp_kv`/`cmp_residual_kv`/`topk_value_mode` |
 | 17 | sparse_attn_sharedkv_metadata `[A3]` | ✅ | `_C_ascend.npu_sparse_attn_sharedkv_metadata` | `cann_ops_transformer.sparse_flash_mla_metadata` | 同当前 | ot 非 exp, AICPU | 同上；新增 `max_seqlen_cmp_kv`；删除 `device` |
 | 18 | kv_quant_sparse_attn_sharedkv `[A5]` | ✅ | `_C_ascend.npu_kv_quant_sparse_attn_sharedkv` | `cann_ops_transformer.mixed_quant_sparse_flash_mla` | 同当前 | ot 非 exp, attention/mixed_quant_sparse_flash_mla/, arch35 ✅ | A5 路径；`kv_quant_mode`→`quant_mode`；删除 `tile_size` |
@@ -76,8 +76,8 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 | 进度 | 数量 | 说明 |
 |------|:---:|------|
-| ✅ 完成 | 17 | 已对齐 DSV4，当前=目标 |
-| 📋 待执行 | 2 | 当前用 cann-recipes wrapper，目标切到 ops-transformer |
+| ✅ 完成 | 19 | 已对齐 DSV4，当前=目标 |
+| 📋 待执行 | 0 | 全部完成 |
 | ⏳ 暂缓 | 3 | 依赖 ops-nn 打包或需改 hash 路径为 native fallback |
 | ❌ 阻塞 | 4 | graph capture 不兼容或无外部对应 |
 | **合计** | 26 | |
@@ -90,7 +90,7 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 | `vllm_ascend/attention/dsa_v1.py` | inplace_partial_rotary_mul/compressor→cann_ops_transformer；rms_norm_dynamic_quant/quant_lightning_indexer→custom；compressor_metadata 保留 `_C_ascend` |
 | `vllm_ascend/attention/context_parallel/dsa_cp.py` | 同上 |
 | `vllm_ascend/models/deepseek_v4.py` | mhc_pre_sinkhorn/mhc_post→cann_ops_transformer |
-| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→custom |
+| `vllm_ascend/device/device_op.py` | compressor→cann_ops_transformer；kv_compress_epilog/indexer_quant_cache→cann_ops_transformer；sparse_flash_mla/mixed_quant_sparse_flash_mla→cann_ops_transformer；quant_lightning_indexer quant_mode→DeviceOperator.get_qli_quant_mode()；scatter_nd_update→torch_npu；moe_gating_top_k/moe_init_routing→torch_npu；swiglu_group_quant→custom |
 | `vllm_ascend/ops/fused_moe/experts_selector.py` | moe_gating_top_k_hash→custom |
 | `vllm_ascend/ops/fused_moe/fused_moe.py` | swiglu_group_quant→custom；dequant_swiglu_quant→torch_npu |
 | `vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py` | 同上 |
@@ -107,21 +107,25 @@ vllm-ascend > experimental > ops-transformer(非experimental) > cann-recipes
 
 ### 3.1 ops-transformer（非 experimental）
 
-**已打包算子（8 个）**：
+**已打包算子（9 个，含 metadata）**：
 ```
-inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla
+inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla,quant_lightning_indexer_v2
 ```
+
+> ⚠️ metadata 算子（`sparse_flash_mla_metadata`、`mixed_quant_sparse_flash_mla_metadata`、`quant_lightning_indexer_v2_metadata`）**必须手动在 `--ops` 中列出**，不会随主算子自动编译。
+>
+> ℹ️ `quant_lightning_indexer_v2` 的 whl C++ 扩展（`csrc/quant_lightning_indexer.cpp`）调用 V2 aclnn 符号（`aclnnQuantLightningIndexerV2` / `aclnnQuantLightningIndexerV2Metadata`），因此 `.run` 包必须编译 `quant_lightning_indexer_v2`（不是 V1 的 `quant_lightning_indexer`）。
 
 ```bash
 cd ops-transformer
 
 # A3
 bash build.sh --pkg --soc=ascend910_93 \
-  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,sparse_flash_mla_metadata,mixed_quant_sparse_flash_mla,mixed_quant_sparse_flash_mla_metadata,quant_lightning_indexer_v2,quant_lightning_indexer_v2_metadata
 
 # A5
 bash build.sh --pkg --soc=ascend950 \
-  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,mixed_quant_sparse_flash_mla
+  --ops=inplace_partial_rotary_mul,kv_compress_epilog,indexer_quant_cache,mhc_pre_sinkhorn,mhc_post,compressor,sparse_flash_mla,sparse_flash_mla_metadata,mixed_quant_sparse_flash_mla,mixed_quant_sparse_flash_mla_metadata,quant_lightning_indexer_v2,quant_lightning_indexer_v2_metadata
 
 # 安装
 ./build_out/cann-ops-transformer-custom_linux-*.run
@@ -129,27 +133,7 @@ bash build.sh --pkg --soc=ascend950 \
 
 ### 3.2 ops-transformer（experimental）
 
-**已打包算子（2 个）**：
-```
-quant_lightning_indexer,quant_lightning_indexer_metadata
-```
-
-```bash
-cd ops-transformer
-
-# A3
-bash build.sh --pkg --experimental --vendor_name=experimental --soc=ascend910_93 \
-  --ops=quant_lightning_indexer,quant_lightning_indexer_metadata
-
-# A5
-bash build.sh --pkg --experimental --vendor_name=experimental --soc=ascend950 \
-  --ops=quant_lightning_indexer,quant_lightning_indexer_metadata
-
-# 安装
-./build_out/cann-ops-transformer-experimental_linux-*.run
-```
-
-> ⚠️ experimental 编译列表**不能**包含 compressor/mhc_post 等与非 experimental 同名 OP_ADD 且参数不兼容的算子。
+> **不再需要**。quant_lightning_indexer + metadata 已迁移到非 experimental（3.1），experimental 包无算子。
 
 ### 3.3 cann-recipes-infer
 
@@ -194,28 +178,21 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 
 `csrc/build_aclnn.sh` 已按 SOC 版本精简编译列表：
 - **A2 (ascend910b)**：不动，保留全部原始算子
-- **A3 (ascend910_93)**：移除已迁移算子，保留 20 个
+- **A3 (ascend910_93)**：移除已迁移算子，保留 18 个
 - **A5 (ascend950)**：移除已迁移算子，保留 6 个（compressor_metadata、load_index_kv_cache、causal_conv1d、recurrent_gated_delta_rule、chunk_fwd_o、chunk_gated_delta_rule_fwd_h）
 
 ### 3.7 编译顺序
 
 1. ops-transformer 非 experimental（.run）
-2. ops-transformer experimental（.run，--vendor_name=experimental）
-3. cann-recipes-infer（.run + whl）
-4. ops-transformer whl 包
-5. vllm-ascend csrc
+2. cann-recipes-infer（.run + whl）
+3. ops-transformer whl 包
+4. vllm-ascend csrc
 
 ---
 
 ## 4. 后续迁移计划
 
-### 4.1 待执行（📋，2 个）
-
-| # | 算子 | 当前 | 目标 | 方案 |
-|---|------|------|------|------|
-| 14-15 | quant_lightning_indexer + metadata | `custom.*` (wrapper, ot exp kernel) | `cann_ops_transformer.*` | 切换 Python API；`layout_k` 改 `PA_BBND`；参数改名 |
-
-### 4.2 暂缓（⏳，3 个）
+### 4.1 暂缓（⏳，3 个）
 
 | # | 算子 | 遗留问题 |
 |---|------|---------|
@@ -255,8 +232,8 @@ COMPILE_CUSTOM_KERNELS=1 pip install -e .
 | InplacePartialRotaryMul | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
 | MhcPost | ❌ | ✅ | ✅ | ❌ | ⚠️ | exp / ot | exp 编译列表不含 mhc_post |
 | KvCompressEpilog | ✅ | ❌ | ✅ | ✅ | ⚠️ | A5: ot / A2A3: vllm | A5 已移除；A2/A3 需移除 |
-| QuantLightningIndexer | ❌ | ✅(已打包) | ✅(有源码未打包) | ❌ | ⚠️ | exp | exp 优先；非 exp 有完整源码但未打包 |
-| QuantLightningIndexerMetadata | ❌ | ✅(已打包) | ❌ | ❌ | 无 | exp | 仅 exp 有 |
+| QuantLightningIndexerV2 | ❌ | ✅(已打包) | ✅(已打包) | ❌ | ⚠️ | ot 非 exp | whl C++ 调 V2 aclnn；`.run` 编译 `quant_lightning_indexer_v2`；A2A3 vllm csrc 需移除 |
+| QuantLightningIndexerV2Metadata | ❌ | ✅(已打包) | ✅(已打包) | ❌ | 无 | ot 非 exp | 同上 |
 | RmsNormDynamicQuant | ✅ | ❌ | ❌ | ✅ | ⚠️ | A5: rc / A2A3: vllm | A5 已移除 |
 | SparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | 新增非 exp 算子，无同名冲突 |
 | MixedQuantSparseFlashMla | ❌ | ❌ | ✅(已打包) | ❌ | 无 | ot | A5 only (arch35)；A3 无 kernel 但 op_def 注册无害 |

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -27,6 +27,11 @@ from vllm_ascend.utils import (
     olora_tp_enable,
 )
 
+try:  # noqa: SIM105
+    import cann_ops_transformer  # noqa: F401  # registers torch.ops.cann_ops_transformer.*
+except ImportError:
+    pass
+
 
 def hadamard_transform_ref(
     x: torch.Tensor,
@@ -864,7 +869,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if metadata is None:
             max_seqlen_q = max(1, int(seq_lens_q.max().item()))
             max_seqlen_k = max(1, int(seq_lens.max().item()))
-            metadata = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
+            metadata = torch.ops.custom.npu_quant_lightning_indexer_metadata(
                 actual_seq_lengths_query=query_start_loc[1:].clone(),
                 actual_seq_lengths_key=seq_lens.clone(),
                 num_heads_q=self.model_config.hf_config.index_n_heads,
@@ -1303,7 +1308,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             self.wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod
         ):
             q_a = self.wq_a(hidden_states_local)
-            qr_local, qr_pertoken_scale_local = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            qr_local, qr_pertoken_scale_local = torch.ops.custom.npu_rms_norm_dynamic_quant(
                 q_a, self.q_norm.weight, epsilon=self.eps
             )
             if getattr(self.wq_b, "_chunk_size", 0):
@@ -1349,7 +1354,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         q = q.unflatten(-1, (self.num_heads, self.head_dim))
 
         q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             local_cos,
             local_sin,
@@ -1363,7 +1368,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         kv = self.kv_norm(kv)
         assert self.rope_head_dim is not None
         kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             kv.unsqueeze(1),
             cos[: kv.shape[0]],
             sin[: kv.shape[0]],
@@ -1399,7 +1404,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(
                 compressor_attn_metadata.req_metadata,
             )
-            compressed_kv = torch.ops._C_ascend.compressor(
+            compressed_kv = DeviceOperator.dsa_compressor(
                 hidden_states_cache,
                 self.compressor_wkv.weight,
                 self.compressor_wgate.weight,
@@ -1497,7 +1502,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         req_metadata = attn_metadata.req_metadata
         cp_metadata = req_metadata.cp_metadata
         num_tokens = local_attn_output.shape[0]
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             local_attn_output.unsqueeze(1),
             cp_metadata.local_cos[layer_name],
             -cp_metadata.local_sin[layer_name],
@@ -1538,7 +1543,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         compressed_cos, compressed_sin, indexer_slot_mapping = self._compute_compressor_metadata(
             indexer_kv_scale_metadata.req_metadata,
         )
-        kv = torch.ops._C_ascend.compressor(
+        kv = DeviceOperator.dsa_compressor(
             x,
             self.indexcom_wkv.weight,
             self.indexcom_wgate.weight,
@@ -1567,7 +1572,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         _, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
             kv,
             indexer_k_cache,
-            indexer_full_cache,
+            indexer_scale_cache,
             indexer_slot_mapping,
         )
         if kv_scale is not None:
@@ -1610,7 +1615,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         else:
             q = self.inderxer_wq_b(qr)
         q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             cos,
             sin,
@@ -1625,7 +1630,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         assert indexer_kv_scale_metadata.req_metadata is not None
         qli_metadata = indexer_kv_scale_metadata.req_metadata.qli_metadata
         block_table = indexer_kv_scale_metadata.req_metadata.block_table
-        topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+        topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
             weights=DeviceOperator.prepare_dsa_indexer_weights(weights),

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1410,19 +1410,25 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 self.compressor_wgate.weight,
                 state_cache.squeeze(-2),
                 self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
+                self.compress_ratio,
                 state_block_table=compressor_kv_state_metadata.req_metadata.block_table,
                 cu_seqlens=actual_seq_lengths_query,
                 seqused=None,
                 start_pos=req_metadata.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
                 coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
                 cache_mode=1,
+            )
+            # RMSNorm + RoPE (was fused inside old compressor kernel)
+            compressed_kv = compressed_kv[..., : self.compressor_head_dim]
+            compressed_kv = torch_npu.npu_rms_norm(
+                compressed_kv, self.compressor_norm.weight.to(torch.float32), self.compressor_norm_eps
+            )[0]
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
+                compressed_kv.view(-1, 1, 1, self.compressor_head_dim),
+                compress_cos.view(-1, 1, 1, self.rope_head_dim),
+                compress_sin.view(-1, 1, 1, self.rope_head_dim),
+                rotary_mode="interleave",
+                partial_slice=[self.compressor_head_dim - self.rope_head_dim, self.compressor_head_dim],
             )
 
             if compressed_kv.numel() == 0:
@@ -1549,19 +1555,23 @@ class AscendDSACPImpl(DSAAttentionImpl):
             self.indexcom_wgate.weight,
             indexer_state_cache.squeeze(-2),
             self.indexcom_ape,
-            self.indexcom_norm.weight,
-            compressed_sin.view(-1, compressed_sin.shape[-1]),
-            compressed_cos.view(-1, compressed_cos.shape[-1]),
+            self.compress_ratio,
             state_block_table=indexer_kv_state_metadata.req_metadata.block_table,
             cu_seqlens=actual_seq_lengths_query,
             seqused=None,
             start_pos=indexer_kv_scale_metadata.req_metadata.start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
             coff=coff,
-            norm_eps=self.compressor_norm_eps,
-            rotary_mode=2,
             cache_mode=1,
+        )
+        # RMSNorm + RoPE (was fused inside old compressor kernel)
+        kv = kv[..., : self.indexcom_head_dim]
+        kv = torch_npu.npu_rms_norm(kv, self.indexcom_norm.weight.to(torch.float32), self.compressor_norm_eps)[0]
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
+            kv.view(-1, 1, 1, self.indexcom_head_dim),
+            compressed_cos.view(-1, 1, 1, self.rope_head_dim),
+            compressed_sin.view(-1, 1, 1, self.rope_head_dim),
+            rotary_mode="interleave",
+            partial_slice=[self.indexcom_head_dim - self.rope_head_dim, self.indexcom_head_dim],
         )
 
         if kv.numel() == 0:

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -860,27 +860,21 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
 
         if metadata is None:
-            max_seqlen_q = max(1, int(seq_lens_q.max().item()))
-            max_seqlen_k = max(1, int(seq_lens.max().item()))
-            metadata = torch.ops.custom.npu_quant_lightning_indexer_metadata(
-                actual_seq_lengths_query=query_start_loc[1:].clone(),
-                actual_seq_lengths_key=seq_lens.clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,
-                num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,
-                query_quant_mode=0,
-                key_quant_mode=0,
+            metadata = torch.ops.cann_ops_transformer.quant_lightning_indexer_metadata(
+                self.model_config.hf_config.index_n_heads,
+                1,
+                self.model_config.hf_config.index_head_dim,
+                self.model_config.hf_config.index_topk,
+                DeviceOperator.get_qli_quant_mode(),
+                cu_seqlens_q=query_start_loc.clone(),
+                seqused_q=seq_lens_q,
+                seqused_k=seq_lens // 4,
+                cmp_residual_k=seq_lens % 4,
                 batch_size=num_reqs,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seqlen_k,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
+                layout_q="TND",
+                layout_k="PA_BBND",
+                mask_mode=3,
                 cmp_ratio=4,
-                device=str(self.seqused_q.device),
             )
         self.common_ratio_to_sas_metadata[cache_key] = metadata
         self.req_qli_metadata[:1024] = metadata
@@ -1637,26 +1631,26 @@ class AscendDSACPImpl(DSAAttentionImpl):
         assert indexer_kv_scale_metadata.req_metadata is not None
         qli_metadata = indexer_kv_scale_metadata.req_metadata.qli_metadata
         block_table = indexer_kv_scale_metadata.req_metadata.block_table
-        topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
-            query=q,
-            key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-            actual_seq_lengths_query=actual_seq_lengths_query[1:],
-            actual_seq_lengths_key=actual_seq_lengths_key,
+        cp_seqused_q = actual_seq_lengths_query[1:] - actual_seq_lengths_query[:-1]
+        topk_idxs, _ = torch.ops.cann_ops_transformer.quant_lightning_indexer(
+            q,
+            indexer_k_cache,
+            DeviceOperator.prepare_dsa_indexer_weights(weights),
+            DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+            DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+            self.index_topk,
+            DeviceOperator.get_qli_quant_mode(),
+            cu_seqlens_q=actual_seq_lengths_query,
+            seqused_q=cp_seqused_q,
+            seqused_k=actual_seq_lengths_key // 4,
+            cmp_residual_k=actual_seq_lengths_key % 4,
             block_table=block_table,
             metadata=qli_metadata,
-            query_quant_mode=0,
-            key_quant_mode=0,
-            layout_query="TND",
-            layout_key="PA_BSND",
-            sparse_count=self.index_topk,
-            sparse_mode=3,
-            pre_tokens=(1 << 63) - 1,
-            next_tokens=(1 << 63) - 1,
+            layout_q="TND",
+            layout_k="PA_BBND",
+            mask_mode=3,
             cmp_ratio=4,
-            return_value=False,
+            return_value=0,
         )
         return topk_idxs
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -466,9 +466,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens_cpu[:num_reqs],
             use_cache=False,
         )
-        local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
-        max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
-        max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
 
         start_pos = self.seq_lens[:num_reqs] - seq_lens_q
 
@@ -478,7 +475,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_heads = self.model_config.hf_config.num_attention_heads
         metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
         metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        metadata_kwargs.setdefault("device", str(self.seqused_q.device))
         cu_seqlens_ori_kv = (
             local_query_start_loc
             if has_prefill
@@ -503,16 +499,14 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cu_seqlens_ori_kv=cu_seqlens_ori_kv,
             cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
             seqused_q=self.seqused_q,
-            seqused_kv=local_seq_lens,
-            max_seqlen_q=max_local_query_len,
-            max_seqlen_kv=max_local_seq_lens,
+            seqused_ori_kv=local_seq_lens,
             batch_size=num_reqs,
             cmp_ratio=1,
             ori_mask_mode=4,
             ori_win_left=self.model_config.hf_config.sliding_window - 1,
             ori_win_right=0,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv="PA_BBND",
             has_ori_kv=True,
             has_cmp_kv=False,
         )
@@ -819,7 +813,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             )
             metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
             metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-            metadata_kwargs.setdefault("device", str(self.seqused_q.device))
             kw = dict(
                 **metadata_kwargs,
                 num_heads_q=num_heads,
@@ -829,20 +822,20 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 cu_seqlens_ori_kv=cu_seqlens_ori_kv,
                 cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                 seqused_q=self.seqused_q,
-                seqused_kv=seq_lens,
-                max_seqlen_q=max_query_len,
-                max_seqlen_kv=max_seq_lens,
+                seqused_ori_kv=seq_lens,
                 batch_size=num_reqs,
                 ori_mask_mode=4,
                 ori_win_left=self.model_config.hf_config.sliding_window - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
+                layout_kv="PA_BBND",
                 has_ori_kv=True,
             )
 
             if self.compressor_ratio > 1:
                 kw["has_cmp_kv"] = True
+                kw["seqused_cmp_kv"] = seq_lens // cmp_ratio
+                kw["cmp_residual_kv"] = seq_lens % cmp_ratio
                 if self.compressor_ratio == 4:
                     kw["cmp_mask_mode"] = 3
                     kw["cmp_topk"] = index_topk
@@ -1444,7 +1437,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         common_attn_kwargs = dict(
             cu_seqlens_q=local_seq_lengths_query,
-            seqused_kv=local_seq_lengths_key,
+            seqused_ori_kv=local_seq_lengths_key,
             sinks=self.attn_sink,
             softmax_scale=self.softmax_scale,
             cmp_ratio=max(self.compress_ratio, 1),
@@ -1452,7 +1445,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             ori_win_left=self.window_size - 1,
             ori_win_right=0,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv="PA_BBND",
             **extra_attn_kwargs,
         )
 
@@ -1469,6 +1462,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
+            common_attn_kwargs["seqused_cmp_kv"] = local_seq_lengths_key // 4
+            common_attn_kwargs["cmp_residual_kv"] = local_seq_lengths_key % 4
+            common_attn_kwargs["cmp_mask_mode"] = 3
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1477,7 +1473,6 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 ori_block_table=swa_metadata.req_metadata.block_table,
                 cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
                 metadata=req_metadata.sas_metadata,
-                cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
         else:
@@ -1485,6 +1480,9 @@ class AscendDSACPImpl(DSAAttentionImpl):
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
+            common_attn_kwargs["seqused_cmp_kv"] = local_seq_lengths_key // 128
+            common_attn_kwargs["cmp_residual_kv"] = local_seq_lengths_key % 128
+            common_attn_kwargs["cmp_mask_mode"] = 3
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1492,7 +1490,6 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 ori_block_table=swa_metadata.req_metadata.block_table,
                 cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
                 metadata=compressor_attn_metadata.req_metadata.sas_metadata,
-                cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
         return attn_output, o_proj_full_handles

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1295,9 +1295,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             self.wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod
         ):
             q_a = self.wq_a(hidden_states_local)
-            qr_local, qr_pertoken_scale_local = torch.ops.custom.npu_rms_norm_dynamic_quant(
-                q_a, self.q_norm.weight, epsilon=self.eps
-            )
+            qr_local, qr_pertoken_scale_local = DeviceOperator.rms_norm_dynamic_quant(q_a, self.q_norm.weight, self.eps)
             if getattr(self.wq_b, "_chunk_size", 0):
                 bias = self.wq_b.bias
                 chunk_size = self.wq_b._chunk_size

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -515,7 +515,7 @@ class AscendSFACPImpl(AscendSFAImpl):
 
     def _execute_indexer_select(self, q, key, weights, actual_seq_lengths_query, actual_seq_lengths_key, block_table):
         if self.use_torch_npu_lightning_indexer:
-            topk_indices, _ = torch_npu.npu_lightning_indexer(
+            topk_indices, _ = torch.ops._C_ascend.npu_lightning_indexer(
                 query=q,
                 key=key,
                 weights=weights,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -36,6 +36,11 @@ from vllm_ascend.utils import (
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
+try:  # noqa: SIM105
+    import cann_ops_transformer  # noqa: F401  # registers torch.ops.cann_ops_transformer.*
+except ImportError:
+    pass
+
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -817,12 +822,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         if self.prefill_ratio_to_sas_metadata.get("qli") is None:
-            self.prefill_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
+            self.prefill_ratio_to_sas_metadata["qli"] = torch.ops.custom.npu_quant_lightning_indexer_metadata(
                 actual_seq_lengths_query=prefill_query_start_loc[1:].clone(),
                 actual_seq_lengths_key=self.seq_lens[reqs_start:].clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
+                num_heads_q=self.model_config.hf_config.index_n_heads,
                 num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,  # 128
+                head_dim=self.model_config.hf_config.index_head_dim,
                 query_quant_mode=0,
                 key_quant_mode=0,
                 batch_size=len(self.seq_lens[reqs_start:]),
@@ -830,7 +835,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 max_seqlen_k=self.seq_lens[reqs_start:].max().item(),
                 layout_query="TND",
                 layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,  # 512
+                sparse_count=self.model_config.hf_config.index_topk,
                 sparse_mode=3,
                 pre_tokens=(1 << 63) - 1,
                 next_tokens=(1 << 63) - 1,
@@ -1048,12 +1053,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         assert self.decode_qli_metadata is not None
         if self.decode_ratio_to_sas_metadata.get("qli") is None:
-            self.decode_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
+            self.decode_ratio_to_sas_metadata["qli"] = torch.ops.custom.npu_quant_lightning_indexer_metadata(
                 actual_seq_lengths_query=query_start_loc[1:].clone(),
                 actual_seq_lengths_key=self.seq_lens[: self.num_decodes].clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
+                num_heads_q=self.model_config.hf_config.index_n_heads,
                 num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,  # 128
+                head_dim=self.model_config.hf_config.index_head_dim,
                 query_quant_mode=0,
                 key_quant_mode=0,
                 batch_size=len(self.seq_lens[: self.num_decodes]),
@@ -1061,7 +1066,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 max_seqlen_k=max_seqlen_kv,
                 layout_query="TND",
                 layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,  # 512
+                sparse_count=self.model_config.hf_config.index_topk,
                 sparse_mode=3,
                 pre_tokens=(1 << 63) - 1,
                 next_tokens=(1 << 63) - 1,
@@ -1714,7 +1719,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         cos = attn_metadata[0].cos[layer_name]
         sin = attn_metadata[0].sin[layer_name]
 
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             o_proj_input.unsqueeze(1),
             cos,
             -sin,
@@ -1768,7 +1773,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             qr_pertoken_scale = None
         elif is_w8a8:
-            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+            qr, qr_pertoken_scale = torch.ops.custom.npu_rms_norm_dynamic_quant(
                 wq_a_result, self.q_norm.weight, epsilon=self.eps
             )
             q_b_quant, q_b_scale = qr, qr_pertoken_scale
@@ -1787,7 +1792,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             kv = self.kv_norm(kv)
             assert self.rope_head_dim is not None
             kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
                 kv.unsqueeze(1),
                 cos,
                 sin,
@@ -1814,7 +1819,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         main_stream.wait_stream(aux_stream)
 
         q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             cos,
             sin,
@@ -1881,7 +1886,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             # q
             if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr, qr_pertoken_scale = torch.ops.custom.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
@@ -1898,7 +1903,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 qr_pertoken_scale = None
             q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
 
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
                 cos,
                 sin,
@@ -1921,7 +1926,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             assert self.rope_head_dim is not None
             kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
 
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
                 kv.unsqueeze(1),
                 cos,
                 sin,
@@ -2000,7 +2005,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # Inline compressor + scatter (c128, c4 non-dual)
-            compressed_kv = torch.ops._C_ascend.compressor(
+            compressed_kv = DeviceOperator.dsa_compressor(
                 hidden_states,
                 self.compressor_wkv.weight,
                 self.compressor_wgate.weight,
@@ -2049,7 +2054,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 kvlens = indexer_scale_prefill_metadata.seq_lens
                 block_table = indexer_scale_prefill_metadata.block_table
                 qli_metadata = indexer_scale_prefill_metadata.qli_metadata
-                compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+                compress_topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
                     weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
@@ -2185,7 +2190,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     )
                 else:
                     q_a = self.wq_a(hidden_states)
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                qr, qr_pertoken_scale = torch.ops.custom.npu_rms_norm_dynamic_quant(
                     q_a, self.q_norm.weight, epsilon=self.eps
                 )
                 q = torch_npu.npu_quant_matmul(
@@ -2214,7 +2219,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
 
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
                 q.unsqueeze(1),
                 cos,
                 sin,
@@ -2238,7 +2243,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             assert self.rope_head_dim is not None
             kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
 
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
                 kv.unsqueeze(1),
                 cos,
                 sin,
@@ -2291,7 +2296,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             )
 
             # Inline compressor + scatter (c128, c4 non-dual)
-            compressed_kv = torch.ops._C_ascend.compressor(
+            compressed_kv = DeviceOperator.dsa_compressor(
                 hidden_states,
                 self.compressor_wkv.weight,
                 self.compressor_wgate.weight,
@@ -2340,7 +2345,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 kvlens = indexer_scale_decode_metadata.seq_lens
                 block_table = indexer_scale_decode_metadata.block_table
                 qli_metadata = indexer_scale_decode_metadata.qli_metadata
-                compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+                compress_topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
                     query=q_quant,
                     key=indexer_k_cache,
                     weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
@@ -2471,7 +2476,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             q = self.inderxer_wq_b(qr)
         q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)  # [T, N, D]
 
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
             q.unsqueeze(1),
             cos,
             sin,
@@ -2499,7 +2504,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 indexer_scale_decode_metadata,
             )
 
-        kv = torch.ops._C_ascend.compressor(
+        kv = DeviceOperator.dsa_compressor(
             x,
             self.indexcom_wkv.weight,
             self.indexcom_wgate.weight,
@@ -2604,7 +2609,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             block_table = indexer_kv_scale_metadata.decode.block_table
             qli_metadata = indexer_kv_scale_metadata.decode.qli_metadata
 
-        topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+        topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
             query=q,
             key=indexer_k_cache,
             weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
@@ -2725,7 +2730,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 indexer_scale_decode_metadata,
             )
 
-        kv = torch.ops._C_ascend.compressor(
+        kv = DeviceOperator.dsa_compressor(
             x,
             self.indexcom_wkv.weight,
             self.indexcom_wgate.weight,
@@ -2760,7 +2765,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             with npu_stream_switch(aux_stream, enabled=True):
                 torch.npu.current_stream().wait_event(e_kv_ready)
                 kv, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
-                    kv, indexer_k_cache, indexer_full_cache, slot_mapping_indexer
+                    kv, indexer_k_cache, indexer_scale_cache, slot_mapping_indexer
                 )
 
         # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
@@ -2782,7 +2787,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)
 
         # ===== Part2: rope[V] (main only) =====
-        torch.ops._C_ascend.inplace_partial_rotary_mul(  # rope
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(  # rope
             q.unsqueeze(1),
             cos,
             sin,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -817,25 +817,21 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 )
             sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
         if self.prefill_ratio_to_sas_metadata.get("qli") is None:
-            self.prefill_ratio_to_sas_metadata["qli"] = torch.ops.custom.npu_quant_lightning_indexer_metadata(
-                actual_seq_lengths_query=prefill_query_start_loc[1:].clone(),
-                actual_seq_lengths_key=self.seq_lens[reqs_start:].clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,
-                num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,
-                query_quant_mode=0,
-                key_quant_mode=0,
+            self.prefill_ratio_to_sas_metadata["qli"] = torch.ops.cann_ops_transformer.quant_lightning_indexer_metadata(
+                self.model_config.hf_config.index_n_heads,
+                1,
+                self.model_config.hf_config.index_head_dim,
+                self.model_config.hf_config.index_topk,
+                DeviceOperator.get_qli_quant_mode(),
+                cu_seqlens_q=prefill_query_start_loc.clone(),
+                seqused_q=seq_lens_q,
+                seqused_k=self.seq_lens[reqs_start:] // 4,
+                cmp_residual_k=self.seq_lens[reqs_start:] % 4,
                 batch_size=len(self.seq_lens[reqs_start:]),
-                max_seqlen_q=seq_lens_q.max().item(),
-                max_seqlen_k=self.seq_lens[reqs_start:].max().item(),
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
+                layout_q="TND",
+                layout_k="PA_BBND",
+                mask_mode=3,
                 cmp_ratio=4,
-                device=str(self.seqused_q.device),
             )
         qli_metadata = self.prefill_ratio_to_sas_metadata.get("qli")
 
@@ -1042,25 +1038,23 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
         assert self.decode_qli_metadata is not None
         if self.decode_ratio_to_sas_metadata.get("qli") is None:
-            self.decode_ratio_to_sas_metadata["qli"] = torch.ops.custom.npu_quant_lightning_indexer_metadata(
-                actual_seq_lengths_query=query_start_loc[1:].clone(),
-                actual_seq_lengths_key=self.seq_lens[: self.num_decodes].clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,
-                num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,
-                query_quant_mode=0,
-                key_quant_mode=0,
+            decode_query_start_loc = self.decode_ratio_to_sas_metadata["query_start_loc"]
+            decode_seq_lens_q = decode_query_start_loc[1:] - decode_query_start_loc[:-1]
+            self.decode_ratio_to_sas_metadata["qli"] = torch.ops.cann_ops_transformer.quant_lightning_indexer_metadata(
+                self.model_config.hf_config.index_n_heads,
+                1,
+                self.model_config.hf_config.index_head_dim,
+                self.model_config.hf_config.index_topk,
+                DeviceOperator.get_qli_quant_mode(),
+                cu_seqlens_q=decode_query_start_loc.clone(),
+                seqused_q=decode_seq_lens_q,
+                seqused_k=self.seq_lens[: self.num_decodes] // 4,
+                cmp_residual_k=self.seq_lens[: self.num_decodes] % 4,
                 batch_size=len(self.seq_lens[: self.num_decodes]),
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seqlen_kv,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
+                layout_q="TND",
+                layout_k="PA_BBND",
+                mask_mode=3,
                 cmp_ratio=4,
-                device=str(self.seqused_q.device),
             )
         self.decode_qli_metadata[:1024] = self.decode_ratio_to_sas_metadata.get("qli")
         decode_metadata = AscendDSADecodeMetadata(
@@ -2029,30 +2023,32 @@ class AscendDSAImpl(DSAAttentionImpl):
                 weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
                 # lightning_indexer
                 indexer_scale_prefill_metadata = _require_prefill_metadata(indexer_kv_scale_metadata)
-                qlens = indexer_scale_prefill_metadata.query_start_loc[1:]
                 kvlens = indexer_scale_prefill_metadata.seq_lens
                 block_table = indexer_scale_prefill_metadata.block_table
                 qli_metadata = indexer_scale_prefill_metadata.qli_metadata
-                compress_topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
-                    query=q_quant,
-                    key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-                    actual_seq_lengths_query=qlens,
-                    actual_seq_lengths_key=kvlens,
+                prefill_seqused_q = (
+                    indexer_scale_prefill_metadata.query_start_loc[1:]
+                    - indexer_scale_prefill_metadata.query_start_loc[:-1]
+                )
+                compress_topk_idxs, _ = torch.ops.cann_ops_transformer.quant_lightning_indexer(
+                    q_quant,
+                    indexer_k_cache,
+                    DeviceOperator.prepare_dsa_indexer_weights(weights),
+                    DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+                    DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    self.index_topk,
+                    DeviceOperator.get_qli_quant_mode(),
+                    cu_seqlens_q=indexer_scale_prefill_metadata.query_start_loc,
+                    seqused_q=prefill_seqused_q,
+                    seqused_k=kvlens // 4,
+                    cmp_residual_k=kvlens % 4,
                     block_table=block_table,
                     metadata=qli_metadata,
-                    query_quant_mode=0,
-                    key_quant_mode=0,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=self.index_topk,
-                    sparse_mode=3,
-                    pre_tokens=(1 << 63) - 1,
-                    next_tokens=(1 << 63) - 1,
+                    layout_q="TND",
+                    layout_k="PA_BBND",
+                    mask_mode=3,
                     cmp_ratio=4,
-                    return_value=False,
+                    return_value=0,
                 )
 
             if self.compress_ratio == 4 and self.use_index_cache:
@@ -2328,30 +2324,32 @@ class AscendDSAImpl(DSAAttentionImpl):
                 weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
                 # lightning_indexer
                 indexer_scale_decode_metadata = _require_decode_metadata(indexer_kv_scale_metadata)
-                qlens = indexer_scale_decode_metadata.query_start_loc[1:]
                 kvlens = indexer_scale_decode_metadata.seq_lens
                 block_table = indexer_scale_decode_metadata.block_table
                 qli_metadata = indexer_scale_decode_metadata.qli_metadata
-                compress_topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
-                    query=q_quant,
-                    key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-                    actual_seq_lengths_query=qlens,
-                    actual_seq_lengths_key=kvlens,
+                decode_seqused_q = (
+                    indexer_scale_decode_metadata.query_start_loc[1:]
+                    - indexer_scale_decode_metadata.query_start_loc[:-1]
+                )
+                compress_topk_idxs, _ = torch.ops.cann_ops_transformer.quant_lightning_indexer(
+                    q_quant,
+                    indexer_k_cache,
+                    DeviceOperator.prepare_dsa_indexer_weights(weights),
+                    DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+                    DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                    self.index_topk,
+                    DeviceOperator.get_qli_quant_mode(),
+                    cu_seqlens_q=indexer_scale_decode_metadata.query_start_loc,
+                    seqused_q=decode_seqused_q,
+                    seqused_k=kvlens // 4,
+                    cmp_residual_k=kvlens % 4,
                     block_table=block_table,
                     metadata=qli_metadata,
-                    query_quant_mode=0,
-                    key_quant_mode=0,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=self.index_topk,
-                    sparse_mode=3,
-                    pre_tokens=(1 << 63) - 1,
-                    next_tokens=(1 << 63) - 1,
+                    layout_q="TND",
+                    layout_k="PA_BBND",
+                    mask_mode=3,
                     cmp_ratio=4,
-                    return_value=False,
+                    return_value=0,
                 )
 
             if self.compress_ratio == 4 and self.use_index_cache:
@@ -2591,37 +2589,44 @@ class AscendDSAImpl(DSAAttentionImpl):
     ):
         if with_prefill:
             assert indexer_kv_scale_metadata.prefill is not None
-            qlens = indexer_kv_scale_metadata.prefill.query_start_loc[1:]
             kvlens = indexer_kv_scale_metadata.prefill.seq_lens
             block_table = indexer_kv_scale_metadata.prefill.block_table
             qli_metadata = indexer_kv_scale_metadata.prefill.qli_metadata
+            cu_seqlens_q = indexer_kv_scale_metadata.prefill.query_start_loc
+            seqused_q = (
+                indexer_kv_scale_metadata.prefill.query_start_loc[1:]
+                - indexer_kv_scale_metadata.prefill.query_start_loc[:-1]
+            )
         else:
             assert indexer_kv_scale_metadata.decode is not None
-            qlens = indexer_kv_scale_metadata.decode.query_start_loc[1:]
             kvlens = indexer_kv_scale_metadata.decode.seq_lens
             block_table = indexer_kv_scale_metadata.decode.block_table
             qli_metadata = indexer_kv_scale_metadata.decode.qli_metadata
+            cu_seqlens_q = indexer_kv_scale_metadata.decode.query_start_loc
+            seqused_q = (
+                indexer_kv_scale_metadata.decode.query_start_loc[1:]
+                - indexer_kv_scale_metadata.decode.query_start_loc[:-1]
+            )
 
-        topk_idxs, _ = torch.ops.custom.npu_quant_lightning_indexer(
-            query=q,
-            key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-            actual_seq_lengths_query=qlens,
-            actual_seq_lengths_key=kvlens,
+        topk_idxs, _ = torch.ops.cann_ops_transformer.quant_lightning_indexer(
+            q,
+            indexer_k_cache,
+            DeviceOperator.prepare_dsa_indexer_weights(weights),
+            DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+            DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+            self.index_topk,
+            DeviceOperator.get_qli_quant_mode(),
+            cu_seqlens_q=cu_seqlens_q,
+            seqused_q=seqused_q,
+            seqused_k=kvlens // 4,
+            cmp_residual_k=kvlens % 4,
             block_table=block_table,
             metadata=qli_metadata,
-            query_quant_mode=0,
-            key_quant_mode=0,
-            layout_query="TND",
-            layout_key="PA_BSND",
-            sparse_count=self.index_topk,
-            sparse_mode=3,
-            pre_tokens=(1 << 63) - 1,
-            next_tokens=(1 << 63) - 1,
+            layout_q="TND",
+            layout_k="PA_BBND",
+            mask_mode=3,
             cmp_ratio=4,
-            return_value=False,
+            return_value=0,
         )
         return topk_idxs
 

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1740,9 +1740,7 @@ class AscendDSAImpl(DSAAttentionImpl):
             q_b_quant, q_b_scale = self.cv_wq_b.quantize(qr)
             qr_pertoken_scale = None
         elif is_w8a8:
-            qr, qr_pertoken_scale = torch.ops.custom.npu_rms_norm_dynamic_quant(
-                wq_a_result, self.q_norm.weight, epsilon=self.eps
-            )
+            qr, qr_pertoken_scale = DeviceOperator.rms_norm_dynamic_quant(wq_a_result, self.q_norm.weight, self.eps)
             q_b_quant, q_b_scale = qr, qr_pertoken_scale
         else:
             qr = self.q_norm(wq_a_result)
@@ -1853,9 +1851,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
             # q
             if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops.custom.npu_rms_norm_dynamic_quant(
-                    q_a, self.q_norm.weight, epsilon=self.eps
-                )
+                qr, qr_pertoken_scale = DeviceOperator.rms_norm_dynamic_quant(q_a, self.q_norm.weight, self.eps)
                 q = torch_npu.npu_quant_matmul(
                     qr,
                     self.wq_b.weight,
@@ -2167,9 +2163,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     )
                 else:
                     q_a = self.wq_a(hidden_states)
-                qr, qr_pertoken_scale = torch.ops.custom.npu_rms_norm_dynamic_quant(
-                    q_a, self.q_norm.weight, epsilon=self.eps
-                )
+                qr, qr_pertoken_scale = DeviceOperator.rms_norm_dynamic_quant(q_a, self.q_norm.weight, self.eps)
                 q = torch_npu.npu_quant_matmul(
                     qr,
                     self.wq_b.weight,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -753,16 +753,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cu_seqlens_ori_kv=prefill_query_start_loc,
                     cu_seqlens_cmp_kv=None,
                     seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
+                    seqused_ori_kv=self.seq_lens[reqs_start:],
                     batch_size=len(self.seq_lens[reqs_start:]),
                     cmp_ratio=1,
                     ori_mask_mode=4,  # 4:sliding window
                     ori_win_left=self.model_config.hf_config.sliding_window - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
+                    layout_kv="PA_BBND",
                     has_ori_kv=True,
                     has_cmp_kv=False,
                 )
@@ -770,7 +768,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         elif self.compressor_ratio == 4:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
                 self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                    **{**metadata_kwargs, "cmp_mask_mode": 3},
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -778,19 +776,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cu_seqlens_ori_kv=prefill_query_start_loc,
                     cu_seqlens_cmp_kv=cu_c4_cmp_seqlen_list,
                     seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
+                    seqused_ori_kv=self.seq_lens[reqs_start:],
+                    seqused_cmp_kv=self.seq_lens[reqs_start:] // 4,
+                    cmp_residual_kv=self.seq_lens[reqs_start:] % 4,
                     batch_size=len(self.seq_lens[reqs_start:]),
                     cmp_topk=index_topk,
-                    # topk=index_topk,
                     cmp_ratio=4,
                     ori_mask_mode=4,
-                    cmp_mask_mode=3,
                     ori_win_left=self.model_config.hf_config.sliding_window - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
+                    layout_kv="PA_BBND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
                 )
@@ -798,7 +794,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         else:
             if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
                 self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                    **{**metadata_kwargs, "cmp_mask_mode": 3},
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -806,17 +802,16 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cu_seqlens_ori_kv=prefill_query_start_loc,
                     cu_seqlens_cmp_kv=cu_c128_cmp_seqlen_list,
                     seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
+                    seqused_ori_kv=self.seq_lens[reqs_start:],
+                    seqused_cmp_kv=self.seq_lens[reqs_start:] // 128,
+                    cmp_residual_kv=self.seq_lens[reqs_start:] % 128,
                     batch_size=len(self.seq_lens[reqs_start:]),
                     cmp_ratio=128,  #
                     ori_mask_mode=4,  # 4:sliding window
-                    cmp_mask_mode=3,  # 3:causal
                     ori_win_left=self.model_config.hf_config.sliding_window - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
+                    layout_kv="PA_BBND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
                 )
@@ -982,17 +977,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cu_seqlens_ori_kv=cu_seqlens_ori_kv,
                     cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],  # cached
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
+                    seqused_ori_kv=self.seq_lens[: self.num_decodes],  # cached
                     batch_size=len(self.seq_lens[: self.num_decodes]),  # cached
                     cmp_ratio=1,
                     ori_mask_mode=4,
-                    cmp_mask_mode=3,
                     ori_win_left=self.model_config.hf_config.sliding_window - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
+                    layout_kv="PA_BBND",
                     has_ori_kv=True,
                     has_cmp_kv=False,
                 )
@@ -1000,7 +992,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         elif self.compressor_ratio == 4:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
                 self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                    **{**metadata_kwargs, "cmp_mask_mode": 3},
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -1008,19 +1000,17 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cu_seqlens_ori_kv=cu_seqlens_ori_kv,
                     cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],  # cached
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
+                    seqused_ori_kv=self.seq_lens[: self.num_decodes],  # cached
+                    seqused_cmp_kv=self.seq_lens[: self.num_decodes] // 4,
+                    cmp_residual_kv=self.seq_lens[: self.num_decodes] % 4,
                     batch_size=len(self.seq_lens[: self.num_decodes]),  # cached
                     cmp_topk=index_topk,
-                    # topk=index_topk,
                     cmp_ratio=4,
                     ori_mask_mode=4,
-                    cmp_mask_mode=3,
                     ori_win_left=self.model_config.hf_config.sliding_window - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
+                    layout_kv="PA_BBND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
                 )
@@ -1028,7 +1018,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         else:
             if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
                 self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
+                    **{**metadata_kwargs, "cmp_mask_mode": 3},
                     num_heads_q=n_local_heads,
                     num_heads_kv=1,
                     head_dim=self.model_config.get_head_size(),
@@ -1036,17 +1026,16 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                     cu_seqlens_ori_kv=cu_seqlens_ori_kv,
                     cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                     seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
+                    seqused_ori_kv=self.seq_lens[: self.num_decodes],
+                    seqused_cmp_kv=self.seq_lens[: self.num_decodes] // 128,
+                    cmp_residual_kv=self.seq_lens[: self.num_decodes] % 128,
                     batch_size=len(self.seq_lens[: self.num_decodes]),
                     cmp_ratio=128,
                     ori_mask_mode=4,
-                    cmp_mask_mode=3,
                     ori_win_left=self.model_config.hf_config.sliding_window - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
+                    layout_kv="PA_BBND",
                     has_ori_kv=True,
                     has_cmp_kv=True,
                 )
@@ -1180,7 +1169,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_prefill_tokens = kwargs.get("num_prefill_tokens")
         query_start_loc = common_attn_metadata.query_start_loc
         prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
-        seq_lens_q = prefill_query_start_loc[1:] - prefill_query_start_loc[:-1]
         seq_lens = common_attn_metadata.seq_lens[reqs_start:]
 
         num_actual_tokens = common_attn_metadata.num_actual_tokens
@@ -1202,16 +1190,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cu_seqlens_ori_kv=prefill_query_start_loc,
             cu_seqlens_cmp_kv=None,
             seqused_q=self.seqused_q,
-            seqused_kv=seq_lens,
-            max_seqlen_q=seq_lens_q.max(),
-            max_seqlen_kv=seq_lens.max(),
+            seqused_ori_kv=seq_lens,
             batch_size=len(seq_lens),
             cmp_ratio=1,
             ori_mask_mode=4,
             ori_win_left=self.model_config.hf_config.sliding_window - 1,
             ori_win_right=0,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv="PA_BBND",
             has_ori_kv=True,
             has_cmp_kv=False,
         )
@@ -1252,16 +1238,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_decode_tokens_typed = num_decode_tokens or 0
         query_start_loc = common_attn_metadata.query_start_loc[: num_decodes_typed + 1]
         seq_lens = common_attn_metadata.seq_lens
-        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: num_decodes_typed + 1]
-        max_seqlen_q = torch.max(query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]).item()
-
-        if common_attn_metadata._seq_lens_cpu is not None:
-            _seq_lens_cpu = common_attn_metadata._seq_lens_cpu
-        elif common_attn_metadata.seq_lens_cpu is not None:
-            _seq_lens_cpu = common_attn_metadata.seq_lens_cpu
-        else:
-            _seq_lens_cpu = common_attn_metadata.seq_lens.cpu()
-        max_seqlen_kv = torch.max(_seq_lens_cpu[:num_decodes]).item()
 
         input_positions = common_attn_metadata.positions[:num_decode_tokens_typed].long()
         # disable use_cache, otherwise, draft_index>0 will override draft_index=0
@@ -1283,17 +1259,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cu_seqlens_ori_kv=self.cu_seqlens_ori_kv,
             cu_seqlens_cmp_kv=self.cu_seqlens_cmp_kv,
             seqused_q=self.seqused_q,
-            seqused_kv=seq_lens[:num_decodes],
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_kv=max_seqlen_kv,
+            seqused_ori_kv=seq_lens[:num_decodes],
             batch_size=len(seq_lens[:num_decodes]),
             cmp_ratio=1,
             ori_mask_mode=4,
-            cmp_mask_mode=3,
             ori_win_left=self.model_config.hf_config.sliding_window - 1,
             ori_win_right=0,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv="PA_BBND",
             has_ori_kv=True,
             has_cmp_kv=False,
         )
@@ -1947,7 +1920,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_kv=swa_kv_cache,
                 ori_block_table=swa_prefill_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
+                seqused_ori_kv=actual_seq_lengths_key,
                 sinks=self.attn_sink,
                 metadata=common_prefill_metadata.sas_metadata,
                 softmax_scale=self.softmax_scale,
@@ -1956,7 +1929,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_win_left=self.window_size - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
+                layout_kv="PA_BBND",
                 **extra_attn_kwargs,
             )[0]
 
@@ -2097,18 +2070,19 @@ class AscendDSAImpl(DSAAttentionImpl):
                     ori_block_table=swa_prefill_metadata.block_table,
                     cmp_block_table=compressor_prefill_metadata.block_table,
                     cu_seqlens_q=actual_seq_lengths_query,
-                    seqused_kv=actual_seq_lengths_key,
+                    seqused_ori_kv=actual_seq_lengths_key,
+                    seqused_cmp_kv=actual_seq_lengths_key // 4,
+                    cmp_residual_kv=actual_seq_lengths_key % 4,
                     sinks=self.attn_sink,
                     metadata=common_prefill_metadata.sas_metadata,
                     softmax_scale=self.softmax_scale,
                     cmp_ratio=self.compress_ratio,
                     ori_mask_mode=4,
-                    cmp_mask_mode=3,
                     ori_win_left=self.window_size - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
-                    **extra_attn_kwargs,
+                    layout_kv="PA_BBND",
+                    **{**extra_attn_kwargs, "cmp_mask_mode": 3},
                 )[0]
             else:
                 DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
@@ -2121,18 +2095,19 @@ class AscendDSAImpl(DSAAttentionImpl):
                     ori_block_table=swa_prefill_metadata.block_table,
                     cmp_block_table=compressor_prefill_metadata.block_table,
                     cu_seqlens_q=actual_seq_lengths_query,
-                    seqused_kv=actual_seq_lengths_key,
+                    seqused_ori_kv=actual_seq_lengths_key,
+                    seqused_cmp_kv=actual_seq_lengths_key // 128,
+                    cmp_residual_kv=actual_seq_lengths_key % 128,
                     sinks=self.attn_sink,
                     metadata=common_prefill_metadata.sas_metadata,
                     softmax_scale=self.softmax_scale,
                     cmp_ratio=self.compress_ratio,
                     ori_mask_mode=4,
-                    cmp_mask_mode=3,
                     ori_win_left=self.window_size - 1,
                     ori_win_right=0,
                     layout_q="TND",
-                    layout_kv="PA_ND",
-                    **extra_attn_kwargs,
+                    layout_kv="PA_BBND",
+                    **{**extra_attn_kwargs, "cmp_mask_mode": 3},
                 )[0]
         return attn_output
 
@@ -2391,7 +2366,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_kv=swa_kv_cache,
                 ori_block_table=swa_decode_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
+                seqused_ori_kv=actual_seq_lengths_key,
                 sinks=self.attn_sink,
                 metadata=swa_decode_metadata.sas_metadata,
                 softmax_scale=self.softmax_scale,
@@ -2400,7 +2375,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_win_left=self.window_size - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
+                layout_kv="PA_BBND",
                 **extra_attn_kwargs,
             )[0]
         elif self.compress_ratio == 4:
@@ -2412,18 +2387,19 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_block_table=swa_decode_metadata.block_table,
                 cmp_block_table=compressor_decode_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
+                seqused_ori_kv=actual_seq_lengths_key,
+                seqused_cmp_kv=actual_seq_lengths_key // 4,
+                cmp_residual_kv=actual_seq_lengths_key % 4,
                 sinks=self.attn_sink,
                 metadata=compressor_decode_metadata.sas_metadata,
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=self.compress_ratio,
                 ori_mask_mode=4,
-                cmp_mask_mode=3,
                 ori_win_left=self.window_size - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
-                **extra_attn_kwargs,
+                layout_kv="PA_BBND",
+                **{**extra_attn_kwargs, "cmp_mask_mode": 3},
             )[0]
         else:
             attn_output = attn_op(
@@ -2433,18 +2409,19 @@ class AscendDSAImpl(DSAAttentionImpl):
                 ori_block_table=swa_decode_metadata.block_table,
                 cmp_block_table=compressor_decode_metadata.block_table,
                 cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
+                seqused_ori_kv=actual_seq_lengths_key,
+                seqused_cmp_kv=actual_seq_lengths_key // 128,
+                cmp_residual_kv=actual_seq_lengths_key % 128,
                 sinks=self.attn_sink,
                 metadata=compressor_decode_metadata.sas_metadata,
                 softmax_scale=self.softmax_scale,
                 cmp_ratio=self.compress_ratio,
                 ori_mask_mode=4,
-                cmp_mask_mode=3,
                 ori_win_left=self.window_size - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
-                **extra_attn_kwargs,
+                layout_kv="PA_BBND",
+                **{**extra_attn_kwargs, "cmp_mask_mode": 3},
             )[0]
         return attn_output
 

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2011,19 +2011,25 @@ class AscendDSAImpl(DSAAttentionImpl):
                 self.compressor_wgate.weight,
                 state_cache.squeeze(-2),
                 self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
+                self.compress_ratio,
                 state_block_table=compressor_state_prefill_metadata.block_table,
                 cu_seqlens=actual_seq_lengths_query,
                 seqused=None,
                 start_pos=common_prefill_metadata.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
                 coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
                 cache_mode=1,
+            )
+            # RMSNorm + RoPE (was fused inside old compressor kernel)
+            compressed_kv = compressed_kv[..., : self.compressor_head_dim]
+            compressed_kv = torch_npu.npu_rms_norm(
+                compressed_kv, self.compressor_norm.weight.to(torch.float32), self.compressor_norm_eps
+            )[0]
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
+                compressed_kv.view(-1, 1, 1, self.compressor_head_dim),
+                compress_cos.view(-1, 1, 1, self.rope_head_dim),
+                compress_sin.view(-1, 1, 1, self.rope_head_dim),
+                rotary_mode="interleave",
+                partial_slice=[self.compressor_head_dim - self.rope_head_dim, self.compressor_head_dim],
             )
 
             # For multistream_dsv4_dsa_overlap with compress_ratio=4:
@@ -2302,19 +2308,25 @@ class AscendDSAImpl(DSAAttentionImpl):
                 self.compressor_wgate.weight,
                 state_cache.squeeze(-2),
                 self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
+                self.compress_ratio,
                 state_block_table=compressor_state_decode_metadata.block_table,
                 cu_seqlens=actual_seq_lengths_query,
                 seqused=None,
                 start_pos=common_decode_metadata.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
                 coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
                 cache_mode=1,
+            )
+            # RMSNorm + RoPE (was fused inside old compressor kernel)
+            compressed_kv = compressed_kv[..., : self.compressor_head_dim]
+            compressed_kv = torch_npu.npu_rms_norm(
+                compressed_kv, self.compressor_norm.weight.to(torch.float32), self.compressor_norm_eps
+            )[0]
+            torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
+                compressed_kv.view(-1, 1, 1, self.compressor_head_dim),
+                compress_cos.view(-1, 1, 1, self.rope_head_dim),
+                compress_sin.view(-1, 1, 1, self.rope_head_dim),
+                rotary_mode="interleave",
+                partial_slice=[self.compressor_head_dim - self.rope_head_dim, self.compressor_head_dim],
             )
 
             # For multistream_dsv4_dsa_overlap with compress_ratio=4:
@@ -2510,19 +2522,23 @@ class AscendDSAImpl(DSAAttentionImpl):
             self.indexcom_wgate.weight,
             indexer_state_cache.squeeze(-2),
             self.indexcom_ape,
-            self.indexcom_norm.weight,
-            compressed_sin.view(-1, compressed_sin.shape[-1]),
-            compressed_cos.view(-1, compressed_cos.shape[-1]),
+            self.compress_ratio,
             state_block_table=kv_block_table,
             cu_seqlens=actual_seq_lengths_query,
             seqused=None,
             start_pos=start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
             coff=coff,
-            norm_eps=self.compressor_norm_eps,
-            rotary_mode=2,
             cache_mode=1,
+        )
+        # RMSNorm + RoPE (was fused inside old compressor kernel)
+        kv = kv[..., : self.indexcom_head_dim]
+        kv = torch_npu.npu_rms_norm(kv, self.indexcom_norm.weight.to(torch.float32), self.compressor_norm_eps)[0]
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
+            kv.view(-1, 1, 1, self.indexcom_head_dim),
+            compressed_cos.view(-1, 1, 1, self.rope_head_dim),
+            compressed_sin.view(-1, 1, 1, self.rope_head_dim),
+            rotary_mode="interleave",
+            partial_slice=[self.indexcom_head_dim - self.rope_head_dim, self.indexcom_head_dim],
         )
 
         if kv.numel() == 0:
@@ -2736,19 +2752,23 @@ class AscendDSAImpl(DSAAttentionImpl):
             self.indexcom_wgate.weight,
             indexer_state_cache.squeeze(-2),
             self.indexcom_ape,
-            self.indexcom_norm.weight,
-            compressed_sin.view(-1, compressed_sin.shape[-1]),
-            compressed_cos.view(-1, compressed_cos.shape[-1]),
+            self.compress_ratio,
             state_block_table=kv_block_table,
             cu_seqlens=actual_seq_lengths_query,
             seqused=None,
             start_pos=start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
             coff=coff,
-            norm_eps=self.compressor_norm_eps,
-            rotary_mode=2,
             cache_mode=1,
+        )
+        # RMSNorm + RoPE (was fused inside old compressor kernel)
+        kv = kv[..., : self.indexcom_head_dim]
+        kv = torch_npu.npu_rms_norm(kv, self.indexcom_norm.weight.to(torch.float32), self.compressor_norm_eps)[0]
+        torch.ops.cann_ops_transformer.inplace_partial_rotary_mul(
+            kv.view(-1, 1, 1, self.indexcom_head_dim),
+            compressed_cos.view(-1, 1, 1, self.rope_head_dim),
+            compressed_sin.view(-1, 1, 1, self.rope_head_dim),
+            rotary_mode="interleave",
+            partial_slice=[self.indexcom_head_dim - self.rope_head_dim, self.indexcom_head_dim],
         )
 
         if kv.numel() == 0:

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -112,7 +112,7 @@ class BaseDeviceAdaptor:
         quant_mode: int = -1,
         act_quant_type: torch.dtype | None = None,
     ):
-        return torch.ops._C_ascend.npu_moe_init_routing_custom(
+        return torch.ops.custom.npu_moe_init_routing_group_quant(
             hidden_states,
             topk_ids,
             scale=scale,
@@ -122,6 +122,8 @@ class BaseDeviceAdaptor:
             expert_tokens_num_flag=expert_tokens_num_flag,
             active_expert_range=active_expert_range,
             quant_mode=quant_mode,
+            drop_pad_mode=0,
+            row_idx_type=0,
         )
 
     @staticmethod
@@ -143,9 +145,12 @@ class BaseDeviceAdaptor:
         eps: float = 1e-20,
         bias_opt: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        topk_weights, topk_ids, out = torch.ops._C_ascend.moe_gating_top_k(
+        topk_weights, topk_ids, out = torch.ops.custom.npu_moe_gating_top_k(
             x,
-            k=k,
+            k,
+            bias=bias_opt,
+            input_ids=None,
+            tid2eid=None,
             k_group=k_group,
             group_count=group_count,
             group_select_mode=group_select_mode,
@@ -154,7 +159,6 @@ class BaseDeviceAdaptor:
             out_flag=out_flag,
             routed_scaling_factor=routed_scaling_factor,
             eps=eps,
-            bias_opt=bias_opt,
         )
         return topk_weights, topk_ids.to(torch.int32), out
 
@@ -551,12 +555,16 @@ class BaseDeviceAdaptor:
 
         return context_layer
 
+    @staticmethod
+    def dsa_compressor(*args, **kwargs):
+        return torch.ops._C_ascend.compressor(*args, **kwargs)
+
     # ===== Sparse Attention Metadata & Op Selectors =====
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_op():
         """Returns the metadata-building operator for sparse attention."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata
+        return torch.ops.custom.npu_sparse_attn_sharedkv_metadata
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_kwargs(device):
@@ -566,7 +574,7 @@ class BaseDeviceAdaptor:
     @staticmethod
     def get_dsa_sparse_attn_op():
         """Returns the sparse attention operator."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv
+        return torch.ops.custom.npu_sparse_attn_sharedkv
 
     @staticmethod
     def get_dsa_sparse_attn_base_kwargs():
@@ -582,8 +590,27 @@ class BaseDeviceAdaptor:
 
     @staticmethod
     def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache. Non-A5: simple scatter of pre-quantized tensor."""
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(cache, slot_mapping, x)
+        """Scatter KV into cache. Non-A5: simple scatter of pre-quantized tensor.
+        Handles both 1D flat and 2D [block_id, block_offset] slot_mapping."""
+        if slot_mapping.dim() == 2 and slot_mapping.shape[-1] == 2:
+            # 2D [N, 2] → flat: block_id * block_size + block_offset
+            block_size = cache.shape[1]
+            flat_idx = slot_mapping[:, 0].to(torch.int64) * block_size + slot_mapping[:, 1].to(torch.int64)
+            # Reshape cache as [num_blocks * block_size, remaining] for flat indexing
+            cache_flat = cache.view(cache.shape[0] * cache.shape[1], -1)
+            x_flat = x.contiguous().view(x.shape[0], -1)
+            torch.ops.custom.scatter_nd_update_asc(
+                cache_flat,
+                flat_idx.view(-1, 1)[: x_flat.shape[0]],
+                x_flat,
+            )
+        else:
+            x_flat = x.view(-1, x.shape[-1])
+            torch.ops.custom.scatter_nd_update_asc(
+                cache.view(-1, cache.shape[-1]),
+                slot_mapping.view(-1, 1)[: x_flat.shape[0]],
+                x_flat,
+            )
 
     # ===== Indexer Quant + Scatter =====
 
@@ -596,9 +623,22 @@ class BaseDeviceAdaptor:
         return q_quant, q_scale
 
     @staticmethod
+    def _to_flat_slot_mapping(slot_mapping, cache):
+        """Convert slot_mapping to flat 1D index compatible with scatter_nd_update_asc.
+        Handles 2D [N, 2] (block_id, block_offset) → flat: block_id * block_size + block_offset.
+        Returns (cache_2d, flat_indices_2d) where cache_2d is [num_blocks*block_size, -1]."""
+        if slot_mapping.dim() == 2 and slot_mapping.shape[-1] == 2:
+            block_size = cache.shape[1]
+            flat_idx = slot_mapping[:, 0].to(torch.int64) * block_size + slot_mapping[:, 1].to(torch.int64)
+            cache_flat = cache.reshape(cache.shape[0] * cache.shape[1], -1)
+            return cache_flat, flat_idx.view(-1, 1)
+        else:
+            return cache.view(-1, cache.shape[-1]), slot_mapping.view(-1, 1)
+
+    @staticmethod
     def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):
         """Quantize q and scatter kv into indexer cache.
-        Non-A5: int8 quant + 2x scatter_nd_update_v2 for k_cache and scale_cache."""
+        Non-A5: int8 quant + 2x scatter_nd_update_asc for k_cache and scale_cache."""
         q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.int8)
         q_scale = q_scale.to(torch.float16)
 
@@ -609,13 +649,24 @@ class BaseDeviceAdaptor:
             kv_scale_out = kv_scale_out.unsqueeze(-1).to(torch.float16)
             if kv_scale_out.ndim < 4:
                 kv_scale_out = kv_scale_out.unsqueeze(-1)
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_out)
-            torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale_out)
+
+            cache_k_flat, idx_flat = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_k_cache)
+            torch.ops.custom.scatter_nd_update_asc(
+                cache_k_flat,
+                idx_flat,
+                kv_out.contiguous().view(kv_out.shape[0], -1),
+            )
+            cache_s_flat, _ = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_scale_cache)
+            torch.ops.custom.scatter_nd_update_asc(
+                cache_s_flat,
+                idx_flat,
+                kv_scale_out.contiguous().view(kv_scale_out.shape[0], -1),
+            )
 
         return q, q_scale, kv_out, kv_scale_out
 
     @staticmethod
-    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_full_cache, slot_mapping):
+    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_scale_cache, slot_mapping):
         """Part1 of multi-stream indexer scatter.
         Non-A5: quantize kv + scatter k_cache.
         Returns (kv_quant, kv_scale) for use in Part3, or (None, None) if kv is None."""
@@ -623,7 +674,11 @@ class BaseDeviceAdaptor:
             return None, None
         kv_out, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=torch.int8)
         kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_out)
+        torch.ops.custom.scatter_nd_update_asc(
+            indexer_k_cache.reshape(-1, indexer_k_cache.shape[-1]),
+            slot_mapping.view(-1, 1)[: kv_out.shape[0]],
+            kv_out.reshape(-1, indexer_k_cache.shape[-1]),
+        )
         return kv_out, kv_scale
 
     @staticmethod
@@ -633,7 +688,12 @@ class BaseDeviceAdaptor:
         kv_scale = kv_scale.to(torch.float16)
         if kv_scale.ndim < 4:
             kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale)
+        cache_flat, idx_flat = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_scale_cache)
+        torch.ops.custom.scatter_nd_update_asc(
+            cache_flat,
+            idx_flat,
+            kv_scale.contiguous().view(kv_scale.shape[0], -1),
+        )
 
     @staticmethod
     def warmup_indexer_quant_scatter(hidden_states, slot_mapping):
@@ -646,8 +706,18 @@ class BaseDeviceAdaptor:
         dummy_shape = (1, 1, 1, kv_dummy.shape[-1])
         indexer_k_cache = torch.zeros(dummy_shape, dtype=kv_dummy.dtype, device=hidden_states.device)
         indexer_scale_cache = torch.zeros(dummy_shape, dtype=torch.float16, device=hidden_states.device)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_k_cache, slot_mapping, kv_dummy)
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(indexer_scale_cache, slot_mapping, kv_scale_dummy)
+        cache_k_flat, idx_flat = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_k_cache)
+        torch.ops.custom.scatter_nd_update_asc(
+            cache_k_flat,
+            idx_flat,
+            kv_dummy.contiguous().view(kv_dummy.shape[0], -1),
+        )
+        cache_s_flat, _ = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_scale_cache)
+        torch.ops.custom.scatter_nd_update_asc(
+            cache_s_flat,
+            idx_flat,
+            kv_scale_dummy.contiguous().view(kv_scale_dummy.shape[0], -1),
+        )
 
     # ===== Lightning Indexer Dtype Prep =====
 
@@ -1043,13 +1113,14 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 output_dtype=torch.bfloat16,
             )[0]
             # DSV4 need swiglu_limit input
-            out, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
+            out, out_scale, _ = torch.ops.custom.npu_swiglu_group_quant(
                 hidden_states,
-                topk_weight=None,
+                weight=None,
                 group_index=None,
                 dst_type=torch.float8_e4m3fn,
-                quant_mode=2,
-                clamp_value=swiglu_limit,
+                quant_mode=1,
+                round_scale=True,
+                clamp_limit=swiglu_limit,
             )
         elif mxfp_quant_dtype == QuantType.W4A16MXFP4:
             hidden_states = torch_npu.npu_grouped_matmul(
@@ -1264,11 +1335,15 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
         return decode_preprocess_res, None
 
+    @staticmethod
+    def dsa_compressor(*args, **kwargs):
+        return torch.ops.custom.compressor(*args, **kwargs)
+
     # ===== Sparse Attention Metadata & Op Selectors =====
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata
+        return torch.ops.custom.npu_kv_quant_sparse_attn_sharedkv_metadata
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_kwargs(device):
@@ -1276,7 +1351,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
     @staticmethod
     def get_dsa_sparse_attn_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv
+        return torch.ops.custom.npu_kv_quant_sparse_attn_sharedkv
 
     @staticmethod
     def get_dsa_sparse_attn_base_kwargs():
@@ -1294,14 +1369,14 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         """Scatter KV into cache with fused quantization+compression.
         A5: kv_compress_epilog handles quant/compress/scatter internally.
         Input x is unquantized bf16; cache shape is [..., head_dim]."""
-        torch.ops._C_ascend.kv_compress_epilog(
-            kv_compress_cache=cache.view(-1, 1, cache.shape[-1]),
+        torch.ops.cann_ops_transformer.kv_compress_epilog(
+            cache=cache.view(torch.uint8),
             x=x.view(-1, x.shape[-1]),
-            slot_mapping=slot_mapping,
+            slot_mapping=slot_mapping.view(-1),
             quant_group_size=64,
-            quant_mode=2,
-            round_scale_flag=True,
-            layout=1,
+            quant_mode="fp8_bf16",
+            round_scale=True,
+            x_scale=1.0,
         )
 
     # ===== Indexer Quant + Scatter =====
@@ -1314,56 +1389,66 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
     @staticmethod
     def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):
-        """Quantize q (fp8) and scatter kv via fused indexer_compress_epilog_v2.
-        On A5, the fused op handles kv quantization, k_cache scatter, and
-        scale_cache scatter internally. q is quantized separately for use
-        by lightning_indexer."""
+        """Quantize q (fp8) and scatter kv via indexer_quant_cache.
+        Uses separate k_cache and scale_cache tensors."""
         q, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.float8_e4m3fn)
 
         kv_out = kv
         kv_scale_out = None
         if kv is not None:
-            torch.ops._C_ascend.indexer_compress_epilog_v2(
-                indexer_compress_cache=indexer_full_cache.view(torch.uint8),
-                x=kv,
-                slot_mapping=slot_mapping,
-                layout=2,
+            quantized_kv, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=torch.float8_e4m3fn)
+            torch.ops.cann_ops_transformer.indexer_quant_cache(
+                cache=indexer_k_cache,
+                cache_scale=indexer_scale_cache,
+                x=kv.reshape(-1, kv.shape[-1]),
+                slot_mapping=slot_mapping.view(-1),
+                quant_mode="fp8",
+                round_scale=True,
+                x_scale=1.0,
             )
+            kv_out = quantized_kv
+            kv_scale_out = kv_scale
 
         return q, q_scale, kv_out, kv_scale_out
 
     @staticmethod
-    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_full_cache, slot_mapping):
+    def indexer_quant_scatter_part1(kv, indexer_k_cache, indexer_scale_cache, slot_mapping):
         """Part1 of multi-stream indexer scatter.
-        A5: fused indexer_compress_epilog_v2 handles both k_cache and scale_cache.
-        Returns (kv, None) to signal Part3 is a no-op."""
+        Uses indexer_quant_cache with separate k_cache and scale_cache."""
         if kv is None:
             return None, None
-        torch.ops._C_ascend.indexer_compress_epilog_v2(
-            indexer_compress_cache=indexer_full_cache.view(torch.uint8),
-            x=kv,
-            slot_mapping=slot_mapping,
-            layout=2,
+        torch.ops.cann_ops_transformer.indexer_quant_cache(
+            cache=indexer_k_cache,
+            cache_scale=indexer_scale_cache,
+            x=kv.reshape(-1, kv.shape[-1]),
+            slot_mapping=slot_mapping.view(-1),
+            quant_mode="fp8",
+            round_scale=True,
+            x_scale=1.0,
         )
         return kv, None
 
     @staticmethod
     def dsa_indexer_scatter_scale_part3(kv_scale, indexer_scale_cache, slot_mapping):
         """Part3 of multi-stream indexer scatter.
-        A5: no-op — fused op in Part1 already handled scale_cache."""
+        scale_cache already handled in Part1, no-op."""
         pass
 
     @staticmethod
     def warmup_indexer_quant_scatter(hidden_states, slot_mapping):
         """Warmup profiling for indexer quant+scatter.
-        A5: fused indexer_compress_epilog_v2 with dummy cache tensor."""
+        Uses indexer_quant_cache with dummy cache tensors."""
         dummy_cache_shape = (1, 1, 1, hidden_states.shape[-1])
-        indexer_full_cache_dummy = torch.zeros(dummy_cache_shape, dtype=torch.uint8, device=hidden_states.device)
-        torch.ops._C_ascend.indexer_compress_epilog_v2(
-            indexer_compress_cache=indexer_full_cache_dummy,
-            x=hidden_states,
-            slot_mapping=slot_mapping,
-            layout=2,
+        dummy_k_cache = torch.zeros(dummy_cache_shape, dtype=torch.float8_e4m3fn, device=hidden_states.device)
+        dummy_scale_cache = torch.zeros(dummy_cache_shape, dtype=torch.float32, device=hidden_states.device)
+        torch.ops.cann_ops_transformer.indexer_quant_cache(
+            cache=dummy_k_cache,
+            cache_scale=dummy_scale_cache,
+            x=hidden_states.reshape(-1, hidden_states.shape[-1]),
+            slot_mapping=slot_mapping.view(-1),
+            quant_mode="fp8",
+            round_scale=True,
+            x_scale=1.0,
         )
 
     # ===== Lightning Indexer Dtype Prep =====

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -624,6 +624,11 @@ class BaseDeviceAdaptor:
         return q_quant, q_scale
 
     @staticmethod
+    def get_qli_quant_mode():
+        """Returns quant_mode for quant_lightning_indexer. Non-A5: 2 (INT8)."""
+        return 2
+
+    @staticmethod
     def _to_flat_slot_mapping(slot_mapping, cache):
         """Convert slot_mapping to flat 1D index compatible with scatter_nd_update_asc.
         Handles 2D [N, 2] (block_id, block_offset) → flat: block_id * block_size + block_offset.
@@ -1387,6 +1392,11 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         """Quantize indexer query. A5: fp8 quant, no extra scale conversion."""
         q_quant, q_scale = torch_npu.npu_dynamic_quant(q, dst_type=torch.float8_e4m3fn)
         return q_quant, q_scale
+
+    @staticmethod
+    def get_qli_quant_mode():
+        """Returns quant_mode for quant_lightning_indexer. A5: 1 (FP8)."""
+        return 1
 
     @staticmethod
     def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -112,7 +112,7 @@ class BaseDeviceAdaptor:
         quant_mode: int = -1,
         act_quant_type: torch.dtype | None = None,
     ):
-        return torch.ops.custom.npu_moe_init_routing_group_quant(
+        return torch_npu.npu_moe_init_routing_v2(
             hidden_states,
             topk_ids,
             scale=scale,
@@ -145,12 +145,10 @@ class BaseDeviceAdaptor:
         eps: float = 1e-20,
         bias_opt: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        topk_weights, topk_ids, out = torch.ops.custom.npu_moe_gating_top_k(
+        topk_weights, topk_ids, out = torch_npu.npu_moe_gating_top_k(
             x,
             k,
             bias=bias_opt,
-            input_ids=None,
-            tid2eid=None,
             k_group=k_group,
             group_count=group_count,
             group_select_mode=group_select_mode,
@@ -599,14 +597,14 @@ class BaseDeviceAdaptor:
             # Reshape cache as [num_blocks * block_size, remaining] for flat indexing
             cache_flat = cache.view(cache.shape[0] * cache.shape[1], -1)
             x_flat = x.contiguous().view(x.shape[0], -1)
-            torch.ops.custom.scatter_nd_update_asc(
+            torch_npu.npu_scatter_nd_update_(
                 cache_flat,
                 flat_idx.view(-1, 1)[: x_flat.shape[0]],
                 x_flat,
             )
         else:
             x_flat = x.view(-1, x.shape[-1])
-            torch.ops.custom.scatter_nd_update_asc(
+            torch_npu.npu_scatter_nd_update_(
                 cache.view(-1, cache.shape[-1]),
                 slot_mapping.view(-1, 1)[: x_flat.shape[0]],
                 x_flat,
@@ -651,13 +649,13 @@ class BaseDeviceAdaptor:
                 kv_scale_out = kv_scale_out.unsqueeze(-1)
 
             cache_k_flat, idx_flat = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_k_cache)
-            torch.ops.custom.scatter_nd_update_asc(
+            torch_npu.npu_scatter_nd_update_(
                 cache_k_flat,
                 idx_flat,
                 kv_out.contiguous().view(kv_out.shape[0], -1),
             )
             cache_s_flat, _ = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_scale_cache)
-            torch.ops.custom.scatter_nd_update_asc(
+            torch_npu.npu_scatter_nd_update_(
                 cache_s_flat,
                 idx_flat,
                 kv_scale_out.contiguous().view(kv_scale_out.shape[0], -1),
@@ -674,7 +672,7 @@ class BaseDeviceAdaptor:
             return None, None
         kv_out, kv_scale = torch_npu.npu_dynamic_quant(kv, dst_type=torch.int8)
         kv_scale = kv_scale.unsqueeze(-1)
-        torch.ops.custom.scatter_nd_update_asc(
+        torch_npu.npu_scatter_nd_update_(
             indexer_k_cache.reshape(-1, indexer_k_cache.shape[-1]),
             slot_mapping.view(-1, 1)[: kv_out.shape[0]],
             kv_out.reshape(-1, indexer_k_cache.shape[-1]),
@@ -689,7 +687,7 @@ class BaseDeviceAdaptor:
         if kv_scale.ndim < 4:
             kv_scale = kv_scale.unsqueeze(-1)
         cache_flat, idx_flat = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_scale_cache)
-        torch.ops.custom.scatter_nd_update_asc(
+        torch_npu.npu_scatter_nd_update_(
             cache_flat,
             idx_flat,
             kv_scale.contiguous().view(kv_scale.shape[0], -1),
@@ -707,13 +705,13 @@ class BaseDeviceAdaptor:
         indexer_k_cache = torch.zeros(dummy_shape, dtype=kv_dummy.dtype, device=hidden_states.device)
         indexer_scale_cache = torch.zeros(dummy_shape, dtype=torch.float16, device=hidden_states.device)
         cache_k_flat, idx_flat = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_k_cache)
-        torch.ops.custom.scatter_nd_update_asc(
+        torch_npu.npu_scatter_nd_update_(
             cache_k_flat,
             idx_flat,
             kv_dummy.contiguous().view(kv_dummy.shape[0], -1),
         )
         cache_s_flat, _ = BaseDeviceAdaptor._to_flat_slot_mapping(slot_mapping, indexer_scale_cache)
-        torch.ops.custom.scatter_nd_update_asc(
+        torch_npu.npu_scatter_nd_update_(
             cache_s_flat,
             idx_flat,
             kv_scale_dummy.contiguous().view(kv_scale_dummy.shape[0], -1),

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -938,7 +938,8 @@ class BaseDeviceAdaptor:
         indices: torch.Tensor,
         value: int,
     ) -> torch.Tensor:
-        tensor.index_fill_(dim, indices, value)
+        if indices.numel() > 0:
+            tensor.index_fill_(dim, indices, value)
         return tensor
 
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -22,6 +22,11 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.triton_utils import HAS_TRITON
 
+try:  # noqa: SIM105
+    import cann_ops_nn  # noqa: F401  # registers torch.ops.cann_ops_nn.*
+except ImportError:
+    pass
+
 from vllm_ascend.device import utils as device_utils
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
@@ -629,6 +634,11 @@ class BaseDeviceAdaptor:
         return 2
 
     @staticmethod
+    def rms_norm_dynamic_quant(x, gamma, epsilon):
+        """Fused RMS norm + dynamic INT8 quantization. Non-A5 uses fused kernel."""
+        return torch.ops.cann_ops_nn.rms_norm_dynamic_quant(x, gamma, epsilon=epsilon)
+
+    @staticmethod
     def _to_flat_slot_mapping(slot_mapping, cache):
         """Convert slot_mapping to flat 1D index compatible with scatter_nd_update_asc.
         Handles 2D [N, 2] (block_id, block_offset) → flat: block_id * block_size + block_offset.
@@ -1119,14 +1129,14 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
                 output_dtype=torch.bfloat16,
             )[0]
             # DSV4 need swiglu_limit input
-            out, out_scale, _ = torch.ops.custom.npu_swiglu_group_quant(
+            out, out_scale, _ = torch.ops.cann_ops_nn.swiglu_group_quant(
                 hidden_states,
                 weight=None,
                 group_index=None,
-                dst_type=torch.float8_e4m3fn,
+                dst_type=24,
                 quant_mode=1,
                 round_scale=True,
-                clamp_limit=swiglu_limit,
+                clamp_limit=swiglu_limit if swiglu_limit is not None else -1.0,
             )
         elif mxfp_quant_dtype == QuantType.W4A16MXFP4:
             hidden_states = torch_npu.npu_grouped_matmul(
@@ -1397,6 +1407,12 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
     def get_qli_quant_mode():
         """Returns quant_mode for quant_lightning_indexer. A5: 1 (FP8)."""
         return 1
+
+    @staticmethod
+    def rms_norm_dynamic_quant(x, gamma, epsilon):
+        """Fused RMS norm + dynamic quantization. A5 splits into norm + quant."""
+        x, _ = torch_npu.npu_rms_norm(x, gamma, epsilon)
+        return torch_npu.npu_dynamic_quant(x)
 
     @staticmethod
     def indexer_quant_scatter(q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -562,22 +562,25 @@ class BaseDeviceAdaptor:
     @staticmethod
     def get_dsa_sparse_attn_metadata_op():
         """Returns the metadata-building operator for sparse attention."""
-        return torch.ops.custom.npu_sparse_attn_sharedkv_metadata
+        return torch.ops.cann_ops_transformer.sparse_flash_mla_metadata
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_kwargs(device):
-        """Returns kwargs for sparse attention metadata builder."""
-        return {"device": str(device)}
+        """Returns kwargs for sparse attention metadata builder.
+        A3: cmp_mask_mode=3 for C1A (cann-recipes: A3 metadata kernel
+        requires causal mode 3)."""
+        return {"cmp_mask_mode": 3}
 
     @staticmethod
     def get_dsa_sparse_attn_op():
         """Returns the sparse attention operator."""
-        return torch.ops.custom.npu_sparse_attn_sharedkv
+        return torch.ops.cann_ops_transformer.sparse_flash_mla
 
     @staticmethod
     def get_dsa_sparse_attn_base_kwargs():
-        """Returns base kwargs for sparse attention (extended by caller)."""
-        return {}
+        """Returns base kwargs for sparse attention (extended by caller).
+        A3: cmp_mask_mode=3 for C1A default."""
+        return {"cmp_mask_mode": 3}
 
     @staticmethod
     def get_dsa_compressor_slot_mapping_format():
@@ -1341,19 +1344,19 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_op():
-        return torch.ops.custom.npu_kv_quant_sparse_attn_sharedkv_metadata
+        return torch.ops.cann_ops_transformer.mixed_quant_sparse_flash_mla_metadata
 
     @staticmethod
     def get_dsa_sparse_attn_metadata_kwargs(device):
-        return {"kv_quant_mode": 1}
+        return {"quant_mode": 1, "rope_head_dim": 64, "cmp_mask_mode": 0}
 
     @staticmethod
     def get_dsa_sparse_attn_op():
-        return torch.ops.custom.npu_kv_quant_sparse_attn_sharedkv
+        return torch.ops.cann_ops_transformer.mixed_quant_sparse_flash_mla
 
     @staticmethod
     def get_dsa_sparse_attn_base_kwargs():
-        return {"kv_quant_mode": 1, "tile_size": 64, "rope_head_dim": 64}
+        return {"quant_mode": 1, "rope_head_dim": 64, "cmp_mask_mode": 0}
 
     @staticmethod
     def get_dsa_compressor_slot_mapping_format():

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -555,7 +555,7 @@ class BaseDeviceAdaptor:
 
     @staticmethod
     def dsa_compressor(*args, **kwargs):
-        return torch.ops._C_ascend.compressor(*args, **kwargs)
+        return torch.ops.cann_ops_transformer.compressor(*args, **kwargs)
 
     # ===== Sparse Attention Metadata & Op Selectors =====
 
@@ -1335,7 +1335,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
     @staticmethod
     def dsa_compressor(*args, **kwargs):
-        return torch.ops.custom.compressor(*args, **kwargs)
+        return torch.ops.cann_ops_transformer.compressor(*args, **kwargs)
 
     # ===== Sparse Attention Metadata & Op Selectors =====
 

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -968,13 +968,20 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
 
     def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_pre_v2(
-            x, hc_fn, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.norm_eps, self.hc_eps
+        y = torch.ops.custom.npu_hc_pre(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            hc_mult=self.hc_mult,
+            hc_sinkhorn_iters=self.hc_sinkhorn_iters,
+            norm_eps=self.norm_eps,
+            hc_eps=self.hc_eps,
         )
         return y
 
     def hc_post(self, x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor, comb: torch.Tensor):
-        y = torch.ops._C_ascend.npu_hc_post(
+        y = torch.ops.custom.npu_hc_post(
             x.unsqueeze(dim=0), residual.unsqueeze(dim=0), post.unsqueeze(dim=0), comb.unsqueeze(dim=0)
         )
         return y.squeeze(dim=0)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -968,23 +968,24 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
 
     def hc_pre(self, x: torch.Tensor, hc_fn: torch.Tensor, hc_scale: torch.Tensor, hc_base: torch.Tensor):
-        y = torch.ops.custom.npu_hc_pre(
-            x,
+        x_4d = x.unsqueeze(1)
+        y, post, comb, _, _, _, _, _ = torch.ops.cann_ops_transformer.mhc_pre_sinkhorn(
+            x_4d,
             hc_fn,
             hc_scale,
             hc_base,
-            hc_mult=self.hc_mult,
-            hc_sinkhorn_iters=self.hc_sinkhorn_iters,
-            norm_eps=self.norm_eps,
-            hc_eps=self.hc_eps,
+            self.hc_mult,
+            self.hc_sinkhorn_iters,
+            self.hc_eps,
+            self.norm_eps,
+            False,
         )
-        return y
+        comb = comb.unflatten(-1, (self.hc_mult, self.hc_mult))
+        return y.squeeze(1), post.squeeze(1), comb.squeeze(1)
 
     def hc_post(self, x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor, comb: torch.Tensor):
-        y = torch.ops.custom.npu_hc_post(
-            x.unsqueeze(dim=0), residual.unsqueeze(dim=0), post.unsqueeze(dim=0), comb.unsqueeze(dim=0)
-        )
-        return y.squeeze(dim=0)
+        y = torch.ops.cann_ops_transformer.mhc_post(residual, comb, x, post)
+        return y
 
     def forward(
         self,

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -192,7 +192,13 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         if get_ascend_device_type() in {AscendDeviceType.A5}:
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-        cached_head_size = self.head_dim + 128 if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_dim
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            # nope(fp8 1B) + rope(bf16 2B) + scales(bf16 2B per group, group_size=64), align_up(32B)
+            rope_head_dim = vllm_config.model_config.hf_config.qk_rope_head_dim
+            nope_head_dim = self.head_dim - rope_head_dim
+            cached_head_size = (nope_head_dim + 2 * rope_head_dim + 2 * nope_head_dim // 64 + 31) & ~31
+        else:
+            cached_head_size = self.head_dim
         return AscendSlidingWindowMLASpec(
             block_size=self.block_size,
             num_kv_heads=1,

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -37,9 +37,9 @@ def get_dsv4_block_sizes():
         32: [[32, 32, 2, 8], [4160, 32768]],
     }
     _DSV4_BLOCK_SIZES_A5 = {
-        128: [[128, 128, 8, 16], [16896, 81920]],
-        64: [[64, 64, 4, 8], [8448, 40960]],
-        32: [[32, 32, 2, 4], [4224, 20480]],
+        128: [[128, 128, 8, 16], [16896, 77824]],
+        64: [[64, 64, 4, 8], [8448, 38912]],
+        32: [[32, 32, 2, 4], [4224, 19456]],
     }
     if get_ascend_device_type() in {AscendDeviceType.A5}:
         return _DSV4_BLOCK_SIZES_A5
@@ -180,9 +180,13 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             kv_cache_dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
-        cached_head_size = (
-            (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
-        )
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            # nope(fp8 1B) + rope(bf16 2B) + scales(bf16 2B per group, group_size=64), align_up(32B)
+            assert self.rope_head_dim is not None
+            nope_head_dim = self.head_size - self.rope_head_dim
+            cached_head_size = (nope_head_dim + 2 * self.rope_head_dim + 2 * nope_head_dim // 64 + 31) & ~31
+        else:
+            cached_head_size = self.head_size
         return AscendMLAAttentionSpec(
             block_size=DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0],
             num_kv_heads=1,

--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -18,6 +18,11 @@
 import torch
 from vllm.triton_utils import HAS_TRITON
 
+try:  # noqa: SIM105
+    import custom_ops  # noqa: F401  # registers torch.ops.custom.* from cann-recipes-infer
+except ImportError:
+    pass
+
 import vllm_ascend.ops.fused_moe.fused_moe  # noqa
 import vllm_ascend.ops.layernorm  # noqa
 import vllm_ascend.ops.register_custom_ops  # noqa

--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -18,11 +18,6 @@
 import torch
 from vllm.triton_utils import HAS_TRITON
 
-try:  # noqa: SIM105
-    import custom_ops  # noqa: F401  # registers torch.ops.custom.* from cann-recipes-infer
-except ImportError:
-    pass
-
 import vllm_ascend.ops.fused_moe.fused_moe  # noqa
 import vllm_ascend.ops.layernorm  # noqa
 import vllm_ascend.ops.register_custom_ops  # noqa

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -271,9 +271,9 @@ def _select_experts_with_fusion_ops(
         else:
             input_ids = None
             tid2eid_ones = None
-        topk_weights, topk_ids, _ = torch.ops._C_ascend.moe_gating_top_k_hash(
-            x=router_logits,
-            k=top_k,
+        topk_weights, topk_ids, _ = torch.ops.custom.npu_moe_gating_top_k(
+            router_logits,
+            top_k,
             bias=e_score_correction_bias,
             input_ids=input_ids,
             tid2eid=tid2eid_ones,

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn.functional as F
+import torch_npu
 from vllm.distributed import get_tp_group
 from vllm.forward_context import get_forward_context
 
@@ -271,19 +272,17 @@ def _select_experts_with_fusion_ops(
         else:
             input_ids = None
             tid2eid_ones = None
-        topk_weights, topk_ids, _ = torch.ops.custom.npu_moe_gating_top_k(
+        topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k(
             router_logits,
             top_k,
             bias=e_score_correction_bias,
             input_ids=input_ids,
             tid2eid=tid2eid_ones,
-            k_group=topk_group,
-            group_count=num_expert_group,
+            k_group=1,
+            group_count=1,
             routed_scaling_factor=routed_scaling_factor,
             eps=1e-20,
             group_select_mode=1,
-            # The hash custom op currently rejects renorm != 0. Apply
-            # norm_topk_prob in Python below before returning to MoE compute.
             renorm=0,
             norm_type=2,
             out_flag=False,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -715,7 +715,7 @@ else:
                     # Execute activation concurrently with gmm2.
 
                     maybe_wait_event(fused_moe_evts.before_gmm2)
-                    quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+                    quantized_x, swiglu_out_scale = torch.ops.custom.npu_dequant_swiglu_clamp_quant(
                         x=hidden_states,
                         weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
                         activation_scale=pertoken_scale,
@@ -727,6 +727,8 @@ else:
                         quant_mode=1,
                         swiglu_mode=1,
                         clamp_limit=fused_moe_evts.swiglu_limit,
+                        glu_alpha=1.0,
+                        glu_bias=0.0,
                     )
                     # Execute the down projection concurrently with the combine
                     # communication.
@@ -752,13 +754,14 @@ else:
                     hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
                     # Execute activation concurrently with gmm2.
                     maybe_wait_event(fused_moe_evts.before_gmm2)
-                    quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
+                    quantized_x, swiglu_out_scale, _ = torch.ops.custom.npu_swiglu_group_quant(
                         hidden_states,
-                        topk_weight=None,
+                        weight=None,
                         group_index=None,
                         dst_type=torch.float8_e4m3fn,
-                        quant_mode=2,
-                        clamp_value=fused_moe_evts.swiglu_limit,
+                        quant_mode=1,
+                        round_scale=True,
+                        clamp_limit=fused_moe_evts.swiglu_limit,
                     )
                     # Execute the down projection concurrently with the combine
                     # communication.

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -22,6 +22,11 @@ from functools import wraps
 import torch
 import torch.nn.functional as F
 import torch_npu
+
+try:  # noqa: SIM105
+    import cann_ops_nn  # noqa: F401  # registers torch.ops.cann_ops_nn.*
+except ImportError:
+    pass
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group, tensor_model_parallel_all_reduce
 from vllm.forward_context import get_forward_context
@@ -757,14 +762,14 @@ else:
                     hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
                     # Execute activation concurrently with gmm2.
                     maybe_wait_event(fused_moe_evts.before_gmm2)
-                    quantized_x, swiglu_out_scale, _ = torch.ops.custom.npu_swiglu_group_quant(
+                    quantized_x, swiglu_out_scale, _ = torch.ops.cann_ops_nn.swiglu_group_quant(
                         hidden_states,
                         weight=None,
                         group_index=None,
-                        dst_type=torch.float8_e4m3fn,
+                        dst_type=24,
                         quant_mode=1,
                         round_scale=True,
-                        clamp_limit=fused_moe_evts.swiglu_limit,
+                        clamp_limit=fused_moe_evts.swiglu_limit if fused_moe_evts.swiglu_limit is not None else -1.0,
                     )
                     # Execute the down projection concurrently with the combine
                     # communication.

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -715,20 +715,23 @@ else:
                     # Execute activation concurrently with gmm2.
 
                     maybe_wait_event(fused_moe_evts.before_gmm2)
-                    quantized_x, swiglu_out_scale = torch.ops.custom.npu_dequant_swiglu_clamp_quant(
+                    swiglu_kwargs = {}
+                    if fused_moe_evts.swiglu_limit and fused_moe_evts.swiglu_limit > 0:
+                        swiglu_kwargs = dict(
+                            swiglu_mode=2,
+                            clamp_limit=fused_moe_evts.swiglu_limit,
+                            glu_alpha=1.0,
+                            glu_bias=0.0,
+                        )
+                    quantized_x, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
                         x=hidden_states,
                         weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
                         activation_scale=pertoken_scale,
-                        bias=None,
                         quant_scale=None,
-                        quant_offset=None,
                         group_index=None,
                         activate_left=True,
                         quant_mode=1,
-                        swiglu_mode=1,
-                        clamp_limit=fused_moe_evts.swiglu_limit,
-                        glu_alpha=1.0,
-                        glu_bias=0.0,
+                        **swiglu_kwargs,
                     )
                     # Execute the down projection concurrently with the combine
                     # communication.

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -585,7 +585,7 @@ class AscendFusedMoE(FusedMoE):
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+                quantized_x, swiglu_out_scale = torch.ops.custom.npu_dequant_swiglu_clamp_quant(
                     x=hidden_states,
                     weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
                     activation_scale=pertoken_scale,
@@ -597,6 +597,8 @@ class AscendFusedMoE(FusedMoE):
                     quant_mode=1,
                     swiglu_mode=1,
                     clamp_limit=fused_moe_evts.swiglu_limit,
+                    glu_alpha=1.0,
+                    glu_bias=0.0,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.
@@ -622,13 +624,14 @@ class AscendFusedMoE(FusedMoE):
                 hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
+                quantized_x, swiglu_out_scale, _ = torch.ops.custom.npu_swiglu_group_quant(
                     hidden_states,
-                    topk_weight=None,
+                    weight=None,
                     group_index=None,
                     dst_type=torch.float8_e4m3fn,
-                    quant_mode=2,
-                    clamp_value=fused_moe_evts.swiglu_limit,
+                    quant_mode=1,
+                    round_scale=True,
+                    clamp_limit=fused_moe_evts.swiglu_limit,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -585,20 +585,23 @@ class AscendFusedMoE(FusedMoE):
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops.custom.npu_dequant_swiglu_clamp_quant(
+                swiglu_kwargs = {}
+                if fused_moe_evts.swiglu_limit and fused_moe_evts.swiglu_limit > 0:
+                    swiglu_kwargs = dict(
+                        swiglu_mode=2,
+                        clamp_limit=fused_moe_evts.swiglu_limit,
+                        glu_alpha=1.0,
+                        glu_bias=0.0,
+                    )
+                quantized_x, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
                     x=hidden_states,
                     weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
                     activation_scale=pertoken_scale,
-                    bias=None,
                     quant_scale=None,
-                    quant_offset=None,
                     group_index=None,
                     activate_left=True,
                     quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
-                    glu_alpha=1.0,
-                    glu_bias=0.0,
+                    **swiglu_kwargs,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -627,14 +627,14 @@ class AscendFusedMoE(FusedMoE):
                 hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale, _ = torch.ops.custom.npu_swiglu_group_quant(
+                quantized_x, swiglu_out_scale, _ = torch.ops.cann_ops_nn.swiglu_group_quant(
                     hidden_states,
                     weight=None,
                     group_index=None,
-                    dst_type=torch.float8_e4m3fn,
+                    dst_type=24,
                     quant_mode=1,
                     round_scale=True,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
+                    clamp_limit=fused_moe_evts.swiglu_limit if fused_moe_evts.swiglu_limit is not None else -1.0,
                 )
                 # Execute the down projection concurrently with the combine
                 # communication.

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -295,55 +295,6 @@ class FusedMC2CommImpl(MoECommMethod):
             "token_dispatcher must be an instance of TokenDispatcherWithMC2."
         )
 
-        # Apply log2phy if needed
-        topk_ids = fused_experts_input.topk_ids
-        if fused_experts_input.routing.log2phy is not None:
-            topk_ids = fused_experts_input.routing.log2phy[topk_ids]
-
-        expert_tokens = None
-        if get_ascend_config().enable_fused_mc2 == 1:
-            assert not (
-                fused_experts_input.weights.w1_scale_bias is None or fused_experts_input.weights.w2_scale_bias is None
-            ), "w1_scale_bias and w2_scale_bias cannot be None when enable_fused_mc2=1."
-
-            out = torch.empty_like(fused_experts_input.hidden_states)
-            torch.ops._C_ascend.dispatch_ffn_combine(  # type: ignore
-                x=fused_experts_input.hidden_states,
-                weight1=fused_experts_input.weights.w1,
-                weight2=fused_experts_input.weights.w2,
-                expert_idx=topk_ids,
-                scale1=fused_experts_input.weights.w1_scale,
-                scale2=fused_experts_input.weights.w2_scale,
-                bias1=fused_experts_input.weights.w1_scale_bias,
-                bias2=fused_experts_input.weights.w2_scale_bias,
-                probs=fused_experts_input.topk_weights.to(torch.float32),
-                group=self.token_dispatcher.moe_all_to_all_group_name,
-                max_output_size=get_ascend_config().mega_moe_max_tokens,
-                swiglu_limit=fused_experts_input.swiglu_limit,
-                x_active_mask=fused_experts_input.routing.mc2_mask,
-                out=out,
-                expert_token_nums=self.expert_token_nums,
-            )
-            expert_tokens = self.expert_token_nums
-        elif get_ascend_config().enable_fused_mc2 == 2:
-            assert fused_experts_input.routing.expert_map is not None, "expert_map cannot be None."
-            out, expert_tokens = torch.ops._C_ascend.dispatch_gmm_combine_decode(  # type: ignore
-                x=fused_experts_input.hidden_states,
-                expert_ids=topk_ids,
-                gmm1_permuted_weight=fused_experts_input.weights.w1,
-                gmm1_permuted_weight_scale=fused_experts_input.weights.w1_scale,
-                gmm2_weight=fused_experts_input.weights.w2,
-                gmm2_weight_scale=fused_experts_input.weights.w2_scale,
-                expert_smooth_scales=None,
-                expert_scales=fused_experts_input.topk_weights.to(torch.float32),
-                group_ep=self.token_dispatcher.moe_all_to_all_group_name,
-                ep_rank_size=self.token_dispatcher.ep_world_size,
-                ep_rank_id=self.token_dispatcher.ep_rank_id,
-                moe_expert_num=self.moe_config.num_experts,
-                global_bs=self.token_dispatcher.global_bs,
-            )
-        else:
-            raise ValueError(f"Wrong value of {get_ascend_config().enable_fused_mc2=}")
-        return FusedExpertsResult(
-            routed_out=out, expert_tokens=expert_tokens, swiglu_limit=fused_experts_input.swiglu_limit
-        )
+        # Decompose fused dispatch_ffn_combine / dispatch_gmm_combine_decode into
+        # separate dispatch + FFN + combine, using the base class implementation.
+        return super().fused_experts(fused_experts_input)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -196,7 +196,7 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
-            hidden_states, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+            hidden_states, swiglu_out_scale = torch.ops.custom.npu_dequant_swiglu_clamp_quant(
                 x=hidden_states,
                 weight_scale=w1_scale[0],
                 activation_scale=pertoken_scale,
@@ -206,6 +206,10 @@ def quant_apply_mlp(
                 group_index=cumsum_group_list(group_list, group_list_type, 1),
                 activate_left=True,
                 quant_mode=1,
+                swiglu_mode=0,
+                clamp_limit=0.0,
+                glu_alpha=1.0,
+                glu_bias=0.0,
             )
         before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -196,20 +196,23 @@ def quant_apply_mlp(
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
             # act_fn: swiglu
-            hidden_states, swiglu_out_scale = torch.ops.custom.npu_dequant_swiglu_clamp_quant(
+            swiglu_kwargs = {}
+            if swiglu_limit and swiglu_limit > 0:
+                swiglu_kwargs = dict(
+                    swiglu_mode=1,
+                    clamp_limit=swiglu_limit,
+                    glu_alpha=1.0,
+                    glu_bias=0.0,
+                )
+            hidden_states, swiglu_out_scale = torch_npu.npu_dequant_swiglu_quant(
                 x=hidden_states,
                 weight_scale=w1_scale[0],
                 activation_scale=pertoken_scale,
-                bias=None,
                 quant_scale=None,
-                quant_offset=None,
                 group_index=cumsum_group_list(group_list, group_list_type, 1),
                 activate_left=True,
                 quant_mode=1,
-                swiglu_mode=0,
-                clamp_limit=0.0,
-                glu_alpha=1.0,
-                glu_bias=0.0,
+                **swiglu_kwargs,
             )
         before_gmm2_evt = torch.npu.current_stream().record_event()
         # gmm2: down_proj

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -22,7 +22,7 @@ from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormG
 
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
-from vllm_ascend.utils import enable_custom_op, get_weight_prefetch_method
+from vllm_ascend.utils import get_weight_prefetch_method
 
 
 class AscendRMSNorm(RMSNorm):
@@ -69,14 +69,9 @@ class AscendRMSNorm(RMSNorm):
 
         if residual is not None:
             residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
-            if enable_custom_op():
-                x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
-                    x, residual, self.weight, self.bias, self.variance_epsilon
-                )
-            else:
-                x, _, residual = torch_npu.npu_add_rms_norm(x, residual, self.weight, self.variance_epsilon)
-                if self.bias is not None:
-                    x.add_(self.bias)
+            x, _, residual = torch_npu.npu_add_rms_norm(x, residual, self.weight, self.variance_epsilon)
+            if self.bias is not None:
+                x.add_(self.bias)
             return x, residual
 
         x, residual = torch_npu.npu_rms_norm(x, self.weight, self.variance_epsilon)
@@ -98,12 +93,7 @@ class AscendGemmaRMSNorm(GemmaRMSNorm):
 
         if residual is not None:
             residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
-            if enable_custom_op():
-                x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
-                    x, residual, 1.0 + self.weight, None, self.variance_epsilon
-                )
-            else:
-                x, _, residual = torch_npu.npu_add_rms_norm(x, residual, 1.0 + self.weight, self.variance_epsilon)
+            x, _, residual = torch_npu.npu_add_rms_norm(x, residual, 1.0 + self.weight, self.variance_epsilon)
             return x, residual
 
         x = DeviceOperator.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)


### PR DESCRIPTION
### What this PR does / why we need it?

replace the vllm-ascend ops with cann ops

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
