### PR TITLE
[BugFix][Core][Scheduler][P/D] Recompute Scheduler main2main to v0.25.1

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -266,7 +266,6 @@ nav:
         - user_guide/feature_guide/batch_invariance.md
         - user_guide/feature_guide/lmcache_ascend_deployment.md
         - user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
-        - user_guide/feature_guide/short_request_first.md
         - user_guide/feature_guide/flash_attention.md
         - user_guide/feature_guide/batch_job_aware_scheduler.md
     - Deployment Guide:

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,23 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import MethodType
+from collections import defaultdict
+from types import MethodType, SimpleNamespace
 
 from vllm.sampling_params import SamplingParams
+from vllm.v1.engine import EngineCoreOutput, FinishReason
 from vllm.v1.request import Request
-from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 
-from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
+from vllm_ascend.core.recompute_scheduler import (
+    RecomputeReqInfo,
+    RecomputeScheduler,
+)
 
 
-def test_pd_consumer_first_step_injects_placeholder_spec_tokens():
+def test_add_request_does_not_inject_placeholder_spec_tokens():
     scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
     scheduler.requests = {}
-    scheduler.is_kv_producer = False
-    scheduler.is_hybrid_model = False
-    scheduler.is_mtp_kv_consumer = True
-    scheduler.num_spec_tokens = 1
-    scheduler.max_model_len = 1024
     scheduler.log_stats = False
     scheduler.connector = None
 
@@ -39,5 +38,32 @@ def test_pd_consumer_first_step_injects_placeholder_spec_tokens():
 
     assert enqueued_requests == [request]
     assert scheduler.requests[request.request_id] is request
