### PR TITLE
[Performance] Switch GDN prefill to aclnn chunk_gated_delta_rule op

### DIFF
--- a/csrc/attention/chunk_gated_delta_rule/CMakeLists.txt
+++ b/csrc/attention/chunk_gated_delta_rule/CMakeLists.txt
@@ -1,0 +1,18 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/chunk_gated_delta_rule/chunk_gated_delta_rule_torch_adpt.h
+++ b/csrc/attention/chunk_gated_delta_rule/chunk_gated_delta_rule_torch_adpt.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_TORCH_ADPT_H
+#define CHUNK_GATED_DELTA_RULE_TORCH_ADPT_H
+
+namespace vllm_ascend {
+
+// Dispatches to the CANN aclnn operator aclnnChunkGatedDeltaRule.
+// The operator is compiled/installed from the chunk_gated_delta_rule source
+// tree under csrc/attention/chunk_gated_delta_rule (see build_aclnn.sh) and
+// resolved at runtime by name via EXEC_NPU_CMD, so no aclnn header include is
+// needed here (same pattern as recurrent_gated_delta_rule_torch_adpt.h).
+//
+// Inputs (TND layout):
+//   query            (T, Nk, Dk)  bf16
+//   key              (T, Nk, Dk)  bf16
+//   value            (T, Nv, Dv)  bf16
+//   beta             (T, Nv)      bf16
+//   initial_state     (B, Nv, Dv, Dk)  bf16/fp32
+//   actual_seq_lengths (B,)        int32
+//   g                (T, Nv)      fp32 (optional; nullptr => all-zero)
+//   scale_value      float
+// Outputs:
+//   out              (T, Nv, Dv)  bf16
+//   final_state       (B, Nv, Dv, Dk)  bf16/fp32
+inline std::tuple<at::Tensor, at::Tensor> npu_chunk_gated_delta_rule(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& beta,
+    const at::Tensor& initial_state,
+    const at::Tensor& actual_seq_lengths,
+    const c10::optional<at::Tensor>& g,
+    double scale_value)
+{
+    TORCH_CHECK(scale_value != 0.0, "scale_value cannot be 0.");
+
+    // out: same shape as value, bf16.
+    auto out_options = value.options().dtype(at::ScalarType::BFloat16);
+    at::Tensor out = at::empty(value.sizes(), out_options);
+
+    // final_state: same shape and dtype as initial_state (bf16 or fp32).
+    at::Tensor final_state = at::empty(initial_state.sizes(), initial_state.options());
+
+    float scale_real = static_cast<float>(scale_value);
+    EXEC_NPU_CMD(aclnnChunkGatedDeltaRule,
+                 query,
+                 key,
+                 value,
+                 beta,
+                 initial_state,
+                 actual_seq_lengths,
+                 g,
+                 scale_real,
+                 out,
+                 final_state);
+    return std::make_tuple(out, final_state);
+}
+
+} // namespace vllm_ascend
+#endif // CHUNK_GATED_DELTA_RULE_TORCH_ADPT_H

--- a/csrc/attention/chunk_gated_delta_rule/op_graph/CMakeLists.txt
+++ b/csrc/attention/chunk_gated_delta_rule/op_graph/CMakeLists.txt
@@ -1,0 +1,11 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+message(STATUS "=== Debug: start ops.attention.chunk_gated_delta_rule.op_graph.CMakeLists.txt ")

--- a/csrc/attention/chunk_gated_delta_rule/op_graph/chunk_gated_delta_rule_proto.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_graph/chunk_gated_delta_rule_proto.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_proto.h
+ * \brief
+ */
+
+#ifndef OPS_OP_PROTO_INC_CHUNK_GATED_DELTA_RULE_OPS_H_
+#define OPS_OP_PROTO_INC_CHUNK_GATED_DELTA_RULE_OPS_H_
+
+#include "graph/operator_reg.h"
+
+namespace ge {
+/**
+ * @brief Chunk Gated Delta Rule.
+ *
+ * @par Inputs:
+ * @li query: A 3D tensor. The type supports bfloat16.
+ * @li key: A 3D tensor. The type supports bfloat16.
+ * @li value: A 3D tensor. The type supports bfloat16.
+ * @li beta: A tensor. The type supports bfloat16.
+ * @li initial_state: A tensor. The type supports bfloat16.
+ * @li actual_seq_lengths: A tensor. The type supports int32.
+ * @li g: An optional tensor. The type supports float32.
+ *
+ * @par Attributes:
+ * @li scale_value: An optional float attribute. Defaults to 1.0.
+ *
+ * @par Outputs:
+ * @li out: A tensor. The type supports bfloat16.
+ * @li final_state: A tensor. The type supports bfloat16.
+ */
+// 图模式算子注册（输入/输出/属性用于 GE 识别与校验）。
+REG_OP(ChunkGatedDeltaRule)
+    .INPUT(query, TensorType({DT_BF16}))
+    .INPUT(key, TensorType({DT_BF16}))
+    .INPUT(value, TensorType({DT_BF16}))
+    .INPUT(beta, TensorType({DT_BF16}))
+    .INPUT(initial_state, TensorType({DT_BF16, DT_FLOAT}))
+    .INPUT(actual_seq_lengths, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(g, TensorType({DT_FLOAT}))
+    .OUTPUT(out, TensorType({DT_BF16}))
+    .OUTPUT(final_state, TensorType({DT_BF16, DT_FLOAT}))
+    .ATTR(scale_value, Float, 1.0)
+    .OP_END_FACTORY_REG(ChunkGatedDeltaRule)
+
+} // namespace ge
+
+#endif // OPS_OP_PROTO_INC_CHUNK_GATED_DELTA_RULE_OPS_H_

--- a/csrc/attention/chunk_gated_delta_rule/op_host/CMakeLists.txt
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/CMakeLists.txt
@@ -1,0 +1,20 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnnExc PRIVATE
+        chunk_gated_delta_rule_def.cpp
+    )
+endif()
+
+add_modules_sources(OPTYPE chunk_gated_delta_rule ACLNNTYPE aclnn_exclude)
+

--- a/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_def.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_def.cpp
@@ -1,0 +1,95 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_def.cpp
+ * \brief
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class ChunkGatedDeltaRule : public OpDef {
+public:
+    explicit ChunkGatedDeltaRule(const char* name) : OpDef(name)
+    {
+        this->Input("query")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("key")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("value")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("beta")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("initial_state")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("actual_seq_lengths")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("g")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Output("out")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Output("final_state")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+
+        this->Attr("scale_value").AttrType(OPTIONAL).Float(1.0);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .ExtendCfgInfo("softsync.flag", "true");
+        this->AICore().AddConfig("ascend910_93");
+        this->AICore().AddConfig("ascend910b", aicoreConfig);
+
+        OpAICoreConfig config_950;
+        config_950.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .ExtendCfgInfo("softsync.flag", "true")
+            .ExtendCfgInfo("opFile.value", "chunk_gated_delta_rule_apt");
+        this->AICore().AddConfig("ascend950", config_950);
+    }
+};
+OP_ADD(ChunkGatedDeltaRule); // 添加算子信息库
+} // namespace ops

