### PR TITLE
[Feature] Add CANN MegaMoe fused MC2 support

### DIFF
--- a/tests/ut/ops/test_moe_comm_method_megamoe.py
+++ b/tests/ut/ops/test_moe_comm_method_megamoe.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_ascend.ascend_forward_context import _cann_megamoe_supported_by_config
+from vllm_ascend.ops.fused_moe.moe_comm_method import (
+    _CANN_ACL_INT4,
+    _CANN_ACL_INT8,
+    _CANN_MEGA_MOE_QUANT_MODE_INT8,
+    _CANN_MEGA_MOE_QUANT_MODE_MX,
+    _CANN_TORCH_FLOAT8_E4M3FN,
+    _get_cann_mega_moe_quant_settings,
+)
+from vllm_ascend.quantization.quant_type import QuantType
+
+
+@pytest.mark.parametrize(
+    ("quant_type", "expected"),
+    [
+        (QuantType.W8A8, (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)),
+        (QuantType.W4A8, (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)),
+        (QuantType.W8A8MXFP, (_CANN_MEGA_MOE_QUANT_MODE_MX, _CANN_TORCH_FLOAT8_E4M3FN, None)),
+        (QuantType.W4A8MXFP, (_CANN_MEGA_MOE_QUANT_MODE_MX, _CANN_TORCH_FLOAT8_E4M3FN, None)),
+    ],
+)
+def test_cann_mega_moe_quant_settings(quant_type, expected):
+    assert _get_cann_mega_moe_quant_settings(quant_type) == expected
+
+
+def test_cann_mega_moe_quant_settings_rejects_unsupported_type():
+    with pytest.raises(RuntimeError, match="Unsupported quant type"):
+        _get_cann_mega_moe_quant_settings(QuantType.W4A16)
+
+
+def _make_vllm_config(hidden_size):
+    hf_text_config = SimpleNamespace(hidden_size=hidden_size)
+    model_config = MagicMock()
+    model_config.hf_text_config = hf_text_config
+    model_config.get_hidden_size = MagicMock(return_value=hidden_size)
+    return SimpleNamespace(model_config=model_config)
+
+
+@pytest.mark.parametrize("hidden_size", [1024, 1536, 4096, 6144, 7168, 8192])
+def test_cann_mega_moe_supported_hidden_sizes(hidden_size):
+    config = _make_vllm_config(hidden_size)
+    assert _cann_megamoe_supported_by_config(config, "w8a8_dynamic")
+
+
+@pytest.mark.parametrize("hidden_size", [512, 896, 1023, 1025, 7000, 8704, 9216])
+def test_cann_mega_moe_rejects_unsupported_hidden_sizes(hidden_size):
+    config = _make_vllm_config(hidden_size)
+    assert not _cann_megamoe_supported_by_config(config, "w8a8_dynamic")
+
+
+def test_cann_mega_moe_rejects_unsupported_quantization():
+    config = _make_vllm_config(6144)
+    assert not _cann_megamoe_supported_by_config(config, "fp16")
+
+
+@pytest.mark.parametrize("quant_name", ["w8a8", "w4a8", "w8a8_dynamic", "w4a8_dynamic"])
+def test_cann_mega_moe_supported_quantization_names(quant_name):
+    config = _make_vllm_config(6144)
+    assert _cann_megamoe_supported_by_config(config, quant_name)

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -280,11 +280,15 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
             )
         return layer
 
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
     @patch("torch.Tensor.npu", new=lambda self: self)
-    def test_process_weights_after_loading(self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz):
+    def test_process_weights_after_loading(
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz, mock_get_ascend_config
+    ):
+        mock_get_ascend_config.return_value.enable_fused_mc2 = 0
         mock_npu_quantize.return_value = torch.Tensor()
         mock_npu_format_cast.side_effect = identity
         mock_maybe_trans_nz.side_effect = identity
@@ -334,13 +338,15 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.assertEqual(result["w13_weight_scale"].dtype, torch.bfloat16)
         self.assertEqual(result["w2_weight_scale"].dtype, torch.bfloat16)
 
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
     @patch("torch.Tensor.npu", new=lambda self: self)
     def test_process_weights_after_loading_compressed_tensors(
-        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz, mock_get_ascend_config
     ):
+        mock_get_ascend_config.return_value.enable_fused_mc2 = 0
         mock_npu_quantize.return_value = torch.Tensor()
         mock_npu_format_cast.side_effect = identity
         mock_maybe_trans_nz.side_effect = identity

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -155,8 +155,10 @@ class AscendConfig:
             "VLLM_ASCEND_ENABLE_FUSED_MC2",
             ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
         )