-    assert request.spec_token_ids == [PLACEHOLDER_TOKEN_ID]
-    assert request.num_tokens_with_spec == request.num_tokens + 1
+    assert request.spec_token_ids == []
+    assert request.num_tokens_with_spec == request.num_tokens
+
+
+def test_recompute_notification_precedes_regular_output():
+    scheduler_output = SimpleNamespace(
+        recomputed_reqs=[
+            RecomputeReqInfo(
+                request_id="recomputed-request",
+                output_token_ids=[],
+                client_index=0,
+            )
+        ]
+    )
+    outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+
+    RecomputeScheduler._add_recomputed_outputs(scheduler_output, outputs)
+    outputs[0].append(
+        EngineCoreOutput(
+            request_id="regular-request",
+            new_token_ids=[1],
+        )
+    )
+
+    output = outputs[0][0]
+    assert output.request_id == "recomputed-request"
+    assert output.finish_reason == FinishReason.STOP
+    assert output.stop_reason == "recomputed"
+    assert outputs[0][1].request_id == "regular-request"

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -3,10 +3,11 @@
 
 from collections import defaultdict
 from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock
 
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine import EngineCoreOutput, FinishReason
-from vllm.v1.request import Request
+from vllm.v1.request import Request, RequestStatus
 
 from vllm_ascend.core.recompute_scheduler import (
     RecomputeReqInfo,
@@ -67,3 +68,44 @@ def test_recompute_notification_precedes_regular_output():
     assert output.finish_reason == FinishReason.STOP
     assert output.stop_reason == "recomputed"
     assert outputs[0][1].request_id == "regular-request"
+
+
+def test_finish_recomputed_request_uses_normal_abort_cleanup():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    request = Request(
+        request_id="fallback-recomputed-request",
+        prompt_token_ids=[1, 2, 3, 4],
+        sampling_params=SamplingParams(max_tokens=8),
+        pooling_params=None,
+    )
+    request.status = RequestStatus.RUNNING
+
+    # The fallback victim has already been popped from the running queue.
+    scheduler.requests = {request.request_id: request}
+    scheduler.running = []
+    scheduler.waiting = MagicMock()
+    scheduler.skipped_waiting = MagicMock()
+    scheduler._inflight_prefills = {request}
+    scheduler._connector_finished = MagicMock(return_value=(False, None))
+    scheduler.encoder_cache_manager = MagicMock()
+    scheduler.finished_req_ids = set()
+    scheduler.finished_req_ids_dict = None
+    scheduler._free_request_blocks = MagicMock()
+
+    recomputed_reqs = []
+    scheduler._finish_recomputed_request(request, recomputed_reqs)
+
+    assert request.status == RequestStatus.FINISHED_ABORTED
+    assert request not in scheduler._inflight_prefills
+    assert request.request_id not in scheduler.requests
+    assert request.request_id in scheduler.finished_req_ids
+    scheduler._connector_finished.assert_called_once_with(request)
+    scheduler.encoder_cache_manager.free.assert_called_once_with(request)
+    scheduler._free_request_blocks.assert_called_once_with(request)
+    assert recomputed_reqs == [
+        RecomputeReqInfo(
+            request_id=request.request_id,
+            output_token_ids=request.output_token_ids,
+            client_index=request.client_index,
+        )
+    ]

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -92,7 +92,7 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
     scheduler.finished_req_ids_dict = None
     scheduler._free_request_blocks = MagicMock()
 
-    recomputed_reqs = []
+    recomputed_reqs: list[RecomputeReqInfo] = []
     scheduler._finish_recomputed_request(request, recomputed_reqs)
 
     assert request.status == RequestStatus.FINISHED_ABORTED

--- a/tests/ut/core/test_recompute_scheduler_short_request_first.py
+++ b/tests/ut/core/test_recompute_scheduler_short_request_first.py
@@ -13,73 +13,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Integration tests for ShortRequestFirst wired into ``RecomputeScheduler``."""
+"""Verify that RecomputeScheduler does not enable ShortRequestFirst."""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import torch
 from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
-from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
-from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec
-from vllm.v1.request import Request
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
 from vllm.v1.structured_output import StructuredOutputManager
 
 from tests.ut.base import TestBase
-from vllm_ascend.ascend_config import ShortRequestFirstConfig
-from vllm_ascend.core.short_request_first_scheduler import ShortRequestFirstRequestQueue
+from vllm_ascend.core.short_request_first_scheduler import (
+    ShortRequestFirstRequestQueue,
+)
 
-EOS_TOKEN_ID = 50256
 MODEL = "Qwen3-0.6B"
-THRESHOLD = 256
 MAX_NUM_BATCHED_TOKENS = 10000
 BLOCK_SIZE = 16
 
 
-class FakeClock:
-    def __init__(self):
-        self.now = 1000.0
-
-    def monotonic(self):
-        return self.now
-
-    def advance(self, seconds: float):
-        self.now += seconds
-
-
-def _fake_ascend_config(**overrides) -> SimpleNamespace:
-    config = {"enabled": True, "threshold": THRESHOLD}
-    config.update(overrides)
-    return SimpleNamespace(scheduler_config=SimpleNamespace(short_request_first_config=ShortRequestFirstConfig(config)))
-
-
-def create_requests(num_tokens_list, max_tokens: int = 16):
-    init_none_hash(sha256)
-    requests = []
-    for i, num_tokens in enumerate(num_tokens_list):
-        sampling_params = SamplingParams(ignore_eos=False, max_tokens=max_tokens)
-        sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
-        request = Request(
-            request_id=f"{i}",
-            prompt_token_ids=[i % 50] * num_tokens,
-            sampling_params=sampling_params,
-            pooling_params=None,
-            mm_features=None,
-            block_hasher=get_request_block_hasher(BLOCK_SIZE, sha256),
-        )
-        requests.append(request)
-    return requests
-
-
-class TestRecomputeSchedulerShortRequestFirst(TestBase):
+class TestRecomputeSchedulerWithoutShortRequestFirst(TestBase):
     @patch("vllm.config.ModelConfig.__post_init__", MagicMock())
     @patch("vllm.config.VllmConfig.__post_init__", MagicMock())
-    @patch("vllm.config.ModelConfig.is_encoder_decoder", PropertyMock(return_value=False))
-    def create_scheduler(self, **config_overrides):
+    @patch(
+        "vllm.config.ModelConfig.is_encoder_decoder",
+        PropertyMock(return_value=False),
+    )
+    def test_waiting_queue_uses_upstream_policy(self):
         from vllm_ascend.core.recompute_scheduler import RecomputeScheduler
 
+        init_none_hash(sha256)
         scheduler_config = SchedulerConfig(
             max_num_seqs=16,
             max_model_len=MAX_NUM_BATCHED_TOKENS,
@@ -89,7 +59,6 @@ class TestRecomputeSchedulerShortRequestFirst(TestBase):
             max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
             is_encoder_decoder=False,
         )
-
         model_config = ModelConfig(
             model=MODEL,
             tokenizer=MODEL,
@@ -113,7 +82,7 @@ class TestRecomputeSchedulerShortRequestFirst(TestBase):
             cache_dtype="auto",
             enable_prefix_caching=False,
         )
-
+        cache_config.num_gpu_blocks = 10000
         vllm_config = VllmConfig(
             scheduler_config=scheduler_config,
             model_config=model_config,
@@ -121,66 +90,31 @@ class TestRecomputeSchedulerShortRequestFirst(TestBase):
             kv_transfer_config=None,
             speculative_config=None,
         )
-
         kv_cache_config = KVCacheConfig(
             num_blocks=10000,
             kv_cache_tensors=[],
             kv_cache_groups=[
                 KVCacheGroupSpec(
                     ["layer"],
-                    FullAttentionSpec(block_size=BLOCK_SIZE, num_kv_heads=1, head_size=1, dtype=torch.float32),
+                    FullAttentionSpec(
+                        block_size=BLOCK_SIZE,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
                 )
             ],
         )
-        cache_config.num_gpu_blocks = 10000
 
-        fake_cfg = _fake_ascend_config(**config_overrides)
-        with (
-            patch("vllm_ascend.core.recompute_scheduler.get_ascend_config", return_value=fake_cfg),
-            patch("vllm_ascend.core.short_request_first_scheduler.get_ascend_config", return_value=fake_cfg),
-        ):
-            scheduler = RecomputeScheduler(
-                vllm_config=vllm_config,
-                kv_cache_config=kv_cache_config,
-                block_size=BLOCK_SIZE,
-                log_stats=True,
-                structured_output_manager=MagicMock(spec=StructuredOutputManager),
-            )
+        scheduler = RecomputeScheduler(
+            vllm_config=vllm_config,
+            kv_cache_config=kv_cache_config,
+            block_size=BLOCK_SIZE,
+            log_stats=True,
+            structured_output_manager=MagicMock(spec=StructuredOutputManager),
+        )
 
-        scheduler.structured_output_manager.should_advance = MagicMock(return_value=False)
-        return scheduler
-
-    def _running_order(self, scheduler):
-        return [req.request_id for req in scheduler.running]
-
-    def test_waiting_queue_is_short_request_first(self):
-        scheduler = self.create_scheduler()
-        self.assertIsInstance(scheduler.waiting, ShortRequestFirstRequestQueue)
-
-    def test_short_prefill_scheduled_before_long(self):
-        scheduler = self.create_scheduler()
-        long_req, short_req = create_requests([THRESHOLD + 1000, 10])
-        scheduler.add_request(long_req)
-        scheduler.add_request(short_req)
-
-        scheduler.schedule()
-
-        order = self._running_order(scheduler)
-        self.assertIn("1", order)
-        self.assertIn("0", order)
-        self.assertLess(order.index("1"), order.index("0"))
-
-    def test_aged_long_promoted_over_short_after_wait(self):
-        clock = FakeClock()
-        with patch("vllm_ascend.core.short_request_first_scheduler.time", clock):
-            scheduler = self.create_scheduler(long_max_wait_ms=100.0)
-            long_req, short_req = create_requests([THRESHOLD + 1000, 10])
-            scheduler.add_request(long_req)
-            scheduler.add_request(short_req)
-
-            clock.advance(0.2)
-            scheduler.schedule()
-
-            order = self._running_order(scheduler)
-            self.assertIn("0", order)
-            self.assertLess(order.index("0"), order.index("1"))
+        self.assertNotIsInstance(
+            scheduler.waiting,
+            ShortRequestFirstRequestQueue,
+        )

--- a/tests/ut/kv_offload/test_recompute_cpu_offload.py
+++ b/tests/ut/kv_offload/test_recompute_cpu_offload.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from vllm.v1.outputs import KVConnectorOutput
-from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 
 # Clean up stale mock modules installed by other kv offload tests that replace
 # real kv_transfer packages with fake modules, breaking imports of this package.
@@ -600,9 +599,6 @@ def test_recompute_scheduler_remote_kv_restore_keeps_exact_token_position():
     scheduler.failed_recving_kv_req_ids = set()
     scheduler.finished_recving_kv_req_ids = {"req-1"}
     scheduler.kv_cache_manager = MagicMock()
-    scheduler.is_mtp_kv_consumer = True
-    scheduler.num_spec_tokens = 2
-    scheduler.max_model_len = 32
 
     request = SimpleNamespace(
         request_id="req-1",
@@ -616,7 +612,7 @@ def test_recompute_scheduler_remote_kv_restore_keeps_exact_token_position():
 
     scheduler.kv_cache_manager.cache_blocks.assert_called_once_with(request, 8)
     assert request.num_computed_tokens == 8
-    assert request.spec_token_ids == [PLACEHOLDER_TOKEN_ID] * 2
+    assert request.spec_token_ids == []
     assert scheduler.finished_recving_kv_req_ids == set()
 
 

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -123,6 +123,25 @@ class RecomputeScheduler(Scheduler):
 
         self.finished_recving_kv_req_ids.remove(request.request_id)
 
+    def _finish_recomputed_request(
+        self,
+        request: Request,
+        recomputed_reqs: list[RecomputeReqInfo],
+    ) -> None:
+        """Finish a fallback-recomputed request through the normal abort path."""
+        recomputed_reqs.append(
+            RecomputeReqInfo(
+                request.request_id,
+                request.output_token_ids,
+                request.client_index,
+            )
+        )
+        finished_reqs = self.finish_requests(
+            request.request_id,
+            RequestStatus.FINISHED_ABORTED,
+        )
+        assert finished_reqs == [(request.request_id, request.client_index)]
+
     def schedule(self, throttle_prefills: bool = False) -> RecomputeSchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -295,7 +314,8 @@ class RecomputeScheduler(Scheduler):
                             )
                         if offloaded:
                             logger.info(
-                                "[RecomputeScheduler] Recompute preemption offload enabled for request %s, computed_tokens=%d.",
+                                "[RecomputeScheduler] Recompute preemption offload "
+                                "enabled for request %s, computed_tokens=%d.",
                                 recomputed_req_id,
                                 recomputed_num_computed_tokens,
                             )
@@ -309,19 +329,15 @@ class RecomputeScheduler(Scheduler):
                             self._preempt_request(recomputed_req, scheduled_timestamp)
                             preempted_reqs.append(recomputed_req)
                         else:
-                            self._free_request_blocks(recomputed_req)
-                            self._inflight_prefills.discard(recomputed_req)
                             logger.info(
-                                "[RecomputeScheduler] Recompute preemption falls back without offload for request %s, computed_tokens=%d.",
+                                "[RecomputeScheduler] Recompute preemption falls back "
+                                "without offload for request %s, computed_tokens=%d.",
                                 recomputed_req_id,
                                 recomputed_num_computed_tokens,
                             )
-                            recomputed_reqs.append(
-                                RecomputeReqInfo(
-                                    recomputed_req_id,
-                                    recomputed_req.output_token_ids,
-                                    recomputed_req.client_index,
-                                )
+                            self._finish_recomputed_request(
+                                recomputed_req,
+                                recomputed_reqs,
                             )
                         if recomputed_req == request:
                             break

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import time
-from collections import defaultdict, deque
+from collections import defaultdict
 from dataclasses import dataclass, fields
 
 from vllm.config import SchedulerConfig, VllmConfig
@@ -45,8 +45,7 @@ from vllm.v1.core.sched.utils import remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs, FinishReason
 from vllm.v1.metrics.perf import PerfStats
 from vllm.v1.outputs import ModelRunnerOutput
-from vllm.v1.request import Request, RequestStatus, StreamingUpdate
-from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
+from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
@@ -97,43 +96,7 @@ class RecomputeScheduler(Scheduler):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # When is_mtp_kv_consumer is true, we will fill request.spec_token_ids
-        # with placeholder tokens to enable full graph when decode nodes pull
-        # the KV cache of one request from prefill nodes.
-        self.is_mtp_kv_consumer = (
-            self.vllm_config.speculative_config
-            and self.vllm_config.kv_transfer_config
-            and self.vllm_config.kv_transfer_config.is_kv_consumer
-        )
         self.is_kv_producer = self.vllm_config.kv_transfer_config and self.vllm_config.kv_transfer_config.is_kv_producer
-
-    def add_request(self, request: Request) -> None:
-        existing = self.requests.get(request.request_id)
-        if existing is not None:
-            update = StreamingUpdate.from_request(request)
-            if existing.status != RequestStatus.WAITING_FOR_STREAMING_REQ:
-                assert existing.streaming_queue is not None, "duplicate request id"
-                # Queue next input chunk (or finished sentinel).
-                existing.streaming_queue.append(update)
-            elif update is not None:
-                # Commence next input chunk.
-                self._update_request_as_session(existing, update)
-            else:
-                # Streaming-input session finished.
-                self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
-        else:
-            if request.resumable:
-                request.streaming_queue = deque()
-            # Fill in placeholder tokens to enable full graph compatibility. Without
-            # placeholders, graph matching may fail, forcing eager mode execution.
-            if self.is_mtp_kv_consumer and (self.max_model_len >= (request.num_tokens + self.num_spec_tokens)):
-                request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
-            self._enqueue_waiting_request(request)
-            self.requests[request.request_id] = request
-            if self.connector is not None:
-                self.connector.on_new_request(request)
-            if self.log_stats:
-                request.record_event(EngineCoreEventType.QUEUED)
 
     def _update_waiting_for_remote_kv(self, request: Request) -> None:
         """
@@ -158,17 +121,10 @@ class RecomputeScheduler(Scheduler):
             self.kv_cache_manager.cache_blocks(request, num_computed_tokens)
             request.num_computed_tokens = num_computed_tokens
 
-            if (
-                self.is_mtp_kv_consumer
-                and request.num_preemptions > 0
-                and not request.spec_token_ids
-                and self.max_model_len >= request.num_tokens + self.num_spec_tokens
-            ):
-                request.spec_token_ids = [PLACEHOLDER_TOKEN_ID] * self.num_spec_tokens
-
         self.finished_recving_kv_req_ids.remove(request.request_id)
 
-    def schedule(self) -> RecomputeSchedulerOutput:
+    def schedule(self, throttle_prefills: bool = False) -> RecomputeSchedulerOutput:
+        self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
         # Each request just has the num_computed_tokens and
@@ -195,6 +151,8 @@ class RecomputeScheduler(Scheduler):
         encoder_compute_budget = self.max_num_encoder_input_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        # Whether the running batch contains any prefill requests.
+        prefill_scheduled = False
 
         # For logging.
         scheduled_timestamp = time.monotonic()
@@ -204,6 +162,12 @@ class RecomputeScheduler(Scheduler):
         if self._pause_state == PauseState.PAUSED_ALL:
             # Do not schedule any requests when paused.
             token_budget = 0
+
+        # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
+        # all prefill compute unless saturated.
+        defer_prefills = (throttle_prefills and not self.prefill_capacity_bound) and any(
+            not r.is_prefill_chunk for r in self.running
+        )
 
         # First, schedule the RUNNING requests.
         req_index = 0
@@ -227,6 +191,18 @@ class RecomputeScheduler(Scheduler):
                 req_index += 1
                 continue
 
+            if self.current_step < request.next_decode_eligible_step:
+                # V2+PP+async: enforce `pp_size` steps between same-req decodes
+                # to match worker-side sampled-tokens broadcast slot ring cadence.
+                req_index += 1
+                continue
+
+            if defer_prefills and request.is_prefill_chunk:
+                # DP prefill balancing: defer this in-progress prefill chunk to a
+                # cadence-aligned step; decodes still run to fill this step.
+                req_index += 1
+                continue
+
             num_new_tokens = (
                 request.num_tokens_with_spec + request.num_output_placeholders - request.num_computed_tokens
             )
@@ -236,7 +212,10 @@ class RecomputeScheduler(Scheduler):
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
-            num_new_tokens = min(num_new_tokens, self.max_model_len - 1 - request.num_computed_tokens)
+            num_new_tokens = min(
+                num_new_tokens,
+                self.max_model_len - request.num_computed_tokens - self.num_sampled_tokens_per_step,
+            )
 
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
@@ -316,7 +295,7 @@ class RecomputeScheduler(Scheduler):
                             )
                         if offloaded:
                             logger.info(
-                                "Recompute preemption offload enabled for request %s, computed_tokens=%d.",
+                                "[RecomputeScheduler] Recompute preemption offload enabled for request %s, computed_tokens=%d.",
                                 recomputed_req_id,
                                 recomputed_num_computed_tokens,
                             )
