### PR TITLE
[CI] Remove stale nightly A2 config pointing to empty dir

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -9,10 +9,6 @@
 a2:
   single_node:
     test_config:
-      # pytest-driven tests
-      - name: test_custom_op_multi_card
-        os: linux-aarch64-a2b3-4
-        tests: tests/e2e/nightly/single_node/ops/multicard_ops_a2/
       # YAML-driven tests
       - name: qwen3-vl-32b-instruct-w8a8
         os: linux-aarch64-a2b3-4

--- a/docs/source/developer_guide/contribution/nightly_ci_test.md
+++ b/docs/source/developer_guide/contribution/nightly_ci_test.md
@@ -245,15 +245,15 @@ This is useful for automated root-cause analysis of nightly regressions.
 
 ## Adding a New Test Case — Worked Example
 
-To add `my-new-test` to the A2 single-node section:
+To add `my-new-test` to the A3 multi-card section:
 
 1. Edit `.github/workflows/configs/nightly_config.yaml`, append under
-   `a2.single_node.test_config`:
+   `a3.multi_card.test_config`:
 
    ```yaml
      - name: my-new-test
-       os: linux-aarch64-a2b3-4
-       tests: tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_my_new.py
+       os: linux-aarch64-nightly-a3-4
+       tests: tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_my_new.py
    ```
 
 2. Commit the new pytest file (`test_my_new.py`) in the same PR.
@@ -267,10 +267,10 @@ To add `my-new-test` to the A2 single-node section:
 The workflow will:
 
 - `pr_nightly_command.yml` reads your PR's `nightly_config.yaml` and resolves
-  `my-new-test` → dispatch A2 only.
-- `Nightly-A2` is dispatched at `main`, but `generate-a2-matrix` checks out your
+  `my-new-test` → dispatch A3 only.
+- `Nightly-A3` is dispatched at `main`, but `setup-vars` checks out your
   PR commit and reads the new entry from the matrix.
-- `single-node-tests` runs one matrix job for `my-new-test`, with
+- `multi-card-tests` runs one matrix job for `my-new-test`, with
   `should_run=true`. The reusable workflow checks out your PR code (via
   `vllm_ascend_ref`) and runs your pytest.
 

--- a/docs/source/developer_guide/contribution/testing.md
+++ b/docs/source/developer_guide/contribution/testing.md
@@ -237,9 +237,6 @@ You can run tests with `pytest` as well. Typical examples:
 
     ```bash
     cd /vllm-workspace/vllm-ascend/
-    # run all multi-card op tests on A2
-    VLLM_USE_MODELSCOPE=true pytest -sv tests/e2e/nightly/single_node/ops/multicard_ops_a2/
-
     # run all multi-card op tests on A3
     VLLM_USE_MODELSCOPE=true pytest -sv tests/e2e/nightly/single_node/ops/multicard_ops_a3/
     ```

--- a/tools/bisect/good_table.py
+++ b/tools/bisect/good_table.py
@@ -21,7 +21,7 @@ these columns::
 
 Example rows (columns abbreviated)::
 
-    test_custom_op_multi_card, .../multicard_ops_a2/, <link>, success, <vllm>, <vllm_ascend>, <time>
+    qwen3-30b-acc, .../test_qwen3_30b_acc.py, <link>, success, <vllm>, <vllm_ascend>, <time>
     Qwen3.5-397B-A17B-w4a8-mtp, .../Qwen3.5-...-A2.yaml, <link>, failure, <vllm>, <vllm_ascend>, <time>
 
 For a given case (matched by ``name`` or by ``yaml/path``) the last-known-good


### PR DESCRIPTION
### What this PR does / why we need it?

PR #12119 ([Refactor] Remove matmulallreduce) deleted the only test file under `tests/e2e/nightly/single_node/ops/multicard_ops_a2/` but left the `nightly_config.yaml` entry `test_custom_op_multi_card` pointing at that now-empty directory. The A2 nightly run executes `pytest -sv` against it, collects 0 tests, and fails with exit code 5.

This drops the stale config entry so the `pytest-driven` step is skipped (`inputs.tests` becomes empty) and A2 nightly proceeds with only the YAML-driven tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Confirmed `tests/e2e/nightly/single_node/ops/multicard_ops_a2/` now contains only an empty `__init__.py`


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