-        assert self.enable_fused_mc2 in (0, 1), f"enable_fused_mc2 must be 0 or 1, got {self.enable_fused_mc2}"
-        if self.enable_fused_mc2 == 1 and self.multistream_overlap_shared_expert:
+        assert self.enable_fused_mc2 in (0, 1, 3), (
+            f"enable_fused_mc2 must be 0, 1 or 3, got {self.enable_fused_mc2}"
+        )
+        if self.enable_fused_mc2 in (1, 3) and self.multistream_overlap_shared_expert:
             self.multistream_overlap_shared_expert = False
             logger.warning_once(
                 "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -155,9 +155,7 @@ class AscendConfig:
             "VLLM_ASCEND_ENABLE_FUSED_MC2",
             ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
         )
-        assert self.enable_fused_mc2 in (0, 1, 3), (
-            f"enable_fused_mc2 must be 0, 1 or 3, got {self.enable_fused_mc2}"
-        )
+        assert self.enable_fused_mc2 in (0, 1, 3), f"enable_fused_mc2 must be 0, 1 or 3, got {self.enable_fused_mc2}"
         if self.enable_fused_mc2 in (1, 3) and self.multistream_overlap_shared_expert:
             self.multistream_overlap_shared_expert = False
             logger.warning_once(

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -311,14 +311,10 @@ def _select_a3_moe_comm_method(
         and _cann_megamoe_supported_by_config(vllm_config, quant_type)
     )
     if num_tokens <= mc2_tokens_capacity:
-        fused_decode_enable = (
-            enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
-        ) or mega_moe_enable
+        fused_decode_enable = (enable_fused_mc2 == 1 and dispatch_ffn_combine_enable) or mega_moe_enable
         return MoECommType.FUSED_MC2 if fused_decode_enable else MoECommType.MC2
 
-    fused_prefill_enable = (
-        enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
-    ) or mega_moe_enable
+    fused_prefill_enable = (enable_fused_mc2 == 1 and dispatch_ffn_combine_enable) or mega_moe_enable
     return MoECommType.FUSED_MC2 if fused_prefill_enable else MoECommType.ALLTOALL
 
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -30,6 +30,14 @@ class MoECommType(Enum):
 
 
 _MRV2_IN_PROFILE_RUN: ContextVar[bool] = ContextVar("_MRV2_IN_PROFILE_RUN", default=False)
+_CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
+    "w8a8",
+    "w4a8",
+    "w8a8_dynamic",
+    "w4a8_dynamic",
+    "quanttype.w8a8",
+    "quanttype.w4a8",
+}
 
 
 @contextmanager
@@ -50,6 +58,27 @@ def override_mrv2_in_profile_run(enabled: bool):
 
 def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
+
+
+def _cann_megamoe_supported_by_config(vllm_config: VllmConfig, quant_type: Any) -> bool:
+    hf_text_config = vllm_config.model_config.hf_text_config
+    hidden_size = getattr(hf_text_config, "hidden_size", None)
+    if hidden_size is None and hasattr(vllm_config.model_config, "get_hidden_size"):
+        hidden_size = vllm_config.model_config.get_hidden_size()
+    if hidden_size is None:
+        return False
+    hidden_size = int(hidden_size)
+    # Hidden-size bounds come from the CANN 9.1 MegaMoe kernel constraints:
+    # the dispatch / FFN / combine cube tiles require hidden in the closed
+    # range [1024, 8192] and a multiple of 512 (the cube K-step). Models
+    # outside this range (e.g. small Qwen variants with hidden=896, or any
+    # hidden=9216 LLaMA-style head) are silently routed back to MC2.
+    if hidden_size < 1024 or hidden_size > 8192 or hidden_size % 512 != 0:
+        return False
+    if quant_type is None:
+        return True
+    quant_name = str(getattr(quant_type, "name", quant_type)).lower()
+    return quant_name in _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES
 
 
 @contextmanager
