### PR TITLE
[CI] Make pre-commit explicit in PR workflow

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -41,17 +41,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-and-select-tests:
+  pre-commit:
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ready' }}
     runs-on: linux-amd64-cpu-8-hk
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
-    outputs:
-      has_tests: ${{ steps.scope.outputs.has_tests || steps.noop.outputs.has_tests }}
-      test_groups: ${{ steps.scope.outputs.test_groups || steps.noop.outputs.test_groups }}
-      matched_modules: ${{ steps.scope.outputs.matched_modules || steps.noop.outputs.matched_modules }}
-      main_commit: ${{ steps.vllm.outputs.main_commit }}
-      release_tag: ${{ steps.vllm.outputs.release_tag }}
     steps:
       - name: Validate PR title prefix
         run: |
@@ -128,22 +122,6 @@ jobs:
               - 'requirements.txt'
               - 'requirements-dev.txt'
               - 'requirements-lint.txt'
-            src:
-              - 'vllm_ascend/**'
-              - 'setup.py'
-              - 'csrc/**'
-              - 'requirements.txt'
-              - 'pyproject.toml'
-              - 'cmake/**'
-              - '.github/workflows/pr_test.yaml'
-              - '.github/workflows/_selected_tests.yaml'
-              - '.github/workflows/scripts/select_tests.py'
-              - '.github/workflows/scripts/run_selected_tests.sh'
-              - '.github/workflows/scripts/test_config.yaml'
-              - '.github/workflows/scripts/runner_label.json'
-              - 'tests/**'
-              - 'tools/**'
-              - 'CMakeLists.txt'
 
       - name: Install vllm-ascend dev (conditional)
         if: steps.filter.outputs.lint_tracker == 'true'
@@ -184,6 +162,62 @@ jobs:
             echo "============================"
           done
 
+  select-tests:
+    needs: pre-commit
+    runs-on: linux-amd64-cpu-8-hk
+    container:
+      image: quay.io/ascend-ci/vllm-ascend:lint
+    outputs:
+      has_tests: ${{ steps.scope.outputs.has_tests || steps.noop.outputs.has_tests }}
+      test_groups: ${{ steps.scope.outputs.test_groups || steps.noop.outputs.test_groups }}
+      matched_modules: ${{ steps.scope.outputs.matched_modules || steps.noop.outputs.matched_modules }}
+      main_commit: ${{ steps.vllm.outputs.main_commit }}
+      release_tag: ${{ steps.vllm.outputs.release_tag }}
+    steps:
+      - name: Checkout vllm-project/vllm-ascend repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Read verified vLLM refs
+        id: vllm
+        run: |
+          main_commit="$(tr -d '[:space:]' < .github/vllm-main-verified.commit)"
+          release_tag="$(tr -d '[:space:]' < .github/vllm-release-tag.commit)"
+          [[ "${main_commit}" =~ ^[0-9a-f]{7,40}$ ]] || {
+            echo "::error file=.github/vllm-main-verified.commit::invalid vLLM main commit: ${main_commit}"
+            exit 1
+          }
+          [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]] || {
+            echo "::error file=.github/vllm-release-tag.commit::invalid vLLM release tag: ${release_tag}"
+            exit 1
+          }
+          {
+            echo "main_commit=${main_commit}"
+            echo "release_tag=${release_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'vllm_ascend/**'
+              - 'setup.py'
+              - 'csrc/**'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+              - 'cmake/**'
+              - '.github/workflows/pr_test.yaml'
+              - '.github/workflows/_selected_tests.yaml'
+              - '.github/workflows/scripts/select_tests.py'
+              - '.github/workflows/scripts/run_selected_tests.sh'
+              - '.github/workflows/scripts/test_config.yaml'
+              - '.github/workflows/scripts/runner_label.json'
+              - 'tests/**'
+              - 'tools/**'
+              - 'CMakeLists.txt'
+
       - name: Validate test coverage config
         run: |
           pip install pyyaml
@@ -210,39 +244,39 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   run-selected-tests:
-    needs: lint-and-select-tests
-    if: ${{ needs.lint-and-select-tests.outputs.has_tests == 'true' && contains(github.event.pull_request.labels.*.name, 'ready') }}
+    needs: select-tests
+    if: ${{ needs.select-tests.outputs.has_tests == 'true' && contains(github.event.pull_request.labels.*.name, 'ready') }}
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.lint-and-select-tests.outputs.main_commit }}
-          - ${{ needs.lint-and-select-tests.outputs.release_tag }}
+          - ${{ needs.select-tests.outputs.main_commit }}
+          - ${{ needs.select-tests.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
       ref: ${{ github.event.pull_request.head.sha }}
       base_ref: ${{ github.base_ref }}
-      test_groups: ${{ needs.lint-and-select-tests.outputs.test_groups }}
+      test_groups: ${{ needs.select-tests.outputs.test_groups }}
   
   run-selected-tests-upstream:
-    needs: lint-and-select-tests
+    needs: select-tests
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.lint-and-select-tests.outputs.main_commit }}
-          - ${{ needs.lint-and-select-tests.outputs.release_tag }}
+          - ${{ needs.select-tests.outputs.main_commit }}
+          - ${{ needs.select-tests.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
       ref: ${{ github.event.pull_request.head.sha }}
       base_ref: ${{ github.base_ref }}
-      test_groups: ${{ needs.lint-and-select-tests.outputs.test_groups }}
+      test_groups: ${{ needs.select-tests.outputs.test_groups }}
 
   generate-hitest:
     name: Generate hitest recommendations
-    needs: lint-and-select-tests
-    if: ${{ needs.lint-and-select-tests.outputs.has_tests == 'true' }}
+    needs: select-tests
+    if: ${{ needs.select-tests.outputs.has_tests == 'true' }}
     uses: ./.github/workflows/_manual-hitest.yaml
     secrets:
       HITEST_APIG_APPCODE: ${{ secrets.HITEST_APIG_APPCODE }}
@@ -252,7 +286,7 @@ jobs:
   # Summary gate job — use this single, stable name as the required status check
   # in GitHub branch protection rules instead of tracking individual matrix job names.
   ci-gate:
-    needs: [lint-and-select-tests, run-selected-tests]
+    needs: [pre-commit, select-tests, run-selected-tests]
     if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'ready') }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