@@ -330,9 +309,10 @@ class RecomputeScheduler(Scheduler):
                             self._preempt_request(recomputed_req, scheduled_timestamp)
                             preempted_reqs.append(recomputed_req)
                         else:
-                            self.kv_cache_manager.free(recomputed_req)
+                            self._free_request_blocks(recomputed_req)
+                            self._inflight_prefills.discard(recomputed_req)
                             logger.info(
-                                "Recompute preemption falls back without offload for request %s, computed_tokens=%d.",
+                                "[RecomputeScheduler] Recompute preemption falls back without offload for request %s, computed_tokens=%d.",
                                 recomputed_req_id,
                                 recomputed_num_computed_tokens,
                             )
@@ -388,6 +368,7 @@ class RecomputeScheduler(Scheduler):
 
             # Schedule the request.
             scheduled_running_reqs.append(request)
+            prefill_scheduled |= request.is_prefill_chunk
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -439,7 +420,10 @@ class RecomputeScheduler(Scheduler):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if len(self.running) == self.max_num_running_reqs:
+                # Paused streaming sessions are not in `running`, but still
+                # hold a model-runner request slot.
+                num_running = len(self.running) + self.num_waiting_for_streaming_input
+                if num_running >= self.max_num_running_reqs:
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
@@ -479,6 +463,7 @@ class RecomputeScheduler(Scheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
+                num_uncached_common_prefix_tokens = 0
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
@@ -492,13 +477,14 @@ class RecomputeScheduler(Scheduler):
                             HybridKVCacheCoordinator,
                         )
                     ):