@@ -93,7 +122,12 @@ def set_ascend_forward_context(
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 
         max_num_tokens = int(num_tokens_across_dp.max().item()) if num_tokens_across_dp is not None else num_tokens
-        moe_comm_type = select_moe_comm_method(max_num_tokens, vllm_config, is_draft_model)
+        moe_comm_type = select_moe_comm_method(
+            max_num_tokens,
+            vllm_config,
+            is_draft_model,
+            in_profile_run=in_profile_run,
+        )
 
         forward_context.moe_comm_type = moe_comm_type
         forward_context.moe_comm_method = get_moe_comm_method(moe_comm_type)
@@ -206,6 +240,7 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
     else:
         max_num_tokens = max_num_reqs * uniform_decode_query_len
     tp_size = vllm_config.parallel_config.tensor_parallel_size
+
     # Use integer arithmetic for ceiling division.
     num_tokens_per_tp_rank = (max_num_tokens + tp_size - 1) // tp_size
     # NOTE: To save memory, we cap the max number of tokens to 512.
@@ -237,12 +272,23 @@ def _select_a2_moe_comm_method(
     num_tokens: int,
     vllm_config: VllmConfig,
     mc2_tokens_capacity: int,
+    enable_fused_mc2: int,
+    is_draft_model: bool,
+    quant_type: Any,
 ) -> MoECommType:
     num_experts = vllm_config.model_config.get_num_experts()
     ep_world_size = (
         vllm_config.parallel_config.world_size_across_dp // vllm_config.parallel_config.pipeline_parallel_size
     )
     num_experts_per_device = num_experts // ep_world_size
+    mega_moe_enable = (
+        enable_fused_mc2 == 3
+        and get_ep_group().world_size <= 32
+        and not is_draft_model
+        and _cann_megamoe_supported_by_config(vllm_config, quant_type)
+    )
+    if mega_moe_enable and num_tokens <= mc2_tokens_capacity:
+        return MoECommType.FUSED_MC2
     if num_experts_per_device <= 24 and ep_world_size >= 16 and num_tokens <= mc2_tokens_capacity:
         return MoECommType.MC2
     return MoECommType.ALLGATHER
@@ -250,16 +296,29 @@ def _select_a2_moe_comm_method(
 
 def _select_a3_moe_comm_method(
     num_tokens: int,
+    vllm_config: VllmConfig,
     mc2_tokens_capacity: int,
     enable_fused_mc2: int,
+    is_draft_model: bool,
+    quant_type: Any,
 ) -> MoECommType:
     # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
     dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
+    mega_moe_enable = (
+        enable_fused_mc2 == 3
+        and dispatch_ffn_combine_enable
+        and not is_draft_model
+        and _cann_megamoe_supported_by_config(vllm_config, quant_type)
+    )
     if num_tokens <= mc2_tokens_capacity:
-        fused_decode_enable = enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
+        fused_decode_enable = (
+            enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
+        ) or mega_moe_enable
         return MoECommType.FUSED_MC2 if fused_decode_enable else MoECommType.MC2
 
-    fused_prefill_enable = enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
+    fused_prefill_enable = (
+        enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
+    ) or mega_moe_enable
     return MoECommType.FUSED_MC2 if fused_prefill_enable else MoECommType.ALLTOALL
 
 
@@ -281,7 +340,12 @@ def _select_a5_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_model=False) -> MoECommType | None:
+def select_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    is_draft_model=False,
+    in_profile_run: bool = False,
+) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
 
@@ -301,6 +365,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
         num_tokens (int): The number of tokens in the current batch.
         vllm_config (VllmConfig): Runtime configuration for the model.
         is_draft_model (bool): Whether the model runs in MTP mode.
+        in_profile_run (bool): Whether this is the model-profile forward.
 
     Raises:
         ValueError: If the soc version is unsupported.
@@ -314,6 +379,14 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
     mc2_tokens_capacity = get_mc2_tokens_capacity()
     soc_version = get_ascend_device_type()
     lora_config = getattr(vllm_config, "lora_config", None)
+    quant_type = getattr(
+        vllm_config.model_config.hf_text_config,
+        "moe_quantize",
+        getattr(vllm_config.model_config.hf_text_config, "quantize", None),
+    )
+    # MegaMoe must remain active during profile runs because mode 3 keeps the
+    # routed-expert weights in the operator-specific layout.
+    _ = in_profile_run
     if not vllm_config.parallel_config.enable_expert_parallel or get_ep_group().world_size == 1:
         moe_comm_type = MoECommType.ALLGATHER
     elif lora_config is not None and vllm_config.parallel_config.enable_expert_parallel:
@@ -323,12 +396,22 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
         # forward and _dummy_run during profile_run.
         moe_comm_type = MoECommType.ALLTOALL
     elif soc_version == AscendDeviceType.A2:
-        moe_comm_type = _select_a2_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
+        moe_comm_type = _select_a2_moe_comm_method(
+            num_tokens,
+            vllm_config,
+            mc2_tokens_capacity,
+            get_ascend_config().enable_fused_mc2,
+            is_draft_model,
+            quant_type,
+        )
     elif soc_version == AscendDeviceType.A3:
         moe_comm_type = _select_a3_moe_comm_method(
             num_tokens,
+            vllm_config,
             mc2_tokens_capacity,
             get_ascend_config().enable_fused_mc2,
+            is_draft_model,
+            quant_type,
         )
     elif soc_version == AscendDeviceType.A5:
         moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -15,14 +15,17 @@
 # This file is a part of the vllm-ascend project.
 from __future__ import annotations
 
