### PR TITLE
[BugFix] Fix GLM-5.2 DSpark acceptance rate problem

### DIFF
--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
+
+import vllm_ascend.models as ascend_models
+import vllm_ascend.models.qwen3_dspark as qwen3_dspark
+from vllm_ascend.models.qwen3_dspark import (
+    AscendQwen3DSparkForCausalLM,
+    process_weight,
+)
+
+
+def test_qwen3_dspark_model_is_registered(monkeypatch):
+    register_model = MagicMock()
+    monkeypatch.setattr(
+        ascend_models.ModelRegistry,
+        "register_model",
+        register_model,
+    )
+
+    ascend_models.register_model()
+
+    register_model.assert_any_call(
+        "Qwen3DSparkModel",
+        "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM",
+    )
+
+
+def test_process_weight_rotates_each_hidden_size_block():
+    linear_weight = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+        ],
+        dtype=torch.bfloat16,
+    )
+    rotation_weight = torch.tensor(
+        [
+            [0.0, 1.0],
+            [1.0, 0.0],
+        ],
+        dtype=torch.bfloat16,
+    )
+
+    actual = process_weight(linear_weight, rotation_weight)
+
+    expected = torch.tensor(
+        [
+            [2.0, 1.0, 4.0, 3.0],
+            [6.0, 5.0, 8.0, 7.0],
+        ],
+        dtype=torch.bfloat16,
+    )
+    assert actual.dtype == linear_weight.dtype
+    torch.testing.assert_close(actual, expected)
+
+
+def test_process_weight_rejects_non_divisible_input_width():
+    with pytest.raises(AssertionError, match="multiple of rotation weight"):
+        process_weight(
+            torch.ones((2, 3), dtype=torch.float32),
+            torch.eye(2, dtype=torch.float32),
+        )
+
+
+@pytest.mark.parametrize(
+    ("quant_config", "expected_rotation_path"),
+    [
+        (object(), Path("/tmp/quarot.safetensors")),
+        (None, None),
+    ],
+)
+def test_qwen3_dspark_initializes_rotation_path_only_for_quantized_target(
+    monkeypatch,
+    quant_config,
+    expected_rotation_path,
+):
+    def fake_base_init(self, **kwargs):
+        torch.nn.Module.__init__(self)
+
+    get_rotation_path = MagicMock(return_value=expected_rotation_path)
+    monkeypatch.setattr(
+        Qwen3DSparkForCausalLM,
+        "__init__",
+        fake_base_init,
+    )
+    monkeypatch.setattr(
+        qwen3_dspark,
+        "get_rotation_path",
+        get_rotation_path,
+    )
+    vllm_config = SimpleNamespace(quant_config=quant_config)
+
+    model = AscendQwen3DSparkForCausalLM(vllm_config=vllm_config)
+
+    assert model.rotation_path == expected_rotation_path
+    if quant_config is None:
+        get_rotation_path.assert_not_called()
+    else:
+        get_rotation_path.assert_called_once_with(vllm_config)
+
+
+def test_qwen3_dspark_load_weights_rotates_only_fc(monkeypatch):
+    captured_weights = []
+
+    def fake_load_weights(self, weights):
+        captured_weights.extend(list(weights))
+
+    monkeypatch.setattr(
+        Qwen3DSparkForCausalLM,
+        "load_weights",
+        fake_load_weights,
+    )
+    monkeypatch.setattr(
+        qwen3_dspark,
+        "get_rotataion_matrix",
+        lambda _: torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 0.0],
+            ],
+            dtype=torch.float32,
+        ),
+    )
+    model = AscendQwen3DSparkForCausalLM.__new__(AscendQwen3DSparkForCausalLM)
+    torch.nn.Module.__init__(model)
+    model.rotation_path = Path("/tmp/quarot.safetensors")
+    fc_weight = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    embed_weight = torch.tensor([[5.0, 6.0, 7.0, 8.0]])
+
+    model.load_weights(
+        [
+            ("model.fc.weight", fc_weight),
+            ("model.embed_tokens.weight", embed_weight),
+        ]
+    )
+
+    assert [name for name, _ in captured_weights] == [
+        "model.fc.weight",
+        "model.embed_tokens.weight",
+    ]
+    torch.testing.assert_close(
+        captured_weights[0][1],
+        torch.tensor([[2.0, 1.0, 4.0, 3.0]]),
+    )
+    torch.testing.assert_close(captured_weights[1][1], embed_weight)
+
+
+def test_qwen3_dspark_load_weights_without_rotation_is_passthrough(
+    monkeypatch,
+):
+    captured_weights = []
+
+    def fake_load_weights(self, weights):
+        captured_weights.extend(list(weights))
+
+    monkeypatch.setattr(
+        Qwen3DSparkForCausalLM,
+        "load_weights",
+        fake_load_weights,
+    )
+    model = AscendQwen3DSparkForCausalLM.__new__(AscendQwen3DSparkForCausalLM)
+    torch.nn.Module.__init__(model)
+    model.rotation_path = None
+    weights = [("model.fc.weight", torch.tensor([[1.0, 2.0]]))]
+
+    model.load_weights(iter(weights))
+
+    assert captured_weights == weights