-                        computed_blocks, num_new_local_computed_tokens = (
+                        computed_blocks, per_group_hits = (
                             self.kv_cache_manager.coordinator.find_longest_cache_hit_per_group(
                                 request.block_hashes,
                                 request.num_tokens - 1,
                             )
                         )
                         new_computed_blocks = self.kv_cache_manager.create_kv_cache_blocks(computed_blocks)
+                        num_new_local_computed_tokens = max(per_group_hits)
                         if self.kv_cache_manager.log_stats:
                             assert self.kv_cache_manager.prefix_cache_stats is not None
                             self.kv_cache_manager.prefix_cache_stats.record(
@@ -509,6 +495,15 @@ class RecomputeScheduler(Scheduler):
                     else:
                         new_computed_blocks, num_new_local_computed_tokens = self.kv_cache_manager.get_computed_blocks(
                             request
+                        )
+
+                    # In case of hybrid models, obtain a hint for the
+                    # Marconi-style APC admission logic.
+                    if self.has_mamba_layers:
+                        num_uncached_common_prefix_tokens = getattr(
+                            self.kv_cache_manager.coordinator,
+                            "num_uncached_common_prefix_tokens",
+                            0,
                         )
 
                     # Get externally-cached tokens if using a KVConnector.
@@ -532,6 +527,16 @@ class RecomputeScheduler(Scheduler):
                     num_computed_tokens = num_new_local_computed_tokens + num_external_computed_tokens
                     assert num_computed_tokens <= request.num_tokens
 
+                    # Skip requests with pending multimodal encoding prefetches.
+                    if (
+                        self.ec_connector is not None
+                        and request.mm_features
+                        and not self.ec_connector.ensure_cache_available(request, num_computed_tokens)
+                    ):
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
+                        continue
+
                     if request.prefill_stats is not None:
                         request.prefill_stats.set(
                             num_prompt_tokens=request.num_prompt_tokens,
@@ -548,20 +553,35 @@ class RecomputeScheduler(Scheduler):
                 encoder_inputs_to_schedule = None
                 external_load_encoder_input = []
                 new_encoder_compute_budget = encoder_compute_budget
+                pad_spec_decode = False
 
                 if load_kv_async:
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
+                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                    # DP prefill balancing: defer this step's local prefill
+                    # compute to a cadence-aligned step.
+                    break
                 else:
                     # Number of tokens to be scheduled.
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
-                    if self.is_mtp_kv_consumer:
-                        num_new_tokens = request.num_tokens_with_spec - num_computed_tokens
-                    else:
-                        num_new_tokens = request.num_tokens - num_computed_tokens
+                    num_new_tokens = request.num_tokens - num_computed_tokens
+
+                    # Pad new decode requests to uniform spec decoding size to
+                    # preserve full cudagraph for this step.
+                    if (
+                        (self.num_spec_tokens > 0 and self.dynamic_sd_lookup is None)
+                        and num_new_tokens == 1
+                        and (scheduled_running_reqs and not prefill_scheduled)
+                    ):
+                        num_new_tokens = 1 + self.num_spec_tokens
+                        if num_new_tokens > token_budget or num_computed_tokens + num_new_tokens > self.max_model_len:
+                            # Prefer to not schedule than schedule un-padded here.
+                            break
+                        pad_spec_decode = True
                     threshold = self.scheduler_config.long_prefill_token_threshold
                     if 0 < threshold < num_new_tokens:
                         num_new_tokens = threshold
@@ -600,21 +620,26 @@ class RecomputeScheduler(Scheduler):
                         num_new_tokens,
                         num_new_local_computed_tokens,
                         num_external_computed_tokens,
+                        num_uncached_common_prefix_tokens,
                     )
                     if num_new_tokens == 0:
                         break
 
-                # Handles an edge case when P/D Disaggregation
-                # is used with Spec Decoding where an
-                # extra block gets allocated which
-                # creates a mismatch between the number
-                # of local and remote blocks.
-                effective_lookahead_tokens = 0 if request.num_computed_tokens == 0 else self.num_lookahead_tokens
+                # During async KV load, no forward pass is run yet. Allocate
+                # speculative lookahead slots later to avoid mismatching local
+                # and remote block counts.
+                limit_lookahead_tokens = load_kv_async and self.num_lookahead_tokens > 0
+                effective_lookahead_tokens = 0 if limit_lookahead_tokens else self.num_lookahead_tokens
 
                 # Determine if we need to allocate cross-attention blocks.
                 num_encoder_tokens = 0
                 if self.is_encoder_decoder and request.has_encoder_inputs and encoder_inputs_to_schedule:
                     num_encoder_tokens = sum(request.get_num_encoder_embeds(i) for i in encoder_inputs_to_schedule)
+
+                reserved_blocks = 0
+                if load_kv_async:
+                    # Async loads hold their blocks without forward progress.
+                    reserved_blocks = self._inflight_prefill_reserved_blocks()
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
@@ -626,6 +651,8 @@ class RecomputeScheduler(Scheduler):
                     delay_cache_blocks=load_kv_async,
                     num_encoder_tokens=num_encoder_tokens,
                     full_sequence_must_fit=self.scheduler_reserve_full_isl,
+                    reserved_blocks=reserved_blocks,
+                    has_scheduled_reqs=bool(self.running),
                 )
 
                 if new_blocks is None:
@@ -674,26 +701,8 @@ class RecomputeScheduler(Scheduler):
                     # _update_waiting_for_remote_kv will then cache
                     # only the successfully loaded tokens.
                     request.num_computed_tokens = num_computed_tokens
+                    self._inflight_prefills.add(request)
                     continue
-
-                # For spec_token_ids, the waiting queue has the same processing
-                # as the running queue.
-                if self.is_mtp_kv_consumer and request.spec_token_ids:
-                    num_scheduled_spec_tokens = (
-                        num_new_tokens
-                        + request.num_computed_tokens
-                        - request.num_tokens
-                        - request.num_output_placeholders
-                    )
-                    if num_scheduled_spec_tokens > 0:
-                        spec_token_ids = request.spec_token_ids
-                        if len(spec_token_ids) > num_scheduled_spec_tokens:
-                            spec_token_ids = spec_token_ids[:num_scheduled_spec_tokens]
-                        scheduled_spec_decode_tokens[request.request_id] = spec_token_ids
-
-                    # New spec tokens will be set in `update_draft_token_ids` before the
-                    # next step when applicable.
-                    request.spec_token_ids = []
 
                 self.running.append(request)
                 if self.log_stats:
@@ -712,6 +721,11 @@ class RecomputeScheduler(Scheduler):
                 token_budget -= num_new_tokens
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
+                if pad_spec_decode:
+                    scheduled_spec_decode_tokens[request_id] = [-1] * self.num_spec_tokens
+                # Only track requests that will still be prefilling after this chunk.
+                if num_computed_tokens + num_new_tokens < request.num_tokens:
+                    self._inflight_prefills.add(request)
                 # Encoder-related.
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
@@ -731,6 +745,11 @@ class RecomputeScheduler(Scheduler):
             # re-queue requests skipped in this pass ahead of older skipped items.
             if step_skipped_waiting:
                 self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+            # On a step that admitted prefills, record whether it was
+            # capacity-bound for DP prefill balancing.
+            if not defer_prefills:
+                self.prefill_capacity_bound = bool(self.waiting)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
@@ -753,8 +772,8 @@ class RecomputeScheduler(Scheduler):
 
         # Construct the scheduler output.
         if self.use_v2_model_runner:
-            scheduled_new_reqs = scheduled_new_reqs + scheduled_resumed_reqs
-            scheduled_resumed_reqs = []
+            scheduled_new_reqs.extend(scheduled_resumed_reqs)
+            scheduled_resumed_reqs.clear()
             new_reqs_data = [
                 NewRequestData.from_request(
                     req,
@@ -778,13 +797,19 @@ class RecomputeScheduler(Scheduler):
                 req_to_new_blocks,
             )
 
-        # Record the request ids that were scheduled in this step.
-        self.prev_step_scheduled_req_ids.clear()
-        self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
+        # Record the request ids that were scheduled in this step (MRV1-only).
+        if not self.use_v2_model_runner:
+            self.prev_step_scheduled_req_ids.clear()
+            self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
         new_block_ids_to_zero = (
             (self.kv_cache_manager.take_new_block_ids() or None) if self.needs_kv_cache_zeroing else None
         )
+
+        # Dynamic speculative decoding: compute optimal K.
+        num_spec_tokens_to_schedule = self.num_spec_tokens
+        if self.dynamic_sd_lookup is not None and num_scheduled_tokens:
+            num_spec_tokens_to_schedule = self.dynamic_sd_lookup[len(num_scheduled_tokens)]
 
         scheduler_output = RecomputeSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
@@ -794,7 +819,7 @@ class RecomputeScheduler(Scheduler):
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
             scheduled_encoder_inputs=scheduled_encoder_inputs,
             num_common_prefix_blocks=num_common_prefix_blocks,
-            preempted_req_ids={req.request_id for req in preempted_reqs},
+            preempted_req_ids=self.reset_preempted_req_ids,
             # finished_req_ids is an existing state in the scheduler,
             # instead of being newly scheduled in this step.
             # It contains the request IDs that are finished in between
@@ -802,6 +827,7 @@ class RecomputeScheduler(Scheduler):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             preempted_reqs=preempted_req_data,
             recomputed_reqs=recomputed_reqs,
         )
@@ -819,6 +845,11 @@ class RecomputeScheduler(Scheduler):
             ec_meta: ECConnectorMetadata = self.ec_connector.build_connector_meta(scheduler_output)
             scheduler_output.ec_connector_metadata = ec_meta
 
+        # Advance the fence only for non-empty steps that will later be
+        # processed by update_from_output.
+        if self.defer_block_free and total_num_scheduled_tokens > 0:
+            self.sched_step_seq += 1
+
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
@@ -827,6 +858,27 @@ class RecomputeScheduler(Scheduler):
         self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
         return connector.build_connector_meta(scheduler_output)
+
+    @staticmethod
+    def _add_recomputed_outputs(
+        scheduler_output: SchedulerOutput,
+        outputs: dict[int, list[EngineCoreOutput]],
+    ) -> None:
+        """Add terminal outputs for requests that must retry on prefill."""
+        recomputed_reqs = getattr(scheduler_output, "recomputed_reqs", None)
+        for req_info in recomputed_reqs or []:
+            logger.warning(
+                "[RecomputeScheduler] Recompute triggered for request %s.",
+                req_info.request_id,
+            )
+            outputs[req_info.client_index].append(
+                EngineCoreOutput(
+                    request_id=req_info.request_id,
+                    finish_reason=FinishReason.STOP,
+                    new_token_ids=[],
+                    stop_reason="recomputed",
+                )
+            )
 
     def update_from_output(
         self,
@@ -842,19 +894,20 @@ class RecomputeScheduler(Scheduler):
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
 
+        # Every GPU write enqueued by this and earlier steps has completed, so it is
+        # safe to return deferred-free blocks to the pool.
+        if self.defer_block_free and scheduler_output.total_num_scheduled_tokens > 0:
+            self.processed_step_seq += 1
+            self._drain_deferred_frees()
+
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        # Keep recompute notifications before regular outputs from this step.
+        self._add_recomputed_outputs(scheduler_output, outputs)
         spec_decoding_stats: SpecDecodingStats | None = None
-        kv_connector_stats: KVConnectorStats | None = (
-            kv_connector_output.kv_connector_stats if kv_connector_output else None
-        )
-        if kv_connector_stats and self.connector:
-            kv_stats = self.connector.get_kv_connector_stats()
-            if kv_stats:
-                kv_connector_stats = kv_connector_stats.aggregate(kv_stats)
 
         failed_kv_load_req_ids = None
         if kv_connector_output and kv_connector_output.invalid_block_ids:
@@ -866,30 +919,22 @@ class RecomputeScheduler(Scheduler):
                 num_scheduled_tokens,
             )
 
-        # return recomputed requests as EngineCoreOutput
-        if scheduler_output.recomputed_reqs is not None:
-            for req_info in scheduler_output.recomputed_reqs:
-                logger.warning("[RecomputeScheduler] Recompute triggered for request %s.", req_info.request_id)
-                outputs[req_info.client_index].append(
-                    EngineCoreOutput(
-                        request_id=req_info.request_id,
-                        finish_reason=FinishReason.STOP,
-                        new_token_ids=[],
-                        stop_reason="recomputed",
-                    )
-                )
-
-        # Persist per-step routed experts into the scheduler-side slot buffer.
-        # MUST precede the per-request routing reads below.
+        # Persist per-step routed experts into the scheduler-side slot
+        # buffer (CPU->CPU fancy-index assign; ~few MB per step).
+        # MUST precede the per-request routing reads below: stopped
+        # requests may terminate on tokens generated in this very step,
+        # whose routing was just D2H'd into model_runner_output.
         routing_data = None
         routing_offsets: dict[str, int] = {}
-        if getattr(self, "enable_return_routed_experts", False) and model_runner_output.routed_experts is not None:
+        if model_runner_output.routed_experts is not None:
             re = model_runner_output.routed_experts
             self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
             routing_data = re.routing_data.astype(
                 self.routed_experts_mgr.routed_experts_by_slot.dtype,
                 copy=False,
             )
+            # Build offset map using model runner's request order
+            # (input_batch ordering), NOT scheduler dict order.
             offset = 0
             for rid in model_runner_output.req_ids:
                 routing_offsets[rid] = offset
@@ -920,9 +965,16 @@ class RecomputeScheduler(Scheduler):
             generated_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
 
             scheduled_spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(req_id)
-            if scheduled_spec_token_ids and generated_token_ids:
+            # Skip a stale frame still pending discard (async_tokens_to_discard
+            # > 0): its pre-reset rejection count would underflow the counters.
+            if (
+                scheduled_spec_token_ids
+                and (generated_token_ids or self.num_sampled_tokens_per_step == 0)
+                and request.async_tokens_to_discard == 0
+            ):
                 num_draft_tokens = len(scheduled_spec_token_ids)
-                num_accepted = len(generated_token_ids) - 1
+                num_sampled = self.num_sampled_tokens_per_step
+                num_accepted = max(len(generated_token_ids) - num_sampled, 0)
                 num_rejected = num_draft_tokens - num_accepted
                 # num_computed_tokens represents the number of tokens
                 # processed in the current step, considering scheduled
@@ -966,14 +1018,16 @@ class RecomputeScheduler(Scheduler):
             if new_token_ids and self.structured_output_manager.should_advance(request):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
-                assert struct_output_request.grammar is not None
-                if not struct_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
-                    req_id, new_token_ids
-                ):
+                grammar = struct_output_request.grammar
+                assert grammar is not None
+                # new_token_ids can be a mixed block of reasoning content, then
+                # the reasoning end marker, then the start of the grammar content.
+                # Trim the reasoning content so the grammar only sees grammar content.
+                advance_token_ids = self.structured_output_manager.trim_reasoning_for_advance(request, new_token_ids)
+                if advance_token_ids and not grammar.accept_tokens(req_id, advance_token_ids):
                     logger.error(
-                        "[RecomputeScheduler] Unexpected: grammar rejected tokens %s for request %s."
-                        " Terminating request.",
-                        new_token_ids,
+                        "Unexpected: grammar rejected tokens %s for request %s. Terminating request.",
+                        advance_token_ids,
                         req_id,
                     )
                     request.status = RequestStatus.FINISHED_ERROR
