### PR TITLE
[Doc][310p] Add Atlas inference products software requirements tabs

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -6,21 +6,29 @@ This document describes how to install vllm-ascend manually.
 
 - OS: Linux
 - Python: >= 3.10, < 3.13
-- Hardware with Ascend NPUs. It's usually the Atlas 800 A2 series.
-- Atlas inference products.
+- Hardware with Ascend NPUs. It's usually the Atlas 800 A2 series and Atlas inference products.
 - Software:
 
-    | Software      | Supported version                | Note                                      |
-    |---------------|----------------------------------|-------------------------------------------|
-    | Ascend HDK    | Refer to the documentation [CANN 9.0.1](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html) | Required for CANN |
-    | CANN          | == 9.0.1                        | Required for vllm-ascend and torch-npu    |
-    | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
-    | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
-    | NNAL          | == 9.0.1                        | Required for libatb.so, enables advanced tensor operations |
+    === "Atlas A2 inference products / Atlas A3 inference products"
 
-!!! note "Atlas inference products"
+        | Software      | Supported version                | Note                                      |
+        |---------------|----------------------------------|-------------------------------------------|
+        | Ascend HDK    | Refer to the documentation [CANN 9.0.1](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html) | Required for CANN |
+        | CANN          | == 9.0.1                        | Required for vllm-ascend and torch-npu    |
+        | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
+        | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
+        | NNAL          | == 9.0.1                        | Required for libatb.so, enables advanced tensor operations |
 
-    Atlas inference products require CANN 9.1.0 beta. The Atlas A2/A3 requirements in the table above remain unchanged.
+    === "Atlas inference products"
+
+        | Software      | Supported version                | Note                                      |
+        |---------------|----------------------------------|-------------------------------------------|
+        | Ascend HDK    | Refer to the documentation [CANN 9.1.0-beta.1](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/910beta1/releasenote/9.1.0-beta.1/release-note.md) | Required for CANN |
+        | CANN          | == 9.1.0-beta.1                 | Required for vllm-ascend and torch-npu    |
+        | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
+        | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
+        | NNAL          | == 9.1.0-beta.1                 | Required for libatb.so, enables advanced tensor operations |
+        | triton / triton-ascend | Not supported          | Uninstalled in `Dockerfile.310p` |
 
 There are two installation methods:
 

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -15,26 +15,39 @@ This section guides you through container-based environment setup and large mode
 - Atlas 800I A2 inference series (Atlas 800I A2)
 - Atlas A3 training series (Atlas 800T A3, Atlas 900 A3 SuperPoD, Atlas 9000 A3 SuperPoD)
 - Atlas 800I A3 inference series (Atlas 800I A3)
-- [Experimental] Atlas inference products
+- Atlas inference products
 
 ## Requirements
 
 - OS: Linux
 - Python: >= 3.10, < 3.13
-- Hardware with Ascend NPUs. It's usually the Atlas 800 A2 series.
+- Hardware with Ascend NPUs. It's usually the Atlas 800 A2 series and Atlas inference products.
 - Software:
 
