### PR TITLE
[BugFix]Fix the precision issue of the npu_dequant_swiglu_quant operator when x.shape=[2,192]

### DIFF
--- a/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp
+++ b/csrc/moe/dequant_swiglu_quant/op_host/dequant_swiglu_quant_tiling.cpp
@@ -625,7 +625,8 @@ ge::graphStatus DequantSwigluQuantDskTiling::CountMaxDim(int64_t& ubFactorDimx) 
   int64_t quantOffsetSpace = quantMode_ == QUANT_MODE_DYNAMIC ? 0 : static_cast<int64_t>(sizeof(float));
 
   // UbFactorDimx is 1,compute maxOutDimy
-  int64_t numerator = static_cast<int64_t>(ubSize_) - UB_RESERVE - BLOCK_SIZE - db * BLOCK_SIZE - static_cast<int64_t>(sizeof(float));
+  int64_t numerator = static_cast<int64_t>(ubSize_) - UB_RESERVE - BLOCK_SIZE - db * BLOCK_SIZE - static_cast<int64_t>(sizeof(float)) -
+                       BLOCK_ELEM * BLOCK_ELEM * static_cast<int64_t>(sizeof(float));
   int64_t denominator =
       5 * static_cast<int64_t>(sizeof(float)) + db * SWI_FACTOR * static_cast<int64_t>(sizeof(float)) + static_cast<int64_t>(sizeof(int8_t)) + biasBufferY + SweiGLUBufferY + quantOffsetSpace;
   maxOutDimy = static_cast<int64_t>(numerator / denominator);
@@ -643,7 +644,8 @@ ge::graphStatus DequantSwigluQuantDskTiling::CountMaxDim(int64_t& ubFactorDimx) 
   numerator = static_cast<int64_t>(ubSize_) - UB_RESERVE - outDimy_ * static_cast<int64_t>(sizeof(float)) - BLOCK_SIZE - SWI_FACTOR * outDimy_ * static_cast<int64_t>(sizeof(float)) - biasBufferX - quantOffsetSpace;
 
   denominator = db * (outDimy_ * SWI_FACTOR + BLOCK_ELEM) * static_cast<int64_t>(sizeof(float)) + outDimy_ * static_cast<int64_t>(sizeof(int8_t)) + static_cast<int64_t>(sizeof(float)) +
-                outDimy_ * SWI_FACTOR * static_cast<int64_t>(sizeof(float)) + SweiGLUBufferX;
+                outDimy_ * SWI_FACTOR * static_cast<int64_t>(sizeof(float)) + SweiGLUBufferX +
+                BLOCK_ELEM * static_cast<int64_t>(sizeof(float));
   ubFactorDimx  = static_cast<int64_t>(numerator / denominator);
   ubFactorDimx = std::min(ubFactorDimx, inDimx_);
   OP_LOGI(context_->GetNodeName(), "Get ubFactorDimx[%ld]", ubFactorDimx);

--- a/csrc/moe/dequant_swiglu_quant/op_kernel/dequant_swiglu_quant.h
+++ b/csrc/moe/dequant_swiglu_quant/op_kernel/dequant_swiglu_quant.h
@@ -132,6 +132,7 @@ protected:
 
     TBuf<TPosition::VECCALC> tmpBuf1_;
     TBuf<TPosition::VECCALC> tmpBuf2_; // only use in swigluMode == 1
+    TBuf<TPosition::VECCALC> scaleBuf_;
 
     uint32_t blockIdx_ = GetBlockIdx();
     int64_t realDimx_ = 0;