@@ -986,6 +1040,9 @@ class RecomputeScheduler(Scheduler):
                 end = req_offset + num_tokens_scheduled
                 block_ids = self._re_block_ids.pop(req_id, [])
                 if num_output_tokens_before == 0:
+                    # Prefill completed: read full prompt routing from
+                    # slot buffer using the block-ID snapshot taken at
+                    # schedule time (immune to async preemption).
                     if (
                         request.sampling_params is not None
                         and request.sampling_params.routed_experts_prompt_start is not None
@@ -999,10 +1056,14 @@ class RecomputeScheduler(Scheduler):
                         request.num_prompt_tokens,
                         token_start=prompt_start,
                     )
-                elif scheduled_spec_token_ids:
-                    routed_experts = routing_data[req_offset : req_offset + len(new_token_ids)]
                 else:
-                    routed_experts = routing_data[end - len(new_token_ids) : end]
+                    if scheduled_spec_token_ids:
+                        # Spec decode: accepted tokens at the START of
+                        # the scheduled range, rejected at the end.
+                        routed_experts = routing_data[req_offset : req_offset + len(new_token_ids)]
+                    else:
+                        # Normal decode / re-prefill: token(s) at the END.
+                        routed_experts = routing_data[end - len(new_token_ids) : end]
 
             finish_reason = None
             if stopped:
