### PR TITLE
[CI] Extract cleanup-fork-branches as composite action

### DIFF
--- a/.github/actions/cleanup-fork-branches/action.yml
+++ b/.github/actions/cleanup-fork-branches/action.yml
@@ -1,0 +1,83 @@
+name: 'Cleanup stale fork branches'
+description: >-
+  Delete branches on a fork repo whose associated PRs in the upstream repo
+  are 'merged' or 'closed'. Branches with open PRs or no associated PRs are
+  left untouched. Results are written to $GITHUB_STEP_SUMMARY.
+
+inputs:
+  prefix:
+    description: 'Branch name prefix to match (e.g. auto-pr/doc-translate-)'
+    required: true
+  fork:
+    description: 'Fork repository (owner/name) holding the branches'
+    required: false
+    default: 'vllm-ascend-ci/vllm-ascend'
+  upstream:
+    description: 'Upstream repository to query PR state'
+    required: false
+    default: 'vllm-project/vllm-ascend'
+  token:
+    description: 'GitHub token with contents:write on the fork'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run cleanup
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PREFIX: ${{ inputs.prefix }}
+        FORK: ${{ inputs.fork }}
+        UPSTREAM: ${{ inputs.upstream }}
+      shell: bash
+      run: |
+        set +e
+        branches_json=$(gh api "repos/${FORK}/branches?per_page=100" --paginate \
+          --jq --arg p "$PREFIX" '[.[] | select(.name | startswith($p))]')
+
+        deleted=()
+        skipped_open=()
+        skipped_orphan=()
+        failed=()
+
+        while IFS= read -r b; do
+          [ -z "$b" ] && continue
+          pr_state=$(gh pr list --repo "$UPSTREAM" \
+            --head "${FORK%%/*}:${b}" --state all --json state \
+            --jq '.[0].state // "none"')
+          case "$pr_state" in
+            merged|closed)
+              if gh api -X DELETE "repos/${FORK}/git/refs/heads/${b}" >/dev/null 2>&1; then
+                deleted+=("${b} (PR ${pr_state})")
+              else
+                failed+=("$b")
+              fi
+              ;;
+            open)
+              skipped_open+=("$b")
+              ;;
+            *)
+              skipped_orphan+=("${b} (PR state: ${pr_state})")
+              ;;
+          esac
+        done < <(echo "$branches_json" | jq -r '.[].name')
+
+        {
+          echo "## Cleanup stale fork branches"
+          echo ""
+          echo "**Fork:** \`${FORK}\`  **Upstream:** \`${UPSTREAM}\`  **Prefix:** \`${PREFIX}\`"
+          echo ""
+          echo "### Deleted (${#deleted[@]})"
+          if [ "${#deleted[@]}" -gt 0 ]; then printf -- '- %s\n' "${deleted[@]}"; else echo "- (none)"; fi
+          echo ""
+          echo "### Skipped — open PR (${#skipped_open[@]})"
+          if [ "${#skipped_open[@]}" -gt 0 ]; then printf -- '- %s\n' "${skipped_open[@]}"; else echo "- (none)"; fi
+          echo ""
+          echo "### Skipped — orphan / no PR (${#skipped_orphan[@]})"
+          if [ "${#skipped_orphan[@]}" -gt 0 ]; then printf -- '- %s\n' "${skipped_orphan[@]}"; else echo "- (none)"; fi
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo ""
+            echo "### Failed (${#failed[@]})"
+            printf -- '- %s\n' "${failed[@]}"
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr_cherry_pick_command.yml
+++ b/.github/workflows/pr_cherry_pick_command.yml
@@ -119,6 +119,13 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
+      - name: Cleanup stale vllm-ascend-ci fork branches
+        continue-on-error: true
+        uses: ./.github/actions/cleanup-fork-branches
+        with:
+          prefix: 'cherry-pick/pr-'
+          token: ${{ secrets.PAT_TOKEN }}
+
       - name: Cherry-pick and create PR
         id: cherry
         env:

--- a/.github/workflows/schedule_doc_translate.yaml
+++ b/.github/workflows/schedule_doc_translate.yaml
@@ -50,6 +50,13 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           ref: ${{ inputs.target_branch || 'main' }}
 
+      - name: Cleanup stale vllm-ascend-ci fork branches
+        continue-on-error: true
+        uses: ./.github/actions/cleanup-fork-branches
+        with:
+          prefix: 'auto-pr/doc-translate-'
+          token: ${{ secrets.PAT_TOKEN }}
+
       - name: Setup git and branch
         run: |
           TARGET_BRANCH="${{ inputs.target_branch || 'main' }}"

--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -48,7 +48,7 @@ concurrency:
 
 jobs:
   select-tests:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     outputs:
       test_groups: ${{ steps.scope.outputs.test_groups }}
       has_tests: ${{ steps.scope.outputs.has_tests }}
@@ -58,6 +58,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Cleanup stale vllm-ascend-ci fork branches
+        continue-on-error: true
+        uses: ./.github/actions/cleanup-fork-branches
+        with:
+          prefix: 'auto/update-estimated-times-'
+          token: ${{ secrets.PAT_TOKEN }}
 
       - uses: actions/setup-python@v6
         with:
@@ -122,7 +129,7 @@ jobs:
   update-estimated-times:
     needs: [run-tests-main, run-tests-release]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-8-hk
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
### What this PR does / why we need it?

The cherry-pick, doc-translate, and update-estimated-times workflows each create new branches on the `vllm-ascend-ci` fork per run. Over time this clutters the fork with hundreds of stale branches. This PR adds a cleanup step to each workflow via a shared composite action.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
