### PR TITLE
[Performance] Optimize EPLB expert update planning

### DIFF
--- a/tests/ut/eplb/core/test_eplb_worker.py
+++ b/tests/ut/eplb/core/test_eplb_worker.py
@@ -1,0 +1,64 @@
+import torch
+
+from vllm_ascend.eplb.core.eplb_worker import EplbWorker
+
+
+def build_worker():
+    worker = EplbWorker.__new__(EplbWorker)
+    worker.rank_id = 0
+    return worker
+
+
+def test_compose_update_info_uses_precomputed_expert_sources():
+    worker = build_worker()
+    current_expert_maps = torch.tensor(
+        [
+            [
+                [0, 1, -1, -1],
+                [-1, 0, 1, -1],
+                [-1, -1, -1, 0],
+            ]
+        ]
+    )
+    updated_expert_maps = torch.tensor(
+        [
+            [
+                [0, -1, -1, 1],
+                [-1, 0, 1, -1],
+                [-1, -1, 2, -1],
+            ]
+        ]
+    )
+
+    update_info = list(worker.compose_expert_update_info_greedy(updated_expert_maps, current_expert_maps))
+
+    send_info, recv_info, new_expert_map, layer_id = update_info[0]
+    assert layer_id == 0
+    assert torch.equal(new_expert_map, updated_expert_maps[0])
+    assert send_info == {1: [(2, 2)], 2: [(0, 3)]}
+    assert recv_info == {0: [(2, 3)], 2: [(1, 2)]}
+
+
+def test_compose_update_info_skips_unchanged_layer():
+    worker = build_worker()
+    current_expert_maps = torch.tensor([[[0, 1], [1, 0]]])
+
+    update_info = list(worker.compose_expert_update_info_greedy(current_expert_maps, current_expert_maps))
+
+    send_info, recv_info, new_expert_map, layer_id = update_info[0]
+    assert layer_id == 0
+    assert send_info == {}
+    assert recv_info == {}
+    assert torch.equal(new_expert_map, current_expert_maps[0])
+
+
+def test_compose_update_info_copies_replica_from_first_holder():
+    worker = build_worker()
+    current_expert_maps = torch.tensor([[[0, -1], [-1, 0], [-1, -1]]])
+    updated_expert_maps = torch.tensor([[[0, -1], [-1, 0], [1, -1]]])
+
+    update_info = list(worker.compose_expert_update_info_greedy(updated_expert_maps, current_expert_maps))
+
+    send_info, recv_info, _new_expert_map, _layer_id = update_info[0]
+    assert send_info == {0: [(2, 0)]}
+    assert recv_info == {2: [(0, 0)]}

--- a/vllm_ascend/eplb/core/eplb_worker.py
+++ b/vllm_ascend/eplb/core/eplb_worker.py
@@ -181,24 +181,26 @@ class EplbWorker:
                 (current_expert_maps_this_layer != -1) & (updated_expert_maps_this_layer == -1)
             )
 
-            for idx in range(len(dst_rank_indices)):
-                dst_rank_id = dst_rank_indices[idx].item()
-                expert_id = experts_to_recv[idx].item()
-                if dst_rank_id not in expert_recv_info_this_layer:
-                    expert_recv_info_this_layer[dst_rank_id] = []
+            send_src_by_expert: dict[int, int] = {}
+            for src_rank_id, expert_id in zip(src_rank_indices.tolist(), experts_to_send.tolist()):
+                send_src_by_expert.setdefault(expert_id, src_rank_id)
 
-                if not torch.isin(torch.tensor(expert_id), experts_to_send).any():
+            holder_src_by_expert: dict[int, int] = {}
+            holder_rank_indices, holder_expert_ids = torch.where(current_expert_maps_this_layer != -1)
+            for src_rank_id, expert_id in zip(holder_rank_indices.tolist(), holder_expert_ids.tolist()):
+                holder_src_by_expert.setdefault(expert_id, src_rank_id)
+
+            for dst_rank_id, expert_id in zip(dst_rank_indices.tolist(), experts_to_recv.tolist()):
+                expert_recv_info_this_layer.setdefault(dst_rank_id, [])
+
+                src_rank_id = send_src_by_expert.get(expert_id)
+                if src_rank_id is None:
                     # if expert_id are not sent out from any npu, it will be copied from one npu holding this expert
-                    candidate_src_rank_indices = torch.where(current_expert_maps_this_layer[:, expert_id] != -1)[0]
-                else:
-                    candidate_src_rank_indices = src_rank_indices[experts_to_send == expert_id]
+                    src_rank_id = holder_src_by_expert[expert_id]
 
                 # TODO: improve selection criterion of NPU sending expert_id,
                 # considering intra-node or inter-node...
-                src_rank_id = candidate_src_rank_indices[0].item()
-                if src_rank_id not in expert_send_info_this_layer:
-                    expert_send_info_this_layer[src_rank_id] = []
-
+                expert_send_info_this_layer.setdefault(src_rank_id, [])
                 expert_send_info_this_layer[src_rank_id].append((dst_rank_id, expert_id))
                 expert_recv_info_this_layer[dst_rank_id].append((src_rank_id, expert_id))
 


### PR DESCRIPTION
## Summary

- precompute the first sending rank and first current holder for each expert
- replace repeated scalar extraction and tiny `torch.isin` / `torch.where` scans in the receive-planning loop with batched tensor-to-list conversion and dictionary lookups
- preserve the existing first-source selection behavior, including replica copies from an expert's first holder

This is a clean extraction of the expert update-planning optimization from [vllm-ascend-hust#36](https://github.com/vllm-hust/vllm-ascend-hust/pull/36), rebased and revalidated against current official `main`. Unrelated changes from that PR are intentionally excluded.

## Correctness and tests

Validated against vLLM-Ascend base `6003e3222b7a6d2f08753e03fe2aa44690da2dcf` and vLLM `54503ecec0f3ac31e5ecfc5f28652e4cc42307b5`.

- `ruff check vllm_ascend/eplb/core/eplb_worker.py tests/ut/eplb/core/test_eplb_worker.py`
- `ruff format --check vllm_ascend/eplb/core/eplb_worker.py tests/ut/eplb/core/test_eplb_worker.py`
- `python -m pytest -q tests/ut/eplb/core/test_eplb_worker.py` (`3 passed`)
- fixed planner benchmark produced exactly identical send/receive plans for baseline and optimized implementations

The focused tests cover planned transfers, unchanged layers, and copying a replicated expert from its first current holder.

## Component benchmark

CPU-side `compose_expert_update_info_greedy` benchmark on aarch64, using 58 layers, 25% of experts moved per layer, seven repeats, and ten planning cycles per sample:

| Ranks / experts | Baseline median | Optimized median | Speedup |
|---|---:|---:|---:|
| 8 / 128 | 328.214 ms | 11.013 ms | 29.80x |
| 16 / 256 | 655.079 ms | 17.470 ms | 37.50x |
| 32 / 256 | 662.498 ms | 22.233 ms | 29.80x |

This measures only the CPU control-plane planning function. I do not currently have a local MoE checkpoint compatible with this path, so this PR intentionally does not claim end-to-end serving improvement. It remains Draft pending upstream MoE/NPU CI or end-to-end validation.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