@@ -1074,6 +1135,20 @@ class RecomputeScheduler(Scheduler):
         # KV Connector: update state for finished KV Transfers.
         if kv_connector_output:
             self._update_from_kv_xfer_finished(kv_connector_output)
+
+        # Worker-side KV connector stats from the model runner output.
+        kv_connector_stats: KVConnectorStats | None = (
+            kv_connector_output.kv_connector_stats if kv_connector_output else None
+        )
+        if self.connector:
+            # Scheduler-side KV connector stats collected after connector update.
+            scheduler_kv_connector_stats = self.connector.get_kv_connector_stats()
+            if scheduler_kv_connector_stats is not None and not scheduler_kv_connector_stats.is_empty():
+                kv_connector_stats = (
+                    kv_connector_stats.aggregate(scheduler_kv_connector_stats)
+                    if kv_connector_stats is not None
+                    else scheduler_kv_connector_stats
+                )
 
         # collect KV cache events from KV cache manager
         events = self.kv_cache_manager.take_events()

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -184,7 +184,7 @@ class RecomputeScheduler(Scheduler):
 
         # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
         # all prefill compute unless saturated.
-        defer_prefills = (throttle_prefills and not self.prefill_capacity_bound) and any(
+        defer_prefills = (throttle_prefills and not self.prefill_capacity_bound) and any(  # type: ignore
             not r.is_prefill_chunk for r in self.running
         )
 

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -50,9 +50,6 @@ from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.utils import ConstantList, record_function_or_nullcontext
 
-from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.core.short_request_first_scheduler import ShortRequestFirstSchedulerMixin
-
 
 @dataclass
 class RecomputeSchedulerConfig(SchedulerConfig):
@@ -95,7 +92,7 @@ class RecomputeSchedulerOutput(SchedulerOutput):
     recomputed_reqs: list[RecomputeReqInfo] | None = None
 
 
-class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
+class RecomputeScheduler(Scheduler):
     running: list[Request]
 
     def __init__(self, *args, **kwargs):
@@ -109,26 +106,6 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
             and self.vllm_config.kv_transfer_config.is_kv_consumer
         )
         self.is_kv_producer = self.vllm_config.kv_transfer_config and self.vllm_config.kv_transfer_config.is_kv_producer