--- a/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_infershape.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_infershape.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/* !
+ * \file chunk_gated_delta_rule_infershape.cpp
+ * \brief
+ */
+
+#include "exe_graph/runtime/infer_shape_context.h"
+#include "exe_graph/runtime/shape.h"
+#include "exe_graph/runtime/storage_shape.h"
+#include "register/op_impl_registry.h"
+#include "tiling_base/error_log.h"
+#include "err/ops_err.h"
+
+using namespace gert;
+namespace ops {
+
+// 输入索引（与算子原型定义保持一致）
+const size_t QUERY_INDEX = 0;
+const size_t KEY_INDEX = 1;
+const size_t VALUE_INDEX = 2;
+const size_t BETA_INDEX = 3;
+const size_t STATE_INDEX = 4;
+const size_t ACTUAL_SEQ_LENGTHS_INDEX = 5;
+const size_t G_INDEX = 6;
+
+// 输出索引
+const size_t OUTPUT_OUT_IDX = 0;
+const size_t OUTPUT_FINAL_STATE_IDX = 1;
+const size_t VALUE_DIM = 3;
+const size_t STATE_DIM = 4;
+
+const size_t DIM_0 = 0;
+const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
+const size_t DIM_3 = 3;
+
+static ge::graphStatus InferShapeChunkGatedDeltaRule(InferShapeContext *context)
+{
+    if (context == nullptr) {
+        OP_LOGE("ChunkGatedDeltaRule", "inference context is null");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto opName = context->GetNodeName();
+    auto shapeValue = context->GetInputShape(VALUE_INDEX);
+    auto shapeInitialState = context->GetInputShape(STATE_INDEX);
+    auto shapeOut = context->GetOutputShape(DIM_0);
+    auto shapeFinalState = context->GetOutputShape(DIM_1);
+    if (shapeValue == nullptr || shapeInitialState == nullptr || shapeOut == nullptr || shapeFinalState == nullptr) {
+        OP_LOGE(opName, "[InferShape] shape is null");
+        return ge::GRAPH_FAILED;
+    }
+
+    // GetDim 之前先校验 value 和 initialState 的 DimNum 是否符合要求
+    OP_CHECK_IF(shapeValue->GetDimNum() != VALUE_DIM,
+                OP_LOGE(opName, "value dim num should be %zu, but got %zu", VALUE_DIM, shapeValue->GetDimNum()),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(
+        shapeInitialState->GetDimNum() != STATE_DIM,
+        OP_LOGE(opName, "initial_state dim num should be %zu, but got %zu", STATE_DIM, shapeInitialState->GetDimNum()),
+        return ge::GRAPH_FAILED);
+
+    // out 形状来自 value 的前三维 (T, Nv, Dv)
+    shapeOut->SetDimNum(VALUE_DIM);
+    int64_t outDim0 = shapeValue->GetDim(DIM_0);
+    int64_t outDim1 = shapeValue->GetDim(DIM_1);
+    int64_t outDim2 = shapeValue->GetDim(DIM_2);
+    shapeOut->SetDim(DIM_0, outDim0);
+    shapeOut->SetDim(DIM_1, outDim1);
+    shapeOut->SetDim(DIM_2, outDim2);
+
+    // final_state 形状与 initial_state 保持一致
+    shapeFinalState->SetDimNum(STATE_DIM);
+    int64_t stateDim0 = shapeInitialState->GetDim(DIM_0);
+    int64_t stateDim1 = shapeInitialState->GetDim(DIM_1);
+    int64_t stateDim2 = shapeInitialState->GetDim(DIM_2);
+    int64_t stateDim3 = shapeInitialState->GetDim(DIM_3);
+    shapeFinalState->SetDim(DIM_0, stateDim0);
+    shapeFinalState->SetDim(DIM_1, stateDim1);
+    shapeFinalState->SetDim(DIM_2, stateDim2);
+    shapeFinalState->SetDim(DIM_3, stateDim3);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus InferDataTypeChunkGatedDeltaRule(gert::InferDataTypeContext *context)
+{
+    if (context == nullptr) {
+        OP_LOGE("ChunkGatedDeltaRule", "inference context is null");
+        return ge::GRAPH_FAILED;
+    }
+    // 根据 query 的输入 dtype 推导 out 的 dtype, finalState 跟随 initialState
+    auto queryDtype = context->GetInputDataType(QUERY_INDEX);
+    auto stateDtype = context->GetInputDataType(STATE_INDEX);
+    context->SetOutputDataType(OUTPUT_OUT_IDX, queryDtype);
+    context->SetOutputDataType(OUTPUT_FINAL_STATE_IDX, stateDtype);
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(ChunkGatedDeltaRule)
+    .InferShape(InferShapeChunkGatedDeltaRule)
+    .InferDataType(InferDataTypeChunkGatedDeltaRule);
+} // namespace ops

--- a/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_tiling.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_tiling.cpp
@@ -1,0 +1,636 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_tiling.cpp
+ * \brief
+ */
+
+#include "chunk_gated_delta_rule_tiling.h"
+#include "../tiling_base/tiling_templates_registry.h"
+#include "register/op_def_registry.h"
+#include "platform/platform_infos_def.h"
+#include "err/ops_err.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "../op_kernel/chunk_gated_delta_rule_tiling_key.h"
+
+namespace optiling {
+REGISTER_OPS_TILING_TEMPLATE(ChunkGatedDeltaRule, ChunkGatedDeltaRuleTiling, 0);
+
+const size_t QUERY_INDEX = 0;
+const size_t KEY_INDEX = 1;
+const size_t VALUE_INDEX = 2;
+const size_t BETA_INDEX = 3;
+const size_t STATE_INDEX = 4;
+const size_t ACTUAL_SEQ_LENGTHS_INDEX = 5;
+const size_t G_INDEX = 6;
+
+const size_t OUTPUT_OUT_IDX = 0;
+const size_t OUTPUT_FINAL_STATE_IDX = 1;
+
+const size_t QKV_DIM_NUM = 3;
+const size_t BETA_DIM_NUM = 2;
+const size_t STATE_DIM_NUM = 4;
+const size_t ACTUAL_SEQ_LENGTHS_DIM_NUM = 1;
+const size_t G_DIM_NUM = 2;
+
+const size_t DIM_0 = 0;
+const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
+const size_t DIM_3 = 3;
+
+// 固定系统 workspace 大小（16 MB）
+constexpr int64_t SYS_WORKSPACE_SIZE = 16777216;
+
+// Matmul tiling 相关常量
+constexpr uint32_t MATMUL_BASE_M = 128;
+constexpr uint32_t MATMUL_BASE_K = 128;
+constexpr uint32_t MATMUL_BASE_N = 128;
+
+constexpr uint32_t STAGE_ONE_TWO = 2;
+constexpr uint32_t STAGE_ONE_THREE = 3;
+constexpr uint32_t STAGE_ONE_PARA_NUM = 4;
+constexpr uint32_t MASK_NUM = 4;
+constexpr int64_t P_NUM = 2;
+
+// 初始化编译信息，读取平台资源，并缓存核数到 tilingData_
+void ChunkGatedDeltaRuleTiling::InitCompileInfo()
+{
+    auto platformInfoPtr = context_->GetPlatformInfo();
+    if (platformInfoPtr == nullptr) {
+        OP_LOGE(context_->GetNodeName(), "platformInfoPtr is null");
+        return;
+    }
+    const auto &ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, compileInfo_.ubSize);
+    compileInfo_.aivNum = ascendcPlatform.GetCoreNumAiv();
+    compileInfo_.aicNum = ascendcPlatform.GetCoreNumAic();
+    socVersion_ = ascendcPlatform.GetSocVersion();
+
+    if (compileInfo_.aivNum <= 0 || compileInfo_.aicNum <= 0) {
+        OP_LOGE(context_->GetNodeName(), "aivNum <= 0 or aicNum <= 0");
+        return;
+    }
+    tilingData_.aiCoreNum = compileInfo_.aicNum;
+}
+
+ge::graphStatus ChunkGatedDeltaRuleTiling::GetPlatformInfo()
+{
+    return ge::GRAPH_SUCCESS;
+};
+
+// 获取输入输出信息，依次完成上下文、dtype、shape、属性、可选输入和 format 校验
+ge::graphStatus ChunkGatedDeltaRuleTiling::GetShapeAttrsInfo()
+{
+    OP_CHECK_IF(CheckContext() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid context."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetOptionalInput() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetOptionalInput."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetScale() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetScale."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeDtype() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid dtypes."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeShapes() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid shapes."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(GetStrides() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid GetStrides."),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(AnalyzeFormat() != ge::GRAPH_SUCCESS, OP_LOGE(inputParams_.opName, "Invalid Format."),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ChunkGatedDeltaRuleTiling::DoOpTiling()
+{
+    int64_t c = 64;    // chunk size 取 64
+    int64_t p = P_NUM; // 一个 chunk 组中，单核最大处理 chunk 数
+    tilingData_.chunkSize = c;
+    tilingData_.maxGroupLength = p * tilingData_.aiCoreNum * tilingData_.chunkSize;
+    tilingData_.stageOneParaNum = STAGE_ONE_PARA_NUM; // stage1 并行数
+
+    tilingData_.interWorkspaceSz = 0;
+    int64_t sizeHigh = ge::GetSizeByDataType(ge::DT_FLOAT);
+    int64_t sizeLow = ge::GetSizeByDataType(ge::DT_BF16);
+    int64_t nv = tilingData_.nv;
+    int64_t dv = tilingData_.dv;
+    int64_t dk = tilingData_.dk;
+    int64_t s = tilingData_.maxGroupLength;
+    tilingData_.interWorkspaceSz += sizeHigh * nv * s;                                   // gCumExp (FP32)
+    tilingData_.interWorkspaceSz += sizeLow * nv * s * dk;                               // kCumDecay (BF16)
+    if (tilingData_.stateIsFp32) {
+        tilingData_.interWorkspaceSz += sizeHigh * nv * s * dv;                           // vInner (FP32)
+        tilingData_.interWorkspaceSz += sizeLow * nv * s * dv;                            // vInnerBf16 (BF16, for stage3)
+    } else {
+        tilingData_.interWorkspaceSz += sizeLow * nv * s * dv;                            // vInner (BF16)
+    }
+    tilingData_.interWorkspaceSz += sizeLow * nv * s * dk;                               // qPrime (BF16)
+    tilingData_.interWorkspaceSz += sizeLow * nv * s * dv;                               // attnInter (BF16, arch22 compat)
+    tilingData_.interWorkspaceSz += sizeLow * nv * s * dk;                               // kg (BF16)
+    tilingData_.interWorkspaceSz += sizeLow * nv * s * c;                                // qkt (BF16)
+    if (tilingData_.stateIsFp32) {
+        tilingData_.interWorkspaceSz += sizeLow * nv * dv * dk;                           // stateBf16Wk (BF16, arch35)
+    } else if (socVersion_ != platform_ascendc::SocVersion::ASCEND950) {
+        tilingData_.interWorkspaceSz += sizeHigh * tilingData_.b * nv * dv * dk;         // highState_ (arch22: kernel unconditionally advances offset)
+    }
+    tilingData_.interWorkspaceSz += sizeHigh * c * c * tilingData_.aiCoreNum * MASK_NUM; // mask (FP32)
+
+    // stage1 临时变量空间
+    tilingData_.stageWorkspaceSz =
+        sizeLow * c * (STAGE_ONE_TWO * c + STAGE_ONE_THREE * dk + dv) * tilingData_.stageOneParaNum;
+    tilingData_.stageWorkspaceSz *= tilingData_.aiCoreNum;
+
+    PrintTilingData();
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ChunkGatedDeltaRuleTiling::DoMatmulTiling()
+{
+    // 计算 baseM、baseN、baseK
+    uint32_t baseM = MATMUL_BASE_M;
+    uint32_t baseK = MATMUL_BASE_K;
+    uint32_t baseN = MATMUL_BASE_N;
+
+    // ========== MT_FP32: FP32 -> FP32 ==========
+    matmul_tiling::MultiCoreMatmulTiling mm_;
+    const auto ascendcPlatform = platform_ascendc::PlatformAscendC(context_->GetPlatformInfo());
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0CSize;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L1, l1Size);
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::L0_C, l0CSize);
+    mm_.SetBufferSpace(l1Size, l0CSize, ubSize);
+    mm_.SetAType(matmul_tiling::TPosition::GM, matmul_tiling::CubeFormat::ND,
+                 matmul_tiling::DataType::DT_BFLOAT16, true);
+    mm_.SetBType(matmul_tiling::TPosition::GM, matmul_tiling::CubeFormat::ND,
+                 matmul_tiling::DataType::DT_BFLOAT16, true);
+    mm_.SetCType(matmul_tiling::TPosition::GM, matmul_tiling::CubeFormat::ND,
+                 matmul_tiling::DataType::DT_BFLOAT16);
+    mm_.SetBias(false);
+    mm_.SetDim(1);
+    mm_.SetShape(baseM, baseN, baseK);
+    mm_.SetOrgShape(baseM, baseN, baseK);
+    mm_.SetFixSplit(baseM, baseN, baseK);
+    if (mm_.GetTiling(tilingData_.matmulTilingFp32) == -1) {
+        OP_LOGE(context_->GetNodeName(), "CGDR: Get Tiling Failed!");
+        return ge::GRAPH_FAILED;
+    }
+    OP_LOGD(context_->GetNodeName(), "CGDR: baseM is %d, baseK is %d, baseN is %d.", baseM, baseK, baseN);
+    tilingData_.matmulTilingFp32.dbL0C = 1;
+    tilingData_.matmulTilingFp32.stepKa = 1;
+    tilingData_.matmulTilingFp32.stepKb = 1;
+    tilingData_.matmulTilingFp32.depthA1 = 1;
+    tilingData_.matmulTilingFp32.depthB1 = 1;
+    tilingData_.matmulTilingFp32.stepM = 1;
+    tilingData_.matmulTilingFp32.stepN = 1;
+
+    // ========== MT_FP32C: BF16 -> BF16 -> FP32 (for FP32 state path) ==========
+    if (tilingData_.stateIsFp32) {
+        matmul_tiling::MultiCoreMatmulTiling mmFp32C;
+        mmFp32C.SetBufferSpace(l1Size, l0CSize, ubSize);
+        mmFp32C.SetAType(matmul_tiling::TPosition::GM, matmul_tiling::CubeFormat::ND,
+                         matmul_tiling::DataType::DT_BFLOAT16, true);
+        mmFp32C.SetBType(matmul_tiling::TPosition::GM, matmul_tiling::CubeFormat::ND,
+                         matmul_tiling::DataType::DT_BFLOAT16, true);
+        mmFp32C.SetCType(matmul_tiling::TPosition::GM, matmul_tiling::CubeFormat::ND,
+                         matmul_tiling::DataType::DT_FLOAT);
+        mmFp32C.SetBias(false);
+        mmFp32C.SetDim(1);
+        mmFp32C.SetShape(baseM, baseN, baseK);
+        mmFp32C.SetOrgShape(baseM, baseN, baseK);
+        mmFp32C.SetFixSplit(baseM, baseN, baseK);
+        if (mmFp32C.GetTiling(tilingData_.matmulTilingFp32C) == -1) {
+            OP_LOGE(context_->GetNodeName(), "CGDR: Get Tiling Fp32C Failed!");
+            return ge::GRAPH_FAILED;
+        }
+        tilingData_.matmulTilingFp32C.dbL0C = 1;
+        tilingData_.matmulTilingFp32C.stepKa = 1;
+        tilingData_.matmulTilingFp32C.stepKb = 1;
+        tilingData_.matmulTilingFp32C.depthA1 = 1;
+        tilingData_.matmulTilingFp32C.depthB1 = 1;
+        tilingData_.matmulTilingFp32C.stepM = 1;
+        tilingData_.matmulTilingFp32C.stepN = 1;
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ChunkGatedDeltaRuleTiling::DoLibApiTiling()
+{
+    tilingKey_ = tilingData_.stateIsFp32 ? TILING_KEY_CGDR_FP32_STATE : TILING_KEY_CGDR_BF16_STATE;
+
+    // 执行 matmul tiling
+    if (DoMatmulTiling() != ge::GRAPH_SUCCESS) {
+        OP_LOGE(context_->GetNodeName(), "DoMatmulTiling failed");
+        return ge::GRAPH_FAILED;
+    }
+
+    return ge::GRAPH_SUCCESS;
+};
+
+// 返回 tiling key
+uint64_t ChunkGatedDeltaRuleTiling::GetTilingKey() const
+{
+    return tilingKey_;
+};
+
+// 计算 workspace 大小
+ge::graphStatus ChunkGatedDeltaRuleTiling::GetWorkspaceSize()
+{
+    workspaceSize_ = SYS_WORKSPACE_SIZE;
+    workspaceSize_ += tilingData_.interWorkspaceSz;
+    workspaceSize_ += tilingData_.stageWorkspaceSz;
+    return ge::GRAPH_SUCCESS;
+};
+
+ge::graphStatus ChunkGatedDeltaRuleTiling::SetScheduleConfig()
+{
+    constexpr uint32_t batchMode = 1U;
+    auto ret = context_->SetScheduleMode(batchMode);
+    OP_CHECK_IF(ret != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetScheduleMode failed, ret=%u", ret),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// 写回 tilingData 和 workspace 信息
+ge::graphStatus ChunkGatedDeltaRuleTiling::PostTiling()
+{
+    context_->SetBlockDim(tilingData_.aiCoreNum);
+
+    auto rawTilingData = context_->GetRawTilingData();
+    OP_CHECK_NULL_WITH_CONTEXT(context_, rawTilingData);
+    OP_CHECK_NULL_WITH_CONTEXT(context_, rawTilingData->GetData());
+
+    auto tilingDataSize = sizeof(ChunkGatedDeltaRule::ChunkGatedDeltaRuleTilingData);
+    OP_CHECK_IF(rawTilingData->GetCapacity() < tilingDataSize,
+                OP_LOGE(context_->GetNodeName(), "raw tiling data capacity %zu is smaller than tiling data size %zu",
+                        rawTilingData->GetCapacity(), tilingDataSize),
+                return ge::GRAPH_FAILED);
+
+    errno_t ret = memcpy_s(rawTilingData->GetData(), rawTilingData->GetCapacity(),
+                           reinterpret_cast<void *>(&tilingData_), tilingDataSize);
+    if (ret != EOK) {
+        OP_LOGE(context_->GetNodeName(), "memcpy_s failed, ret=%d", ret);
+        return ge::GRAPH_FAILED;
+    }
+    rawTilingData->SetDataSize(tilingDataSize);
+
+    size_t *workspaces = context_->GetWorkspaceSizes(1); // set workspace
+    OP_CHECK_IF(workspaces == nullptr, OPS_REPORT_CUBE_INNER_ERR(context_->GetNodeName(), "workspaces is null"),
+                return ge::GRAPH_FAILED);
+    workspaces[0] = workspaceSize_;
+
+    OP_CHECK_IF(SetScheduleConfig() != ge::GRAPH_SUCCESS, OP_LOGE(context_->GetNodeName(), "SetScheduleMode failed"),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// 校验上下文中必选输入、可选输入和输出是否存在
+ge::graphStatus ChunkGatedDeltaRuleTiling::CheckContext()
+{
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(QUERY_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(QUERY_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(KEY_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(KEY_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(VALUE_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(VALUE_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(BETA_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(BETA_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(STATE_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(STATE_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(ACTUAL_SEQ_LENGTHS_INDEX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(ACTUAL_SEQ_LENGTHS_INDEX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetOutputShape(OUTPUT_OUT_IDX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetOutputDesc(OUTPUT_OUT_IDX));
+
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetOutputShape(OUTPUT_FINAL_STATE_IDX));
+    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetOutputDesc(OUTPUT_FINAL_STATE_IDX));
+
+    auto gDesc = context_->GetOptionalInputDesc(G_INDEX);
+    auto gTensor = context_->GetOptionalInputTensor(G_INDEX);
+    auto gShape = context_->GetOptionalInputShape(G_INDEX);
+    bool hasDesc = (gDesc != nullptr);
+    bool hasTensor = (gTensor != nullptr);
+    bool hasShape = (gShape != nullptr);
+    OP_CHECK_IF((hasDesc != hasTensor) || (hasDesc != hasShape),
+                OP_LOGE(context_->GetNodeName(), "gamma desc, tensor and shape should all exist or all be null"),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// 校验输入输出 dtype：q/k/v/beta/state/out/final_state 为 bf16，actual_seq_lengths 为 int32，可选 g 为 float
+ge::graphStatus ChunkGatedDeltaRuleTiling::AnalyzeDtype()
+{
+    auto queryDtype = context_->GetInputDesc(QUERY_INDEX)->GetDataType();
+    auto keyDtype = context_->GetInputDesc(KEY_INDEX)->GetDataType();
+    auto valueDtype = context_->GetInputDesc(VALUE_INDEX)->GetDataType();
+    OP_CHECK_IF(queryDtype != ge::DT_BF16 || keyDtype != ge::DT_BF16 || valueDtype != ge::DT_BF16,
+                OP_LOGE(context_->GetNodeName(), "query dtype, key dtype and value dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+
+    auto betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
+    auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    OP_CHECK_IF(betaDtype != ge::DT_BF16,
+                OP_LOGE(context_->GetNodeName(), "beta dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(stateDtype != ge::DT_BF16 && stateDtype != ge::DT_FLOAT,
+                OP_LOGE(context_->GetNodeName(), "state dtype should be bfloat16 or float32"),
+                return ge::GRAPH_FAILED);
+    if (stateDtype == ge::DT_FLOAT && socVersion_ != platform_ascendc::SocVersion::ASCEND950) {
+        OP_LOGE(context_->GetNodeName(), "FP32 state is only supported on Ascend950");
+        return ge::GRAPH_FAILED;
+    }
+    tilingData_.stateIsFp32 = (stateDtype == ge::DT_FLOAT) ? 1 : 0;
+
+    auto actualSeqLengthsDtype = context_->GetInputDesc(ACTUAL_SEQ_LENGTHS_INDEX)->GetDataType();
+    OP_CHECK_IF(actualSeqLengthsDtype != ge::DT_INT32,
+                OP_LOGE(context_->GetNodeName(), "actual_seq_lengths dtype should be int32"), return ge::GRAPH_FAILED);
+
+    if (tilingData_.hasGamma != 0) {
+        auto gammaDtype = context_->GetOptionalInputDesc(G_INDEX)->GetDataType();
+        OP_CHECK_IF(gammaDtype != ge::DT_FLOAT, OP_LOGE(context_->GetNodeName(), "gamma dtype should be float32"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    auto outDtype = context_->GetOutputDesc(OUTPUT_OUT_IDX)->GetDataType();
+    auto finalStateDtype = context_->GetOutputDesc(OUTPUT_FINAL_STATE_IDX)->GetDataType();
+    OP_CHECK_IF(outDtype != ge::DT_BF16, OP_LOGE(context_->GetNodeName(), "output dtype should be bfloat16"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(finalStateDtype != ge::DT_BF16 && finalStateDtype != ge::DT_FLOAT,
+                OP_LOGE(context_->GetNodeName(), "final_state dtype should be bfloat16 or float32"), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(stateDtype != finalStateDtype,
+                OP_LOGE(context_->GetNodeName(),
+                        "initial_state and final_state must have the same dtype, got initial_state=%d, final_state=%d",
+                        static_cast<int>(stateDtype), static_cast<int>(finalStateDtype)),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+
+// 校验 shape 的维度数是否符合预期
+bool ChunkGatedDeltaRuleTiling::CheckDim(const gert::Shape &shape, const size_t dim, const std::string &dimDesc)
+{
+    if (shape.GetDimNum() != dim) {
+        OP_LOGE(context_->GetNodeName(), "The number of dimensions of %s should be %zu, but it is %zu", dimDesc.c_str(),
+                dim, shape.GetDimNum());
+        return false;
+    }
+    return true;
+}
+
+// 统一校验所有输入输出 shape 是否与理想 shape 一致
+ge::graphStatus ChunkGatedDeltaRuleTiling::CheckExpectedShapes(
+    const gert::Shape &queryShape, const gert::Shape &keyShape, const gert::Shape &valueShape,
+    const gert::Shape &betaShape, const gert::Shape &stateShape, const gert::Shape &actualSeqLengthsShape,
+    const gert::Shape &outShape, const gert::Shape &finalStateShape, const gert::Shape *gShape)
+{
+    const gert::Shape expectQueryShape = gert::Shape({tilingData_.t, tilingData_.nk, tilingData_.dk});
+    const gert::Shape expectKeyShape = gert::Shape({tilingData_.t, tilingData_.nk, tilingData_.dk});
+    const gert::Shape expectValueShape = gert::Shape({tilingData_.t, tilingData_.nv, tilingData_.dv});
+    const gert::Shape expectBetaShape = gert::Shape({tilingData_.t, tilingData_.nv});
+    const gert::Shape expectStateShape = gert::Shape({tilingData_.b, tilingData_.nv, tilingData_.dv, tilingData_.dk});
+    const gert::Shape expectActualSeqLengthsShape = gert::Shape({tilingData_.b});
+    const gert::Shape expectOutShape = gert::Shape({tilingData_.t, tilingData_.nv, tilingData_.dv});
+    const gert::Shape expectFinalStateShape =
+        gert::Shape({tilingData_.b, tilingData_.nv, tilingData_.dv, tilingData_.dk});
+
+    OP_CHECK_IF(queryShape != expectQueryShape, OP_LOGE(context_->GetNodeName(), "query shape is invalid"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(keyShape != expectKeyShape, OP_LOGE(context_->GetNodeName(), "key shape is invalid"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(valueShape != expectValueShape, OP_LOGE(context_->GetNodeName(), "value shape is invalid"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(betaShape != expectBetaShape, OP_LOGE(context_->GetNodeName(), "beta shape is invalid"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(stateShape != expectStateShape, OP_LOGE(context_->GetNodeName(), "state shape is invalid"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(actualSeqLengthsShape != expectActualSeqLengthsShape,
+                OP_LOGE(context_->GetNodeName(), "actual_seq_lengths shape is invalid"), return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(outShape != expectOutShape, OP_LOGE(context_->GetNodeName(), "out shape is invalid"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(finalStateShape != expectFinalStateShape,
+                OP_LOGE(context_->GetNodeName(), "final_state shape is invalid"), return ge::GRAPH_FAILED);
+
+    if (gShape != nullptr) {
+        const gert::Shape expectGShape = gert::Shape({tilingData_.t, tilingData_.nv});
+        OP_CHECK_IF(*gShape != expectGShape, OP_LOGE(context_->GetNodeName(), "g shape is invalid"),
+                    return ge::GRAPH_FAILED);
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// 校验从 shape 推导出的维度约束
+ge::graphStatus ChunkGatedDeltaRuleTiling::CheckDerivedDimConstraints()
+{
+    OP_CHECK_IF(
+        tilingData_.t <= 0 || tilingData_.b <= 0 || tilingData_.nk <= 0 || tilingData_.dk <= 0 || tilingData_.nv <= 0 ||
+            tilingData_.dv <= 0,
+        OP_LOGE(inputParams_.opName,
+                "T, B, Nk, Dk, Nv, Dv should be greater than 0, but T=%ld, B=%ld, Nk=%ld, Dk=%ld, Nv=%ld, Dv=%ld",
+                tilingData_.t, tilingData_.b, tilingData_.nk, tilingData_.dk, tilingData_.nv, tilingData_.dv),
+        return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(tilingData_.nk > 64 || tilingData_.nv > 64,
+                OP_LOGE(inputParams_.opName, "nk and nv should no bigger than 64, but nk is %ld, nv is %ld",
+                        tilingData_.nk, tilingData_.nv),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(tilingData_.dv > 128 || tilingData_.dk > 128,
+                OP_LOGE(inputParams_.opName, "dv and dk should be no bigger than 128, but dv is %ld, dk is %ld",
+                        tilingData_.dv, tilingData_.dk),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(tilingData_.nv % tilingData_.nk != 0,
+                OP_LOGE(inputParams_.opName, "nv should be an integer multiple of nk, but nv is %ld, nk is %ld",
+                        tilingData_.nv, tilingData_.nk),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// 统一校验输入输出 shape/rank 约束，并从锚点 shape 中解析 tilingData 维度
+ge::graphStatus ChunkGatedDeltaRuleTiling::AnalyzeShapes()
+{
+    const auto &queryShape = context_->GetInputShape(QUERY_INDEX)->GetOriginShape();
+    const auto &keyShape = context_->GetInputShape(KEY_INDEX)->GetOriginShape();
+    const auto &valueShape = context_->GetInputShape(VALUE_INDEX)->GetOriginShape();
+    const auto &betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
+    const auto &stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
+    const auto &actualSeqLengthsShape = context_->GetInputShape(ACTUAL_SEQ_LENGTHS_INDEX)->GetOriginShape();
+    const auto &outShape = context_->GetOutputShape(OUTPUT_OUT_IDX)->GetOriginShape();
+    const auto &finalStateShape = context_->GetOutputShape(OUTPUT_FINAL_STATE_IDX)->GetOriginShape();
+    const gert::Shape *gShape = nullptr;
+
+    // 先校验锚点 rank，保证后续 GetDim 安全
+    if (!CheckDim(queryShape, QKV_DIM_NUM, "query") || !CheckDim(valueShape, QKV_DIM_NUM, "value") ||
+        !CheckDim(stateShape, STATE_DIM_NUM, "state")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    // 从锚点 shape 中解析公共参数
+    tilingData_.t = queryShape.GetDim(DIM_0);
+    tilingData_.nk = queryShape.GetDim(DIM_1);
+    tilingData_.dk = queryShape.GetDim(DIM_2);
+    tilingData_.nv = valueShape.GetDim(DIM_1);
+    tilingData_.dv = valueShape.GetDim(DIM_2);
+    tilingData_.b = stateShape.GetDim(DIM_0);
+
+    OP_CHECK_IF(CheckDerivedDimConstraints() != ge::GRAPH_SUCCESS,
+                OP_LOGE(inputParams_.opName, "Invalid derived dim constraints."), return ge::GRAPH_FAILED);
+
+    if (tilingData_.hasGamma != 0) {
+        gShape = &context_->GetOptionalInputShape(G_INDEX)->GetOriginShape();
+    }
+
+    OP_CHECK_IF(CheckExpectedShapes(queryShape, keyShape, valueShape, betaShape, stateShape, actualSeqLengthsShape,
+                                    outShape, finalStateShape, gShape) != ge::GRAPH_SUCCESS,
+                OP_LOGE(inputParams_.opName, "Invalid shape constraints."), return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// tiling 阶段基于 primary format 做格式校验。
+// GetPrimaryFormat() 可以吸收一部分派生格式，但 NCL/NCHW 等布局不会统一折回 ND。
+// 因此这里只拦截当前明确不支持的 FRACTAL_NZ，以避免误拦其他合法的 ND 派生布局。
+bool ChunkGatedDeltaRuleTiling::CheckFormat(const gert::CompileTimeTensorDesc *desc, const std::string &name)
+{
+    auto primaryFormat = static_cast<ge::Format>(ge::GetPrimaryFormat(desc->GetStorageFormat()));
+    OP_CHECK_IF(primaryFormat == ge::FORMAT_FRACTAL_NZ,
+                OP_LOGE(context_->GetNodeName(), "%s format %s is not supported", name.c_str(),
+                        ge::TypeUtils::FormatToSerialString(primaryFormat).c_str()),
+                return false);
+    return true;
+}
+
+// 校验输入输出 format，可选 gamma 存在时也需要校验
+ge::graphStatus ChunkGatedDeltaRuleTiling::AnalyzeFormat()
+{
+    if (!CheckFormat(context_->GetInputDesc(QUERY_INDEX), "query") ||
+        !CheckFormat(context_->GetInputDesc(KEY_INDEX), "key") ||
+        !CheckFormat(context_->GetInputDesc(VALUE_INDEX), "value") ||
+        !CheckFormat(context_->GetInputDesc(BETA_INDEX), "beta") ||
+        !CheckFormat(context_->GetInputDesc(STATE_INDEX), "state") ||
+        !CheckFormat(context_->GetInputDesc(ACTUAL_SEQ_LENGTHS_INDEX), "actual_seq_lengths") ||
+        !CheckFormat(context_->GetOutputDesc(OUTPUT_OUT_IDX), "out") ||
+        !CheckFormat(context_->GetOutputDesc(OUTPUT_FINAL_STATE_IDX), "final_state")) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (tilingData_.hasGamma != 0) {
+        if (!CheckFormat(context_->GetOptionalInputDesc(G_INDEX), "gamma")) {
+            return ge::GRAPH_FAILED;
+        }
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ChunkGatedDeltaRuleTiling::GetScale()
+{
+    auto attrs = context_->GetAttrs();
+    OP_CHECK_IF(attrs == nullptr, OP_LOGE(context_->GetNodeName(), "attrs is null"), return ge::GRAPH_FAILED);
+    auto scalePtr = attrs->GetAttrPointer<float>(0);
+    OP_CHECK_IF(scalePtr == nullptr, OP_LOGE(context_->GetNodeName(), "scale attr is null"), return ge::GRAPH_FAILED);
+    tilingData_.scale = *scalePtr;
+    return ge::GRAPH_SUCCESS;
+}
+
+ ge::graphStatus ChunkGatedDeltaRuleTiling::GetStrides()
+{
+    auto strideState = context_->GetInputStride(STATE_INDEX);
+    if (strideState != nullptr && strideState->GetDimNum() == STATE_DIM_NUM) {
+        tilingData_.stateStride0 = strideState->GetStride(0);
+        tilingData_.stateStride1 = strideState->GetStride(1);
+    } else {
+        tilingData_.stateStride1 = static_cast<uint64_t>(tilingData_.dk) * static_cast<uint64_t>(tilingData_.dv);
+        tilingData_.stateStride0 = static_cast<uint64_t>(tilingData_.nv) * tilingData_.stateStride1;
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+// 负责判断 gamma 是否存在，并将状态写入 tilingData_.hasGamma（0 或 1）
+ge::graphStatus ChunkGatedDeltaRuleTiling::GetOptionalInput()
+{
+    auto gDesc = context_->GetOptionalInputDesc(G_INDEX);
+    auto gTensor = context_->GetOptionalInputTensor(G_INDEX);
+    auto gShape = context_->GetOptionalInputShape(G_INDEX);
+
+    tilingData_.hasGamma = (gDesc != nullptr && gTensor != nullptr && gShape != nullptr) ? 1 : 0;
+    return ge::GRAPH_SUCCESS;
+}
+
+
+void ChunkGatedDeltaRuleTiling::PrintTilingData()
+{
+    OP_LOGD(context_->GetNodeName(), "aiCoreNum: [%ld]", tilingData_.aiCoreNum);
+    OP_LOGD(context_->GetNodeName(), "t: [%ld]", tilingData_.t);
+    OP_LOGD(context_->GetNodeName(), "nk: [%ld]", tilingData_.nk);
+    OP_LOGD(context_->GetNodeName(), "dk: [%ld]", tilingData_.dk);
+    OP_LOGD(context_->GetNodeName(), "nv: [%ld]", tilingData_.nv);
+    OP_LOGD(context_->GetNodeName(), "dv: [%ld]", tilingData_.dv);
+    OP_LOGD(context_->GetNodeName(), "b: [%ld]", tilingData_.b);
+    OP_LOGD(context_->GetNodeName(), "hasGamma: [%ld]", tilingData_.hasGamma);
+    OP_LOGD(context_->GetNodeName(), "chunkSize: [%ld]", tilingData_.chunkSize);
+    OP_LOGD(context_->GetNodeName(), "maxGroupLength: [%ld]", tilingData_.maxGroupLength);
+    OP_LOGD(context_->GetNodeName(), "interWorkspaceSz: [%ld]", tilingData_.interWorkspaceSz);
+    OP_LOGD(context_->GetNodeName(), "stageWorkspaceSz: [%ld]", tilingData_.stageWorkspaceSz);
+    OP_LOGD(context_->GetNodeName(), "stageOneParaNum: [%ld]", tilingData_.stageOneParaNum);
+    OP_LOGD(context_->GetNodeName(), "stateStride0: [%ld]", tilingData_.stateStride0);
+    OP_LOGD(context_->GetNodeName(), "stateStride1: [%ld]", tilingData_.stateStride1);
+    OP_LOGD(context_->GetNodeName(), "scale: [%f]", tilingData_.scale);
+    OP_LOGD(context_->GetNodeName(), "stateIsFp32: [%ld]", tilingData_.stateIsFp32);
+}
+
+// tiling 调度入口
+static ge::graphStatus ChunkGatedDeltaRuleTilingFunc(gert::TilingContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_CUBE_INNER_ERR("ChunkGatedDeltaRule", "context is null"),
+                return ge::GRAPH_FAILED);
+    return Ops::Transformer::OpTiling::TilingRegistry::GetInstance().DoTilingImpl(context);
+}
+
+// tiling parse 阶段准备，校验编译信息是否存在
+static ge::graphStatus TilingPrepareForChunkGatedDeltaRule(gert::TilingParseContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_CUBE_INNER_ERR("ChunkGatedDeltaRule", "context is null"),
+                return ge::GRAPH_FAILED);
+
+    fe::PlatFormInfos *platformInfo = context->GetPlatformInfo();
+    OP_CHECK_IF(platformInfo == nullptr, OPS_REPORT_CUBE_INNER_ERR(context->GetNodeName(), "platformInfoPtr is null"),
+                return ge::GRAPH_FAILED);
+
+    auto compileInfoPtr = context->GetCompiledInfo<ChunkGatedDeltaRuleCompileInfo>();
+    OP_CHECK_IF(compileInfoPtr == nullptr, OPS_REPORT_CUBE_INNER_ERR(context->GetNodeName(), "compileInfoPtr is null"),
+                return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(ChunkGatedDeltaRule)
+    .Tiling(ChunkGatedDeltaRuleTilingFunc)
+    .TilingParse<ChunkGatedDeltaRuleCompileInfo>(TilingPrepareForChunkGatedDeltaRule);
+} // namespace optiling

--- a/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_tiling.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/chunk_gated_delta_rule_tiling.h
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_tiling.h
+ * \brief
+ */
+#ifndef __OP_HOST_CHUNK_GATED_DELTA_RULE_TILING_H__
+#define __OP_HOST_CHUNK_GATED_DELTA_RULE_TILING_H__
+
+#include <tiling/tiling_api.h>
+#include "register/tilingdata_base.h"
+#include "../tiling_base/tiling_base.h"
+#include "err/ops_err.h"
+#include "../op_kernel/chunk_gated_delta_rule_tiling_data.h"
+
+namespace optiling {
+
+struct ChunkGatedDeltaRuleCompileInfo {
+    uint64_t aivNum{0UL};
+    uint64_t aicNum{0UL};
+    uint64_t ubSize{0UL};
+};
+
+struct ChunkGatedDeltaRuleInfo {
+public:
+    int64_t usedCoreNum = 0;
+    const char *opName = "ChunkGatedDeltaRule";
+};
+
+class ChunkGatedDeltaRuleTiling : public Ops::Transformer::OpTiling::TilingBaseClass {
+public:
+    explicit ChunkGatedDeltaRuleTiling(gert::TilingContext *context)
+        : Ops::Transformer::OpTiling::TilingBaseClass(context)
+    {
+        InitCompileInfo();
+    };
+    ~ChunkGatedDeltaRuleTiling() override = default;
+
+protected:
+    bool IsCapable() override
+    {
+        return true;
+    }
+    // 1、获取平台信息比如CoreNum、UB/L1/L0C资源大小
+    ge::graphStatus GetPlatformInfo() override;
+
+    // 2、获取INPUT/OUTPUT/ATTR信息
+    ge::graphStatus GetShapeAttrsInfo() override;
+
+    // 3、计算数据切分TilingData
+    ge::graphStatus DoOpTiling() override;
+
+    // 4、计算高阶API的TilingData
+    ge::graphStatus DoLibApiTiling() override;
+
+    // 5、计算TilingKey
+    uint64_t GetTilingKey() const override;
+
+    // 6、计算Workspace 大小
+    ge::graphStatus GetWorkspaceSize() override;
+
+    // 7、保存Tiling数据
+    ge::graphStatus PostTiling() override;
+
+protected:
+    void InitCompileInfo();
+    void PrintTilingData();
+
+    ge::graphStatus CheckContext();
+    ge::graphStatus AnalyzeDtype();
+    ge::graphStatus AnalyzeShapes();
+    ge::graphStatus CheckDerivedDimConstraints();
+    ge::graphStatus GetScale();
+    ge::graphStatus GetStrides();
+    ge::graphStatus GetOptionalInput();
+    ge::graphStatus AnalyzeFormat();
+    ge::graphStatus DoMatmulTiling();
+    ge::graphStatus SetScheduleConfig();
+    ge::graphStatus CheckExpectedShapes(const gert::Shape &queryShape, const gert::Shape &keyShape,
+                                        const gert::Shape &valueShape, const gert::Shape &betaShape,
+                                        const gert::Shape &stateShape, const gert::Shape &actualSeqLengthsShape,
+                                        const gert::Shape &outShape, const gert::Shape &finalStateShape,
+                                        const gert::Shape *gShape);
+    bool CheckDim(const gert::Shape &shape, const size_t dim, const std::string &dimDesc);
+    bool CheckFormat(const gert::CompileTimeTensorDesc *desc, const std::string &name);
+
+    ChunkGatedDeltaRuleCompileInfo compileInfo_;
+    ChunkGatedDeltaRule::ChunkGatedDeltaRuleTilingData tilingData_;
+    ChunkGatedDeltaRuleInfo inputParams_;
+    platform_ascendc::SocVersion socVersion_;
+};
+
+} // namespace optiling
+#endif // __OP_HOST_CHUNK_GATED_DELTA_RULE_TILING_H__

--- a/csrc/attention/chunk_gated_delta_rule/op_host/op_api/aclnn_chunk_gated_delta_rule.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/op_api/aclnn_chunk_gated_delta_rule.cpp
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file aclnn_chunk_gated_delta_rule.cpp
+ * \brief
+ */
+
+#include "aclnn_chunk_gated_delta_rule.h"
+#include "chunk_gated_delta_rule.h"
+
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/tensor_view_utils.h"
+
+#include "aclnn_kernels/contiguous.h"
+
+using namespace op;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace {
+constexpr uint64_t INITIAL_STATE_DIMS_NUM = 4;
+
+struct ChunkGatedDeltaRuleParams {
+    // 必选输入
+    const aclTensor *query{nullptr};
+    const aclTensor *key{nullptr};
+    const aclTensor *value{nullptr};
+    const aclTensor *beta{nullptr};
+    const aclTensor *initialState{nullptr};
+    const aclTensor *actualSeqLengths{nullptr};
+    // 可选输入
+    const aclTensor *g{nullptr};
+    // 常量输入
+    float scale{1.0f};
+    // 输出
+    const aclTensor *out{nullptr};
+    const aclTensor *finalState{nullptr};
+};
+
+// 校验相关：支持的数据类型
+static const std::initializer_list<op::DataType> QKV_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
+static const std::initializer_list<op::DataType> STATE_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16, op::DataType::DT_FLOAT};
+static const std::initializer_list<op::DataType> BETA_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
+static const std::initializer_list<op::DataType> SEQ_LENS_TYPE_SUPPORT_LIST = {op::DataType::DT_INT32};
+static const std::initializer_list<op::DataType> G_TYPE_SUPPORT_LIST = {op::DataType::DT_FLOAT};
+static const std::initializer_list<op::DataType> OUT_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
+
+// 校验函数：做指针非空校验，gOptional 为可选输入，不做非空校验
+static inline bool CheckNotNull(const ChunkGatedDeltaRuleParams &params)
+{
+    OP_CHECK_NULL(params.query, return false);
+    OP_CHECK_NULL(params.key, return false);
+    OP_CHECK_NULL(params.value, return false);
+    OP_CHECK_NULL(params.initialState, return false);
+    OP_CHECK_NULL(params.beta, return false);
+    OP_CHECK_NULL(params.actualSeqLengths, return false);
+    OP_CHECK_NULL(params.out, return false);
+    OP_CHECK_NULL(params.finalState, return false);
+
+    return true;
+}
+
+// 校验函数：做 dtype 校验
+static inline bool CheckDtypeValid(const ChunkGatedDeltaRuleParams &params)
+{
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.query, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.key, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.value, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.initialState, STATE_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.beta, BETA_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.actualSeqLengths, SEQ_LENS_TYPE_SUPPORT_LIST, return false);
+
+    // gOptional 仅在非空时校验 dtype
+    if (params.g != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(params.g, G_TYPE_SUPPORT_LIST, return false);
+    }
+
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.out, OUT_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.finalState, STATE_TYPE_SUPPORT_LIST, return false);
+
+    return true;
+}
+
+// 校验函数：这里校验 dtype，shape/rank 约束由 tiling 侧保证
+static aclnnStatus CheckParams(ChunkGatedDeltaRuleParams &params)
+{
+    CHECK_RET(CheckDtypeValid(params), ACLNN_ERR_PARAM_INVALID);
+    OP_LOGD("ChunkGatedDeltaRule check params success.");
+
+    return ACLNN_SUCCESS;
+}
+
+// 预处理：同步 view 的原始 shape
+static aclnnStatus PreProcess(ChunkGatedDeltaRuleParams &params)
+{
+    params.query->SetOriginalShape(params.query->GetViewShape());
+    params.key->SetOriginalShape(params.key->GetViewShape());
+    params.value->SetOriginalShape(params.value->GetViewShape());
+    params.beta->SetOriginalShape(params.beta->GetViewShape());
+    params.initialState->SetOriginalShape(params.initialState->GetViewShape());
+    params.actualSeqLengths->SetOriginalShape(params.actualSeqLengths->GetViewShape());
+    if (params.g != nullptr) {
+        params.g->SetOriginalShape(params.g->GetViewShape());
+    }
+
+    return ACLNN_SUCCESS;
+}
+} // namespace
+
+aclnnStatus aclnnChunkGatedDeltaRuleGetWorkspaceSize(const aclTensor *query, const aclTensor *key,
+                                                     const aclTensor *value, const aclTensor *beta,
+                                                     const aclTensor *initialState, const aclTensor *actualSeqLengths,
+                                                     const aclTensor *gOptional, float scaleValue, const aclTensor *out,
+                                                     const aclTensor *finalState, uint64_t *workspaceSize,
+                                                     aclOpExecutor **executor)
+{
+    L2_DFX_PHASE_1(aclnnChunkGatedDeltaRule,
+                   DFX_IN(query, key, value, beta, initialState, actualSeqLengths, gOptional, scaleValue),
+                   DFX_OUT(out, finalState));
+
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+
+    ChunkGatedDeltaRuleParams params{query,     key,        value, beta,      initialState, actualSeqLengths,
+                                     gOptional, scaleValue, out,   finalState};
+    CHECK_RET(CheckNotNull(params), ACLNN_ERR_PARAM_INVALID);
+    CHECK_RET(CheckParams(params) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
+
+    auto ret = PreProcess(params);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+    // 空输出时直接返回，避免无效执行
+    if (out->IsEmpty() && finalState->IsEmpty()) {
+        *workspaceSize = 0;
+        uniqueExecutor.ReleaseTo(executor);
+        return ACLNN_SUCCESS;
+    }
+
+    auto query_ = l0op::Contiguous(query, uniqueExecutor.get());
+    CHECK_RET(query_ != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto key_ = l0op::Contiguous(key, uniqueExecutor.get());
+    CHECK_RET(key_ != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto value_ = l0op::Contiguous(value, uniqueExecutor.get());
+    CHECK_RET(value_ != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto beta_ = l0op::Contiguous(beta, uniqueExecutor.get());
+    CHECK_RET(beta_ != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    // 仅在Ascend950支持initialState 0或1轴非连续时传入非连续tensor，使用CreateView设置stride信息
+    int64_t *stateShapeDims = nullptr;
+    uint64_t stateShapeDimsNum = 0;
+    int64_t *stateStrideDims = nullptr;
+    uint64_t stateStrideDimsNum = 0;
+    ret = aclGetViewShape(initialState, &stateShapeDims, &stateShapeDimsNum);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+    ret = aclGetViewStrides(initialState, &stateStrideDims, &stateStrideDimsNum);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+    CHECK_RET(stateShapeDimsNum == INITIAL_STATE_DIMS_NUM && stateStrideDimsNum == INITIAL_STATE_DIMS_NUM,
+        ACLNN_ERR_INNER_CREATE_EXECUTOR);
+    auto initialState_ = initialState;
+
+    const char *socName = aclrtGetSocName();
+    CHECK_RET(socName != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    bool isAscend950 = std::strstr(socName, "Ascend950") != nullptr;
+    if (isAscend950 &&
+        stateStrideDims[stateStrideDimsNum - 1] == 1 &&
+        stateStrideDims[stateStrideDimsNum - 2] == stateShapeDims[stateShapeDimsNum - 1]) {
+        initialState_ = uniqueExecutor.get()->CreateView(
+            initialState,
+            initialState->GetViewShape(),
+            initialState->GetStorageShape(),
+            initialState->GetViewStrides(),
+            initialState->GetViewOffset());
+    } else {
+        initialState_ = l0op::Contiguous(initialState, uniqueExecutor.get());
+    }
+    CHECK_RET(initialState_ != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    
+    auto actualSeqLengths_ = l0op::Contiguous(actualSeqLengths, uniqueExecutor.get());
+    CHECK_RET(actualSeqLengths_ != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    // gOptional 为可选输入，非空时才做 contiguous
+    if (gOptional != nullptr) {
+        gOptional = l0op::Contiguous(gOptional, uniqueExecutor.get());
+        CHECK_RET(gOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    // 调用 L0 接口，得到两个输出
+    auto outRet = l0op::ChunkGatedDeltaRule(query_, key_, value_, beta_, initialState_, actualSeqLengths_, gOptional,
+                                            scaleValue, uniqueExecutor.get());
+    if (outRet[0] == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+    if (outRet[1] == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+
+    auto outRet0 = outRet[0];
+    auto outRet1 = outRet[1];
+
+    // 将 L0 输出回写到用户输出 tensor
+    // 输出 tensor 不做 Contiguous：ViewCopy 可直接写回非连续输出 tensor，
+    // 对输出在调用L0接口前调用 Contiguous 会将数据写入 workspace 而非用户 tensor， 会导致报错
+    auto ViewCopyOut = l0op::ViewCopy(outRet0, out, uniqueExecutor.get());
+    auto ViewCopyFinalState = l0op::ViewCopy(outRet1, finalState, uniqueExecutor.get());
+    if (ViewCopyOut == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+    if (ViewCopyFinalState == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+
+    // 获取计算所需 workspace 大小
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor);
+
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnChunkGatedDeltaRule(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+                                     aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnChunkGatedDeltaRule);
+    return CommonOpExecutorRun(workspace, workspaceSize, executor, stream);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/attention/chunk_gated_delta_rule/op_host/op_api/aclnn_chunk_gated_delta_rule.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/op_api/aclnn_chunk_gated_delta_rule.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+#ifndef OP_API_ACLNN_CHUNK_GATED_DELTA_RULE_H
+#define OP_API_ACLNN_CHUNK_GATED_DELTA_RULE_H
+
+#include "aclnn/aclnn_base.h"
+#include "aclnn_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ChunkGatedDeltaRule 的第一段接口，根据具体的计算流程，计算workspace大小。
+ * @param [in] query: 数据类型支持：bfloat16。
+ * @param [in] key: 数据类型支持：bfloat16。
+ * @param [in] value: 数据类型支持：bfloat16。
+ * @param [in] beta: 数据类型支持：bfloat16。
+ * @param [in] initialState: 数据类型支持：bfloat16。
+ * @param [in] actualSeqLengths: 数据类型支持：int32。
+ * @param [in] gOptional: 数据类型支持：float32。
+ * @param [in] scaleValue: 数据类型支持：float32。
+ * @param [out] out: 数据类型支持：bfloat16。
+ * @param [out] finalState: 数据类型支持：bfloat16。
+ * @param [out] 返回需要在npu device侧申请的workspace大小。
+ * @param [out] executor: 返回op执行器，包含了算子计算流程。
+ * @return aclnnStatus: 返回状态码
+ */
+ACLNN_API aclnnStatus aclnnChunkGatedDeltaRuleGetWorkspaceSize(
+    const aclTensor *query, const aclTensor *key, const aclTensor *value, const aclTensor *beta,
+    const aclTensor *initialState, const aclTensor *actualSeqLengths, const aclTensor *gOptional, float scaleValue,
+    const aclTensor *out, const aclTensor *finalState, uint64_t *workspaceSize, aclOpExecutor **executor);
+
+/**
+ * @brief
+ * @param [in] workspace: 在npu device侧申请的workspace内存起址。
+ * @param [in] workspaceSize: 在npu
+ * device侧申请的workspace大小，由第一段接口aclnnRecurrentGatedDeltaRuleGetWorkspaceSize获取。
+ * @param [in] executor: op执行器，包含了算子计算流程。
+ * @param [in] stream: acl stream流。
+ * @return aclnnStatus: 返回状态码
+ */
+ACLNN_API aclnnStatus aclnnChunkGatedDeltaRule(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+                                               aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OP_API_ACLNN_CHUNK_GATED_DELTA_RULE_H

--- a/csrc/attention/chunk_gated_delta_rule/op_host/op_api/chunk_gated_delta_rule.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/op_api/chunk_gated_delta_rule.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule.cpp
+ * \brief
+ */
+
+#include "chunk_gated_delta_rule.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_def.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "level0/fill.h"
+
+using namespace op;
+
+namespace l0op {
+OP_TYPE_REGISTER(ChunkGatedDeltaRule);
+
+const std::array<const aclTensor *, 2>
+ChunkGatedDeltaRule(const aclTensor *query, const aclTensor *key, const aclTensor *value, const aclTensor *beta,
+                    const aclTensor *initialState, const aclTensor *actualSeqLengths, const aclTensor *gOptional,
+                    float scaleValue, aclOpExecutor *executor)
+{
+    L0_DFX(ChunkGatedDeltaRule, query, key, value, beta, initialState, actualSeqLengths, gOptional, scaleValue);
+
+    DataType outType = value->GetDataType();
+    DataType stateType = initialState->GetDataType();
+    Format format = Format::FORMAT_ND;
+    auto out = executor->AllocTensor(outType, format, format);
+    auto finalState = executor->AllocTensor(stateType, format, format);
+
+    auto ret =
+        INFER_SHAPE(ChunkGatedDeltaRule, OP_INPUT(query, key, value, beta, initialState, actualSeqLengths, gOptional),
+                    OP_OUTPUT(out, finalState), OP_ATTR(scaleValue));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ChunkGatedDeltaRule InferShape failed.");
+        return {nullptr, nullptr};
+    }
+
+    ret = ADD_TO_LAUNCHER_LIST_AICORE(ChunkGatedDeltaRule,
+                                      OP_INPUT(query, key, value, beta, initialState, actualSeqLengths, gOptional),
+                                      OP_OUTPUT(out, finalState), OP_ATTR(scaleValue));
+    if (ret != ACLNN_SUCCESS) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "ChunkGatedDeltaRule ADD_TO_LAUNCHER_LIST_AICORE failed.");
+        return {nullptr, nullptr};
+    }
+
+    return {out, finalState};
+}
+} // namespace l0op

--- a/csrc/attention/chunk_gated_delta_rule/op_host/op_api/chunk_gated_delta_rule.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_host/op_api/chunk_gated_delta_rule.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+#ifndef PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE
+#define PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE
+
+#include "opdev/op_executor.h"
+#include "opdev/make_op_executor.h"
+
+namespace l0op {
+const std::array<const aclTensor *, 2>
+ChunkGatedDeltaRule(const aclTensor *query, const aclTensor *key, const aclTensor *value, const aclTensor *beta,
+                    const aclTensor *initialState, const aclTensor *actualSeqLengths, const aclTensor *gOptional,
+                    float scaleValue, aclOpExecutor *executor);
+}
+#endif // PTA_NPU_OP_API_COMMON_INC_LEVEL0_OP_CHUNK_GATED_DELTA_RULE

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule.h
@@ -1,0 +1,320 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_H
+#define CHUNK_GATED_DELTA_RULE_H
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+#include "chunk_gated_delta_rule_stage1.h"
+#include "chunk_gated_delta_rule_stage2.h"
+#include "chunk_gated_delta_rule_stage3.h"
+#include "chunk_gated_delta_rule_utils.h"
+
+namespace ChunkGatedDeltaRule {
+
+using namespace AscendC;
+
+struct CGDRInitParams {
+    GM_ADDR query;
+    GM_ADDR key;
+    GM_ADDR value;
+    GM_ADDR beta;
+    GM_ADDR initState;
+    GM_ADDR seqlens;
+    GM_ADDR gOptional;
+    GM_ADDR attnOut;
+    GM_ADDR finalState;
+};
+
+template <typename srcType, typename dstType>
+__aicore__ inline void CopyCast(
+    const GlobalTensor<srcType>& src,
+    const GlobalTensor<dstType>& dst,
+    TPipe* pipe,
+    const int64_t totalDataCount,
+    const RoundMode& roundMode)
+{
+    if ASCEND_IS_AIV {
+        int64_t blkNum = GetBlockNum();
+        int64_t blkId = GetBlockIdx();
+        int64_t dataPerCore = (totalDataCount + blkNum - 1) / blkNum;
+        int64_t startPos = dataPerCore * blkId;
+        int64_t endPos = startPos + dataPerCore;
+        if (startPos >= totalDataCount) {
+            return;
+        }
+        if (endPos > totalDataCount) {
+            endPos = totalDataCount;
+        }
+        TQue<QuePosition::VECIN, TQUE_DEPTH_TWO> inQueue;
+        TQue<QuePosition::VECOUT, TQUE_DEPTH_TWO> outQueue;
+        pipe->InitBuffer(inQueue, BUFFER_NUM_TWO, TILE_LEN * sizeof(srcType));   // use 2 buffer
+        pipe->InitBuffer(outQueue, BUFFER_NUM_TWO, TILE_LEN * sizeof(dstType));  // use 2 buffer
+        for (int64_t i = startPos; i < endPos; i += TILE_LEN) {
+            uint32_t blockLen = i + TILE_LEN > endPos ? endPos - i : TILE_LEN;
+            // copy in
+            DataCopyExtParams inParams{1, static_cast<uint32_t>(blockLen * sizeof(srcType)), 0, 0, 0};
+            DataCopyPadExtParams<srcType> inPadParams{false, 0, 0, 0};
+            auto inLocal = inQueue.AllocTensor<srcType>();
+            DataCopyPad(inLocal, src[i], inParams, inPadParams);
+            inQueue.EnQue(inLocal);
+            // cast
+            auto stateIn = inQueue.DeQue<srcType>();
+            auto stateOut = outQueue.AllocTensor<dstType>();
+            Cast(stateOut, stateIn, roundMode, blockLen);
+            outQueue.EnQue(stateOut);
+            inQueue.FreeTensor(stateIn);
+            // copy out
+            auto outLocal = outQueue.DeQue<dstType>();
+            DataCopyExtParams outParams{1, static_cast<uint32_t>(blockLen * sizeof(dstType)), 0, 0, 0};
+            DataCopyPad(dst[i], outLocal, outParams);
+            outQueue.FreeTensor(outLocal);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+}
+
+
+template <typename lowType, typename highType>
+class CGDR {
+public:
+    __aicore__ inline CGDR(TPipe *pipe, const ChunkGatedDeltaRuleTilingData *tilingData)
+        : stageOneOp_(stage1MT_)
+    {
+        pipe_ = pipe;
+        tiling_ = tilingData;
+    };
+
+    __aicore__ inline void InitMatmul()
+    {
+        if ASCEND_IS_AIC {
+            // 使用 tiling 中的 matmul tiling 数据初始化
+            stage1MT_.Init(&tiling_->matmulTilingFp32, pipe_);
+            stage2MT_.Init(&tiling_->matmulTilingFp32, pipe_);
+            stage3MT_.Init(&tiling_->matmulTilingFp32, pipe_);
+        }
+    }
+
+    __aicore__ inline void InitMask()
+    {
+        if ASCEND_IS_AIV {
+            // 初始化mask矩阵
+            uint32_t cBlockSize = tiling_->chunkSize * tiling_->chunkSize;
+            pipe_->InitBuffer(tmpBuff_, cBlockSize * sizeof(float));
+            auto cCFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(cBlockSize), 0);
+            Duplicate<float>(cCFloat_, 0, tiling_->chunkSize);
+            int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::V_MTE3));
+            SetFlag<HardEvent::V_MTE3>(eventID);
+            WaitFlag<HardEvent::V_MTE3>(eventID);
+            DataCopyExtParams copyParams;
+            copyParams.blockCount = static_cast<uint16_t>(1);
+            copyParams.blockLen = static_cast<uint32_t>(tiling_->chunkSize * sizeof(float));
+            copyParams.srcStride = static_cast<uint32_t>(0);
+            copyParams.dstStride = static_cast<uint32_t>((0) * sizeof(float));
+            for (int i = 0; i < tiling_->chunkSize; ++i) {
+                DataCopyPad(stageOneMask_[GetBlockIdx() * cBlockSize + i * tiling_->chunkSize], cCFloat_, copyParams);
+                eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::MTE3_S));
+                SetFlag<HardEvent::MTE3_S>(eventID);
+                WaitFlag<HardEvent::MTE3_S>(eventID);
+                cCFloat_.SetValue(i, 1);
+                eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_MTE3));
+                SetFlag<HardEvent::S_MTE3>(eventID);
+                WaitFlag<HardEvent::S_MTE3>(eventID);
+                DataCopyPad(stageThreeMask_[GetBlockIdx() * cBlockSize + i * tiling_->chunkSize], cCFloat_, copyParams);
+            }
+            eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::MTE3_MTE2));
+            SetFlag<HardEvent::MTE3_MTE2>(eventID); // 这里必须同步, 否则会有提前拷出的问题
+            WaitFlag<HardEvent::MTE3_MTE2>(eventID);
+            pipe_->Reset();
+        }
+    }
+
+    __aicore__ inline void Init(const CGDRInitParams &initParams, GM_ADDR user)
+    {
+        uint64_t dataSize = tiling_->t * tiling_->nk * tiling_->dk;
+        query_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.query), dataSize);
+        key_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.key), dataSize);
+
+        dataSize = tiling_->t * tiling_->nv * tiling_->dv;
+        value_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.value), dataSize);
+        out_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.attnOut), dataSize);
+
+        dataSize = tiling_->t * tiling_->nv;
+        beta_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.beta), dataSize);
+        if (initParams.gOptional != nullptr) {
+            g_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(initParams.gOptional), dataSize);
+            gFlag_ = true;
+        }
+
+        dataSize = tiling_->b * tiling_->nv * tiling_->dv * tiling_->dk;
+        initState_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.initState), dataSize);
+        finalState_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.finalState), dataSize);
+
+        actualSeqLens_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(initParams.seqlens), tiling_->b);
+
+        uint64_t offset = 0;
+        gCum_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->nv * tiling_->maxGroupLength;
+
+        kCumDecay_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dk;
+
+        vInner_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dv;
+
+        qPrime_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dk;
+
+        attnInter_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dv;
+
+        kg_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dk;
+
+        qkt_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->chunkSize;
+
+        highState_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->b * tiling_->nv * tiling_->dv * tiling_->dk;
+
+        stageOneMask_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->chunkSize * tiling_->chunkSize * tiling_->aiCoreNum * TASK_RATIO;
+
+        stageThreeMask_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->chunkSize * tiling_->chunkSize * tiling_->aiCoreNum * TASK_RATIO;
+
+        stageWsAddr_ = user + offset;
+
+        InitMatmul();
+        InitMask();
+    }
+
+    __aicore__ inline void Process()
+    {
+        SyncAll<false>();
+        int64_t seqStart = 0;
+        int64_t seqEnd = 0;
+        ChunkGroup cg;
+        cg.chunkSize = tiling_->chunkSize;
+        for (int64_t bid = 0; bid < tiling_->b; bid++) {
+            int32_t length = actualSeqLens_.GetValue(bid);
+            seqStart = seqEnd;
+            seqEnd = seqStart + (int64_t)length;
+            for (int64_t pos = seqStart; pos < seqEnd; pos += tiling_->maxGroupLength) {
+                // set chunk group
+                cg.startPos = pos;
+                if (pos + tiling_->maxGroupLength > seqEnd) {
+                    cg.length = seqEnd - pos;
+                } else {
+                    cg.length = tiling_->maxGroupLength;
+                }
+                auto curState = (pos == seqStart) ?
+                                initState_[bid * tiling_->nv * tiling_->dv * tiling_->dk] :
+                                finalState_[bid * tiling_->nv * tiling_->dv * tiling_->dk];
+                // compute this chunk group
+                RunStage1(cg);
+                SyncAll<false>();
+
+                RunStage2(cg, curState,
+                          finalState_[bid * tiling_->nv * tiling_->dv * tiling_->dk]);
+                SyncAll<false>();
+
+                RunStage3(cg);
+                SyncAll<false>();
+            }
+        }
+    }
+
+private:
+    __aicore__ inline void RunStage1(const ChunkGroup& cg)
+    {
+        GDRStageOneInitParams initStageOneParams {query_, key_, value_, beta_, g_,
+                                                gCum_, kCumDecay_, vInner_, qPrime_, kg_, qkt_,
+                                                stageWsAddr_, stageOneMask_, cg, gFlag_};
+        stageOneOp_.Init(initStageOneParams, pipe_, tiling_);
+        stageOneOp_.Process();
+        pipe_->Reset();
+    }
+
+    __aicore__ inline void RunStage2(ChunkGroup& cg, GlobalTensor<lowType> stateIn,
+                                     GlobalTensor<lowType> stateOut)
+    {
+        Stage2 stageTwoOp;
+        StageTwoParams initStageTwoParams{
+            qPrime_, vInner_, gCum_, kCumDecay_, stateIn, stateOut, kg_,
+            out_[cg.startPos * tiling_->nv * tiling_->dv], stageWsAddr_, &stage2MT_, pipe_, &cg,
+            tiling_->nv, tiling_->nk, tiling_->dv, tiling_->dk, gFlag_};
+        stageTwoOp.Init(&initStageTwoParams, tiling_->aiCoreNum);
+        stageTwoOp.Process();
+        pipe_->Reset();
+    }
+
+    __aicore__ inline void RunStage3(ChunkGroup& cg)
+    {
+        Stage3 stageThreeOp;
+        StageThreeParams initStageThreeParams{
+            qkt_, gCum_, vInner_,
+            stageThreeMask_[int(GetBlockIdx() / 2) * tiling_->chunkSize * tiling_->chunkSize],
+            stageWsAddr_, out_[cg.startPos * tiling_->nv * tiling_->dv],
+            &stage3MT_, pipe_, &cg, tiling_->scale,
+            tiling_->nv, tiling_->nk, tiling_->dv, tiling_->dk, gFlag_};
+        stageThreeOp.Init(&initStageThreeParams, tiling_->aiCoreNum);
+        stageThreeOp.Process();
+        pipe_->Reset();
+    }
+
+private:
+    TPipe *pipe_;
+    const ChunkGatedDeltaRuleTilingData *tiling_;
+    GlobalTensor<lowType> query_;
+    GlobalTensor<lowType> key_;
+    GlobalTensor<lowType> value_;
+    GlobalTensor<lowType> beta_;
+    GlobalTensor<highType> g_;
+    GlobalTensor<lowType> out_;
+    float scale_;
+    GlobalTensor<lowType> finalState_;
+    GlobalTensor<lowType> initState_;
+    GlobalTensor<int32_t> actualSeqLens_;
+
+    GlobalTensor<highType> gCum_;      // (Nv, maxGroupLength)
+    GlobalTensor<lowType> kCumDecay_;     // (Nv, maxGroupLength, Dk)
+    GlobalTensor<lowType> vInner_;       // (Nv, maxGroupLength, Dv)
+    GlobalTensor<lowType> qPrime_;        // (Nv, maxGroupLength, Dk)
+    GlobalTensor<lowType> attnInter_;    // (Nv, maxGroupLength, Dv)
+    GlobalTensor<lowType> kg_;           // (Nv, maxGroupLength, Dk)
+    GlobalTensor<lowType> qkt_;          // (Nv, maxGroupLength, C)
+    GlobalTensor<highType> highState_;
+    // mask矩阵
+    GlobalTensor<highType> stageOneMask_;          // (Nv, maxGroupLength, C)
+    GlobalTensor<highType> stageThreeMask_;          // (Nv, maxGroupLength, C)
+    GM_ADDR stageWsAddr_;                 // temporary space addr for stages
+
+    TBuf<TPosition::VECCALC> tmpBuff_;  // 构造mask矩阵
+
+    // Matmul objects
+    StageOneMT stage1MT_;
+    StageTwoMT stage2MT_;
+    StageThreeMT stage3MT_;
+
+    // Stage operators
+    Stage1 stageOneOp_;
+    bool gFlag_ = false;
+};
+
+} // namespace ChunkGatedDeltaRule
+#endif  // CHUNK_GATED_DELTA_RULE_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_stage1.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_stage1.h
@@ -1,0 +1,929 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_stage1.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_STAGE1_H
+#define CHUNK_GATED_DELTA_RULE_STAGE1_H
+
+#include "kernel_tiling/kernel_tiling.h"
+#include "chunk_gated_delta_rule_utils.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+
+namespace ChunkGatedDeltaRule {
+using namespace AscendC;
+using namespace matmul;
+
+using aT1 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using bT1 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using cT1 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using StageOneMT = matmul::MatmulImpl<aT1, bT1, cT1>;
+
+constexpr uint64_t UB_REST_BYTES = 140 * 1024;  // 140KB
+constexpr uint64_t INVERSE_SHAPE = 32;          // 对角块边长
+constexpr uint64_t INVERSE_COUNT = 5;           // 求逆所需空间
+constexpr uint32_t ALIGN_SIZE = 16;
+constexpr uint32_t MAX_PARALLEL_NUM = 6;
+constexpr uint32_t HALF_TWO = 2;
+
+// Matmul 形状参数结构体
+struct MatmulShapeParams {
+    uint64_t m;    // 原始 M 维度
+    uint64_t n;    // 原始 N 维度
+    uint64_t k;    // 原始 K 维度
+    uint64_t sm;   // 单次计算 M 维度
+    uint64_t sn;   // 单次计算 N 维度
+    uint64_t sk;   // 单次计算 K 维度
+};
+
+struct GDRStageOneInitParams {
+    // input
+    GlobalTensor<bfloat16_t> query;     // (T, Nk, Dk)
+    GlobalTensor<bfloat16_t> key;       // (T, Nk, Dk)
+    GlobalTensor<bfloat16_t> value;     // (T, Nv, Dv)
+    GlobalTensor<bfloat16_t> beta;      // (T, Nv)
+    GlobalTensor<float> g;              // (T, Nv)
+    // ouput
+    GlobalTensor<float> gCumExp;        // (Nv, cg_len)
+    GlobalTensor<bfloat16_t> kCumdecay;      // (Nv, cg_len, Dk)
+    GlobalTensor<bfloat16_t> vInner;         // (Nv, cg_len, Dv)
+    GlobalTensor<bfloat16_t> qPrime;         // (Nv, cg_len, Dk)
+    GlobalTensor<bfloat16_t> kG;             // (Nv, cg_len, Dk)
+    GlobalTensor<bfloat16_t> qK;             // (Nv, cg_len, C)
+    // other
+    GM_ADDR ws;
+    GlobalTensor<float> stageOneMask;   // (Nv, cg_len, C)
+    ChunkGroup cg;
+    bool gOptional;
+};
+
+class Stage1 {
+public:
+    __aicore__ inline Stage1(StageOneMT &mm) : mm(mm) {}
+    __aicore__ inline void SetGlobalTensors(const GDRStageOneInitParams &initParams)
+    {
+        queryGm_ = initParams.query;
+        keyGm_ = initParams.key;
+        valueGm_ = initParams.value;
+        betaGm_ = initParams.beta;
+
+        outGCumExpGm_ = initParams.gCumExp;
+        outKCumdecayGm_ = initParams.kCumdecay;
+        outVInnerGm_ = initParams.vInner;
+        outQPrimeGm_ = initParams.qPrime;
+        outKgBaseGm_ = initParams.kG;
+        outQkGm_ = initParams.qK;
+        stageOneMask_ = initParams.stageOneMask;
+
+        if (gOptional_) {
+            gGm_ = initParams.g;
+        }
+        // ckOffset_
+        uint64_t workSpaceOffset = 0;
+        uint64_t curWS = coreIdx_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+        gBKWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+
+        queryConGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+
+        keyConGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+        
+        // ccOffset_
+        curWS = coreIdx_ * paraNum_ * ccOffset_ * sizeof(bfloat16_t);
+        kkWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ccOffset_ * sizeof(bfloat16_t);
+        
+        attnWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ccOffset_ * sizeof(bfloat16_t);
+
+        // cvOffset_
+        curWS = coreIdx_ * paraNum_ * cvOffset_ * sizeof(bfloat16_t);
+        vBetaWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        maxLen_ = AscendC::Std::max(AscendC::Std::max(dvAligned_ / HALF_TWO, dkAligned_ / HALF_TWO), chunkSize_);
+        pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, chunkSize_ * maxLen_ * sizeof(float));
+        pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, chunkSize_ * maxLen_ * sizeof(float));
+        if (gOptional_) {
+            pipe_->InitBuffer(gOutQueue_, BUFFER_NUM_ONE, chunkSize_ * sizeof(float));
+        }
+
+        pipe_->InitBuffer(tmpBuff_, UB_REST_BYTES);
+        uint32_t buffOffset = 0;
+        betaUbBfloat16_ = tmpBuff_.GetWithOffset<bfloat16_t>(static_cast<uint32_t>(halfChunkSize_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(bfloat16_t);
+        
+        gCumUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(float);
+
+        gBUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(halfChunkSize_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(float);
+
+        gEndBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(halfChunkSize_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(float);
+
+        betaUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(halfChunkSize_ * paraNum_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(float) * paraNum_;
+
+        uint64_t tmpBufferLen = chunkSize_ * maxLen_ * paraNum_;
+        gBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        gammaUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        valueUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        qUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+
+        tmpBufferLen = chunkSize_ * maxLen_;
+        gTransBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        attnUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        gCumExpBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+
+        tmpBufferLen = halfChunkSize_ * dkAligned_;
+        qUbFloatCon_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        kUbFloatCon_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+
+        inputGatherBuffer_ = tmpBuff_.GetWithOffset<uint32_t>(static_cast<uint32_t>(chunkSize_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(uint32_t);
+
+        gCumSumUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_ * paraNum_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(float) * paraNum_;
+
+        gCumExpUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_ * paraNum_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(float) * paraNum_;
+
+        tmpBufferLen = halfChunkSize_ * halfChunkSize_ * INVERSE_COUNT;
+        inverseBuffer_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        qPrimeUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        vBetaUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        gBKUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        kgUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        kkLocal_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+        
+        inverseGatherBuffer_ = tmpBuff_.GetWithOffset<uint32_t>(static_cast<uint32_t>(INVERSE_SHAPE), buffOffset);
+        buffOffset += INVERSE_SHAPE * sizeof(uint32_t);
+        
+        inverseRes_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_ * halfChunkSize_), buffOffset);
+    }
+
+    __aicore__ inline void InitGatherBuffer()
+    {
+        for (uint32_t i = 0; i < chunkSize_; ++i) {
+            inputGatherBuffer_.SetValue(i, i * BLOCK_SIZE);
+        }
+        for (uint32_t i = 0; i < INVERSE_SHAPE; ++i) {
+            inverseGatherBuffer_.SetValue<uint32_t>(i, (i * chunkSize_) * sizeof(float));
+        }
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(eventID);
+        WaitFlag<HardEvent::S_V>(eventID);
+    }
+
+    __aicore__ inline void Init(const GDRStageOneInitParams &initParams, TPipe *pipe,
+                                const ChunkGatedDeltaRuleTilingData *tilingData)
+    {
+        pipe_ = pipe;
+        tiling_ = tilingData;
+        nk_ = tiling_->nk;
+        nv_ = tiling_->nv;
+        chunkSize_ = tiling_->chunkSize;
+        dk_ = tiling_->dk;
+        dv_ = tiling_->dv;
+        paraNum_ = tiling_->stageOneParaNum;
+        dkAligned_ = (dk_ + ALIGN_SIZE - 1) / ALIGN_SIZE * ALIGN_SIZE;
+        dvAligned_ = (dv_ + ALIGN_SIZE - 1) / ALIGN_SIZE * ALIGN_SIZE;
+        scale_ = tiling_->scale;
+        coreNum_ = tiling_->aiCoreNum;
+        cg_ = initParams.cg;
+        gOptional_ = initParams.gOptional;
+        vRowStride_ = nv_ * dv_;
+        numChunk_ = (cg_.length + chunkSize_ - 1) / chunkSize_;
+        subBlockIdx_ = GetSubBlockIdx();
+        halfChunkSize_ = chunkSize_ / TASK_RATIO;
+        subOffset_ = subBlockIdx_ * halfChunkSize_;
+        coreIdx_ = GetBlockIdx();
+        ccOffset_ = chunkSize_ * chunkSize_;
+        ckOffset_ = chunkSize_ * dk_;
+        cvOffset_ = chunkSize_ * dv_;
+        if ASCEND_IS_AIV {
+            coreIdx_ /= TASK_RATIO;
+            InitLocalBuffers();
+            InitGatherBuffer();
+        }
+        SetGlobalTensors(initParams);
+    }
+
+    __aicore__ inline void Process()
+    {
+        uint32_t totalChunk = nv_ * numChunk_;
+        uint32_t tailChunkNum = totalChunk / coreNum_;   // tail核处理的块数
+        uint32_t formerChunkNum = tailChunkNum + 1;      // former核处理的块数
+        uint32_t formerCoreNum = totalChunk % coreNum_;  // former核数量
+        uint32_t start;
+        uint32_t end;
+        if (coreIdx_ < formerCoreNum) {
+            start = coreIdx_ * formerChunkNum;
+            end = start + formerChunkNum;
+        } else {
+            start = formerCoreNum * formerChunkNum + (coreIdx_ - formerCoreNum) * tailChunkNum;
+            end = start + tailChunkNum;
+        }
+
+        for (uint32_t taskId = start; taskId < end; taskId += paraNum_) {
+            uint32_t curParaNum = paraNum_ < end - taskId ? paraNum_ : end - taskId;
+            // 获取每个chunk有效长度
+            for (uint32_t i = 0; i < curParaNum; ++i) {
+                uint32_t curTaskId = taskId + i;
+                uint64_t curNId = curTaskId % nv_;
+                uint64_t curCgId = curTaskId / nv_;
+                SetChunkOffset(i, curNId, curCgId);
+            }
+            ProcessParaChunk(curParaNum);
+        }
+    }
+
+private:
+    // ----------------------------------------------------------
+    // SetChunkOffset
+    //   curNId  : head 编号 (Nv 维度)
+    //   curCgId : CG 内的 chunk 编号 (0 ~ CG_CHUNKS-1)
+    // ----------------------------------------------------------
+    __aicore__ inline void SetChunkOffset(uint64_t id, uint64_t curNId, uint64_t curCgId)
+    {
+        validLenBatch_[id] = chunkSize_;
+        // 尾chunk处理
+        if (curCgId == numChunk_ - 1 && cg_.length % chunkSize_ != 0) {
+            validLenBatch_[id] = cg_.length % chunkSize_;
+        }
+        if (validLenBatch_[id] < halfChunkSize_) {
+            subValidLenBatch_[id] = (subBlockIdx_ == 0) ? validLenBatch_[id] : 0;
+        } else {
+            subValidLenBatch_[id] = (subBlockIdx_ == 0) ? halfChunkSize_ : validLenBatch_[id] - halfChunkSize_;
+        }
+        // offset
+        uint64_t cgLenPad = (cg_.length + chunkSize_ - 1) / chunkSize_ * chunkSize_;
+        chunkRowBase_[id] = curNId * cgLenPad + curCgId * chunkSize_;
+
+        chunkStartRowBatch_[id] = cg_.startPos + curCgId * chunkSize_;
+        nIdBatch_[id] = curNId;
+        bgOffsetBatch_[id] = chunkStartRowBatch_[id] * nv_ + curNId;
+    }
+
+    __aicore__ inline void ProcessParaChunk(int32_t curParaNum)
+    {
+        if ASCEND_IS_AIC {
+            ParaChunkAIC(curParaNum);
+        }
+        if ASCEND_IS_AIV {
+            ParaChunkAIV(curParaNum);
+        }
+    }
+
+    __aicore__ inline void ParaChunkAIC(int32_t curParaNum)
+    {
+        AscendC::CrossCoreWaitFlag(0x9); // 同步0
+        // key @ key.transpose(-1,-2)
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(keyConGm_[i * ckOffset_], keyConGm_[i * ckOffset_], kkWsGm_[i * ccOffset_],
+                       {chunkSize_, chunkSize_, dk_, chunkSize_, chunkSize_, dk_}, true);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(0x8); // 同步1
+
+        // query @ key.transpose(-1,-2)   stage1 out
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(queryConGm_[i * ckOffset_], keyConGm_[i * ckOffset_], outQkGm_[chunkRowBase_[i] * chunkSize_],
+                       {validLenBatch_[i], validLenBatch_[i], dk_, validLenBatch_[i], validLenBatch_[i], dk_},
+                       true);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(0xA); // 同步5
+        AscendC::CrossCoreWaitFlag(0x7); // 同步2
+
+        // 求逆左下角矩阵
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AttnInverseMMCompute(i * ccOffset_);
+        }
+        AscendC::CrossCoreWaitFlag(0x6); // 同步3
+
+        // attn @ k_cumdecay
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(attnWsGm_[i * ccOffset_], gBKWsGm_[i * ckOffset_], outKCumdecayGm_[chunkRowBase_[i] * dk_],
+                       {chunkSize_, dk_, chunkSize_, chunkSize_, dk_, chunkSize_});
+        }
+        AscendC::CrossCoreWaitFlag(0x5); // 同步4
+
+        // attn @ v_beta    stage1 out
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(attnWsGm_[i * ccOffset_], vBetaWsGm_[i * cvOffset_], outVInnerGm_[chunkRowBase_[i] * dv_],
+                       {chunkSize_, dv_, chunkSize_, chunkSize_, dv_, chunkSize_});
+        }
+    }
+
+    __aicore__ inline void ParaChunkAIV(int32_t curParaNum)
+    {
+        // 获取连续QK
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            uint64_t subRow = chunkStartRowBatch_[i] + subOffset_;
+            uint64_t qk_base = subRow * nk_ * dk_ + nIdBatch_[i] * nk_ / nv_ * dk_;
+            uint64_t wsOffset_ = i * ckOffset_ + subOffset_ * dk_;
+            outKgGm_ = outKgBaseGm_[chunkRowBase_[i] * dk_];
+            QKPreProcess(queryGm_[qk_base], queryConGm_[wsOffset_], outKgGm_, subValidLenBatch_[i]);
+            QKPreProcess(keyGm_[qk_base], keyConGm_[wsOffset_], outKgGm_, subValidLenBatch_[i], true);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x9); // 同步0
+        if (gOptional_) {
+            for (uint32_t i = 0; i < curParaNum; ++i) {
+                // g_cum_exp = g.cumsum(dim=-1).exp()
+                GCumExpCompute(gGm_[bgOffsetBatch_[i]], outGCumExpGm_[chunkRowBase_[i]],
+                               gCumSumUbFloat_[i * chunkSize_], gCumExpUbFloat_[i * chunkSize_], validLenBatch_[i]);
+                // attn_1 = (g_cum_exp[:None] / g_cum_exp[None,:]) * mask
+                uint64_t gUbOffset = i * chunkSize_ * maxLen_;
+                GammaCompute(gBroadUbFloat_[gUbOffset], gammaUbFloat_[gUbOffset], gCumSumUbFloat_[i * chunkSize_]);
+            }
+        }
+        
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            uint64_t betaUbOffset = i * halfChunkSize_;
+            BetaCopyInWithStride(betaGm_[bgOffsetBatch_[i]], betaUbFloat_[betaUbOffset], subValidLenBatch_[i]);
+        }
+        AscendC::CrossCoreWaitFlag(0x8); // 同步1
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // attn_1 = kkt * attn_1
+            KKBetaCompute(kkWsGm_[i * ccOffset_], betaUbFloat_[i * halfChunkSize_]);
+            // attn_1对角块求逆，对角块shape为INVERSE_SHAPE=32
+            InverseCompute(attnWsGm_[i * ccOffset_], gammaUbFloat_[i * chunkSize_ * maxLen_]);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x7); // 同步2
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // kg = key * (g_cum_exp[-1, None] / g_cum_exp)[..., None]
+            // k_cumdecay = -1.0 * k * beta * g_cum_exp
+            outKgGm_ = outKgBaseGm_[chunkRowBase_[i] * dk_];
+            uint64_t wsOffset_ = i * ckOffset_ + subOffset_ * dk_;
+            GBKCompute(gBKWsGm_[i * ckOffset_], outKgGm_, betaUbFloat_[i * halfChunkSize_],
+                       gCumSumUbFloat_[i * chunkSize_], gCumExpUbFloat_[i * chunkSize_], keyConGm_[wsOffset_]);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x6); // 同步3
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // v_beta = value * beta.unsqueeze(-1)  # (C, Dv)
+            uint64_t betaUbOffset = i * halfChunkSize_;
+            uint64_t vOffset = chunkStartRowBatch_[i] * vRowStride_ + nIdBatch_[i] * dv_;
+            uint64_t valueUbOffset = i * chunkSize_ * maxLen_;
+            VBetaCompute(valueGm_[vOffset], vBetaWsGm_[i * cvOffset_], betaUbFloat_[betaUbOffset],
+                         valueUbFloat_[valueUbOffset], subValidLenBatch_[i]);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x5); // 同步4
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // q_prime = query * scale_ * g_cum_exp[:, None]  # (C, Dk)
+            uint64_t wsOffset_ = i * ckOffset_ + subOffset_ * dk_;
+            QPrimeCompute(outQPrimeGm_[chunkRowBase_[i] * dk_],
+                          gCumSumUbFloat_[i * chunkSize_], gCumExpUbFloat_[i * chunkSize_], queryConGm_[wsOffset_]);
+        }
+        AscendC::CrossCoreWaitFlag(0xA); // 同步5
+    }
+    __aicore__ inline void QKPreProcess(const GlobalTensor<bfloat16_t>& srcGm, const GlobalTensor<bfloat16_t>& dstGm,
+                                        const GlobalTensor<bfloat16_t>& outKgGm,
+                                        uint32_t subValidRows, bool kgFlag = false)
+    {
+        // copyOut
+        auto tmpTensor = outQueue_.AllocTensor<bfloat16_t>();
+        if (subValidRows > 0) {
+            // copyIn
+            DataCopyInBf16WithStride(subValidRows, dk_, srcGm, nk_ * dk_);
+            LocalTensor<bfloat16_t> bf16Tensor = inQueue_.DeQue<bfloat16_t>();
+            DataCopy(tmpTensor, bf16Tensor, subValidRows * dkAligned_);
+            inQueue_.FreeTensor(bf16Tensor);
+        }
+        
+        if (subValidRows < halfChunkSize_) {
+            Duplicate(tmpTensor[subValidRows * dkAligned_], static_cast<bfloat16_t>(0.0f),
+                      (halfChunkSize_ - subValidRows) * dkAligned_);
+            PipeBarrier<PIPE_V>();
+        }
+        outQueue_.EnQue(tmpTensor);
+        tmpTensor = outQueue_.DeQue<bfloat16_t>();
+
+        uint32_t srcStride = (dkAligned_ - dk_) * sizeof(bfloat16_t) / BLOCK_SIZE;
+        DataCopyExtParams outParams{static_cast<uint16_t>(halfChunkSize_),
+                                    static_cast<uint32_t>(dk_ * sizeof(bfloat16_t)), srcStride, 0, 0};
+        DataCopyPad(dstGm, tmpTensor, outParams);
+        if (!gOptional_ && kgFlag) {
+            DataCopyPad(outKgGm[subOffset_ * dk_], tmpTensor, outParams);
+        }
+        outQueue_.FreeTensor(tmpTensor);
+    }
+
+    __aicore__ inline void GCumExpCompute(const GlobalTensor<float> src, const GlobalTensor<float> dst,
+                                          LocalTensor<float> gCumSumUbFloat, LocalTensor<float> gCumExpUbFloat,
+                                          uint32_t validLen)
+    {
+        // Copy g
+        GCopyInWithStride(src, validLen);
+        // CumSum计算
+        uint32_t outer = 1;
+        uint32_t inner = chunkSize_;
+        CumSumInfo cumSumInfo{outer, inner};
+        CumSum<float>(gCumSumUbFloat, gCumUbFloat_, gCumUbFloat_, cumSumInfo);
+        PipeBarrier<PIPE_V>();
+        // Exp计算
+        Exp<float, 0, true>(gCumExpUbFloat, gCumSumUbFloat, chunkSize_);
+        PipeBarrier<PIPE_V>();
+
+        if (subBlockIdx_ == 0) {
+            auto tmpOut = gOutQueue_.AllocTensor<float>();
+            DataCopy(tmpOut, gCumSumUbFloat, chunkSize_);
+            gOutQueue_.EnQue(tmpOut);
+            tmpOut = gOutQueue_.DeQue<float>();
+            DataCopyExtParams params{static_cast<uint16_t>(1),
+                                    static_cast<uint32_t>(validLen * sizeof(float)), 0, 0, 0};
+            DataCopyPad(dst, tmpOut, params);
+            gOutQueue_.FreeTensor(tmpOut);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void GammaCompute(const LocalTensor<float> gBroadUbFloat,
+                                        LocalTensor<float> gammaUbFloat, LocalTensor<float> gCumSumUbFloat)
+    {
+        // BroadCast
+        uint32_t divShape[2] = {chunkSize_, chunkSize_};
+        uint32_t gShape[2] = {chunkSize_, 1};
+        uint32_t gTransShape[2] = {1, chunkSize_};
+        Broadcast<float, BROADCAST_AXIS, 1>(gBroadUbFloat, gCumSumUbFloat, divShape, gShape);
+        Broadcast<float, BROADCAST_AXIS, 0>(gTransBroadUbFloat_, gCumSumUbFloat, divShape, gTransShape);
+        PipeBarrier<PIPE_V>();
+        // div
+        Sub(gammaUbFloat, gBroadUbFloat, gTransBroadUbFloat_, ccOffset_);
+        PipeBarrier<PIPE_V>();
+        // mask  1
+        DataCopyInFp32(ccOffset_, stageOneMask_[GetBlockIdx() * ccOffset_]);
+        auto maskLocal = inQueue_.DeQue<float>();
+        Mul(gammaUbFloat, gammaUbFloat, maskLocal, ccOffset_);
+        PipeBarrier<PIPE_V>();
+        // exp
+        Exp<float, 0, true>(gammaUbFloat, gammaUbFloat, ccOffset_);
+        PipeBarrier<PIPE_V>();
+        // mask  2
+        Mul(gammaUbFloat, gammaUbFloat, maskLocal, ccOffset_);
+        PipeBarrier<PIPE_V>();
+
+        inQueue_.FreeTensor(maskLocal);
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void KKBetaCompute(const GlobalTensor<bfloat16_t> src, LocalTensor<float> betaUbFloat)
+    {
+        // copy value
+        uint32_t kkLength = chunkSize_ * halfChunkSize_;
+        uint64_t kkBeginOffset = subOffset_ * chunkSize_;
+        DataCopyInBf16(kkLength, src[kkBeginOffset]);
+        auto bf16Local = inQueue_.DeQue<bfloat16_t>();
+        Cast(kkLocal_, bf16Local, RoundMode::CAST_NONE, kkLength);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(bf16Local);
+
+        uint32_t betaShape[2] = {halfChunkSize_, 1};
+        uint32_t kkShape[2] = {halfChunkSize_, chunkSize_};
+        Broadcast<float, BROADCAST_AXIS, 1>(attnUbFloat_, betaUbFloat, kkShape, betaShape);
+        PipeBarrier<PIPE_V>();
+        Mul(attnUbFloat_, kkLocal_, attnUbFloat_, chunkSize_ * halfChunkSize_);
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void InverseCompute(const GlobalTensor<bfloat16_t> dst, LocalTensor<float> gammaUbFloat)
+    {
+        uint64_t curVecLen = chunkSize_ * halfChunkSize_;
+        if (gOptional_) {
+            Mul(attnUbFloat_, attnUbFloat_, gammaUbFloat[subOffset_ * chunkSize_], curVecLen);
+        } else {
+            DataCopyInFp32(curVecLen, stageOneMask_[GetBlockIdx() * ccOffset_ + subOffset_ * chunkSize_]);
+            auto maskLocal = inQueue_.DeQue<float>();
+            Mul(attnUbFloat_, attnUbFloat_, maskLocal, curVecLen);
+            inQueue_.FreeTensor(maskLocal);
+        }
+        PipeBarrier<PIPE_V>();
+
+        Muls(inverseRes_, attnUbFloat_, static_cast<float>(-1.0), curVecLen);
+        PipeBarrier<PIPE_V>();
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::V_S));
+        SetFlag<HardEvent::V_S>(eventID);
+        WaitFlag<HardEvent::V_S>(eventID);
+
+        InverseAIV(subOffset_, INVERSE_SHAPE);
+        auto tmp = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(tmp, inverseRes_, RoundMode::CAST_RINT, curVecLen);
+        outQueue_.EnQue(tmp);
+        DataCopyOutBf16(halfChunkSize_, chunkSize_, chunkSize_, dst[subOffset_ * chunkSize_]);
+    }
+
+    __aicore__ inline void InverseAIV(uint64_t offset, uint32_t inverseVecLen)
+    {
+        PipeBarrier<PIPE_V>();
+        uint64_t inverseBufferOffset = 0;
+        auto row = inverseBuffer_[inverseBufferOffset];
+        inverseBufferOffset += inverseVecLen * inverseVecLen;
+        auto col = inverseBuffer_[inverseBufferOffset];
+        inverseBufferOffset += inverseVecLen * inverseVecLen + inverseVecLen;
+        auto yLocal = inverseBuffer_[inverseBufferOffset];
+        inverseBufferOffset += inverseVecLen * inverseVecLen;
+        auto ei = inverseBuffer_[inverseBufferOffset];
+
+        Duplicate(ei, static_cast<float>(0.0), inverseVecLen);
+        Duplicate(yLocal, static_cast<float>(0.0), inverseVecLen * inverseVecLen); // yLocal清零
+        inverseRes_.SetValue(offset, static_cast<float>(1.0));
+        
+        uint32_t srcShape[2] = {1, inverseVecLen};
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(eventID);
+        WaitFlag<HardEvent::S_V>(eventID);
+        for (int i = 1; i < inverseVecLen; ++i) {
+            uint32_t curI = i - 1;
+            uint32_t validRows = inverseVecLen - i;
+            Gather(col, attnUbFloat_[offset + i * chunkSize_ + curI], inverseGatherBuffer_, (uint32_t)0, validRows);
+            PipeBarrier<PIPE_V>();
+            uint32_t dstShape[2] = {validRows, inverseVecLen};
+            uint32_t colSrcShape[2] = {validRows, 1};
+            Broadcast<float, BROADCAST_AXIS, 1>(col[inverseVecLen], col, dstShape, colSrcShape);
+            Broadcast<float, BROADCAST_AXIS, 0>(row, inverseRes_[offset + curI * chunkSize_], dstShape, srcShape);
+            PipeBarrier<PIPE_V>();
+            MulAddDst(yLocal[i * inverseVecLen], col[inverseVecLen], row, inverseVecLen * validRows);
+            PipeBarrier<PIPE_V>();
+            int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::V_S));
+            SetFlag<HardEvent::V_S>(eventID);
+            WaitFlag<HardEvent::V_S>(eventID);
+            ei.SetValue(i - 1, static_cast<float>(0.0));
+            ei.SetValue(i, static_cast<float>(1.0));
+            eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_V));
+            SetFlag<HardEvent::S_V>(eventID);
+            WaitFlag<HardEvent::S_V>(eventID);
+            // xi = (I - SUM) / Lii = I - SUM
+            Sub(inverseRes_[offset + i * chunkSize_], ei, yLocal[i * inverseVecLen], inverseVecLen);
+            PipeBarrier<PIPE_V>();
+        }
+    }
+
+    __aicore__ inline void GBKCompute(const GlobalTensor<bfloat16_t> gBKWsGm, const GlobalTensor<bfloat16_t> outKgGm,
+                                      LocalTensor<float> betaUbFloat, LocalTensor<float> gCumSumUbFloat,
+                                      LocalTensor<float> gCumExpUbFloat, const GlobalTensor<bfloat16_t> keyContinousGm)
+    {
+        if (gOptional_) {
+            // tmp = -1.0 * beta * exp(g_cum)
+            Mul(gBUbFloat_, betaUbFloat, gCumExpUbFloat[subOffset_], halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Muls(gBUbFloat_, gBUbFloat_, static_cast<float>(-1), halfChunkSize_);
+        } else {
+            Muls(gBUbFloat_, betaUbFloat, static_cast<float>(-1), halfChunkSize_);
+        }
+        PipeBarrier<PIPE_V>();
+        // k_cumdecay = k * tmp =  -1.0 * k * beta * g_cum_exp
+        uint32_t betaShape[2] = {halfChunkSize_, 1};
+        uint32_t kShape[2] = {halfChunkSize_, dkAligned_};
+        Broadcast<float, BROADCAST_AXIS, 1>(gBKUbFloat_, gBUbFloat_, kShape, betaShape);
+        PipeBarrier<PIPE_V>();
+        // data copy in kUbFloatCon_
+        DataCopyInBf16WithStride(halfChunkSize_, dk_, keyContinousGm, dk_);
+        auto bf16Key = inQueue_.DeQue<bfloat16_t>();
+        Cast(kUbFloatCon_, bf16Key, RoundMode::CAST_NONE, halfChunkSize_ * dkAligned_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(bf16Key);
+        // compute
+        Mul(gBKUbFloat_, gBKUbFloat_, kUbFloatCon_, halfChunkSize_ * dkAligned_);
+        PipeBarrier<PIPE_V>();
+        gBKLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(gBKLocal_, gBKUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dkAligned_);
+        outQueue_.EnQue<bfloat16_t>(gBKLocal_);
+        uint64_t gBKBeginOffset = subOffset_ * dk_;
+        DataCopyOutBf16(halfChunkSize_, dk_, dkAligned_, gBKWsGm[gBKBeginOffset]);
+        PipeBarrier<PIPE_V>();
+        if (gOptional_) {
+            // kg = k * (g_cum_exp[-1, None] / g_cum_exp)[..., None]
+            uint32_t gEndShape[2] = {1, 1};
+            uint32_t gBroadShape[2] = {halfChunkSize_, 1};
+            Broadcast<float, BROADCAST_AXIS, 0>(gEndBroadUbFloat_, gCumSumUbFloat[chunkSize_ - 1],
+                                                gBroadShape, gEndShape);
+            PipeBarrier<PIPE_V>();
+            Sub(gEndBroadUbFloat_, gEndBroadUbFloat_, gCumSumUbFloat[subOffset_], halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Exp<float, 0, true>(gEndBroadUbFloat_, gEndBroadUbFloat_, halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Broadcast<float, BROADCAST_AXIS, 1>(kgUbFloat_, gEndBroadUbFloat_, kShape, gBroadShape);
+            PipeBarrier<PIPE_V>();
+            Mul(kgUbFloat_, kgUbFloat_, kUbFloatCon_, halfChunkSize_ * dkAligned_);
+            PipeBarrier<PIPE_V>();
+            uint64_t kgBeginOffset = subOffset_ * dk_;
+            kgLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+            Cast(kgLocal_, kgUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dkAligned_);
+            outQueue_.EnQue<bfloat16_t>(kgLocal_);
+            DataCopyOutBf16(halfChunkSize_, dk_, dkAligned_, outKgGm[kgBeginOffset]);  // stage1 out
+        }
+    }
+
+    __aicore__ inline void VBetaCompute(const GlobalTensor<bfloat16_t> valueGm,
+                                        const GlobalTensor<bfloat16_t> vBetaWsGm, LocalTensor<float> betaUbFloat,
+                                        LocalTensor<float> valueUbFloat, uint32_t subValidRows)
+    {
+        uint64_t vBeginOffset = subOffset_ * vRowStride_;
+        DataCopyInBf16WithStride(subValidRows, dv_, valueGm[vBeginOffset], vRowStride_);
+        valueLocal_ = inQueue_.DeQue<bfloat16_t>();
+        Cast(valueUbFloat, valueLocal_, AscendC::RoundMode::CAST_NONE, subValidRows * dvAligned_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(valueLocal_);
+        if (subValidRows < halfChunkSize_) {
+            Duplicate(valueUbFloat[subValidRows * dvAligned_], static_cast<float>(0.0f),
+                      (halfChunkSize_ - subValidRows) * dvAligned_);
+            PipeBarrier<PIPE_V>();
+        }
+        uint32_t betaShape[2] = {halfChunkSize_, 1};
+        uint32_t vShape[2] = {halfChunkSize_, dvAligned_};
+        Broadcast<float, BROADCAST_AXIS, 1>(vBetaUbFloat_, betaUbFloat, vShape, betaShape);
+        PipeBarrier<PIPE_V>();
+        Mul(vBetaUbFloat_, valueUbFloat, vBetaUbFloat_, halfChunkSize_ * dvAligned_);
+        PipeBarrier<PIPE_V>();
+        vBetaLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(vBetaLocal_, vBetaUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dvAligned_);
+        outQueue_.EnQue<bfloat16_t>(vBetaLocal_);
+        DataCopyOutBf16(halfChunkSize_, dv_, dvAligned_, vBetaWsGm[subOffset_ * dv_]);
+    }
+
+    __aicore__ inline void QPrimeCompute(const GlobalTensor<bfloat16_t> outQPrimeGm,
+                                         LocalTensor<float> gCumSumUbFloat, LocalTensor<float> gCumExpUbFloat,
+                                         const GlobalTensor<bfloat16_t> queryContinousGm)
+    {
+        // data copy in qUbFloatCon_
+        DataCopyInBf16WithStride(halfChunkSize_, dk_, queryContinousGm, dk_);
+        auto bf16Query = inQueue_.DeQue<bfloat16_t>();
+        Cast(qUbFloatCon_, bf16Query, RoundMode::CAST_NONE, halfChunkSize_ * dkAligned_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(bf16Query);
+        // query * scale
+        if (gOptional_) {
+            Muls(qUbFloat_, qUbFloatCon_, scale_, halfChunkSize_ * dkAligned_);
+            PipeBarrier<PIPE_V>();
+            uint32_t gCumExpShape[2] = {halfChunkSize_, 1};
+            uint32_t qShape[2] = {halfChunkSize_, dkAligned_};
+            Broadcast<float, BROADCAST_AXIS, 1>(gCumExpBroadUbFloat_, gCumExpUbFloat[subOffset_], qShape, gCumExpShape);
+            PipeBarrier<PIPE_V>();
+            // query * scale * exp(g_cum)[:, None]       # (C, Dk)
+            Mul(qPrimeUbFloat_, qUbFloat_, gCumExpBroadUbFloat_, halfChunkSize_ * dkAligned_);
+        } else {
+            Muls(qPrimeUbFloat_, qUbFloatCon_, scale_, halfChunkSize_ * dkAligned_);
+        }
+        PipeBarrier<PIPE_V>();
+        uint64_t qgBeginOffset = subOffset_ * dk_;
+        qPrimeLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(qPrimeLocal_, qPrimeUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dkAligned_);
+        outQueue_.EnQue<bfloat16_t>(qPrimeLocal_);
+        DataCopyOutBf16(halfChunkSize_, dk_, dkAligned_, outQPrimeGm[qgBeginOffset]);  // stage1 out
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void DataCopyInFp32(uint64_t len, GlobalTensor<float> y)
+    {
+        DataCopyPadExtParams<float> padParams;
+        DataCopyExtParams kkParams{static_cast<uint16_t>(1), static_cast<uint32_t>(len * sizeof(float)), 0, 0, 0};
+        fp32InLocal_ = inQueue_.AllocTensor<float>();
+        DataCopyPad(fp32InLocal_, y, kkParams, padParams);
+        inQueue_.EnQue<float>(fp32InLocal_);
+    }
+
+    __aicore__ inline void DataCopyInBf16(uint64_t len, GlobalTensor<bfloat16_t> y)
+    {
+        DataCopyPadExtParams<bfloat16_t> padParams;
+        DataCopyExtParams kkParams{static_cast<uint16_t>(1),
+                                static_cast<uint32_t>(len * sizeof(bfloat16_t)), 0, 0, 0};
+        bf16InLocal_ = inQueue_.AllocTensor<bfloat16_t>();
+        DataCopyPad(bf16InLocal_, y, kkParams, padParams);
+        inQueue_.EnQue<bfloat16_t>(bf16InLocal_);
+    }
+
+    __aicore__ inline void BetaCopyInWithStride(const GlobalTensor<bfloat16_t> src, LocalTensor<float> betaUbFloat,
+                                                uint32_t subValidRows)
+    {
+        uint64_t betaBeginOffset = subOffset_ * nv_;
+        DataCopyInBf16WithStride(subValidRows, 1, src[betaBeginOffset], nv_);
+        betaLocal_ = inQueue_.DeQue<bfloat16_t>();
+        if (subValidRows < halfChunkSize_) {
+            Duplicate(betaUbBfloat16_, bfloat16_t(0.0f), halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+        }
+        Gather(betaUbBfloat16_, betaLocal_, inputGatherBuffer_, static_cast<uint32_t>(0), subValidRows);
+        PipeBarrier<PIPE_V>();
+
+        Cast(betaUbFloat, betaUbBfloat16_, AscendC::RoundMode::CAST_NONE, halfChunkSize_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(betaLocal_);
+    }
+
+    __aicore__ inline void GCopyInWithStride(const GlobalTensor<float> src, uint32_t validLen)
+    {
+        DataCopyInFp32WithStride(validLen, 1, src, nv_);
+        gLocal_ = inQueue_.DeQue<float>();
+        if (validLen < chunkSize_) {
+            Duplicate(gCumUbFloat_, 0.0f, chunkSize_);
+            PipeBarrier<PIPE_V>();
+        }
+        Gather(gCumUbFloat_, gLocal_, inputGatherBuffer_, static_cast<uint32_t>(0), validLen);
+        PipeBarrier<PIPE_V>();
+
+        inQueue_.FreeTensor(gLocal_);
+    }
+
+    __aicore__ inline void DataCopyInFp32WithStride(uint64_t rows,  // 要搬的行数
+                                                    uint64_t cols,  // 每行的元素数
+                                                    const GlobalTensor<float> src,
+                                                    uint64_t srcRowStride,  // GM上相邻行的间距(元素数)
+                                                    uint32_t dstRowStride = 0)
+    {
+        DataCopyPadExtParams<float> padParams = {false, static_cast<uint8_t>(0), static_cast<uint8_t>(0),
+                                                 static_cast<float>(0)};
+        uint32_t srcGap = (srcRowStride - cols) * sizeof(float);
+        DataCopyExtParams params{static_cast<uint16_t>(rows),
+                                 static_cast<uint32_t>(cols * sizeof(float)),
+                                 static_cast<uint32_t>(srcGap), static_cast<uint32_t>(dstRowStride), 0};
+        fp32InLocal_ = inQueue_.AllocTensor<float>();
+        DataCopyPad(fp32InLocal_, src, params, padParams);
+        inQueue_.EnQue<float>(fp32InLocal_);
+    }
+
+    __aicore__ inline void DataCopyInBf16WithStride(uint64_t rows,  // 要搬的行数
+                                                    uint64_t cols,  // 每行的元素数
+                                                    GlobalTensor<bfloat16_t> src,
+                                                    uint64_t srcRowStride) // GM上相邻行的间距(元素数)
+    {
+        DataCopyPadExtParams<bfloat16_t> padParams = {false, static_cast<uint8_t>(0), static_cast<uint8_t>(0),
+                                                      static_cast<float>(0)};
+        uint32_t srcGap = (srcRowStride - cols) * sizeof(bfloat16_t);
+        DataCopyExtParams params{static_cast<uint16_t>(rows),
+                                 static_cast<uint32_t>(cols * sizeof(bfloat16_t)),
+                                 static_cast<uint32_t>(srcGap), 0, 0};
+        bf16InLocal_ = inQueue_.AllocTensor<bfloat16_t>();
+        DataCopyPad(bf16InLocal_, src, params, padParams);
+        inQueue_.EnQue<bfloat16_t>(bf16InLocal_);
+    }
+
+    __aicore__ inline void DataCopyOutBf16(uint32_t rows, uint32_t cols,
+                                        uint32_t colsAligned, GlobalTensor<bfloat16_t> y)
+    {
+        auto tmpLocal = outQueue_.DeQue<bfloat16_t>();
+        uint32_t srcStride = (colsAligned - cols) * sizeof(bfloat16_t) / BLOCK_SIZE;
+        DataCopyExtParams yGMParams{static_cast<uint16_t>(rows),
+                                    static_cast<uint32_t>(cols * sizeof(bfloat16_t)),
+                                    static_cast<uint32_t>(srcStride), 0, 0};
+        DataCopyPad(y, tmpLocal, yGMParams);
+        outQueue_.FreeTensor(tmpLocal);
+    }
+
+    __aicore__ inline void AttnInverseMMCompute(uint64_t offset)
+    {
+        uint64_t leftDown = offset + chunkSize_ * INVERSE_SHAPE;
+        uint64_t rightDown = leftDown + INVERSE_SHAPE;
+        // 右矩阵左下角 @ 右矩阵左上角 -> 右矩阵左下角
+        InverseAICProcess(attnWsGm_[leftDown], attnWsGm_[offset], attnWsGm_[leftDown]);
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::FIX_MTE2));
+        SetFlag<HardEvent::FIX_MTE2>(eventID);
+        WaitFlag<HardEvent::FIX_MTE2>(eventID);
+        // 右矩阵右下角 @ 右矩阵左下角 -> 右矩阵左下角
+        InverseAICProcess(attnWsGm_[rightDown], attnWsGm_[leftDown], attnWsGm_[leftDown]);
+        eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::FIX_MTE2));
+        SetFlag<HardEvent::FIX_MTE2>(eventID);
+        WaitFlag<HardEvent::FIX_MTE2>(eventID);
+    }
+
+    __aicore__ inline void AICProcess(GlobalTensor<bfloat16_t> x, GlobalTensor<bfloat16_t> y,
+                                      GlobalTensor<bfloat16_t> z, const MatmulShapeParams &shape, bool transB = false)
+    {
+        mm.SetOrgShape(shape.m, shape.n, shape.k);
+        mm.SetSingleShape(shape.sm, shape.sn, shape.sk);
+        mm.SetTensorA(x);
+        mm.SetTensorB(y, transB);
+        mm.IterateAll(z);
+        mm.End();
+    }
+
+    __aicore__ inline void InverseAICProcess(GlobalTensor<bfloat16_t> x, GlobalTensor<bfloat16_t> y,
+                                             GlobalTensor<bfloat16_t> z)
+    {
+        mm.SetOrgShape(chunkSize_, chunkSize_, chunkSize_);
+        mm.SetSingleShape(INVERSE_SHAPE, INVERSE_SHAPE, INVERSE_SHAPE);
+        mm.SetTensorA(x);
+        mm.SetTensorB(y);
+        mm.IterateAll(z);
+        mm.End();
+    }
+    
+    TPipe *pipe_;
+    StageOneMT &mm;
+    const ChunkGatedDeltaRuleTilingData *tiling_;
+    ChunkGroup cg_;
+    uint32_t nk_;
+    uint32_t nv_;
+    uint32_t dk_;
+    uint32_t dv_;
+    uint32_t dkAligned_;
+    uint32_t dvAligned_;
+    uint32_t numChunk_;
+    uint64_t vRowStride_;
+    uint32_t halfChunkSize_;
+    uint32_t subBlockIdx_;
+    uint32_t subOffset_;
+    uint32_t coreIdx_;
+    uint32_t chunkSize_;
+    uint32_t maxLen_;
+    uint32_t coreNum_;
+    float scale_;
+    bool gOptional_;
+    uint32_t paraNum_;
+    uint64_t ccOffset_;
+    uint64_t ckOffset_;
+    uint64_t cvOffset_;
+    uint32_t validLenBatch_[MAX_PARALLEL_NUM];
+    uint32_t subValidLenBatch_[MAX_PARALLEL_NUM];
+    uint32_t chunkRowBase_[MAX_PARALLEL_NUM];
+    uint64_t chunkStartRowBatch_[MAX_PARALLEL_NUM];
+    uint64_t nIdBatch_[MAX_PARALLEL_NUM];
+    uint64_t bgOffsetBatch_[MAX_PARALLEL_NUM];
+
+    // chunk GM pointers
+    GlobalTensor<bfloat16_t> queryGm_;
+    GlobalTensor<bfloat16_t> keyGm_;
+    GlobalTensor<bfloat16_t> valueGm_;
+    GlobalTensor<bfloat16_t> betaGm_;
+    GlobalTensor<float> gGm_;
+    GlobalTensor<float> outGCumExpGm_;
+    GlobalTensor<bfloat16_t> outKCumdecayGm_;
+    GlobalTensor<bfloat16_t> outVInnerGm_;
+    GlobalTensor<bfloat16_t> outQPrimeGm_;
+    GlobalTensor<bfloat16_t> outKgBaseGm_;
+    GlobalTensor<bfloat16_t> outKgGm_;
+    GlobalTensor<bfloat16_t> outQkGm_;
+    GlobalTensor<bfloat16_t> vBetaWsGm_;
+    GlobalTensor<bfloat16_t> kkWsGm_;
+    GlobalTensor<bfloat16_t> attnWsGm_;
+    GlobalTensor<bfloat16_t> gBKWsGm_;
+    GlobalTensor<bfloat16_t> queryConGm_;
+    GlobalTensor<bfloat16_t> keyConGm_;
+    GlobalTensor<float> stageOneMask_;
+
+    // UB queues
+    TQue<QuePosition::VECIN, 1> inQueue_;
+    TQue<QuePosition::VECOUT, 1> outQueue_;
+    TQue<QuePosition::VECOUT, 1> gOutQueue_;
+
+    TBuf<TPosition::VECCALC> tmpBuff_;
+
+    // UB tensors
+    LocalTensor<bfloat16_t> betaUbBfloat16_;
+    LocalTensor<float> betaUbFloat_;
+    LocalTensor<float> valueUbFloat_;
+    LocalTensor<float> attnUbFloat_;
+    LocalTensor<float> inverseBuffer_;
+    LocalTensor<float> inverseRes_;
+    LocalTensor<float> gCumUbFloat_;
+    LocalTensor<float> gCumSumUbFloat_;
+    LocalTensor<float> gCumExpUbFloat_;
+    LocalTensor<float> gCumExpBroadUbFloat_;
+    LocalTensor<float> gBUbFloat_;
+    LocalTensor<float> qUbFloat_;
+    LocalTensor<float> gBroadUbFloat_;
+    LocalTensor<float> gTransBroadUbFloat_;
+    LocalTensor<float> gEndBroadUbFloat_;
+    LocalTensor<float> gammaUbFloat_;
+    LocalTensor<uint32_t> inverseGatherBuffer_;
+    LocalTensor<float> qUbFloatCon_;
+    LocalTensor<float> kUbFloatCon_;
+    LocalTensor<float> gBKUbFloat_;
+    LocalTensor<float> kgUbFloat_;
+    LocalTensor<float> vBetaUbFloat_;
+    LocalTensor<float> qPrimeUbFloat_;
+    LocalTensor<uint32_t> inputGatherBuffer_;
+
+    LocalTensor<bfloat16_t> betaLocal_;
+    LocalTensor<bfloat16_t> valueLocal_;
+    LocalTensor<bfloat16_t> qPrimeLocal_;
+    LocalTensor<bfloat16_t> vBetaLocal_;
+    LocalTensor<float> kkLocal_;
+    LocalTensor<float> gLocal_;
+    LocalTensor<bfloat16_t> gBKLocal_;
+    LocalTensor<bfloat16_t> kgLocal_;
+    
+    LocalTensor<bfloat16_t> bf16InLocal_;
+    LocalTensor<float> fp32InLocal_;
+};
+} // namespace ChunkGatedDeltaRule
+#endif // CHUNK_GATED_DELTA_RULE_STAGE1_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_stage2.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_stage2.h
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule_stage2.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_STAGE2_H
+#define CHUNK_GATED_DELTA_RULE_STAGE2_H
+
+#include "kernel_tiling/kernel_tiling.h"
+#include "chunk_gated_delta_rule_utils.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+
+namespace ChunkGatedDeltaRule {
+using namespace AscendC;
+using namespace matmul;
+
+using aT2 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using bT2 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using cT2 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using StageTwoMT = matmul::MatmulImpl<aT2, bT2, cT2>;
+
+struct StageTwoParams {
+    GlobalTensor<bfloat16_t> qPrime;    // (Nv, Sp, Dk)
+    GlobalTensor<bfloat16_t> vInner;    // (Nv, Sp, Dv)
+    GlobalTensor<float> gCum;   // (Nv, Sp)
+    GlobalTensor<bfloat16_t> kCumdecay; // (Nv, Sp, Dk)
+    GlobalTensor<bfloat16_t> curState;  // (Nv, Dv, Dk)
+    GlobalTensor<bfloat16_t> finalState;  // (Nv, Dv, Dk)
+    GlobalTensor<bfloat16_t> kg;
+    GlobalTensor<bfloat16_t> out;
+    GM_ADDR ws;
+    StageTwoMT *mm1;
+    TPipe *pipe;
+    ChunkGroup *cg;
+    int64_t Nv;
+    int64_t Nk;
+    int64_t Dv;
+    int64_t Dk;
+    bool gOptional;
+};
+
+class Stage2 {
+public:
+    __aicore__ inline void Init(StageTwoParams *initParams, int32_t coreNum)
+    {
+        sTP_ = initParams;
+        pipe_ = sTP_->pipe;
+        chunkSize_ = sTP_->cg->chunkSize;
+        seqLength_ = sTP_->cg->length;
+        Sp_ = (seqLength_ + chunkSize_ - 1) / chunkSize_  * chunkSize_;
+        chunkNum_ = Sp_ / chunkSize_;
+        coreNum_ = coreNum;
+        Nv_ = sTP_->Nv;
+        Nk_ = sTP_->Nk;
+        Dv_ = sTP_->Dv;
+        Dk_ = sTP_->Dk;
+        curDk_ = Ceil(Dk_, BLOCK_SIZE / sizeof(bfloat16_t)) * (BLOCK_SIZE / sizeof(bfloat16_t));
+        curChunkSize_ = chunkSize_;
+        gOptional_ = sTP_->gOptional;
+        InitLocalBuffers();
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        if ASCEND_IS_AIC {
+            return;
+        }
+        pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, Std::max((uint64_t)chunkSize_,
+                                                             (uint64_t)Dv_) * curDk_ * sizeof(bfloat16_t));
+        uint64_t outQueueSize = Std::max((uint64_t)chunkSize_ * chunkSize_ * sizeof(bfloat16_t),
+                                         (uint64_t)Dv_ * curDk_ * sizeof(bfloat16_t));
+        pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, outQueueSize);
+        pipe_->InitBuffer(tmpBuff_, (Std::max((uint64_t)chunkSize_, (uint64_t)Dv_) * curDk_ +
+                                     BLOCK_FLOAT_NUM) *sizeof(float));
+        uint32_t buffOffset = 0;
+        tmpBuffer1_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(Dv_ * curDk_), buffOffset);
+        buffOffset += Ceil(Dv_ * curDk_ * sizeof(float), BLOCK_SIZE) * BLOCK_SIZE;
+        // 暂存所取的最后一位数
+        lastGCum_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(NUM_ONE), buffOffset);
+    }
+
+    __aicore__ inline void Process()
+    {
+        int64_t coreId = GetBlockIdx();
+        if ASCEND_IS_AIV {
+            coreId /= AIC_AIV_1_1;
+        }
+        int64_t nvPerCore = (Nv_ + coreNum_ - 1) / coreNum_;
+        int64_t nvStart = coreId * nvPerCore;
+        int64_t nvEnd = nvStart + nvPerCore;
+        nvEnd = nvEnd > Nv_ ? Nv_ : nvEnd;
+        int64_t lastChunkSize = seqLength_ % chunkSize_ == 0 ? chunkSize_ : seqLength_ % chunkSize_;
+        for (int64_t nvId = nvStart; nvId < nvEnd; nvId++) {
+            curChunkSize_ = chunkSize_;
+            for (int64_t cId = 0; cId < chunkNum_; cId++) {
+                auto curState = (cId == 0) ? sTP_->curState[nvId * Dv_ * Dk_] : sTP_->finalState[nvId * Dv_ * Dk_];
+                auto finalState = sTP_->finalState[nvId * Dv_ * Dk_];
+                int64_t length = cId * chunkSize_;
+                if (cId == chunkNum_ - 1) {
+                    curChunkSize_ = lastChunkSize;
+                }
+                if ASCEND_IS_AIV {
+                    if (GetSubBlockIdx() == 0) {
+                        CopyIn(curState, Dv_, Dk_);
+                        CalGCumExp(sTP_->gCum[nvId * Sp_ + length]);
+                    }
+                    CrossCoreWaitFlag(0x2);
+                    if (GetSubBlockIdx() == 0) {
+                        CopyOutState(finalState);
+                    }
+                    CrossCoreSetFlag<0x2, PIPE_MTE3>(0x5);
+                    CrossCoreWaitFlag(0x4);
+                }
+                if ASCEND_IS_AIC {
+                    uint64_t mm_offset0 = nvId * Sp_ * Dk_ + length * Dk_;
+                    uint64_t mm_offset1 = nvId * Sp_ * Dv_ + length * Dv_;
+                    CalVPrime(sTP_->kCumdecay[mm_offset0], curState, sTP_->vInner[mm_offset1]);
+                    CalAttnInter(sTP_->qPrime[mm_offset0], curState,
+                                 sTP_->out[nvId * Dv_ + cId * chunkSize_ * Nv_ * Dv_]);
+                    CrossCoreSetFlag<0x2, PIPE_FIX>(0x2);   // 读完之前AIV不能写
+                    CrossCoreWaitFlag(0x5);
+                    CalStateNew(sTP_->vInner[mm_offset1], sTP_->kg[mm_offset0], finalState);
+                    SetFlag<HardEvent::FIX_MTE2>(FIX_MTE2_EVENT);
+                    WaitFlag<HardEvent::FIX_MTE2>(FIX_MTE2_EVENT);
+                    CrossCoreSetFlag<0x2, PIPE_FIX>(0x4);
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void CalGCumExp(GlobalTensor<float> gCum)
+    {
+        if (gOptional_) {
+            // 刷新cache
+            DataCacheCleanAndInvalid<float,
+                                     CacheLine::SINGLE_CACHE_LINE,
+                                     DcciDst::CACHELINE_OUT>(gCum[curChunkSize_ - 1]);
+            float tmpFloat = gCum.GetValue(curChunkSize_ - 1);
+            lastGCum_.SetValue(0, tmpFloat);
+            SetFlag<HardEvent::S_V>(S_V_EVENT);
+            WaitFlag<HardEvent::S_V>(S_V_EVENT);
+            Exp<float, 0, true>(lastGCum_, lastGCum_, 1);
+        } else {
+            lastGCum_.SetValue(0, 1.0f);
+        }
+        float tmpFloat = lastGCum_.GetValue(0);
+        auto stateIn = inQueue_.DeQue<bfloat16_t>();
+        auto stateOut = outQueue_.AllocTensor<bfloat16_t>();
+        SetFlag<HardEvent::MTE2_V>(MTE2_V_EVENT);
+        WaitFlag<HardEvent::MTE2_V>(MTE2_V_EVENT);
+        Cast(tmpBuffer1_, stateIn, RoundMode::CAST_NONE, Dv_ * curDk_);
+        SetFlag<HardEvent::S_V>(S_V_EVENT);
+        WaitFlag<HardEvent::S_V>(S_V_EVENT);
+        Muls(tmpBuffer1_, tmpBuffer1_, tmpFloat, Dv_ * curDk_);
+        Cast(stateOut, tmpBuffer1_, RoundMode::CAST_RINT, Dv_ * curDk_);
+        SetFlag<HardEvent::V_MTE3>(V_MTE3_EVENT);
+        WaitFlag<HardEvent::V_MTE3>(V_MTE3_EVENT);
+        outQueue_.EnQue(stateOut);
+        inQueue_.FreeTensor(stateIn);
+    }
+
+    __aicore__ inline void CalAttnInter(GlobalTensor<bfloat16_t> qPrime,
+                                        GlobalTensor<bfloat16_t> state,
+                                        GlobalTensor<bfloat16_t> out)
+    {
+        // q_prime @ state.transpose(0, 1)
+        sTP_->mm1->SetOrgShape(curChunkSize_, Dv_, Dk_, Dk_, Nv_ * Dv_);    // MNKaKbN
+        sTP_->mm1->SetSingleShape(curChunkSize_, Dv_, Dk_);                 // SingleCoreMNK
+        sTP_->mm1->SetTensorA(qPrime, false);
+        sTP_->mm1->SetTensorB(state, true);
+        sTP_->mm1->IterateAll(out);
+        sTP_->mm1->End();
+    }
+
+    __aicore__ inline void CalVPrime(GlobalTensor<bfloat16_t> kCumdecay,
+                                     GlobalTensor<bfloat16_t> state,
+                                     GlobalTensor<bfloat16_t> vPrime)
+    {
+        // v_inner += k_cumdecay @ state.transpose(0, 1)
+        sTP_->mm1->SetOrgShape(curChunkSize_, Dv_, Dk_);    // MNK
+        sTP_->mm1->SetSingleShape(curChunkSize_, Dv_, Dk_); // SingleCoreMNK
+        sTP_->mm1->SetTensorA(kCumdecay, false);
+        sTP_->mm1->SetTensorB(state, true);
+        sTP_->mm1->IterateAll(vPrime, 1);
+        sTP_->mm1->End();
+    }
+
+    __aicore__ inline void CalStateNew(GlobalTensor<bfloat16_t> vInner,
+                                       GlobalTensor<bfloat16_t> kg,
+                                       GlobalTensor<bfloat16_t> state)
+    {
+        // state_out = v_new.transpose(0, 1) @ kg
+        sTP_->mm1->SetOrgShape(Dv_, Dk_, curChunkSize_);    // MNK
+        sTP_->mm1->SetSingleShape(Dv_, Dk_, curChunkSize_); // SingleCoreMNK
+        sTP_->mm1->SetTensorA(vInner, true);
+        sTP_->mm1->SetTensorB(kg, false);
+        sTP_->mm1->IterateAll(state, 1);
+        sTP_->mm1->End();
+    }
+
+    template <typename inType>
+    __aicore__ inline void CopyIn(GlobalTensor<inType> tmpGM, int32_t row, int32_t col)
+    {
+        LocalTensor<inType> inLocal = inQueue_.AllocTensor<inType>();
+        DataCopyExtParams inParams{static_cast<uint16_t>(row),
+                                   static_cast<uint32_t>(col * sizeof(inType)), // 非对齐情况需要补0
+                                   static_cast<uint32_t>(0),
+                                   0, 0};
+        int padding = Ceil(col, BLOCK_SIZE / sizeof(inType)) * (BLOCK_SIZE / sizeof(inType)) - col;
+        DataCopyPadExtParams<inType> copyPadParams{true, 0, static_cast<uint8_t>(padding), 0};
+        DataCopyPad(inLocal, tmpGM, inParams, copyPadParams);
+        inQueue_.EnQue(inLocal);
+    }
+
+    __aicore__ inline void CopyOutState(GlobalTensor<bfloat16_t> stateNew)
+    {
+        CopyOut<bfloat16_t>(stateNew, Dv_, Dk_, false);
+    }
+
+    template <typename outType>
+    __aicore__ inline void CopyOut(GlobalTensor<outType> tmpGM, int32_t row, int32_t col, bool setAtomic = false)
+    {
+        auto outLocal = outQueue_.DeQue<outType>();
+        DataCopyExtParams copyParams;
+        copyParams.blockCount = static_cast<uint16_t>(row);
+        copyParams.blockLen = static_cast<uint32_t>(col * sizeof(outType));
+        copyParams.srcStride = static_cast<uint32_t>(0);
+        copyParams.dstStride = static_cast<uint32_t>(0);
+        if (setAtomic) {
+            SetAtomicAdd<outType>();
+        }
+        DataCopyPad(tmpGM, outLocal, copyParams);
+        if (setAtomic) {
+            SetAtomicNone();
+        }
+        outQueue_.FreeTensor(outLocal);
+    }
+
+private:
+    StageTwoParams *sTP_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, BUFFER_NUM_ONE> inQueue_;
+    TQue<QuePosition::VECOUT, BUFFER_NUM_ONE> outQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff_;
+    LocalTensor<float> tmpBuffer1_;
+    LocalTensor<float> lastGCum_;
+    int64_t Nk_;
+    int64_t Nv_;
+    int64_t Dk_;
+    int64_t Dv_;
+    int64_t seqLength_;
+    int32_t chunkSize_;
+    int32_t curChunkSize_;
+    int32_t curDk_;
+    int64_t Sp_;
+    int32_t chunkNum_;
+    int32_t coreNum_;
+    bool gOptional_;
+};
+} // namespace ChunkGatedDeltaRule
+#endif // CHUNK_GATED_DELTA_RULE_STAGE2_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_stage3.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_stage3.h
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_stage3.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_STAGE3_H
+#define CHUNK_GATED_DELTA_RULE_STAGE3_H
+
+#include "kernel_tiling/kernel_tiling.h"
+#include "chunk_gated_delta_rule_utils.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+
+namespace ChunkGatedDeltaRule {
+using namespace AscendC;
+using namespace matmul;
+
+using aT3 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using bT3 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using cT3 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using StageThreeMT = matmul::MatmulImpl<aT3, bT3, cT3>;
+
+struct StageThreeParams {
+    GlobalTensor<bfloat16_t> qkt;       // (Nv, Sp, Dk)
+    GlobalTensor<float> gCumExp;           // (Nv, Sp)
+    GlobalTensor<bfloat16_t> vInner;
+    GlobalTensor<float> maskTensor;
+    GM_ADDR ws;
+    GlobalTensor<bfloat16_t> attnOut;
+    StageThreeMT *mm3;
+    TPipe *pipe;
+    ChunkGroup *cg;
+    float scale;
+    int64_t Nv;
+    int64_t Nk;
+    int64_t Dv;
+    int64_t Dk;
+    bool gOptional;
+};
+
+class Stage3 {
+public:
+    __aicore__ inline void Init(StageThreeParams *initParams, int32_t coreNum)
+    {
+        coreId_ = GetBlockIdx();
+        sTP_ = initParams;
+        pipe_ = sTP_->pipe;
+        chunkSize_ = sTP_->cg->chunkSize;
+        seqLength_ = sTP_->cg->length;
+        Sp_ = (seqLength_ + chunkSize_ - 1) / chunkSize_  * chunkSize_;
+        chunkNum_ = (seqLength_ + chunkSize_ - 1) / chunkSize_ ;
+        coreNum_ = coreNum;
+        Nv_ = sTP_->Nv;
+        Nk_ = sTP_->Nk;
+        Dv_ = sTP_->Dv;
+        Dk_ = sTP_->Dk;
+        paddedDv_ = Ceil(Dv_, BLOCK_SIZE / sizeof(bfloat16_t)) * (BLOCK_SIZE / sizeof(bfloat16_t));
+        gOptional_ = sTP_->gOptional;
+        uint64_t workSpaceOffset = 0;
+        tmpGM_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(
+                               initParams->ws + workSpaceOffset +
+                               coreNum_ * chunkSize_ * chunkSize_ * sizeof(float)));
+        if ASCEND_IS_AIC {
+            return;
+        }
+        coreId_ /= AIC_AIV_1_1;
+        if (GetSubBlockIdx() == 1) {
+            return;
+        }
+        uint64_t inQueueSize = static_cast<uint64_t>(chunkSize_) *
+                               AscendC::Std::max((int64_t)chunkSize_, paddedDv_) * sizeof(bfloat16_t);
+        pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, inQueueSize);
+        pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, chunkSize_ > paddedDv_ ?
+                          chunkSize_ * chunkSize_ * sizeof(float) : chunkSize_ * paddedDv_ * sizeof(bfloat16_t));
+        pipe_->InitBuffer(tmpBuff_, (STAGE3_BUFFER_COUNT * chunkSize_ * chunkSize_ * sizeof(float)));
+        uint64_t buffOffset = 0;
+        uint64_t tmpOffset = chunkSize_ * chunkSize_;
+        tmpBuffer1_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpOffset), buffOffset);
+        buffOffset += tmpOffset * sizeof(float);
+        tmpBuffer2_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpOffset), buffOffset);
+        buffOffset += tmpOffset * sizeof(float);
+        maskBuffer_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpOffset), buffOffset);
+
+        // 搬入mask
+        DataCopyExtParams inParams{static_cast<uint16_t>(chunkSize_),
+                                   static_cast<uint32_t>(chunkSize_ * sizeof(float)),
+                                   0, 0, 0};
+        DataCopyPadExtParams<float> copyPadParams{false, 0, 0, 0};
+        DataCopyPad(maskBuffer_, sTP_->maskTensor, inParams, copyPadParams);
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(eventID);
+        WaitFlag<HardEvent::MTE2_V>(eventID);
+    }
+
+    __aicore__ inline void Process()
+    {
+        int64_t totalChunks = Nv_ * chunkNum_;  // Nv Nc 融合
+        int64_t chunksPerCore = (totalChunks + coreNum_ -1) / coreNum_;
+        int64_t lastChunkSize = seqLength_ % chunkSize_ == 0 ? chunkSize_ : seqLength_ % chunkSize_;
+        int64_t startChunk = coreId_ * chunksPerCore;
+        int64_t endChunk = startChunk + chunksPerCore > totalChunks ? totalChunks : startChunk + chunksPerCore;
+        for (int64_t idx = startChunk; idx < endChunk; idx++) {
+            int64_t nvId = idx / chunkNum_;
+            int64_t chunkId = idx % chunkNum_;
+            int64_t chunkPos = chunkId * chunkSize_;    // 当前chunk起始位置
+            curChunkSize_ = (chunkId == chunkNum_ - 1) ? lastChunkSize : chunkSize_; // 尾块
+            if ASCEND_IS_AIV {
+                if (GetSubBlockIdx() == 0) {
+                    CalMaskedQKT(tmpGM_[coreId_ * chunkSize_ * chunkSize_], nvId, chunkPos);
+                }
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(0x4);
+                CrossCoreWaitFlag(0x3);
+            }
+
+            if ASCEND_IS_AIC {
+                CrossCoreWaitFlag(0x4);
+                AICProcess(tmpGM_[coreId_ * chunkSize_ * chunkSize_],
+                           sTP_->vInner[nvId * Sp_ * Dv_ + chunkPos * Dv_],
+                           sTP_->attnOut[nvId * Dv_ + chunkPos * Nv_ * Dv_]);
+                CrossCoreSetFlag<0x2, PIPE_FIX>(0x3);
+            }
+        }
+    }
+    
+    __aicore__ inline void CalMaskedQKT(GlobalTensor<bfloat16_t> outGM, int nvId, int chunkPos)
+    {
+        // chunkSize 大小进行自动补齐
+        if (gOptional_) {
+            AlignedCopyIn(sTP_->gCumExp[nvId * Sp_ + chunkPos], 1, curChunkSize_);  // 自动补齐
+            auto g_cum = inQueue_.DeQue<float>();
+            const uint32_t srcShape1[] = {static_cast<uint32_t>(chunkSize_), static_cast<uint32_t>(1)};
+            const uint32_t srcShape2[] = {static_cast<uint32_t>(1), static_cast<uint32_t>(chunkSize_)};
+            const uint32_t dstShape[] = {static_cast<uint32_t>(chunkSize_),
+                                         static_cast<uint32_t>(chunkSize_)};
+            Broadcast<float, BROADCAST_AXIS, 1>(tmpBuffer1_, g_cum, dstShape, srcShape1);
+            Broadcast<float, BROADCAST_AXIS, 0>(tmpBuffer2_, g_cum, dstShape, srcShape2);
+            PipeBarrier<PIPE_V>();
+            Sub(tmpBuffer1_, tmpBuffer1_, tmpBuffer2_, curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+            Mul(tmpBuffer1_, tmpBuffer1_, maskBuffer_, curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+            Exp<float, 0, true>(tmpBuffer1_, tmpBuffer1_, curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+            inQueue_.FreeTensor(g_cum);
+        } else {
+            Duplicate(tmpBuffer1_, static_cast<float>(1.0f), curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+        }
+ 
+        // qkt
+        AlignedCopyIn(sTP_->qkt[nvId * Sp_ * chunkSize_ + chunkPos * chunkSize_], curChunkSize_, curChunkSize_);
+        auto qkt = inQueue_.DeQue<bfloat16_t>();
+        auto scale_qkt = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(tmpBuffer2_, qkt, RoundMode::CAST_NONE, curChunkSize_ * chunkSize_);
+        Muls(tmpBuffer2_, tmpBuffer2_, sTP_->scale, curChunkSize_ * chunkSize_);
+        Mul(tmpBuffer2_, tmpBuffer2_, tmpBuffer1_, curChunkSize_ * chunkSize_);
+        // mask
+        Mul(tmpBuffer2_, tmpBuffer2_, maskBuffer_, curChunkSize_ * chunkSize_);
+        Cast(scale_qkt, tmpBuffer2_, RoundMode::CAST_RINT, curChunkSize_ * chunkSize_);
+        outQueue_.EnQue(scale_qkt);
+        AlignedCopyOut(outGM, curChunkSize_, curChunkSize_);
+        inQueue_.FreeTensor(qkt);
+    }
+
+    __aicore__ inline void AICProcess(GlobalTensor<bfloat16_t>tmpGM,
+                                      GlobalTensor<bfloat16_t>vInner,
+                                      GlobalTensor<bfloat16_t>attnInter)
+    {
+        // masked_qkt @ v_inner
+        sTP_->mm3->SetOrgShape(curChunkSize_, Dv_, curChunkSize_, curChunkSize_, Nv_ * Dv_);    // MNK
+        sTP_->mm3->SetSingleShape(curChunkSize_, Dv_, curChunkSize_); // SingleCoreMNK
+        sTP_->mm3->SetTensorA(tmpGM);
+        sTP_->mm3->SetTensorB(vInner);
+        sTP_->mm3->IterateAll(attnInter, 1);
+        sTP_->mm3->End();
+    }
+
+    template <typename inType>
+    __aicore__ inline void AlignedCopyIn(GlobalTensor<inType> tmpGM, int32_t row, int32_t col)
+    {
+        LocalTensor<inType> inLocal = inQueue_.AllocTensor<inType>();
+        // 非对齐拷入会自动对齐, 然后离散拷入UB
+        int paddingCol = Ceil(col, BLOCK_SIZE / sizeof(inType)) * (BLOCK_SIZE / sizeof(inType));
+        DataCopyExtParams inParams{static_cast<uint16_t>(row),
+                                   static_cast<uint32_t>(col * sizeof(inType)),
+                                   static_cast<uint32_t>(0),
+                                   static_cast<uint32_t>((chunkSize_ - paddingCol) * sizeof(inType) / BLOCK_SIZE),
+                                   0};
+        DataCopyPadExtParams<inType> copyPadParams{false, 0, 0, 0};
+        DataCopyPad(inLocal, tmpGM, inParams, copyPadParams);
+        inQueue_.EnQue(inLocal);
+    }
+
+    template <typename outType>
+    __aicore__ inline void AlignedCopyOut(GlobalTensor<outType> tmpGM, int32_t row, int32_t col)
+    {
+        auto outLocal = outQueue_.DeQue<outType>();
+        int paddingCol = Ceil(col, BLOCK_SIZE / sizeof(outType)) * (BLOCK_SIZE / sizeof(outType));
+        DataCopyExtParams copyParams;
+        copyParams.blockCount = static_cast<uint16_t>(row);
+        copyParams.blockLen = static_cast<uint32_t>(col * sizeof(outType));
+        copyParams.srcStride = static_cast<uint32_t>((chunkSize_ - paddingCol) * sizeof(outType) / BLOCK_SIZE);
+        copyParams.dstStride = static_cast<uint32_t>((0) * sizeof(outType));
+        DataCopyPad(tmpGM, outLocal, copyParams);
+        outQueue_.FreeTensor(outLocal);
+    }
+
+private:
+    StageThreeParams *sTP_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, BUFFER_NUM_ONE> inQueue_;
+    TQue<QuePosition::VECOUT, BUFFER_NUM_ONE> outQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff_;
+    GlobalTensor<bfloat16_t> tmpGM_;
+    LocalTensor<float> tmpBuffer1_;
+    LocalTensor<float> tmpBuffer2_;
+    LocalTensor<float> maskBuffer_;
+    int64_t seqLength_;
+    int64_t Sp_;
+    int64_t Nv_;
+    int64_t Nk_;
+    int64_t Dv_;
+    int64_t Dk_;
+    int64_t paddedDv_;
+    int32_t chunkNum_;
+    int32_t coreNum_;
+    int32_t curChunkSize_;
+    int32_t chunkSize_;
+    int32_t coreId_;
+    bool gOptional_;
+};
+
+} // namespace ChunkGatedDeltaRule
+#endif // CHUNK_GATED_DELTA_RULE_STAGE3_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_utils.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch22/chunk_gated_delta_rule_utils.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_utils.h
+ * \brief Common constants for chunk_gated_delta_rule kernels
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_UTILS_H__
+#define CHUNK_GATED_DELTA_RULE_UTILS_H__
+
+#include "kernel_vec_intf.h"
+#include "kernel_cube_intf.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+
+namespace ChunkGatedDeltaRule {
+    // 同步信号
+    constexpr uint64_t V_MTE3_EVENT = 0;
+    constexpr uint64_t V_S_EVENT = 1;
+    constexpr uint64_t MTE2_V_EVENT = 2;
+    constexpr uint64_t S_V_EVENT = 3;
+    constexpr uint64_t MTE3_MTE2_EVENT = 4;
+    constexpr uint64_t MTE3_S_EVENT = 5;
+    constexpr uint64_t FIX_MTE2_EVENT = 6;
+    constexpr uint64_t S_MTE3_EVENT = 6;
+
+    constexpr uint64_t NUM_ONE = 1;
+    constexpr uint64_t BUFFER_NUM_ONE = 1;
+    constexpr uint64_t BUFFER_NUM_TWO = 2;
+    constexpr uint64_t TQUE_DEPTH_TWO = 2;
+    constexpr uint64_t AIC_AIV_1_1 = 2;
+    constexpr uint64_t BROADCAST_AXIS = 2;
+    constexpr uint64_t TASK_RATIO = 2;
+    constexpr uint64_t STAGE3_BUFFER_COUNT = 4;
+    constexpr uint32_t MAX_L0_SIZE = 64 * 1024; // 64KB
+    constexpr uint32_t BLOCK_SIZE = 32;         // copypad对齐块大小
+    constexpr uint32_t BLOCK_FLOAT_NUM = 8;
+    constexpr uint32_t BLOCK_BF16_NUM = 16;
+    constexpr uint32_t TILE_LEN = 1024;   // 1024 = 1kb，经测试1kb和10kb性能差异很小
+}  // ChunkGatedDeltaRule
+
+#endif  // __CHUNK_GATED_DELTA_RULE_UTILS_H__

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule.h
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_H
+#define CHUNK_GATED_DELTA_RULE_H
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+#include "chunk_gated_delta_rule_stage1.h"
+#include "chunk_gated_delta_rule_stage2.h"
+#include "chunk_gated_delta_rule_stage3.h"
+#include "chunk_gated_delta_rule_utils.h"
+
+namespace ChunkGatedDeltaRule {
+
+using namespace AscendC;
+
+struct CGDRInitParams {
+    GM_ADDR query;
+    GM_ADDR key;
+    GM_ADDR value;
+    GM_ADDR beta;
+    GM_ADDR initState;
+    GM_ADDR seqlens;
+    GM_ADDR gOptional;
+    GM_ADDR attnOut;
+    GM_ADDR finalState;
+};
+
+
+template <typename lowType, typename highType, typename stateType = lowType>
+class CGDR {
+public:
+    static constexpr bool kStateIsFp32 = std::is_same_v<stateType, float>;
+    using vInnerType = std::conditional_t<kStateIsFp32, float, lowType>;
+    using StageOneMmVInner = StageOneMTT<vInnerType>;
+    __aicore__ inline CGDR(TPipe *pipe, const ChunkGatedDeltaRuleTilingData *tilingData)
+        : stageOneOp_(stage1MmBf16_, stage1MmVInner_)
+    {
+        pipe_ = pipe;
+        tiling_ = tilingData;
+    };
+
+    __aicore__ inline void InitMatmul()
+    {
+        if ASCEND_IS_AIC {
+            stage1MmBf16_.Init(&tiling_->matmulTilingFp32, pipe_);
+            if constexpr (kStateIsFp32) {
+                stage1MmVInner_.Init(&tiling_->matmulTilingFp32C, pipe_);
+            } else {
+                stage1MmVInner_.Init(&tiling_->matmulTilingFp32, pipe_);
+            }
+            stage2MmBf16_.Init(&tiling_->matmulTilingFp32, pipe_);
+            if constexpr (kStateIsFp32) {
+                stage2MmFp32_.Init(&tiling_->matmulTilingFp32C, pipe_);
+            }
+            stage3Mm_.Init(&tiling_->matmulTilingFp32, pipe_);
+        }
+    }
+
+    __aicore__ inline void InitMask()
+    {
+        if ASCEND_IS_AIV {
+            // 初始化mask矩阵
+            uint32_t cBlockSize = tiling_->chunkSize * tiling_->chunkSize;
+            pipe_->InitBuffer(tmpBuff_, cBlockSize * sizeof(float));
+            auto cCFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(cBlockSize), 0);
+            Duplicate<float>(cCFloat_, 0, tiling_->chunkSize);
+            int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::V_MTE3));
+            SetFlag<HardEvent::V_MTE3>(eventID);
+            WaitFlag<HardEvent::V_MTE3>(eventID);
+            DataCopyExtParams copyParams;
+            copyParams.blockCount = static_cast<uint16_t>(1);
+            copyParams.blockLen = static_cast<uint32_t>(tiling_->chunkSize * sizeof(float));
+            copyParams.srcStride = static_cast<uint32_t>(0);
+            copyParams.dstStride = static_cast<uint32_t>((0) * sizeof(float));
+            for (int i = 0; i < tiling_->chunkSize; ++i) {
+                DataCopyPad(stageOneMask_[GetBlockIdx() * cBlockSize + i * tiling_->chunkSize], cCFloat_, copyParams);
+                eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::MTE3_S));
+                SetFlag<HardEvent::MTE3_S>(eventID);
+                WaitFlag<HardEvent::MTE3_S>(eventID);
+                cCFloat_.SetValue(i, 1);
+                eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_MTE3));
+                SetFlag<HardEvent::S_MTE3>(eventID);
+                WaitFlag<HardEvent::S_MTE3>(eventID);
+                DataCopyPad(stageThreeMask_[GetBlockIdx() * cBlockSize + i * tiling_->chunkSize], cCFloat_, copyParams);
+            }
+            eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::MTE3_MTE2));
+            SetFlag<HardEvent::MTE3_MTE2>(eventID); // 这里必须同步, 否则会有提前拷出的问题
+            WaitFlag<HardEvent::MTE3_MTE2>(eventID);
+            pipe_->Reset();
+        }
+    }
+
+    __aicore__ inline void Init(const CGDRInitParams &initParams, GM_ADDR user)
+    {
+        uint64_t dataSize = tiling_->t * tiling_->nk * tiling_->dk;
+        query_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.query), dataSize);
+        key_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.key), dataSize);
+
+        dataSize = tiling_->t * tiling_->nv * tiling_->dv;
+        value_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.value), dataSize);
+        out_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.attnOut), dataSize);
+
+        dataSize = tiling_->t * tiling_->nv;
+        beta_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(initParams.beta), dataSize);
+        if (initParams.gOptional != nullptr) {
+            g_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(initParams.gOptional), dataSize);
+            gFlag_ = true;
+        }
+
+        dataSize = tiling_->b * tiling_->nv * tiling_->dv * tiling_->dk;
+        initState_.SetGlobalBuffer(reinterpret_cast<__gm__ stateType *>(initParams.initState), dataSize);
+        finalState_.SetGlobalBuffer(reinterpret_cast<__gm__ stateType *>(initParams.finalState), dataSize);
+
+        actualSeqLens_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(initParams.seqlens), tiling_->b);
+
+        uint64_t offset = 0;
+        gCum_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->nv * tiling_->maxGroupLength;
+
+        kCumDecay_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dk;
+
+        vInner_.SetGlobalBuffer(reinterpret_cast<__gm__ vInnerType *>(user + offset));
+        offset += sizeof(vInnerType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dv;
+
+        if constexpr (kStateIsFp32) {
+            vInnerBf16_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+            offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dv;
+        }
+
+        qPrime_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dk;
+
+        attnInter_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dv;
+
+        kg_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->dk;
+
+        qkt_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset));
+        offset += sizeof(lowType) * tiling_->nv * tiling_->maxGroupLength * tiling_->chunkSize;
+
+        if constexpr (kStateIsFp32) {
+            uint64_t stateWkElemCnt = tiling_->nv * tiling_->dv * tiling_->dk;
+            curStateBf16_.SetGlobalBuffer(reinterpret_cast<__gm__ lowType *>(user + offset), stateWkElemCnt);
+            offset += sizeof(lowType) * stateWkElemCnt;
+        }
+
+        stageOneMask_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->chunkSize * tiling_->chunkSize * tiling_->aiCoreNum * TASK_RATIO;
+
+        stageThreeMask_.SetGlobalBuffer(reinterpret_cast<__gm__ highType *>(user + offset));
+        offset += sizeof(highType) * tiling_->chunkSize * tiling_->chunkSize * tiling_->aiCoreNum * TASK_RATIO;
+
+        stageWsAddr_ = user + offset;
+
+        InitMatmul();
+        InitMask();
+    }
+
+    __aicore__ inline void Process()
+    {
+        SyncAll<false>();
+        int64_t seqStart = 0;
+        int64_t seqEnd = 0;
+        ChunkGroup cg;
+        cg.chunkSize = tiling_->chunkSize;
+        for (int64_t bid = 0; bid < tiling_->b; bid++) {
+            int32_t length = actualSeqLens_.GetValue(bid);
+            seqStart = seqEnd;
+            seqEnd = seqStart + (int64_t)length;
+
+            for (int64_t pos = seqStart; pos < seqEnd; pos += tiling_->maxGroupLength) {
+                cg.startPos = pos;
+                if (pos + tiling_->maxGroupLength > seqEnd) {
+                    cg.length = seqEnd - pos;
+                } else {
+                    cg.length = tiling_->maxGroupLength;
+                }
+                bool useInitialState = (pos == seqStart);
+                auto curState = (useInitialState) ?
+                                initState_[bid * tiling_->stateStride0] :
+                                finalState_[bid * tiling_->nv * tiling_->dv * tiling_->dk];
+                // compute this chunk group
+                RunStage1(cg);
+                SyncAll<false>();
+
+                RunStage2(cg, curState,
+                          finalState_[bid * tiling_->nv * tiling_->dv * tiling_->dk], useInitialState);
+                SyncAll<false>();
+
+                RunStage3(cg);
+                SyncAll<false>();
+            }
+        }
+    }
+
+private:
+    __aicore__ inline void RunStage1(const ChunkGroup& cg)
+    {
+        GDRStageOneInitParams<vInnerType> initStageOneParams {query_, key_, value_, beta_, g_,
+                                                gCum_, kCumDecay_, vInner_, qPrime_, kg_, qkt_,
+                                                stageWsAddr_, stageOneMask_, cg, gFlag_};
+        stageOneOp_.Init(initStageOneParams, pipe_, tiling_);
+        stageOneOp_.Process();
+        pipe_->Reset();
+    }
+
+    template <typename sType>
+    __aicore__ inline void RunStage2(ChunkGroup& cg, GlobalTensor<sType> stateIn,
+                                     GlobalTensor<sType> stateOut, bool isFirstGroup)
+    {
+        Stage2<sType> stageTwoOp;
+        StageTwoParams<sType> initStageTwoParams;
+        initStageTwoParams.qPrime = qPrime_;
+        initStageTwoParams.vInner = vInner_;
+        if constexpr (std::is_same_v<sType, float>) {
+            initStageTwoParams.vInnerBf16 = vInnerBf16_;
+        }
+        initStageTwoParams.gCum = gCum_;
+        initStageTwoParams.kCumdecay = kCumDecay_;
+        initStageTwoParams.kg = kg_;
+        initStageTwoParams.out = out_[cg.startPos * tiling_->nv * tiling_->dv];
+        initStageTwoParams.ws = stageWsAddr_;
+        initStageTwoParams.mm1Bf16 = &stage2MmBf16_;
+        initStageTwoParams.mm1Fp32 = &stage2MmFp32_;
+        initStageTwoParams.pipe = pipe_;
+        initStageTwoParams.cg = &cg;
+        initStageTwoParams.Nv = tiling_->nv;
+        initStageTwoParams.Nk = tiling_->nk;
+        initStageTwoParams.Dv = tiling_->dv;
+        initStageTwoParams.Dk = tiling_->dk;
+        initStageTwoParams.stateStride1 = tiling_->stateStride1;
+        initStageTwoParams.useInitialState = isFirstGroup;
+        initStageTwoParams.gOptional = gFlag_;
+        initStageTwoParams.isFirstGroup = isFirstGroup;
+        initStageTwoParams.stateIn = stateIn;
+        initStageTwoParams.stateOut = stateOut;
+        if constexpr (std::is_same_v<sType, float>) {
+            initStageTwoParams.curStateBf16 = curStateBf16_;
+        } else {
+            initStageTwoParams.curStateBf16 = stateIn;
+        }
+        stageTwoOp.Init(&initStageTwoParams, tiling_->aiCoreNum);
+        stageTwoOp.Process();
+        pipe_->Reset();
+    }
+
+    __aicore__ inline void RunStage3(ChunkGroup& cg)
+    {
+        if ASCEND_IS_AIC {
+            stage3Mm_.Init(&tiling_->matmulTilingFp32, pipe_);
+        }
+        GlobalTensor<lowType> vInnerBf16;
+        if constexpr (kStateIsFp32) {
+            vInnerBf16 = vInnerBf16_;
+        } else {
+            vInnerBf16 = vInner_;
+        }
+        Stage3 stageThreeOp;
+        StageThreeParams initStageThreeParams{
+            qkt_, gCum_, vInnerBf16,
+            stageThreeMask_[int(GetBlockIdx() / 2) * tiling_->chunkSize * tiling_->chunkSize],
+            stageWsAddr_, out_[cg.startPos * tiling_->nv * tiling_->dv],
+            &stage3Mm_, pipe_, &cg, tiling_->scale,
+            tiling_->nv, tiling_->nk, tiling_->dv, tiling_->dk, gFlag_};
+        stageThreeOp.Init(&initStageThreeParams, tiling_->aiCoreNum);
+        stageThreeOp.Process();
+        pipe_->Reset();
+    }
+
+private:
+    TPipe *pipe_;
+    const ChunkGatedDeltaRuleTilingData *tiling_;
+    GlobalTensor<lowType> query_;
+    GlobalTensor<lowType> key_;
+    GlobalTensor<lowType> value_;
+    GlobalTensor<lowType> beta_;
+    GlobalTensor<highType> g_;
+    GlobalTensor<lowType> out_;
+    float scale_;
+    GlobalTensor<stateType> finalState_;
+    GlobalTensor<stateType> initState_;
+    GlobalTensor<int32_t> actualSeqLens_;
+
+    GlobalTensor<lowType> curStateBf16_;
+    GlobalTensor<lowType> vInnerBf16_;   // (Nv, maxGroupLength, Dv) BF16 vInner for stage3 (FP32 path only)
+
+    GlobalTensor<highType> gCum_;      // (Nv, maxGroupLength)
+    GlobalTensor<lowType> kCumDecay_;     // (Nv, maxGroupLength, Dk)
+    GlobalTensor<vInnerType> vInner_;     // (Nv, maxGroupLength, Dv) primary vInner
+    GlobalTensor<lowType> qPrime_;        // (Nv, maxGroupLength, Dk)
+    GlobalTensor<lowType> attnInter_;    // (Nv, maxGroupLength, Dv)
+    GlobalTensor<lowType> kg_;           // (Nv, maxGroupLength, Dk)
+    GlobalTensor<lowType> qkt_;          // (Nv, maxGroupLength, C)
+    // mask矩阵
+    GlobalTensor<highType> stageOneMask_;          // (Nv, maxGroupLength, C)
+    GlobalTensor<highType> stageThreeMask_;          // (Nv, maxGroupLength, C)
+    GM_ADDR stageWsAddr_;                 // temporary space addr for stages
+
+    TBuf<TPosition::VECCALC> tmpBuff_;  // 构造mask矩阵
+
+    // Matmul objects
+    StageOneMTT<bfloat16_t> stage1MmBf16_;
+    StageOneMmVInner stage1MmVInner_;
+    StageTwoMT stage2MmBf16_;
+    StageTwoMTFp32C stage2MmFp32_;
+    StageThreeMT stage3Mm_;
+
+    // Stage operators
+    Stage1<kStateIsFp32> stageOneOp_;
+    bool gFlag_ = false;
+};
+
+} // namespace ChunkGatedDeltaRule
+#endif  // CHUNK_GATED_DELTA_RULE_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_stage1.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_stage1.h
@@ -1,0 +1,928 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_stage1.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_STAGE1_H
+#define CHUNK_GATED_DELTA_RULE_STAGE1_H
+
+#include "kernel_tiling/kernel_tiling.h"
+#include "chunk_gated_delta_rule_utils.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+
+namespace ChunkGatedDeltaRule {
+using namespace AscendC;
+using namespace matmul;
+
+using aT1 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using bT1 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+template <typename cType>
+using StageOneMTT = matmul::MatmulImpl<aT1, bT1, MatmulType<TPosition::GM, CubeFormat::ND, cType>>;
+
+constexpr uint64_t UB_REST_BYTES = 140 * 1024;  // 140KB
+constexpr uint64_t INVERSE_SHAPE = 32;          // 对角块边长
+constexpr uint64_t INVERSE_COUNT = 5;           // 求逆所需空间
+constexpr uint32_t ALIGN_SIZE = 16;
+constexpr uint32_t MAX_PARALLEL_NUM = 6;
+constexpr uint32_t HALF_TWO = 2;
+
+// Matmul 形状参数结构体
+struct MatmulShapeParams {
+    uint64_t m;    // 原始 M 维度
+    uint64_t n;    // 原始 N 维度
+    uint64_t k;    // 原始 K 维度
+    uint64_t sm;   // 单次计算 M 维度
+    uint64_t sn;   // 单次计算 N 维度
+    uint64_t sk;   // 单次计算 K 维度
+};
+
+template <typename vInnerType>
+struct GDRStageOneInitParams {
+    // input
+    GlobalTensor<bfloat16_t> query;     // (T, Nk, Dk)
+    GlobalTensor<bfloat16_t> key;       // (T, Nk, Dk)
+    GlobalTensor<bfloat16_t> value;     // (T, Nv, Dv)
+    GlobalTensor<bfloat16_t> beta;      // (T, Nv)
+    GlobalTensor<float> g;              // (T, Nv)
+    // ouput
+    GlobalTensor<float> gCumExp;        // (Nv, cg_len)
+    GlobalTensor<bfloat16_t> kCumdecay;      // (Nv, cg_len, Dk)
+    GlobalTensor<vInnerType> vInner;         // (Nv, cg_len, Dv)
+    GlobalTensor<bfloat16_t> qPrime;         // (Nv, cg_len, Dk)
+    GlobalTensor<bfloat16_t> kG;             // (Nv, cg_len, Dk)
+    GlobalTensor<bfloat16_t> qK;             // (Nv, cg_len, C)
+    // other
+    GM_ADDR ws;
+    GlobalTensor<float> stageOneMask;   // (Nv, cg_len, C)
+    ChunkGroup cg;
+    bool gOptional;
+};
+
+template <bool kStateIsFp32 = false>
+class Stage1 {
+public:
+    using vInnerType = std::conditional_t<kStateIsFp32, float, bfloat16_t>;
+    using MMBf16 = StageOneMTT<bfloat16_t>;
+    using MMVInner = StageOneMTT<vInnerType>;
+    __aicore__ inline Stage1(MMBf16 &mmBf16, MMVInner &mmVInner) : mmBf16_(mmBf16), mmVInner_(mmVInner) {}
+    __aicore__ inline void SetGlobalTensors(const GDRStageOneInitParams<vInnerType> &initParams)
+    {
+        queryGm_ = initParams.query;
+        keyGm_ = initParams.key;
+        valueGm_ = initParams.value;
+        betaGm_ = initParams.beta;
+
+        outGCumExpGm_ = initParams.gCumExp;
+        outKCumdecayGm_ = initParams.kCumdecay;
+        outVInnerGm_ = initParams.vInner;
+        outQPrimeGm_ = initParams.qPrime;
+        outKgBaseGm_ = initParams.kG;
+        outQkGm_ = initParams.qK;
+        stageOneMask_ = initParams.stageOneMask;
+
+        if (gOptional_) {
+            gGm_ = initParams.g;
+        }
+        // ckOffset_
+        uint64_t workSpaceOffset = 0;
+        uint64_t curWS = coreIdx_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+        gBKWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+
+        queryConGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+
+        keyConGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ckOffset_ * sizeof(bfloat16_t);
+        
+        // ccOffset_
+        curWS = coreIdx_ * paraNum_ * ccOffset_ * sizeof(bfloat16_t);
+        kkWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ccOffset_ * sizeof(bfloat16_t);
+        
+        attnWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+        workSpaceOffset += coreNum_ * paraNum_ * ccOffset_ * sizeof(bfloat16_t);
+
+        // cvOffset_
+        curWS = coreIdx_ * paraNum_ * cvOffset_ * sizeof(bfloat16_t);
+        vBetaWsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(initParams.ws + workSpaceOffset + curWS));
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        maxLen_ = AscendC::Std::max(AscendC::Std::max(dvAligned_ / HALF_TWO, dkAligned_ / HALF_TWO), chunkSize_);
+        pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, chunkSize_ * maxLen_ * sizeof(float));
+        pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, chunkSize_ * maxLen_ * sizeof(float));
+        if (gOptional_) {
+            pipe_->InitBuffer(gOutQueue_, BUFFER_NUM_ONE, chunkSize_ * sizeof(float));
+        }
+
+        pipe_->InitBuffer(tmpBuff_, UB_REST_BYTES);
+        uint32_t buffOffset = 0;
+        betaUbBfloat16_ = tmpBuff_.GetWithOffset<bfloat16_t>(static_cast<uint32_t>(halfChunkSize_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(bfloat16_t);
+        
+        gCumUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(float);
+
+        gBUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(halfChunkSize_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(float);
+
+        gEndBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(halfChunkSize_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(float);
+
+        betaUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(halfChunkSize_ * paraNum_), buffOffset);
+        buffOffset += halfChunkSize_ * sizeof(float) * paraNum_;
+
+        uint64_t tmpBufferLen = chunkSize_ * maxLen_ * paraNum_;
+        gBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        gammaUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        valueUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        qUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+
+        tmpBufferLen = chunkSize_ * maxLen_;
+        gTransBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        attnUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        gCumExpBroadUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+
+        tmpBufferLen = halfChunkSize_ * dkAligned_;
+        qUbFloatCon_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        kUbFloatCon_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+
+        inputGatherBuffer_ = tmpBuff_.GetWithOffset<uint32_t>(static_cast<uint32_t>(chunkSize_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(uint32_t);
+
+        gCumSumUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_ * paraNum_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(float) * paraNum_;
+
+        gCumExpUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_ * paraNum_), buffOffset);
+        buffOffset += chunkSize_ * sizeof(float) * paraNum_;
+
+        tmpBufferLen = halfChunkSize_ * halfChunkSize_ * INVERSE_COUNT;
+        inverseBuffer_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        qPrimeUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        vBetaUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        gBKUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        kgUbFloat_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        kkLocal_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpBufferLen), buffOffset);
+        buffOffset += tmpBufferLen * sizeof(float);
+        
+        inverseGatherBuffer_ = tmpBuff_.GetWithOffset<uint32_t>(static_cast<uint32_t>(INVERSE_SHAPE), buffOffset);
+        buffOffset += INVERSE_SHAPE * sizeof(uint32_t);
+        
+        inverseRes_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(chunkSize_ * halfChunkSize_), buffOffset);
+    }
+
+    __aicore__ inline void InitGatherBuffer()
+    {
+        for (uint32_t i = 0; i < chunkSize_; ++i) {
+            inputGatherBuffer_.SetValue(i, i * BLOCK_SIZE);
+        }
+        for (uint32_t i = 0; i < INVERSE_SHAPE; ++i) {
+            inverseGatherBuffer_.SetValue<uint32_t>(i, (i * chunkSize_) * sizeof(float));
+        }
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(eventID);
+        WaitFlag<HardEvent::S_V>(eventID);
+    }
+
+    __aicore__ inline void Init(const GDRStageOneInitParams<vInnerType> &initParams, TPipe *pipe,
+                                const ChunkGatedDeltaRuleTilingData *tilingData)
+    {
+        pipe_ = pipe;
+        tiling_ = tilingData;
+        nk_ = tiling_->nk;
+        nv_ = tiling_->nv;
+        chunkSize_ = tiling_->chunkSize;
+        dk_ = tiling_->dk;
+        dv_ = tiling_->dv;
+        paraNum_ = tiling_->stageOneParaNum;
+        dkAligned_ = (dk_ + ALIGN_SIZE - 1) / ALIGN_SIZE * ALIGN_SIZE;
+        dvAligned_ = (dv_ + ALIGN_SIZE - 1) / ALIGN_SIZE * ALIGN_SIZE;
+        scale_ = tiling_->scale;
+        coreNum_ = tiling_->aiCoreNum;
+        cg_ = initParams.cg;
+        gOptional_ = initParams.gOptional;
+        vRowStride_ = nv_ * dv_;
+        numChunk_ = (cg_.length + chunkSize_ - 1) / chunkSize_;
+        subBlockIdx_ = GetSubBlockIdx();
+        halfChunkSize_ = chunkSize_ / TASK_RATIO;
+        subOffset_ = subBlockIdx_ * halfChunkSize_;
+        coreIdx_ = GetBlockIdx();
+        ccOffset_ = chunkSize_ * chunkSize_;
+        ckOffset_ = chunkSize_ * dk_;
+        cvOffset_ = chunkSize_ * dv_;
+        if ASCEND_IS_AIV {
+            coreIdx_ /= TASK_RATIO;
+            InitLocalBuffers();
+            InitGatherBuffer();
+        }
+        SetGlobalTensors(initParams);
+    }
+
+    __aicore__ inline void Process()
+    {
+        uint32_t totalChunk = nv_ * numChunk_;
+        uint32_t tailChunkNum = totalChunk / coreNum_;   // tail核处理的块数
+        uint32_t formerChunkNum = tailChunkNum + 1;      // former核处理的块数
+        uint32_t formerCoreNum = totalChunk % coreNum_;  // former核数量
+        uint32_t start;
+        uint32_t end;
+        if (coreIdx_ < formerCoreNum) {
+            start = coreIdx_ * formerChunkNum;
+            end = start + formerChunkNum;
+        } else {
+            start = formerCoreNum * formerChunkNum + (coreIdx_ - formerCoreNum) * tailChunkNum;
+            end = start + tailChunkNum;
+        }
+
+        for (uint32_t taskId = start; taskId < end; taskId += paraNum_) {
+            uint32_t curParaNum = paraNum_ < end - taskId ? paraNum_ : end - taskId;
+            // 获取每个chunk有效长度
+            for (uint32_t i = 0; i < curParaNum; ++i) {
+                uint32_t curTaskId = taskId + i;
+                uint64_t curNId = curTaskId % nv_;
+                uint64_t curCgId = curTaskId / nv_;
+                SetChunkOffset(i, curNId, curCgId);
+            }
+            ProcessParaChunk(curParaNum);
+        }
+    }
+
+private:
+    // ----------------------------------------------------------
+    // SetChunkOffset
+    //   curNId  : head 编号 (Nv 维度)
+    //   curCgId : CG 内的 chunk 编号 (0 ~ CG_CHUNKS-1)
+    // ----------------------------------------------------------
+    __aicore__ inline void SetChunkOffset(uint64_t id, uint64_t curNId, uint64_t curCgId)
+    {
+        validLenBatch_[id] = chunkSize_;
+        // 尾chunk处理
+        if (curCgId == numChunk_ - 1 && cg_.length % chunkSize_ != 0) {
+            validLenBatch_[id] = cg_.length % chunkSize_;
+        }
+        if (validLenBatch_[id] < halfChunkSize_) {
+            subValidLenBatch_[id] = (subBlockIdx_ == 0) ? validLenBatch_[id] : 0;
+        } else {
+            subValidLenBatch_[id] = (subBlockIdx_ == 0) ? halfChunkSize_ : validLenBatch_[id] - halfChunkSize_;
+        }
+        // offset
+        uint64_t cgLenPad = (cg_.length + chunkSize_ - 1) / chunkSize_ * chunkSize_;
+        chunkRowBase_[id] = curNId * cgLenPad + curCgId * chunkSize_;
+
+        chunkStartRowBatch_[id] = cg_.startPos + curCgId * chunkSize_;
+        nIdBatch_[id] = curNId;
+        bgOffsetBatch_[id] = chunkStartRowBatch_[id] * nv_ + curNId;
+    }
+
+    __aicore__ inline void ProcessParaChunk(int32_t curParaNum)
+    {
+        if ASCEND_IS_AIC {
+            ParaChunkAIC(curParaNum);
+        }
+        if ASCEND_IS_AIV {
+            ParaChunkAIV(curParaNum);
+        }
+    }
+
+    __aicore__ inline void ParaChunkAIC(int32_t curParaNum)
+    {
+        AscendC::CrossCoreWaitFlag(0x9); // 同步0
+        // key @ key.transpose(-1,-2)
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(mmBf16_, keyConGm_[i * ckOffset_], keyConGm_[i * ckOffset_], kkWsGm_[i * ccOffset_],
+                       {chunkSize_, chunkSize_, dk_, chunkSize_, chunkSize_, dk_}, true);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(0x8); // 同步1
+
+        // query @ key.transpose(-1,-2)   stage1 out
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(mmBf16_, queryConGm_[i * ckOffset_], keyConGm_[i * ckOffset_], outQkGm_[chunkRowBase_[i] * chunkSize_],
+                       {validLenBatch_[i], validLenBatch_[i], dk_, validLenBatch_[i], validLenBatch_[i], dk_},
+                       true);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_FIX>(0xA); // 同步5
+        AscendC::CrossCoreWaitFlag(0x7); // 同步2
+
+        // 求逆左下角矩阵
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AttnInverseMMCompute(i * ccOffset_);
+        }
+        AscendC::CrossCoreWaitFlag(0x6); // 同步3
+
+        // attn @ k_cumdecay
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(mmBf16_, attnWsGm_[i * ccOffset_], gBKWsGm_[i * ckOffset_], outKCumdecayGm_[chunkRowBase_[i] * dk_],
+                       {chunkSize_, dk_, chunkSize_, chunkSize_, dk_, chunkSize_});
+        }
+        AscendC::CrossCoreWaitFlag(0x5); // 同步4
+
+        // attn @ v_beta    stage1 out
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            AICProcess(mmVInner_, attnWsGm_[i * ccOffset_], vBetaWsGm_[i * cvOffset_],
+                       outVInnerGm_[chunkRowBase_[i] * dv_],
+                       {chunkSize_, dv_, chunkSize_, chunkSize_, dv_, chunkSize_});
+        }
+    }
+
+    __aicore__ inline void ParaChunkAIV(int32_t curParaNum)
+    {
+        // 获取连续QK
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            uint64_t subRow = chunkStartRowBatch_[i] + subOffset_;
+            uint64_t qk_base = subRow * nk_ * dk_ + nIdBatch_[i] * nk_ / nv_ * dk_;
+            uint64_t wsOffset_ = i * ckOffset_ + subOffset_ * dk_;
+            outKgGm_ = outKgBaseGm_[chunkRowBase_[i] * dk_];
+            QKPreProcess(queryGm_[qk_base], queryConGm_[wsOffset_], outKgGm_, subValidLenBatch_[i]);
+            QKPreProcess(keyGm_[qk_base], keyConGm_[wsOffset_], outKgGm_, subValidLenBatch_[i], true);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x9); // 同步0
+        if (gOptional_) {
+            for (uint32_t i = 0; i < curParaNum; ++i) {
+                // g_cum_exp = g.cumsum(dim=-1).exp()
+                GCumExpCompute(gGm_[bgOffsetBatch_[i]], outGCumExpGm_[chunkRowBase_[i]],
+                               gCumSumUbFloat_[i * chunkSize_], gCumExpUbFloat_[i * chunkSize_], validLenBatch_[i]);
+                // attn_1 = (g_cum_exp[:None] / g_cum_exp[None,:]) * mask
+                uint64_t gUbOffset = i * chunkSize_ * maxLen_;
+                GammaCompute(gBroadUbFloat_[gUbOffset], gammaUbFloat_[gUbOffset], gCumSumUbFloat_[i * chunkSize_]);
+            }
+        }
+        
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            uint64_t betaUbOffset = i * halfChunkSize_;
+            BetaCopyInWithStride(betaGm_[bgOffsetBatch_[i]], betaUbFloat_[betaUbOffset], subValidLenBatch_[i]);
+        }
+        AscendC::CrossCoreWaitFlag(0x8); // 同步1
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // attn_1 = kkt * attn_1
+            KKBetaCompute(kkWsGm_[i * ccOffset_], betaUbFloat_[i * halfChunkSize_]);
+            // attn_1对角块求逆，对角块shape为INVERSE_SHAPE=32
+            InverseCompute(attnWsGm_[i * ccOffset_], gammaUbFloat_[i * chunkSize_ * maxLen_]);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x7); // 同步2
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // kg = key * (g_cum_exp[-1, None] / g_cum_exp)[..., None]
+            // k_cumdecay = -1.0 * k * beta * g_cum_exp
+            outKgGm_ = outKgBaseGm_[chunkRowBase_[i] * dk_];
+            uint64_t wsOffset_ = i * ckOffset_ + subOffset_ * dk_;
+            GBKCompute(gBKWsGm_[i * ckOffset_], outKgGm_, betaUbFloat_[i * halfChunkSize_],
+                       gCumSumUbFloat_[i * chunkSize_], gCumExpUbFloat_[i * chunkSize_], keyConGm_[wsOffset_]);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x6); // 同步3
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // v_beta = value * beta.unsqueeze(-1)  # (C, Dv)
+            uint64_t betaUbOffset = i * halfChunkSize_;
+            uint64_t vOffset = chunkStartRowBatch_[i] * vRowStride_ + nIdBatch_[i] * dv_;
+            uint64_t valueUbOffset = i * chunkSize_ * maxLen_;
+            VBetaCompute(valueGm_[vOffset], vBetaWsGm_[i * cvOffset_], betaUbFloat_[betaUbOffset],
+                         valueUbFloat_[valueUbOffset], subValidLenBatch_[i]);
+        }
+        AscendC::CrossCoreSetFlag<0x2, PIPE_MTE3>(0x5); // 同步4
+
+        for (uint32_t i = 0; i < curParaNum; ++i) {
+            // q_prime = query * scale_ * g_cum_exp[:, None]  # (C, Dk)
+            uint64_t wsOffset_ = i * ckOffset_ + subOffset_ * dk_;
+            QPrimeCompute(outQPrimeGm_[chunkRowBase_[i] * dk_],
+                          gCumSumUbFloat_[i * chunkSize_], gCumExpUbFloat_[i * chunkSize_], queryConGm_[wsOffset_]);
+        }
+        AscendC::CrossCoreWaitFlag(0xA); // 同步5
+    }
+    __aicore__ inline void QKPreProcess(const GlobalTensor<bfloat16_t>& srcGm, const GlobalTensor<bfloat16_t>& dstGm,
+                                        const GlobalTensor<bfloat16_t>& outKgGm,
+                                        uint32_t subValidRows, bool kgFlag = false)
+    {
+        // copyOut
+        auto tmpTensor = outQueue_.AllocTensor<bfloat16_t>();
+        if (subValidRows > 0) {
+            // copyIn
+            DataCopyInBf16WithStride(subValidRows, dk_, srcGm, nk_ * dk_);
+            LocalTensor<bfloat16_t> bf16Tensor = inQueue_.DeQue<bfloat16_t>();
+            DataCopy(tmpTensor, bf16Tensor, subValidRows * dkAligned_);
+            inQueue_.FreeTensor(bf16Tensor);
+        }
+        
+        if (subValidRows < halfChunkSize_) {
+            Duplicate(tmpTensor[subValidRows * dkAligned_], static_cast<bfloat16_t>(0.0f),
+                      (halfChunkSize_ - subValidRows) * dkAligned_);
+            PipeBarrier<PIPE_V>();
+        }
+        outQueue_.EnQue(tmpTensor);
+        tmpTensor = outQueue_.DeQue<bfloat16_t>();
+
+        uint32_t srcStride = (dkAligned_ - dk_) * sizeof(bfloat16_t) / BLOCK_SIZE;
+        DataCopyExtParams outParams{static_cast<uint16_t>(halfChunkSize_),
+                                    static_cast<uint32_t>(dk_ * sizeof(bfloat16_t)), srcStride, 0, 0};
+        DataCopyPad(dstGm, tmpTensor, outParams);
+        if (!gOptional_ && kgFlag) {
+            DataCopyPad(outKgGm[subOffset_ * dk_], tmpTensor, outParams);
+        }
+        outQueue_.FreeTensor(tmpTensor);
+    }
+
+    __aicore__ inline void GCumExpCompute(const GlobalTensor<float> src, const GlobalTensor<float> dst,
+                                          LocalTensor<float> gCumSumUbFloat, LocalTensor<float> gCumExpUbFloat,
+                                          uint32_t validLen)
+    {
+        // Copy g
+        GCopyInWithStride(src, validLen);
+        // CumSum计算
+        uint32_t outer = 1;
+        uint32_t inner = chunkSize_;
+        CumSumInfo cumSumInfo{outer, inner};
+        CumSum<float>(gCumSumUbFloat, gCumUbFloat_, gCumUbFloat_, cumSumInfo);
+        PipeBarrier<PIPE_V>();
+        // Exp计算
+        Exp<float, 0, true>(gCumExpUbFloat, gCumSumUbFloat, chunkSize_);
+        PipeBarrier<PIPE_V>();
+
+        if (subBlockIdx_ == 0) {
+            auto tmpOut = gOutQueue_.AllocTensor<float>();
+            DataCopy(tmpOut, gCumSumUbFloat, chunkSize_);
+            gOutQueue_.EnQue(tmpOut);
+            tmpOut = gOutQueue_.DeQue<float>();
+            DataCopyExtParams params{static_cast<uint16_t>(1),
+                                    static_cast<uint32_t>(validLen * sizeof(float)), 0, 0, 0};
+            DataCopyPad(dst, tmpOut, params);
+            gOutQueue_.FreeTensor(tmpOut);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void GammaCompute(const LocalTensor<float> gBroadUbFloat,
+                                        LocalTensor<float> gammaUbFloat, LocalTensor<float> gCumSumUbFloat)
+    {
+        // BroadCast
+        uint32_t divShape[2] = {chunkSize_, chunkSize_};
+        uint32_t gShape[2] = {chunkSize_, 1};
+        uint32_t gTransShape[2] = {1, chunkSize_};
+        Broadcast<float, BROADCAST_AXIS, 1>(gBroadUbFloat, gCumSumUbFloat, divShape, gShape);
+        Broadcast<float, BROADCAST_AXIS, 0>(gTransBroadUbFloat_, gCumSumUbFloat, divShape, gTransShape);
+        PipeBarrier<PIPE_V>();
+        // div
+        Sub(gammaUbFloat, gBroadUbFloat, gTransBroadUbFloat_, ccOffset_);
+        PipeBarrier<PIPE_V>();
+        // mask  1
+        DataCopyInFp32(ccOffset_, stageOneMask_[GetBlockIdx() * ccOffset_]);
+        auto maskLocal = inQueue_.DeQue<float>();
+        Mul(gammaUbFloat, gammaUbFloat, maskLocal, ccOffset_);
+        PipeBarrier<PIPE_V>();
+        // exp
+        Exp<float, 0, true>(gammaUbFloat, gammaUbFloat, ccOffset_);
+        PipeBarrier<PIPE_V>();
+        // mask  2
+        Mul(gammaUbFloat, gammaUbFloat, maskLocal, ccOffset_);
+        PipeBarrier<PIPE_V>();
+
+        inQueue_.FreeTensor(maskLocal);
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void KKBetaCompute(const GlobalTensor<bfloat16_t> src, LocalTensor<float> betaUbFloat)
+    {
+        // copy value
+        uint32_t kkLength = chunkSize_ * halfChunkSize_;
+        uint64_t kkBeginOffset = subOffset_ * chunkSize_;
+        DataCopyInBf16(kkLength, src[kkBeginOffset]);
+        auto bf16Local = inQueue_.DeQue<bfloat16_t>();
+        Cast(kkLocal_, bf16Local, RoundMode::CAST_NONE, kkLength);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(bf16Local);
+
+        uint32_t betaShape[2] = {halfChunkSize_, 1};
+        uint32_t kkShape[2] = {halfChunkSize_, chunkSize_};
+        Broadcast<float, BROADCAST_AXIS, 1>(attnUbFloat_, betaUbFloat, kkShape, betaShape);
+        PipeBarrier<PIPE_V>();
+        Mul(attnUbFloat_, kkLocal_, attnUbFloat_, chunkSize_ * halfChunkSize_);
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void InverseCompute(const GlobalTensor<bfloat16_t> dst, LocalTensor<float> gammaUbFloat)
+    {
+        uint64_t curVecLen = chunkSize_ * halfChunkSize_;
+        if (gOptional_) {
+            Mul(attnUbFloat_, attnUbFloat_, gammaUbFloat[subOffset_ * chunkSize_], curVecLen);
+        } else {
+            DataCopyInFp32(curVecLen, stageOneMask_[GetBlockIdx() * ccOffset_ + subOffset_ * chunkSize_]);
+            auto maskLocal = inQueue_.DeQue<float>();
+            Mul(attnUbFloat_, attnUbFloat_, maskLocal, curVecLen);
+            inQueue_.FreeTensor(maskLocal);
+        }
+        PipeBarrier<PIPE_V>();
+
+        Muls(inverseRes_, attnUbFloat_, static_cast<float>(-1.0), curVecLen);
+        PipeBarrier<PIPE_V>();
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::V_S));
+        SetFlag<HardEvent::V_S>(eventID);
+        WaitFlag<HardEvent::V_S>(eventID);
+
+        InverseAIV(subOffset_, INVERSE_SHAPE);
+        auto tmp = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(tmp, inverseRes_, RoundMode::CAST_RINT, curVecLen);
+        outQueue_.EnQue(tmp);
+        DataCopyOutBf16(halfChunkSize_, chunkSize_, chunkSize_, dst[subOffset_ * chunkSize_]);
+    }
+
+    __aicore__ inline void InverseAIV(uint64_t offset, uint32_t inverseVecLen)
+    {
+        PipeBarrier<PIPE_V>();
+        uint64_t inverseBufferOffset = 0;
+        auto row = inverseBuffer_[inverseBufferOffset];
+        inverseBufferOffset += inverseVecLen * inverseVecLen;
+        auto col = inverseBuffer_[inverseBufferOffset];
+        inverseBufferOffset += inverseVecLen * inverseVecLen + inverseVecLen;
+        auto yLocal = inverseBuffer_[inverseBufferOffset];
+        inverseBufferOffset += inverseVecLen * inverseVecLen;
+        auto ei = inverseBuffer_[inverseBufferOffset];
+
+        Duplicate(ei, static_cast<float>(0.0), inverseVecLen);
+        Duplicate(yLocal, static_cast<float>(0.0), inverseVecLen * inverseVecLen); // yLocal清零
+        inverseRes_.SetValue(offset, static_cast<float>(1.0));
+        
+        uint32_t srcShape[2] = {1, inverseVecLen};
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(eventID);
+        WaitFlag<HardEvent::S_V>(eventID);
+        for (int i = 1; i < inverseVecLen; ++i) {
+            uint32_t curI = i - 1;
+            uint32_t validRows = inverseVecLen - i;
+            Gather(col, attnUbFloat_[offset + i * chunkSize_ + curI], inverseGatherBuffer_, (uint32_t)0, validRows);
+            PipeBarrier<PIPE_V>();
+            uint32_t dstShape[2] = {validRows, inverseVecLen};
+            uint32_t colSrcShape[2] = {validRows, 1};
+            Broadcast<float, BROADCAST_AXIS, 1>(col[inverseVecLen], col, dstShape, colSrcShape);
+            Broadcast<float, BROADCAST_AXIS, 0>(row, inverseRes_[offset + curI * chunkSize_], dstShape, srcShape);
+            PipeBarrier<PIPE_V>();
+            MulAddDst(yLocal[i * inverseVecLen], col[inverseVecLen], row, inverseVecLen * validRows);
+            PipeBarrier<PIPE_V>();
+            int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::V_S));
+            SetFlag<HardEvent::V_S>(eventID);
+            WaitFlag<HardEvent::V_S>(eventID);
+            ei.SetValue(i - 1, static_cast<float>(0.0));
+            ei.SetValue(i, static_cast<float>(1.0));
+            eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::S_V));
+            SetFlag<HardEvent::S_V>(eventID);
+            WaitFlag<HardEvent::S_V>(eventID);
+            // xi = (I - SUM) / Lii = I - SUM
+            Sub(inverseRes_[offset + i * chunkSize_], ei, yLocal[i * inverseVecLen], inverseVecLen);
+            PipeBarrier<PIPE_V>();
+        }
+    }
+
+    __aicore__ inline void GBKCompute(const GlobalTensor<bfloat16_t> gBKWsGm, const GlobalTensor<bfloat16_t> outKgGm,
+                                      LocalTensor<float> betaUbFloat, LocalTensor<float> gCumSumUbFloat,
+                                      LocalTensor<float> gCumExpUbFloat, const GlobalTensor<bfloat16_t> keyContinousGm)
+    {
+        if (gOptional_) {
+            // tmp = -1.0 * beta * exp(g_cum)
+            Mul(gBUbFloat_, betaUbFloat, gCumExpUbFloat[subOffset_], halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Muls(gBUbFloat_, gBUbFloat_, static_cast<float>(-1), halfChunkSize_);
+        } else {
+            Muls(gBUbFloat_, betaUbFloat, static_cast<float>(-1), halfChunkSize_);
+        }
+        PipeBarrier<PIPE_V>();
+        // k_cumdecay = k * tmp =  -1.0 * k * beta * g_cum_exp
+        uint32_t betaShape[2] = {halfChunkSize_, 1};
+        uint32_t kShape[2] = {halfChunkSize_, dkAligned_};
+        Broadcast<float, BROADCAST_AXIS, 1>(gBKUbFloat_, gBUbFloat_, kShape, betaShape);
+        PipeBarrier<PIPE_V>();
+        // data copy in kUbFloatCon_
+        DataCopyInBf16WithStride(halfChunkSize_, dk_, keyContinousGm, dk_);
+        auto bf16Key = inQueue_.DeQue<bfloat16_t>();
+        Cast(kUbFloatCon_, bf16Key, RoundMode::CAST_NONE, halfChunkSize_ * dkAligned_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(bf16Key);
+        // compute
+        Mul(gBKUbFloat_, gBKUbFloat_, kUbFloatCon_, halfChunkSize_ * dkAligned_);
+        PipeBarrier<PIPE_V>();
+        gBKLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(gBKLocal_, gBKUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dkAligned_);
+        outQueue_.EnQue<bfloat16_t>(gBKLocal_);
+        uint64_t gBKBeginOffset = subOffset_ * dk_;
+        DataCopyOutBf16(halfChunkSize_, dk_, dkAligned_, gBKWsGm[gBKBeginOffset]);
+        PipeBarrier<PIPE_V>();
+        if (gOptional_) {
+            // kg = k * (g_cum_exp[-1, None] / g_cum_exp)[..., None]
+            uint32_t gEndShape[2] = {1, 1};
+            uint32_t gBroadShape[2] = {halfChunkSize_, 1};
+            Broadcast<float, BROADCAST_AXIS, 0>(gEndBroadUbFloat_, gCumSumUbFloat[chunkSize_ - 1],
+                                                gBroadShape, gEndShape);
+            PipeBarrier<PIPE_V>();
+            Sub(gEndBroadUbFloat_, gEndBroadUbFloat_, gCumSumUbFloat[subOffset_], halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Exp<float, 0, true>(gEndBroadUbFloat_, gEndBroadUbFloat_, halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Broadcast<float, BROADCAST_AXIS, 1>(kgUbFloat_, gEndBroadUbFloat_, kShape, gBroadShape);
+            PipeBarrier<PIPE_V>();
+            Mul(kgUbFloat_, kgUbFloat_, kUbFloatCon_, halfChunkSize_ * dkAligned_);
+            PipeBarrier<PIPE_V>();
+            uint64_t kgBeginOffset = subOffset_ * dk_;
+            kgLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+            Cast(kgLocal_, kgUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dkAligned_);
+            outQueue_.EnQue<bfloat16_t>(kgLocal_);
+            DataCopyOutBf16(halfChunkSize_, dk_, dkAligned_, outKgGm[kgBeginOffset]);  // stage1 out
+        }
+    }
+
+    __aicore__ inline void VBetaCompute(const GlobalTensor<bfloat16_t> valueGm,
+                                        const GlobalTensor<bfloat16_t> vBetaWsGm, LocalTensor<float> betaUbFloat,
+                                        LocalTensor<float> valueUbFloat, uint32_t subValidRows)
+    {
+        uint64_t vBeginOffset = subOffset_ * vRowStride_;
+        DataCopyInBf16WithStride(subValidRows, dv_, valueGm[vBeginOffset], vRowStride_);
+        valueLocal_ = inQueue_.DeQue<bfloat16_t>();
+        Cast(valueUbFloat, valueLocal_, AscendC::RoundMode::CAST_NONE, subValidRows * dvAligned_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(valueLocal_);
+        if (subValidRows < halfChunkSize_) {
+            Duplicate(valueUbFloat[subValidRows * dvAligned_], static_cast<float>(0.0f),
+                      (halfChunkSize_ - subValidRows) * dvAligned_);
+            PipeBarrier<PIPE_V>();
+        }
+        uint32_t betaShape[2] = {halfChunkSize_, 1};
+        uint32_t vShape[2] = {halfChunkSize_, dvAligned_};
+        Broadcast<float, BROADCAST_AXIS, 1>(vBetaUbFloat_, betaUbFloat, vShape, betaShape);
+        PipeBarrier<PIPE_V>();
+        Mul(vBetaUbFloat_, valueUbFloat, vBetaUbFloat_, halfChunkSize_ * dvAligned_);
+        PipeBarrier<PIPE_V>();
+        vBetaLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(vBetaLocal_, vBetaUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dvAligned_);
+        outQueue_.EnQue<bfloat16_t>(vBetaLocal_);
+        DataCopyOutBf16(halfChunkSize_, dv_, dvAligned_, vBetaWsGm[subOffset_ * dv_]);
+    }
+
+    __aicore__ inline void QPrimeCompute(const GlobalTensor<bfloat16_t> outQPrimeGm,
+                                         LocalTensor<float> gCumSumUbFloat, LocalTensor<float> gCumExpUbFloat,
+                                         const GlobalTensor<bfloat16_t> queryContinousGm)
+    {
+        // data copy in qUbFloatCon_
+        DataCopyInBf16WithStride(halfChunkSize_, dk_, queryContinousGm, dk_);
+        auto bf16Query = inQueue_.DeQue<bfloat16_t>();
+        Cast(qUbFloatCon_, bf16Query, RoundMode::CAST_NONE, halfChunkSize_ * dkAligned_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(bf16Query);
+        // query * scale
+        if (gOptional_) {
+            Muls(qUbFloat_, qUbFloatCon_, scale_, halfChunkSize_ * dkAligned_);
+            PipeBarrier<PIPE_V>();
+            uint32_t gCumExpShape[2] = {halfChunkSize_, 1};
+            uint32_t qShape[2] = {halfChunkSize_, dkAligned_};
+            Broadcast<float, BROADCAST_AXIS, 1>(gCumExpBroadUbFloat_, gCumExpUbFloat[subOffset_], qShape, gCumExpShape);
+            PipeBarrier<PIPE_V>();
+            // query * scale * exp(g_cum)[:, None]       # (C, Dk)
+            Mul(qPrimeUbFloat_, qUbFloat_, gCumExpBroadUbFloat_, halfChunkSize_ * dkAligned_);
+        } else {
+            Muls(qPrimeUbFloat_, qUbFloatCon_, scale_, halfChunkSize_ * dkAligned_);
+        }
+        PipeBarrier<PIPE_V>();
+        uint64_t qgBeginOffset = subOffset_ * dk_;
+        qPrimeLocal_ = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(qPrimeLocal_, qPrimeUbFloat_, RoundMode::CAST_RINT, halfChunkSize_ * dkAligned_);
+        outQueue_.EnQue<bfloat16_t>(qPrimeLocal_);
+        DataCopyOutBf16(halfChunkSize_, dk_, dkAligned_, outQPrimeGm[qgBeginOffset]);  // stage1 out
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void DataCopyInFp32(uint64_t len, GlobalTensor<float> y)
+    {
+        DataCopyPadExtParams<float> padParams;
+        DataCopyExtParams kkParams{static_cast<uint16_t>(1), static_cast<uint32_t>(len * sizeof(float)), 0, 0, 0};
+        fp32InLocal_ = inQueue_.AllocTensor<float>();
+        DataCopyPad(fp32InLocal_, y, kkParams, padParams);
+        inQueue_.EnQue<float>(fp32InLocal_);
+    }
+
+    __aicore__ inline void DataCopyInBf16(uint64_t len, GlobalTensor<bfloat16_t> y)
+    {
+        DataCopyPadExtParams<bfloat16_t> padParams;
+        DataCopyExtParams kkParams{static_cast<uint16_t>(1),
+                                static_cast<uint32_t>(len * sizeof(bfloat16_t)), 0, 0, 0};
+        bf16InLocal_ = inQueue_.AllocTensor<bfloat16_t>();
+        DataCopyPad(bf16InLocal_, y, kkParams, padParams);
+        inQueue_.EnQue<bfloat16_t>(bf16InLocal_);
+    }
+
+    __aicore__ inline void BetaCopyInWithStride(const GlobalTensor<bfloat16_t> src, LocalTensor<float> betaUbFloat,
+                                                uint32_t subValidRows)
+    {
+        uint64_t betaBeginOffset = subOffset_ * nv_;
+        DataCopyInBf16WithStride(subValidRows, 1, src[betaBeginOffset], nv_);
+        betaLocal_ = inQueue_.DeQue<bfloat16_t>();
+        if (subValidRows < halfChunkSize_) {
+            Duplicate(betaUbBfloat16_, bfloat16_t(0.0f), halfChunkSize_);
+            PipeBarrier<PIPE_V>();
+        }
+        Gather(betaUbBfloat16_, betaLocal_, inputGatherBuffer_, static_cast<uint32_t>(0), subValidRows);
+        PipeBarrier<PIPE_V>();
+
+        Cast(betaUbFloat, betaUbBfloat16_, AscendC::RoundMode::CAST_NONE, halfChunkSize_);
+        PipeBarrier<PIPE_V>();
+        inQueue_.FreeTensor(betaLocal_);
+    }
+
+    __aicore__ inline void GCopyInWithStride(const GlobalTensor<float> src, uint32_t validLen)
+    {
+        DataCopyInFp32WithStride(validLen, 1, src, nv_);
+        gLocal_ = inQueue_.DeQue<float>();
+        if (validLen < chunkSize_) {
+            Duplicate(gCumUbFloat_, 0.0f, chunkSize_);
+            PipeBarrier<PIPE_V>();
+        }
+        Gather(gCumUbFloat_, gLocal_, inputGatherBuffer_, static_cast<uint32_t>(0), validLen);
+        PipeBarrier<PIPE_V>();
+
+        inQueue_.FreeTensor(gLocal_);
+    }
+
+    __aicore__ inline void DataCopyInFp32WithStride(uint64_t rows,  // 要搬的行数
+                                                    uint64_t cols,  // 每行的元素数
+                                                    const GlobalTensor<float> src,
+                                                    uint64_t srcRowStride,  // GM上相邻行的间距(元素数)
+                                                    uint32_t dstRowStride = 0)
+    {
+        DataCopyPadExtParams<float> padParams = {false, static_cast<uint8_t>(0), static_cast<uint8_t>(0),
+                                                 static_cast<float>(0)};
+        uint32_t srcGap = (srcRowStride - cols) * sizeof(float);
+        DataCopyExtParams params{static_cast<uint16_t>(rows),
+                                 static_cast<uint32_t>(cols * sizeof(float)),
+                                 static_cast<uint32_t>(srcGap), static_cast<uint32_t>(dstRowStride), 0};
+        fp32InLocal_ = inQueue_.AllocTensor<float>();
+        DataCopyPad(fp32InLocal_, src, params, padParams);
+        inQueue_.EnQue<float>(fp32InLocal_);
+    }
+
+    __aicore__ inline void DataCopyInBf16WithStride(uint64_t rows,  // 要搬的行数
+                                                    uint64_t cols,  // 每行的元素数
+                                                    GlobalTensor<bfloat16_t> src,
+                                                    uint64_t srcRowStride) // GM上相邻行的间距(元素数)
+    {
+        DataCopyPadExtParams<bfloat16_t> padParams = {false, static_cast<uint8_t>(0), static_cast<uint8_t>(0),
+                                                      static_cast<float>(0)};
+        uint32_t srcGap = (srcRowStride - cols) * sizeof(bfloat16_t);
+        DataCopyExtParams params{static_cast<uint16_t>(rows),
+                                 static_cast<uint32_t>(cols * sizeof(bfloat16_t)),
+                                 static_cast<uint32_t>(srcGap), 0, 0};
+        bf16InLocal_ = inQueue_.AllocTensor<bfloat16_t>();
+        DataCopyPad(bf16InLocal_, src, params, padParams);
+        inQueue_.EnQue<bfloat16_t>(bf16InLocal_);
+    }
+
+    __aicore__ inline void DataCopyOutBf16(uint32_t rows, uint32_t cols,
+                                        uint32_t colsAligned, GlobalTensor<bfloat16_t> y)
+    {
+        auto tmpLocal = outQueue_.DeQue<bfloat16_t>();
+        uint32_t srcStride = (colsAligned - cols) * sizeof(bfloat16_t) / BLOCK_SIZE;
+        DataCopyExtParams yGMParams{static_cast<uint16_t>(rows),
+                                    static_cast<uint32_t>(cols * sizeof(bfloat16_t)),
+                                    static_cast<uint32_t>(srcStride), 0, 0};
+        DataCopyPad(y, tmpLocal, yGMParams);
+        outQueue_.FreeTensor(tmpLocal);
+    }
+
+    __aicore__ inline void AttnInverseMMCompute(uint64_t offset)
+    {
+        uint64_t leftDown = offset + chunkSize_ * INVERSE_SHAPE;
+        uint64_t rightDown = leftDown + INVERSE_SHAPE;
+        // 右矩阵左下角 @ 右矩阵左上角 -> 右矩阵左下角
+        AICProcess(mmBf16_, attnWsGm_[leftDown], attnWsGm_[offset], attnWsGm_[leftDown],
+                   {chunkSize_, chunkSize_, chunkSize_, INVERSE_SHAPE, INVERSE_SHAPE, INVERSE_SHAPE});
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::FIX_MTE2));
+        SetFlag<HardEvent::FIX_MTE2>(eventID);
+        WaitFlag<HardEvent::FIX_MTE2>(eventID);
+        // 右矩阵右下角 @ 右矩阵左下角 -> 右矩阵左下角
+        AICProcess(mmBf16_, attnWsGm_[rightDown], attnWsGm_[leftDown], attnWsGm_[leftDown],
+                   {chunkSize_, chunkSize_, chunkSize_, INVERSE_SHAPE, INVERSE_SHAPE, INVERSE_SHAPE});
+        eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::FIX_MTE2));
+        SetFlag<HardEvent::FIX_MTE2>(eventID);
+        WaitFlag<HardEvent::FIX_MTE2>(eventID);
+    }
+
+    template <typename MMType, typename CType>
+    __aicore__ inline void AICProcess(MMType &mmRef, GlobalTensor<bfloat16_t> x, GlobalTensor<bfloat16_t> y,
+                                      GlobalTensor<CType> z, const MatmulShapeParams &shape, bool transB = false)
+    {
+        mmRef.SetOrgShape(shape.m, shape.n, shape.k);
+        mmRef.SetSingleShape(shape.sm, shape.sn, shape.sk);
+        mmRef.SetTensorA(x);
+        mmRef.SetTensorB(y, transB);
+        mmRef.IterateAll(z);
+        mmRef.End();
+    }
+    
+    TPipe *pipe_;
+    MMBf16 &mmBf16_;
+    MMVInner &mmVInner_;
+    const ChunkGatedDeltaRuleTilingData *tiling_;
+    ChunkGroup cg_;
+    uint32_t nk_;
+    uint32_t nv_;
+    uint32_t dk_;
+    uint32_t dv_;
+    uint32_t dkAligned_;
+    uint32_t dvAligned_;
+    uint32_t numChunk_;
+    uint64_t vRowStride_;
+    uint32_t halfChunkSize_;
+    uint32_t subBlockIdx_;
+    uint32_t subOffset_;
+    uint32_t coreIdx_;
+    uint32_t chunkSize_;
+    uint32_t maxLen_;
+    uint32_t coreNum_;
+    float scale_;
+    bool gOptional_;
+    uint32_t paraNum_;
+    uint64_t ccOffset_;
+    uint64_t ckOffset_;
+    uint64_t cvOffset_;
+    uint32_t validLenBatch_[MAX_PARALLEL_NUM];
+    uint32_t subValidLenBatch_[MAX_PARALLEL_NUM];
+    uint32_t chunkRowBase_[MAX_PARALLEL_NUM];
+    uint64_t chunkStartRowBatch_[MAX_PARALLEL_NUM];
+    uint64_t nIdBatch_[MAX_PARALLEL_NUM];
+    uint64_t bgOffsetBatch_[MAX_PARALLEL_NUM];
+
+    // chunk GM pointers
+    GlobalTensor<bfloat16_t> queryGm_;
+    GlobalTensor<bfloat16_t> keyGm_;
+    GlobalTensor<bfloat16_t> valueGm_;
+    GlobalTensor<bfloat16_t> betaGm_;
+    GlobalTensor<float> gGm_;
+    GlobalTensor<float> outGCumExpGm_;
+    GlobalTensor<bfloat16_t> outKCumdecayGm_;
+    GlobalTensor<vInnerType> outVInnerGm_;
+    GlobalTensor<bfloat16_t> outQPrimeGm_;
+    GlobalTensor<bfloat16_t> outKgBaseGm_;
+    GlobalTensor<bfloat16_t> outKgGm_;
+    GlobalTensor<bfloat16_t> outQkGm_;
+    GlobalTensor<bfloat16_t> vBetaWsGm_;
+    GlobalTensor<bfloat16_t> kkWsGm_;
+    GlobalTensor<bfloat16_t> attnWsGm_;
+    GlobalTensor<bfloat16_t> gBKWsGm_;
+    GlobalTensor<bfloat16_t> queryConGm_;
+    GlobalTensor<bfloat16_t> keyConGm_;
+    GlobalTensor<float> stageOneMask_;
+
+    // UB queues
+    TQue<QuePosition::VECIN, 1> inQueue_;
+    TQue<QuePosition::VECOUT, 1> outQueue_;
+    TQue<QuePosition::VECOUT, 1> gOutQueue_;
+
+    TBuf<TPosition::VECCALC> tmpBuff_;
+
+    // UB tensors
+    LocalTensor<bfloat16_t> betaUbBfloat16_;
+    LocalTensor<float> betaUbFloat_;
+    LocalTensor<float> valueUbFloat_;
+    LocalTensor<float> attnUbFloat_;
+    LocalTensor<float> inverseBuffer_;
+    LocalTensor<float> inverseRes_;
+    LocalTensor<float> gCumUbFloat_;
+    LocalTensor<float> gCumSumUbFloat_;
+    LocalTensor<float> gCumExpUbFloat_;
+    LocalTensor<float> gCumExpBroadUbFloat_;
+    LocalTensor<float> gBUbFloat_;
+    LocalTensor<float> qUbFloat_;
+    LocalTensor<float> gBroadUbFloat_;
+    LocalTensor<float> gTransBroadUbFloat_;
+    LocalTensor<float> gEndBroadUbFloat_;
+    LocalTensor<float> gammaUbFloat_;
+    LocalTensor<uint32_t> inverseGatherBuffer_;
+    LocalTensor<float> qUbFloatCon_;
+    LocalTensor<float> kUbFloatCon_;
+    LocalTensor<float> gBKUbFloat_;
+    LocalTensor<float> kgUbFloat_;
+    LocalTensor<float> vBetaUbFloat_;
+    LocalTensor<float> qPrimeUbFloat_;
+    LocalTensor<uint32_t> inputGatherBuffer_;
+
+    LocalTensor<bfloat16_t> betaLocal_;
+    LocalTensor<bfloat16_t> valueLocal_;
+    LocalTensor<bfloat16_t> qPrimeLocal_;
+    LocalTensor<bfloat16_t> vBetaLocal_;
+    LocalTensor<float> kkLocal_;
+    LocalTensor<float> gLocal_;
+    LocalTensor<bfloat16_t> gBKLocal_;
+    LocalTensor<bfloat16_t> kgLocal_;
+    
+    LocalTensor<bfloat16_t> bf16InLocal_;
+    LocalTensor<float> fp32InLocal_;
+};
+} // namespace ChunkGatedDeltaRule
+#endif // CHUNK_GATED_DELTA_RULE_STAGE1_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_stage2.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_stage2.h
@@ -1,0 +1,472 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule_stage2.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_STAGE2_H
+#define CHUNK_GATED_DELTA_RULE_STAGE2_H
+
+#include "kernel_tiling/kernel_tiling.h"
+#include "chunk_gated_delta_rule_utils.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+
+namespace ChunkGatedDeltaRule {
+using namespace AscendC;
+using namespace matmul;
+
+using aT2 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using bT2 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+template <typename cType>
+using StageTwoMTT = matmul::MatmulImpl<aT2, bT2, MatmulType<TPosition::GM, CubeFormat::ND, cType>>;
+using StageTwoMT = StageTwoMTT<bfloat16_t>;
+using StageTwoMTFp32C = StageTwoMTT<float>;
+
+template <typename stateType>
+struct StageTwoParams {
+    GlobalTensor<bfloat16_t> qPrime;        // (Nv, Sp, Dk)
+    GlobalTensor<stateType> vInner;         // (Nv, Sp, Dv)
+    GlobalTensor<bfloat16_t> vInnerBf16;    // (Nv, Sp, Dv) BF16 vInner for stage3/CalStateNew (FP32 path)
+    GlobalTensor<float> gCum;               // (Nv, Sp)
+    GlobalTensor<bfloat16_t> kCumdecay;     // (Nv, Sp, Dk)
+    GlobalTensor<bfloat16_t> curStateBf16;  // (Nv, Dv, Dk) BF16 state for AIC
+    GlobalTensor<stateType> stateIn;        // (Nv, Dv, Dk) state input
+    GlobalTensor<stateType> stateOut;       // (Nv, Dv, Dk) state output
+    GlobalTensor<bfloat16_t> kg;
+    GlobalTensor<bfloat16_t> out;
+    GM_ADDR ws;
+    StageTwoMT *mm1Bf16;
+    StageTwoMTFp32C *mm1Fp32;
+    TPipe *pipe;
+    ChunkGroup *cg;
+    int64_t Nv;
+    int64_t Nk;
+    int64_t Dv;
+    int64_t Dk;
+    int64_t stateStride1;
+    bool useInitialState;
+    bool gOptional;
+    bool isFirstGroup;
+};
+
+template <typename stateType = bfloat16_t>
+class Stage2 {
+public:
+    static constexpr bool kIsFp32 = std::is_same_v<stateType, float>;
+
+    __aicore__ inline void Init(StageTwoParams<stateType> *initParams, int32_t coreNum)
+    {
+        sTP_ = initParams;
+        pipe_ = sTP_->pipe;
+        chunkSize_ = sTP_->cg->chunkSize;
+        seqLength_ = sTP_->cg->length;
+        Sp_ = (seqLength_ + chunkSize_ - 1) / chunkSize_  * chunkSize_;
+        chunkNum_ = Sp_ / chunkSize_;
+        coreNum_ = coreNum;
+        Nv_ = sTP_->Nv;
+        Nk_ = sTP_->Nk;
+        Dv_ = sTP_->Dv;
+        Dk_ = sTP_->Dk;
+        curDk_ = Ceil(Dk_, BLOCK_SIZE / sizeof(bfloat16_t)) * (BLOCK_SIZE / sizeof(bfloat16_t));
+        curChunkSize_ = chunkSize_;
+        useInitialState_ = sTP_->useInitialState;
+        stateStride1_ = (useInitialState_) ? sTP_->stateStride1 : Dv_ * Dk_;
+        gOptional_ = sTP_->gOptional;
+        isFirstGroup_ = sTP_->isFirstGroup;
+        InitLocalBuffers();
+    }
+
+    __aicore__ inline void InitLocalBuffers()
+    {
+        if ASCEND_IS_AIC {
+            return;
+        }
+        if constexpr (kIsFp32) {
+            uint64_t inSize = Std::max((uint64_t)chunkSize_, (uint64_t)Dv_) * curDk_ * sizeof(float);
+            uint64_t vInnerCastInSize = chunkSize_ * Dv_ * sizeof(float);
+            uint64_t vInnerCastOutSize = chunkSize_ * Dv_ * sizeof(bfloat16_t);
+            pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, Std::max(inSize, vInnerCastInSize));
+            uint64_t outSize = Std::max(inSize, vInnerCastOutSize);
+            pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, outSize);
+            pipe_->InitBuffer(tmpBuff_, (Dv_ * curDk_ + BLOCK_FLOAT_NUM) * sizeof(float));
+            uint32_t buffOffset = 0;
+            stateFp32Ub_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(Dv_ * curDk_), buffOffset);
+            buffOffset += Ceil(Dv_ * curDk_ * sizeof(float), BLOCK_SIZE) * BLOCK_SIZE;
+            lastGCum_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(NUM_ONE), buffOffset);
+        } else {
+            pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, Std::max((uint64_t)chunkSize_,
+                                                                 (uint64_t)Dv_) * curDk_ * sizeof(bfloat16_t));
+            uint64_t outQueueSize = Std::max((uint64_t)chunkSize_ * chunkSize_ * sizeof(bfloat16_t),
+                                             (uint64_t)Dv_ * curDk_ * sizeof(bfloat16_t));
+            pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, outQueueSize);
+            pipe_->InitBuffer(tmpBuff_, (Std::max((uint64_t)chunkSize_, (uint64_t)Dv_) * curDk_ +
+                                         BLOCK_FLOAT_NUM) *sizeof(float));
+            uint32_t buffOffset = 0;
+            tmpBuffer1_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(Dv_ * curDk_), buffOffset);
+            buffOffset += Ceil(Dv_ * curDk_ * sizeof(float), BLOCK_SIZE) * BLOCK_SIZE;
+            lastGCum_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(NUM_ONE), buffOffset);
+        }
+    }
+
+    __aicore__ inline void Process()
+    {
+        int64_t coreId = GetBlockIdx();
+        if ASCEND_IS_AIV {
+            coreId /= AIC_AIV_1_1;
+        }
+        int64_t nvPerCore = (Nv_ + coreNum_ - 1) / coreNum_;
+        int64_t nvStart = coreId * nvPerCore;
+        int64_t nvEnd = nvStart + nvPerCore;
+        nvEnd = nvEnd > Nv_ ? Nv_ : nvEnd;
+        int64_t lastChunkSize = seqLength_ % chunkSize_ == 0 ? chunkSize_ : seqLength_ % chunkSize_;
+        for (int64_t nvId = nvStart; nvId < nvEnd; nvId++) {
+            curChunkSize_ = chunkSize_;
+            for (int64_t cId = 0; cId < chunkNum_; cId++) {
+                int64_t length = cId * chunkSize_;
+                if (cId == chunkNum_ - 1) {
+                    curChunkSize_ = lastChunkSize;
+                }
+                if ASCEND_IS_AIV {
+                    if constexpr (kIsFp32) {
+                        ProcessAivFp32(nvId, cId, length);
+                    } else {
+                        ProcessAivBf16(nvId, cId, length);
+                    }
+                }
+                if ASCEND_IS_AIC {
+                    ProcessAic(nvId, cId, length);
+                }
+            }
+        }
+    }
+
+    __aicore__ inline void ProcessAivFp32(int64_t nvId, int64_t cId, int64_t length)
+    {
+        if (GetSubBlockIdx() == 0) {
+            if (isFirstGroup_ && cId == 0) {
+                CopyIn<float>(sTP_->stateIn[nvId * stateStride1_], Dv_, Dk_);
+            } else {
+                CopyIn<float>(sTP_->stateOut[nvId * Dv_ * Dk_], Dv_, Dk_);
+            }
+            auto stateIn = inQueue_.DeQue<float>();
+            DataCopy(stateFp32Ub_, stateIn, Dv_ * curDk_);
+            inQueue_.FreeTensor(stateIn);
+            SetFlag<HardEvent::MTE2_V>(MTE2_V_EVENT);
+            WaitFlag<HardEvent::MTE2_V>(MTE2_V_EVENT);
+            auto bf16State = outQueue_.AllocTensor<bfloat16_t>();
+            Cast(bf16State, stateFp32Ub_, RoundMode::CAST_RINT, Dv_ * curDk_);
+            outQueue_.EnQue(bf16State);
+            CopyOut<bfloat16_t>(sTP_->curStateBf16[nvId * Dv_ * Dk_], Dv_, Dk_, false, curDk_);
+            CalGCumExpFp32(sTP_->gCum[nvId * Sp_ + length]);
+            SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+            WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+            PipeBarrier<PIPE_MTE3>();
+            auto fp32Local = outQueue_.AllocTensor<float>();
+            DataCopy(fp32Local, stateFp32Ub_, Dv_ * curDk_);
+            outQueue_.EnQue(fp32Local);
+            CopyOut<float>(sTP_->stateOut[nvId * Dv_ * Dk_], Dv_, Dk_, false, curDk_);
+        }
+        CrossCoreSetFlag<0x2, PIPE_MTE3>(0x3);
+        CrossCoreWaitFlag(0x2);
+        if (GetSubBlockIdx() == 0) {
+            PipeBarrier<PIPE_MTE3>();
+            uint64_t mm_offset1 = nvId * Sp_ * Dv_ + length * Dv_;
+            CastGmToGm<float, bfloat16_t>(sTP_->vInner[mm_offset1],
+                                          sTP_->vInnerBf16[mm_offset1],
+                                          curChunkSize_ * Dv_);
+        }
+        CrossCoreSetFlag<0x2, PIPE_MTE3>(0x5);
+        CrossCoreWaitFlag(0x4);
+    }
+
+    __aicore__ inline void ProcessAivBf16(int64_t nvId, int64_t cId, int64_t length)
+    {
+        auto curState = (cId == 0) ? sTP_->curStateBf16[nvId * stateStride1_]
+                                   : sTP_->stateOut[nvId * Dv_ * Dk_];
+        auto finalState = sTP_->stateOut[nvId * Dv_ * Dk_];
+        if (GetSubBlockIdx() == 0) {
+            CopyIn(curState, Dv_, Dk_);
+            CalGCumExpBf16(sTP_->gCum[nvId * Sp_ + length]);
+        }
+        CrossCoreWaitFlag(0x2);
+        if (GetSubBlockIdx() == 0) {
+            CopyOutState(finalState);
+        }
+        CrossCoreSetFlag<0x2, PIPE_MTE3>(0x5);
+        CrossCoreWaitFlag(0x4);
+    }
+
+    __aicore__ inline void ProcessAic(int64_t nvId, int64_t cId, int64_t length)
+    {
+        uint64_t mm_offset0 = nvId * Sp_ * Dk_ + length * Dk_;
+        uint64_t mm_offset1 = nvId * Sp_ * Dv_ + length * Dv_;
+        auto stateOut = sTP_->stateOut[nvId * Dv_ * Dk_];
+        GlobalTensor<bfloat16_t> stateForAic;
+        if constexpr (kIsFp32) {
+            CrossCoreWaitFlag(0x3);
+            stateForAic = sTP_->curStateBf16[nvId * Dv_ * Dk_];
+        } else {
+            stateForAic = (cId == 0) ? sTP_->curStateBf16[nvId * stateStride1_]
+                                     : sTP_->stateOut[nvId * Dv_ * Dk_];
+        }
+        CalVPrime(sTP_->kCumdecay[mm_offset0], stateForAic, sTP_->vInner[mm_offset1]);
+        CalAttnInter(sTP_->qPrime[mm_offset0], stateForAic,
+                     sTP_->out[nvId * Dv_ + cId * chunkSize_ * Nv_ * Dv_]);
+        CrossCoreSetFlag<0x2, PIPE_FIX>(0x2);
+        CrossCoreWaitFlag(0x5);
+        if constexpr (kIsFp32) {
+            CalStateNew(sTP_->vInnerBf16[mm_offset1],
+                        sTP_->kg[mm_offset0], stateOut);
+        } else {
+            CalStateNew(sTP_->vInner[mm_offset1], sTP_->kg[mm_offset0], stateOut);
+        }
+        SetFlag<HardEvent::FIX_MTE2>(FIX_MTE2_EVENT);
+        WaitFlag<HardEvent::FIX_MTE2>(FIX_MTE2_EVENT);
+        CrossCoreSetFlag<0x2, PIPE_FIX>(0x4);
+    }
+
+    __aicore__ inline void CalGCumExpFp32(GlobalTensor<float> gCum)
+    {
+        if (!gOptional_) {
+            return;
+        }
+        DataCacheCleanAndInvalid<float,
+                                 CacheLine::SINGLE_CACHE_LINE,
+                                 DcciDst::CACHELINE_OUT>(gCum[curChunkSize_ - 1]);
+        float gVal = gCum.GetValue(curChunkSize_ - 1);
+        lastGCum_.SetValue(0, gVal);
+        SetFlag<HardEvent::S_V>(S_V_EVENT);
+        WaitFlag<HardEvent::S_V>(S_V_EVENT);
+        Exp<float, 0, true>(lastGCum_, lastGCum_, 1);
+        float tmpFloat = lastGCum_.GetValue(0);
+        SetFlag<HardEvent::S_V>(S_V_EVENT);
+        WaitFlag<HardEvent::S_V>(S_V_EVENT);
+        Muls(stateFp32Ub_, stateFp32Ub_, tmpFloat, Dv_ * curDk_);
+        PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void CalGCumExpBf16(GlobalTensor<float> gCum)
+    {
+        if (gOptional_) {
+            DataCacheCleanAndInvalid<float,
+                                     CacheLine::SINGLE_CACHE_LINE,
+                                     DcciDst::CACHELINE_OUT>(gCum[curChunkSize_ - 1]);
+            float tmpFloat = gCum.GetValue(curChunkSize_ - 1);
+            lastGCum_.SetValue(0, tmpFloat);
+            SetFlag<HardEvent::S_V>(S_V_EVENT);
+            WaitFlag<HardEvent::S_V>(S_V_EVENT);
+            Exp<float, 0, true>(lastGCum_, lastGCum_, 1);
+        } else {
+            lastGCum_.SetValue(0, 1.0f);
+        }
+        float tmpFloat = lastGCum_.GetValue(0);
+        auto stateIn = inQueue_.DeQue<bfloat16_t>();
+        auto stateOut = outQueue_.AllocTensor<bfloat16_t>();
+        SetFlag<HardEvent::MTE2_V>(MTE2_V_EVENT);
+        WaitFlag<HardEvent::MTE2_V>(MTE2_V_EVENT);
+        Cast(tmpBuffer1_, stateIn, RoundMode::CAST_NONE, Dv_ * curDk_);
+        SetFlag<HardEvent::S_V>(S_V_EVENT);
+        WaitFlag<HardEvent::S_V>(S_V_EVENT);
+        Muls(tmpBuffer1_, tmpBuffer1_, tmpFloat, Dv_ * curDk_);
+        Cast(stateOut, tmpBuffer1_, RoundMode::CAST_RINT, Dv_ * curDk_);
+        SetFlag<HardEvent::V_MTE3>(V_MTE3_EVENT);
+        WaitFlag<HardEvent::V_MTE3>(V_MTE3_EVENT);
+        outQueue_.EnQue(stateOut);
+        inQueue_.FreeTensor(stateIn);
+    }
+
+    template <typename MMType, typename AT, typename BT, typename CT>
+    __aicore__ inline void RunMatmul(MMType *mm, GlobalTensor<AT> a, bool transA,
+                                     GlobalTensor<BT> b, bool transB,
+                                     GlobalTensor<CT> c, int64_t M, int64_t N, int64_t K, int32_t accum)
+    {
+        mm->SetOrgShape(M, N, K);
+        mm->SetSingleShape(M, N, K);
+        mm->SetTensorA(a, transA);
+        mm->SetTensorB(b, transB);
+        mm->IterateAll(c, accum);
+        mm->End();
+    }
+
+    template <typename MMType, typename AT, typename BT, typename CT>
+    __aicore__ inline void RunMatmul(MMType *mm, GlobalTensor<AT> a, bool transA,
+                                     GlobalTensor<BT> b, bool transB,
+                                     GlobalTensor<CT> c, int64_t M, int64_t N, int64_t K,
+                                     int64_t Ka, int64_t Kb, int32_t accum = 0)
+    {
+        mm->SetOrgShape(M, N, K, Ka, Kb);
+        mm->SetSingleShape(M, N, K);
+        mm->SetTensorA(a, transA);
+        mm->SetTensorB(b, transB);
+        mm->IterateAll(c, accum);
+        mm->End();
+    }
+
+    __aicore__ inline void CalAttnInter(GlobalTensor<bfloat16_t> qPrime,
+                                        GlobalTensor<bfloat16_t> state,
+                                        GlobalTensor<bfloat16_t> out)
+    {
+        RunMatmul(sTP_->mm1Bf16, qPrime, false, state, true, out,
+                  curChunkSize_, Dv_, Dk_, Dk_, Nv_ * Dv_);
+    }
+
+    template <typename vInnerType>
+    __aicore__ inline void CalVPrime(GlobalTensor<bfloat16_t> kCumdecay,
+                                     GlobalTensor<bfloat16_t> state,
+                                     GlobalTensor<vInnerType> vPrime)
+    {
+        if constexpr (kIsFp32) {
+            RunMatmul(sTP_->mm1Fp32, kCumdecay, false, state, true, vPrime,
+                      curChunkSize_, Dv_, Dk_, 1);
+        } else {
+            RunMatmul(sTP_->mm1Bf16, kCumdecay, false, state, true, vPrime,
+                      curChunkSize_, Dv_, Dk_, 1);
+        }
+    }
+
+    template <typename stateOutType>
+    __aicore__ inline void CalStateNew(GlobalTensor<bfloat16_t> vInner,
+                                       GlobalTensor<bfloat16_t> kg,
+                                       GlobalTensor<stateOutType> state)
+    {
+        if constexpr (kIsFp32) {
+            RunMatmul(sTP_->mm1Fp32, vInner, true, kg, false, state,
+                      Dv_, Dk_, curChunkSize_, 1);
+        } else {
+            RunMatmul(sTP_->mm1Bf16, vInner, true, kg, false, state,
+                      Dv_, Dk_, curChunkSize_, 1);
+        }
+    }
+
+    template <typename srcType, typename dstType>
+    __aicore__ inline void CastGmToGm(GlobalTensor<srcType> srcGm, GlobalTensor<dstType> dstGm,
+                                       int32_t count)
+    {
+        int32_t paddedCount = Ceil(count, BLOCK_SIZE / sizeof(dstType)) * (BLOCK_SIZE / sizeof(dstType));
+        int32_t srcAlign = BLOCK_SIZE / sizeof(srcType);
+        int32_t srcPadded = Ceil(count, srcAlign) * srcAlign;
+        int32_t padding = srcPadded - count;
+
+        auto srcLocal = inQueue_.AllocTensor<srcType>();
+        if (paddedCount > srcPadded) {
+            Duplicate<srcType>(srcLocal, static_cast<srcType>(0), paddedCount);
+            SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+            WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+        }
+        DataCopyExtParams inParams{1, static_cast<uint32_t>(count * sizeof(srcType)), 0, 0, 0};
+        DataCopyPadExtParams<srcType> inPadParams{true, 0, static_cast<uint8_t>(padding), 0};
+        DataCopyPad(srcLocal, srcGm, inParams, inPadParams);
+        inQueue_.EnQue(srcLocal);
+
+        srcLocal = inQueue_.DeQue<srcType>();
+        auto dstLocal = outQueue_.AllocTensor<dstType>();
+        Cast(dstLocal, srcLocal, RoundMode::CAST_RINT, paddedCount);
+        inQueue_.FreeTensor(srcLocal);
+        outQueue_.EnQue(dstLocal);
+
+        dstLocal = outQueue_.DeQue<dstType>();
+        DataCopyExtParams outParams{1, static_cast<uint32_t>(count * sizeof(dstType)), 0, 0, 0};
+        DataCopyPadExtParams<dstType> outPadParams{false, 0, 0, 0};
+        DataCopyPad(dstGm, dstLocal, outParams);
+        outQueue_.FreeTensor(dstLocal);
+    }
+
+    template <typename inType>
+    __aicore__ inline void CopyIn(GlobalTensor<inType> tmpGM, int32_t row, int32_t col)
+    {
+        LocalTensor<inType> inLocal = inQueue_.AllocTensor<inType>();
+        int padding;
+        uint32_t dstStride = 0;
+        if constexpr (kIsFp32 && std::is_same_v<inType, float>) {
+            int32_t floatAligned = Ceil(col, BLOCK_FLOAT_NUM) * BLOCK_FLOAT_NUM;
+            padding = floatAligned - col;
+            if (floatAligned < curDk_) {
+                uint32_t dataBlocks = static_cast<uint32_t>(floatAligned * sizeof(float) / BLOCK_SIZE);
+                uint32_t rowBlocks = static_cast<uint32_t>(curDk_ * sizeof(float) / BLOCK_SIZE);
+                dstStride = rowBlocks - dataBlocks;
+                Duplicate<inType>(inLocal, static_cast<inType>(0), row * curDk_);
+                SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+                WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+            }
+        } else {
+            padding = Ceil(col, BLOCK_SIZE / sizeof(inType)) * (BLOCK_SIZE / sizeof(inType)) - col;
+        }
+        DataCopyExtParams inParams{static_cast<uint16_t>(row),
+                                   static_cast<uint32_t>(col * sizeof(inType)),
+                                   static_cast<uint32_t>(0),
+                                   dstStride, 0};
+        DataCopyPadExtParams<inType> copyPadParams{true, 0, static_cast<uint8_t>(padding), 0};
+        DataCopyPad(inLocal, tmpGM, inParams, copyPadParams);
+        inQueue_.EnQue(inLocal);
+    }
+
+    __aicore__ inline void CopyOutState(GlobalTensor<bfloat16_t> stateNew)
+    {
+        CopyOut<bfloat16_t>(stateNew, Dv_, Dk_, false);
+    }
+
+    template <typename outType>
+    __aicore__ inline void CopyOut(GlobalTensor<outType> tmpGM, int32_t row, int32_t col,
+                                   bool setAtomic = false, int32_t srcCol = 0)
+    {
+        auto outLocal = outQueue_.DeQue<outType>();
+        DataCopyExtParams copyParams;
+        copyParams.blockCount = static_cast<uint16_t>(row);
+        copyParams.blockLen = static_cast<uint32_t>(col * sizeof(outType));
+        if (srcCol > col) {
+            uint32_t actualReadBytes = Ceil(col * sizeof(outType), BLOCK_SIZE) * BLOCK_SIZE;
+            uint32_t srcRowBytes = srcCol * sizeof(outType);
+            if (srcRowBytes >= actualReadBytes && (srcRowBytes - actualReadBytes) % BLOCK_SIZE == 0) {
+                copyParams.srcStride = (srcRowBytes - actualReadBytes) / BLOCK_SIZE;
+            } else {
+                copyParams.srcStride = 0;
+            }
+        } else {
+            copyParams.srcStride = static_cast<uint32_t>(0);
+        }
+        copyParams.dstStride = static_cast<uint32_t>(0);
+        if (setAtomic) {
+            SetAtomicAdd<outType>();
+        }
+        DataCopyPad(tmpGM, outLocal, copyParams);
+        if (setAtomic) {
+            SetAtomicNone();
+        }
+        outQueue_.FreeTensor(outLocal);
+    }
+
+private:
+    StageTwoParams<stateType> *sTP_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, BUFFER_NUM_ONE> inQueue_;
+    TQue<QuePosition::VECOUT, BUFFER_NUM_ONE> outQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff_;
+    LocalTensor<float> tmpBuffer1_;
+    LocalTensor<float> lastGCum_;
+    LocalTensor<float> stateFp32Ub_;
+    int64_t Nk_;
+    int64_t Nv_;
+    int64_t Dk_;
+    int64_t Dv_;
+    int64_t seqLength_;
+    int32_t chunkSize_;
+    int32_t curChunkSize_;
+    int32_t curDk_;
+    int64_t Sp_;
+    int32_t chunkNum_;
+    int32_t coreNum_;
+    int64_t stateStride1_;
+    bool useInitialState_;
+    bool gOptional_;
+    bool isFirstGroup_;
+};
+} // namespace ChunkGatedDeltaRule
+#endif // CHUNK_GATED_DELTA_RULE_STAGE2_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_stage3.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_stage3.h
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_stage3.h
+ * \brief
+ */
+#ifndef CHUNK_GATED_DELTA_RULE_STAGE3_H
+#define CHUNK_GATED_DELTA_RULE_STAGE3_H
+
+#include "kernel_tiling/kernel_tiling.h"
+#include "chunk_gated_delta_rule_utils.h"
+#include "../chunk_gated_delta_rule_tiling_data.h"
+
+namespace ChunkGatedDeltaRule {
+using namespace AscendC;
+using namespace matmul;
+
+using aT3 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using bT3 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t, true>;
+using cT3 = MatmulType<TPosition::GM, CubeFormat::ND, bfloat16_t>;
+using StageThreeMT = matmul::MatmulImpl<aT3, bT3, cT3>;
+
+struct StageThreeParams {
+    GlobalTensor<bfloat16_t> qkt;       // (Nv, Sp, Dk)
+    GlobalTensor<float> gCumExp;           // (Nv, Sp)
+    GlobalTensor<bfloat16_t> vInner;
+    GlobalTensor<float> maskTensor;
+    GM_ADDR ws;
+    GlobalTensor<bfloat16_t> attnOut;
+    StageThreeMT *mm3;
+    TPipe *pipe;
+    ChunkGroup *cg;
+    float scale;
+    int64_t Nv;
+    int64_t Nk;
+    int64_t Dv;
+    int64_t Dk;
+    bool gOptional;
+};
+
+class Stage3 {
+public:
+    __aicore__ inline void Init(StageThreeParams *initParams, int32_t coreNum)
+    {
+        coreId_ = GetBlockIdx();
+        sTP_ = initParams;
+        pipe_ = sTP_->pipe;
+        chunkSize_ = sTP_->cg->chunkSize;
+        seqLength_ = sTP_->cg->length;
+        Sp_ = (seqLength_ + chunkSize_ - 1) / chunkSize_  * chunkSize_;
+        chunkNum_ = (seqLength_ + chunkSize_ - 1) / chunkSize_ ;
+        coreNum_ = coreNum;
+        Nv_ = sTP_->Nv;
+        Nk_ = sTP_->Nk;
+        Dv_ = sTP_->Dv;
+        Dk_ = sTP_->Dk;
+        paddedDv_ = Ceil(Dv_, BLOCK_SIZE / sizeof(bfloat16_t)) * (BLOCK_SIZE / sizeof(bfloat16_t));
+        gOptional_ = sTP_->gOptional;
+        uint64_t workSpaceOffset = 0;
+        tmpGM_.SetGlobalBuffer(reinterpret_cast<__gm__ bfloat16_t *>(
+                               initParams->ws + workSpaceOffset +
+                               coreNum_ * chunkSize_ * chunkSize_ * sizeof(float)));
+        if ASCEND_IS_AIC {
+            return;
+        }
+        coreId_ /= AIC_AIV_1_1;
+        if (GetSubBlockIdx() == 1) {
+            return;
+        }
+        uint64_t inQueueSize = static_cast<uint64_t>(chunkSize_) *
+                               AscendC::Std::max((int64_t)chunkSize_, paddedDv_) * sizeof(bfloat16_t);
+        pipe_->InitBuffer(inQueue_, BUFFER_NUM_ONE, inQueueSize);
+        pipe_->InitBuffer(outQueue_, BUFFER_NUM_ONE, chunkSize_ > paddedDv_ ?
+                          chunkSize_ * chunkSize_ * sizeof(float) : chunkSize_ * paddedDv_ * sizeof(bfloat16_t));
+        pipe_->InitBuffer(tmpBuff_, (STAGE3_BUFFER_COUNT * chunkSize_ * chunkSize_ * sizeof(float)));
+        uint64_t buffOffset = 0;
+        uint64_t tmpOffset = chunkSize_ * chunkSize_;
+        tmpBuffer1_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpOffset), buffOffset);
+        buffOffset += tmpOffset * sizeof(float);
+        tmpBuffer2_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpOffset), buffOffset);
+        buffOffset += tmpOffset * sizeof(float);
+        maskBuffer_ = tmpBuff_.GetWithOffset<float>(static_cast<uint32_t>(tmpOffset), buffOffset);
+
+        // 搬入mask
+        DataCopyExtParams inParams{static_cast<uint16_t>(chunkSize_),
+                                   static_cast<uint32_t>(chunkSize_ * sizeof(float)),
+                                   0, 0, 0};
+        DataCopyPadExtParams<float> copyPadParams{false, 0, 0, 0};
+        DataCopyPad(maskBuffer_, sTP_->maskTensor, inParams, copyPadParams);
+        int32_t eventID = static_cast<int32_t>(pipe_->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(eventID);
+        WaitFlag<HardEvent::MTE2_V>(eventID);
+    }
+
+    __aicore__ inline void Process()
+    {
+        int64_t totalChunks = Nv_ * chunkNum_;  // Nv Nc 融合
+        int64_t chunksPerCore = (totalChunks + coreNum_ -1) / coreNum_;
+        int64_t lastChunkSize = seqLength_ % chunkSize_ == 0 ? chunkSize_ : seqLength_ % chunkSize_;
+        int64_t startChunk = coreId_ * chunksPerCore;
+        int64_t endChunk = startChunk + chunksPerCore > totalChunks ? totalChunks : startChunk + chunksPerCore;
+        for (int64_t idx = startChunk; idx < endChunk; idx++) {
+            int64_t nvId = idx / chunkNum_;
+            int64_t chunkId = idx % chunkNum_;
+            int64_t chunkPos = chunkId * chunkSize_;    // 当前chunk起始位置
+            curChunkSize_ = (chunkId == chunkNum_ - 1) ? lastChunkSize : chunkSize_; // 尾块
+            if ASCEND_IS_AIV {
+                if (GetSubBlockIdx() == 0) {
+                    CalMaskedQKT(tmpGM_[coreId_ * chunkSize_ * chunkSize_], nvId, chunkPos);
+                }
+                CrossCoreSetFlag<0x2, PIPE_MTE3>(0x4);
+                CrossCoreWaitFlag(0x3);
+            }
+
+            if ASCEND_IS_AIC {
+                CrossCoreWaitFlag(0x4);
+                AICProcess(tmpGM_[coreId_ * chunkSize_ * chunkSize_],
+                           sTP_->vInner[nvId * Sp_ * Dv_ + chunkPos * Dv_],
+                           sTP_->attnOut[nvId * Dv_ + chunkPos * Nv_ * Dv_]);
+                CrossCoreSetFlag<0x2, PIPE_FIX>(0x3);
+            }
+        }
+    }
+    
+    __aicore__ inline void CalMaskedQKT(GlobalTensor<bfloat16_t> outGM, int nvId, int chunkPos)
+    {
+        // chunkSize 大小进行自动补齐
+        if (gOptional_) {
+            AlignedCopyIn(sTP_->gCumExp[nvId * Sp_ + chunkPos], 1, curChunkSize_);  // 自动补齐
+            auto g_cum = inQueue_.DeQue<float>();
+            const uint32_t srcShape1[] = {static_cast<uint32_t>(chunkSize_), static_cast<uint32_t>(1)};
+            const uint32_t srcShape2[] = {static_cast<uint32_t>(1), static_cast<uint32_t>(chunkSize_)};
+            const uint32_t dstShape[] = {static_cast<uint32_t>(chunkSize_),
+                                         static_cast<uint32_t>(chunkSize_)};
+            Broadcast<float, BROADCAST_AXIS, 1>(tmpBuffer1_, g_cum, dstShape, srcShape1);
+            Broadcast<float, BROADCAST_AXIS, 0>(tmpBuffer2_, g_cum, dstShape, srcShape2);
+            PipeBarrier<PIPE_V>();
+            Sub(tmpBuffer1_, tmpBuffer1_, tmpBuffer2_, curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+            Mul(tmpBuffer1_, tmpBuffer1_, maskBuffer_, curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+            Exp<float, 0, true>(tmpBuffer1_, tmpBuffer1_, curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+            inQueue_.FreeTensor(g_cum);
+        } else {
+            Duplicate(tmpBuffer1_, static_cast<float>(1.0f), curChunkSize_ * chunkSize_);
+            PipeBarrier<PIPE_V>();
+        }
+ 
+        // qkt
+        AlignedCopyIn(sTP_->qkt[nvId * Sp_ * chunkSize_ + chunkPos * chunkSize_], curChunkSize_, curChunkSize_);
+        auto qkt = inQueue_.DeQue<bfloat16_t>();
+        auto scale_qkt = outQueue_.AllocTensor<bfloat16_t>();
+        Cast(tmpBuffer2_, qkt, RoundMode::CAST_NONE, curChunkSize_ * chunkSize_);
+        Muls(tmpBuffer2_, tmpBuffer2_, sTP_->scale, curChunkSize_ * chunkSize_);
+        Mul(tmpBuffer2_, tmpBuffer2_, tmpBuffer1_, curChunkSize_ * chunkSize_);
+        // mask
+        Mul(tmpBuffer2_, tmpBuffer2_, maskBuffer_, curChunkSize_ * chunkSize_);
+        Cast(scale_qkt, tmpBuffer2_, RoundMode::CAST_RINT, curChunkSize_ * chunkSize_);
+        outQueue_.EnQue(scale_qkt);
+        AlignedCopyOut(outGM, curChunkSize_, curChunkSize_);
+        inQueue_.FreeTensor(qkt);
+    }
+
+    __aicore__ inline void AICProcess(GlobalTensor<bfloat16_t>tmpGM,
+                                      GlobalTensor<bfloat16_t>vInner,
+                                      GlobalTensor<bfloat16_t>attnInter)
+    {
+        // masked_qkt @ v_inner
+        sTP_->mm3->SetOrgShape(curChunkSize_, Dv_, curChunkSize_, curChunkSize_, Nv_ * Dv_);    // MNK
+        sTP_->mm3->SetSingleShape(curChunkSize_, Dv_, curChunkSize_); // SingleCoreMNK
+        sTP_->mm3->SetTensorA(tmpGM);
+        sTP_->mm3->SetTensorB(vInner);
+        sTP_->mm3->IterateAll(attnInter, 1);
+        sTP_->mm3->End();
+    }
+
+    template <typename inType>
+    __aicore__ inline void AlignedCopyIn(GlobalTensor<inType> tmpGM, int32_t row, int32_t col)
+    {
+        LocalTensor<inType> inLocal = inQueue_.AllocTensor<inType>();
+        // 非对齐拷入会自动对齐, 然后离散拷入UB
+        int paddingCol = Ceil(col, BLOCK_SIZE / sizeof(inType)) * (BLOCK_SIZE / sizeof(inType));
+        DataCopyExtParams inParams{static_cast<uint16_t>(row),
+                                   static_cast<uint32_t>(col * sizeof(inType)),
+                                   static_cast<uint32_t>(0),
+                                   static_cast<uint32_t>((chunkSize_ - paddingCol) * sizeof(inType) / BLOCK_SIZE),
+                                   0};
+        DataCopyPadExtParams<inType> copyPadParams{false, 0, 0, 0};
+        DataCopyPad(inLocal, tmpGM, inParams, copyPadParams);
+        inQueue_.EnQue(inLocal);
+    }
+
+    template <typename outType>
+    __aicore__ inline void AlignedCopyOut(GlobalTensor<outType> tmpGM, int32_t row, int32_t col)
+    {
+        auto outLocal = outQueue_.DeQue<outType>();
+        int paddingCol = Ceil(col, BLOCK_SIZE / sizeof(outType)) * (BLOCK_SIZE / sizeof(outType));
+        DataCopyExtParams copyParams;
+        copyParams.blockCount = static_cast<uint16_t>(row);
+        copyParams.blockLen = static_cast<uint32_t>(col * sizeof(outType));
+        copyParams.srcStride = static_cast<uint32_t>((chunkSize_ - paddingCol) * sizeof(outType) / BLOCK_SIZE);
+        copyParams.dstStride = static_cast<uint32_t>((0) * sizeof(outType));
+        DataCopyPad(tmpGM, outLocal, copyParams);
+        outQueue_.FreeTensor(outLocal);
+    }
+
+private:
+    StageThreeParams *sTP_;
+    TPipe *pipe_;
+    TQue<QuePosition::VECIN, BUFFER_NUM_ONE> inQueue_;
+    TQue<QuePosition::VECOUT, BUFFER_NUM_ONE> outQueue_;
+    TBuf<TPosition::VECCALC> tmpBuff_;
+    GlobalTensor<bfloat16_t> tmpGM_;
+    LocalTensor<float> tmpBuffer1_;
+    LocalTensor<float> tmpBuffer2_;
+    LocalTensor<float> maskBuffer_;
+    int64_t seqLength_;
+    int64_t Sp_;
+    int64_t Nv_;
+    int64_t Nk_;
+    int64_t Dv_;
+    int64_t Dk_;
+    int64_t paddedDv_;
+    int32_t chunkNum_;
+    int32_t coreNum_;
+    int32_t curChunkSize_;
+    int32_t chunkSize_;
+    int32_t coreId_;
+    bool gOptional_;
+};
+
+} // namespace ChunkGatedDeltaRule
+#endif // CHUNK_GATED_DELTA_RULE_STAGE3_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_utils.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/arch35/chunk_gated_delta_rule_utils.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_utils.h
+ * \brief Common constants for chunk_gated_delta_rule kernels
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_UTILS_H__
+#define CHUNK_GATED_DELTA_RULE_UTILS_H__
+
+#include "kernel_vec_intf.h"
+#include "kernel_cube_intf.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+
+namespace ChunkGatedDeltaRule {
+    // 同步信号
+    constexpr uint64_t V_MTE3_EVENT = 0;
+    constexpr uint64_t V_S_EVENT = 1;
+    constexpr uint64_t MTE2_V_EVENT = 2;
+    constexpr uint64_t S_V_EVENT = 3;
+    constexpr uint64_t MTE3_MTE2_EVENT = 4;
+    constexpr uint64_t MTE3_S_EVENT = 5;
+    constexpr uint64_t FIX_MTE2_EVENT = 6;
+    constexpr uint64_t S_MTE3_EVENT = 6;
+    constexpr uint64_t V_MTE2_EVENT = 7;
+
+    constexpr uint64_t NUM_ONE = 1;
+    constexpr uint64_t BUFFER_NUM_ONE = 1;
+    constexpr uint64_t BUFFER_NUM_TWO = 2;
+    constexpr uint64_t TQUE_DEPTH_TWO = 2;
+    constexpr uint64_t AIC_AIV_1_1 = 2;
+    constexpr uint64_t BROADCAST_AXIS = 2;
+    constexpr uint64_t TASK_RATIO = 2;
+    constexpr uint64_t STAGE3_BUFFER_COUNT = 4;
+    constexpr uint32_t MAX_L0_SIZE = 64 * 1024; // 64KB
+    constexpr uint32_t BLOCK_SIZE = 32;         // copypad对齐块大小
+    constexpr uint32_t BLOCK_FLOAT_NUM = 8;
+    constexpr uint32_t BLOCK_BF16_NUM = 16;
+    constexpr uint32_t TILE_LEN = 1024;   // 1024 = 1kb，经测试1kb和10kb性能差异很小
+}  // ChunkGatedDeltaRule
+
+#endif  // __CHUNK_GATED_DELTA_RULE_UTILS_H__

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule.cpp
+ * \brief
+ */
+
+#include "arch22/chunk_gated_delta_rule.h"
+#include "chunk_gated_delta_rule_tiling_data.h"
+
+using namespace AscendC;
+using namespace matmul;
+using namespace ChunkGatedDeltaRule;
+
+extern "C" __global__ __aicore__ void chunk_gated_delta_rule(
+    GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR beta, GM_ADDR initialState, GM_ADDR seqlens, GM_ADDR gOptional,
+    GM_ADDR out, GM_ADDR finalState, GM_ADDR workspaceGM, GM_ADDR tilingGM)
+{
+    REGISTER_TILING_DEFAULT(ChunkGatedDeltaRuleTilingData);
+    GET_TILING_DATA(tilingData, tilingGM);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    TPipe pipe;
+
+    __gm__ uint8_t *user = GetUserWorkspace(workspaceGM);
+    
+    CGDR<bfloat16_t, float> op(&pipe, &tilingData);
+    CGDRInitParams initParams{
+        query, key, value, beta, initialState, seqlens, gOptional,
+        out, finalState};
+    op.Init(initParams, user);
+    op.Process();
+}

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule_apt.cpp
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule_apt.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule.cpp
+ * \brief
+ */
+
+#include "arch35/chunk_gated_delta_rule.h"
+#include "chunk_gated_delta_rule_tiling_data.h"
+#include "chunk_gated_delta_rule_tiling_key.h"
+
+using namespace AscendC;
+using namespace matmul;
+using namespace ChunkGatedDeltaRule;
+
+extern "C" __global__ __aicore__ void chunk_gated_delta_rule(
+    GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR beta, GM_ADDR initialState, GM_ADDR seqlens, GM_ADDR gOptional,
+    GM_ADDR out, GM_ADDR finalState, GM_ADDR workspaceGM, GM_ADDR tilingGM)
+{
+    REGISTER_TILING_DEFAULT(ChunkGatedDeltaRuleTilingData);
+    GET_TILING_DATA(tilingData, tilingGM);
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    TPipe pipe;
+
+    __gm__ uint8_t *user = GetUserWorkspace(workspaceGM);
+    CGDRInitParams initParams{
+        query, key, value, beta, initialState, seqlens, gOptional,
+        out, finalState};
+    if (TILING_KEY_IS(TILING_KEY_CGDR_FP32_STATE)) {
+        CGDR<bfloat16_t, float, float> op(&pipe, &tilingData);
+        op.Init(initParams, user);
+        op.Process();
+    } else if (TILING_KEY_IS(TILING_KEY_CGDR_BF16_STATE)) {
+        CGDR<bfloat16_t, float, bfloat16_t> op(&pipe, &tilingData);
+        op.Init(initParams, user);
+        op.Process();
+    }
+}

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule_tiling_data.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule_tiling_data.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file chunk_gated_delta_rule_tiling_data.h
+ * \brief
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_TILING_DATA_H
+#define CHUNK_GATED_DELTA_RULE_TILING_DATA_H
+
+#include "kernel_tiling/kernel_tiling.h"
+
+namespace ChunkGatedDeltaRule {
+    constexpr uint64_t STRUCT_ALIGNAS = 8;
+    #pragma pack(push, 8)
+    struct alignas(STRUCT_ALIGNAS) ChunkGatedDeltaRuleTilingData {
+        int64_t aiCoreNum;
+        int64_t t;
+        int64_t nk;
+        int64_t dk;
+        int64_t nv;
+        int64_t dv;
+        int64_t b;
+        int64_t hasGamma;
+        int64_t chunkSize;
+        int64_t maxGroupLength;    // maxGroupLength = p * chunkSize
+        int64_t interWorkspaceSz;
+        int64_t stageWorkspaceSz;
+        int64_t stageOneParaNum;
+        float scale;
+        AscendC::tiling::TCubeTiling matmulTilingFp32;    // BF16 C matmul tiling
+        AscendC::tiling::TCubeTiling matmulTilingFp32C;   // FP32 C matmul tiling (for FP32 state path)
+        int64_t stateIsFp32;
+        int64_t stateStride0;
+        int64_t stateStride1;
+    };
+    #pragma pack(pop)
+
+    struct ChunkGroup {
+        int64_t startPos = 0;    // 该ChunkGroup在T上的起始位置
+        int64_t length = 0;      // 该ChunkGroup的长度
+        int64_t chunkSize = 0;   // 每个chunk的长度
+        int64_t coreStart = 0;   // 预留
+        int64_t coreEnd = 0;     // 预留
+    };
+}  // ChunkGatedDeltaRule
+
+#endif  // CHUNK_GATED_DELTA_RULE_TILING_DATA_H

--- a/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule_tiling_key.h
+++ b/csrc/attention/chunk_gated_delta_rule/op_kernel/chunk_gated_delta_rule_tiling_key.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file chunk_gated_delta_rule_tiling_key.h
+ * \brief chunk_gated_delta_rule tiling key definitions
+ */
+
+#ifndef CHUNK_GATED_DELTA_RULE_TILING_KEY_H
+#define CHUNK_GATED_DELTA_RULE_TILING_KEY_H
+
+#define TILING_KEY_CGDR_BF16_STATE 0UL
+#define TILING_KEY_CGDR_FP32_STATE 1UL
+
+#endif // CHUNK_GATED_DELTA_RULE_TILING_KEY_H

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/data_copy_transpose_tiling.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/data_copy_transpose_tiling.h
@@ -1,0 +1,51 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling.h
+ * \brief
+ */
+
+#pragma once
+
+#include <vector>
+#include <graph/tensor.h>
+#include "data_copy_transpose_tiling_def.h"
+
+namespace optiling {
+
+inline void GetDataCopyTransposeTiling(const ge::Shape &dstShape, const ge::Shape &srcShape, const uint32_t typeSize,
+                                       optiling::CopyTransposeTiling &tiling)
+{
+    constexpr int64_t B_INDEX = 0;
+    constexpr int64_t N_INDEX = 1;
+    constexpr int64_t S_INDEX = 2;
+    constexpr int64_t H_INDEX = 3;
+    std::vector<int64_t> dstShapeInfo = dstShape.GetDims();
+    std::vector<int64_t> srcShapeInfo = srcShape.GetDims();
+
+    tiling.set_dstShapeB(dstShapeInfo[B_INDEX]);
+    tiling.set_dstShapeN(dstShapeInfo[N_INDEX]);
+    tiling.set_dstShapeS(dstShapeInfo[S_INDEX]);
+    tiling.set_dstShapeH(dstShapeInfo[H_INDEX]);
+    tiling.set_dstShapeHN(tiling.get_dstShapeH() / tiling.get_dstShapeN());
+
+    tiling.set_srcShapeB(srcShapeInfo[B_INDEX]);
+    tiling.set_srcShapeN(srcShapeInfo[N_INDEX]);
+    tiling.set_srcShapeS(srcShapeInfo[S_INDEX]);
+    tiling.set_srcShapeHN(srcShapeInfo[H_INDEX]);
+    tiling.set_originalShapeNLen(tiling.get_srcShapeHN() * typeSize);
+    tiling.set_shapeSHValue(tiling.get_dstShapeS() * tiling.get_dstShapeH());
+    tiling.set_shapeNsValue(tiling.get_dstShapeN() * tiling.get_dstShapeS());
+    tiling.set_shapeNsnValue(tiling.get_dstShapeN() * tiling.get_srcShapeS() * tiling.get_srcShapeN());
+    tiling.set_shapeBHValue(tiling.get_dstShapeB() * tiling.get_dstShapeH());
+}
+
+} // namespace optiling

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/data_copy_transpose_tiling_def.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/data_copy_transpose_tiling_def.h
@@ -1,0 +1,43 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file data_copy_transpose_tiling_def.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <register/tilingdata_base.h>
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(CopyTransposeTiling)
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, dstShapeH);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeB);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeN);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeS);
+TILING_DATA_FIELD_DEF(uint32_t, srcShapeHN);
+TILING_DATA_FIELD_DEF(uint32_t, originalShapeNLen);
+TILING_DATA_FIELD_DEF(uint32_t, shapeSHValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsValue);
+TILING_DATA_FIELD_DEF(uint32_t, shapeNsnValue);
+TILING_DATA_FIELD_DEF(uint32_t, invalidParamCopyTransposeTiling);
+TILING_DATA_FIELD_DEF(uint32_t, shapeBHValue);
+TILING_DATA_FIELD_DEF(uint32_t, paramsAlign);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(CopyTransposeTilingOp, CopyTransposeTiling)
+
+} // namespace optiling

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/error_log.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/error_log.h
@@ -1,0 +1,63 @@
+#ifndef OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+#define OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_
+
+#include <cstdio>
+#include <string>
+#include "toolchain/slog.h"
+
+#define OP_LOGI(opname, ...)
+#define OP_LOGW(opname, ...)             \
+    do {                                 \
+        (void)(opname);                  \
+        std::printf("[WARN] ");          \
+        std::printf(__VA_ARGS__);        \
+        std::printf("\n");              \
+    } while (0)
+
+#define OP_LOGE_WITHOUT_REPORT(opname, ...) \
+    do {                                    \
+        (void)(opname);                     \
+        std::printf("[ERRORx] ");           \
+        std::printf(__VA_ARGS__);           \
+        std::printf("\n");                 \
+    } while (0)
+
+#define OP_LOGE(opname, ...)              \
+    do {                                  \
+        (void)(opname);                   \
+        std::printf("[ERROR] ");          \
+        std::printf(__VA_ARGS__);         \
+        std::printf("\n");               \
+    } while (0)
+
+#define OP_LOGD(opname, ...)
+
+namespace optiling {
+
+#define VECTOR_INNER_ERR_REPORT_TILIING(op_name, err_msg, ...)   \
+    do {                                                         \
+        OP_LOGE_WITHOUT_REPORT(op_name, err_msg, ##__VA_ARGS__); \
+    } while (0)
+
+// Modify OP_TILING_CHECK macro to ensure proper handling of expressions
+#define OP_CHECK_IF(cond, log_func, expr) \
+    do {                                      \
+        if (cond) {                           \
+            log_func;                         \
+            expr;                             \
+        }                                     \
+    } while (0)
+
+
+
+#define OP_CHECK_NULL_WITH_CONTEXT(context, ptr)                          \
+    do {                                                                  \
+        if ((ptr) == nullptr) {                                           \
+            OP_LOGE(context->GetNodeType(), "%s is null", #ptr);               \
+            return ge::GRAPH_FAILED;                                      \
+        }                                                                 \
+    } while (0)
+
+}  // namespace optiling
+
+#endif  // OPS_BUILT_IN_OP_TILING_ERROR_LOG_H_

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_base.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_base.h
@@ -1,0 +1,256 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_base.h
+ * \brief
+ */
+
+#pragma once
+
+#include <sstream>
+#include <exe_graph/runtime/tiling_context.h>
+#include <graph/utils/type_utils.h>
+#include "tiling/platform/platform_ascendc.h"
+#include "error_log.h"
+
+#ifdef ASCENDC_OP_TEST
+#define ASCENDC_EXTERN_C extern "C"
+#else
+#define ASCENDC_EXTERN_C
+#endif
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+struct AiCoreParams {
+    uint64_t ubSize = 0;
+    uint64_t blockDim = 0;
+    uint64_t aicNum = 0;
+    uint64_t l1Size = 0;
+    uint64_t l0aSize = 0;
+    uint64_t l0bSize = 0;
+    uint64_t l0cSize = 0;
+};
+
+struct CompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+struct FlashAttentionScoreGradCompileInfo {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    platform_ascendc::SocVersion socVersion;
+};
+
+struct FACompileInfoCommon {
+    uint32_t aivNum;
+    uint32_t aicNum;
+    uint64_t ubSize;
+    uint64_t l1Size;
+    uint64_t l0aSize;
+    uint64_t l0bSize;
+    uint64_t l0cSize;
+    uint64_t l2CacheSize;
+    int64_t coreNum;
+    int32_t socVersion;
+    uint32_t rsvd;
+};
+
+class TilingBaseClass {
+public:
+    explicit TilingBaseClass(gert::TilingContext* context) : context_(context)
+    {}
+
+    virtual ~TilingBaseClass() = default;
+
+    // Tiling execution framework
+    //     1. GRAPH_SUCCESS: Success, and no need to continue executing subsequent Tiling class implementations
+    //     2. GRAPH_FAILED: Failure, abort the entire Tiling process
+    //     3. GRAPH_PARAM_INVALID: This class does not support, need to continue executing other Tiling class implementations
+    ge::graphStatus DoTiling()
+    {
+        auto ret = GetShapeAttrsInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetPlatformInfo();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        if (!IsCapable()) {
+            return ge::GRAPH_PARAM_INVALID;
+        }
+        ret = DoOpTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = DoLibApiTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = GetWorkspaceSize();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        ret = PostTiling();
+        if (ret != ge::GRAPH_SUCCESS) {
+            return ret;
+        }
+        context_->SetTilingKey(GetTilingKey());
+        DumpTilingInfo();
+        return ge::GRAPH_SUCCESS;
+    }
+
+    // Update context
+    virtual void Reset(gert::TilingContext* context)
+    {
+        context_ = context;
+    }
+
+protected:
+    virtual bool IsCapable() = 0;
+    // 1. Get platform information such as CoreNum, UB/L1/L0C resource sizes
+    virtual ge::graphStatus GetPlatformInfo() = 0;
+    // 2. Get INPUT/OUTPUT/ATTR information
+    virtual ge::graphStatus GetShapeAttrsInfo() = 0;
+    // 3. Calculate data splitting TilingData
+    virtual ge::graphStatus DoOpTiling() = 0;
+    // 4. Calculate high-level API TilingData
+    virtual ge::graphStatus DoLibApiTiling() = 0;
+    // 5. Calculate TilingKey
+    [[nodiscard]] virtual uint64_t GetTilingKey() const = 0;
+    // 6. Calculate Workspace size
+    virtual ge::graphStatus GetWorkspaceSize() = 0;
+    // 7. Save Tiling data
+    virtual ge::graphStatus PostTiling() = 0;
+    // 8. Dump Tiling data
+    virtual void DumpTilingInfo()
+    {
+        int32_t enable = CheckLogLevel(static_cast<int32_t>(OP), DLOG_DEBUG);
+        if (enable != 1) {
+            return;
+        }
+        auto buf = (uint32_t*)context_->GetRawTilingData()->GetData();
+        auto bufLen = context_->GetRawTilingData()->GetDataSize();
+        std::ostringstream oss;
+        oss << "Start to dump tiling info. tilingkey:" << context_->GetTilingKey() << ", tiling data size:" << bufLen
+            << ", content:";
+        for (size_t i = 0; i < bufLen / sizeof(uint32_t); i++) {
+            oss << *(buf + i) << ",";
+            if (oss.str().length() > 640) { // Split according to 640 to avoid truncation
+                OP_LOGD(context_, "%s", oss.str().c_str());
+                oss.str("");
+            }
+        }
+        OP_LOGD(context_, "%s", oss.str().c_str());
+    }
+
+    static uint32_t CalcTschBlockDim(uint32_t sliceNum, uint32_t aicCoreNum, uint32_t aivCoreNum)
+    {
+        uint32_t ration;
+        if (aicCoreNum == 0 || aivCoreNum == 0 || aicCoreNum > aivCoreNum) {
+            return sliceNum;
+        }
+        ration = aivCoreNum / aicCoreNum;
+        return (sliceNum + (ration - 1)) / ration;
+    }
+
+    template <typename T>
+    [[nodiscard]] std::string GetShapeDebugStr(const T& shape) const
+    {
+        std::ostringstream oss;
+        oss << "[";
+        if (shape.GetDimNum() > 0) {
+            for (size_t i = 0; i < shape.GetDimNum() - 1; ++i) {
+                oss << shape.GetDim(i) << ", ";
+            }
+            oss << shape.GetDim(shape.GetDimNum() - 1);
+        }
+        oss << "]";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTensorDebugStr(
+        const gert::StorageShape* shape, const gert::CompileTimeTensorDesc* tensor)
+    {
+        if (shape == nullptr || tensor == nullptr) {
+            return "nil ";
+        }
+        std::ostringstream oss;
+        oss << "(dtype: " << ge::TypeUtils::DataTypeToSerialString(tensor->GetDataType()) << "),";
+        oss << "(shape:" << GetShapeDebugStr(shape->GetStorageShape()) << "),";
+        oss << "(ori_shape:" << GetShapeDebugStr(shape->GetOriginShape()) << "),";
+        oss << "(format: "
+            << ge::TypeUtils::FormatToSerialString(
+                   static_cast<ge::Format>(ge::GetPrimaryFormat(tensor->GetStorageFormat())))
+            << "),";
+        oss << "(ori_format: " << ge::TypeUtils::FormatToSerialString(tensor->GetOriginFormat()) << ") ";
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingContextDebugStr()
+    {
+        std::ostringstream oss;
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetInputsNum(); ++i) {
+            oss << "input" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetInputShape(i), context_->GetInputDesc(i));
+        }
+
+        for (size_t i = 0; i < context_->GetComputeNodeInfo()->GetOutputsNum(); ++i) {
+            oss << "output" << i << ": ";
+            oss << GetTensorDebugStr(context_->GetOutputShape(i), context_->GetOutputDesc(i));
+        }
+        return oss.str();
+    }
+
+    [[nodiscard]] std::string GetTilingDataDebugStr() const
+    {
+        auto rawTilingData = context_->GetRawTilingData();
+        auto rawTilingDataSize = rawTilingData->GetDataSize();
+        auto data = reinterpret_cast<const int32_t*>(rawTilingData->GetData());
+        size_t len = rawTilingDataSize / sizeof(int32_t);
+        std::ostringstream oss;
+        for (size_t i = 0; i < len; i++) {
+            oss << data[i] << ", ";
+        }
+        return oss.str();
+    }
+
+protected:
+    gert::TilingContext* context_ = nullptr;
+    std::unique_ptr<platform_ascendc::PlatformAscendC> ascendcPlatform_{nullptr};
+    uint32_t blockDim_{0};
+    uint64_t workspaceSize_{0};
+    uint64_t tilingKey_{0};
+    AiCoreParams aicoreParams_;
+};
+
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_key.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_key.h
@@ -1,0 +1,63 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_key.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr uint64_t kBase = 10; // Base-10 carry base
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + kBase * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace Optiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_templates_registry.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_templates_registry.h
@@ -1,0 +1,351 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_templates_registry.h
+ * \brief
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+#include "exe_graph/runtime/tiling_context.h"
+#include "tiling_base.h"
+#include "error_log.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+
+template <typename T>
+std::unique_ptr<TilingBaseClass> TILING_CLASS(gert::TilingContext* context)
+{
+    return std::unique_ptr<T>(new (std::nothrow) T(context));
+}
+
+using TilingClassCase = std::unique_ptr<TilingBaseClass> (*)(gert::TilingContext*);
+
+class TilingCases {
+public:
+    explicit TilingCases(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    void AddTiling(int32_t priority)
+    {
+        OP_CHECK_IF(
+            cases_.find(priority) != cases_.end(), OP_LOGE(op_type_, "There are duplicate registrations."), return);
+        cases_[priority] = TILING_CLASS<T>;
+        OP_CHECK_IF(
+            cases_[priority] == nullptr,
+            OP_LOGE(op_type_, "Register op tiling func failed, please check the class name."), return);
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingCases()
+    {
+        return cases_;
+    }
+
+private:
+    std::map<int32_t, TilingClassCase> cases_;
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce with soc version --------------------------------
+class TilingRegistryNew {
+public:
+    TilingRegistryNew() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistryNew& GetInstance();
+#else
+    static TilingRegistryNew& GetInstance()
+    {
+        static TilingRegistryNew registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        if (soc_iter == registry_map_.end()) {
+            std::map<std::string, std::shared_ptr<TilingCases>> op_type_map;
+            op_type_map[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            registry_map_[soc_version] = op_type_map;
+        } else {
+            if (soc_iter->second.find(op_type) == soc_iter->second.end()) {
+                soc_iter->second[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+            }
+        }
+
+        OP_CHECK_IF(
+            registry_map_[soc_version][op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[soc_version][op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        int32_t soc_version = (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION;
+        const char* op_type = context->GetNodeType();
+        fe::PlatFormInfos* platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = static_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+            if (soc_version == (int32_t)platform_ascendc::SocVersion::RESERVED_VERSION) {
+                OP_LOGE(op_type, "Do op tiling failed, cannot find soc version.");
+                return ge::GRAPH_FAILED;
+            }
+        }
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        int32_t soc_version;
+        const char* op_type = context->GetNodeType();
+        auto platformInfoPtr = context->GetPlatformInfo();
+        if (platformInfoPtr == nullptr) {
+            auto compileInfoPtr = reinterpret_cast<const CompileInfoCommon*>(context->GetCompileInfo());
+            OP_CHECK_IF(
+                compileInfoPtr == nullptr, OP_LOGE(op_type, "compileInfoPtr is null."), return ge::GRAPH_FAILED);
+            soc_version = compileInfoPtr->socVersion;
+            OP_LOGD(context, "soc version in compileInfo is %d", soc_version);
+        } else {
+            auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfoPtr);
+            soc_version = static_cast<int32_t>(ascendcPlatform.GetSocVersion());
+            OP_LOGD(context, "soc version is %d", soc_version);
+        }
+
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type, soc_version);
+        for (auto priority_id : priorities) {
+            auto tilingCaseIter = tilingTemplateRegistryMap.find(priority_id);
+            if (tilingCaseIter != tilingTemplateRegistryMap.end()) {
+                auto templateFunc = tilingCaseIter->second(context);
+                if (templateFunc != nullptr) {
+                    ge::graphStatus status = templateFunc->DoTiling();
+                    if (status == ge::GRAPH_SUCCESS) {
+                        OP_LOGD(context, "Do general op tiling success priority=%d", priority_id);
+                        return status;
+                    }
+                    OP_LOGD(context, "Ignore general op tiling priority=%d", priority_id);
+                }
+            }
+        }
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type, int32_t soc_version)
+    {
+        auto soc_iter = registry_map_.find(soc_version);
+        OP_CHECK_IF(
+            soc_iter == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the soc version %d", soc_version),
+            return empty_tiling_case_);
+        auto op_iter = soc_iter->second.find(op_type);
+        OP_CHECK_IF(
+            op_iter == soc_iter->second.end(), OP_LOGE(op_type, "Get op tiling func failed, please check the op name."),
+            return empty_tiling_case_);
+        return op_iter->second->GetTilingCases();
+    }
+
+private:
+    std::map<int32_t, std::map<std::string, std::shared_ptr<TilingCases>>> registry_map_; // key is socversion
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_{};
+};
+
+class RegisterNew {
+public:
+    explicit RegisterNew(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, int32_t soc_version)
+    {
+        auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+    template <typename T>
+    RegisterNew& tiling(int32_t priority, const std::vector<int32_t>& soc_versions)
+    {
+        for (int32_t soc_version : soc_versions) {
+            auto tilingCases = TilingRegistryNew::GetInstance().RegisterOp(op_type_, soc_version);
+            OP_CHECK_IF(
+                tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."),
+                return *this);
+            tilingCases->AddTiling<T>(priority);
+        }
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+
+// --------------------------------Interfacce without soc version --------------------------------
+class TilingRegistry {
+public:
+    TilingRegistry() = default;
+
+#ifdef ASCENDC_OP_TEST
+    static TilingRegistry& GetInstance();
+#else
+    static TilingRegistry& GetInstance()
+    {
+        static TilingRegistry registry_impl_;
+        return registry_impl_;
+    }
+#endif
+
+    std::shared_ptr<TilingCases> RegisterOp(const std::string& op_type)
+    {
+        if (registry_map_.find(op_type) == registry_map_.end()) {
+            registry_map_[op_type] = std::shared_ptr<TilingCases>(new (std::nothrow) TilingCases(op_type));
+        }
+        OP_CHECK_IF(
+            registry_map_[op_type] == nullptr,
+            OP_LOGE(op_type, "Register tiling func failed, please check the class name."), return nullptr);
+        return registry_map_[op_type];
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto it = tilingTemplateRegistryMap.begin(); it != tilingTemplateRegistryMap.end(); ++it) {
+            auto tilingTemplate = it->second(context);
+            if (tilingTemplate != nullptr) {
+                ge::graphStatus status = tilingTemplate->DoTiling();
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", it->first);
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", it->first);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    ge::graphStatus DoTilingImpl(gert::TilingContext* context, const std::vector<int32_t>& priorities)
+    {
+        const char* op_type = context->GetNodeType();
+        auto tilingTemplateRegistryMap = GetTilingTemplates(op_type);
+        for (auto priorityId : priorities) {
+            auto templateFunc = tilingTemplateRegistryMap[priorityId](context);
+            if (templateFunc != nullptr) {
+                ge::graphStatus status = templateFunc->DoTiling();
+                if (status == ge::GRAPH_SUCCESS) {
+                    OP_LOGD(context, "Do general op tiling success priority=%d", priorityId);
+                    return status;
+                }
+                if (status != ge::GRAPH_PARAM_INVALID) {
+                    OP_LOGD(context, "Do op tiling failed");
+                    return status;
+                }
+                OP_LOGD(context, "Ignore general op tiling priority=%d", priorityId);
+            }
+        }
+        OP_LOGE(op_type, "Do op tiling failed, no valid template is found.");
+        return ge::GRAPH_FAILED;
+    }
+
+    const std::map<int32_t, TilingClassCase>& GetTilingTemplates(const std::string& op_type)
+    {
+        OP_CHECK_IF(
+            registry_map_.find(op_type) == registry_map_.end(),
+            OP_LOGE(op_type, "Get op tiling func failed, please check the op name."), return empty_tiling_case_);
+        return registry_map_[op_type]->GetTilingCases();
+    }
+
+private:
+    std::map<std::string, std::shared_ptr<TilingCases>> registry_map_;
+    const std::map<int32_t, TilingClassCase> empty_tiling_case_;
+};
+
+class Register {
+public:
+    explicit Register(std::string op_type) : op_type_(std::move(op_type))
+    {}
+
+    template <typename T>
+    Register& tiling(int32_t priority)
+    {
+        auto tilingCases = TilingRegistry::GetInstance().RegisterOp(op_type_);
+        OP_CHECK_IF(
+            tilingCases == nullptr, OP_LOGE(op_type_, "Register op tiling failed, please the op name."), return *this);
+        tilingCases->AddTiling<T>(priority);
+        return *this;
+    }
+
+private:
+    const std::string op_type_;
+};
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops
+
+// op_type: operator name, class_name: registered tiling class, soc_version: chip version number
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_WITH_SOCVERSION(op_type, class_name, soc_versions, priority)    \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_versions)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+#define REGISTER_TILING_TEMPLATE(op_type, class_name, priority)                                \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register VAR_UNUSED##op_type_##class_name##priority_register = \
+        Ops::Transformer::OpTiling::Register(op_type).tiling<class_name>(priority)
+
+// op_type: operator name, class_name: registered tiling class
+// soc_version: SOC version, used to distinguish different SOCs
+// priority: priority of tiling class, smaller value means higher priority, i.e., this tiling class will be selected first
+#define REGISTER_TILING_TEMPLATE_NEW(op_type, class_name, soc_version, priority)                 \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::RegisterNew VAR_UNUSED##op_type##class_name##priority_register = \
+        Ops::Transformer::OpTiling::RegisterNew(#op_type).tiling<class_name>(priority, soc_version)
+
+// op_type: operator name, class_name: registered tiling class
+// priority: priority of tiling class, smaller value means higher priority, i.e., higher probability of being selected
+// Replaces REGISTER_TILING_TEMPLATE, if op_type is a string constant, remove the quotes
+#define REGISTER_OPS_TILING_TEMPLATE(op_type, class_name, priority)                       \
+    [[maybe_unused]] uint32_t op_impl_register_template_##op_type##_##class_name##priority;      \
+    static Ops::Transformer::OpTiling::Register                                                  \
+        __attribute__((unused)) tiling_##op_type##_##class_name##_##priority##_register = \
+            Ops::Transformer::OpTiling::Register(#op_type).tiling<class_name>(priority)

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_type.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_type.h
@@ -1,0 +1,139 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_type.h
+ * \brief
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace optiling {
+
+enum class AxisEnum {
+    B = 0,
+    N2 = 1,
+    G = 2,
+    S1 = 3,
+    S2 = 4,
+    D = 5,
+    NONE = 9,
+};
+
+enum class DtypeEnum {
+    FLOAT16 = 0,
+    FLOAT32 = 1,
+    BFLOAT16 = 2,
+    FLOAT16_PRECISION = 3,
+};
+
+enum class PerformanceOrientedEnum {
+    BIG_BUFFER = 1,
+    BIG_DOUBLE_BUFFER = 2,
+};
+
+enum class MatmulConfig {
+    NULL_CONFIG = 0,
+    NORMAL_CONFIG = 1,
+    MDL_CONFIG = 2
+};
+
+enum class PseConfig {
+    NO_PSE = 0,
+    EXIST_PSE = 1
+};
+
+enum class AttenMaskConfig {
+    NO_ATTEN_MASK = 0,
+    EXIST_ATTEN_MASK = 1
+};
+
+enum class DropOutConfig {
+    NO_DROP_OUT = 0,
+    EXIST_DROP_OUT = 1
+};
+
+enum class CubeFormatEnum {
+    ND = 0,
+    NZ = 1
+};
+enum class LayoutEnum {
+    BSND = 0,
+    SBND = 1,
+    BNSD = 2,
+    TND = 3,
+    NTD_TND = 4
+};
+
+enum class CubeInputSourceEnum {
+    GM = 0,
+    L1 = 1
+};
+
+enum class OptionEnum {
+    DISABLE = 0,
+    ENABLE = 1
+};
+
+enum class SparseEnum {
+    ALL = 0,
+    NONE = 1,
+    ANY = 2,
+    CAUSAL = 3,
+    BAND = 4,
+    PREFIX = 5,
+    BAND_COMPRESS = 6,
+    RIGHT_DOWN_CAUSAL = 7,
+    RIGHT_DOWN_CAUSAL_BAND = 8,
+    BAND_LEFT_UP_CAUSAL = 9
+};
+
+constexpr uint64_t RecursiveSum()
+{
+    return 0;
+}
+
+constexpr int64_t base10Multiplier = 10;
+
+template <typename T, typename... Args> constexpr uint64_t RecursiveSum(T templateId, Args... templateIds)
+{
+    return static_cast<uint64_t>(templateId) + base10Multiplier * RecursiveSum(templateIds...);
+}
+
+// TilingKey generation rules:
+// FlashAttentionScore/FlashAttentionScoreGrad assembles tiling key using decimal digits, containing the following key parameters from low to high: Ub0, Ub1,
+// Block, DataType, Format, Sparse. Specialized template Ub0, Ub1:
+//     Represents the axis for UB intra-core splitting, using AxisEnum. Since we allow at most two axes to be split, UB0 and UB1 exist. If there is no UB intra-core splitting,
+//     fill with AXIS_NONE. UB0 and UB1 each occupy one decimal digit;
+//     Block: Represents the axis used by UB for multi-core splitting, using AxisEnum, occupies one decimal digit;
+//     DataType: Represents the input/output data types supported by the current tiling key, using SupportedDtype enum, occupies one decimal digit
+//     Format: Represents the Format supported by the current tiling key, using InputLayout enum, occupies one decimal digit
+//     Sparse: Represents whether the current tiling key supports Sparse, using SparseCapability enum, occupies one decimal digit
+//     For other specialized scenarios, define your own bit fields and values
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = GET_FLASHATTENTION_TILINGKEY(AxisEnum::AXIS_S1, AxisEnum::AXIS_S2, AxisEnum::AXIS_N2,
+//                                     SupportedDtype::FLOAT32, InputLayout::BSH, SparseCapability::SUPPORT_ALL)
+
+constexpr uint64_t TILINGKEYOFFSET = uint64_t(10000000000000000000UL); // 10^19
+template <typename... Args> constexpr uint64_t GET_TILINGKEY(Args... templateIds)
+{
+    return TILINGKEYOFFSET + RecursiveSum(templateIds...);
+}
+
+// usage: get tilingKey from inputted types
+//     uint64_t tilingKey = TILINGKEY(S2, S1, N2, FLOAT32, BSND, ALL)
+
+#define TILINGKEY(ub2, ub1, block, dtype, layout, sparse)                                                              \
+    (GET_TILINGKEY(AxisEnum::ub2, AxisEnum::ub1, AxisEnum::block, DtypeEnum::dtype, LayoutEnum::layout,                \
+                   SparseEnum::sparse))
+
+} // namespace optiling

--- a/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_util.h
+++ b/csrc/attention/chunk_gated_delta_rule/tiling_base/tiling_util.h
@@ -1,0 +1,30 @@
+/**
+ * This program is free software, you can redistribute it and/or modify.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file tiling_util.h
+ * \brief
+ */
+
+#pragma once
+
+#include "register/op_impl_registry.h"
+
+namespace Ops {
+namespace Transformer {
+namespace OpTiling {
+bool IsRegbaseSocVersion(const gert::TilingParseContext* context);
+
+bool IsRegbaseSocVersion(const gert::TilingContext* context);
+
+const gert::Shape& EnsureNotScalar(const gert::Shape& inShape);
+} // namespace OpTiling
+} // namespace Transformer
+} // namespace Ops

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -129,6 +129,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "ngram_spec_decode"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "chunk_gated_delta_rule"
         "store_kv_block"
         "store_kv_block_metadata"
     )
@@ -178,6 +179,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "ngram_spec_decode"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "chunk_gated_delta_rule"
         "store_kv_block"
         "store_kv_block_metadata"
     )
@@ -211,6 +213,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "recurrent_gated_delta_rule"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "chunk_gated_delta_rule"
         "store_kv_block"
         "store_kv_block_metadata"
     )

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -47,6 +47,7 @@
 #include "moe/causal_conv1d_v310/causal_conv1d_310_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
+#include "attention/chunk_gated_delta_rule/chunk_gated_delta_rule_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp"
 #include <c10/core/Device.h>
@@ -2124,6 +2125,17 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                               Tensor? g=None, "
         "                               Tensor? gk=None) -> Tensor");
     ops.impl("npu_recurrent_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule);
+
+    ops.def(
+        "npu_chunk_gated_delta_rule(Tensor query, "
+        "                          Tensor key, "
+        "                          Tensor value, "
+        "                          Tensor beta, "
+        "                          Tensor initial_state, "
+        "                          Tensor actual_seq_lengths, "
+        "                          Tensor? g=None, "
+        "                          float scale_value=1.0) -> (Tensor out, Tensor final_state)");
+    ops.impl("npu_chunk_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_chunk_gated_delta_rule);
 
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
     // Direct kernel custom ops

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -598,6 +598,25 @@ at::Tensor npu_recurrent_gated_delta_rule_meta(
     return output;
 }
 
+// Meta for npu_chunk_gated_delta_rule. Returns (out, final_state) with the same
+// shapes as value (bf16) and initial_state respectively. No real computation.
+std::tuple<at::Tensor, at::Tensor> npu_chunk_gated_delta_rule_meta(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& beta,
+    const at::Tensor& initial_state,
+    const at::Tensor& actual_seq_lengths,
+    const c10::optional<at::Tensor>& g,
+    double scale_value)
+{
+    auto out_options = value.options().dtype(at::ScalarType::BFloat16);
+    at::Tensor out = at::empty_symint(value.sym_sizes(), out_options);
+    at::Tensor final_state =
+        at::empty_symint(initial_state.sym_sizes(), initial_state.options());
+    return std::make_tuple(out, final_state);
+}
+
 std::vector<at::Tensor> moe_grouped_matmul_meta(
     at::Tensor x,
     at::Tensor weight,
@@ -1543,6 +1562,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_gemma_rms_norm", &vllm_ascend::meta::npu_gemma_rms_norm_meta);
     // recurrent_gated_delta_rule meta implementation
     ops.impl("npu_recurrent_gated_delta_rule", &vllm_ascend::meta::npu_recurrent_gated_delta_rule_meta);
+    ops.impl("npu_chunk_gated_delta_rule", &vllm_ascend::meta::npu_chunk_gated_delta_rule_meta);
     // Launch host print from device
     ops.impl("device_print", &vllm_ascend::meta::device_print_meta);
     // launch host print from device for tensors

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -30,7 +30,6 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm_ascend.attention.utils import maybe_save_kv_layer_to_connector
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
-from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
@@ -399,22 +398,52 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 g_non_spec = g_non_spec[:, num_decode_tokens:]
                 beta_non_spec = beta_non_spec[:, num_decode_tokens:]
 
-            initial_state = ssm_state[prefill_state_indices].transpose(-1, -2).contiguous()
+            # aclnn chunk op expects initial_state in (B, Nv, Dv, Dk) layout,
+            # which is exactly ssm_state's native (Nv, Dv, Dk)-per-seq layout
+            # (see MambaStateShapeCalculator.gated_delta_net_state_shape).
+            # Unlike the prior triton path (whose fwd_h sub-op used (B, Nv, Dk,
+            # Dv) and so required a transpose), NO transpose is needed here.
+            initial_state = ssm_state[prefill_state_indices].contiguous()
             clear_ssm_states(initial_state, prefill_has_initial_state)
-            (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=prefill_query_start_loc,
-                prebuilt_meta=attn_metadata.non_spec_prefill_metadata.chunk,
-                head_first=False,
-                use_qk_l2norm_in_kernel=True,
+
+            # q/k/v/g/beta are [1, T, H, *] (head_first=False, batch is flat B=1
+            # over the concatenated prefill tokens). The aclnn chunk_gated_delta
+            # rule op requires TND layout, so drop the leading batch dim.
+            # Note: this op does NOT l2-normalize q/k internally (the prior
+            # triton entry did via use_qk_l2norm_in_kernel=True), so do it here.
+            q_tnd = l2norm_fwd(query_non_spec.squeeze(0))   # (T, Nk, Dk)
+            k_tnd = l2norm_fwd(key_non_spec.squeeze(0))     # (T, Nk, Dk)
+            v_tnd = value_non_spec.squeeze(0)               # (T, Nv, Dv)
+            beta_tnd = beta_non_spec.squeeze(0)             # (T, Nv)
+            g_tnd = g_non_spec.squeeze(0)                    # (T, Nv), fp32 log-gate
+
+            # cu_seqlens [0, s1, s1+s2, ...] -> per-seq lengths (B,) int32.
+            # initial_state.shape[0] == num prefill sequences == B.
+            actual_seq_lengths = (
+                prefill_query_start_loc[1:] - prefill_query_start_loc[:-1]
+            ).to(torch.int32).contiguous()
+
+            scale = q_tnd.shape[-1] ** -0.5
+            core_attn_out_non_spec, last_recurrent_state = (
+                torch.ops._C_ascend.npu_chunk_gated_delta_rule(
+                    q_tnd,
+                    k_tnd,
+                    v_tnd,
+                    beta_tnd,
+                    initial_state,
+                    actual_seq_lengths,
+                    g_tnd,
+                    scale,
+                )
             )
-            ssm_state[prefill_state_indices] = last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+
+            # Op returns out=(T, Nv, Dv) bf16; restore the batch dim -> [1, T, Nv, Dv].
+            core_attn_out_non_spec = core_attn_out_non_spec.unsqueeze(0)
+            # final_state=(B, Nv, Dv, Dk), already matching ssm_state's native
+            # layout (no transpose needed, unlike the prior triton path).
+            # .contiguous() is a no-op here (the op returns an at::empty tensor,
+            # always contiguous) but kept for symmetry/defensiveness.
+            ssm_state[prefill_state_indices] = last_recurrent_state.contiguous().to(ssm_state.dtype)
             if split_non_spec:
                 core_attn_out_non_spec = torch.cat(
                     [core_attn_out_decode, core_attn_out_non_spec],


### PR DESCRIPTION
Replace the triton-based chunk_gated_delta_rule entry in gdn.py's prefill path with the single aclnn aclnnChunkGatedDeltaRule operator, targeting Ascend A3 (910_93).

Source tree under csrc/attention/chunk_gated_delta_rule/ is vendored from ops-transformer (op_graph/op_host/op_kernel + arch22/arch35 kernels, no tests/examples/docs) and registered to the ascend910_93 build in build_aclnn.sh. A torch binding (chunk_gated_delta_rule_torch_adpt.h) plus ops.def/.impl in torch_binding.cpp and the meta impl in torch_binding_meta.cpp expose it as
torch.ops._C_ascend.npu_chunk_gated_delta_rule, mirroring the existing recurrent_gated_delta_rule integration.

In gdn.py the prefill call is rewritten to TND layout:
- squeeze the flat B=1 batch dim off q/k/v/g/beta
- l2-normalize q/k before the call (the new op does not normalize internally, unlike the triton entry's use_qk_l2norm_in_kernel=True)
- derive actual_seq_lengths (int32) from prefill_query_start_loc
- pass g as the raw float32 log-gate (the op cumsums internally; fused gating already produces the raw log-gate)
- restore the batch dim on out and transpose final_state back to the ssm_state (B, Nv, Dk, Dv) layout

PCP is single-card only here, so the triton entry's PCP correction branch is dropped; the triton chunk import in gdn.py is removed as it is no longer referenced. chunk.py itself is left untouched for any other callers.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