@@ -260,15 +294,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          LINT_RESULT="${{ needs.lint-and-select-tests.result }}"
-          HAS_TESTS="${{ needs.lint-and-select-tests.outputs.has_tests }}"
+          PRE_COMMIT_RESULT="${{ needs.pre-commit.result }}"
+          SELECT_TESTS_RESULT="${{ needs.select-tests.result }}"
+          HAS_TESTS="${{ needs.select-tests.outputs.has_tests }}"
 
           echo "=== CI Gate Summary ==="
-          echo "lint-and-select-tests: ${LINT_RESULT}"
+          echo "pre-commit: ${PRE_COMMIT_RESULT}"
+          echo "select-tests: ${SELECT_TESTS_RESULT}"
           echo "has_tests: ${HAS_TESTS}"
 
-          if [ "${LINT_RESULT}" != "success" ] && [ "${LINT_RESULT}" != "skipped" ]; then
-            echo "::error::lint-and-select-tests did not succeed (result: ${LINT_RESULT})"
+          if [ "${PRE_COMMIT_RESULT}" != "success" ] && [ "${PRE_COMMIT_RESULT}" != "skipped" ]; then
+            echo "::error::pre-commit did not succeed (result: ${PRE_COMMIT_RESULT})"
+            exit 1
+          fi
+
+          if [ "${SELECT_TESTS_RESULT}" != "success" ] && [ "${SELECT_TESTS_RESULT}" != "skipped" ]; then
+            echo "::error::select-tests did not succeed (result: ${SELECT_TESTS_RESULT})"
             exit 1
           fi
 

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -46,6 +46,9 @@ jobs:
     runs-on: linux-amd64-cpu-8-hk
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
+    outputs:
+      main_commit: ${{ steps.vllm.outputs.main_commit }}
+      release_tag: ${{ steps.vllm.outputs.release_tag }}
     steps:
       - name: Validate PR title prefix
         run: |
@@ -171,31 +174,11 @@ jobs:
       has_tests: ${{ steps.scope.outputs.has_tests || steps.noop.outputs.has_tests }}
       test_groups: ${{ steps.scope.outputs.test_groups || steps.noop.outputs.test_groups }}
       matched_modules: ${{ steps.scope.outputs.matched_modules || steps.noop.outputs.matched_modules }}