-    | Software      | Supported version                | Note                                      |
-    |---------------|----------------------------------|-------------------------------------------|
-    | Ascend HDK    | Refer to the documentation [CANN 9.0.1](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html) | Required for CANN |  
-    | CANN          | == 9.0.1                        | Required for vllm-ascend and torch-npu    |
-    | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
-    | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
-    | NNAL          | == 9.0.1                        | Required for libatb.so, enables advanced tensor operations |
+    === "Atlas A2 inference products / Atlas A3 inference products"
+
+        | Software      | Supported version                | Note                                      |
+        |---------------|----------------------------------|-------------------------------------------|
+        | Ascend HDK    | Refer to the documentation [CANN 9.0.1](https://www.hiascend.com/document/detail/zh/canncommercial/900/releasenote/releasenote_0000.html) | Required for CANN |
+        | CANN          | == 9.0.1                        | Required for vllm-ascend and torch-npu    |
+        | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
+        | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
+        | NNAL          | == 9.0.1                        | Required for libatb.so, enables advanced tensor operations |
+
+    === "Atlas inference products"
+
+        | Software      | Supported version                | Note                                      |
+        |---------------|----------------------------------|-------------------------------------------|
+        | Ascend HDK    | Refer to the documentation [CANN 9.1.0-beta.1](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/910beta1/releasenote/9.1.0-beta.1/release-note.md) | Required for CANN |
+        | CANN          | == 9.1.0-beta.1                 | Required for vllm-ascend and torch-npu    |
+        | torch-npu     | == 2.10.0.post2                 | Required for vllm-ascend, No need to install manually, it will be auto installed in below steps |
+        | torch         | == 2.10.0                       | Required for torch-npu and vllm, No need to install manually, it will be auto installed in below steps |
+        | NNAL          | == 9.1.0-beta.1                 | Required for libatb.so, enables advanced tensor operations |
+        | triton / triton-ascend | Not supported          | Uninstalled in `Dockerfile.310p` |
 
 !!! note "Atlas inference products"
 
-    Atlas inference products use CANN 9.1.0 beta and `float16`. Use the `-310p` image suffix for Ubuntu or `-310p-openeuler` for openEuler. Atlas inference products do not support `triton` or `triton-ascend`.
+    Atlas inference products use `float16`. Use the `-310p` image suffix for Ubuntu or `-310p-openeuler` for openEuler. Atlas inference products do not support `triton` or `triton-ascend`.
 
     Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
 

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -289,8 +289,6 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 
 === "Atlas inference products"
 
-    Atlas inference products use the W8A8SC-310 quantized weights from the Eco-Tech official ModelScope repository. Keep an explicit `--max-model-len` for 310P deployment to avoid OOM caused by oversized attention mask allocation.
-
     Qwen3-8B-W8A8SC:
 
     ```bash
@@ -308,7 +306,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}' \
         --quantization ascend \
-        --max-model-len 16384 \
+        --max-model-len 20480 \
         --no-enable-prefix-caching \
         --load-format sharded_state
     ```
@@ -330,7 +328,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
         --quantization ascend \
-        --max-model-len 16384 \
+        --max-model-len 20480 \
         --no-enable-prefix-caching \
         --load-format sharded_state
     ```

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -250,7 +250,7 @@ Single-node deployment runs both Prefill and Decode on the same node. `Qwen3.6-3
     - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}'` enables decode ACLGraph replay and explicitly limits capture sizes for Atlas inference products.
     - `--no-enable-prefix-caching` is the default recommendation for this Atlas inference products example to reduce memory pressure.
     - `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.
-    - To enable MTP speculative decoding, use --speculative_config '{"method": "mtp", "num_speculative_tokens": 1}'. We recommend setting num_speculative_tokens to 1.
+    - To enable MTP speculative decoding, use --speculative_config '{"method": "mtp", "num_speculative_tokens": 1}'. We recommend setting num_speculative_tokens to 1. If your usage scenario involves fewer than two concurrent requests, it is recommended to enable MTP. Otherwise, it is recommended not to enable MTP.
 
 Common Issues Tip: If the service fails to start, HBM is insufficient, or requests are not scheduled as expected, refer to [FAQs](../../faqs.md) first, and then check the model-specific FAQ in Section 10.
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the software requirements tables in the installation and quick start docs to separate Atlas A2/A3 inference products from Atlas inference products using tabs.
It keeps the existing A2/A3 requirements unchanged, and documents the Atlas inference products stack based on Dockerfile.310p, including CANN/NNAL 9.1.0-beta.1, the current mainline torch/torch-npu pairing, and the unsupported triton / triton-ascend note.

### Does this PR introduce _any_ user-facing change?
Yes. Documentation only.
Users can now clearly see the different software requirements for Atlas A2/A3 inference products and Atlas inference products.

### How was this patch tested?
Local Test

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
