### PR TITLE
[CI] Add pod readiness signaling for A3 560T nightly test

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node_560t.yaml
@@ -95,7 +95,19 @@ on:
         type: boolean
         default: false
         description: enable Pod AOP pipeline on failure
+      send_ready_signal:
+        required: false
+        type: boolean
+        default: false
+        description: send a commit status signal after LWS is created (used by double-node to unblock downstream jobs)
+      run_id:
+        required: false
+        type: string
+        default: ''
+        description: unique run identifier to isolate signals across concurrent runs (e.g. github.run_id)
     secrets:
+      PAT_TOKEN:
+        required: false
       KUBECONFIG_B64_560T:
         required: true
       OBS_ACCESS_KEY_ID:
@@ -243,6 +255,7 @@ jobs:
           kubectl apply -f ./lws.yaml
 
       - name: Wait for pods ready
+        id: wait-pods
         run: |
           set -euo pipefail
           SIZE="${{ inputs.size }}"
@@ -284,6 +297,25 @@ jobs:
             fi
             sleep 2
           done
+
+      - name: Signal pods status via commit status
+        if: always() && inputs.send_ready_signal
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          STATUS_CONTEXT="double-node-pods-ready-560t/${{ inputs.run_id }}/${{ inputs.name || inputs.config_file_path }}"
+          if [ "${{ steps.wait-pods.outcome }}" = "success" ]; then
+            STATE="success"
+            DESC="Pods ready"
+          else
+            STATE="failure"
+            DESC="Wait pods timeout or failed"
+          fi
+          curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -d "{\"state\":\"${STATE}\",\"description\":\"${DESC}\",\"context\":\"${STATUS_CONTEXT}\"}"
 
       - name: Stream logs
         id: stream_logs

--- a/.github/workflows/_nightly_wait_for_pods_ready.yaml
+++ b/.github/workflows/_nightly_wait_for_pods_ready.yaml
@@ -1,0 +1,171 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Reusable workflow that polls GitHub commit statuses to determine when all
+# pods for a given test matrix have been launched.
+#
+# Used by:
+#   - schedule_nightly_test_a3.yaml  (double-node)
+#   - schedule_weekly_test_a3.yaml   (double-node)
+#   - schedule_nightly_test_a2.yaml  (multi-node, future)
+
+name: 'Wait for pods launched signal'
+
+on:
+  workflow_call:
+    inputs:
+      matrix_json:
+        required: true
+        type: string
+        description: 'JSON array of test configs [{name, config_file_path}, ...]'
+      filter:
+        required: true
+        type: string
+        description: '"all" or ",name1,name2," (same as parse-trigger output)'
+      context_prefix:
+        required: true
+        type: string
+        description: 'Commit status context prefix, e.g. "double-node-pods-ready"'
+      run_id:
+        required: true
+        type: string
+        description: 'Unique run identifier to match the correct signal (e.g. github.run_id)'
+      max_parallel:
+        required: false
+        default: 4
+        type: number
+        description: 'max-parallel of the upstream matrix job'
+      testcase_timeout_minutes:
+        required: false
+        default: 120
+        type: number
+        description: 'timeout per test case (minutes)'
+      pod_wait_minutes:
+        required: false
+        default: 20
+        type: number
+        description: 'max time for a single pod launch + wait (minutes)'
+      buffer_minutes:
+        required: false
+        default: 20
+        type: number
+        description: 'extra safety buffer (minutes)'
+
+jobs:
+  poll:
+    name: Poll GitHub commit statuses
+    runs-on: ubuntu-latest
+    timeout-minutes: 720
+    steps:
+      - uses: actions/github-script@v9
+        id: poll
+        env:
+          MATRIX_JSON: ${{ inputs.matrix_json }}
+          FILTER: ${{ inputs.filter }}
+          CONTEXT_PREFIX: ${{ inputs.context_prefix }}
+          RUN_ID: ${{ inputs.run_id }}
+          MAX_PARALLEL: ${{ inputs.max_parallel }}
+          TESTCASE_TIMEOUT_MINUTES: ${{ inputs.testcase_timeout_minutes }}
+          POD_WAIT_MINUTES: ${{ inputs.pod_wait_minutes }}
+          BUFFER_MINUTES: ${{ inputs.buffer_minutes }}
+        with:
+          script: |
+            const matrix = JSON.parse(process.env.MATRIX_JSON);
+            const filter = process.env.FILTER.trim();
+            const contextPrefix = process.env.CONTEXT_PREFIX;
+            const runId = process.env.RUN_ID;
+
+            let runningEntries = matrix;
+            if (filter !== 'all') {
+              runningEntries = matrix.filter(entry =>
+                filter.includes(`,${entry.name},`)
+              );
+            }
+
+            const expectedContexts = runningEntries.map(entry =>
+              `${contextPrefix}/${runId}/${entry.name || entry.config_file_path}`
+            );
+
+            console.log(`Expecting ${expectedContexts.length} entries from matrix:`);
+            expectedContexts.forEach(c => console.log(`  - ${c}`));
+
+            if (expectedContexts.length === 0) {
+              console.log('No entries to wait for, done.');
+              return;
+            }
+
+            const maxParallel = parseInt(process.env.MAX_PARALLEL, 10) || 4;
+            const testcaseTimeoutMin = parseInt(process.env.TESTCASE_TIMEOUT_MINUTES, 10) || 120;
+            const podWaitMin = parseInt(process.env.POD_WAIT_MINUTES, 10) || 20;
+            const bufferMin = parseInt(process.env.BUFFER_MINUTES, 10) || 20;
+
+            const N = expectedContexts.length;
+            const batches = Math.ceil(N / maxParallel);
+            const dynamicTimeoutMin = podWaitMin + testcaseTimeoutMin * (batches - 1) + bufferMin;
+
+            console.log(
+              `N=${N} max_parallel=${maxParallel} batches=${batches} ` +
+              `dynamic_timeout=${dynamicTimeoutMin}min`
+            );
+
+            const POLL_INTERVAL_MS = 10_000;
+            const MAX_ATTEMPTS = Math.ceil(dynamicTimeoutMin * 60 * 1000 / POLL_INTERVAL_MS);
+            let readyCount = 0;
+
+            for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+              const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+              });
+
+              const signaledContexts = new Set(
+                statuses
+                  .filter(s => s.state === 'success' || s.state === 'failure')
+                  .map(s => s.context)
+              );
+
+              if (expectedContexts.every(c => signaledContexts.has(c))) {
+                const failed = expectedContexts.filter(c => {
+                  const st = statuses.find(s => s.context === c);
+                  return st && st.state === 'failure';
+                });
+                if (failed.length > 0) {
+                  console.log(
+                    `Note: ${failed.length} entries signaled failure ` +
+                    `(no pods running, safe to proceed):`
+                  );
+                  failed.forEach(c => console.log(`  - ${c}`));
+                }
+                console.log(`All ${expectedContexts.length} entries have signaled!`);
+                return;
+              }
+
+              readyCount = expectedContexts.filter(c => signaledContexts.has(c)).length;
+              console.log(
+                `[${new Date().toISOString()}] ` +
+                `Waiting... ${readyCount}/${expectedContexts.length} entries signaled ` +
+                `(attempt ${attempt + 1}/${MAX_ATTEMPTS})`
+              );
+
+              await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+            }
+
+            core.setFailed(
+              `Timeout after ${dynamicTimeoutMin} min. ` +
+              `Only ${readyCount}/${expectedContexts.length} entries signaled.`
+            );

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -58,6 +58,7 @@ permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -177,7 +178,7 @@ jobs:
 
   multi-node-tests:
     name: multi-node
