### PR TITLE
[Feature] Support Qwen3 MoE expert pruning

### DIFF
--- a/tests/e2e/pull_request/two_card/test_qwen3_moe_expert_pruning.py
+++ b/tests/e2e/pull_request/two_card/test_qwen3_moe_expert_pruning.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from transformers import AutoConfig
+from vllm import SamplingParams
+from vllm.sampling_params import RequestOutputKind
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from vllm_ascend.utils import vllm_version_is
+
+pytestmark = pytest.mark.skipif(
+    not (vllm_version_is("0.22.1") or vllm_version_is("0.23.0")),
+    reason="Qwen3 MoE pruning patch is verified with vLLM v0.22.1/v0.23.0.",
+)
+
+
+def _get_model_path() -> str:
+    local_model = Path("/root/models/Qwen/Qwen3-30B-A3B-W8A8")
+    return str(local_model) if local_model.is_dir() else "vllm-ascend/Qwen3-30B-A3B-W8A8"
+
+
+def _get_text_config(model: str):
+    config = AutoConfig.from_pretrained(model, trust_remote_code=True)
+    return getattr(config, "text_config", config)
+
+
+def _write_ordered_expert_list(model: str, path: Path) -> tuple[float, int]:
+    config = _get_text_config(model)
+    num_layers = config.num_hidden_layers
+    num_experts = config.num_experts
+    top_k = config.num_experts_per_tok
+    prune_ratio = 0.5
+    kept_experts = max(top_k, int(num_experts * (1.0 - prune_ratio)))
+    lines = [json.dumps({str(layer_idx): list(range(num_experts))}) for layer_idx in range(num_layers)]
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return prune_ratio, kept_experts
+
+
+@patch.dict(os.environ, {"OMP_NUM_THREADS": "1"})
+@wait_until_npu_memory_free()
+def test_qwen3_moe_expert_pruning_generates_with_pruned_expert_ids(tmp_path):
+    model = _get_model_path()
+    expert_list_file = tmp_path / "qwen3_moe_ordered_expert_list.jsonl"
+    prune_ratio, kept_experts = _write_ordered_expert_list(model, expert_list_file)
+
+    prompts = [
+        "Briefly explain what deep learning is.",
+    ]
+
+    with VllmRunner(
+        model,
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        enable_return_routed_experts=True,
+        distributed_executor_backend="mp",
+        quantization="ascend",
+        max_model_len=1024,
+        additional_config={
+            "expert_list_file": str(expert_list_file),
+            "expert_prune_ratio": prune_ratio,
+        },
+        cudagraph_capture_sizes=[1, 2, 4, 8],
+    ) as vllm_model:
+        sampling_params = SamplingParams(
+            max_tokens=8,
+            temperature=0.0,
+            output_kind=RequestOutputKind.FINAL_ONLY,
+        )
+        outputs = vllm_model.model.generate(
+            prompts=vllm_model.get_inputs(prompts=prompts),
+            sampling_params=sampling_params,
+        )
+
+    assert outputs[0].finished
+    assert outputs[0].outputs[0].text
+    routed_experts = outputs[0].outputs[0].routed_experts
+    assert routed_experts.size > 0
+    assert int(routed_experts.max()) < kept_experts

