### PR TITLE
[Bugfix] Fix DSpark DP-padded metadata

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -19,8 +19,10 @@ import vllm_ascend.spec_decode.llm_base_proposer as llm_base_proposer
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import clear_ascend_config, init_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder, build_dspark_swa_indices
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
 from vllm_ascend.utils import enable_custom_op
@@ -184,6 +186,98 @@ def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
 
     assert spec_common_attn_metadata._seq_lens_cpu is internal_seq_lens_cpu
     assert spec_common_attn_metadata.seq_lens_cpu is None
+
+
+def test_dspark_draft_metadata_uses_dp_padded_positions_and_slots():
+    proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
+    proposer.method = "dspark"
+    proposer.use_compress = False
+    proposer.parallel_drafting_token_id = 99
+    proposer.input_ids = torch.arange(10, dtype=torch.int64)
+    proposer.positions = torch.arange(10, dtype=torch.int32)
+    proposer._slot_mapping_buffer = torch.arange(10, dtype=torch.int32)
+    proposer._per_group_block_table_buffers = {0: torch.zeros((1, 1), dtype=torch.int32)}
+    proposer._per_group_query_slot_mapping_buffers = {0: torch.arange(10, dtype=torch.int32)}
+
+    builder = MagicMock()
+    builder.build_for_drafting.return_value = SimpleNamespace(causal=False)
+    proposer.draft_attn_groups = [
+        SimpleNamespace(
+            kv_cache_group_id=0,
+            layer_names=["draft_layer"],
+            get_metadata_builder=lambda: builder,
+        )
+    ]
+    metadata = SimpleNamespace(
+        num_reqs=1,
+        num_actual_tokens=5,
+        num_input_tokens=5,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=proposer._slot_mapping_buffer[:5],
+        positions=proposer.positions[:5],
+    )
+
+    proposer.build_draft_attn_metadata(metadata, 10, 5)
+
+    draft_metadata = builder.build_for_drafting.call_args.args[0]
+    assert draft_metadata.positions.shape[0] == 10
+    assert torch.equal(draft_metadata.positions[5:], torch.zeros(5, dtype=torch.int32))
+    assert torch.equal(draft_metadata.slot_mapping[5:], torch.full((5,), -1, dtype=torch.int32))
+
+
+def test_dspark_drafting_uses_dp_padded_decode_token_count():
+    builder = AscendDSAMetadataBuilder.__new__(AscendDSAMetadataBuilder)
+    builder.compressor_ratio = 1
+    builder.block_size = 16
+    builder.decode_threshold = 6
+    builder.spec_slot_mapping = [torch.empty(15, dtype=torch.int32)]
+    builder.metadata_cls = SimpleNamespace
+    builder.model_config = SimpleNamespace(get_head_size=lambda: 128)
+    builder.build_decode_metadata_for_drafting = MagicMock(return_value=SimpleNamespace())
+
+    common_metadata = SimpleNamespace(
+        causal=False,
+        num_reqs=3,
+        num_actual_tokens=5,
+        num_input_tokens=15,
+        max_query_len=5,
+        query_start_loc=torch.tensor([0, 5, 10, 15], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 5, 10, 15], dtype=torch.int32),
+        positions=torch.zeros(15, dtype=torch.int32),
+        slot_mapping=torch.full((15,), -1, dtype=torch.int32),
+        attn_state=AscendAttentionState.ChunkedPrefill,
+        prefill_context_parallel_metadata=None,
+    )
+    rope = torch.zeros((15, 1), dtype=torch.float32)
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa", return_value=(rope, rope)),
+        patch(
+            "vllm_ascend.attention.dsa_v1.DeviceOperator.format_dsa_slot_mapping",
+            return_value=common_metadata.slot_mapping,
+        ),
+    ):
+        metadata = builder.build_for_drafting(common_metadata, draft_index=1)
+
+    assert metadata.num_actual_tokens == 5
+    assert builder.build_decode_metadata_for_drafting.call_args.kwargs["num_decode_tokens"] == 15
+
+
+def test_dspark_swa_indices_mask_dp_padded_tokens():
+    indices, lens = build_dspark_swa_indices(
+        block_table=torch.tensor([[10]], dtype=torch.int32),
+        num_speculative_tokens=5,
+        window_size=7,
+        block_size=16,
+        query_start_loc=torch.tensor([0, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([12], dtype=torch.int32),
+        num_decode_tokens=15,
+        index_width=16,
+    )
+
+    torch.testing.assert_close(lens[:5], torch.full((5,), 12, dtype=torch.int32))
+    assert torch.all(lens[5:] == 0)
+    assert torch.all(indices[5:] == -1)
 
 
 class TestSlidingWindowAdapter:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -420,8 +420,16 @@ def build_dspark_swa_indices(
     slot_ids = (block_ids * block_size + block_offsets).to(torch.int32)
     slot_ids = slot_ids.where(col_mask, torch.full_like(slot_ids, -1))
 
-    per_token_slots = torch.repeat_interleave(slot_ids, query_lens, dim=0, output_size=num_decode_tokens).unsqueeze(1)
-    per_token_lens = torch.repeat_interleave(visible_lens, query_lens, dim=0, output_size=num_decode_tokens)
+    if num_decode_tokens is None:
+        num_decode_tokens = query_start_loc[-1]
+    token_rows = torch.arange(num_decode_tokens, dtype=torch.long, device=query_start_loc.device)
+    token_to_req = torch.bucketize(token_rows, query_start_loc[1:].long(), right=True)
+    inactive_tokens = token_to_req >= slot_ids.shape[0]
+    safe_token_to_req = token_to_req.clamp(max=slot_ids.shape[0] - 1)
+    per_token_slots = slot_ids.index_select(0, safe_token_to_req).unsqueeze(1)
+    per_token_slots.masked_fill_(inactive_tokens[:, None, None], -1)
+    per_token_lens = visible_lens.index_select(0, safe_token_to_req)
+    per_token_lens.masked_fill_(inactive_tokens, 0)
 
     return per_token_slots, per_token_lens
 
@@ -1188,6 +1196,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
             common_attn_metadata, decode_threshold=self.decode_threshold
         )
+        if not common_attn_metadata.causal and num_prefills == 0:
+            num_decode_tokens = common_attn_metadata.num_input_tokens
         num_input_tokens = common_attn_metadata.num_input_tokens
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
         if num_prefills:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -930,7 +930,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         multi_steps_attn_metadata, attn_metadata_i = self.build_draft_attn_metadata(
             common_attn_metadata, num_input_tokens, num_tokens
         )
-        self._pad_draft_buffers(num_tokens, num_input_tokens)
+        if self.method != "dspark":
+            self._pad_draft_buffers(num_tokens, num_input_tokens)
 
         if self.uses_mrope:
             used_update_positions = self.mrope_positions[:, token_indices_to_sample]
@@ -2136,6 +2137,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     ):
         # FIXME(woosuk): The below two ops cause synchronization. Optimize.
         assert len(self.draft_attn_groups) > 0
+        if self.method == "dspark":
+            self._pad_draft_buffers(num_actual_tokens, num_input_tokens)
         per_layer_attn_metadata: dict[str, Any] = {}
         for attn_group in self.draft_attn_groups:
             builder = attn_group.get_metadata_builder()
@@ -2150,6 +2153,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             if self.method == "dspark":
                 gid = attn_group.kv_cache_group_id
                 common_attn_metadata = copy.copy(common_attn_metadata)
+                common_attn_metadata.positions = self.positions[:num_input_tokens]
                 block_table = getattr(self, "_per_group_block_table_buffers", {}).get(gid)
                 if block_table is not None:
                     common_attn_metadata.block_table_tensor = block_table[: common_attn_metadata.num_reqs]


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #12640.

DSpark V1 can receive a DP-padded `num_input_tokens` larger than the current rank's actual drafter token count. Before this change, the metadata path mixed those two sizes:

- draft attention metadata was built before token buffers received padding sentinels;
- non-causal DSA metadata kept the actual decode-token count;
- SWA index expansion had no defined rows for the padded tail.

The mismatch eventually surfaced as `aclnnInplacePartialRotaryMul: dim0 must be equal`, including with `--enforce-eager`.

This PR keeps the fix in DSpark/DSA metadata construction:

- pad DSpark buffers before building draft attention metadata;
- pass padded positions and slots (`positions=0`, `slot_mapping=-1` for inactive rows);
- align the non-causal DSA decode-token count with `num_input_tokens`;
- generate SWA padded rows with `lens=0` and `slots=-1`.

Rotary, SAS operator, scheduler, graph-capture, and non-DSpark paths are unchanged.

Related #12612 fixes the positions slice only. This PR also covers the decode-token count and SWA padded-tail contract required by the real DP4 reproducer.

### Does this PR introduce _any_ user-facing change?

Yes. DSpark V1 no longer crashes when DP ranks require different amounts of drafter token padding.

### How was this patch tested?

Unit tests:

```text
tests/ut/spec_decode/a2/test_eagle_proposer.py: 73 passed, 13 skipped
tests/ut/spec_decode/test_llm_base_proposer.py: 9 passed
```

Static checks:

```text
ruff check: passed
ruff format --check: passed
py_compile: passed
git diff --check: passed
```

Real-weight test with `/models/DeepSeek-V4-Flash-DSpark-w4a8`, V1, TP4/DP4/EP, 16 NPUs, `--enforce-eager`, 16 heterogeneous prompts, output length 256, concurrency 4:

| Revision | Completed | Failed | Output tokens |
| --- | ---: | ---: | ---: |
| latest `main` (`f5b5514af`) | 4 | 12 | 813 before engine failure |
| this PR | 16 | 0 | 4096 |

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
