### PR TITLE
[BugFix] Deduplicate reused AscendStore blocks

### DIFF
--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -423,6 +423,38 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         finished = t.get_and_clear_finished_requests()
         self.assertIn("r1", finished)
 
+    def test_handle_request_keeps_latest_reused_physical_block(self):
+        store = FakeStore()
+        db = FakeTokenDatabase()
+        t = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+        )
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=64, can_load=True, token_len=64)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[1, 2, 1, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            load_spec=load_spec,
+        )
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        self.assertEqual(len(store.get_calls), 1)
+        keys, addrs, _ = store.get_calls[0]
+        self.assertEqual(len(keys), 3)
+        self.assertTrue(keys[0].endswith("@k1"))
+        self.assertTrue(keys[1].endswith("@k2"))
+        self.assertTrue(keys[2].endswith("@k3"))
+        self.assertEqual(addrs, [[1002], [1001], [1003]])
+
     def test_handle_request_applies_load_mask(self):
         store = FakeStore()
         db = MaskedFakeTokenDatabase(masks=([True, False],))

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -195,9 +195,9 @@ class TestKVTransferThread(unittest.TestCase):
 
 
 class TestKVCacheStoreSendingThread(unittest.TestCase):
-    def _make_thread(self, exists_result=None, kv_role="kv_producer", enable_kv_event=False):
+    def _make_thread(self, exists_result=None, kv_role="kv_producer", enable_kv_event=False, db=None):
         store = FakeStore(exists_result or [0, 0, 0, 0])
-        db = FakeTokenDatabase()
+        db = db or FakeTokenDatabase()
         t = KVCacheStoreSendingThread(
             m_store=store,
             token_database=db,
@@ -228,8 +228,9 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 2)
 
-    def test_handle_request_keeps_latest_reused_physical_block(self):
-        t, store = self._make_thread([0, 0, 0])
+    def test_handle_request_drops_reused_block_if_latest_is_masked(self):
+        db = MaskedFakeTokenDatabase(masks=([True, True, False, True],))
+        t, store = self._make_thread([0, 0], db=db)
         req = ReqMeta(
             req_id="r1",
             token_len_chunk=64,
@@ -243,11 +244,10 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
         self.assertEqual(len(store.put_calls), 1)
         keys, addrs, _ = store.put_calls[0]
-        self.assertEqual(len(keys), 3)
+        self.assertEqual(len(keys), 2)
         self.assertTrue(keys[0].endswith("@k1"))
-        self.assertTrue(keys[1].endswith("@k2"))
-        self.assertTrue(keys[2].endswith("@k3"))
-        self.assertEqual(addrs, [[1002], [1001], [1003]])
+        self.assertTrue(keys[1].endswith("@k3"))
+        self.assertEqual(addrs, [[1002], [1003]])
 
     def test_handle_request_all_exist_no_put(self):
         t, store = self._make_thread([1, 1])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -228,6 +228,27 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 2)
 
