### PR TITLE
[Feature][MRV2] Support MTP

### DIFF
--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -100,10 +100,13 @@ class AscendInputBatch(InputBatch):
         # when dummy run for memory profiling,
         # attention metadata isn't needed,
         # we can also set attn_state to AscendAttentionState.DecodeOnly.
-        input_batch.attn_state = AscendAttentionState.DecodeOnly
         # For mla/sfa, update cos/sin. Here is for _dummy_run.
         update_cos_sin(input_batch.positions)
-        return cls(**asdict(input_batch), seq_lens_np=seq_lens_np)
+        return cls(
+            **asdict(input_batch),
+            seq_lens_np=seq_lens_np,
+            attn_state=AscendAttentionState.DecodeOnly,
+        )
 
 
 @triton.jit

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -51,6 +51,7 @@ from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.spec_decode import init_speculator
 from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
+from vllm_ascend.worker.v2.spec_decode.mtp.speculator import AscendMTPSpeculator
 from vllm_ascend.worker.v2.states import AscendRequestState
 from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
 
@@ -80,10 +81,9 @@ class NPUModelRunner(GPUModelRunner):
         del self.input_buffers
         del self.speculator
 
-        # we define AscendEagleSpeculator in vllm_ascend.worker.v2.spec_decode.eagle.speculator
-        # init_speculator will return AscendEagleSpeculator when eagle is used.
-        # so here we just call init_speculator to reinitialize speculator.
-        self.speculator: AscendEagleSpeculator | None = None
+        # Reinitialize the speculator via init_speculator (returns the Ascend
+        # speculator matching speculative_config: Eagle / MTP / DSpark / DFlash).
+        self.speculator: AscendEagleSpeculator | AscendMTPSpeculator | None = None
         if self.speculative_config is not None:
             self.speculator = init_speculator(self.vllm_config, self.device)
 

--- a/vllm_ascend/worker/v2/spec_decode/__init__.py
+++ b/vllm_ascend/worker/v2/spec_decode/__init__.py
@@ -41,6 +41,16 @@ def init_speculator(
         )
 
         return AscendDFlashSpeculator(vllm_config, device)
+    if (
+        speculative_config.method == "mtp"
+        and not speculative_config.use_gemma4_mtp()
+        and not speculative_config.use_step3p5_mtp()
+    ):
+        from vllm_ascend.worker.v2.spec_decode.mtp.speculator import (
+            AscendMTPSpeculator,
+        )
+
+        return AscendMTPSpeculator(vllm_config, device)
     if speculative_config.use_eagle():
         from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
 

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -202,7 +202,11 @@ class DecodeEagleAclGraphManager(DecodeSpeculatorCudaGraphManager):
         else:
             logger.info_once("DecodeEagleAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
 
-        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
+        # ``get_draft_decode_num_reqs_padded`` is MLA-aware on MTP (padded
+        # num_tokens / FIA TND) and returns num_reqs for flat Eagle.
+        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
+            self.speculator.get_draft_decode_num_reqs_padded(desc), self.is_draft_model_prefill
+        )
 
         ret = super().run_fullgraph(desc)
 

--- a/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/speculator.py
@@ -31,6 +31,7 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import AttentionStatePair, BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import AutoRegressiveSpeculator
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -40,11 +41,23 @@ from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
 logger = logging.getLogger(__name__)
 
 
