### PR TITLE
[Feature] Remove additional config option 'dp_allreduce_on_npu'

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -269,10 +269,6 @@ class AscendConfig:
         if self.mega_moe_max_tokens <= 0:
             raise ValueError(f"mega_moe_max_tokens must be a positive integer, got {self.mega_moe_max_tokens}")
 
-        # Whether to use NPU device group for DP metadata all_reduce.
-        # "True": use NPU device group, "False" (default): use CPU group.
-        self.dp_allreduce_on_npu = additional_config.get("dp_allreduce_on_npu", False)
-
         # Enable optimized reduce sampling scheme
         self.enable_reduce_sample = additional_config.get("enable_reduce_sample", False)
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -679,20 +679,10 @@ class NPUModelRunner(GPUModelRunner):
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 
-        # On certain devices, CPU-side all_reduce may return dirty data. 
-        # When dp_allreduce_on_npu is True, route DP metadata
-        # synchronization through the NPU device group to avoid data corruption.
-        device_str, group = (
-            ("npu", get_dp_group().device_group)
-            if self.ascend_config.dp_allreduce_on_npu
-            else ("cpu", get_dp_group().cpu_group)
-        )
-        packed_tensor = torch.zeros(2, self.dp_size, device=device_str, dtype=torch.int32)
+        packed_tensor = torch.zeros(2, self.dp_size, device="cpu", dtype=torch.int32)
         packed_tensor[0][self.dp_rank] = num_tokens
         packed_tensor[1][self.dp_rank] = cudagraph_mode.value
-        dist.all_reduce(packed_tensor, group=group)
-        if device_str == "npu":
-            packed_tensor = packed_tensor.cpu()
+        dist.all_reduce(packed_tensor, group=get_dp_group().cpu_group)
 
         # Unpack the results
         num_tokens_across_dp = packed_tensor[0, :]


### PR DESCRIPTION
### What this PR does / why we need it?
  Removes the dp_allreduce_on_npu configuration option and its associated runtime logic. This option was introduced as a workaround for certain devices
  where CPU-side all_reduce could return dirty data, routing DP metadata synchronization through the NPU device group instead. Since this workaround is no
  longer needed, the conditional branch is removed and DP metadata all_reduce now unconditionally uses the CPU group, which simplifies the code path.

  Changes:
  - vllm_ascend/ascend_config.py: Removed dp_allreduce_on_npu configuration attribute
  - vllm_ascend/worker/model_runner_v1.py: Removed the NPU-vs-CPU device selection branch in the DP metadata all_reduce call — always uses cpu device and
  get_dp_group().cpu_group
### Does this PR introduce _any_ user-facing change?
Yes — the dp_allreduce_on_npu key in VLLM_ASCEND_CONFIG is no longer recognized. Users who previously set dp_allreduce_on_npu=True should remove it from
  their configuration; the value is silently ignored (no error is raised) but the NPU-path behavior is no longer available.
### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
