### PR TITLE
[Cherry-pick][releases/v0.24.0rc][Doc][Misc] Forward-port v0.23.0rc1 release documentation (from #12242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ vLLM Ascend Plugin
 ---
 *Latest News* 🔥
 
+- [2026/07] We released the first release candidate [v0.23.0rc1](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0rc1)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/05] We released the new official version [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.18.0/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/02] We released the new official version [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.13.0/) to start using vLLM Ascend Plugin on Ascend.
 
@@ -76,7 +77,7 @@ Please use the following recommended versions to get started quickly:
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-| v0.22.1rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/latest/installation.html) for more details |
+| v0.23.0rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/installation.html) for more details |
 | v0.18.0 | Latest stable version | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.18.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html) for more details |
 
 ## Branch
@@ -99,6 +100,7 @@ Below are the maintained branches:
 | releases/v0.18.0 | Maintained   | CI commitment for vLLM 0.18.0 version |
 | releases/v0.20.2rc | Maintained | CI commitment for vLLM 0.20.2 version |
 | rfc/feature-name | Maintained   | [Feature branches](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html#feature-branches) for collaboration |
+| releases/v0.23.0 | Maintained   | CI commitment for vLLM 0.23.0 version |
   
 Please refer to [Versioning policy](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html) for more details.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,7 @@ vLLM Ascend Plugin
 ---
 *最新消息* 🔥
 
+- [2026/07] 我们发布了首个候选版本 [v0.23.0rc1](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0rc1)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/)开始在 Ascend 上部署 vLLM Ascend Plugin。
 - [2026/05] 我们发布了新的正式版本 [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/)开始在Ascend上部署vLLM Ascend Plugin。
 - [2026/02] 我们发布了新的正式版本 [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.13.0/)开始在Ascend上部署vLLM Ascend Plugin。
 
@@ -70,7 +71,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-| v0.22.1rc1 | 最新RC版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/latest/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/latest/installation.html)了解更多 |
+| v0.23.0rc1 | 最新RC版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/installation.html)了解更多 |
 | v0.18.0 | 最新正式/稳定版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.18.0/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html)了解更多 |
 
 ## 分支策略