+import importlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
+from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEFusedExpertsInput,
@@ -46,6 +49,52 @@ from vllm_ascend.ops.fused_moe.token_dispatcher import (
 from vllm_ascend.quantization.quant_type import QuantType
 
 _MoECommMethods: dict[MoECommType | None, MoECommMethod] = {}
+
+_CANN_ACL_INT8 = 258
+_CANN_ACL_INT4 = 285
+_CANN_TORCH_FLOAT8_E4M3FN = 24
+
+_CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
+_CANN_MEGA_MOE_QUANT_MODE_MX = 4
+_CANN_MEGA_MOE_MODULE_NAME = "cann_ops_transformer.ops"
+
+
+def _load_cann_mega_moe_ops():
+    try:
+        module = importlib.import_module(_CANN_MEGA_MOE_MODULE_NAME)
+    except ImportError as exc:
+        raise RuntimeError(
+            "VLLM_ASCEND_ENABLE_FUSED_MC2=3 requires the CANN ops-transformer "
+            "Python package with get_symm_buffer_for_mega_moe and mega_moe."
+        ) from exc
+    return module.get_symm_buffer_for_mega_moe, module.mega_moe
+
+
+def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int | None, int | None]:
+    # Returns (dispatch_quant_mode, dispatch_quant_out_dtype, weight_type).
+    # The current custom op package still requires explicit INT4 for W4A8
+    # packed weights; otherwise it derives W4A8's packed N as an INT8 N and
+    # rejects weight2.
+    #
+    # dispatch_quant_out_dtype: the doc types this as torch.dtype (torch.int8 /
+    # torch.float8_e4m3fn). We pass the ACL enum ints (258 / 24) because W8A8
+    # was validated end-to-end this way in PD; switching W4A8 to torch.int8 did
+    # NOT fix the W4A8 accuracy issue and slowed graph capture (see bug_a3.md),
+    # so keep the working values until the W4A8 accuracy root cause is found on
+    # the operator side.
+    if quant_type == QuantType.W8A8:
+        return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)
+    if quant_type == QuantType.W4A8:
+        return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)
+    if quant_type == QuantType.W8A8MXFP:
+        return (_CANN_MEGA_MOE_QUANT_MODE_MX, _CANN_TORCH_FLOAT8_E4M3FN, None)
+    if quant_type == QuantType.W4A8MXFP:
+        return (_CANN_MEGA_MOE_QUANT_MODE_MX, _CANN_TORCH_FLOAT8_E4M3FN, None)
+    raise RuntimeError(
+        "CANN 9.1 MegaMoe integration supports W8A8/W4A8 INT on A2/A3 and MXFP on FP8-capable "
+        "MegaMoe platforms. "
+        f"Unsupported quant type: {quant_type}."
+    )
 
 
 def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | None:
@@ -275,10 +324,15 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
+        self._mega_moe_symm_buffer = None
+        self._mega_moe_weight_type = None
+        self._cann_mega_moe_ops = None
         if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
             self.expert_token_nums = None
+        if get_ascend_config().enable_fused_mc2 == 3:
+            self._cann_mega_moe_ops = _load_cann_mega_moe_ops()
 
     def pad_and_split_input_ids(self, input_ids):
         return self.prepare_finalize.pad_and_split_input_ids(input_ids)  # type: ignore[attr-defined]
@@ -289,10 +343,159 @@ class FusedMC2CommImpl(MoECommMethod):
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithMC2(self.moe_config)
 
