### PR TITLE
[Doc][Misc] Backport Atlas context length updates to v0.23.0

### DIFF
--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -117,10 +117,10 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Model | Support | Note | BF16 | Supported Hardware | W8A8 | Chunked Prefill | Automatic Prefix Cache | LoRA | Speculative Decoding | Async Scheduling | Tensor Parallel | Prefill-decode Disaggregation | Piecewise AclGraph | Fullgraph AclGraph | max-model-len | Doc |
 |-------|---------|------|------|--------------------|------|-----------------|------------------------|------|----------------------|------------------|-----------------|-------------------------------|--------------------|--------------------|---------------|-----|
 | Qwen3-VL | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | 🟡 | ✅ | ✅ | ❌ | ✅ | ✅ | 16k | [Qwen-VL-Dense](../../tutorials/models/Qwen-VL-Dense.md) |
-| Qwen3.5-Dense | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 16k | [Qwen3.5-Dense](../../tutorials/models/Qwen3.5-Dense.md) |
-| Qwen3.5-35B-A3B | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 16k | |
+| Qwen3.5-Dense | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 256k | [Qwen3.5-Dense](../../tutorials/models/Qwen3.5-Dense.md) |
+| Qwen3.5-35B-A3B | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 256k | [Qwen3.5-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md) |
 | Qwen3.6-27B | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 256k | [Qwen3.6-27B](../../tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md) |
-| Qwen3.6-35B-A3B | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 16k | [Qwen3.6-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md) |
+| Qwen3.6-35B-A3B | ✅ |  | ❌ | Atlas inference products | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 256k | [Qwen3.6-35B-A3B](../../tutorials/models/Qwen3.6-35B-A3B.md) |
 | PaddleOCR-VL | ✅ |  | ❌ | Atlas inference products | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | 16k | [PaddleOCR-VL](../../tutorials/models/PaddleOCR-VL.md) |
 | Qwen3-ASR | ✅ |  | ❌ | Atlas inference products | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | 🟡 | ❌ | ✅ | ✅ | 4096 | [Qwen3-ASR-1.7B](../../tutorials/models/Qwen3-ASR-1.7B.md) |
 


### PR DESCRIPTION
## What this PR does

Backports the latest Atlas inference product support-matrix corrections to `releases/v0.23.0` without changing the previously merged backport PR.

- Updates the Atlas inference product `max-model-len` for Qwen3.5-Dense, Qwen3.5-35B-A3B, and Qwen3.6-35B-A3B from `16k` to `256k`.
- Adds the missing Qwen3.5-35B-A3B documentation link, reusing the existing Qwen3.6-35B-A3B deployment tutorial because no standalone Qwen3.5-35B-A3B tutorial exists in this release branch.
- Leaves all other model rows unchanged.

## Validation

- `python -m pre_commit run markdownlint --hook-stage manual --files docs/source/user_guide/support_matrix/supported_models.md`
- `python -m sphinx -W --keep-going -b html docs/source .codex-doc-site`
- `git diff --check vllm-main/releases/v0.23.0...HEAD`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