-        if get_ascend_config().scheduler_config.short_request_first_config.enabled:
-            self._init_short_request_first_waiting_queue()
-
-    def _pop_waiting_request(
-        self,
-        request_queue,
-        count_with_short_request_first: bool,
-        *,
-        count_as_removal: bool = False,
-        skip_or_requeue_reason: str | None = None,
-    ) -> Request:
-        if count_with_short_request_first:
-            short_request_first_waiting = self._short_request_first_waiting_queue()
-            assert short_request_first_waiting is not None
-            return short_request_first_waiting.pop_request_from_queue(
-                request_queue,
-                count_as_removal=count_as_removal,
-                skip_or_requeue_reason=skip_or_requeue_reason,
-            )
-        return request_queue.pop_request()
 
     def add_request(self, request: Request) -> None:
         existing = self.requests.get(request.request_id)
@@ -221,9 +198,6 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
 
         # For logging.
         scheduled_timestamp = time.monotonic()
-        short_request_first_waiting = self._short_request_first_waiting_queue()
-        if short_request_first_waiting is not None:
-            short_request_first_waiting.begin_step(self.max_num_scheduled_tokens)
 
         self.kv_cache_manager.new_step_starts()
 
@@ -471,13 +445,6 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None
 
-                # skipped_waiting is not owned by ShortRequestFirstRequestQueue,
-                # so only route pops through it when the selected queue is one
-                # of its managed sub-queues.
-                count_with_short_request_first = (
-                    short_request_first_waiting is not None and short_request_first_waiting.owns_queue(request_queue)
-                )
-
                 request = request_queue.peek_request()
                 request_id = request.request_id
 