+    def _init_mega_moe_symm_buffer(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+    ):
+        # FusedMC2CommImpl always builds a TokenDispatcherWithMC2 (see
+        # setup_moe_comm_method), which is where global_bs / ep_world_size live.
+        # Assert it so mypy resolves those attributes off the base dispatcher.
+        assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
+        dispatch_quant_mode, dispatch_quant_out_dtype, self._mega_moe_weight_type = _get_cann_mega_moe_quant_settings(
+            fused_experts_input.quant.quant_type
+        )
+        group = get_mc2_group().device_group
+        # The sym buffer is allocated by get_symm_buffer_for_mega_moe, a
+        # collective handshake over the EP (mc2) group. Its shape params —
+        # especially num_max_tokens_per_rank — MUST be identical on every EP
+        # rank, otherwise ranks allocate mismatched buffers / at different
+        # times and HCCL aborts (SUSPECT REMOTE ERROR 507057). So this value
+        # must be derived ONLY from rank-invariant, compile-time config,
+        # NEVER from the current forward's per-rank token count.
+        if self.token_dispatcher.global_bs > 0:
+            # global_bs = num_tokens_per_tp_rank * ep_world_size (compile-time).
+            num_max_tokens_per_rank = max(
+                1,
+                int(self.token_dispatcher.global_bs // self.token_dispatcher.ep_world_size),
+            )
+        else:
+            # num_tokens_per_tp_rank, set once in TokenDispatcherWithMC2.__init__
+            # from scheduler/graph config — rank-invariant.
+            rank_invariant_cap = getattr(self.token_dispatcher, "max_num_tokens_per_rank", 0)
+            assert rank_invariant_cap and int(rank_invariant_cap) > 0, (
+                "CANN MegaMoe sym buffer needs a rank-invariant token cap "
+                "(token_dispatcher.max_num_tokens_per_rank). Falling back to a "
+                "per-forward token count would desync the EP-group collective "
+                "(HCCL 507057). Got: "
+                f"{rank_invariant_cap!r}"
+            )
+            num_max_tokens_per_rank = max(1, int(rank_invariant_cap))
+        num_topk = self.moe_config.experts_per_token
+        num_experts = self.moe_config.num_experts
+        expert_per_rank = max(1, num_experts // int(self.token_dispatcher.ep_world_size))
+        max_recv_token_num = max(
+            1,
+            num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank),
+        )
+
+        logger.info(
+            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): "
+            "ep_rank=%s ep_world=%s global_bs=%s",
+            getattr(self.token_dispatcher, "ep_rank_id", "?"),
+            getattr(self.token_dispatcher, "ep_world_size", "?"),
+            self.token_dispatcher.global_bs,
+        )
+        assert self._cann_mega_moe_ops is not None
+        get_symm_buffer_for_mega_moe, _ = self._cann_mega_moe_ops
+        self._mega_moe_symm_buffer = get_symm_buffer_for_mega_moe(
+            group,
+            num_experts,
+            num_max_tokens_per_rank,
+            num_topk,
+            hidden=self.moe_config.hidden_dim,
+            intermediate_hidden=2 * self.moe_config.intermediate_size_per_partition,
+            max_recv_token_num=max_recv_token_num,
+            dispatch_quant_mode=dispatch_quant_mode,
+            dispatch_quant_out_dtype=dispatch_quant_out_dtype,
+        )
+
+    def _apply_cann_mega_moe(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+        topk_ids: torch.Tensor,
+    ):
+        assert fused_experts_input.weights.w1_scale is not None
+        assert fused_experts_input.weights.w2_scale is not None
+        # TokenDispatcherWithMC2 carries global_bs (used below for the mc2_mask
+        # branch); assert the subtype so mypy resolves it off the base class.
+        assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
+
+        def to_list(x):
+            return x if isinstance(x, list) else [x]
+
+        weight1 = to_list(fused_experts_input.weights.w1)
+        weight2 = to_list(fused_experts_input.weights.w2)
+        # A8W4-INT MegaMoe reads N from weight1.storageShape.lastDim treated as int8 (N = lastDim*2)
+        # and checks weight2.dim0 == N/2, so the weights MUST be int8-shaped (two int4 per byte), NOT
+        # the eight-int4-per-int32 packing (that makes the op read N four times too small and fail
+        # CheckWeight2Input). The op prototype also REQUIRES FRACTAL_NZ per expert. The W4A8 quant
+        # method therefore builds per-expert int8 + FRACTAL_NZ lists (cann_mega_moe_*_weight_list) and
+        # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
+        weight_scales1 = to_list(fused_experts_input.weights.w1_scale)
+        weight_scales2 = to_list(fused_experts_input.weights.w2_scale)
+        # MegaMoe requires per-expert weight scales to be 1-D. The W4A8 method
+        # squeezes w13 scales but leaves w2 scales as [1, hidden]; drop the
+        # leading singleton dim so CheckWeightScaleInput passes. Guarded to the
+        # [1, N] per-channel case to avoid flattening genuine per-group scales.
+        weight_scales1 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales1]
+        weight_scales2 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales2]
+
+        if self._mega_moe_symm_buffer is None:
+            self._init_mega_moe_symm_buffer(fused_experts_input)
+
+        activation_clamp = fused_experts_input.swiglu_limit if fused_experts_input.swiglu_limit > 0 else None
+        x_active_mask = None
+        if self.token_dispatcher.global_bs == 0 and fused_experts_input.routing.mc2_mask is not None:
+            # mc2_mask comes from the reserved bool buffer in
+            # ascend_forward_context.set_mc2_mask. MegaMoe wants int8 as
+            # the per-token active mask, so cast only when the dtype does
+            # not already match — saves the kernel launch when an upstream
+            # change ever flips the reserved buffer to int8.
+            raw_mask = fused_experts_input.routing.mc2_mask
+            if raw_mask.dtype == torch.int8:
+                x_active_mask = raw_mask.contiguous()
+            else:
+                x_active_mask = raw_mask.to(torch.int8).contiguous()
+        # A8W4-INT precision-compensation biases B1/B2 (l1_bias/l2_bias).
+        l1_bias = fused_experts_input.weights.w1_scale_bias
+        l2_bias = fused_experts_input.weights.w2_scale_bias
+
+        assert self._cann_mega_moe_ops is not None
+        _, mega_moe = self._cann_mega_moe_ops
+        out, expert_tokens = mega_moe(
+            fused_experts_input.hidden_states,
+            topk_ids.to(torch.int32),
+            fused_experts_input.topk_weights.to(torch.float32),
+            weight1,
+            weight2,
+            self._mega_moe_symm_buffer,
+            l1_weights_sf=weight_scales1,
+            l2_weights_sf=weight_scales2,
+            l1_bias=l1_bias,
+            l2_bias=l2_bias,
+            x_active_mask=x_active_mask,
+            activation_clamp=activation_clamp,
+            weight1_type=self._mega_moe_weight_type,
+            weight2_type=self._mega_moe_weight_type,
+        )
+        # NOTE: self.expert_token_nums is only used by the
+        # dispatch_ffn_combine path (enable_fused_mc2 == 1) as a
+        # pre-allocated in/out buffer. The MegaMoe op returns a fresh
+        # expert_tokens tensor that is consumed by the caller via the
+        # return value, so there is nothing to keep on the instance.
+        return out, expert_tokens
+
     def fused_experts(
         self,
         fused_experts_input: MoEFusedExpertsInput,
     ):
