### PR TITLE
[Misc] spec_decode: remove redundant warning introduced by debug logging probes

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -175,7 +175,11 @@ class AscendRejectionSampler(RejectionSampler):
                 Contains the final output token IDs and their logprobs if
                 requested.
         """
-        assert metadata.max_spec_len <= MAX_SPEC_LEN
+        assert metadata.max_spec_len <= MAX_SPEC_LEN, (
+            f"rejection_sampler.forward: max_spec_len={metadata.max_spec_len} "
+            f"exceeds MAX_SPEC_LEN={MAX_SPEC_LEN}; rejection sampling cannot "
+            "proceed."
+        )
 
         self._log_rejection_sampler_entry(logits, metadata)
         bonus_logits_indices = metadata.bonus_logits_indices
@@ -248,6 +252,71 @@ class AscendRejectionSampler(RejectionSampler):
         return SamplerOutput(
             sampled_token_ids=output_token_ids,
             logprobs_tensors=logprobs_tensors,
+        )
+
+    def _log_rejection_sampler_entry(
+        self,
+        logits: torch.Tensor,
+        metadata: SpecDecodeMetadata,
+    ) -> None:
+        """DFX entry probe for rejection sampling.
+
+        Captures the shape/dtype baseline at the rejection-sampling boundary
+        so that mismatches between the target-model output and the spec decode
+        metadata can be diagnosed without re-running the workload. All payload
+        fields are host scalars / tuple shapes -- no device sync. Gated by
+        isEnabledFor(DEBUG) so production builds pay only one integer compare.
+        """
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+        logger.debug(
+            "[spec/dfx] rejection_sampler entry: "
+            "logits.shape=%s, logits.dtype=%s, max_spec_len=%d, "
+            "num_total_drafts=%d, num_reqs=%d, "
+            "logprobs_mode=%s(processed=%s), top_k=%s",
+            tuple(logits.shape),
+            logits.dtype,
+            metadata.max_spec_len,
+            int(metadata.num_draft_tokens.sum().item())
+            if torch.is_tensor(metadata.num_draft_tokens)
+            else sum(metadata.num_draft_tokens),
+            metadata.cu_num_draft_tokens.shape[0],
+            self.sampler.logprobs_mode,
+            self.is_processed_logprobs_mode,
+            self.top_k,
+        )
+
+    def _log_rejection_sampler_exit(
+        self,
+        output_token_ids: torch.Tensor,
+        metadata: SpecDecodeMetadata,
+    ) -> None:
+        """DFX exit probe (acceptance signal) for rejection sampling.
+
+        Reports placeholder fill rate and an approximate acceptance ratio so
+        operators can tell at a glance whether the draft/target pairing is
+        healthy. The .ne()/.sum() calls force a host sync and only run when
+        DEBUG is on; production paths return early.
+        """
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+        valid_mask = output_token_ids.ne(PLACEHOLDER_TOKEN_ID)
+        num_accepted = int(valid_mask.sum().item())
+        num_slots = int(output_token_ids.numel())
+        num_total_drafts = (
+            int(metadata.num_draft_tokens.sum().item())
+            if torch.is_tensor(metadata.num_draft_tokens)
+            else sum(metadata.num_draft_tokens)
+        )
+        logger.debug(
+            "[spec/dfx] rejection_sampler done: "
+            "accepted=%d/%d (slot_fill=%.1f%%), drafted=%d, "
+            "approx_accept_rate=%.1f%%",
+            num_accepted,
+            num_slots,
+            100.0 * num_accepted / max(num_slots, 1),
+            num_total_drafts,
+            100.0 * num_accepted / max(num_total_drafts + output_token_ids.shape[0], 1),
         )
 
 
@@ -399,7 +468,14 @@ def rejection_sample(
     assert draft_probs is None or draft_probs.is_contiguous()
     assert target_logits.is_contiguous()
     assert bonus_token_ids.is_contiguous()
-    assert target_logits.shape[0] == num_tokens
+    assert target_logits.shape[0] == num_tokens, (
+        "rejection_sample: target/draft row mismatch - "
+        f"target_logits.shape[0]={target_logits.shape[0]} != "
+        f"num_tokens(draft_token_ids)={num_tokens} "
+        f"(batch_size={batch_size}, max_spec_len={max_spec_len}). "
+        "Target output does not align with draft tokens; spec decode "
+        "results will be incorrect."
+    )
 
     # Block verify requires enable_block_verify config and max_spec_len >= 3.
     using_block_verify = max_spec_len >= 3 and bool(get_ascend_config().rejection_sampler_config.enable_block_verify)

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from dataclasses import replace
 
 import torch
@@ -174,7 +175,37 @@ class AscendRejectionSampler(RejectionSampler):
                 Contains the final output token IDs and their logprobs if
                 requested.
         """
