### PR TITLE
[CI] Add Gemma4 Dense graph smoke test on A3

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -76,6 +76,7 @@
   source_file_dependencies:
     - vllm_ascend/attention/attention_v1.py
   tests:
+    - tests/e2e/pull_request/four_card/test_gemma4.py
     - tests/e2e/pull_request/two_card/test_gemma4.py
 
 - name: attention_fa3
@@ -785,6 +786,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/test_qwen3_5.py: 610
   tests/e2e/pull_request/four_card/test_qwen3_next.py: 1180
   tests/e2e/pull_request/four_card/test_graph_mode.py: 480
+  tests/e2e/pull_request/four_card/test_gemma4.py: 1200
   tests/e2e/pull_request/two_card/test_gemma4.py: 1200
   tests/ut/attention/a2/test_attention_cp.py: 40
   tests/ut/attention/a2/test_attention_cp_precision.py: 30

--- a/tests/e2e/pull_request/four_card/test_gemma4.py
+++ b/tests/e2e/pull_request/four_card/test_gemma4.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+_GRAPH_ENV = {
+    "HCCL_BUFFSIZE": "1024",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+}
+
+
+@pytest.mark.e2e_model("google/gemma-4-31B-it")
+@pytest.mark.e2e_coverage(
+    arch="dense",
+    feature="",
+    parallel="TP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="full_decode_only",
+)
+@patch.dict(os.environ, _GRAPH_ENV)
+@wait_until_npu_memory_free()
+def test_gemma4_31b_dense_tp4_full_decode_graph() -> None:
+    """Verify Gemma4 Dense startup, graph capture, and short generation."""
+    with VllmRunner(
+        "google/gemma-4-31B-it",
+        tensor_parallel_size=4,
+        distributed_executor_backend="mp",
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        max_num_seqs=8,
+        gpu_memory_utilization=0.8,
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [1, 2, 4, 8],
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(["Explain what an NPU is in one sentence."], max_tokens=4)
+
+    assert len(outputs) == 1
+    output_ids, _ = outputs[0]
+    assert output_ids


### PR DESCRIPTION
### What this PR does / why we need it?

Adds pull-request E2E smoke coverage for Gemma4 31B Dense graph execution on four Ascend A3 NPUs.

The test starts `google/gemma-4-31B-it` with TP4 and `FULL_DECODE_ONLY` ACLGraph mode, then performs a short greedy generation. This guards model startup, graph capture, replay, and token generation without adding a time-consuming accuracy evaluation to pull-request CI.

The test is registered under the GQA attention test group so changes to `vllm_ascend/attention/attention_v1.py` select both Gemma4 Dense and MoE graph coverage.

### Does this PR introduce _any_ user-facing change?

No. This PR only adds pull-request CI coverage.

### How was this patch tested?

- Repeated A3 four-card E2E validation against both the verified vLLM main commit and vLLM `v0.25.1`:
  - https://github.com/vllm-project/vllm-ascend/actions/runs/29808765544
  - https://github.com/vllm-project/vllm-ascend/actions/runs/29809847819
  - https://github.com/vllm-project/vllm-ascend/actions/runs/29809857789
  - https://github.com/vllm-project/vllm-ascend/actions/runs/29811001614
  - https://github.com/vllm-project/vllm-ascend/actions/runs/29811012751
  - https://github.com/vllm-project/vllm-ascend/actions/runs/29811021608
- `python3 .github/workflows/scripts/coverage.py`
- `python3 -m ruff check tests/e2e/pull_request/four_card/test_gemma4.py`
- `python3 -m ruff format --check tests/e2e/pull_request/four_card/test_gemma4.py`
- `python3 -m py_compile tests/e2e/pull_request/four_card/test_gemma4.py`
- `git diff --check`

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
