### PR TITLE
[BugFix] Ensure contiguous weight tensors after transpose in FusedMoE

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -79,8 +79,8 @@ def test_process_weights_after_loading_310_uses_version_specific_layout(
 
     torch.testing.assert_close(layer.w13_weight, original_w13.transpose(1, 2))
     torch.testing.assert_close(layer.w2_weight, original_w2.transpose(1, 2))
-    assert layer.w13_weight.is_contiguous() is False
-    assert layer.w2_weight.is_contiguous() is False
+    assert layer.w13_weight.is_contiguous() is True
+    assert layer.w2_weight.is_contiguous() is True
 
 
 class _Projection(nn.Module):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -73,8 +73,8 @@ def test_process_weights_after_loading_uses_version_specific_layout(
 
     torch.testing.assert_close(layer.w13_weight, original_w13.transpose(1, 2))
     torch.testing.assert_close(layer.w2_weight, original_w2.transpose(1, 2))
-    assert layer.w13_weight.is_contiguous() is False
-    assert layer.w2_weight.is_contiguous() is False
+    assert layer.w13_weight.is_contiguous() is True
+    assert layer.w2_weight.is_contiguous() is True
 
 
 @pytest.mark.parametrize("moe_comm_type", [MoECommType.ALLGATHER, MoECommType.FUSED_MC2])

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -48,11 +48,11 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
     def process_weights_after_loading(self, layer):
         super().process_weights_after_loading(layer)
 
-        w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2)
+        w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
         w13_data = maybe_trans_nz(w13_data)
         layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
 
-        w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2)
+        w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
         w2_data = maybe_trans_nz(w2_data)
         layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -106,10 +106,10 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     def process_weights_after_loading(self, layer):
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
 
-        w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2)
+        w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
         layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
 
-        w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2)
+        w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
         layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
 
         # TODO: Current dispatch_ffn_combine fusion operator ONLY supports NZ format.


### PR DESCRIPTION
### What this PR does / why we need it?
fix: https://github.com/vllm-project/vllm-ascend/actions/runs/29756582240/job/88436386887

On Ascend NPUs, operators like npu_format_cast require contiguous memory layouts. Non-contiguous tensors from .transpose(1,2) caused runtime failures in nightly tests.


### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