@@ -198,6 +199,8 @@ __aicore__ inline void DequantSwigluQuantBase<TEMPLATE_DSQ_ARGS>::Init(
     pipe_->InitBuffer(outQueue_, 1, UbSingleOutSize_ * sizeof(int8_t) + tl_->UbFactorDimx * sizeof(float) + BLOCK_SIZE);
 
     pipe_->InitBuffer(tmpBuf1_, UbSingleOutSize_ * SWI_FACTOR * sizeof(float));
+    pipe_->InitBuffer(scaleBuf_,
+        ((tl_->UbFactorDimx + BLOCK_ELEM - 1) / BLOCK_ELEM) * BLOCK_ELEM * BLOCK_ELEM * sizeof(float));
     if (tl_->swigluMode == 1) {
         pipe_->InitBuffer(
             tmpBuf2_,
@@ -704,25 +707,27 @@ __aicore__ inline void DequantSwigluQuantBase<TEMPLATE_DSQ_ARGS>::DynamicQuant(
     // Calc quant: proDimsx * 64 -> proDimsx
     // repeatTimes:proDimsx, dstRepStride:1(dtype), srcBlkStride:1, srcRepStride:tl_->UbFactorDimy / 64 * 8
     WholeReduceMax(
-        tmpUbF32Gate, tmpUbF32Gate, MASK_NUM_T32, proDimsx, 1, 1, tl_->UbFactorDimy / MASK_NUM_T32 * MASK_BLK_STRIDE,
-        ReduceOrder::ORDER_ONLY_VALUE);
+        tmpUbF32Gate, tmpUbF32Gate, MASK_NUM_T32, proDimsx, 1, 1, tl_->UbFactorDimy / BLOCK_ELEM,
+         ReduceOrder::ORDER_ONLY_VALUE);
     PipeBarrier<PIPE_V>();
     // Calc quant: scaleOut / 127.0
     Muls(scaleOut, tmpUbF32Gate, DYNAMIC_QUANT_FACTOR, proDimsx);
     PipeBarrier<PIPE_V>();
     // Calc Broadcast: proDimsx -> proDimsx,8
     int64_t blockCount = (proDimsx + BLOCK_ELEM - 1) / BLOCK_ELEM;
-    Brcb(outLocal, scaleOut, blockCount, {1, MASK_BLK_STRIDE});
+    LocalTensor<float> brcbTmp = scaleBuf_.AllocTensor<float>();
+    Brcb(brcbTmp, scaleOut, blockCount, {1, MASK_BLK_STRIDE});
     PipeBarrier<PIPE_V>();
     // Copy scale: [proDimsx,8] -> [proDimsx,H]
     SetMaskCount();
     SetVectorMask<float, MaskMode::COUNTER>(tl_->UbFactorDimy);
     Copy<float, false>(
-        tmpUbF32Gate, outLocal, AscendC::MASK_PLACEHOLDER, proDimsx,
+        tmpUbF32Gate, brcbTmp, AscendC::MASK_PLACEHOLDER, proDimsx,
         {1, 0, static_cast<uint16_t>(tl_->UbFactorDimy / BLOCK_ELEM), 1});
     SetMaskNorm();
     ResetMask();
     PipeBarrier<PIPE_V>();
+    scaleBuf_.FreeTensor(brcbTmp);
     // Calc y: tmpUbF32Act = tmpUbF32Act / scaleOut
     Div(tmpUbF32Act, tmpUbF32Act, tmpUbF32Gate, tl_->UbFactorDimy * proDimsx);
     PipeBarrier<PIPE_V>();

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements-lint.txt
 -r requirements.txt
-modelscope>=1.35.1
+modelscope==1.35.1
 openai
 pytest >= 6.0,<9.0.0
 pytest-asyncio

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -1,7 +1,4 @@
 import gc
-import math
-import os
-from pathlib import Path
 
 import pytest
 import torch
@@ -10,20 +7,10 @@ import torch_npu
 
 from vllm_ascend.utils import enable_custom_op
 
-# Default data dump location; override with DATA_DUMP_TP16_TENSOR env var
-_DEFAULT_DATA_DIR = "/home/z00893411/glm5/script/data_dump_tp16_tensor"
-DATA_DIR = Path(os.environ.get("DATA_DUMP_TP16_TENSOR", _DEFAULT_DATA_DIR))
-
 # enable internal format
 torch_npu.npu.config.allow_internal_format = True
 # enable vllm-ascend custom ops
 enable_custom_op()
-
-
-def _has_effective_swiglu_limit(swiglu_limit: int | float) -> bool:
-    limit = float(swiglu_limit)
-    # 0.0 is treated as "no clamp" but still uses the manual reference path.
-    return math.isfinite(limit) and 0.0 <= limit < 1_000_000.0
 
 
 def _shared_dequant_swiglu_quant(
@@ -33,21 +20,6 @@ def _shared_dequant_swiglu_quant(
     swiglu_limit: int | float,
     output_dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not _has_effective_swiglu_limit(swiglu_limit):
-        return torch.ops._C_ascend.npu_dequant_swiglu_quant(
-            x=hidden_states,
-            weight_scale=weight_scale,
-            activation_scale=activation_scale,
-            bias=None,
-            quant_scale=None,
-            quant_offset=None,
-            group_index=None,
-            activate_left=True,
-            quant_mode=1,
-            swiglu_mode=1,
-            clamp_limit=swiglu_limit,
-        )
-
     if hidden_states.shape[0] == 0:
         output_shape = hidden_states.shape[:-1] + (hidden_states.shape[-1] // 2,)
         return (
@@ -114,20 +86,14 @@ _REPRO_CASES = [
 @torch.inference_mode()
 @pytest.mark.parametrize("x_shape,clamp_limit,desc", _REPRO_CASES, ids=[c[2] for c in _REPRO_CASES])
 def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
-    swiglu_mode = 1
     # Use values with non-trivial abs() so reduce-max is meaningful
     x = torch.randint(-100, 100, x_shape, dtype=torch.int32)
     weight_scale = torch.randn(x_shape[1], dtype=torch.float32) * 0.1
     activate_scale = torch.randn((x_shape[0], 1), dtype=torch.float32) * 0.5
-    quant_mode = 1
 
     x = x.npu()
     weight_scale = weight_scale.npu()
     activate_scale = activate_scale.npu()
-
-    out_dimy = x_shape[1] // 2
-    print(f"\n=== Case: {desc} ===")
-    print(f"x_shape={x_shape}, outDimy={out_dimy}, outDimy%64={out_dimy % 64}, clamp_limit={clamp_limit}")
 
     # 1. Golden reference (pure PyTorch + npu_dynamic_quant)
     output_golden, output_scale_golden = _shared_dequant_swiglu_quant(
@@ -150,8 +116,8 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
             quant_offset=None,
             group_index=None,
             activate_left=True,
-            quant_mode=quant_mode,
-            swiglu_mode=swiglu_mode,
+            quant_mode=1,
+            swiglu_mode=1,
             clamp_limit=clamp_limit,
             glu_alpha=1.0,
             glu_bias=0.0,
@@ -161,21 +127,17 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
     # 3. Small ops workaround (manual dequant + npu_swiglu + npu_dynamic_quant)
     workaround_output, workaround_scale = _small_ops_dequant_swiglu_quant(x, weight_scale, activate_scale)
 
-    def _diff(a, b):
-        d = (a.float().cpu() - b.float().cpu()).abs()
-        return f"max_abs={d.max().item():.4f}, mean_abs={d.mean().item():.4f}"
-
-    print("\n--- Output diff ---")
-    print(f"Golden vs Fused      : {_diff(output_golden, output)}")
-    print(f"Golden vs Workaround : {_diff(output_golden, workaround_output)}")
-    print("--- Scale diff ---")
-    print(f"Golden vs Fused      : {_diff(output_scale_golden, output_scale)}")
-    print(f"Golden vs Workaround : {_diff(output_scale_golden, workaround_scale)}")
-
-    # int8 quantization output: atol=1 covers the rounding error (max_abs=1 in all cases)
-    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
-    # Dynamic quant scale: relax tolerance to cover both aligned and non-64-aligned outDimy
-    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=0.05, rtol=0.1)
+    # Compare all three results pairwise with strict tolerance
+    atol, rtol = 1e-4, 5e-3
+    # Golden vs Fused
+    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=atol, rtol=rtol)
+    # Golden vs Workaround
+    torch.testing.assert_close(workaround_output.cpu(), output_golden.cpu(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(workaround_scale.cpu(), output_scale_golden.cpu(), atol=atol, rtol=rtol)
+    # Fused vs Workaround
+    torch.testing.assert_close(workaround_output.cpu(), output.cpu(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(workaround_scale.cpu(), output_scale.cpu(), atol=atol, rtol=rtol)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -1,11 +1,18 @@
 import gc
 import math
+import os
+from pathlib import Path
 
+import pytest
 import torch
 import torch.nn.functional as F
 import torch_npu
 
 from vllm_ascend.utils import enable_custom_op
+
+# Default data dump location; override with DATA_DUMP_TP16_TENSOR env var
+_DEFAULT_DATA_DIR = "/home/z00893411/glm5/script/data_dump_tp16_tensor"
+DATA_DIR = Path(os.environ.get("DATA_DUMP_TP16_TENSOR", _DEFAULT_DATA_DIR))
 
 # enable internal format
 torch_npu.npu.config.allow_internal_format = True
@@ -15,7 +22,8 @@ enable_custom_op()
 
 def _has_effective_swiglu_limit(swiglu_limit: int | float) -> bool:
     limit = float(swiglu_limit)
-    return math.isfinite(limit) and 0.0 < limit < 1_000_000.0
+    # 0.0 is treated as "no clamp" but still uses the manual reference path.
+    return math.isfinite(limit) and 0.0 <= limit < 1_000_000.0
 
 
 def _shared_dequant_swiglu_quant(
@@ -53,13 +61,45 @@ def _shared_dequant_swiglu_quant(
 
     half = gate_up.shape[-1] // 2
     limit = float(swiglu_limit)
-    gate = torch.clamp(gate_up[..., :half], max=limit)
-    up = torch.clamp(gate_up[..., half:], min=-limit, max=limit)
+    gate = gate_up[..., :half]
+    up = gate_up[..., half:]
+    # Skip clamp when limit == 0 (treated as "no clamp")
+    if limit > 0.0:
+        gate = torch.clamp(gate, max=limit)
+        up = torch.clamp(up, min=-limit, max=limit)
     swiglu = F.silu(gate) * up
     if swiglu.dtype not in (torch.float16, torch.bfloat16):
         swiglu = swiglu.to(output_dtype if output_dtype in (torch.float16, torch.bfloat16) else torch.bfloat16)
     return torch_npu.npu_dynamic_quant(swiglu)
 
+def _small_ops_dequant_swiglu_quant(
+    x: torch.Tensor,
+    weight_scale: torch.Tensor,
+    activation_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Small ops workaround for npu_dequant_swiglu_quant.
+
+    Uses manual dequant + npu_swiglu + npu_dynamic_quant instead of the fused op.
+    This replicates the workaround in fused_moe.py.
+    """
+    # Ensure 1-D for correct broadcasting via unsqueeze
+    if activation_scale.dim() > 1:
+        activation_scale = activation_scale.squeeze(-1)
+    if weight_scale.dim() > 1:
+        weight_scale = weight_scale.squeeze(0)
+
+    # Dequant: int32 -> float32 -> multiply activation & weight scales -> bfloat16
+    hidden_states_fp = x.to(torch.float32)
+    hidden_states_fp = hidden_states_fp * activation_scale.unsqueeze(-1)
+    hidden_states_fp = hidden_states_fp * weight_scale.unsqueeze(0)
+    hidden_states_bf = hidden_states_fp.to(torch.bfloat16)
+
+    # SwiGLU activation
+    swiglu_out = torch_npu.npu_swiglu(hidden_states_bf)
+
+    # Dynamic quantization
+    quantized_x, swiglu_out_scale = torch_npu.npu_dynamic_quant(swiglu_out)
+    return quantized_x, swiglu_out_scale
 
 _REPRO_CASES = [
     ([4608, 2048], 0.0, "large_2048_aligned"),
@@ -133,18 +173,10 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
     print(f"Golden vs Fused      : {_diff(output_scale_golden, output_scale)}")
     print(f"Golden vs Workaround : {_diff(output_scale_golden, workaround_scale)}")
 
-
-    # Bug signature: fused op returns wrong scale when outDimy is not 64-aligned.
-    # xfail then return so the assertions below only run for 64-aligned cases.
-    if out_dimy % 64 != 0:
-        pytest.xfail(
-            f"Known bug: outDimy={out_dimy} is not 64-aligned, "
-            f"DynamicQuant returns wrong scale"
-        )
-        return
-
-    # torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
-    # torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=1e-4, rtol=5e-3)
+    # int8 quantization output: atol=1 covers the rounding error (max_abs=1 in all cases)
+    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
+    # Dynamic quant scale: relax tolerance to cover both aligned and non-64-aligned outDimy
+    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=0.05, rtol=0.1)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -180,4 +180,3 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
-

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -72,6 +72,7 @@ def _shared_dequant_swiglu_quant(
         swiglu = swiglu.to(output_dtype if output_dtype in (torch.float16, torch.bfloat16) else torch.bfloat16)
     return torch_npu.npu_dynamic_quant(swiglu)
 
+
 def _small_ops_dequant_swiglu_quant(
     x: torch.Tensor,
     weight_scale: torch.Tensor,
@@ -101,11 +102,12 @@ def _small_ops_dequant_swiglu_quant(
     quantized_x, swiglu_out_scale = torch_npu.npu_dynamic_quant(swiglu_out)
     return quantized_x, swiglu_out_scale
 
+
 _REPRO_CASES = [
     ([4608, 2048], 0.0, "large_2048_aligned"),
-    ([2, 192],     0.0, "small_192_misaligned"),
-    ([4, 192],     0.0, "small_192_misaligned_4rows"),
-    ([8, 384],     0.0, "small_384_aligned"),
+    ([2, 192], 0.0, "small_192_misaligned"),
+    ([4, 192], 0.0, "small_192_misaligned_4rows"),
+    ([8, 384], 0.0, "small_384_aligned"),
 ]
 
 
@@ -125,8 +127,7 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
 
     out_dimy = x_shape[1] // 2
     print(f"\n=== Case: {desc} ===")
-    print(f"x_shape={x_shape}, outDimy={out_dimy}, "
-          f"outDimy%64={out_dimy % 64}, clamp_limit={clamp_limit}")
+    print(f"x_shape={x_shape}, outDimy={out_dimy}, outDimy%64={out_dimy % 64}, clamp_limit={clamp_limit}")
 
     # 1. Golden reference (pure PyTorch + npu_dynamic_quant)
     output_golden, output_scale_golden = _shared_dequant_swiglu_quant(
@@ -158,18 +159,16 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
     graph.replay()
 
     # 3. Small ops workaround (manual dequant + npu_swiglu + npu_dynamic_quant)
-    workaround_output, workaround_scale = _small_ops_dequant_swiglu_quant(
-        x, weight_scale, activate_scale
-    )
+    workaround_output, workaround_scale = _small_ops_dequant_swiglu_quant(x, weight_scale, activate_scale)
 
     def _diff(a, b):
         d = (a.float().cpu() - b.float().cpu()).abs()
         return f"max_abs={d.max().item():.4f}, mean_abs={d.mean().item():.4f}"
 
-    print(f"\n--- Output diff ---")
+    print("\n--- Output diff ---")
     print(f"Golden vs Fused      : {_diff(output_golden, output)}")
     print(f"Golden vs Workaround : {_diff(output_golden, workaround_output)}")
-    print(f"--- Scale diff ---")
+    print("--- Scale diff ---")
     print(f"Golden vs Fused      : {_diff(output_scale_golden, output_scale)}")
     print(f"Golden vs Workaround : {_diff(output_scale_golden, workaround_scale)}")
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -61,27 +61,43 @@ def _shared_dequant_swiglu_quant(
     return torch_npu.npu_dynamic_quant(swiglu)
 
 
-@torch.inference_mode()
-def test_npu_dequant_swiglu_quant_with_limit():
-    swiglu_mode = 1
-    x_shape = [4608, 2048]
-    x = torch.randint(-10, 10, x_shape, dtype=torch.int32)
-    weight_scale = torch.randn(x_shape[1], dtype=torch.float32)
-    activate_scale = torch.randn((x_shape[0], 1), dtype=torch.float32)
-    clamp_limit = 2.0
-    quant_mode = 1
+_REPRO_CASES = [
+    ([4608, 2048], 0.0, "large_2048_aligned"),
+    ([2, 192],     0.0, "small_192_misaligned"),
+    ([4, 192],     0.0, "small_192_misaligned_4rows"),
+    ([8, 384],     0.0, "small_384_aligned"),
+]
 
-    output_golden, output_scale_golden = _shared_dequant_swiglu_quant(
-        x.npu(),
-        weight_scale.npu(),
-        activate_scale.npu(),
-        clamp_limit,
-        torch.bfloat16,
-    )
+
+@torch.inference_mode()
+@pytest.mark.parametrize("x_shape,clamp_limit,desc", _REPRO_CASES, ids=[c[2] for c in _REPRO_CASES])
+def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
+    swiglu_mode = 1
+    # Use values with non-trivial abs() so reduce-max is meaningful
+    x = torch.randint(-100, 100, x_shape, dtype=torch.int32)
+    weight_scale = torch.randn(x_shape[1], dtype=torch.float32) * 0.1
+    activate_scale = torch.randn((x_shape[0], 1), dtype=torch.float32) * 0.5
+    quant_mode = 1
 
     x = x.npu()
     weight_scale = weight_scale.npu()
     activate_scale = activate_scale.npu()
+
+    out_dimy = x_shape[1] // 2
+    print(f"\n=== Case: {desc} ===")
+    print(f"x_shape={x_shape}, outDimy={out_dimy}, "
+          f"outDimy%64={out_dimy % 64}, clamp_limit={clamp_limit}")
+
+    # 1. Golden reference (pure PyTorch + npu_dynamic_quant)
+    output_golden, output_scale_golden = _shared_dequant_swiglu_quant(
+        x,
+        weight_scale,
+        activate_scale,
+        clamp_limit,
+        torch.bfloat16,
+    )
+
+    # 2. Fused op (NPUGraph, same as production code)
     graph = torch.npu.NPUGraph()
     with torch.npu.graph(graph, capture_error_mode="thread_local", auto_dispatch_capture=True):
         output, output_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
@@ -101,9 +117,36 @@ def test_npu_dequant_swiglu_quant_with_limit():
         )
     graph.replay()
 
-    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
-    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=1e-4, rtol=5e-3)
+    # 3. Small ops workaround (manual dequant + npu_swiglu + npu_dynamic_quant)
+    workaround_output, workaround_scale = _small_ops_dequant_swiglu_quant(
+        x, weight_scale, activate_scale
+    )
+
+    def _diff(a, b):
+        d = (a.float().cpu() - b.float().cpu()).abs()
+        return f"max_abs={d.max().item():.4f}, mean_abs={d.mean().item():.4f}"
+
+    print(f"\n--- Output diff ---")
+    print(f"Golden vs Fused      : {_diff(output_golden, output)}")
+    print(f"Golden vs Workaround : {_diff(output_golden, workaround_output)}")
+    print(f"--- Scale diff ---")
+    print(f"Golden vs Fused      : {_diff(output_scale_golden, output_scale)}")
+    print(f"Golden vs Workaround : {_diff(output_scale_golden, workaround_scale)}")
+
+
+    # Bug signature: fused op returns wrong scale when outDimy is not 64-aligned.
+    # xfail then return so the assertions below only run for 64-aligned cases.
+    if out_dimy % 64 != 0:
+        pytest.xfail(
+            f"Known bug: outDimy={out_dimy} is not 64-aligned, "
+            f"DynamicQuant returns wrong scale"
+        )
+        return
+
+    # torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
+    # torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=1e-4, rtol=5e-3)
 
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -50,6 +50,7 @@ _REPRO_CASES = [
     ([2, 192], 0.0, "small_192_misaligned"),
     ([4, 192], 0.0, "small_192_misaligned_4rows"),
     ([8, 384], 0.0, "small_384_aligned"),
+    ([1, 256], 0.0, "single_row_256_aligned"),
 ]
 
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_swiglu_quant.py
@@ -45,36 +45,6 @@ def _shared_dequant_swiglu_quant(
     return torch_npu.npu_dynamic_quant(swiglu)
 
 
-def _small_ops_dequant_swiglu_quant(
-    x: torch.Tensor,
-    weight_scale: torch.Tensor,
-    activation_scale: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Small ops workaround for npu_dequant_swiglu_quant.
-
-    Uses manual dequant + npu_swiglu + npu_dynamic_quant instead of the fused op.
-    This replicates the workaround in fused_moe.py.
-    """
-    # Ensure 1-D for correct broadcasting via unsqueeze
-    if activation_scale.dim() > 1:
-        activation_scale = activation_scale.squeeze(-1)
-    if weight_scale.dim() > 1:
-        weight_scale = weight_scale.squeeze(0)
-
-    # Dequant: int32 -> float32 -> multiply activation & weight scales -> bfloat16
-    hidden_states_fp = x.to(torch.float32)
-    hidden_states_fp = hidden_states_fp * activation_scale.unsqueeze(-1)
-    hidden_states_fp = hidden_states_fp * weight_scale.unsqueeze(0)
-    hidden_states_bf = hidden_states_fp.to(torch.bfloat16)
-
-    # SwiGLU activation
-    swiglu_out = torch_npu.npu_swiglu(hidden_states_bf)
-
-    # Dynamic quantization
-    quantized_x, swiglu_out_scale = torch_npu.npu_dynamic_quant(swiglu_out)
-    return quantized_x, swiglu_out_scale
-
-
 _REPRO_CASES = [
     ([4608, 2048], 0.0, "large_2048_aligned"),
     ([2, 192], 0.0, "small_192_misaligned"),
@@ -124,20 +94,10 @@ def test_npu_dequant_swiglu_quant_with_limit(x_shape, clamp_limit, desc):
         )
     graph.replay()
 
-    # 3. Small ops workaround (manual dequant + npu_swiglu + npu_dynamic_quant)
-    workaround_output, workaround_scale = _small_ops_dequant_swiglu_quant(x, weight_scale, activate_scale)
-
-    # Compare all three results pairwise with strict tolerance
-    atol, rtol = 1e-4, 5e-3
-    # Golden vs Fused
-    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=atol, rtol=rtol)
-    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=atol, rtol=rtol)
-    # Golden vs Workaround
-    torch.testing.assert_close(workaround_output.cpu(), output_golden.cpu(), atol=atol, rtol=rtol)
-    torch.testing.assert_close(workaround_scale.cpu(), output_scale_golden.cpu(), atol=atol, rtol=rtol)
-    # Fused vs Workaround
-    torch.testing.assert_close(workaround_output.cpu(), output.cpu(), atol=atol, rtol=rtol)
-    torch.testing.assert_close(workaround_scale.cpu(), output_scale.cpu(), atol=atol, rtol=rtol)
+    # int8 quantization output: atol=1 covers the rounding error (max_abs=1 in all cases)
+    torch.testing.assert_close(output.cpu(), output_golden.cpu(), atol=1, rtol=0.1)
+    # Dynamic quant scale: relax tolerance to cover both aligned and non-64-aligned outDimy
+    torch.testing.assert_close(output_scale.cpu(), output_scale_golden.cpu(), atol=1e-4, rtol=5e-3)
 
     gc.collect()
     torch.npu.empty_cache()


### PR DESCRIPTION

### What this PR does / why we need it?
Fix the precision issue caused by the bug in small shape tiling. Additionally, add corresponding single-operator test cases.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
test

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