+    def test_handle_request_keeps_latest_reused_physical_block(self):
+        t, store = self._make_thread([0, 0, 0])
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[1, 2, 1, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            current_event=None,
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        self.assertEqual(len(store.put_calls), 1)
+        keys, addrs, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 3)
+        self.assertTrue(keys[0].endswith("@k1"))
+        self.assertTrue(keys[1].endswith("@k2"))
+        self.assertTrue(keys[2].endswith("@k3"))
+        self.assertEqual(addrs, [[1002], [1001], [1003]])
+
     def test_handle_request_all_exist_no_put(self):
         t, store = self._make_thread([1, 1])
         req = ReqMeta(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -733,6 +733,21 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     block_hashes.append(group_block_hashes[start // group_block_size])
                     key_block_ids.append(block_id)
 
+                if len(set(key_block_ids)) != len(key_block_ids):
+                    last_index_by_block_id = {block_id: index for index, block_id in enumerate(key_block_ids)}
+                    keep_indices = sorted(last_index_by_block_id.values())
+                    logger.debug(
+                        "Deduplicating %d reused physical KV blocks for request %s in group %d",
+                        len(key_block_ids) - len(keep_indices),
+                        req_id,
+                        group_id,
+                    )
+                    starts = [starts[index] for index in keep_indices]
+                    ends = [ends[index] for index in keep_indices]
+                    keys = [keys[index] for index in keep_indices]
+                    block_hashes = [block_hashes[index] for index in keep_indices]
+                    key_block_ids = [key_block_ids[index] for index in keep_indices]
+
                 if (
                     not self.dcp_size > 1
                     and not req_meta.disable_tp_key_sharding

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -914,6 +914,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             group_ids = req_meta.kv_cache_group_ids or [0]
             load_masks = self._load_mask(req_meta, token_len)
             for group_id in group_ids:
+                starts = []
+                ends = []
+                keys = []
+                key_block_ids = []
                 block_ids = req_meta.block_ids_by_group[group_id]
                 group_block_size = self._get_block_size(group_id)
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
@@ -927,14 +931,34 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 ):
                     if not self._mask_allows_chunk(load_masks, group_id, start):
                         continue
+                    starts.append(start)
+                    ends.append(end)
+                    keys.append(key)
+                    key_block_ids.append(block_id)
+
+                if len(set(key_block_ids)) != len(key_block_ids):
+                    last_index_by_block_id = {block_id: index for index, block_id in enumerate(key_block_ids)}
+                    keep_indices = sorted(last_index_by_block_id.values())
+                    logger.debug(
+                        "Deduplicating %d reused physical KV blocks before load for request %s in group %d",
+                        len(key_block_ids) - len(keep_indices),
+                        req_id,
+                        group_id,
+                    )
+                    starts = [starts[index] for index in keep_indices]
+                    ends = [ends[index] for index in keep_indices]
+                    keys = [keys[index] for index in keep_indices]
+                    key_block_ids = [key_block_ids[index] for index in keep_indices]
+
+                for index, start in enumerate(starts):
                     addr, size, block_id = self._prepare_value(
                         start,
-                        end,
+                        ends[index],
                         block_ids,
                         kv_cache_group_id=group_id,
-                        block_id=block_id,
+                        block_id=key_block_ids[index],
                     )
-                    key_list.append(key.to_string())
+                    key_list.append(keys[index].to_string())
                     addr_list.append(addr)
                     size_list.append(size)
                     block_id_list.append(block_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -526,7 +526,7 @@ class KVTransferThread(threading.Thread):
     ):
         process_with_block_ids = getattr(self.token_database, "process_tokens_with_block_ids", None)
         if process_with_block_ids is not None:
-            return process_with_block_ids(
+            token_iter = process_with_block_ids(
                 token_len,
                 block_hashes,
                 block_ids,
@@ -535,23 +535,27 @@ class KVTransferThread(threading.Thread):
                 skip_null_blocks=skip_null_blocks,
                 cache_role=cache_role,
             )
+        else:
 
-        def iter_with_legacy_process_tokens():
-            try:
-                token_iter = self.token_database.process_tokens(token_len, block_hashes, mask_num)
-            except TypeError:
-                token_iter = self.token_database.process_tokens(token_len, block_hashes)
-            group_block_size = self._get_block_size(kv_cache_group_id)
-            for start, end, key in token_iter:
-                block_idx = start // group_block_size
-                if block_idx >= len(block_ids):
-                    continue
-                block_id = block_ids[block_idx]
-                if skip_null_blocks and cache_role == "kv" and block_id <= 0:
-                    continue
-                yield start, end, key, block_id
+            def iter_with_legacy_process_tokens():
+                try:
+                    token_iter = self.token_database.process_tokens(token_len, block_hashes, mask_num)
+                except TypeError:
+                    token_iter = self.token_database.process_tokens(token_len, block_hashes)
+                group_block_size = self._get_block_size(kv_cache_group_id)
+                for start, end, key in token_iter:
+                    block_idx = start // group_block_size
+                    if block_idx >= len(block_ids):
+                        continue
+                    block_id = block_ids[block_idx]
+                    if skip_null_blocks and cache_role == "kv" and block_id <= 0:
+                        continue
+                    yield start, end, key, block_id
 
-        return iter_with_legacy_process_tokens()
+            token_iter = iter_with_legacy_process_tokens()
+
+        latest_chunks = {chunk[3]: chunk for chunk in token_iter}
+        return iter(sorted(latest_chunks.values(), key=lambda chunk: chunk[0]))
 
     def _prepare_value(
         self,
@@ -733,21 +737,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     block_hashes.append(group_block_hashes[start // group_block_size])
                     key_block_ids.append(block_id)
 
-                if len(set(key_block_ids)) != len(key_block_ids):
-                    last_index_by_block_id = {block_id: index for index, block_id in enumerate(key_block_ids)}
-                    keep_indices = sorted(last_index_by_block_id.values())
-                    logger.debug(
-                        "Deduplicating %d reused physical KV blocks for request %s in group %d",
-                        len(key_block_ids) - len(keep_indices),
-                        req_id,
-                        group_id,
-                    )
-                    starts = [starts[index] for index in keep_indices]
-                    ends = [ends[index] for index in keep_indices]
-                    keys = [keys[index] for index in keep_indices]
-                    block_hashes = [block_hashes[index] for index in keep_indices]
-                    key_block_ids = [key_block_ids[index] for index in keep_indices]
-
                 if (
                     not self.dcp_size > 1
                     and not req_meta.disable_tp_key_sharding
@@ -914,10 +903,6 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             group_ids = req_meta.kv_cache_group_ids or [0]
             load_masks = self._load_mask(req_meta, token_len)
             for group_id in group_ids:
-                starts = []
-                ends = []
-                keys = []
-                key_block_ids = []
                 block_ids = req_meta.block_ids_by_group[group_id]
                 group_block_size = self._get_block_size(group_id)
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
@@ -931,34 +916,14 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 ):
                     if not self._mask_allows_chunk(load_masks, group_id, start):
                         continue
-                    starts.append(start)
-                    ends.append(end)
-                    keys.append(key)
-                    key_block_ids.append(block_id)
-
-                if len(set(key_block_ids)) != len(key_block_ids):
-                    last_index_by_block_id = {block_id: index for index, block_id in enumerate(key_block_ids)}
-                    keep_indices = sorted(last_index_by_block_id.values())
-                    logger.debug(
-                        "Deduplicating %d reused physical KV blocks before load for request %s in group %d",
-                        len(key_block_ids) - len(keep_indices),
-                        req_id,
-                        group_id,
-                    )
-                    starts = [starts[index] for index in keep_indices]
-                    ends = [ends[index] for index in keep_indices]
-                    keys = [keys[index] for index in keep_indices]
-                    key_block_ids = [key_block_ids[index] for index in keep_indices]
-
-                for index, start in enumerate(starts):
                     addr, size, block_id = self._prepare_value(
                         start,
-                        ends[index],
+                        end,
                         block_ids,
                         kv_cache_group_id=group_id,
-                        block_id=key_block_ids[index],
+                        block_id=block_id,
                     )
-                    key_list.append(keys[index].to_string())
+                    key_list.append(key.to_string())
                     addr_list.append(addr)
                     size_list.append(size)
                     block_id_list.append(block_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -524,38 +524,40 @@ class KVTransferThread(threading.Thread):
         skip_null_blocks: bool = False,
         cache_role: str = "kv",
     ):
+        def keep_latest(token_iter):
+            latest_chunks = {chunk[3]: chunk for chunk in token_iter}
+            return iter(sorted(latest_chunks.values(), key=lambda chunk: chunk[0]))
+
         process_with_block_ids = getattr(self.token_database, "process_tokens_with_block_ids", None)
         if process_with_block_ids is not None:
-            token_iter = process_with_block_ids(
-                token_len,
-                block_hashes,
-                block_ids,
-                mask_num,
-                kv_cache_group_id=kv_cache_group_id,
-                skip_null_blocks=skip_null_blocks,
-                cache_role=cache_role,
+            return keep_latest(
+                process_with_block_ids(
+                    token_len,
+                    block_hashes,
+                    block_ids,
+                    mask_num,
+                    kv_cache_group_id=kv_cache_group_id,
+                    skip_null_blocks=skip_null_blocks,
+                    cache_role=cache_role,
+                )
             )
-        else:
 
-            def iter_with_legacy_process_tokens():
-                try:
-                    token_iter = self.token_database.process_tokens(token_len, block_hashes, mask_num)
-                except TypeError:
-                    token_iter = self.token_database.process_tokens(token_len, block_hashes)
-                group_block_size = self._get_block_size(kv_cache_group_id)
-                for start, end, key in token_iter:
-                    block_idx = start // group_block_size
-                    if block_idx >= len(block_ids):
-                        continue
-                    block_id = block_ids[block_idx]
-                    if skip_null_blocks and cache_role == "kv" and block_id <= 0:
-                        continue
-                    yield start, end, key, block_id
+        def iter_with_legacy_process_tokens():
+            try:
+                token_iter = self.token_database.process_tokens(token_len, block_hashes, mask_num)
+            except TypeError:
+                token_iter = self.token_database.process_tokens(token_len, block_hashes)
+            group_block_size = self._get_block_size(kv_cache_group_id)
+            for start, end, key in token_iter:
+                block_idx = start // group_block_size
+                if block_idx >= len(block_ids):
+                    continue
+                block_id = block_ids[block_idx]
+                if skip_null_blocks and cache_role == "kv" and block_id <= 0:
+                    continue
+                yield start, end, key, block_id
 
-            token_iter = iter_with_legacy_process_tokens()
-
-        latest_chunks = {chunk[3]: chunk for chunk in token_iter}
-        return iter(sorted(latest_chunks.values(), key=lambda chunk: chunk[0]))
+        return keep_latest(iter_with_legacy_process_tokens())
 
     def _prepare_value(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

AscendStore can receive the same physical KV block ID at multiple logical positions for sliding-window or recycled-block groups. The physical block contains the latest logical position's data, so storing every mapping can write current data under a stale hash key and duplicate puts across TP ranks.

This PR keeps only the latest logical chunk for each physical block in the shared token iterator, before the sending and receiving paths apply their store/load masks. Both paths therefore use the same mapping, and a masked latest chunk cannot cause current data to be transferred under an older stale key. This follows the ownership-side deduplication principle used by vLLM in https://github.com/vllm-project/vllm/pull/42903 while preserving AscendStore's existing group and mask semantics.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. AscendStore no longer stores or loads stale key mappings for reused physical KV blocks.

### How was this patch tested?

- Added sending and receiving unit tests for physical block IDs `[1, 2, 1, 3]`, including a masked latest chunk, to verify that stale mappings are never transferred.
- Existing AscendStore store-mask and load-mask tests pass.
- All changed-file pre-commit hooks pass.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