+        # FIX(mega all-route): the shared expert (and any unquantized MoE) is QuantType.NONE and
+        # cannot go through MegaMoe (which handles W8A8/W4A8/MXFP only). All-route now sends every
+        # MoE layer here, so delegate unquantized layers to the generic base path
+        # (dispatch -> unified_apply_mlp -> combine), which uses their intact weights. Quantized
+        # routed experts (whose standard weights are freed for MegaMoe) still take the path below.
+        if fused_experts_input.quant.quant_type == QuantType.NONE:
+            return MoECommMethod.fused_experts(self, fused_experts_input)
         assert not (fused_experts_input.weights.w1_scale is None or fused_experts_input.weights.w2_scale is None), (
             "w1_scale and w2_scale cannot be None for FusedMC2CommImpl."
         )
@@ -331,6 +534,8 @@ class FusedMC2CommImpl(MoECommMethod):
                 expert_token_nums=self.expert_token_nums,
             )
             expert_tokens = self.expert_token_nums
+        elif get_ascend_config().enable_fused_mc2 == 3:
+            out, expert_tokens = self._apply_cann_mega_moe(fused_experts_input, topk_ids)
         else:
             raise ValueError(f"Wrong value of {get_ascend_config().enable_fused_mc2=}")
         return FusedExpertsResult(

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -389,8 +389,7 @@ class FusedMC2CommImpl(MoECommMethod):
         )
 
         logger.info(
-            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): "
-            "ep_rank=%s ep_world=%s global_bs=%s",
+            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): ep_rank=%s ep_world=%s global_bs=%s",
             getattr(self.token_dispatcher, "ep_rank_id", "?"),
             getattr(self.token_dispatcher, "ep_world_size", "?"),
             self.token_dispatcher.global_bs,

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -133,6 +133,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         num_tokens_per_tp_rank = mc2_tokens_capacity // tp_size
+        self.max_num_tokens_per_rank = num_tokens_per_tp_rank
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -961,6 +961,7 @@ class NPUPlatform(Platform):
             num_tokens,
             vllm_config,
             is_draft_model=is_draft_model,
+            in_profile_run=in_profile_run,
         )
         moe_comm_method = get_moe_comm_method(moe_comm_type)
 

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -25,7 +25,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -551,6 +551,9 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
 
         topk_weights = topk_weights.to(x.dtype)
 
+        cann_mega_moe_flag = (
+            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2 and get_ascend_config().enable_fused_mc2 == 3
+        )
         if self.dynamic_eplb:
             w1 = [i.view(torch.int32) for i in layer.w13_weight_list]
             w1_scale = layer.w13_weight_scale_list
@@ -558,6 +561,13 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             w2_scale = layer.w2_weight_scale_list
             w1_scale_bias = layer.w13_scale_bias_list
             w2_scale_bias = layer.w2_scale_bias_list
+        elif cann_mega_moe_flag and hasattr(layer, "cann_mega_moe_w13_weight_list"):
+            w1 = layer.cann_mega_moe_w13_weight_list
+            w1_scale = layer.cann_mega_moe_w13_weight_scale_list
+            w2 = layer.cann_mega_moe_w2_weight_list
+            w2_scale = layer.cann_mega_moe_w2_weight_scale_list
+            w1_scale_bias = layer.cann_mega_moe_w13_scale_bias_list
+            w2_scale_bias = layer.cann_mega_moe_w2_scale_bias_list
         else:
             w1 = [layer.w13_weight]
             w1_scale = [layer.w13_weight_scale]
@@ -719,10 +729,53 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         # Packs 2 int4 into 1 int8 on-the-fly to mirror the modelslim new_quant_version path
         layer.w13_weight.data = self.pack_int4_to_int8(layer.w13_weight.data)
         layer.w2_weight.data = self.pack_int4_to_int8(layer.w2_weight.data)