--- a/tests/ut/spec_decode/test_glm52_dspark_eager.py
+++ b/tests/ut/spec_decode/test_glm52_dspark_eager.py
@@ -1,0 +1,310 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import vllm_ascend.spec_decode.dspark_proposer as dspark_module
+import vllm_ascend.spec_decode.llm_base_proposer as base_module
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+from vllm_ascend.spec_decode.llm_base_proposer import (
+    AscendSpecDecodeBaseProposer,
+)
+
+
+def _make_config(*, bonus_anchor=None, draft_sample_method="greedy"):
+    hf_config = SimpleNamespace()
+    if bonus_anchor is not None:
+        hf_config.dspark_bonus_anchor = bonus_anchor
+    draft_model_config = SimpleNamespace(
+        hf_config=hf_config,
+        get_hidden_size=lambda: 3,
+    )
+    speculative_config = SimpleNamespace(
+        draft_model_config=draft_model_config,
+        draft_sample_method=draft_sample_method,
+    )
+    return SimpleNamespace(speculative_config=speculative_config)
+
+
+def _fake_dflash_init(self, vllm_config, device, runner=None):
+    self.vllm_config = vllm_config
+    self.speculative_config = vllm_config.speculative_config
+    self.draft_model_config = self.speculative_config.draft_model_config
+    self.num_speculative_tokens = 7
+    self.max_batch_size = 4
+    self.max_num_tokens = 64
+    self.dtype = torch.float32
+    self.device = device
+    self.hidden_size = 2
+    self.hidden_states = torch.zeros((64, 2), device=device)
+    self._dflash_hidden_states = torch.zeros((64, 2), device=device)
+
+
+@pytest.mark.parametrize(
+    ("bonus_anchor", "sample_from_anchor", "num_query_per_req"),
+    [
+        (None, True, 7),
+        (False, True, 7),
+        (True, False, 8),
+    ],
+)
+def test_dspark_initializes_anchor_contract_and_forces_eager(
+    monkeypatch,
+    bonus_anchor,
+    sample_from_anchor,
+    num_query_per_req,
+):
+    monkeypatch.setattr(
+        AscendDflashProposer,
+        "__init__",
+        _fake_dflash_init,
+    )
+
+    proposer = AscendDSparkProposer(
+        _make_config(bonus_anchor=bonus_anchor),
+        torch.device("cpu"),
+    )
+
+    assert proposer.sample_from_anchor is sample_from_anchor
+    assert proposer.num_query_per_req == num_query_per_req
+    assert proposer.max_query_tokens == 4 * num_query_per_req
+    assert proposer.positions.shape == (4 * num_query_per_req,)
+    assert proposer._slot_mapping_buffer.shape == (4 * num_query_per_req,)
+    assert proposer.use_cuda_graph is False
+
+
+def test_dspark_rejects_probabilistic_draft_sampling(monkeypatch):
+    monkeypatch.setattr(
+        AscendDflashProposer,
+        "__init__",
+        _fake_dflash_init,
+    )
+
+    with pytest.raises(ValueError, match="probabilistic"):
+        AscendDSparkProposer(
+            _make_config(draft_sample_method="probabilistic"),
+            torch.device("cpu"),
+        )
+
+
+class _KernelRecorder:
+    def __init__(self):
+        self.grid = None
+        self.kwargs = None
+
+    def __getitem__(self, grid):
+        self.grid = grid
+        return self
+
+    def __call__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_input_proposer(*, sample_from_anchor, num_query_per_req):
+    kv_cache_spec = SimpleNamespace(block_size=128)
+    attn_group = SimpleNamespace(
+        kv_cache_group_id=0,
+        kv_cache_spec=kv_cache_spec,
+    )
+    return SimpleNamespace(
+        num_speculative_tokens=7,
+        sample_from_anchor=sample_from_anchor,
+        num_query_per_req=num_query_per_req,
+        max_query_tokens=2 * num_query_per_req,
+        device=torch.device("cpu"),
+        parallel_drafting_token_id=999,
+        kv_cache_gid=0,
+        draft_attn_groups=[attn_group],
+        _per_group_block_tables={0: torch.tensor([[0, 1], [2, 3]], dtype=torch.int32)},
+        _per_group_slot_mappings={0: torch.tensor([10, 11, 12, 13], dtype=torch.int32)},
+        _per_group_query_slot_mapping_buffers={0: torch.zeros(2 * num_query_per_req, dtype=torch.int32)},
+        _per_group_context_slot_mapping_buffers={0: torch.zeros(32, dtype=torch.int32)},
+        _layer_group_idx=[0],
+        _dspark_seed_buffer=torch.zeros(4, dtype=torch.int64),
+        _dflash_hidden_states=torch.zeros((32, 3), dtype=torch.float32),
+        _context_positions_buffer=torch.zeros(32, dtype=torch.int32),
+        input_ids=torch.zeros(2 * num_query_per_req, dtype=torch.int64),
+        positions=torch.zeros(2 * num_query_per_req, dtype=torch.int32),
+        arange_dflash=torch.arange(3, dtype=torch.int32),
+        token_arange_np=np.arange(3, dtype=np.int32),
+    )
+
+
+@pytest.mark.parametrize(
+    ("sample_from_anchor", "num_query_per_req"),
+    [
+        (True, 7),
+        (False, 8),
+    ],
+)
+def test_dspark_first_pass_uses_anchor_width_and_updates_metadata(
+    monkeypatch,
+    sample_from_anchor,
+    num_query_per_req,
+):
+    kernel = _KernelRecorder()
+    monkeypatch.setattr(
+        dspark_module,
+        "copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+        kernel,
+    )
+    proposer = _make_input_proposer(
+        sample_from_anchor=sample_from_anchor,
+        num_query_per_req=num_query_per_req,
+    )
+    cad = SimpleNamespace(
+        num_reqs=2,
+        query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+        max_seq_len=20,
+        actual_seq_lengths_q=[],
+        decode_token_per_req=0,
+    )
+    target_hidden_states = torch.arange(12, dtype=torch.float32).reshape(
+        4,
+        3,
+    )
+    num_rejected_tokens = torch.tensor([1, 2], dtype=torch.int32)
+
+    num_query_total, token_indices, updated_cad, long_seq = AscendDSparkProposer.set_inputs_first_pass(
+        proposer,
+        target_token_ids=torch.zeros(2, dtype=torch.int64),
+        next_token_ids=torch.tensor([101, 102], dtype=torch.int64),
+        target_positions=torch.tensor([9, 19], dtype=torch.int32),
+        target_hidden_states=target_hidden_states,
+        token_indices_to_sample=None,
+        cad=cad,
+        num_rejected_tokens_gpu=num_rejected_tokens,
+    )
+
+    assert kernel.grid == (1,)
+    assert kernel.kwargs["num_query_per_req"] == num_query_per_req
+    assert kernel.kwargs["num_speculative_tokens"] == 7
+    assert kernel.kwargs["SAMPLE_FROM_ANCHOR"] is sample_from_anchor
+    assert num_query_total == 2 * num_query_per_req
+    assert token_indices.shape == (14,)
+    assert long_seq is None
+    torch.testing.assert_close(
+        proposer._dspark_seed_buffer,
+        torch.tensor([101, 102, 0, 0], dtype=torch.int64),
+    )
+    torch.testing.assert_close(
+        proposer._dflash_hidden_states[:4],
+        target_hidden_states,
+    )
+    torch.testing.assert_close(
+        updated_cad.query_start_loc,
+        torch.tensor(
+            [0, num_query_per_req, 2 * num_query_per_req],
+            dtype=torch.int32,
+        ),
+    )
+    torch.testing.assert_close(
+        updated_cad.seq_lens,
+        torch.tensor(
+            [
+                10 - 1 + num_query_per_req,
+                20 - 2 + num_query_per_req,
+            ],
+            dtype=torch.int32,
+        ),
+    )
+    assert updated_cad.actual_seq_lengths_q == [num_query_per_req] * 2
+    assert updated_cad.decode_token_per_req == num_query_per_req
+    assert updated_cad.num_actual_tokens == 2 * num_query_per_req
+    assert updated_cad.num_input_tokens == 2 * num_query_per_req
+    assert updated_cad.max_query_len == num_query_per_req
+    assert updated_cad.max_seq_len == 20 + num_query_per_req
+    assert updated_cad.slot_mapping.shape == (2 * num_query_per_req,)
+    assert updated_cad.positions.shape == (2 * num_query_per_req,)
+    assert updated_cad.causal is False
+    assert updated_cad.attn_mask is None
+    assert updated_cad.attn_state == AscendAttentionState.ChunkedPrefill
+
+
+class _MarkovModel:
+    def __init__(self, hidden_states):
+        self.hidden_states = hidden_states
+        self.compute_logits_input = None
+
+    def __call__(self, **kwargs):
+        return self.hidden_states
+
+    def compute_logits(self, hidden_states):
+        self.compute_logits_input = hidden_states.clone()
+        return torch.zeros((hidden_states.shape[0], 2), dtype=torch.float32)
+
+    def markov_embed(self, token_ids):
+        return torch.zeros((token_ids.shape[0], 2), dtype=torch.float32)
+
+    def markov_bias(self, hidden_states):
+        return torch.zeros((hidden_states.shape[0], 2), dtype=torch.float32)
+
+
+def test_dspark_markov_logits_use_sampled_hidden_states(monkeypatch):
+    monkeypatch.setattr(base_module, "lmhead_tp_enable", lambda: False)
+    monkeypatch.setattr(
+        base_module,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_reduce_sample=False),
+    )
+    hidden_states = torch.tensor(
+        [
+            [1.0, 10.0],
+            [2.0, 20.0],
+            [3.0, 30.0],
+            [4.0, 40.0],
+        ]
+    )
+    model = _MarkovModel(hidden_states)
+    proposer = SimpleNamespace(
+        input_ids=torch.zeros(4, dtype=torch.int64),
+        _get_positions=lambda num_tokens: torch.arange(
+            num_tokens,
+            dtype=torch.int32,
+        ),
+        method="dspark",
+        _context_slot_mapping_buffers=[],
+        build_model_inputs_first_pass=lambda *args: None,
+        pass_hidden_states_to_model=False,
+        model=model,
+        model_returns_tuple=lambda: False,
+        _share_mtp_indices=False,
+        maybe_all_gather_and_unpad=lambda last, positions, hidden: (
+            last,
+            positions,
+            hidden,
+        ),
+        runner=SimpleNamespace(pcp_manager=None),
+        pcp_size=1,
+        num_speculative_tokens=1,
+        parallel_drafting=True,
+        _dspark_draft_buffer=torch.zeros((2, 2), dtype=torch.int64),
+        _dspark_seed_buffer=torch.tensor([7, 8], dtype=torch.int64),
+        device=torch.device("cpu"),
+    )
+    token_indices = torch.tensor([1, 3], dtype=torch.int64)
+
+    output = AscendSpecDecodeBaseProposer._run_merged_draft(
+        proposer,
+        num_input_tokens=4,
+        batch_size=2,
+        token_indices_to_sample=token_indices,
+        target_positions=torch.arange(4, dtype=torch.int32),
+        inputs_embeds=None,
+        multi_steps_attn_metadata=[],
+        num_tokens=4,
+    )
+
+    torch.testing.assert_close(
+        model.compute_logits_input,
+        hidden_states[token_indices],
+    )
+    torch.testing.assert_close(
+        output,
+        torch.zeros((2, 1), dtype=torch.int64),
+    )

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -3,7 +3,6 @@ from vllm import ModelRegistry
 
 def register_model():
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
-
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
     ModelRegistry.register_model(
         "DSparkDraftModel",
@@ -12,3 +11,4 @@ def register_model():
     ModelRegistry.register_model(
         "LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM"
     )
+    ModelRegistry.register_model("Qwen3DSparkModel", "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM")

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -1,0 +1,43 @@
+from collections.abc import Iterable
+
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
+
+from vllm_ascend.patch.worker.patch_draft_quarot import get_rotataion_matrix, get_rotation_path
+
+
+def process_weight(linear_weight: torch.Tensor, rotation_weight: torch.Tensor):
+    assert linear_weight.shape[1] % rotation_weight.shape[0] == 0, (
+        f"Linear weight shape[1] must be a multiple of rotation weight shape[0],"
+        f" but get {linear_weight.shape[1]=} and {rotation_weight.shape[0]=}"
+    )
+    if rotation_weight.dtype != torch.float32:
+        rotation_weight = rotation_weight.to(torch.float32)
+    hidden_size = rotation_weight.shape[0]
+    ori_dtype = linear_weight.dtype
+    processed_weight = torch.empty(linear_weight.shape, dtype=torch.float32)
+    for start_pos in range(0, linear_weight.shape[1], hidden_size):
+        linear_weight_chunked = linear_weight[:, start_pos : start_pos + hidden_size].to(torch.float32)
+        processed_weight[:, start_pos : start_pos + hidden_size].copy_(
+            torch.matmul(linear_weight_chunked, rotation_weight)
+        )
+    return processed_weight.to(ori_dtype)
+
+
+class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        if self.rotation_path is not None:
+            processed_weights: list[tuple[str, torch.Tensor]] = []
+            rotation_weight = get_rotataion_matrix(self.rotation_path)
+            for name, loaded_weight in weights:
+                if "fc." in name:
+                    loaded_weight = process_weight(loaded_weight, rotation_weight)
+                processed_weights.append((name, loaded_weight))
+            super().load_weights(processed_weights)
+        else:
+            super().load_weights(weights)

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -37,6 +37,12 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "DSpark probabilistic draft sampling is not supported on the v1 "
                 "model runner; use greedy (the default) instead."
             )
