### PR TITLE
[v0.24.0rc][BugFix] Ensure contiguous weight tensors after transpose in FusedMoE

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -61,7 +61,7 @@ def test_runner_310_installs_specialized_unquantized_method_and_comm():
 
 @pytest.mark.parametrize(
     "is_v024, expected_contiguous",
-    [(True, True), (False, False)],
+    [(True, True), (False, True)],
 )
 def test_process_weights_after_loading_310_uses_version_specific_layout(
     monkeypatch,
@@ -74,11 +74,6 @@ def test_process_weights_after_loading_310_uses_version_specific_layout(
     original_w13 = layer.w13_weight.detach().clone()
     original_w2 = layer.w2_weight.detach().clone()
 
-    monkeypatch.setattr(
-        fused_moe_310_module,
-        "vllm_version_is",
-        lambda version: is_v024 and version == "0.24.0",
-    )
     monkeypatch.setattr(fused_moe_310_module, "maybe_trans_nz", lambda weight: weight)
     monkeypatch.setattr(
         fused_moe_310_module.UnquantizedFusedMoEMethod,

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -52,7 +52,7 @@ def test_ascend_unquantized_skips_upstream_modular_kernel_init():
 
 @pytest.mark.parametrize(
     "is_v024, expected_contiguous",
-    [(True, True), (False, False)],
+    [(True, True), (False, True)],
 )
 def test_process_weights_after_loading_uses_version_specific_layout(
     monkeypatch,
@@ -65,7 +65,6 @@ def test_process_weights_after_loading_uses_version_specific_layout(
     original_w2 = layer.w2_weight.detach().clone()
     ascend_config = SimpleNamespace(enable_fused_mc2=False)
 
-    monkeypatch.setattr(fused_moe_module, "vllm_version_is", lambda version: is_v024 and version == "0.24.0")
     monkeypatch.setattr(fused_moe_module, "get_ascend_config", lambda: ascend_config)
     monkeypatch.setattr(fused_moe_module, "maybe_trans_nz", lambda weight: weight)
     upstream_method_base = AscendUnquantizedFusedMoEMethod.__mro__[2]

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -26,7 +26,7 @@ from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import maybe_trans_nz, vllm_version_is
+from vllm_ascend.utils import maybe_trans_nz
 
 from .experts_selector import select_experts
 from .moe_comm_method import AllGatherCommImpl310
@@ -48,24 +48,13 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
     def process_weights_after_loading(self, layer):
         super().process_weights_after_loading(layer)
 
-        # vLLM PR #44589 landed after the v0.24 main-line cut point
-        # (798185d) and is present in the verified main commit only.
-        if not vllm_version_is("0.24.0"):
-            w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2)
-            w13_data = maybe_trans_nz(w13_data)
-            layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
+        w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
+        w13_data = maybe_trans_nz(w13_data)
+        layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
 
-            w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2)
-            w2_data = maybe_trans_nz(w2_data)
-            layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
-        else:
-            w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
-            w13_data = maybe_trans_nz(w13_data)
-            layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
-
-            w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
-            w2_data = maybe_trans_nz(w2_data)
-            layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
+        w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
+        w2_data = maybe_trans_nz(w2_data)
+        layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
 
     def apply(
         self,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -49,7 +49,6 @@ from vllm_ascend.utils import (
     npu_stream_switch,
     shared_expert_dp_enabled,
     shared_experts_calculation_stream,
-    vllm_version_is,
 )
 
 
@@ -107,20 +106,11 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     def process_weights_after_loading(self, layer):
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
 
-        # vLLM PR #44589 landed after the v0.24 main-line cut point
-        # (798185d) and is present in the verified main commit only.
-        if not vllm_version_is("0.24.0"):
-            w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2)
-            layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
+        w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
+        layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
 
-            w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2)
-            layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
-        else:
-            w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
-            layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
-
-            w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
-            layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
+        w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
+        layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
 
         # TODO: Current dispatch_ffn_combine fusion operator ONLY supports NZ format.
         # Therefore, we must cast weights to NZ when fusion is enabled.


### PR DESCRIPTION

### What this PR does / why we need it?

cherry-pick: https://github.com/vllm-project/vllm-ascend/pull/12494

fix: https://github.com/vllm-project/vllm-ascend/actions/runs/29756582240/job/88436386887

On Ascend NPUs, operators like npu_format_cast require contiguous memory layouts. Non-contiguous tensors from .transpose(1,2) caused runtime failures in nightly tests.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
