### PR TITLE
[feature] phase1 log quality gate

### DIFF
--- a/.agents/skills/log-quality-governance/SKILL.md
+++ b/.agents/skills/log-quality-governance/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: log-quality-governance
+description: >
+  Phase-1 stock log-quality governance for vllm-ascend: periodic scan of
+  existing logger calls, prioritized P0/P1/P2 findings, and rewrite candidates
+  only. Does not block PRs. Use when asked to scan stock logs, batch-fix log
+  quality, rewrite vague/missing ERROR logs, run phase1-stock governance, or
+  produce a log-quality remediation backlog for vllm_ascend/.
+---
+
+# Log Quality Governance (Phase 1 Stock Layer)
+
+This skill is the **third layer** of vLLM-Ascend Phase-1 log quality:
+
+| Layer | Role | Lives in |
+|---|---|---|
+| `pre-commit` | Hard-fail incremental gate (LQ001–LQ005) | `tools/check_log_quality.py`, `tools/check_logger.sh` |
+| Gemini Review | Context MUST/MUST NOT on PR diffs | `.gemini/styleguide.md` → Logging Quality |
+| **This skill** | Stock inventory + rewrite candidates | `.agents/skills/log-quality-governance/` |
+
+It does **not** replace pre-commit or Gemini. It does **not** auto-apply patches or commit.
+
+Default mode is **`phase1-stock`** (minimum quality bar + stock scan standard).
+Use **`full-standard`** only when the user explicitly asks for the full 8-rule ideal bar.
+
+Authoritative references:
+[references/phase1-stock-scan-standard.md](references/phase1-stock-scan-standard.md),
+[references/rewrite-guide.md](references/rewrite-guide.md).
+
+---
+
+## When to use
+
+- Periodic / batch scan of `vllm_ascend/**/*.py` logger quality
+- Produce a remediation backlog (P0 → P1 → P2)
+- Generate rewrite candidates / diffs for selected findings
+- User says: stock log scan, phase1-stock, log quality governance, batch rewrite logs
+
+## When NOT to use
+
+- Reviewing a normal PR diff → use pre-commit + Gemini styleguide
+- Diagnosing a CI failure root cause → `ci-ai-diagnosis-agent`
+- User only wants the hard gate explained → point to `tools/log_quality_rules.toml`
+
+---
+
+## Input contract
+
+| Input | Required | Notes |
+|---|---|---|
+| Repo root | yes | This checkout |
+| Scope | optional | Default `vllm_ascend/`; may narrow to a module path |
+| Mode | optional | Default `phase1-stock`; `full-standard` only if requested |
+| Priority filter | optional | Default rewrite **P0+P1 only**; include P2 only if asked |
+| Runtime logs | optional | CI/run log file for optional live-log validation |
+
+---
+
+## Workflow (must follow)
+
+```
+1. Load the Phase-1 stock scan standard (references/phase1-stock-scan-standard.md)
+2. Scan code (logger extraction + checks) → findings with P0/P1/P2
+3. Optional: scan a runtime log file with the same priority model
+4. If user wants rewrite: only P0/P1 (unless P2 requested) → candidates + diff
+5. Stop for human review — never apply, never git commit / merge
+```
+
+### Step 1 — Load口径
+
+Read `references/phase1-stock-scan-standard.md`. Do **not** load the personal Hermes
+`external-standard.md` as the default pass/fail bar for stock scans.
+That full standard is `full-standard` mode only.
+
+### Step 2 — Code scan
+
+Extract logger calls under scope:
+
+```bash
+rg -n --glob 'vllm_ascend/**/*.py' \
+  'logger\.(debug|info|warning|error|exception|critical)\(|self\.logger\.(debug|info|warning|error|exception|critical)\('
+```
+
+For each call, capture: path, line, level, message template, kwargs / format args,
+surrounding loop/retry/`raise` context (read nearby lines; do not invent CFG).
+
+Emit findings using the **nine coverage buckets** in
+`phase1-stock-scan-standard.md`, each item tagged **P0 / P1 / P2**.
+
+Also run a coarse raise-gap pass (see coverage bucket 9). Prefer precision over
+recall: skip generated/tests helpers; do not mark every `raise` as P0.
+
+**Out of scope for code scan**
+
+- Ops retention / log shipping / disk aging (full-standard “运维管理”)
+- Forcing `[repo/module]` component prefixes in source (runtime logger name)
+- Forcing Chinese “可检查” text
+- Forcing `event=` / fixed `reason=` as hard failures in `phase1-stock`
+
+### Step 3 — Optional runtime log scan
+
+If the user provides a `.log` / CI artifact, check the same P0/P1 themes
+(privacy leak, vague ERROR, missing id on request path). Mark items that only
+appear in runtime as `source=runtime`.
+
+### Step 4 — Rewrite candidates
+
+Follow `references/rewrite-guide.md`.
+
+Rules:
+
+- Match surrounding file style (English; `logger.*`; `%s` / f-string as in file)
+- Prefer `req_id=` for new request-path fields; accept legacy `request_id=`
+- Only change logger statements (+ optional rate-limit helpers if already used nearby)
+- **MUST NOT** change retry/backoff, returns, thread loops, HTTP calls, or exception control flow
+- Output Markdown before/after table + unified diff draft
+- **Do not** apply the diff; **do not** `git commit` / `git merge`
+
+### Step 5 — Human gate
+
+End with a short backlog:
+
+| Priority | Count | Suggested next batch |
+|---|---|---|
+| P0 | N | … |
+| P1 | N | … |
+| P2 | N | (defer unless asked) |
+
+Ask which batch to rewrite next if not already specified.
+
+---
+
+## Output templates
+
+### Scan report
+
+```markdown
+# vLLM-Ascend log quality stock scan (phase1-stock)
+
+- Scope: …
+- Mode: phase1-stock
+- Logger calls scanned: N
+
+## Summary by priority
+| Priority | Count | Meaning |
+|---|---|---|
+| P0 | | Sensitive / empty ERROR / critical failure path silent |
+| P1 | | Missing diagnostic / cross-component / final failure summary |
+| P2 | | Naming / weak readability / incomplete closure |
+
+## Findings
+### P0
+| ID | Bucket | Location | Evidence | Suggested fix direction |
+|---|---|---|---|---|
+
+### P1
+…
+
+### P2
+…
+```
+
+### Rewrite pack
+
+```markdown
+# Rewrite candidates (P0/P1 only)
+
+| ID | Before | After | Priority | Notes |
+|---|---|---|---|---|
+
+## Diff draft
+```diff
+…
+```
+
+Human review required before apply. No business-control-flow edits included.
+```
+
+---
+
+## Hard boundaries
+
+| Allowed | Forbidden |
+|---|---|
+| Scan + report + candidate diffs | Auto-apply patches |
+| Narrow scope / priority | Bind this skill into PR/CI gate |
+| `full-standard` when user asks | Treat full ideal bar as default stock gate |
+| Point to pre-commit for incremental hard fails | Re-implement LQ001–LQ005 as a second blocker here |
+
+---
+
+## Relation to repo tools
+
+| Artifact | Use with this skill |
+|---|---|
+| `tools/log_quality_rules.toml` | Same privacy / vague literals for P0 detection heuristics |
+| `tools/check_log_quality.py` | Incremental only; may run on a file for cross-check, not as stock inventory |
+| `.gemini/styleguide.md` Logging Quality | Field names (`req_id`, `peer_component`, …) for P1 rewrite guidance |

