### PR TITLE
[Misc] spec_decode: remove redundant warning introduced by debug logging probes

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -574,10 +574,6 @@ def rejection_sample(
     # For random sampling with selected logits
     # target_logits is [num_tokens, top_k*tp_size] with indices [num_tokens, top_k*tp_size]
     if target_indices is not None:
-        if draft_probs is None:
-            logger.warning(
-                "[spec/dfx] rejection_sample: draft_probs is None in random sampling path; acceptance may be degraded.",
-            )
         # Enable reduce_sampling: logits are [num_tokens, top_k*tp_size]
         # We need to handle rejection sampling with selected vocab
         selected_vocab_size = target_logits.shape[-1]


### PR DESCRIPTION
### What this PR does / why we need it?

This pull request removes a warning log statement in `rejection_sample` that was triggered when `draft_probs` is `None` in the random sampling path. This warning is no longer necessary or was redundant.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No tests were added as this is a minor cleanup of a warning log.