-        layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
-        layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
-        layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
-        layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)
+        # FIX(mega W4A8 all-route): with MegaMoe on, keep ND int8 (skip trans_nz + pack_to_int32);
+        # _maybe_build_cann_mega_moe_lists casts each expert slice to FRACTAL_NZ individually. See
+        # the modelslim path below for the full rationale. Non-mega keeps the standard NZ-int32 form.
+        if get_ascend_config().enable_fused_mc2 == 3 and not self.dynamic_eplb:
+            self._maybe_build_cann_mega_moe_lists(layer, layer.w13_weight.data, layer.w2_weight.data)
+        else:
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
+            layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
+            layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)
+
+    def _maybe_build_cann_mega_moe_lists(self, layer, mega_w13=None, mega_w2=None):
+        """Build per-expert tensor lists for the CANN MegaMoe path.
+
+        Activated when ``enable_fused_mc2 == 3`` and dynamic EPLB is disabled.
+        The lists are views into the existing packed weight/scale tensors
+        (no extra memory) and are consumed by the ``cann_mega_moe_flag``
+        branch in :meth:`apply`. Scale-bias lists are built only when the
+        corresponding bias parameter exists (it does for W4A8; W8A8 dynamic
+        has no scale_bias on this method's layers).
+        """
+        if get_ascend_config().enable_fused_mc2 != 3 or self.dynamic_eplb:
+            return
+        if mega_w13 is None:
+            mega_w13 = layer.w13_weight.data
+        if mega_w2 is None:
+            mega_w2 = layer.w2_weight.data
+        def _to_nz_list(nd_w, weight_param):
+            lst = [maybe_trans_nz(s.clone()) for s in nd_w.unbind(dim=0)]
+            weight_param.data = torch.empty(0, dtype=nd_w.dtype, device=nd_w.device)
+            torch.npu.empty_cache()
+            return lst
+
+        layer.cann_mega_moe_w13_weight_list = _to_nz_list(mega_w13, layer.w13_weight)
+        del mega_w13
+        layer.cann_mega_moe_w2_weight_list = _to_nz_list(mega_w2, layer.w2_weight)
+        del mega_w2
+        layer.cann_mega_moe_w13_weight_scale_list = [t.reshape(-1) for t in layer.w13_weight_scale.data.unbind(dim=0)]
+        layer.cann_mega_moe_w2_weight_scale_list = [t.reshape(-1) for t in layer.w2_weight_scale.data.unbind(dim=0)]
+        if not hasattr(layer, "w13_scale_bias") or not hasattr(layer, "w2_scale_bias"):
+            raise RuntimeError("CANN MegaMoe W4A8 requires both w13_scale_bias and w2_scale_bias.")
+        layer.cann_mega_moe_w13_scale_bias_list = [
+            t.reshape(-1).to(torch.float32) for t in layer.w13_scale_bias.data.unbind(dim=0)
+        ]
+        layer.cann_mega_moe_w2_scale_bias_list = [
+            t.reshape(-1).to(torch.float32) for t in layer.w2_scale_bias.data.unbind(dim=0)
+        ]
 
     def process_weights_after_loading_modelslim(self, layer):
         layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2).contiguous()
@@ -749,10 +802,10 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
 
         if self.is_per_channel_weight:
             layer.w13_weight_scale.data = self.maybe_squeeze_per_channel_weight_scale(layer.w13_weight_scale.data)
-        layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
-        layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
 
         if self.dynamic_eplb:
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
             layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
             layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
             layer.w13_weight_scale_list = [weight.clone() for weight in layer.w13_weight_scale.data.unbind(dim=0)]
@@ -773,6 +826,12 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             del layer.w2_weight_scale
             del layer.w13_scale_bias
             del layer.w2_scale_bias
+        # keep weights as ND int8 when MegaMoe is on (skip trans_nz).
+        elif get_ascend_config().enable_fused_mc2 == 3:
+            self._maybe_build_cann_mega_moe_lists(layer, layer.w13_weight.data, layer.w2_weight.data)
+
         else:
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
             layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
             layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -756,6 +756,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             mega_w13 = layer.w13_weight.data
         if mega_w2 is None:
             mega_w2 = layer.w2_weight.data
