### PR TITLE
[Doc][BugFix] Update Atlas 310P startup configuration to disable npugraph_ex v0.23.0

### DIFF
--- a/docs/source/developer_guide/Design_Documents/npugraph_ex.md
+++ b/docs/source/developer_guide/Design_Documents/npugraph_ex.md
@@ -6,6 +6,10 @@ This is an optimization based on FX graphs, which can be considered an accelerat
 
 You can get its code [code](https://gitcode.com/Ascend/torchair)
 
+```{note}
+Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
+```
+
 ## Default FX Graph Optimization
 
 ### FX Graph pass

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -35,6 +35,8 @@ This section guides you through container-based environment setup and large mode
 ```{note}
 Atlas inference products use CANN 9.1.0 beta and `float16`. Use the `-310p` image suffix for Ubuntu or `-310p-openeuler` for openEuler. Atlas inference products do not support `triton` or `triton-ascend`.
 
+Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
+
 Atlas 200I Pro requires additional device nodes and driver mounts. See [Set up using Docker](installation.md#set-up-using-docker) for the complete container commands.
 ```
 

--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -194,7 +194,8 @@ vllm serve Qwen/Qwen3-VL-8B-Instruct \
 vllm serve Qwen/Qwen3-VL-8B-Instruct \
 --dtype float16 \
 --max_model_len 16384 \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}'
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}' \
+--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'
 ```
 
 :::{note}
@@ -202,6 +203,7 @@ On Atlas inference products:
 
 - Only `float16` dtype is supported.
 - Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**. If your CANN version is lower, replace `--compilation-config` with `--enforce-eager`.
+- `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required because `enable_npugraph_ex` is not supported on Atlas inference products.
 :::
 
 ::::

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -320,7 +320,7 @@ vllm serve Eco-Tech/Qwen3-8B-w8a8sc-310-vllm/TP1/Qwen3-8B-w8a8sc-310-vllm-tp1 \
     --max-num-seqs 32 \
     --served-model-name qwen3 \
     --dtype float16 \
-    --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+    --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}' \
     --quantization ascend \
     --max-model-len 16384 \
@@ -342,7 +342,7 @@ vllm serve Eco-Tech/Qwen3-14B-w8a8sc-310-vllm/TP1/Qwen3-14B-w8a8sc-310-vllm-tp1 
     --max-num-seqs 16 \
     --served-model-name qwen3 \
     --dtype float16 \
-    --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+    --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
     --quantization ascend \
     --max-model-len 16384 \
@@ -364,7 +364,7 @@ vllm serve Eco-Tech/Qwen3-32B-w8a8sc-310-vllm/TP4/Qwen3-32B-w8a8sc-310-vllm-tp4 
     --max-num-seqs 32 \
     --served-model-name qwen3 \
     --dtype float16 \
-    --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+    --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [16,32]}' \
     --quantization ascend \
     --max-model-len 20480 \

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -245,7 +245,7 @@ vllm serve Eco-Tech/Qwen3.6-35B-A3B-w8a8 \
   --max-num-seqs 16 \
   --served-model-name qwen3.6 \
   --dtype float16 \
-  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+  --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
   --quantization ascend \
   --max-model-len 20480 \
@@ -258,7 +258,7 @@ vllm serve Eco-Tech/Qwen3.6-35B-A3B-w8a8 \
 - `--dtype float16` is used for Atlas inference products to match the Atlas inference execution path.
 - `--max-num-seqs 16` limits concurrent active requests to reduce KV cache and graph capture pressure on Atlas inference products.
 - `--gpu-memory-utilization` controls KV cache capacity. Reduce it if startup or runtime requests report OOM.
-- `--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'` disables norm-quant fusion for the Atlas inference products serving path.
+- `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required because `enable_npugraph_ex` is not supported on Atlas inference products.
 - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}'` enables decode ACLGraph replay and explicitly limits capture sizes for Atlas inference products.
 - `--no-enable-prefix-caching` is the default recommendation for this Atlas inference products example to reduce memory pressure.
 - `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.

--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -123,6 +123,10 @@ This is most likely to appear in `PIECEWISE` or `FULL_AND_PIECEWISE` configurati
 
 As introduced in the [RFC](https://github.com/vllm-project/vllm-ascend/issues/4715), Npugraph_ex is a compile-time FX graph optimization layer that works together with ACLGraph. It optimizes the model's FX graph before ACLGraph captures it at runtime. Its performance benefits mainly come from fusing multiple operators into single kernels (e.g., add + rms_norm → npu_add_rms_norm) to reduce kernel launch overhead.
 
+```{note}
+Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
+```
+
 ### Default behavior
 
 Npugraph_ex is **enabled by default** when `cudagraph_mode` is `FULL` or `FULL_DECODE_ONLY`. It is automatically disabled in `PIECEWISE` or `NONE` modes.


### PR DESCRIPTION
### What this PR does / why we need it?
Add the 310P device to start the VLLM service requires the documentation for `--additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}`.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Local test

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
