### PR TITLE
[Doc][Test] Add ut and document for configuration option dp_allreduce_on_npu

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -93,6 +93,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature depends on FLASHCOMM1. Please ensure that FLASHCOMM1 is enabled before enabling this feature.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
 | `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
+| `dp_allreduce_on_npu`              | bool | `False` | Whether to use NPU device group for DP metadata all-reduce. When `True`, DP metadata synchronization (e.g., `num_tokens`, cudagraph mode flags) is routed through the NPU device group instead of the CPU group. This can avoid data corruption issues on certain devices where CPU-side all-reduce may return dirty data. |
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. |
 
 The details of each configuration option are as follows:

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -67,6 +67,7 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
         self.assertFalse(ascend_config.enable_kv_nz)
+        self.assertFalse(ascend_config.dp_allreduce_on_npu)
 
         ascend_compilation_config = ascend_config.ascend_compilation_config
         self.assertTrue(ascend_compilation_config.fuse_norm_quant)
@@ -411,6 +412,21 @@ class TestAscendConfig(TestBase):
         second_ascend_config = init_ascend_config(second_vllm_config)
         self.assertIsNot(first_ascend_config, second_ascend_config)
         self.assertTrue(second_ascend_config.ascend_compilation_config.enable_npugraph_ex)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_dp_allreduce_on_npu_default(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        ascend_config = init_ascend_config(test_vllm_config)
+        self.assertFalse(ascend_config.dp_allreduce_on_npu)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_dp_allreduce_on_npu_with_additional_config(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"dp_allreduce_on_npu": True}
+        ascend_config = init_ascend_config(test_vllm_config)
+        self.assertTrue(ascend_config.dp_allreduce_on_npu)
 
 
 class TestShortRequestFirstConfig(TestBase):


### PR DESCRIPTION
### What this PR does / why we need it?
Add documentation and unit test coverage for the dp_allreduce_on_npu configuration option.

  dp_allreduce_on_npu is already implemented in the codebase (ascend_config.py and model_runner_v1.py), but it was missing from the additional_config.md
  documentation and lacked dedicated unit test coverage. This PR fills both gaps:

  - Docs: Added the dp_allreduce_on_npu entry to the Configuration options table in additional_config.md, documenting its type, default value, and purpose.
  - Tests: Added two dedicated test cases in test_ascend_config.py (default value check + enabled via additional_config), plus added a default-value
  assertion for dp_allreduce_on_npu in the existing test_init_ascend_config_without_additional_config test.
### Does this PR introduce _any_ user-facing change?
No — documentation and tests only; no behavioral changes.
### How was this patch tested?
- Unit tests: pytest -sv tests/ut/test_ascend_config.py::TestAscendConfig::test_dp_allreduce_on_npu_default
  tests/ut/test_ascend_config.py::TestAscendConfig::test_dp_allreduce_on_npu_with_additional_config
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
