### PR TITLE
[BugFix]refresh Ascend MoE comm state after L2 wake to fix ep+sleep level2 precision issue

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
+from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -67,6 +68,27 @@ def set_gmmswigluquant_method():
 
     ascend_config = get_ascend_config()
     return ascend_config.ascend_fusion_config.fusion_ops_gmmswigluquant
+
+
+def refresh_all2all_expert_ids_after_l2_discard() -> None:
+    """Re-fill All2AllV ``expert_ids_per_ep_rank`` after sleep level 2 discard (not in named_buffers)."""
+    try:
+        for comm_method in list(_MoECommMethods.values()):
+            if not isinstance(comm_method, AlltoAllCommImpl):
+                continue
+            dispatcher = comm_method.token_dispatcher
+            ids = getattr(dispatcher, "expert_ids_per_ep_rank", None)
+            num_local = getattr(dispatcher, "num_local_experts", 0)
+            num_experts = getattr(dispatcher, "num_experts", 0)
+            if ids is None or num_local <= 1 or num_experts <= 0:
+                continue
+            correct = torch.arange(num_experts, dtype=ids.dtype, device=ids.device) % num_local
+            if ids.shape == correct.shape:
+                ids.copy_(correct)
+            else:
+                dispatcher.expert_ids_per_ep_rank = correct
+    except Exception as exc:
+        logger.warning("Failed to restore expert_ids_per_ep_rank after L2 wake: %s", exc)
 
 
 @dataclass

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -61,6 +61,7 @@ from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
+from vllm_ascend.ops.fused_moe.moe_comm_method import refresh_all2all_expert_ids_after_l2_discard
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
@@ -143,6 +144,7 @@ class NPUWorker(WorkerBase):
         if vllm_config.model_config and vllm_config.model_config.enable_sleep_mode:
             # Buffers saved before sleep
             self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
+            self._needs_all2all_expert_ids_refresh = False
         self.sleep_wakeup_manager = SleepWakeupManager(vllm_config, self, lambda: getattr(self, "model_runner", None))
 
         # Weight transfer engine is created in `load_model` once the model
@@ -214,6 +216,7 @@ class NPUWorker(WorkerBase):
         free_bytes_before_sleep = torch.npu.mem_get_info()[0]
         # Save the buffers before level 2 sleep
         if level == 2:
+            self._needs_all2all_expert_ids_refresh = True
             model = self.model_runner.model
             self._sleep_saved_buffers = {name: buffer.cpu().clone() for name, buffer in model.named_buffers()}
 
@@ -275,6 +278,10 @@ class NPUWorker(WorkerBase):
         cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
         if cleanup_enabled:
             self.sleep_wakeup_manager.wakeup(tags)
+            
+        if getattr(self, "_needs_all2all_expert_ids_refresh", False):
+            self._needs_all2all_expert_ids_refresh = False
+            refresh_all2all_expert_ids_after_l2_discard()
 
     def _check_weight_transfer_engine(self) -> None:
         if self.weight_transfer_engine is None:


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes incorrect rollout outputs on Ascend NPU + vLLM sleep level 2 (L2) + expert parallel (EP > 1) in hybrid (colocated) training.

After engine.sleep(level=2) discards NPU weights and actor weights are reloaded via IPC, vllm-ascend’s all-to-all MoE dispatcher keeps a persistent tensor expert_ids_per_ep_rank that is not recreated by weight reload. Stale/garbage values cause wrong expert routing → fluent but incorrect generations after the first post-sleep sync.

This PR restores expert_ids_per_ep_rank in-place after IPC reload when VLLM_SLEEP_LEVEL == 2 on NPU. It also re-applies patch_vllm_moe_model_weight_loader after process_weights_after_loading, because Ascend MoE post-load transforms recreate Parameter objects without weight_loader (needed for the next IPC sync; applies to L1 and L2).

Scope: single file — verl/workers/rollout/vllm_rollout/utils.py. No API / config changes.

Related context: vllm-ascend TokenDispatcherWithAll2AllV (vllm_ascend/ops/fused_moe/token_dispatcher.py).

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
