### PR TITLE
[CI]fix: include RoutedExperts in _is_fused_moe_layer for compressed_tensors and fp8 configs

### DIFF
--- a/vllm_ascend/quantization/compressed_tensors_config.py
+++ b/vllm_ascend/quantization/compressed_tensors_config.py
@@ -22,7 +22,7 @@ from typing import Any, Optional, cast
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy, QuantizationType
 from vllm.logger import logger
-from vllm.model_executor.layers.fused_moe import MoERunner
+from vllm.model_executor.layers.fused_moe import MoERunner, RoutedExperts
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS, register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
@@ -39,7 +39,7 @@ from .methods import AscendLinearScheme, AscendMoEScheme
 
 
 def _is_fused_moe_layer(layer: torch.nn.Module) -> bool:
-    return isinstance(layer, MoERunner)
+    return isinstance(layer, (MoERunner, RoutedExperts))
 
 
 # Remove the original compressed_tensors method to replace with our implementation

--- a/vllm_ascend/quantization/fp8_config.py
+++ b/vllm_ascend/quantization/fp8_config.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, cast
 import torch
 from compressed_tensors.quantization import QuantizationArgs
 from vllm.logger import logger
-from vllm.model_executor.layers.fused_moe import MoERunner
+from vllm.model_executor.layers.fused_moe import MoERunner, RoutedExperts
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS, register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
@@ -14,7 +14,7 @@ from .methods import get_scheme_class
 
 
 def _is_fused_moe_layer(layer: torch.nn.Module) -> bool:
-    return isinstance(layer, MoERunner)
+    return isinstance(layer, (MoERunner, RoutedExperts))
 
 
 QUANTIZATION_SCHEME_MAP_TYPE = dict[str, dict[str, QuantizationArgs] | None]


### PR DESCRIPTION

### What this PR does / why we need it?
MoE Layer Detection: Updated the _is_fused_moe_layer helper function to include RoutedExperts in addition to MoERunner.
Configuration Support: Applied the detection update to both compressed_tensors and fp8 quantization configurations to ensure consistent MoE layer handling.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