@@ -490,12 +457,7 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
                             "[RecomputeScheduler] %s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
-                    self._pop_waiting_request(
-                        request_queue,
-                        count_with_short_request_first,
-                        count_as_removal=True,
-                        skip_or_requeue_reason="blocked_waiting_status",
-                    )
+                    request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -510,12 +472,7 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
                     )
                 ):
                     # Scheduling would exceed max_loras, skip.
-                    self._pop_waiting_request(
-                        request_queue,
-                        count_with_short_request_first,
-                        count_as_removal=True,
-                        skip_or_requeue_reason="max_loras",
-                    )
+                    request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
 
@@ -564,12 +521,7 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
-                            self._pop_waiting_request(
-                                request_queue,
-                                count_with_short_request_first,
-                                count_as_removal=True,
-                                skip_or_requeue_reason="remote_kv_not_ready",
-                            )
+                            request_queue.pop_request()
                             step_skipped_waiting.prepend_request(request)
                             continue
                         num_external_computed_tokens = ext_tokens
@@ -702,7 +654,7 @@ class RecomputeScheduler(ShortRequestFirstSchedulerMixin, Scheduler):
                             preempted=request.num_preemptions > 0,
                         )
 
-                request = self._pop_waiting_request(request_queue, count_with_short_request_first)
+                request = request_queue.pop_request()
                 if load_kv_async:
                     # If loading async, allocate memory and put request
                     # into the WAITING_FOR_REMOTE_KV state.


### PR DESCRIPTION
### What this PR does / why we need it?
Recompute Scheduler main2main to v0.25.1. And drop short request schedule on Recompute Scheduler, because it does not support enable on prefill nodes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By nightly.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