@@ -93,6 +94,7 @@ vllm-ascend有主干分支和开发分支。
 | releases/v0.18.0 | Maintained   | 基于vLLM v0.18.0版本CI看护 |
 | releases/v0.20.2rc | Maintained | 基于vLLM v0.20.2版本CI看护 |
 | rfc/feature-name | Maintained   | 为协作创建的[特性分支](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html#feature-branches) |
+| releases/v0.23.0 | Maintained   | 基于vLLM v0.23.0版本CI看护 |
 
 请参阅[版本策略](https://docs.vllm.ai/projects/ascend/en/latest/community/versioning_policy.html)了解更多详细信息。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,6 @@ vLLM Ascend Plugin
 ---
 *最新消息* 🔥
 
-- [2026/07] 我们发布了首个候选版本 [v0.23.0rc1](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0rc1)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/)开始在 Ascend 上部署 vLLM Ascend Plugin。
 - [2026/05] 我们发布了新的正式版本 [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/)开始在Ascend上部署vLLM Ascend Plugin。
 - [2026/02] 我们发布了新的正式版本 [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.13.0/)开始在Ascend上部署vLLM Ascend Plugin。
 

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -25,10 +25,39 @@
 
 Every release of vLLM Ascend would not have been possible without the following contributors:
 
-Updated on 2026-06-24:
+Updated on 2026-07-17:
 
 | Number | Contributor | Date | Commit ID |
 |:------:|:-----------:|:-----:|:---------:|
+| 500 | [@singzhou](https://github.com/singzhou) | 2026/07/15 | [f924703](https://github.com/vllm-project/vllm-ascend/commit/f924703d7d97a90c5d72d58bf32865501b7f87c0) |
+| 499 | [@ZhangwenTaoHW](https://github.com/ZhangwenTaoHW) | 2026/07/13 | [b89a491](https://github.com/vllm-project/vllm-ascend/commit/b89a491644cd02a16a5b17c1a124cec254866559) |
+| 498 | [@zhaochuang001](https://github.com/zhaochuang001) | 2026/07/11 | [7be596c](https://github.com/vllm-project/vllm-ascend/commit/7be596cd3fa93c45a4ef4ff5384d0c852659d83c) |
+| 497 | [@Liuchenbing-2026](https://github.com/Liuchenbing-2026) | 2026/07/10 | [123c5cc](https://github.com/vllm-project/vllm-ascend/commit/123c5ccc78d3aabe3f793223e096ee5e97606a20) |
+| 496 | [@KadenZhang3321](https://github.com/KadenZhang3321) | 2026/07/08 | [d17a99c](https://github.com/vllm-project/vllm-ascend/commit/d17a99cd51d535c4026ffb596bafa0a23fa87064) |
+| 495 | [@TYYTao](https://github.com/TYYTao) | 2026/07/06 | [79928c2](https://github.com/vllm-project/vllm-ascend/commit/79928c2ff1b5521d7f57c58233c87782ec77afc1) |
+| 494 | [@ShySummer](https://github.com/ShySummer) | 2026/07/05 | [9154baa](https://github.com/vllm-project/vllm-ascend/commit/9154baadc9dbac857fe197d03bccb1731664f3df) |
+| 493 | [@tyy0829](https://github.com/tyy0829) | 2026/07/05 | [a0219ac](https://github.com/vllm-project/vllm-ascend/commit/a0219ac14caad375c74793539ad230688b58f9d6) |
+| 492 | [@xinhai9906](https://github.com/xinhai9906) | 2026/07/04 | [f81dd51](https://github.com/vllm-project/vllm-ascend/commit/f81dd51845185d18ea26cfbef2042f9b3bc0de2e) |
+| 491 | [@shiqiangA](https://github.com/shiqiangA) | 2026/07/03 | [b5fbfff](https://github.com/vllm-project/vllm-ascend/commit/b5fbfffe1dc29261c3c8e0778808cfffb19a95fb) |
+| 490 | [@LebudiPrince](https://github.com/LebudiPrince) | 2026/07/03 | [76d338a](https://github.com/vllm-project/vllm-ascend/commit/76d338a722521e813e92bd89513181a73ea8b895) |
+| 489 | [@Sunwish](https://github.com/Sunwish) | 2026/07/03 | [bb2666d](https://github.com/vllm-project/vllm-ascend/commit/bb2666df29c4cddab74fd340103f18bd5bf2bb9f) |
+| 488 | [@czydyy](https://github.com/czydyy) | 2026/07/02 | [ee8bbbd](https://github.com/vllm-project/vllm-ascend/commit/ee8bbbd5f15958f03c870c3b98af745c02af3fd6) |
+| 487 | [@RainyStone](https://github.com/RainyStone) | 2026/06/30 | [52f9bb0](https://github.com/vllm-project/vllm-ascend/commit/52f9bb06e0b5682c1b694efeb9a9eb6882935f3c) |
+| 486 | [@garrygale](https://github.com/garrygale) | 2026/06/30 | [49a4720](https://github.com/vllm-project/vllm-ascend/commit/49a47208b61ab7e7252e48a472a8389c1c07b686) |
+| 485 | [@guxin108](https://github.com/guxin108) | 2026/06/27 | [0e982ed](https://github.com/vllm-project/vllm-ascend/commit/0e982ed5479470c4f55a6eac0dc96affbf704116) |
+| 484 | [@AJF-cmd](https://github.com/AJF-cmd) | 2026/06/27 | [43e8b0a](https://github.com/vllm-project/vllm-ascend/commit/43e8b0a92e3e40b65aabeb9d8c263a51a785056e) |
+| 483 | [@shihan-lin168](https://github.com/shihan-lin168) | 2026/06/27 | [1178b73](https://github.com/vllm-project/vllm-ascend/commit/1178b733b940c4ea90ef96dfac3d825a5ec3e59b) |
+| 482 | [@jiajinzhu2](https://github.com/jiajinzhu2) | 2026/06/27 | [463a6a1](https://github.com/vllm-project/vllm-ascend/commit/463a6a1d065d246918e4cb4319e07ae63a2d2c9e) |
+| 481 | [@Alex-stack-hub](https://github.com/Alex-stack-hub) | 2026/06/26 | [8cc7bcd](https://github.com/vllm-project/vllm-ascend/commit/8cc7bcd4c35ab7a4fbd50b36c362b136df7c0d95) |
+| 480 | [@wangzhishenghw](https://github.com/wangzhishenghw) | 2026/06/26 | [8fd6a0c](https://github.com/vllm-project/vllm-ascend/commit/8fd6a0c2c39d5931e62edc2f342c9dad94d3701d) |
+| 479 | [@delwen123](https://github.com/delwen123) | 2026/06/26 | [17f14dd](https://github.com/vllm-project/vllm-ascend/commit/17f14dd4c194375b619fe1b348a4f0d71ef0e33b) |
+| 478 | [@Alexzhang369](https://github.com/Alexzhang369) | 2026/06/25 | [db4cc43](https://github.com/vllm-project/vllm-ascend/commit/db4cc43041407553675ff4a35d1b5758129fc73e) |
+| 477 | [@TallMessiWu](https://github.com/TallMessiWu) | 2026/06/25 | [419755b](https://github.com/vllm-project/vllm-ascend/commit/419755b4fbb07d36baa947d78cd94cb31931451d) |
+| 476 | [@bowgneo](https://github.com/bowgneo) | 2026/06/25 | [e2f1028](https://github.com/vllm-project/vllm-ascend/commit/e2f1028f6da43130adfda5ce655c4a290659470b) |
+| 475 | [@yongfuFang](https://github.com/yongfuFang) | 2026/06/25 | [55c27ec](https://github.com/vllm-project/vllm-ascend/commit/55c27ec8b97fb67b8b67802bd53b8db3760e9468) |
+| 474 | [@wzx0726](https://github.com/wzx0726) | 2026/06/24 | [a08abea](https://github.com/vllm-project/vllm-ascend/commit/a08abea79ddb62c0fee047f1f09f0e0c6aa236a0) |
+| 473 | [@recky-c](https://github.com/recky-c) | 2026/06/24 | [5bd4e39](https://github.com/vllm-project/vllm-ascend/commit/5bd4e3950c2c1df9e8d4eabf6accaf6f071eef74) |
+| 472 | [@liuhanhui](https://github.com/liuhanhui) | 2026/06/22 | [2c88d67](https://github.com/vllm-project/vllm-ascend/commit/2c88d67f465c6578c1d653c2523f7d52d8966cba) |
 | 471 | [@1478931959](https://github.com/1478931959) | 2026/06/24 | [eb81619](https://github.com/vllm-project/vllm-ascend/commit/eb816194a8d2ce1f4048b4037bb4b6e8a269d307) |
 | 470 | [@RICHARDNAN](https://github.com/RICHARDNAN) | 2026/06/23 | [9788211](https://github.com/vllm-project/vllm-ascend/commit/9788211ce67a18aa2f76bc3bcb176e378edc13a8) |
 | 469 | [@LostFox11](https://github.com/LostFox11) | 2026/06/23 | [4467a23](https://github.com/vllm-project/vllm-ascend/commit/4467a23d084ee8c497e663d9caf85c5329851a78) |

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -23,6 +23,7 @@ The table below is the release compatibility matrix for vLLM Ascend release.
 
 | vLLM Ascend | vLLM              | Python          | Stable CANN |        PyTorch/torch_npu        |   Triton Ascend   |    Mooncake  |
 |-------------|-------------------|-----------------|-------------|---------------------------------|-------------------|--------------|
+| v0.23.0rc1  | v0.23.0           | >= 3.10, < 3.13 | 9.0.1       | 2.10.0 / 2.10.0.post2           | 3.2.1             | v0.3.11.post1 |
 | v0.22.1rc1  | v0.22.1           | >= 3.10, < 3.13 | 9.0.0       | 2.10.0 / 2.10.0                 | 3.2.1             | v0.3.9       |
 | v0.21.0rc1  | v0.21.0           | >= 3.10, < 3.13 | 9.0.0       | 2.10.0 / 2.10.0                 | 3.2.1             | v0.3.9       |
 | v0.20.2rc1  | v0.20.2           | >= 3.10, < 3.12 | 9.0.0       | 2.10.0 / 2.10.0                 | 3.2.1             | v0.3.8.post1 |
@@ -74,6 +75,7 @@ For main branch of vLLM Ascend, we usually make it compatible with the latest vL
 
 | Date       | Event                                     |
 |------------|-------------------------------------------|
+| 2026.07.20 | Release candidates, v0.23.0rc1            |
 | 2026.06.30 | Release candidates, v0.22.1rc1            |
 | 2026.06.16 | Release candidates, v0.21.0rc1            |
 | 2026.06.03 | Release candidates, v0.20.2rc1            |
@@ -140,6 +142,7 @@ Usually, each minor version of vLLM (such as 0.7) corresponds to a vLLM Ascend v
 | Branch     | State        | Note                                                     |
 | ---------- | ------------ | -------------------------------------------------------- |
 | main       | Maintained   | CI commitment for vLLM main branch and vLLM {{main_vllm_tag}}  tag |
+| releases/v0.23.0 | Maintained | CI commitment for vLLM 0.23.0 version                |
 | releases/v0.18.0 | Maintained | CI commitment for vLLM 0.18.0 version                |
 | releases/v0.13.0 | Maintained | CI commitment for vLLM 0.13.0 version                |
 | v0.11.0-dev| Maintained   | CI commitment for vLLM 0.11.0 version |

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,6 +2,7 @@
 
 ## Version Specific FAQs
 
+- [[v0.23.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/12238)
 - [[v0.22.1rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/10593)
 - [[v0.21.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/9970)
 - [[v0.20.2rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/9586)

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,5 +1,91 @@
 # Release Notes
 
+## v0.23.0rc1 - 2026.07.20
+
+We're excited to announce v0.23.0rc1, the first release candidate for the vLLM Ascend v0.23.0 release line. This release aligns the plugin with upstream vLLM v0.23.0 and expands model, context-parallel, KV-cache offload, and Ascend 950 support. Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/) to get started.
+
+### Highlights
+
+- **Expanded model support**: Added GLM-5.2 support on A2 and A3, and Ascend 310P support for Qwen3-ASR-1.7B, Qwen3.5, and Qwen3.6. [#10441](https://github.com/vllm-project/vllm-ascend/pull/10441) [#11264](https://github.com/vllm-project/vllm-ascend/pull/11264) [#10257](https://github.com/vllm-project/vllm-ascend/pull/10257) [#12115](https://github.com/vllm-project/vllm-ascend/pull/12115)
+- **Sparse attention and context parallelism**: Added SFA DCP with a replicated indexer, compact KV gather, and C8 support. [#11819](https://github.com/vllm-project/vllm-ascend/pull/11819) [#11981](https://github.com/vllm-project/vllm-ascend/pull/11981) [#11846](https://github.com/vllm-project/vllm-ascend/pull/11846) [#11871](https://github.com/vllm-project/vllm-ascend/pull/11871)
+- **KV-cache lifecycle and offload**: Added recompute KV-cache offload for P/D decoder nodes, AscendStore coordination, and layerwise KV Pooling with a Memcache backend. [#10742](https://github.com/vllm-project/vllm-ascend/pull/10742) [#10393](https://github.com/vllm-project/vllm-ascend/pull/10393) [#11585](https://github.com/vllm-project/vllm-ascend/pull/11585)
+- **Ascend 950 quantization and communication**: Added W4A16 MXFP4, all-gather EP MXFP4, and low-accuracy token-dispatch paths. [#11014](https://github.com/vllm-project/vllm-ascend/pull/11014) [#11287](https://github.com/vllm-project/vllm-ascend/pull/11287) [#11718](https://github.com/vllm-project/vllm-ascend/pull/11718) [#11766](https://github.com/vllm-project/vllm-ascend/pull/11766)
+
+### Features
+
+- Added DeepSeek V4 MTP graph support. [#11062](https://github.com/vllm-project/vllm-ascend/pull/11062)
+- Added Virtual Width Network Eagle3 and Eagle3 support with chunked pipeline parallelism. [#10042](https://github.com/vllm-project/vllm-ascend/pull/10042) [#10566](https://github.com/vllm-project/vllm-ascend/pull/10566)
+
+### Experimental Features or Optimizations
+
+- Added experimental Step3P7 and Step3P5 support, including Step3P5 MTP. [#10697](https://github.com/vllm-project/vllm-ascend/pull/10697)
+- Added experimental Gemma4 support on A2 and Ascend 950. [#11091](https://github.com/vllm-project/vllm-ascend/pull/11091) [#10643](https://github.com/vllm-project/vllm-ascend/pull/10643)
+- Improved the DeepSeek V4 prefix-cache hit rate. [#11107](https://github.com/vllm-project/vllm-ascend/pull/11107)
+
+### Performance
+
+- Optimized SFA DSA-CP output merge with All-to-All communication and PCP FlashAttention restore/output merge. [#12137](https://github.com/vllm-project/vllm-ascend/pull/12137) [#11842](https://github.com/vllm-project/vllm-ascend/pull/11842)
+- Avoided H2D synchronization in context-parallel speculative decoding metadata and snapshotted query locations before asynchronous H2D copies. [#11862](https://github.com/vllm-project/vllm-ascend/pull/11862) [#12071](https://github.com/vllm-project/vllm-ascend/pull/12071)
+- Parallelized KV-cache receive with a thread pool and enabled asynchronous all-gather for DSA-CP output-projection TP weights. [#10548](https://github.com/vllm-project/vllm-ascend/pull/10548) [#10694](https://github.com/vllm-project/vllm-ascend/pull/10694)
+- Vectorized local sequence-length computation in SFA metadata. [#11816](https://github.com/vllm-project/vllm-ascend/pull/11816)
+
+### Stability and Bug Fixes
+
+- Fixed GLM-5.1 IndexCache weight loading and a GLM-4.7-Flash `IndexError` on the first request with MTP and layerwise MemCache. [#11363](https://github.com/vllm-project/vllm-ascend/pull/11363) [#11829](https://github.com/vllm-project/vllm-ascend/pull/11829)
+- Fixed Qwen3.5 GDN accuracy regressions across PCP, MTP, and DCP graph replay, including a mixed-length PCP out-of-bounds crash, while restoring the previous model-runner dispatch behavior. [#11195](https://github.com/vllm-project/vllm-ascend/pull/11195) [#11893](https://github.com/vllm-project/vllm-ascend/pull/11893) [#12027](https://github.com/vllm-project/vllm-ascend/pull/12027) [#12283](https://github.com/vllm-project/vllm-ascend/pull/12283)
+- Fixed Qwen3.5 speculative-decoding accuracy, garbled output, and out-of-bounds failures on Ascend 310P with MTP/EAGLE and full-graph execution. [#11337](https://github.com/vllm-project/vllm-ascend/pull/11337) [#11408](https://github.com/vllm-project/vllm-ascend/pull/11408) [#11920](https://github.com/vllm-project/vllm-ascend/pull/11920)
+- Fixed Qwen MoE routing overflow and shared-expert gate matrix-multiplication failures on Ascend 310P. [#11391](https://github.com/vllm-project/vllm-ascend/pull/11391) [#11730](https://github.com/vllm-project/vllm-ascend/pull/11730)
+- Fixed Qwen3-Omni ModelSlim W8A8 checkpoint loading failures caused by mismatched weight names and unquantized embedding metadata. [#12321](https://github.com/vllm-project/vllm-ascend/pull/12321)
+- Fixed Qwen3-VL rotary-embedding copy races on Ascend 310P and restored the device-specific VisionTransformer patch. [#11679](https://github.com/vllm-project/vllm-ascend/pull/11679) [#12132](https://github.com/vllm-project/vllm-ascend/pull/12132)
+- Fixed the DeepSeek-R1-0528 W8A8 shared-expert no-clamp accuracy path without regressing the clamped DeepSeek V4 path. [#11775](https://github.com/vllm-project/vllm-ascend/pull/11775)
+- Fixed DeepSeek V4 Flash W4A8-MXFP4 all-gather EP inference on Ascend 950 by preserving routing-weight precision. [#11498](https://github.com/vllm-project/vllm-ascend/issues/11498) [#11663](https://github.com/vllm-project/vllm-ascend/pull/11663) [#11718](https://github.com/vllm-project/vllm-ascend/pull/11718)
+- Fixed malformed streamed tool-call arguments and TP8+EP startup compatibility for MiniMax-M2 and MiniMax-M2.5. [#11505](https://github.com/vllm-project/vllm-ascend/pull/11505)
+- Fixed silent prefix-cache output corruption and block-table overflow for Qwen3-Next, Qwen3.5, and other hybrid Mamba models using MTP/EAGLE, plus a 310P Mamba align-postprocess hang. [#11353](https://github.com/vllm-project/vllm-ascend/pull/11353) [#11659](https://github.com/vllm-project/vllm-ascend/pull/11659) [#12038](https://github.com/vllm-project/vllm-ascend/pull/12038)
+- Fixed Mooncake KV-transfer grouping for Kimi-K2.7 Code with Kimi-K2.5-DFlash when P/D nodes use unequal TP sizes and target/draft models have different global KV-head counts. [#11887](https://github.com/vllm-project/vllm-ascend/pull/11887)
+- Fixed the AscendStore parent-block hash chain when a KV block group is only partially missing. [#12252](https://github.com/vllm-project/vllm-ascend/pull/12252)
+- Disabled shared-expert multistream overlap when fused MC2 is enabled to avoid an unsupported configuration. [#12245](https://github.com/vllm-project/vllm-ascend/pull/12245)
+- Fixed DCP/DP service hangs and restricted the recompute scheduler to decode nodes. [#12034](https://github.com/vllm-project/vllm-ascend/pull/12034) [#11490](https://github.com/vllm-project/vllm-ascend/pull/11490)
+- Delayed AscendStore initialization until the first real decode request. [#11673](https://github.com/vllm-project/vllm-ascend/pull/11673)
+- Fixed low MTP acceptance rates for SFA with DSA-CP and multiple speculative tokens. [#10878](https://github.com/vllm-project/vllm-ascend/pull/10878)
+
+### Dependencies
+
+- **Upstream vLLM**: v0.23.0.
+- **Python**: >= 3.10, < 3.13.
+- **CANN**: 9.0.1 for A2, A3, and Ascend 950; refer to the 310P installation guide for its platform-specific CANN package.
+- **PyTorch / torch_npu**: 2.10.0 / 2.10.0.post2.
+- **Triton Ascend**: 3.2.1.
+- **Mooncake**: 0.3.11.post1 in the release images.
+
+### Ready to Deprecate
+
+The following features and optimizations are planned for deprecation in a future release:
+
+- Layer sharding.
+- FlashComm2.
+- The FlashComm3 multistream-overlap gate.
+- Hamming sparse.
+- Asynchronous exponential overlap.
+- Matmul all-reduce and matmul all-reduce RMSNorm fusions.
+- Weight prefetch.
+- Dynamic-batch SLO.
+- KV offload in KV Pool.
+- Fused MC2 mode 2 (`enable_fused_mc2=2`).
+- Paged attention and `pa_shape_list`.
+- Selected plugin environment variables; their configuration will be migrated to equivalent `--additional-config` options.
+
+### Known Issues
+
+- The combination of pipeline parallelism (PP) and prefill context parallelism (PCP) is not supported in v0.23.0. Support for this combination is deferred to a later release.
+- The former `enable_sparse_c8` option has been split into `enable_sparse_sfa_c8` and `enable_sparse_li_c8`. Existing `--additional-config` settings must use one or both new options depending on whether Sparse Flash Attention C8, LightningIndexer C8, or both are required. [#12351](https://github.com/vllm-project/vllm-ascend/pull/12351)
+- The load-balance proxy can swallow decode errors and return an empty HTTP 200 response. [#12166](https://github.com/vllm-project/vllm-ascend/issues/12166)
+- Qwen3-30B-A3B floating-point serving can show a 1-2 ms TPOT regression at batch size 1 in the reported TP4 full-graph configuration. [#12337](https://github.com/vllm-project/vllm-ascend/issues/12337)
+- In the reported DeepSeek V4 Flash W8A8 MTP P/D-disaggregated deployment, the second aisbench round can cause a worker process from another card to appear on an NPU device. [#12338](https://github.com/vllm-project/vllm-ascend/issues/12338)
+- On Ascend 950, Qwen3.5-397B-W8A8-MXFP8-FULL_QUANT in a P/D-disaggregated deployment without MTP can alternate between correct and incorrect outputs. [#12339](https://github.com/vllm-project/vllm-ascend/issues/12339)
+- DeepSeek V4 Pro on A3 and A5 can show continuously increasing memory usage in both P/D-disaggregated and co-located deployments, eventually causing OOM or service instability. [#12345](https://github.com/vllm-project/vllm-ascend/issues/12345)
+- DeepSeek-V3.1-Terminus can show about a 15% output-throughput regression against the reported v0.18.0 baseline in high-throughput P/D-disaggregated deployments; the regression was reported on an A3 four-node 2P1D setup and an A2 large-EP setup. [#12349](https://github.com/vllm-project/vllm-ascend/issues/12349)
+- KV-cache transfer can produce precision issues and TP-shard inconsistencies when reformatting occurs before all pull tasks for a request have completed. [#12359](https://github.com/vllm-project/vllm-ascend/pull/12359)
+
 ## v0.22.1rc1 - 2026.06.30
 
 We're excited to announce the release of v0.22.1rc1 for vLLM Ascend. This is the first release candidate for the v0.22.1 release line, building on v0.21.0rc1 and aligning the plugin with upstream vLLM v0.22.1. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/releases-v0.22.1rc) to get started.

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -2,7 +2,7 @@
 
 ## v0.23.0rc1 - 2026.07.20
 
-We're excited to announce v0.23.0rc1, the first release candidate for the vLLM Ascend v0.23.0 release line. This release aligns the plugin with upstream vLLM v0.23.0 and expands model, context-parallel, KV-cache offload, and Ascend 950 support. Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/) to get started.
+We're excited to announce v0.23.0rc1, the first release candidate for the vLLM Ascend v0.23.0 release line. This release aligns the plugin with upstream vLLM v0.23.0 and expands model, context-parallel, KV-cache offload, and Ascend 950 support. Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.23.0/) to get started.
 
 ### Highlights
 


### PR DESCRIPTION
## What this PR does / why we need it?

This PR forward-ports the applicable v0.23.0rc1 release documentation from source PR #12242 to `releases/v0.24.0rc`. The corresponding main-branch forward-port is #12485; the intended landing order is main first (#12485), then this release-branch PR.

This is a target-specific, selective six-file adaptation based on expected release-branch base SHA `01e44e76934efba9971abe9ba3e4b29926c9d7a7`. It changes only:

- `README.md`
- `README.zh.md`
- `docs/source/community/contributors.md`
- `docs/source/community/versioning_policy.md`
- `docs/source/faqs.md`
- `docs/source/user_guide/release_notes.md`

It deliberately excludes `docs/source/conf.py`, `mkdocs.yml`, and `.github/workflows/schedule_image_build_and_push.yaml` because version/build configuration and scheduled image workflow state are owned by the target release branch and should not be overwritten by the source PR's branch-specific configuration.

## Does this PR introduce _any_ user-facing change?

No. This is a docs-only forward-port.

## How was this patch tested?

- `bash format.sh ci`: PASS.
- Tracked-root English and Chinese documentation builds: PASS.
- Rendered localhost link/href QA: PASS.
- `git diff --check` and exact/source checks: PASS.
- The literal `make -C docs build` and `make -C docs build-zh` entry points fail because the pre-existing `docs/tools/rtd_build.sh` wrapper is missing; the tracked-root builds above validate both documentation variants directly.
- The external link checker was blocked uniformly by the environment's self-signed CA; this was an environment limitation rather than a content-specific failure.
- NPU tests were not run because this change is documentation-only.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
