### PR TITLE
[Doc] fix link failure issue in Qwen3-ASR-1.7B.md

### DIFF
--- a/docs/source/tutorials/models/Qwen3-ASR-1.7B.md
+++ b/docs/source/tutorials/models/Qwen3-ASR-1.7B.md
@@ -138,7 +138,7 @@ Single-node deployment runs both audio prefill and decoding on one NPU, making i
         - `--gpu-memory-utilization 0.9` sets the fraction of device memory available to the vLLM executor. Lower this value if other workloads share the NPU.
         - `--enforce-eager` disables graph execution. It is used in the Atlas 300I A2 2UP example for compatibility.
 
-When the service starts successfully, the log contains `Application startup complete`. If startup fails, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) and the [Atlas inference products guide](../hardwares/310p.md).
+When the service starts successfully, the log contains `Application startup complete`. If startup fails, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html)
 
 ## 6 Functional Verification
 
@@ -201,4 +201,4 @@ For common environment, installation, and general parameter issues, see the [Pub
 
 **Cause:** On Atlas inference products, an automatically detected large context length can create a full causal attention mask whose memory consumption grows quadratically with `max_model_len`.
 
-**Solution:** Always set `--max-model-len` explicitly to a conservative value, such as `4096`, and increase it only after verifying available NPU memory. See the [Atlas inference products guide](../hardwares/310p.md) for details.
+**Solution:** Always set `--max-model-len` explicitly to a conservative value, such as `4096`, and increase it only after verifying available NPU memory.


### PR DESCRIPTION
### What this PR does / why we need it?
fix: 
```
WARNING -  Doc file 'tutorials/models/Qwen3-ASR-1.7B.md' contains a link '../hardwares/310p.md', 
but the target 'tutorials/hardwares/310p.md' is not found among documentation files.
```

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