--- a/tests/ut/patch/worker/test_patch_qwen3_moe_pruning.py
+++ b/tests/ut/patch/worker/test_patch_qwen3_moe_pruning.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+def _load_pruning_module():
+    module_path = Path(__file__).parents[4] / "vllm_ascend" / "patch" / "worker" / "patch_qwen3_moe_pruning.py"
+    spec = importlib.util.spec_from_file_location("patch_qwen3_moe_pruning_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+pruning = _load_pruning_module()
+
+
+def _write_expert_list(tmp_path, expert_table):
+    expert_list_file = tmp_path / "expert_list.jsonl"
+    lines = [json.dumps({str(layer_idx): expert_ids}) for layer_idx, expert_ids in expert_table.items()]
+    expert_list_file.write_text("\n".join(lines), encoding="utf-8")
+    pruning._load_ordered_expert_map.cache_clear()
+    return str(expert_list_file)
+
+
+def _make_vllm_config(expert_list_file=None, num_experts=8, top_k=2, prune_ratio=0.5):
+    additional_config = {}
+    if expert_list_file is not None:
+        additional_config = {
+            "expert_list_file": expert_list_file,
+            "expert_prune_ratio": prune_ratio,
+        }
+    return SimpleNamespace(
+        additional_config=additional_config,
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                num_experts=num_experts,
+                num_experts_per_tok=top_k,
+            )
+        ),
+    )
+
+
+def test_load_ordered_expert_map_parses_jsonl_layer_ids(tmp_path):
+    expert_list_file = _write_expert_list(
+        tmp_path,
+        {
+            "0": [3, 1, 5],
+            "2": [4, 0],
+        },
+    )
+
+    assert pruning._load_ordered_expert_map(expert_list_file) == {
+        0: (3, 1, 5),
+        2: (4, 0),
+    }
+
+
+@pytest.mark.parametrize(
+    ("content", "match"),
+    [
+        ('{"layer0": [0]}', "Invalid Qwen3MoE expert pruning layer id"),
+        ("[0, 1]", "single-key objects"),
+        ('{"0": [0], "1": [1]}', "single-key objects"),
+        ('{"0": ["0"]}', "integer expert ids"),
+        ('{"0": [1, 1]}', "duplicate expert ids"),
+        ("", "JSONL file is empty"),
+    ],
+)
+def test_load_ordered_expert_map_rejects_invalid_jsonl(tmp_path, content, match):
+    expert_list_file = tmp_path / "expert_list.jsonl"
+    expert_list_file.write_text(content, encoding="utf-8")
+    pruning._load_ordered_expert_map.cache_clear()
+
+    with pytest.raises(ValueError, match=match):
+        pruning._load_ordered_expert_map(str(expert_list_file))
+
+
+@pytest.mark.parametrize(
+    ("prune_ratio", "match"),
+    [
+        (None, "requires additional_config"),
+        ("0.5", "must be a number"),
+        (True, "must be a number"),
+        (-0.1, r"must be in \[0, 1\)"),
+        (1.0, r"must be in \[0, 1\)"),
+    ],
+)
+def test_get_expert_prune_ratio_validates_config(prune_ratio, match):
+    additional_config = {"expert_list_file": "experts.jsonl"}
+    if prune_ratio is not None:
+        additional_config["expert_prune_ratio"] = prune_ratio
+    vllm_config = SimpleNamespace(additional_config=additional_config)
+
+    with pytest.raises(ValueError, match=match):
+        pruning._get_expert_prune_ratio(vllm_config)
+
+
+def test_get_pruned_expert_count_uses_prune_ratio():
+    assert pruning._get_pruned_expert_count(total_num_experts=8, top_k=2, prune_ratio=0.5) == 4
+    assert pruning._get_pruned_expert_count(total_num_experts=8, top_k=2, prune_ratio=0.25) == 6
+
+    with pytest.raises(ValueError, match="num_experts_per_tok=3"):
+        pruning._get_pruned_expert_count(total_num_experts=8, top_k=3, prune_ratio=0.75)
+
+
+def test_get_pruned_expert_ids_returns_none_when_disabled():
+    vllm_config = _make_vllm_config(expert_list_file=None)
+
+    assert pruning._get_pruned_expert_ids(vllm_config, layer_idx=0, total_num_experts=8, top_k=2) is None
+
+
+def test_get_pruned_expert_ids_validates_layer_topk_and_bounds(tmp_path):
+    expert_list_file = _write_expert_list(tmp_path, {"0": [7, 3, 5, 1]})
+    vllm_config = _make_vllm_config(expert_list_file, num_experts=8, top_k=2, prune_ratio=0.5)
+
+    assert pruning._get_pruned_expert_ids(vllm_config, layer_idx=0, total_num_experts=8, top_k=2) == (7, 3, 5, 1)
+
+    with pytest.raises(ValueError, match="missing an entry for layer 1"):
+        pruning._get_pruned_expert_ids(vllm_config, layer_idx=1, total_num_experts=8, top_k=2)
+
+    short_expert_list_file = _write_expert_list(tmp_path, {"0": [7, 3]})
+    short_vllm_config = _make_vllm_config(short_expert_list_file, num_experts=8, top_k=2, prune_ratio=0.5)
+    with pytest.raises(ValueError, match="requires 4"):
+        pruning._get_pruned_expert_ids(short_vllm_config, layer_idx=0, total_num_experts=8, top_k=2)
+
+    bounds_expert_list_file = tmp_path / "bounds_expert_list.jsonl"
+    bounds_expert_list_file.write_text(json.dumps({"0": [7, 3, 5, 1]}), encoding="utf-8")
+    pruning._load_ordered_expert_map.cache_clear()
+    bounds_vllm_config = _make_vllm_config(str(bounds_expert_list_file), num_experts=8, top_k=2, prune_ratio=0.5)
+    with pytest.raises(ValueError, match=r"expert ids must be in \[0, 7\)"):
+        pruning._get_pruned_expert_ids(bounds_vllm_config, layer_idx=0, total_num_experts=7, top_k=2)
+
+
+def test_maybe_prune_gate_weight_selects_configured_expert_rows():
+    gate_weight = torch.arange(24, dtype=torch.float32).reshape(8, 3)
+
+    pruned = pruning._maybe_prune_gate_weight(
+        "model.layers.0.mlp.gate.weight",
+        gate_weight,
+        {0: (7, 3, 1)},
+    )
+
+    torch.testing.assert_close(pruned, gate_weight[[7, 3, 1]])
+
+
+def test_maybe_prune_gate_weight_ignores_non_gate_or_unlisted_layer():
+    weight = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+
+    assert pruning._maybe_prune_gate_weight("model.layers.0.mlp.down_proj.weight", weight, {0: (3, 1)}) is weight
+    assert pruning._maybe_prune_gate_weight("model.layers.1.mlp.gate.weight", weight, {0: (3, 1)}) is weight
+    assert pruning._maybe_prune_gate_weight("model.layers.0.mlp.gate.weight", weight, None) is weight
+
+
+def test_maybe_prune_gate_weight_rejects_out_of_bounds_expert_id():
+    gate_weight = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        pruning._maybe_prune_gate_weight(
+            "model.layers.0.mlp.gate.weight",
+            gate_weight,
+            {0: (4,)},
+        )
+
+
+def test_sparse_moe_block_init_temporarily_uses_pruned_num_experts(tmp_path, monkeypatch):
+    expert_list_file = _write_expert_list(tmp_path, {"0": [7, 3, 1, 5]})
+    vllm_config = _make_vllm_config(expert_list_file, num_experts=8, top_k=2, prune_ratio=0.5)
+    block = SimpleNamespace()
+    observed_num_experts = []
+
+    def fake_original_init(self, config, prefix):
+        observed_num_experts.append(config.model_config.hf_text_config.num_experts)
+        self.original_init_prefix = prefix
+        return "initialized"
+
+    monkeypatch.setattr(pruning.qm, "extract_layer_index", lambda prefix: 0)
+    monkeypatch.setattr(pruning.qm.Qwen3MoeSparseMoeBlock, "_ascend_original_init", fake_original_init, raising=False)
+
+    result = pruning._patched_sparse_moe_block_init(block, vllm_config, "model.layers.0.mlp")
+
+    assert result == "initialized"
+    assert observed_num_experts == [4]
+    assert vllm_config.model_config.hf_text_config.num_experts == 8
+    assert block.original_num_experts == 8
+    assert block.pruned_expert_ids == (7, 3, 1, 5)
+
+
+def test_sparse_moe_block_init_delegates_when_pruning_disabled(monkeypatch):
+    vllm_config = _make_vllm_config(expert_list_file=None, num_experts=8, top_k=2)
+    block = SimpleNamespace()
+    observed_num_experts = []
+
+    def fake_original_init(self, config, prefix):
+        observed_num_experts.append(config.model_config.hf_text_config.num_experts)
+        return "original"
+
+    monkeypatch.setattr(pruning.qm, "extract_layer_index", lambda prefix: 0)
+    monkeypatch.setattr(pruning.qm.Qwen3MoeSparseMoeBlock, "_ascend_original_init", fake_original_init, raising=False)
+
+    assert pruning._patched_sparse_moe_block_init(block, vllm_config, "model.layers.0.mlp") == "original"
+    assert observed_num_experts == [8]
+    assert not hasattr(block, "pruned_expert_ids")
+
+
+def test_get_expert_mapping_remaps_original_experts_to_pruned_slots():
+    model = SimpleNamespace(
+        expert_pruning_map={1: (7, 3)},
+        named_parameters=lambda: [],
+    )
+
+    mapping = pruning._patched_get_expert_mapping(model)
+
+    assert mapping == [
+        ("layers.1.mlp.experts.w13_weight", "layers.1.mlp.experts.7.gate_proj.weight", 0, "w1"),
+        ("layers.1.mlp.experts.w2_weight", "layers.1.mlp.experts.7.down_proj.weight", 0, "w2"),
+        ("layers.1.mlp.experts.w13_weight", "layers.1.mlp.experts.7.up_proj.weight", 0, "w3"),
+        ("layers.1.mlp.experts.w13_weight_scale", "layers.1.mlp.experts.7.gate_proj.weight_scale", 0, "w1"),
+        ("layers.1.mlp.experts.w2_weight_scale", "layers.1.mlp.experts.7.down_proj.weight_scale", 0, "w2"),
+        ("layers.1.mlp.experts.w13_weight_scale", "layers.1.mlp.experts.7.up_proj.weight_scale", 0, "w3"),
+        ("layers.1.mlp.experts.w13_weight", "layers.1.mlp.experts.3.gate_proj.weight", 1, "w1"),
+        ("layers.1.mlp.experts.w2_weight", "layers.1.mlp.experts.3.down_proj.weight", 1, "w2"),
+        ("layers.1.mlp.experts.w13_weight", "layers.1.mlp.experts.3.up_proj.weight", 1, "w3"),
+        ("layers.1.mlp.experts.w13_weight_scale", "layers.1.mlp.experts.3.gate_proj.weight_scale", 1, "w1"),
+        ("layers.1.mlp.experts.w2_weight_scale", "layers.1.mlp.experts.3.down_proj.weight_scale", 1, "w2"),
+        ("layers.1.mlp.experts.w13_weight_scale", "layers.1.mlp.experts.3.up_proj.weight_scale", 1, "w3"),
+    ]
+    assert not any("weight_offset" in weight_name for _, weight_name, _, _ in mapping)
+
+
+def test_get_expert_mapping_delegates_without_pruning(monkeypatch):
+    model = MagicMock(expert_pruning_map=None)
+    original_get_expert_mapping = MagicMock(return_value=["original"])
+    monkeypatch.setattr(
+        pruning.qm.Qwen3MoeModel,
+        "_ascend_original_get_expert_mapping",
+        original_get_expert_mapping,
+        raising=False,
+    )
+
+    assert pruning._patched_get_expert_mapping(model) == ["original"]
+    original_get_expert_mapping.assert_called_once_with(model)

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -34,6 +34,7 @@ if HAS_TRITON:
 import vllm_ascend.patch.worker.patch_process_weights_after_loading  # noqa
 import vllm_ascend.patch.worker.patch_weight_utils  # noqa
 import vllm_ascend.patch.worker.patch_distributed  # noqa
