### PR TITLE
[CI] Remove stale Transformers nightly overrides

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
@@ -15,8 +15,6 @@ env_common: &env_common
   VLLM_RPC_TIMEOUT: 600
   SERVER_PORT: 8078
 
-special_dependencies:
-  transformers: "5.2.0"
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 
 deployment:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -15,8 +15,6 @@ env_common: &env_common
   VLLM_RPC_TIMEOUT: "600"
   SERVER_PORT: 8080
 
-special_dependencies:
-  transformers: "5.2.0"
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 
 deployment:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
@@ -14,8 +14,6 @@ env_common: &env_common
   VLLM_RPC_TIMEOUT: "600"
   SERVER_PORT: 8080
 
-special_dependencies:
-  transformers: "5.12.0"
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 
 deployment:

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
@@ -5,8 +5,6 @@
 test_cases:
   - name: "DeepSeek-V4-Flash-W8A8-A3"
     model: "Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp"
-    special_dependencies:
-      transformers: "5.9.0"
     envs:
       OMP_PROC_BIND: "false"
       OMP_NUM_THREADS: "1"


### PR DESCRIPTION
### What this PR does / why we need it?

Removes the per-case `special_dependencies.transformers` overrides from these nightly configurations:

- `multi-node-GLM-5.1-w8a8-A2`
- `multi-node-GLM-5.1-w8a8-A3`
- `multi-node-GLM-5.2-w8a8-A3`
- `DeepSeek-V4-Flash-W8A8-A3`

The overrides downgrade Transformers to 5.2.0, 5.12.0, and 5.9.0 after the test image is prepared. Those versions are stale for the current vLLM/vllm-ascend main dependency set: the GLM-5.1 cases fail on vLLM imports, while the GLM-5.2 and DeepSeek-V4 cases fail when the global Hunyuan processor compatibility module is imported.

Without the per-model overrides, these cases inherit the centrally managed Transformers version from the nightly image instead of replacing it at runtime.

### Does this PR introduce _any_ user-facing change?

No. This only changes nightly test dependency overrides.

### How was this patch tested?

- Parsed all four changed YAML files with `yaml.safe_load`.
- Verified that none of the four test cases retains a `special_dependencies` entry.
- Ran `git diff --check`.
- The four affected nightly cases will be triggered by PR comment.

https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