-class AscendEagleSpeculator(EagleSpeculator):
+class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
+    """Shared Ascend spec-decode loop for AscendEagle/AscendMTPSpeculator.
+
+    Subclasses AutoRegressiveSpeculator (the common base of EagleSpeculator and
+    MTPSpeculator) so the Ascend overrides are type-checked against a concrete
+    base. Each override keeps its ``super()`` call; on a combined subclass
+    (e.g. AscendEagleSpeculator) the cooperative MRO routes ``super()`` to the
+    concrete upstream speculator (Eagle/MTP) before reaching
+    AutoRegressiveSpeculator.
+    """
+
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
-        """Override GPU EagleSpeculator.__init__ for Ascend NPUs.
-        attnention metadata building in Ascend backend needs more information,
-        such as seq_lens_cpu from input_batch, so we need to override __init__.
+        """Override the upstream __init__ for Ascend NPUs.
+
+        Ascend attention-metadata building needs more information (e.g.
+        seq_lens_cpu from input_batch), so we replace input_buffers with
+        AscendInputBuffers after super().__init__.
         """
         super().__init__(vllm_config, device)
 
@@ -289,6 +302,15 @@ class AscendEagleSpeculator(EagleSpeculator):
                 metadata.attn_state = AscendAttentionState.DecodeOnly
         return attn_metadata
 
+    def get_draft_decode_num_reqs_padded(self, desc: BatchExecutionDescriptor) -> int:
+        """Padded request count for building draft decode attention metadata.
+
+        Eagle (flat attention) uses ``num_reqs``; MLA-aware subclasses override
+        to use padded ``num_tokens`` (FIA TND) so the decode aclgraph replays
+        with the right batch shape.
+        """
+        return desc.num_reqs
+
     def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
         """Build draft_attn_metadatas for partial-merged draft graph."""
         attn_metadata = self.model_state.attn_metadata
@@ -371,6 +393,13 @@ class AscendEagleSpeculator(EagleSpeculator):
         assert self.input_batch is not None
         seq_lens_cpu = torch.from_numpy(self.input_batch.seq_lens_np)
         return seq_lens_cpu
+
+
+class AscendEagleSpeculator(AscendAutoRegressiveSpeculator, EagleSpeculator):
+    """Ascend Eagle speculator: the NPU loop from AscendAutoRegressiveSpeculator
+    layered on upstream EagleSpeculator (flat/GQA attention)."""
+
+    pass
 
 
 # TODO Remove this patch when cann fix the gather bug.

--- a/vllm_ascend/worker/v2/spec_decode/mtp/__init__.py
+++ b/vllm_ascend/worker/v2/spec_decode/mtp/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#

--- a/vllm_ascend/worker/v2/spec_decode/mtp/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/mtp/speculator.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+# AscendMTPSpeculator is a sibling of AscendEagleSpeculator: both mix in
+# AscendSpecDecodeMixin for the shared flat NPU draft loop and layer it on their
+# own upstream base (MTPSpeculator vs EagleSpeculator). MTP's draft uses MLA
+# attention, so it overrides only the MLA-specific pieces; the flat loop is
+# inherited unchanged. Nothing MLA-specific lives in the mixin or Eagle.
+from contextlib import contextmanager
+from copy import copy
+from typing import Any
+
+import torch
+import vllm.v1.worker.gpu.spec_decode.speculator as _upstream_speculator
+from vllm.config import VllmConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
+
+from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendAutoRegressiveSpeculator
+
+
+@contextmanager
+def build_wrapper(positions, pad):
+    """Temporarily wrap build_attn_metadata to forward MLA rotary positions.
+
+    The flat draft-metadata path (upstream ``_build_draft_attn_metadata``) calls
+    ``build_attn_metadata`` without ``positions``, but MLA reads positions
+    *inside* ``build_decode_metadata`` for rotary cos/sin. This caches the
+    original ``build_attn_metadata``, replaces it for the duration of the block
+    with one that forwards ``positions[:pad]``, and restores it on exit -- so
+    MTP can reuse the flat ``super()._build_draft_attn_metadata()`` path instead
+    of duplicating the ``build_attn_metadata`` call and all its arguments.
+
+    Must run inside ``build_attn_metadata_wrapper()``, which has already
+    replaced the module-level ``build_attn_metadata`` with the Ascend builder.
+    """
+    raw = _upstream_speculator.build_attn_metadata  # cache
+
+    def build_attn_metadata(*args, **kwargs):
+        kwargs["positions"] = positions[:pad]
+        return raw(*args, **kwargs)
+
+    try:
+        _upstream_speculator.build_attn_metadata = build_attn_metadata
+        yield
+    finally:
+        _upstream_speculator.build_attn_metadata = raw  # restore
+
+
+class AscendMTPSpeculator(AscendAutoRegressiveSpeculator, MTPSpeculator):
+    """Ascend MTP speculator (MLA draft).
+
+    Sibling of AscendEagleSpeculator: inherits the shared flat NPU draft loop
+    from AscendSpecDecodeMixin (layered on upstream MTPSpeculator) and overrides
+    only the MLA-specific pieces. MLA differs from flat in three ways: rotary
+    ``positions`` must reach ``build_attn_metadata``, the decode aclgraph pads
+    by ``num_tokens`` (FIA TND) instead of ``num_reqs``, and MLA metadata
+    carries a ``.decode`` sub-object needing per-step upkeep. Flat (non-MLA)
+    MTP models fall back to the inherited flat loop via the
+    ``if not self.draft_uses_mla`` guards. ``draft_uses_mla`` is read from
+    ``model_config.is_deepseek_mla`` in ``__init__`` (config-level, available
+    upfront -- same check as v1's llm_base_proposer); the MLA block-table
+    buffer is pre-allocated in ``set_attn``. No lazy init, no getattr.
+    """
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        super().__init__(vllm_config, device)
+        self.draft_uses_mla = self.vllm_config.model_config.is_deepseek_mla
+
+    def set_attn(
+        self,
+        model_state: ModelState,
+        kv_cache_config: KVCacheConfig,
+        block_tables: BlockTables,
+    ) -> None:
+        """Ascend setup: build attn_backends (via super), then pre-allocate the
+        stable MLA block-table buffer (max-sized, so the captured decode graph
+        can reference it by identity). ``draft_uses_mla`` is set in __init__."""
+        super().set_attn(model_state, kv_cache_config, block_tables)
+        if self.draft_uses_mla:
+            # MLA draft has a single KV cache group; allocate a stable zero
+            # buffer matching its block table for the captured decode graph.
+            block_table = block_tables.input_block_tables[0]
+            self._draft_block_table_buf = torch.zeros_like(block_table)
+
+    def _build_draft_attn_metadata(
+        self,
+        num_reqs: int,
+        num_reqs_padded: int,
+        num_tokens_padded: int,
+        num_query_per_req: int = 1,
+        causal: bool = True,
+    ) -> dict[str, Any] | None:
+        # Flat MTP reuses the flat super() build (positions are not needed).
+        if not self.draft_uses_mla:
+            return super()._build_draft_attn_metadata(
+                num_reqs, num_reqs_padded, num_tokens_padded, num_query_per_req, causal
+            )
+        # MLA: rotary positions must reach build_attn_metadata, but the flat
+        # super() path does not forward them. Wrap build_attn_metadata to inject
+        # positions[:num_tokens_padded] and reuse super() (no arg duplication).
+        with build_wrapper(self.input_buffers.positions, num_tokens_padded):
+            return super()._build_draft_attn_metadata(
+                num_reqs, num_reqs_padded, num_tokens_padded, num_query_per_req, causal
+            )
+
+    def get_draft_decode_num_reqs_padded(self, desc: BatchExecutionDescriptor) -> int:
+        # MLA decode aclgraph pads by num_tokens (FIA TND); flat pads by num_reqs.
+        return desc.num_tokens if self.draft_uses_mla else desc.num_reqs
+
+    def _init_decode_draft_attn_metadatas(self, attn_metadata, num_reqs_padded):
+        # MLA: if the live base is a stale prefill residual (.decode=None),
+        # rebuild it fresh BEFORE super() copies it per step.
+        if self.draft_uses_mla:
+            attn_metadata = self._get_decode_base_metadata(attn_metadata, num_reqs_padded)
+        # MLA: snapshot each step's .decode block_table into the stable buffer
+        # after super builds per-step copies. Flat uses the base as-is.
+        draft_attn_metadatas = super()._init_decode_draft_attn_metadatas(attn_metadata, num_reqs_padded)
+        if self.draft_uses_mla:
+            for per_step_attn_metadata in draft_attn_metadatas:
+                for metadata in per_step_attn_metadata.values():
+                    self._prepare_step_decode_fields(metadata, num_reqs_padded)
+        return draft_attn_metadatas
+
+    def _update_decode_attn_metadata(self, attn_metadata, step, num_reqs=None):
+        # Flat: super updates the base fields. MLA: also mirror them onto .decode.
+        super()._update_decode_attn_metadata(attn_metadata, step, num_reqs)
+        if self.draft_uses_mla:
+            for metadata in attn_metadata.values():
+                self._write_decode_step_fields(metadata, metadata.actual_seq_lengths_q, metadata.seq_lens_list)
+
+    def _get_decode_base_metadata(self, attn_metadata, num_reqs_padded):
+        # Rebuild fresh if live metadata is a stale prefill residual (.decode=None).
+        need_fresh = any(m.decode is None for m in attn_metadata.values())
+        if need_fresh:
+            assert self.input_batch is not None
+            return self._build_draft_attn_metadata(
+                num_reqs=self.input_batch.num_reqs,
+                num_reqs_padded=num_reqs_padded,
+                num_tokens_padded=num_reqs_padded,
+            )
+        return attn_metadata
+
+    def _prepare_step_decode_fields(self, metadata, num_reqs_padded):
+        # Snapshot the MLA .decode block_table into the stable pre-allocated
+        # buffer (the captured decode graph references it by identity; async
+        # add_requests mutates input_block_tables in place between steps).
+        if metadata.num_decodes > 0:
+            metadata.decode = copy(metadata.decode)
+            block_table = self.block_tables.input_block_tables[0]
+            buf = self._draft_block_table_buf
+            buf[:num_reqs_padded].copy_(block_table[:num_reqs_padded])
+            metadata.decode.block_table = buf[:num_reqs_padded]
+
+    def _write_decode_step_fields(self, metadata, query_lens_list, seq_lens_list):
+        # Mirror per-step seq-len fields onto the MLA .decode sub-metadata.
+        if metadata.num_decodes > 0:
+            metadata.decode.actual_seq_lengths_q = query_lens_list
+            metadata.decode.seq_lens_list = seq_lens_list


### PR DESCRIPTION
### What this PR does / why we need it?
Added support for MTP in MRV2, including both eager and FullGraph execution modes.
This pull request introduces support for DeepSeek-style MTP speculative decoding in MRV2. It adds MTP-specific speculator and aclgraph managers (`AscendMTPSpeculator`, `PrefillMTPAclGraphManager`, and `DecodeMTPAclGraphManager`) to handle MLA-aware draft models, ensuring correct attention metadata and padded token handling.

TODO：
vLLM uses AutoRegressiveSpeculator as the base class for Eagle and MTP. vLLM-Ascend needs to consider this design and implement the corresponding refactoring. 

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
```shell
set -x
export HCCL_OP_EXPANSION_MODE="AIV"
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export PYTHONPATH=/home/j00893003/mr2/vllm:/home/j00893003/mr2/vllm-ascend:$PYTHONPATH
export VLLM_ASCEND_BALANCE_SCHEDULING=1
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10

export VLLM_TORCH_PROFILER_WITH_STACK=0
export HCCL_BUFFSIZE=500
export VLLM_ASCEND_ENABLE_MLAPO=1
export TASK_QUEUE_ENABLE=1
export VLLM_ENGINE_READY_TIMEOUT_S=6000
export VLLM_USE_V2_MODEL_RUNNER=1

exec vllm serve /mnt/a800_weight/DeepSeek-V3.1-w4a8-perchannle \
    --host 90.90.97.29 \
    --port 8000 \
    --data-parallel-size 2 \
    --tensor-parallel-size 8 \
    --quantization ascend \
    --seed 1024 \
    --served-model-name deepseek_v3 \
    --enable-expert-parallel \
    --max-num-seqs 96 \
    --max-model-len 32768 \
    --max-num-batched-tokens 6000 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --gpu-memory-utilization 0.9 \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
    --enforce-eager
~  
```

```text
------------------------------------------------------------
ModelRunnerV2 + Full Graph         
------------------------------------------------------------
num_drafts=7340.0
num_accepted_tokens_per_pos=[6804.0, 5263.0, 3046.0]
acceptance_per_pos=[0.9269754768392371, 0.7170299727520436, 0.4149863760217984]
acceptance_len=3.058991825613079

------------------------------------------------------------
ModelRunnerV2 + eager
------------------------------------------------------------ 
num_drafts=7023.0
num_accepted_tokens_per_pos=[6474.0, 5028.0, 2807.0]
acceptance_per_pos=[0.9218282785134558, 0.7159333618111918, 0.39968674355688455]
acceptance_len=3.0374483838815323

------------------------------------------------------------
ModelRunnerV1 + Full Graph  
------------------------------------------------------------
num_drafts=7250.0
num_accepted_tokens_per_pos=[6723.0, 5184.0, 2810.0]
acceptance_per_pos=[0.9273103448275862, 0.7150344827586207, 0.3875862068965517]
acceptance_len=3.029931034482759

------------------------------------------------------------
ModelRunnerV1 + eager
------------------------------------------------------------
num_drafts=7162.0
num_accepted_tokens_per_pos=[6641.0, 5145.0, 2975.0]
acceptance_per_pos=[0.9272549567160011, 0.718374755654845, 0.41538676347389]
acceptance_len=3.061016475844736
```


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