+import vllm_ascend.patch.worker.patch_qwen3_moe_pruning  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2  # noqa
 import vllm_ascend.patch.worker.patch_minimax_m2_linear_attn  # noqa
 import vllm_ascend.patch.worker.patch_mamba_utils  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_moe_pruning.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_moe_pruning.py
@@ -1,0 +1,267 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Patch Qwen3MoE expert pruning support into vLLM.
+
+The pruning table is passed by:
+--additional-config '{"expert_list_file":"/path/to/experts.jsonl","expert_prune_ratio":0.5}'
+"""
+
+import json
+from functools import lru_cache, wraps
+
+import torch
+from vllm.model_executor.models import qwen3_moe as qm
+
+
+@lru_cache
+def _load_ordered_expert_map(expert_list_file: str) -> dict[int, tuple[int, ...]]:
+    ordered_map: dict[int, tuple[int, ...]] = {}
+
+    with open(expert_list_file, encoding="utf-8") as f:
+        for line_num, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                layer_entry = json.loads(line)
+            except json.JSONDecodeError as err:
+                raise ValueError(f"Invalid Qwen3MoE expert pruning JSONL at line {line_num}.") from err
+
+            if not isinstance(layer_entry, dict) or len(layer_entry) != 1:
+                raise ValueError(
+                    "Qwen3MoE expert pruning JSONL entries must be single-key objects, "
+                    f"got {type(layer_entry).__name__} at line {line_num}."
+                )
+
+            layer_idx, expert_ids = next(iter(layer_entry.items()))
+            try:
+                parsed_layer_idx = int(layer_idx)
+            except ValueError as err:
+                raise ValueError(f"Invalid Qwen3MoE expert pruning layer id: {layer_idx!r}") from err
+
+            if parsed_layer_idx in ordered_map:
+                raise ValueError(f"Qwen3MoE expert pruning layer {parsed_layer_idx} appears more than once.")
+            if not isinstance(expert_ids, list) or not all(isinstance(expert_id, int) for expert_id in expert_ids):
+                raise ValueError(
+                    f"Qwen3MoE expert pruning entry must contain integer expert ids for layer {layer_idx}."
+                )
+            if len(set(expert_ids)) != len(expert_ids):
+                raise ValueError(f"Qwen3MoE expert pruning layer {layer_idx} contains duplicate expert ids.")
+
+            ordered_map[parsed_layer_idx] = tuple(expert_ids)
+
+    if not ordered_map:
+        raise ValueError("Qwen3MoE expert pruning JSONL file is empty.")
+
+    return ordered_map
+
+
+def _get_expert_list_file(vllm_config) -> str | None:
+    return vllm_config.additional_config.get("expert_list_file")
+
+
+def _get_expert_prune_ratio(vllm_config) -> float:
+    ratio = vllm_config.additional_config.get("expert_prune_ratio")
+    if ratio is None:
+        raise ValueError("Qwen3MoE expert pruning requires additional_config['expert_prune_ratio'].")
+    if not isinstance(ratio, (int, float)) or isinstance(ratio, bool):
+        raise ValueError("Qwen3MoE expert_prune_ratio must be a number.")
+    ratio = float(ratio)
+    if ratio < 0.0 or ratio >= 1.0:
+        raise ValueError("Qwen3MoE expert_prune_ratio must be in [0, 1).")
+    return ratio
+
+
+def _get_pruned_expert_count(total_num_experts: int, top_k: int, prune_ratio: float) -> int:
+    pruned_expert_count = int(total_num_experts * (1.0 - prune_ratio))
+    if pruned_expert_count <= 0:
+        raise ValueError(f"Qwen3MoE expert_prune_ratio={prune_ratio} prunes all {total_num_experts} experts.")
+    if top_k > pruned_expert_count:
+        raise ValueError(
+            f"Qwen3MoE keeps {pruned_expert_count} experts with expert_prune_ratio={prune_ratio}, "
+            f"but num_experts_per_tok={top_k}."
+        )
+    return pruned_expert_count
+
+
+def _get_pruned_expert_ids(
+    vllm_config,
+    layer_idx: int,
+    total_num_experts: int,
+    top_k: int,
+) -> tuple[int, ...] | None:
+    expert_list_file = _get_expert_list_file(vllm_config)
+    if not expert_list_file:
+        return None
+
+    ordered_map = _load_ordered_expert_map(expert_list_file)
+    if layer_idx not in ordered_map:
+        raise ValueError(f"Qwen3MoE expert pruning file is missing an entry for layer {layer_idx}.")
+
+    prune_ratio = _get_expert_prune_ratio(vllm_config)
+    pruned_expert_count = _get_pruned_expert_count(total_num_experts, top_k, prune_ratio)
+    ordered_expert_ids = ordered_map[layer_idx]
+    if len(ordered_expert_ids) < pruned_expert_count:
+        raise ValueError(
+            f"Qwen3MoE layer {layer_idx} provides {len(ordered_expert_ids)} ordered experts, "
+            f"but expert_prune_ratio={prune_ratio} requires {pruned_expert_count}."
+        )
+
+    expert_ids = ordered_expert_ids[:pruned_expert_count]
+    if any(expert_id < 0 or expert_id >= total_num_experts for expert_id in expert_ids):
+        raise ValueError(
+            f"Qwen3MoE layer {layer_idx} expert ids must be in [0, {total_num_experts}). Got {expert_ids}."
+        )
+
+    return expert_ids
+
+
+def _get_expert_pruning_map(vllm_config) -> dict[int, tuple[int, ...]] | None:
+    expert_list_file = _get_expert_list_file(vllm_config)
+    if expert_list_file is None:
+        return None
+
+    config = vllm_config.model_config.hf_text_config
+    ordered_map = _load_ordered_expert_map(expert_list_file)
+    return {
+        layer_idx: _get_pruned_expert_ids(
+            vllm_config,
+            layer_idx,
+            config.num_experts,
+            config.num_experts_per_tok,
+        )
+        for layer_idx in ordered_map
+    }
+
+
+def _maybe_prune_gate_weight(
+    name: str,
+    loaded_weight: torch.Tensor,
+    expert_pruning_map: dict[int, tuple[int, ...]] | None,
+) -> torch.Tensor:
+    if expert_pruning_map is None or not name.endswith(".mlp.gate.weight"):
+        return loaded_weight
+
+    layer_idx = qm.extract_layer_index(name)
+    expert_ids = expert_pruning_map.get(layer_idx)
+    if expert_ids is None:
+        return loaded_weight
+
+    if max(expert_ids) >= loaded_weight.shape[0]:
+        raise ValueError(
+            f"Cannot prune gate weight {name}: expert id {max(expert_ids)} "
+            f"is out of bounds for loaded shape {tuple(loaded_weight.shape)}."
+        )
+
+    index = torch.tensor(expert_ids, dtype=torch.long, device=loaded_weight.device)
+    return loaded_weight.index_select(0, index)
+
+
+def _patched_sparse_moe_block_init(self, vllm_config, prefix: str = ""):
+    config = vllm_config.model_config.hf_text_config
+    original_num_experts = config.num_experts
+    layer_idx = qm.extract_layer_index(prefix)
+    pruned_expert_ids = _get_pruned_expert_ids(
+        vllm_config,
+        layer_idx,
+        original_num_experts,
+        config.num_experts_per_tok,
+    )
+
+    if pruned_expert_ids is None:
+        original_init = qm.Qwen3MoeSparseMoeBlock._ascend_original_init
+        return original_init(self, vllm_config, prefix)
+
+    self.original_num_experts = original_num_experts
+    self.layer_idx = layer_idx
+    self.pruned_expert_ids = pruned_expert_ids
+
+    try:
+        config.num_experts = len(pruned_expert_ids)
+        original_init = qm.Qwen3MoeSparseMoeBlock._ascend_original_init
+        return original_init(self, vllm_config, prefix)
+    finally:
+        config.num_experts = original_num_experts
+
+
+def _patched_get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+    if getattr(self, "expert_pruning_map", None) is not None:
+        base_layer = "base_layer." if any(".base_layer." in name for name, _ in self.named_parameters()) else ""
+        remapped_suffixes = ("weight", "weight_scale")
+        return [
+            (
+                f"layers.{layer_idx}.mlp.experts.{base_layer}w13_{suffix}"
+                if weight_name in ["gate_proj", "up_proj"]
+                else f"layers.{layer_idx}.mlp.experts.{base_layer}w2_{suffix}",
+                f"layers.{layer_idx}.mlp.experts.{original_expert_id}.{weight_name}.{base_layer}{suffix}",
+                pruned_expert_id,
+                shard_id,
+            )
+            for layer_idx, expert_ids in sorted(self.expert_pruning_map.items())
+            for pruned_expert_id, original_expert_id in enumerate(expert_ids)
+            for suffix in remapped_suffixes
+            for shard_id, weight_name in [
+                ("w1", "gate_proj"),
+                ("w2", "down_proj"),
+                ("w3", "up_proj"),
+            ]
+        ]
+
+    original_get_expert_mapping = qm.Qwen3MoeModel._ascend_original_get_expert_mapping
+    return original_get_expert_mapping(self)
+
+
+def _patch_qwen3_moe_pruning() -> None:
+    if hasattr(qm, "_load_ordered_expert_map"):
+        return
+    if getattr(qm.Qwen3MoeModel, "_ascend_expert_pruning_patched", False):
+        return
+
+    qm.Qwen3MoeSparseMoeBlock._ascend_original_init = qm.Qwen3MoeSparseMoeBlock.__init__
+    qm.Qwen3MoeSparseMoeBlock.__init__ = _patched_sparse_moe_block_init
+
+    original_model_init = qm.Qwen3MoeModel.__init__
+    original_load_weights = qm.Qwen3MoeModel.load_weights
+    qm.Qwen3MoeModel._ascend_original_get_expert_mapping = qm.Qwen3MoeModel.get_expert_mapping
+
+    @wraps(original_model_init)
+    def patched_model_init(self, *args, **kwargs):
+        original_model_init(self, *args, **kwargs)
+        vllm_config = kwargs.get("vllm_config")
+        if vllm_config is None and args:
+            vllm_config = args[0]
+        self.expert_pruning_map = _get_expert_pruning_map(vllm_config)
+
+    @wraps(original_load_weights)
+    def patched_load_weights(self, weights):
+        def pruned_weights():
+            for name, loaded_weight in weights:
+                if getattr(self, "expert_pruning_map", None) is not None and ".mlp.experts." in name and (
+                    ".weight_offset" in name or "_weight_offset" in name
+                ):
+                    continue
+                yield name, _maybe_prune_gate_weight(name, loaded_weight, getattr(self, "expert_pruning_map", None))
+
+        return original_load_weights(self, pruned_weights())
+
+    qm.Qwen3MoeModel.__init__ = patched_model_init
+    qm.Qwen3MoeModel.get_expert_mapping = _patched_get_expert_mapping
+    qm.Qwen3MoeModel.load_weights = patched_load_weights
+    qm.Qwen3MoeModel._ascend_expert_pruning_patched = True
+
+_patch_qwen3_moe_pruning()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds static expert pruning support for Qwen3 MoE models on vLLM-Ascend.

Users can provide a per-layer ordered expert list and an expert prune ratio through `additional_config`. During model loading, vLLM-Ascend keeps the top-ranked experts for each MoE layer, remaps the selected original expert weights into compact expert slots, and prunes the router gate weight consistently so runtime routing only targets retained experts.

This reduces MoE weight memory and improves serving throughput when a calibrated expert ranking is available.

### User-facing change

Launch Qwen3 MoE with:

```bash
--additional-config '{"expert_list_file":"/path/to/math-541.jsonl","expert_prune_ratio":0.5}'
```

`expert_list_file` uses JSONL format. Each line contains one layer id and a full ordered expert list:

```json
{"0":[106,65,113,84,104,53,127,11]}
{"1":[86,48,18,3,117,9,32,72]}
```

`expert_prune_ratio` is in `[0, 1)`. For example, with 128 global experts and `expert_prune_ratio=0.5`, 64 experts are kept globally. The implementation validates that the retained expert count is not smaller than `num_experts_per_tok`.

No new environment variable is introduced.

### Implementation notes

- Patch Qwen3 MoE model loading only; no new model is added.
- Build a per-layer pruning map from `additional_config`.
- Temporarily adjust `num_experts` while constructing each `Qwen3MoeSparseMoeBlock`, then restore the original config value.
- Remap expert weights from original expert ids to compact pruned expert slots.
- Prune `.mlp.gate.weight` rows to match the retained experts.
- Skip expert weight offset tensors that no longer correspond to the compact pruned layout.

### Test plan

UT:

- JSONL expert list parsing.
- Invalid config validation: missing ratio, non-numeric ratio, out-of-range ratio, duplicate experts, missing layers, insufficient experts, expert id out of bounds.
- Pruned expert count calculation.
- Gate weight row pruning.
- Sparse MoE block initialization with temporary expert count override.
- Expert weight mapping from original expert ids to compact pruned slots.

E2E:

- Launch Qwen3-30B-A3B-W8A8 with TP=2 and expert parallel enabled.
- Generate one prompt with pruning enabled.
- Assert generation finishes and routed expert ids are within the retained expert range.

E2E is needed here because the feature touches real model construction, weight loading, expert remapping, and runtime routed expert ids. UT covers the pure mapping and validation logic, while E2E guards integration with vLLM model loading and Ascend expert parallel execution.

### Accuracy and performance validation

Environment:

- Model: `/root/models/Qwen/Qwen3-30B-A3B-W8A8`
- Dataset: GSM8K full
- Accuracy: `max_out_len=4096`, `batch_size=32`
- Performance: AISBench streaming, `num_prompts=128`, `max_out_len=1024`, `batch_size=32`
- Parallel config: TP=2, DP=4, expert parallel enabled, 8 Ascend NPUs

| Prune ratio | Experts | GSM8K accuracy | TPOT | Request throughput | Output throughput | Total throughput | Weight memory |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 16/128 | 91.05 | 28.5 ms | 1.0854 req/s | 1055.3378 tok/s | 1129.5858 tok/s | 4.45 GiB |
| 0.25 | 12/96 | 90.37 | 27.4 ms | 1.1267 req/s | 1091.5825 tok/s | 1168.6579 tok/s | 3.60 GiB |
| 0.5 | 8/64 | 87.87 | 26.3 ms | 1.1706 req/s | 1162.3653 tok/s | 1242.4414 tok/s | 2.74 GiB |

Observed tradeoff:

- 25% pruning keeps accuracy close to baseline while reducing weight memory.
- 50% pruning gives a stronger memory/performance tradeoff with moderate accuracy loss.

### Next Plan

This PR implements static uniform per-layer pruning based on an externally generated expert ranking. A follow-up can add calibration-aware non-uniform pruning, where sensitive layers keep more experts and less sensitive layers keep fewer experts.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