-      main_commit: ${{ steps.vllm.outputs.main_commit }}
-      release_tag: ${{ steps.vllm.outputs.release_tag }}
     steps:
       - name: Checkout vllm-project/vllm-ascend repo
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Read verified vLLM refs
-        id: vllm
-        run: |
-          main_commit="$(tr -d '[:space:]' < .github/vllm-main-verified.commit)"
-          release_tag="$(tr -d '[:space:]' < .github/vllm-release-tag.commit)"
-          [[ "${main_commit}" =~ ^[0-9a-f]{7,40}$ ]] || {
-            echo "::error file=.github/vllm-main-verified.commit::invalid vLLM main commit: ${main_commit}"
-            exit 1
-          }
-          [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]] || {
-            echo "::error file=.github/vllm-release-tag.commit::invalid vLLM release tag: ${release_tag}"
-            exit 1
-          }
-          {
-            echo "main_commit=${main_commit}"
-            echo "release_tag=${release_tag}"
-          } >> "$GITHUB_OUTPUT"
 
       - uses: dorny/paths-filter@v4
         id: filter
@@ -244,13 +227,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   run-selected-tests:
-    needs: select-tests
+    needs: [pre-commit, select-tests]
     if: ${{ needs.select-tests.outputs.has_tests == 'true' && contains(github.event.pull_request.labels.*.name, 'ready') }}
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.select-tests.outputs.main_commit }}
-          - ${{ needs.select-tests.outputs.release_tag }}
+          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -259,13 +242,13 @@ jobs:
       test_groups: ${{ needs.select-tests.outputs.test_groups }}
   
   run-selected-tests-upstream:
-    needs: select-tests
+    needs: [pre-commit, select-tests]
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.select-tests.outputs.main_commit }}
-          - ${{ needs.select-tests.outputs.release_tag }}
+          - ${{ needs.pre-commit.outputs.main_commit }}
+          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:
       vllm: ${{ matrix.vllm_version }}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #12508.

This PR makes the PR workflow show the pre-commit phase explicitly, following the upstream vLLM pipeline shape where `pre-commit` is a visible job instead of being hidden under a combined lint/select job.

Minimal workflow changes:

- Rename the old combined lint phase into a dedicated `pre-commit` job.
- Keep PR title validation, pre-commit, and mypy in that job.
- Move selected-test discovery into a new `select-tests` job that depends on `pre-commit`.
- Preserve the existing selected-test outputs (`has_tests`, `test_groups`, `matched_modules`, `main_commit`, `release_tag`) for downstream E2E jobs.
- Update downstream `needs` references and `ci-gate` reporting from `lint-and-select-tests` to `pre-commit` / `select-tests`.

Mypy review:

- Upstream vLLM integrates mypy through pre-commit hooks, but vLLM Ascend currently runs mypy via `tools/mypy.sh` for Python 3.10, 3.11, and 3.12.
- This PR integrates mypy into the visible `pre-commit` job while keeping the existing `tools/mypy.sh` implementation.
- Moving mypy into `.pre-commit-config.yaml` would change hook dependencies and local developer behavior, so that is intentionally left out of this minimal CI display cleanup.

Scope Guard:

- Issue contract: make pre-commit visible as its own PR workflow job while preserving existing PR test selection behavior.
- Archetype: CI And Workflow Correctness.
- Changed file: `.github/workflows/pr_test.yaml` only.
- No test-selection logic, reusable workflow, Docker image, or pre-commit hook changes are included.

### Does this PR introduce _any_ user-facing change?

No. This is CI workflow structure only. It changes how PR checks are displayed and grouped, not runtime behavior.

### How was this patch tested?

- `pre-commit run actionlint --hook-stage manual --files .github/workflows/pr_test.yaml`
- PyYAML structure assertion verifying:
  - `pre-commit` and `select-tests` jobs exist
  - `lint-and-select-tests` is no longer referenced
  - downstream jobs consume `select-tests` outputs
  - `ci-gate` depends on `pre-commit`, `select-tests`, and `run-selected-tests`
- `rg -n "lint-and-select-tests|needs\.lint-and-select-tests" .github\workflows\pr_test.yaml` returned no stale references
- `git diff --check`
- Commit-time pre-commit hooks passed, including actionlint
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
