### PR TITLE
  [BugFix][Worker] Tighten mrope gate in patch_qwen3_5 for non-mrope Qwen3.5-backbone VLMs

### DIFF
--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -31,6 +31,7 @@ except ImportError:
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
 from vllm_ascend.utils import is_310p
 
 _GDN_PATCH_TARGET = _GDNBaseCls
@@ -39,7 +40,7 @@ _GDN_PATCH_TARGET = _GDNBaseCls
 class AscendQwen3NextAttention(Qwen3NextAttention):
     def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor, output: torch.Tensor = None):
         qkv, _ = self.qkv_proj(hidden_states)
-        if "qwen3_5" in self.config.model_type:
+        if "qwen3_5" in self.config.model_type and isinstance(self.rotary_emb, AscendMRotaryEmbedding):
             cos_sin = self.rotary_emb.cos_sin_cache[positions]
             if cos_sin.device != qkv.device:
                 cos_sin = cos_sin.to(qkv.device)


### PR DESCRIPTION
## What this PR does / why we need it?

The mrope fast path in `patch_qwen3_5.py` is gated on `"qwen3_5" in self.config.model_type`, which is true for MiniCPM-V-4.6 (its `model_type` is swizzled to `qwen3_5_text` because it reuses the Qwen3.5 text backbone). But MiniCPM-V-4.6 uses embedding injection for vision, not M-RoPE, which is what the current logic admits thinking it's a Qwen-VL model, and the execution crashes:

```
AttributeError: 'AscendRotaryEmbedding' object has no attribute 'mrope_section'
```

Fix: also require `isinstance(self.rotary_emb, AscendMRotaryEmbedding)`, same pattern `patch_qwen3vl.py:37` already uses. When false, fall through to the polymorphic `else` branch.

## Does this PR introduce _any_ user-facing change?

Fixes a crash on model load for MiniCPM-V-4.6 (and any Qwen3.5-backbone VLM using embedding injection instead of M-RoPE). No API change.

## How was this patch tested?

Verified manually on `quay.io/ascend/vllm-ascend:v0.22.1rc1-a3-openeuler` (Ascend910_9392, CANN 9.0.0, transformers 5.7.0).       **Before fix:**
```
`AttributeError: 'AscendRotaryEmbedding' object has no attribute 'mrope_section'` at model load.
```
**After fix:**
```
[smoke] model loaded in 56.3s
[smoke] generate() took 57.5s
[smoke] OUTPUT: '\nThe image is a solid purple color with no other visible elements.'
[smoke] PASS
```

- vLLM version: v0.25.0
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