+        self.sample_from_anchor = not getattr(self.draft_model_config.hf_config, "dspark_bonus_anchor", False)
+        if self.sample_from_anchor:
+            self.num_query_per_req = self.num_speculative_tokens
+        else:
+            self.num_query_per_req = 1 + self.num_speculative_tokens
+
         blk = 1 + self.num_speculative_tokens
         self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
         self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
@@ -55,10 +61,8 @@ class AscendDSparkProposer(AscendDflashProposer):
         )
         # DSpark runs eager only (Ascend cudagraph unsupported on this path).
         self.use_cuda_graph = False
-        # Max query tokens = max_batch_size * num_speculative_tokens
-        # (anchor-first: N query tokens per request, no bonus token, unlike
-        # DFlash's 1+N). Overrides dflash:28; v2 derives via num_query_per_req.
-        self.max_query_tokens = self.max_batch_size * self.num_speculative_tokens
+        # Max query tokens depend on whether sampling from anchor or not.
+        self.max_query_tokens = self.max_batch_size * self.num_query_per_req
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -205,8 +209,8 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._dspark_seed_buffer[:n].copy_(next_token_ids)
         self._dspark_seed_buffer[n:].fill_(0)
         batch_size = cad.num_reqs
-        block_size = self.num_speculative_tokens
-        num_query_total = batch_size * block_size
+        num_query_total = batch_size * self.num_query_per_req
+        num_sample_total = batch_size * self.num_speculative_tokens
         has_num_rejected = num_rejected_tokens_gpu is not None
         primary_gid = getattr(self, "kv_cache_gid", 0)
         self._per_group_block_table_buffers = {
@@ -217,16 +221,15 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
 
-        # below (SAMPLE_FROM_ANCHOR=True, anchor included) -- not arange here.
         token_indices_to_sample = torch.empty(
-            num_query_total,
+            num_sample_total,
             dtype=torch.int32,
             device=self.device,
         )
 
         # Query block: reuse the DFlash inputs kernel logic (host-side ref)
         # per kv-cache-group to fill positions / input_ids / query slot_mapping
-        # / token_indices (SAMPLE_FROM_ANCHOR: anchor at q_idx=0 is sampled too).
+        # / token_indices.
         draft_attn_groups = getattr(self, "draft_attn_groups", [])
         for attn_group in draft_attn_groups:
             gid = attn_group.kv_cache_group_id
@@ -256,12 +259,12 @@ class AscendDSparkProposer(AscendDflashProposer):
                 # Scalars
                 parallel_drafting_token_id=self.parallel_drafting_token_id,
                 block_size=kv_block_size,
-                num_query_per_req=block_size,
-                num_speculative_tokens=block_size,
+                num_query_per_req=self.num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
                 total_input_tokens=self._dflash_num_context,
                 batch_size=batch_size,
                 HAS_NUM_REJECTED=has_num_rejected,
-                SAMPLE_FROM_ANCHOR=True,
+                SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
@@ -272,21 +275,21 @@ class AscendDSparkProposer(AscendDflashProposer):
         if has_num_rejected:
             effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
 
-        cad.query_start_loc = self.arange_dflash[: batch_size + 1] * block_size
-        cad.seq_lens = effective_seq_lens + block_size
-        cad.query_start_loc_cpu = (torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * block_size).to(
-            torch.int32
-        )
+        cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
+        cad.seq_lens = effective_seq_lens + self.num_query_per_req
+        cad.query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * self.num_query_per_req
+        ).to(torch.int32)
 
         if hasattr(cad, "actual_seq_lengths_q"):