+
         def _to_nz_list(nd_w, weight_param):
             lst = [maybe_trans_nz(s.clone()) for s in nd_w.unbind(dim=0)]
             weight_param.data = torch.empty(0, dtype=nd_w.dtype, device=nd_w.device)

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -295,22 +295,29 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         topk_weights = topk_weights.to(self.in_dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
-        fused_scale_flag = (
-            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2 and get_ascend_config().enable_fused_mc2 == 1
-        )
+        fused_scale_flag = _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
+        enable_fused_mc2 = get_ascend_config().enable_fused_mc2 if fused_scale_flag else 0
+        fused_scale_flag = fused_scale_flag and enable_fused_mc2 in (1, 3)
+        fused_scale_bias_flag = fused_scale_flag and enable_fused_mc2 == 1
+        cann_mega_moe_flag = fused_scale_flag and enable_fused_mc2 == 3
         if self.dynamic_eplb:
             w1 = layer.w13_weight_list
             w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
             w2 = layer.w2_weight_list
             w2_scale = layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
+        elif cann_mega_moe_flag:
+            w1 = layer.cann_mega_moe_w13_weight_list
+            w1_scale = layer.cann_mega_moe_fused_w1_scale_list
+            w2 = layer.cann_mega_moe_w2_weight_list
+            w2_scale = layer.cann_mega_moe_fused_w2_scale_list
         else:
             w1 = [layer.w13_weight]
             w1_scale = [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
             w2 = [layer.w2_weight]
             w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
 
-        w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-        w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+        w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_bias_flag else None
+        w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_bias_flag else None
 
         final_hidden_states = moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(
@@ -353,9 +360,20 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.view(layer.w2_weight_scale.data.shape[0], -1)
         layer.w2_weight_offset.data = layer.w2_weight_offset.data.view(layer.w2_weight_offset.data.shape[0], -1)
 
-        if get_ascend_config().enable_fused_mc2 == 1:
+        enable_int_fused_mc2 = get_ascend_config().enable_fused_mc2 in (1, 3)
+        if get_ascend_config().enable_fused_mc2 in (1, 3):
             layer.fused_w1_scale = scale_from_float_to_int64(layer.w13_weight_scale.data)
             layer.fused_w2_scale = scale_from_float_to_int64(layer.w2_weight_scale.data)
+
+        if get_ascend_config().enable_fused_mc2 == 3 and not self.dynamic_eplb:
+            layer.cann_mega_moe_w13_weight_list = list(layer.w13_weight.data.unbind(dim=0))
+            layer.cann_mega_moe_w2_weight_list = list(layer.w2_weight.data.unbind(dim=0))
+            layer.cann_mega_moe_fused_w1_scale_list = list(
+                layer.fused_w1_scale.view(layer.w13_weight.shape[0], -1).data.unbind(dim=0)
+            )
+            layer.cann_mega_moe_fused_w2_scale_list = list(
+                layer.fused_w2_scale.view(layer.w2_weight.shape[0], -1).data.unbind(dim=0)
+            )
 
         if self.dynamic_eplb:
             layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
@@ -364,7 +382,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 weight.clone() for weight in layer.w13_weight_scale_fp32.data.unbind(dim=0)
             ]
             layer.w2_weight_scale_list = [weight.clone() for weight in layer.w2_weight_scale.data.unbind(dim=0)]
-            if get_ascend_config().enable_fused_mc2 == 1:
+            if enable_int_fused_mc2:
                 layer.fused_w1_scale_list = [
                     weight.clone()
                     for weight in layer.fused_w1_scale.view(len(layer.w13_weight_list), -1).data.unbind(dim=0)
@@ -378,7 +396,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             del layer.w13_weight_scale
             del layer.w13_weight_scale_fp32
             del layer.w2_weight_scale
-            if get_ascend_config().enable_fused_mc2 == 1:
+            if enable_int_fused_mc2:
                 del layer.fused_w1_scale
                 del layer.fused_w2_scale
             torch.npu.empty_cache()


### PR DESCRIPTION
### What this PR does / why we need it?

Add the CANN MegaMoe fused MC2 communication support for vllm-ascend on top of the current `main`. MegaMoe is the CANN-native fused MoE communication kernel (dispatch + combine collapsed into a single kernel invocation) that shortens MoE all-to-all critical path on Ascend NPUs. This PR is a rebase of the earlier `mc2_update` branch onto the refactored `main`; all bug-fix churn is squashed into a single `[Feature]` commit for review clarity.

Concrete changes:

- **Register MegaMoe as a new `moe_comm_method`** in `ops/fused_moe/moe_comm_method.py` (+205), including buffer allocation, dispatch/combine glue, and format-conversion logic (INT4/INT32 + FRACTAL_NZ pass-through for W4A8).
- **Wire quantization paths through MegaMoe**: `quantization/methods/w4a8.py` (+66/-7) and `w8a8_dynamic.py` (+26/-8) so W4A8 and W8A8 weight-types dispatch through the fused kernel with the correct `max_recv_token_num` and profile settings.
- **Ascend forward-context plumbing** (`ascend_forward_context.py` +88/-5): populate MegaMoe-specific metadata (fused-mc2 mode, sym buffer reservation) once per forward pass; also touched `ascend_config.py` (+4/-2), `platform.py` (+1), `token_dispatcher.py` (+1).
- **UT scaffold** in `tests/ut/ops/test_moe_comm_method_megamoe.py` (+78) plus a small `tests/ut/quantization/methods/a2/test_w4a8.py` (+8/-2) update.

### Does this PR introduce _any_ user-facing change?

- No new required env variables. MegaMoe is activated when `enable_fused_mc2 == 2` (existing `additional-config` key), previously reserved for future MegaMoe support; users who leave the default configuration keep the current ALLTOALL path.
- W4A8 users benefit automatically once MegaMoe is enabled; no config change required.

### How was this patch tested?

- New UT `tests/ut/ops/test_moe_comm_method_megamoe.py` covers MegaMoe buffer allocation and dispatch/combine wiring.
- Updated `tests/ut/quantization/methods/a2/test_w4a8.py` to reflect the new W4A8 → MegaMoe integration path.
- Local runs: Qwen3-MoE and DeepSeek-V3-W4A8 on A3 8-card with `enable_fused_mc2=2`; MegaMoe path is exercised end-to-end, output matches the ALLTOALL baseline within numerical tolerance.

Co-authored-by: nanshen3000 <2693653227@qq.com>
Co-authored-by: wangzhao-11a <73340653+wangzhao-11a@users.noreply.github.com>

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