-        assert metadata.max_spec_len <= MAX_SPEC_LEN
+        if metadata.max_spec_len > MAX_SPEC_LEN:
+            raise ValueError(
+                "rejection_sampler.forward: max_spec_len="
+                f"{metadata.max_spec_len} exceeds MAX_SPEC_LEN={MAX_SPEC_LEN}; "
+                "rejection sampling cannot proceed."
+            )
+
+        # rejection sampler entry probe.
+        # Captures the shape/dtype baseline at the rejection-sampling boundary
+        # so that mismatches between the target-model output and the spec
+        # decode metadata can be diagnosed without re-running the workload.
+        # All payload fields are host scalars / tuple shapes -- no device sync.
+        # The whole block is gated by isEnabledFor(DEBUG) so production builds
+        # pay only the cost of one integer compare.
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "[spec/dfx] rejection_sampler entry: "
+                "logits.shape=%s, logits.dtype=%s, max_spec_len=%d, "
+                "num_total_drafts=%d, num_reqs=%d, "
+                "logprobs_mode=%s(processed=%s), top_k=%s",
+                tuple(logits.shape),
+                logits.dtype,
+                metadata.max_spec_len,
+                int(metadata.num_draft_tokens.sum().item())
+                if torch.is_tensor(metadata.num_draft_tokens)
+                else sum(metadata.num_draft_tokens),
+                metadata.cu_num_draft_tokens.shape[0],
+                self.sampler.logprobs_mode,
+                self.is_processed_logprobs_mode,
+                self.top_k,
+            )
         bonus_logits_indices = metadata.bonus_logits_indices
         target_logits_indices = metadata.target_logits_indices
 
@@ -228,6 +259,31 @@ class AscendRejectionSampler(RejectionSampler):
             sampling_metadata,
             ori_target_logits=raw_target_logits,
         )
+
+        # rejection sampler exit probe (acceptance signal).
+        # Reports placeholder fill rate and an approximate acceptance ratio so
+        # operators can tell at a glance whether the draft/target pairing is
+        # healthy. The .ne()/.sum() calls force a host sync and only run when
+        # DEBUG is on; production paths skip the entire block.
+        if logger.isEnabledFor(logging.DEBUG):
+            valid_mask = output_token_ids.ne(PLACEHOLDER_TOKEN_ID)
+            num_accepted = int(valid_mask.sum().item())
+            num_slots = int(output_token_ids.numel())
+            num_total_drafts = (
+                int(metadata.num_draft_tokens.sum().item())
+                if torch.is_tensor(metadata.num_draft_tokens)
+                else sum(metadata.num_draft_tokens)
+            )
+            logger.debug(
+                "[spec/dfx] rejection_sampler done: "
+                "accepted=%d/%d (slot_fill=%.1f%%), drafted=%d, "
+                "approx_accept_rate=%.1f%%",
+                num_accepted,
+                num_slots,
+                100.0 * num_accepted / max(num_slots, 1),
+                num_total_drafts,
+                100.0 * num_accepted / max(num_total_drafts + output_token_ids.shape[0], 1),
+            )
 
         logprobs_tensors = None
         if sampling_metadata.max_num_logprobs is not None:
@@ -394,7 +450,15 @@ def rejection_sample(
     assert draft_probs is None or draft_probs.is_contiguous()
     assert target_logits.is_contiguous()
     assert bonus_token_ids.is_contiguous()
-    assert target_logits.shape[0] == num_tokens
+    if target_logits.shape[0] != num_tokens:
+        raise ValueError(
+            "rejection_sample: target/draft row mismatch - "
+            f"target_logits.shape[0]={target_logits.shape[0]} != "
+            f"num_tokens(draft_token_ids)={num_tokens} "
+            f"(batch_size={batch_size}, max_spec_len={max_spec_len}). "
+            "Target output does not align with draft tokens; spec decode "
+            "results will be incorrect."
+        )
 
     # Block verify requires enable_block_verify config and max_spec_len >= 3.
     using_block_verify = max_spec_len >= 3 and bool(get_ascend_config().rejection_sampler_config.enable_block_verify)
@@ -493,6 +557,10 @@ def rejection_sample(
     # For random sampling with selected logits
     # target_logits is [num_tokens, top_k*tp_size] with indices [num_tokens, top_k*tp_size]
     if target_indices is not None:
+        if draft_probs is None:
+            logger.warning(
+                "[spec/dfx] rejection_sample: draft_probs is None in random sampling path; acceptance may be degraded.",
+            )
         # Enable reduce_sampling: logits are [num_tokens, top_k*tp_size]
         # We need to handle rejection sampling with selected vocab
         selected_vocab_size = target_logits.shape[-1]

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -175,37 +175,9 @@ class AscendRejectionSampler(RejectionSampler):
                 Contains the final output token IDs and their logprobs if
                 requested.
         """
-        if metadata.max_spec_len > MAX_SPEC_LEN:
-            raise ValueError(
-                "rejection_sampler.forward: max_spec_len="
-                f"{metadata.max_spec_len} exceeds MAX_SPEC_LEN={MAX_SPEC_LEN}; "
-                "rejection sampling cannot proceed."
-            )
+        assert metadata.max_spec_len <= MAX_SPEC_LEN
 
-        # rejection sampler entry probe.
-        # Captures the shape/dtype baseline at the rejection-sampling boundary
-        # so that mismatches between the target-model output and the spec
-        # decode metadata can be diagnosed without re-running the workload.
-        # All payload fields are host scalars / tuple shapes -- no device sync.
-        # The whole block is gated by isEnabledFor(DEBUG) so production builds
-        # pay only the cost of one integer compare.
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "[spec/dfx] rejection_sampler entry: "
-                "logits.shape=%s, logits.dtype=%s, max_spec_len=%d, "
-                "num_total_drafts=%d, num_reqs=%d, "
-                "logprobs_mode=%s(processed=%s), top_k=%s",
-                tuple(logits.shape),
-                logits.dtype,
-                metadata.max_spec_len,
-                int(metadata.num_draft_tokens.sum().item())
-                if torch.is_tensor(metadata.num_draft_tokens)
-                else sum(metadata.num_draft_tokens),
-                metadata.cu_num_draft_tokens.shape[0],
-                self.sampler.logprobs_mode,
-                self.is_processed_logprobs_mode,
-                self.top_k,
-            )
+        self._log_rejection_sampler_entry(logits, metadata)
         bonus_logits_indices = metadata.bonus_logits_indices
         target_logits_indices = metadata.target_logits_indices
 
@@ -260,30 +232,7 @@ class AscendRejectionSampler(RejectionSampler):
             ori_target_logits=raw_target_logits,
         )
 
-        # rejection sampler exit probe (acceptance signal).
-        # Reports placeholder fill rate and an approximate acceptance ratio so
-        # operators can tell at a glance whether the draft/target pairing is
-        # healthy. The .ne()/.sum() calls force a host sync and only run when
-        # DEBUG is on; production paths skip the entire block.
-        if logger.isEnabledFor(logging.DEBUG):
-            valid_mask = output_token_ids.ne(PLACEHOLDER_TOKEN_ID)
-            num_accepted = int(valid_mask.sum().item())
-            num_slots = int(output_token_ids.numel())
-            num_total_drafts = (
-                int(metadata.num_draft_tokens.sum().item())
-                if torch.is_tensor(metadata.num_draft_tokens)
-                else sum(metadata.num_draft_tokens)
-            )
-            logger.debug(
-                "[spec/dfx] rejection_sampler done: "
-                "accepted=%d/%d (slot_fill=%.1f%%), drafted=%d, "
-                "approx_accept_rate=%.1f%%",
-                num_accepted,
-                num_slots,
-                100.0 * num_accepted / max(num_slots, 1),
-                num_total_drafts,
-                100.0 * num_accepted / max(num_total_drafts + output_token_ids.shape[0], 1),
-            )
+        self._log_rejection_sampler_exit(output_token_ids, metadata)
 
         logprobs_tensors = None
         if sampling_metadata.max_num_logprobs is not None:
@@ -450,15 +399,7 @@ def rejection_sample(
     assert draft_probs is None or draft_probs.is_contiguous()
     assert target_logits.is_contiguous()
     assert bonus_token_ids.is_contiguous()
-    if target_logits.shape[0] != num_tokens:
-        raise ValueError(
-            "rejection_sample: target/draft row mismatch - "
-            f"target_logits.shape[0]={target_logits.shape[0]} != "
-            f"num_tokens(draft_token_ids)={num_tokens} "
-            f"(batch_size={batch_size}, max_spec_len={max_spec_len}). "
-            "Target output does not align with draft tokens; spec decode "
-            "results will be incorrect."
-        )
+    assert target_logits.shape[0] == num_tokens
 
     # Block verify requires enable_block_verify config and max_spec_len >= 3.
     using_block_verify = max_spec_len >= 3 and bool(get_ascend_config().rejection_sampler_config.enable_block_verify)

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -574,10 +574,6 @@ def rejection_sample(
     # For random sampling with selected logits
     # target_logits is [num_tokens, top_k*tp_size] with indices [num_tokens, top_k*tp_size]
     if target_indices is not None:
-        if draft_probs is None:
-            logger.warning(
-                "[spec/dfx] rejection_sample: draft_probs is None in random sampling path; acceptance may be degraded.",
-            )
         # Enable reduce_sampling: logits are [num_tokens, top_k*tp_size]
         # We need to handle rejection sampling with selected vocab
         selected_vocab_size = target_logits.shape[-1]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1681,35 +1681,7 @@ class NPUModelRunner(GPUModelRunner):
         sample_hidden_states: torch.Tensor = None,
         target_model_batch_desc: BatchDescriptor = None,
     ) -> list[list[int]] | None:
-        # propose_draft_token_ids entry probe.
-        # Records which speculative-decoding sub-path is about to run
-        # (ngram / medusa / eagle / extract_hidden_states / ...). When the
-        # `Unknown speculative decoding method` ValueError fires further
-        # down, or when end-to-end speedup is unexpectedly absent, this
-        # single line tells the operator which drafter object was actually
-        # constructed and whether k (num_speculative_tokens) is non-trivial.
-        # Type lookups and getattr are host-only; the entire block is
-        # gated by isEnabledFor(DEBUG).
-        if logger.isEnabledFor(logging.DEBUG):
-            drafter_type = type(self.drafter).__name__ if self.drafter else None
-            spec_meta_state = (
-                "None" if spec_decode_metadata is None
-                else f"max_spec_len={spec_decode_metadata.max_spec_len}"
-            )
-            logger.debug(
-                "[spec/dfx] propose_draft_token_ids entry: "
-                "drafter=%s, method=%s, k=%d, num_reqs=%d, "
-                "num_scheduled_tokens=%d, spec_decode_metadata=%s, "
-                "use_cp=%s, pcp_size=%d",
-                drafter_type,
-                self.speculative_config.method if self.speculative_config else None,
-                self.num_spec_tokens,
-                self.input_batch.num_reqs,
-                num_scheduled_tokens,
-                spec_meta_state,
-                getattr(self, "use_cp", False),
-                getattr(self, "pcp_size", 1),
-            )
+        self._log_propose_draft_token_ids_entry(spec_decode_metadata, num_scheduled_tokens)
 
         if not self.drafter:
             # Speculative decoding is not enabled.
@@ -1945,6 +1917,43 @@ class NPUModelRunner(GPUModelRunner):
             raise ValueError(f"Unknown speculative decoding method: {self.speculative_config.method}")
 
         return draft_token_ids
+
+    def _log_propose_draft_token_ids_entry(
+        self,
+        spec_decode_metadata: SpecDecodeMetadata,
+        num_scheduled_tokens: int,
+    ) -> None:
+        """DFX entry probe for propose_draft_token_ids.
+
+        Records which speculative-decoding sub-path is about to run
+        (ngram / medusa / eagle / extract_hidden_states / ...). When the
+        `Unknown speculative decoding method` ValueError fires further down,
+        or when end-to-end speedup is unexpectedly absent, this tells the
+        operator which drafter object was actually constructed and whether k
+        (num_speculative_tokens) is non-trivial. Type lookups and getattr are
+        host-only; gated by isEnabledFor(DEBUG).
+        """
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+        drafter_type = type(self.drafter).__name__ if self.drafter else None
+        spec_meta_state = (
+            "None" if spec_decode_metadata is None
+            else f"max_spec_len={spec_decode_metadata.max_spec_len}"
+        )
+        logger.debug(
+            "[spec/dfx] propose_draft_token_ids entry: "
+            "drafter=%s, method=%s, k=%d, num_reqs=%d, "
+            "num_scheduled_tokens=%d, spec_decode_metadata=%s, "
+            "use_cp=%s, pcp_size=%d",
+            drafter_type,
+            self.speculative_config.method if self.speculative_config else None,
+            self.num_spec_tokens,
+            self.input_batch.num_reqs,
+            num_scheduled_tokens,
+            spec_meta_state,
+            getattr(self, "use_cp", False),
+            getattr(self, "pcp_size", 1),
+        )
 
     def _copy_draft_token_ids_to_cpu(
         self, scheduler_output: "SchedulerOutput", zeros_only: bool = False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1681,6 +1681,36 @@ class NPUModelRunner(GPUModelRunner):
         sample_hidden_states: torch.Tensor = None,
         target_model_batch_desc: BatchDescriptor = None,
     ) -> list[list[int]] | None:
+        # propose_draft_token_ids entry probe.
+        # Records which speculative-decoding sub-path is about to run
+        # (ngram / medusa / eagle / extract_hidden_states / ...). When the
+        # `Unknown speculative decoding method` ValueError fires further
+        # down, or when end-to-end speedup is unexpectedly absent, this
+        # single line tells the operator which drafter object was actually
+        # constructed and whether k (num_speculative_tokens) is non-trivial.
+        # Type lookups and getattr are host-only; the entire block is
+        # gated by isEnabledFor(DEBUG).
+        if logger.isEnabledFor(logging.DEBUG):
+            drafter_type = type(self.drafter).__name__ if self.drafter else None
+            spec_meta_state = (
+                "None" if spec_decode_metadata is None
+                else f"max_spec_len={spec_decode_metadata.max_spec_len}"
+            )
+            logger.debug(
+                "[spec/dfx] propose_draft_token_ids entry: "
+                "drafter=%s, method=%s, k=%d, num_reqs=%d, "
+                "num_scheduled_tokens=%d, spec_decode_metadata=%s, "
+                "use_cp=%s, pcp_size=%d",
+                drafter_type,
+                self.speculative_config.method if self.speculative_config else None,
+                self.num_spec_tokens,
+                self.input_batch.num_reqs,
+                num_scheduled_tokens,
+                spec_meta_state,
+                getattr(self, "use_cp", False),
+                getattr(self, "pcp_size", 1),
+            )
+
         if not self.drafter:
             # Speculative decoding is not enabled.
             draft_token_ids = None


### PR DESCRIPTION
### What this PR does / why we need it?
This PR removes a redundant `logger.warning` check (`if draft_probs is None:`) that was previously introduced in PR #11123 for speculative decoding diagnostics.

**Why it is needed:**
In the current execution path, `draft_probs` is consistently `None`. Keeping this check causes the warning to be triggered and printed continuously during normal operation. This results in:
1. Unnecessary log pollution, making it harder to spot real issues.
2. Potential performance degradation due to excessive I/O overhead from continuous logging.

Removing this redundant check cleans up the diagnostic output without affecting the actual sampling correctness or debugging capabilities.

### Does this PR introduce _any_ user-facing change?
No. This is purely an internal logging cleanup. It does not change any APIs, interfaces, or the actual behavior of speculative decoding.

### How was this patch tested?
- Verified by running standard speculative decoding workloads (e.g., using DFlash/PARD or standard draft models).
- Confirmed that the spurious `"[spec/dfx] rejection_sample: draft_probs is None..."` warning no longer appears in the logs.
- Confirmed that the sampling behavior and acceptance rate remain correct and unaffected.
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
