### PR TITLE
[Cherry-pick][releases/v0.24.0rc][CI] Remove stale Transformers nightly overrides (from #12503)

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
@@ -15,8 +15,6 @@ env_common: &env_common
   VLLM_RPC_TIMEOUT: 600
   SERVER_PORT: 8078
 
-special_dependencies:
-  transformers: "5.2.0"
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 
 deployment:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -15,8 +15,6 @@ env_common: &env_common
   VLLM_RPC_TIMEOUT: "600"
   SERVER_PORT: 8080
 
-special_dependencies:
-  transformers: "5.2.0"
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 
 deployment:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_2-W8A8-A3-dual-nodes.yaml
@@ -14,8 +14,6 @@ env_common: &env_common
   VLLM_RPC_TIMEOUT: "600"
   SERVER_PORT: 8080
 
-special_dependencies:
-  transformers: "5.12.0"
 # TODO: need to identify why TP and mtp+1 divisibility rules break on dual-node case
 
 deployment:

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V4-Flash-W8A8-A3.yaml
@@ -5,8 +5,6 @@
 test_cases:
   - name: "DeepSeek-V4-Flash-W8A8-A3"
     model: "Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp"
-    special_dependencies:
-      transformers: "5.9.0"
     envs:
       OMP_PROC_BIND: "false"
       OMP_NUM_THREADS: "1"


### PR DESCRIPTION
Cherry-pick of PR #12503 onto `releases/v0.24.0rc`.

Original PR: #12503
Original author: @zhao-stack

---

### What this PR does / why we need it?

Removes the per-case `special_dependencies.transformers` overrides from these nightly configurations:

- `multi-node-GLM-5.1-w8a8-A2`
- `multi-node-GLM-5.1-w8a8-A3`
- `multi-node-GLM-5.2-w8a8-A3`
- `DeepSeek-V4-Flash-W8A8-A3`

These cases now inherit the centrally managed Transformers version from the nightly image instead of downgrading it at runtime. This keeps the release branch aligned with the fix merged on main.

### Does this PR introduce _any_ user-facing change?

No. This only changes nightly test dependency overrides.

### How was this patch tested?

- Cherry-picked merge commit `9327cc399` cleanly with `-x`.
- Parsed all four changed YAML files with `yaml.safe_load`.
- Verified none of the four configurations retains a `special_dependencies` entry.
- `git diff --check` passed.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