-    needs: [setup-vars, parse-trigger, build-image, double-node-tests]
+    needs: [setup-vars, parse-trigger, build-image]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -202,6 +203,7 @@ jobs:
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
       request_id: ${{ inputs.request_id || '' }}
+      send_ready_signal: false
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -216,7 +218,7 @@ jobs:
 
   double-node-tests:
     name: double-node
-    needs: [setup-vars, parse-trigger, build-image, single-node-tests, multi-card-tests]
+    needs: [setup-vars, parse-trigger, build-image, multi-node-tests]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -241,6 +243,8 @@ jobs:
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       aop_multi_enabled: ${{ inputs.aop_enabled }}
       request_id: ${{ inputs.request_id || '' }}
+      send_ready_signal: true
+      run_id: ${{ github.run_id }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -249,13 +253,28 @@ jobs:
           )
         }}
     secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       KUBECONFIG_B64_560T: ${{ secrets.KUBECONFIG_B64_560T }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
 
+  double-node-pods-started:
+    name: Wait for all double-node pods launched
+    needs: [setup-vars, parse-trigger, build-image, multi-node-tests]
+    if: >-
+      always() &&
+      needs.parse-trigger.outputs.run == 'true' &&
+      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    uses: ./.github/workflows/_nightly_wait_for_pods_ready.yaml
+    with:
+      matrix_json: ${{ needs.setup-vars.outputs.double_node }}
+      filter: ${{ needs.parse-trigger.outputs.filter }}
+      context_prefix: 'double-node-pods-ready-560t'
+      run_id: ${{ github.run_id }}
+
   single-node-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image]
+    needs: [setup-vars, parse-trigger, build-image, double-node-pods-started]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -285,7 +304,7 @@ jobs:
 
   multi-card-tests:
     name: single-node
-    needs: [setup-vars, parse-trigger, build-image]
+    needs: [setup-vars, parse-trigger, build-image, double-node-pods-started]
     if: >-
       always() &&
       needs.parse-trigger.outputs.run == 'true' &&
@@ -343,3 +362,23 @@ jobs:
           pattern: nightly-test-benchmark-results-*
           compression-level: 0
           delete-merged: true
+
+  remove-taints:
+    name: Remove node taints
+    needs: [multi-node-tests, double-node-tests, single-node-tests, multi-card-tests]
+    if: >-
+      always() &&
+      inputs.request_id == '' &&
+      (needs.multi-node-tests.result != 'skipped' || needs.double-node-tests.result != 'skipped')
+    runs-on: linux-aarch64-a3-0-cn12-001
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-cpu
+      env:
+        KUBECONFIG: /tmp/kubeconfig
+    steps:
+      - name: Decode kubeconfig
+        run: echo "${{ secrets.KUBECONFIG_B64_560T }}" | base64 -d > "$KUBECONFIG"
+
+      - name: Remove dedicated taint from test nodes
+        run: |
+          kubectl taint nodes ${{ vars.A3_560T_TAINT_NODES }} dedicated- || true


### PR DESCRIPTION
### What this PR does / why we need it?

RFC: https://github.com/vllm-project/vllm-ascend/issues/12078

Adapt the double-node pod readiness coordination mechanism from the A3 nightly workflow to the A3 560T cluster, allowing single-node and multi-card tests to start as soon as double-node pods are ready rather than waiting for full test completion.

Changes:
- Add send_ready_signal to _e2e_nightly_multi_node_560t.yaml
- Create _nightly_wait_for_pods_ready.yaml reusable polling workflow
- Add double-node-pods-started job with isolated context prefix (double-node-pods-ready-560t) to avoid conflict with A3
- Restructure job dependencies: single-node/multi-card now depend on double-node-pods-started instead of double-node-tests
- Add remove-taints job for cleanup
- Make PAT_TOKEN optional to avoid requiring it for multi-node callers

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