--- a/.agents/skills/log-quality-governance/references/phase1-stock-scan-standard.md
+++ b/.agents/skills/log-quality-governance/references/phase1-stock-scan-standard.md
@@ -1,0 +1,111 @@
+# Phase-1 stock scan standard (`phase1-stock`)
+
+Authoritative scan standard for the default `phase1-stock` mode in
+`.agents/skills/log-quality-governance`.
+This is the **minimum quality line + stock scan coverage definition**, not the full ideal log standard.
+
+Related Phase-1 layers:
+
+- Incremental hard gate: `tools/check_log_quality.py` + `tools/log_quality_rules.toml`
+- PR context review: `.gemini/styleguide.md` → Logging Quality
+
+---
+
+## Priority model (single scale)
+
+| Priority | Meaning | Typical action |
+|---|---|---|
+| **P0** | Sensitive leak; totally vague ERROR; critical failure path with no log | Fix in first remediation batch |
+| **P1** | Missing key diagnostic / cross-component fields; retry without final ERROR | Second batch |
+| **P2** | Naming inconsistency; weak readability; incomplete start/success/failure closure | Defer unless asked |
+
+Do not invent a parallel P0–P3 raise scale. Map raise gaps into this table.
+
+---
+
+## Minimum bar (must detect)
+
+| Category | Stock requirement | Default priority if violated |
+|---|---|---|
+| Privacy | Do not log raw `messages`, passwords, secrets, private keys, certificates, bare tokens, full HTTP body, large tensors/lists | **P0** |
+| Readable errors | ERROR / exception / critical must not be only `failed` / `error` / `timeout` (see `log_quality_rules.toml` `[hard_fail.vague]`) | **P0** |
+| Diagnostic carrier | ERROR should carry args, key=value fields, exception text, or `exc_info=True` / `logger.exception` | **P0** if empty/short with no carrier; else **P1** if weak |
+| Linkable | Request-path / cross-component / retry final failure should carry correlators (`req_id`/`request_id`, peer fields, etc.) | **P1** (not P0 in phase1-stock) |
+| Maintainable | Remediation must not rewrite business control flow | Process rule (rewrite-guide) |
+
+Token-name allowlist for privacy (do **not** flag): see
+`tools/log_quality_rules.toml` → `allowlist_names` (`num_tokens`, `input_tokens`, …).
+
+---
+
+## Nine coverage buckets (scan report must cover)
+
+| # | Bucket | What to extract / check | Default priority |
+|---|---|---|---|
+| 1 | Logger inventory | path, line, level, template, args | info |
+| 2 | Level × module distribution | counts under `vllm_ascend/` | info |
+| 3 | Sensitive hits | privacy identifiers in message / arg names | **P0** |
+| 4 | Vague ERROR/WARNING candidates | exact vague literals / empty message | **P0** |
+| 5 | Diagnostic carrier | ERROR/WARNING with no `%`/`{}`/kwargs/`exc_info` | **P0/P1** |
+| 6 | Request-id coverage | high-risk request dirs missing `req_id`/`request_id` | **P1** |
+| 7 | Cross-component fields | missing `peer_component` / `result` / `duration_ms` / `peer_addr` on call boundaries | **P1** |
+| 8 | Loop / retry spam | ERROR inside tight retry loop without final summary | **P1** |
+| 9 | Raise / failure gap | business failure path with no nearby warning/error/exception log | **P0** if silent critical path; else **P1** |
+
+### High-risk request / link directories (hint list, not exclusive)
+
+Prefer deeper `req_id` checks under paths that touch serving, connector, KV, worker RPC, platform init — e.g.:
+
+- `vllm_ascend/worker/`
+- `vllm_ascend/platform.py` and platform helpers
+- connector / KV / disaggregate related modules under `vllm_ascend/`
+
+If unsure whether a file is request-path, mark **P2** “possible missing req_id” instead of P1.
+
+### Raise-gap precision rules
+
+Skip:
+
+- `tests/**`, generated protobuf, `__init__` trivial paths
+- Framework raises (`KeyError`, `AttributeError`, …) that are programmer bugs
+- Private helpers that are assert-like
+- Raises already followed within ~20 lines by `logger.exception` / `logger.error` in the **same file**
+
+Do not require a log before every `raise`.
+
+---
+
+## Field vocabulary (align with Gemini styleguide)
+
+| Concern | Preferred fields |
+|---|---|
+| Request correlation | `req_id` (new), `request_id` (legacy OK) |
+| Cross-component | `peer_component=`, `result=`, `duration_ms=`, `peer_addr=` when network/process boundary |
+| Retry | `attempt=`, `max_attempts=`, `final_result=`, `last_error=`; final failure → summary ERROR |
+| Background / periodic | `task_id` / `job_id` / stable task name |
+
+`trace_id` is acceptable if already used in a file; do **not** mass-rename to `trace_id` in rewrites. Prefer `req_id` for new request-path text.
+
+---
+
+## Explicitly NOT hard-fail in `phase1-stock`
+
+These may appear as **P2** suggestions only (or be ignored):
+
+- Missing `event=`
+- Missing fixed `reason=`
+- Missing Chinese “可检查 / 根因” prose
+- Missing `[vllm/…]` component prefix in the Python string
+- Incomplete start/success/failure closure on non-critical flows
+- Ops retention / shipping / aging
+
+In **`full-standard`** mode (user opt-in only), agents may apply a broader ideal bar, but must still emit the same P0/P1/P2 labels and must still refuse business-control-flow edits.
+
+---
+
+## Mode switch
+
+| Mode | When | Bar |
+|---|---|---|
+| `phase1-stock` (default) | Periodic governance, batch backlog | This file |
+| `full-standard` | User explicitly asks for full ideal standard | Broader SHOULD rules; still no PR gate; still no auto-apply |