-            cad.actual_seq_lengths_q = [block_size] * batch_size
+            cad.actual_seq_lengths_q = [self.num_query_per_req] * batch_size
         if hasattr(cad, "decode_token_per_req"):
-            cad.decode_token_per_req = block_size
+            cad.decode_token_per_req = self.num_query_per_req
 
         cad.num_actual_tokens = num_query_total
         cad.num_input_tokens = num_query_total
-        cad.max_query_len = block_size
-        cad.max_seq_len = cad.max_seq_len + block_size
+        cad.max_query_len = self.num_query_per_req
+        cad.max_seq_len = cad.max_seq_len + self.num_query_per_req
         cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
         cad.positions = self.positions[:num_query_total]
         cad.causal = False
@@ -307,11 +310,7 @@ class AscendDSparkProposer(AscendDflashProposer):
         is_profile=False,
         **kwargs,
     ) -> None:
-        # Run dummy_run at full load: the query length of each request is self.num_speculative_tokens
-        # Unlike DFlash, where the query length is self.num_speculative_tokens + 1.
-        # Ensure that the maximum batch token is within the limit of self.max_query_tokens.
-        num_query_per_req = self.num_speculative_tokens
-        num_query_total = num_reqs * num_query_per_req
+        num_query_total = num_reqs * self.num_query_per_req
         num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
 
         (

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1175,7 +1175,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
                 # The MarkovHead performs bias correction on logits.
                 # The ConfidenceHead predicts the expected acceptance length of tokens(Not yet achieved).
-                raw_logits = self.model.compute_logits(last_hidden_states)
+                raw_logits = self.model.compute_logits(sample_hidden_states)
                 logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
                 num_blk = logits.shape[0]
                 draft_token_ids = self._dspark_draft_buffer[:num_blk]


### PR DESCRIPTION
### What this PR does / why we need it?
GLM-5.2 DSpark acceptance rates are extremely low, due to the following reasons:
- GLM-5.2 should not sample from anchor token, since `dspark_bonus_anchor=True`, which is different from DeepSeek-V4 DSpark
- When target model uses rotary quantization, the first linear weight (`fc.weight` in this case) need to be processed with global rotation matrix.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GLM-5.2 W4A8 + DSpark BF16 acceptance rates are as follows
```
num_drafts=16397.0
num_accepted_tokens_per_pos=[14302.0, 11935.0, 9840.0, 7981.0, 6458.0, 5168.0, 3929.0]
acceptance_per_pos=[0.8722327254985668, 0.7278770506800024, 0.6001097761785692, 0.4867353784228822, 0.393852534000122, 0.31517960602549244, 0.23961700311032505]
acceptance_len=4.63560407391596
```
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