--- a/.agents/skills/log-quality-governance/references/rewrite-guide.md
+++ b/.agents/skills/log-quality-governance/references/rewrite-guide.md
@@ -1,0 +1,106 @@
+# Rewrite guide (stock remediation candidates)
+
+Used by `log-quality-governance` after a `phase1-stock` scan.
+Produces **candidates only** — human applies patches.
+
+---
+
+## Scope of edits
+
+| Do | Do not |
+|---|---|
+| Change logger call level / message / fields | Change retry/backoff timing or count logic |
+| Add `exc_info=True` or switch to `logger.exception` when appropriate | Change `return` / `raise` targets or control flow “to make room for logs” |
+| Reuse existing rate-limit helpers already in the module | Introduce new threading, HTTP clients, or sleep policies |
+| Keep English prose consistent with the file | Force Chinese templates or Hermes-style “可检查：…” blocks |
+| Prefer `req_id=` on new request-path fields | Mass-rename working `request_id` / `trace_id` without need |
+
+Never `git commit` or `git merge` as part of this skill.
+
+---
+
+## Priority filter
+
+Default rewrite set = **P0 + P1** from the scan report.
+Include **P2** only when the user asks.
+
+Suggested batching:
+
+1. P0 privacy + empty/vague ERROR
+2. P0 silent critical failure paths
+3. P1 diagnostic / `req_id` / cross-component / retry summary
+
+---
+
+## Style matching (vllm_ascend)
+
+Before rewriting a site, sample nearby logger calls in the same file:
+
+1. Method style: `logger.error(...)` vs `self.logger.error(...)`
+2. Formatting: `%s` vs f-string vs `.format`
+3. Natural language: almost always **English** in this tree
+4. Whether structured `key=value` already appears
+
+Rewrite must look native to that file.
+
+---
+
+## Fix patterns by finding type
+
+### Privacy (P0)
+
+- Remove or redact sensitive names (`messages`, raw token/secret/password, full body, huge containers)
+- Keep safe dimensions: `input_len`, `num_tokens`, `prompt_hash` (allowlisted)
+
+### Vague / no carrier (P0)
+
+```python
+# bad
+logger.error("failed")
+
+# better (illustrative — match local formatting)
+logger.error(
+    "NPU query failed: local_rank=%s error=%s",
+    self.local_rank,
+    e,
+)
+# or
+logger.exception("NPU query failed: local_rank=%s", self.local_rank)
+```
+
+Do **not** invent peer IPs, ports, or root causes not available in scope.
+If a value is not in scope, omit it rather than fabricating.
+
+### Request path missing id (P1)
+
+Add `req_id=` (or keep `request_id=` if that is the local convention) when the
+id is already available in the function. If not available, note
+`needs_context_plumbing` in the candidate and **do not** invent a random id
+generator mid-function unless the user explicitly wants that design.
+
+### Cross-component (P1)
+
+When the log sits on an outbound/inbound RPC or connector boundary, prefer:
+
+`peer_component=... result=... duration_ms=...` and `peer_addr=...` if address exists.
+
+### Retry spam (P1)
+
+- Per-attempt failures: WARNING/DEBUG inside the loop
+- Final failure: one ERROR with `attempt=` / `max_attempts=` / `last_error=` / `final_result=`
+- Do not delete per-attempt visibility entirely; downgrade level if needed
+
+### Raise gap (P0/P1)
+
+Add a logger call **adjacent** to the failure site only if it does not require
+restructuring control flow. If the clean fix needs control-flow change, mark
+the finding `needs_human_design` and skip auto-diff.
+
+---
+
+## Diff output rules
+
+1. One finding → one hunk when possible
+2. No drive-by refactors, import churn, or formatting-only noise
+3. State clearly: “draft only — do not apply without review”
+4. If a fix would touch non-logger statements, stop and escalate to the user

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -88,3 +88,28 @@ Your description of testing approach.
 ```
 
 And please print your review suggestion in markdown format no matter the pull request description is empty or not.
+
+## Logging Quality (PR incremental)
+
+When reviewing changes that add or modify logger calls in `vllm_ascend/`, apply the following rules.
+Hard violations (privacy, vague ERROR, missing diagnostic carrier, `init_logger(__name__)`) are enforced by pre-commit (`tools/check_log_quality.py`, `tools/check_logger.sh`).
+Do **not** repeat those checks here. Focus on context-dependent MUST / MUST NOT issues only.
+Stock / periodic inventory and rewrite candidates are handled by
+`.agents/skills/log-quality-governance/` (`phase1-stock`); do not turn those
+stock findings into PR-blocking comments unless they are also incremental MUST issues on this diff.
+
+Comment only when confidence is HIGH. Avoid style-only suggestions.
+
+| Issue type | Review focus |
+|---|---|
+| Error semantics | ERROR / WARNING must express failure semantics; do not require a fixed `reason=` field |
+| Request tracing | Request-path logs should include `req_id` or legacy-compatible `request_id`; prefer `req_id` for new logs |
+| Cross-component calls | Logs should be self-evident: clearly describe the call relationship and what happened (outcome, timing). Prefer `peer_component=`, `result=`, `duration_ms=`; add `peer_addr=` at process/network boundaries. Do not treat field names as a checklist |
+| Retry loops | Include `attempt=`, `max_attempts=`, `final_result=`, `last_error=` where applicable; final failure must have a summary ERROR |
+| Hot paths | Success paths should use DEBUG, sampling, or rate limiting to avoid log flooding |
+| Long-running flows | Model load, KV link, resource allocation should have start / success / failure closure |
+| Background tasks | Periodic or long-lived tasks should carry `task_id`, `job_id`, or a stable task name |
+| Privacy | Do not log raw user input, keys, certificates, passwords, full HTTP body, large tensors, or large lists |
+| Change boundary | Do not modify retry/backoff, return paths, thread loops, HTTP calls, or business control flow just to add logs |
+
+If a PR only fixes pre-commit hard violations without context issues, do not add logging comments.

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -682,6 +682,7 @@
     - tools/
   tests:
     - tests/ut/_tools
+    - tests/ut/tools/test_check_log_quality.py
 
 ---
 # === Estimated Times ===

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,14 @@ repos:
     language: script
     types: [python]
     pass_filenames: false
+  - id: check-log-quality
+    name: Basic log quality checks for vllm_ascend
+    entry: python tools/check_log_quality.py --incremental
+    language: python
+    types: [python]
+    files: ^vllm_ascend/
+    pass_filenames: true
+    additional_dependencies: [regex]
   - id: check-forbidden-imports
     name: Check for forbidden imports
     entry: python tools/check_forbidden_imports.py

--- a/tests/ut/tools/test_check_log_quality.py
+++ b/tests/ut/tools/test_check_log_quality.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+import pytest
+
+from tools.check_log_quality import Rules, check_file, load_rules
+
+
+def _write_sample(path: Path, source: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _issues_for(source: str, tmp_path: Path, rel_path: str = "vllm_ascend/sample.py") -> list:
+    sample = tmp_path / rel_path
+    _write_sample(sample, source)
+    rules = load_rules(Path("tools/log_quality_rules.toml"))
+    old_cwd = Path.cwd()
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        return check_file(sample, rules, incremental=False)
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_privacy_sensitive_argument_fails(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.error('failed', messages)\n",
+        tmp_path,
+    )
+    assert any(issue.rule == "LQ001-privacy-in-argument" for issue in issues)
+
+
+def test_privacy_allowlist_num_tokens_passes(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.info('batch size', num_tokens)\n",
+        tmp_path,
+    )
+    assert not any(issue.rule.startswith("LQ001") for issue in issues)
+
+
+def test_privacy_allowlist_prompt_hash_passes(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.info('hash', prompt_hash)\n",
+        tmp_path,
+    )
+    assert not any(issue.rule.startswith("LQ001") for issue in issues)
+
+
+def test_privacy_allowlist_does_not_bypass_other_fields(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.error('num_tokens=%s password=%s', num_tokens, password)\n",
+        tmp_path,
+    )
+    assert any(issue.rule == "LQ001-privacy-in-message" for issue in issues)
+
+
+def test_dynamic_log_message_is_not_flagged_empty(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.error(err_msg)\n",
+        tmp_path,
+    )
+    assert not any(issue.rule == "LQ004-empty-log-message" for issue in issues)
+
+
+def test_short_fstring_with_placeholder_passes(tmp_path: Path):
+    issues = _issues_for(
+        'from vllm.logger import logger\n\nlogger.error(f"NPU error: {code}")\n',
+        tmp_path,
+    )
+    assert not any(issue.rule == "LQ004-short-log-message" for issue in issues)
+
+
+def test_non_logger_error_method_is_ignored(tmp_path: Path):
+    issues = _issues_for(
+        "class Parser:\n    def error(self, msg):\n        pass\n\nParser().error('failed')\n",
+        tmp_path,
+    )
+    assert issues == []
+
+
+def test_vague_error_message_fails(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.error('failed')\n",
+        tmp_path,
+    )
+    assert any(issue.rule == "LQ003-vague-log-message" for issue in issues)
+
+
+def test_error_with_parameter_passes(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.error('load model failed: %s', err)\n",
+        tmp_path,
+    )
+    assert not any(issue.level == "error" for issue in issues)
+
+
+def test_incremental_skips_unchanged_lines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    source = "\n".join(
+        [
+            "from vllm.logger import logger",
+            "",
+            "logger.error('failed')",
+            "logger.error('load model failed: %s', err)",
+        ]
+    )
+    sample = tmp_path / "vllm_ascend/sample.py"
+    _write_sample(sample, source)
+    rules = Rules()
+    monkeypatch.setattr(
+        "tools.check_log_quality.parse_staged_changed_lines",
+        lambda _rel_path: {4},
+    )
+    old_cwd = Path.cwd()
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        issues = check_file(sample, rules, incremental=True)
+    finally:
+        os.chdir(old_cwd)
+    assert not any(issue.rule == "LQ003-vague-log-message" for issue in issues)
+    assert not issues
+
+
+def test_out_of_scope_file_is_skipped(tmp_path: Path):
+    issues = _issues_for(
+        "from vllm.logger import logger\n\nlogger.error('failed')\n",
+        tmp_path,
+        rel_path="tests/sample.py",
+    )
+    assert issues == []

--- a/tools/check_log_quality.py
+++ b/tools/check_log_quality.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: basic log quality checks for vllm_ascend/ Python code."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import regex as re
+
+LOG_METHODS = frozenset({"debug", "info", "warning", "error", "exception", "critical"})
+WARN_METHODS = frozenset({"warning", "error", "exception", "critical"})
+LOGGER_OBJECT_NAMES = frozenset({"logger", "_logger", "logging", "log", "_log"})
+RULES_PATH = Path(__file__).with_name("log_quality_rules.toml")
+
+_GIT_EXE = shutil.which("git")
+
+DEFAULT_RULES = {
+    "path_prefixes": ["vllm_ascend/"],
+    "privacy_identifiers": [
+        "messages",
+        "password",
+        "passwd",
+        "api_key",
+        "access_token",
+        "secret",
+        "secret_key",
+        "private_key",
+        "certificate",
+        "token",
+    ],
+    "privacy_allowlist_names": [
+        "num_tokens",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "max_tokens",
+        "prompt_hash",
+        "token_ids",
+        "token_id",
+    ],
+    "vague_exact_messages": ["failed", "error", "timeout", "link failed", "connect failed"],
+    "min_message_length": 15,
+    "info_failure_keywords": ["fail", "failed", "error", "exception", "timeout", "unable"],
+}
+
+
+@dataclass
+class Issue:
+    path: Path
+    line: int
+    level: str  # "error" | "warning"
+    rule: str
+    message: str
+
+
+@dataclass
+class Rules:
+    path_prefixes: list[str] = field(default_factory=lambda: list(DEFAULT_RULES["path_prefixes"]))
+    privacy_identifiers: list[str] = field(default_factory=lambda: list(DEFAULT_RULES["privacy_identifiers"]))
+    privacy_allowlist_names: list[str] = field(default_factory=lambda: list(DEFAULT_RULES["privacy_allowlist_names"]))
+    vague_exact_messages: list[str] = field(default_factory=lambda: list(DEFAULT_RULES["vague_exact_messages"]))
+    min_message_length: int = DEFAULT_RULES["min_message_length"]
+    info_failure_keywords: list[str] = field(default_factory=lambda: list(DEFAULT_RULES["info_failure_keywords"]))
+
+
+def _import_toml_module():
+    try:
+        import tomllib
+
+        return tomllib
+    except ModuleNotFoundError:
+        try:
+            import tomli
+
+            return tomli
+        except ModuleNotFoundError:
+            return None
+
+
+def load_rules(path: Path) -> Rules:
+    rules = Rules()
+    if not path.is_file():
+        return rules
+
+    toml = _import_toml_module()
+    if toml is None:
+        print(
+            "check_log_quality: warning: TOML parser (tomllib or tomli) not found. "
+            f"Using default rules instead of loading from {path}.",
+            file=sys.stderr,
+        )
+        return rules
+
+    data = toml.loads(path.read_text(encoding="utf-8"))
+    scope = data.get("scope", {})
+    hard_fail = data.get("hard_fail", {})
+    privacy = hard_fail.get("privacy", {})
+    vague = hard_fail.get("vague", {})
+    soft_warn = data.get("soft_warn", {})
+
+    if scope.get("path_prefixes"):
+        rules.path_prefixes = list(scope["path_prefixes"])
+    if privacy.get("identifiers"):
+        rules.privacy_identifiers = [str(x).lower() for x in privacy["identifiers"]]
+    if privacy.get("allowlist_names"):
+        rules.privacy_allowlist_names = [str(x).lower() for x in privacy["allowlist_names"]]
+    if vague.get("exact_messages"):
+        rules.vague_exact_messages = [str(x).lower() for x in vague["exact_messages"]]
+    if vague.get("min_message_length") is not None:
+        rules.min_message_length = int(vague["min_message_length"])
+    if soft_warn.get("info_failure_keywords"):
+        rules.info_failure_keywords = [str(x).lower() for x in soft_warn["info_failure_keywords"]]
+
+    return rules
+
+
+def repo_relative(path: Path) -> str:
+    cwd = Path.cwd()
+    try:
+        return str(path.resolve().relative_to(cwd.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def in_scope(rel_path: str, prefixes: Iterable[str]) -> bool:
+    return any(rel_path.startswith(prefix) for prefix in prefixes)
+
+
+def _run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _require_git() -> str:
+    if _GIT_EXE is None:
+        print(
+            "check_log_quality: git not found in PATH, cannot run incremental check",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return _GIT_EXE
+
+
+def parse_staged_changed_lines(rel_path: str) -> set[int] | None:
+    git_exe = _require_git()
+    result = _run_git([git_exe, "diff", "--cached", "-U0", "--", rel_path])
+    stdout = result.stdout or ""
+    if result.returncode != 0:
+        return None
+
+    changed: set[int] = set()
+    for line in stdout.splitlines():
+        if line.startswith("@@"):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if not match:
+                continue
+            start = int(match.group(1))
+            count = int(match.group(2) or "1")
+            if count == 0:
+                continue
+            changed.update(range(start, start + count))
+    return changed
+
+
+def node_intersects_changed(node: ast.AST, changed_lines: set[int] | None) -> bool:
+    if changed_lines is None:
+        return True
+    if not changed_lines:
+        return False
+    start = getattr(node, "lineno", None)
+    if start is None:
+        return False
+    end = getattr(node, "end_lineno", start) or start
+    return any(line in changed_lines for line in range(start, end + 1))
+
+
+def _is_logger_object(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id in LOGGER_OBJECT_NAMES
+    if isinstance(node, ast.Attribute):
+        return (
+            isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+            and node.attr in ("logger", "_logger", "log", "_log")
+        )
+    return False
+
+
+def is_logger_call(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr in LOG_METHODS:
+        if _is_logger_object(func.value):
+            return func.attr
+    return None
+
+
+def iter_string_parts(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+        return parts
+    return []
+
+
+def message_text(node: ast.AST) -> str:
+    return "".join(iter_string_parts(node)).strip()
+
+
+def is_allowlisted_name(name: str, allowlist: set[str]) -> bool:
+    lowered = name.lower()
+    return lowered in allowlist
+
+
+def message_has_sensitive_field(part: str, identifier: str) -> bool:
+    if identifier == "token":
+        return bool(
+            re.search(r"(?<![a-z0-9_])token\s*=", part, re.IGNORECASE)
+            or re.search(r"\{(?<![a-z0-9_])token\}", part, re.IGNORECASE)
+        )
+    return bool(
+        re.search(rf"\b{re.escape(identifier)}\s*=", part, re.IGNORECASE)
+        or re.search(rf"\{{{re.escape(identifier)}\}}", part, re.IGNORECASE)
+    )
+
+
+def direct_sensitive_arguments(
+    node: ast.Call,
+    privacy: set[str],
+    allowlist: set[str],
+) -> str | None:
+    for arg in node.args:
+        if isinstance(arg, ast.Name):
+            if is_allowlisted_name(arg.id, allowlist):
+                continue
+            if arg.id.lower() in privacy:
+                return arg.id.lower()
+        if isinstance(arg, ast.FormattedValue):
+            if isinstance(arg.value, ast.Name):
+                if is_allowlisted_name(arg.value.id, allowlist):
+                    continue
+                if arg.value.id.lower() in privacy:
+                    return arg.value.id.lower()
+    for keyword in node.keywords:
+        if keyword.arg and is_allowlisted_name(keyword.arg, allowlist):
+            continue
+        if keyword.arg and keyword.arg.lower() in privacy:
+            return keyword.arg.lower()
+        if isinstance(keyword.value, ast.Name):
+            if is_allowlisted_name(keyword.value.id, allowlist):
+                continue
+            if keyword.value.id.lower() in privacy:
+                return keyword.value.id.lower()
+    return None
+
+
+def has_diagnostic_carrier(node: ast.Call) -> bool:
+    if any(keyword.arg == "exc_info" for keyword in node.keywords):
+        return True
+    if len(node.args) > 1:
+        return True
+    if node.args:
+        arg = node.args[0]
+        if isinstance(arg, ast.JoinedStr):
+            if any(isinstance(val, ast.FormattedValue) for val in arg.values):
+                return True
+        text = message_text(arg)
+        if "%" in text or "{" in text:
+            return True
+    return False
+
+
+class LogQualityChecker(ast.NodeVisitor):
+    def __init__(self, path: Path, rel_path: str, rules: Rules, changed_lines: set[int] | None) -> None:
+        self.path = path
+        self.rel_path = rel_path
+        self.rules = rules
+        self.changed_lines = changed_lines
+        self.issues: list[Issue] = []
+
+    def _add(
+        self,
+        node: ast.AST,
+        level: str,
+        rule: str,
+        message: str,
+    ) -> None:
+        if not node_intersects_changed(node, self.changed_lines):
+            return
+        line = getattr(node, "lineno", 1) or 1
+        self.issues.append(Issue(self.path, line, level, rule, message))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        method = is_logger_call(node)
+        if method is None:
+            self.generic_visit(node)
+            return
+
+        self._check_privacy(node)
+        if method in WARN_METHODS:
+            self._check_vague_message(node, method)
+        if method == "info":
+            self._check_info_failure_keywords(node)
+
+        self.generic_visit(node)
+
+    def _check_privacy(self, node: ast.Call) -> None:
+        privacy = set(self.rules.privacy_identifiers)
+        allowlist = set(self.rules.privacy_allowlist_names)
+        for part in iter_string_parts(node.args[0]) if node.args else []:
+            for identifier in privacy:
+                if message_has_sensitive_field(part, identifier):
+                    self._add(
+                        node,
+                        "error",
+                        "LQ001-privacy-in-message",
+                        "log message appears to log a sensitive field value",
+                    )
+                    return
+
+        sensitive_arg = direct_sensitive_arguments(node, privacy, allowlist)
+        if sensitive_arg:
+            self._add(
+                node,
+                "error",
+                "LQ001-privacy-in-argument",
+                f"log call must not pass sensitive identifier '{sensitive_arg}'",
+            )
+
+    def _check_vague_message(self, node: ast.Call, method: str) -> None:
+        if not node.args:
+            self._add(
+                node,
+                "error",
+                "LQ004-empty-log-message",
+                f"logger.{method}() has no message",
+            )
+            return
+
+        arg = node.args[0]
+        if not isinstance(arg, (ast.Constant, ast.JoinedStr)):
+            return
+
+        text = message_text(arg)
+        if not text:
+            self._add(
+                node,
+                "error",
+                "LQ004-empty-log-message",
+                f"logger.{method}() message is empty",
+            )
+            return
+
+        normalized = text.lower()
+        if normalized in self.rules.vague_exact_messages:
+            self._add(
+                node,
+                "error",
+                "LQ003-vague-log-message",
+                f"logger.{method}() message is too vague: {text!r}",
+            )
+            return
+
+        if len(text) < self.rules.min_message_length and not has_diagnostic_carrier(node):
+            self._add(
+                node,
+                "error",
+                "LQ004-short-log-message",
+                f"logger.{method}() message is too short ({len(text)} chars); describe what failed and key parameters",
+            )
+
+    def _check_info_failure_keywords(self, node: ast.Call) -> None:
+        if not node.args:
+            return
+        text = message_text(node.args[0]).lower()
+        if not text:
+            return
+        for keyword in self.rules.info_failure_keywords:
+            if re.search(rf"\b{re.escape(keyword)}\b", text):
+                self._add(
+                    node,
+                    "warning",
+                    "info-looks-like-error",
+                    f"logger.info() message contains failure keyword '{keyword}'; consider logger.warning/error",
+                )
+                return
+
+
+def check_file(path: Path, rules: Rules, incremental: bool) -> list[Issue]:
+    rel_path = repo_relative(path)
+    if not in_scope(rel_path, rules.path_prefixes):
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=rel_path)
+    except SyntaxError as exc:
+        return [
+            Issue(
+                path,
+                exc.lineno or 1,
+                "error",
+                "syntax-error",
+                f"cannot parse file for log checks: {exc.msg}",
+            )
+        ]
+
+    changed_lines = parse_staged_changed_lines(rel_path) if incremental else None
+    if incremental and changed_lines is not None and not changed_lines:
+        status = _run_git([_require_git(), "diff", "--cached", "--name-status", "--", rel_path])
+        status_out = status.stdout or ""
+        if status_out.startswith("A\t") or status_out.startswith("A "):
+            changed_lines = None  # new file: check entire file
+
+    checker = LogQualityChecker(path, rel_path, rules, changed_lines)
+    checker.visit(tree)
+    return checker.issues
+
+
+def format_issue(issue: Issue) -> str:
+    rel = repo_relative(issue.path)
+    return f"{rel}:{issue.line}: [{issue.level}] {issue.rule}: {issue.message}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Basic log quality checks for vllm_ascend/ code.")
+    parser.add_argument("files", nargs="*", help="Files to check (from pre-commit).")
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        default="PRE_COMMIT" in __import__("os").environ,
+        help="Only report issues on staged changed lines (default under pre-commit).",
+    )
+    parser.add_argument(
+        "--all-lines",
+        action="store_true",
+        help="Check entire file contents (disables incremental line filtering).",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat warnings as errors (for CI).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.files:
+        return 0
+
+    rules = load_rules(RULES_PATH)
+    incremental = args.incremental and not args.all_lines
+
+    errors: list[Issue] = []
+    warnings: list[Issue] = []
+    for file_arg in args.files:
+        path = Path(file_arg)
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        for issue in check_file(path, rules, incremental=incremental):
+            if issue.level == "error":
+                errors.append(issue)
+            else:
+                warnings.append(issue)
+
+    for issue in errors:
+        print(format_issue(issue))
+    for issue in warnings:
+        print(format_issue(issue))
+
+    if errors:
+        return 1
+    if args.strict and warnings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/log_quality_rules.toml
+++ b/tools/log_quality_rules.toml
@@ -1,0 +1,56 @@
+# Basic log quality rules for pre-commit (vllm_ascend/ production code).
+# Phase 1: LQ001-LQ004 hard fail, LQ005 handled by tools/check_logger.sh
+# Stock scan / rewrite candidates (not a PR gate):
+#   .agents/skills/log-quality-governance/  (default mode: phase1-stock)
+# Full ideal standard is opt-in via that skill's full-standard mode only.
+
+[scope]
+path_prefixes = ["vllm_ascend/"]
+
+[hard_fail.privacy]
+# Match log message text, keyword names, or variable names passed to logger calls.
+identifiers = [
+  "messages",
+  "password",
+  "passwd",
+  "api_key",
+  "access_token",
+  "secret",
+  "secret_key",
+  "private_key",
+  "certificate",
+  "token",
+]
+
+# LQ002: safe token-related names that must not trigger bare-token privacy checks.
+allowlist_names = [
+  "num_tokens",
+  "input_tokens",
+  "output_tokens",
+  "total_tokens",
+  "max_tokens",
+  "prompt_hash",
+  "token_ids",
+  "token_id",
+]
+
+[hard_fail.vague]
+# ERROR/WARNING/exception/critical with a single literal message matching these fail.
+exact_messages = [
+  "failed",
+  "error",
+  "timeout",
+  "link failed",
+  "connect failed",
+]
+min_message_length = 15
+
+[soft_warn]
+info_failure_keywords = [
+  "fail",
+  "failed",
+  "error",
+  "exception",
+  "timeout",
+  "unable",
+]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces the **Phase-1 log quality framework** for `vllm_ascend/` in two layers:
please see https://github.com/vllm-project/vllm-ascend/issues/11229

**1. Incremental hard gate (pre-commit, commit 1)**

- Add `tools/check_log_quality.py`: AST-based checker for `vllm_ascend/**/*.py` logger calls, with **incremental mode** (only staged changed lines; new files are checked in full).
- Add `tools/log_quality_rules.toml`: centralized rule config shared with stock-scan heuristics.
- Wire pre-commit hook `check-log-quality` (scope: `^vllm_ascend/`, alongside existing `check-logger` for LQ005).
- Extend `.gemini/styleguide.md` with **Logging Quality (PR incremental)** so Gemini review focuses on context-dependent MUST/MUST NOT items, not duplicating pre-commit hard rules.

Hard-fail rules on touched lines:

| Rule | Check |
|------|--------|
| LQ001 | Privacy: sensitive identifiers in log message or arguments (`messages`, `password`, `token`, …; with allowlist e.g. `num_tokens`, `prompt_hash`) |
| LQ003 | Vague ERROR/WARNING/exception/critical: bare literals like `failed`, `error`, `timeout` |
| LQ004 | Empty or too-short log messages on warn/error paths |
| LQ005 | (existing) `init_logger(__name__)` via `tools/check_logger.sh` |

**2. Stock governance skill (commit 2)**

- Add `.agents/skills/log-quality-governance/` for **periodic / batch inventory** of existing logger calls.
- Default mode `phase1-stock`: P0/P1/P2 findings + rewrite candidates only; **does not block PRs** and does not auto-apply patches.
- References: `phase1-stock-scan-standard.md`, `rewrite-guide.md`.

**Why:** vLLM-Ascend log quality needs a clear split: **incremental gate on PR diffs** (prevent new bad logs) vs **stock remediation backlog** (batch-fix legacy logs without blocking every PR). This PR establishes that three-layer model (pre-commit → Gemini review → stock skill).

### Does this PR introduce _any_ user-facing change?

**Contributor-facing yes; runtime/API no.**

- Contributors who modify `vllm_ascend/` Python files will see new pre-commit failures on **changed lines** when logger calls violate LQ001/LQ003/LQ004 (or existing LQ005).
- Unchanged legacy log lines are not scanned by pre-commit; stock remediation is opt-in via the new skill.
- No change to inference API, CLI flags, model behavior, or end-user log output format.

### How was this patch tested?

- Unit tests added: `tests/ut/tools/test_check_log_quality.py`
  - LQ001 privacy (including allowlist: `num_tokens`, `prompt_hash`)
  - LQ003 vague error message
  - Parameterized error messages pass
  - Incremental mode skips unchanged lines
  - Out-of-scope paths skipped

```bash
pytest -sv tests/ut/tools/test_check_log_quality.py

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
