### PR TITLE
[Performance] Vectorize EPLB log2phy map generation

### DIFF
--- a/tests/ut/eplb/core/a2/test_eplb_utils.py
+++ b/tests/ut/eplb/core/a2/test_eplb_utils.py
@@ -91,6 +91,23 @@ class TestAscendConfig(unittest.TestCase):
         self.assertTrue(torch.equal(rotated_tail_dp0, torch.tensor([3, 4], dtype=torch.int32)))
         self.assertTrue(torch.equal(rotated_tail_dp1, torch.tensor([0, 5], dtype=torch.int32)))
 
+    def test_generate_log2phy_map_selects_replicas_from_tensor(self):
+        global_expert_map = torch.tensor(
+            [
+                [0, 1, -1, -1],
+                [0, -1, 1, -1],
+                [-1, 0, -1, 1],
+                [-1, -1, 0, 1],
+            ],
+            dtype=torch.int32,
+        )
+
+        fallback = generate_log2phy_map(global_expert_map, ep_rank=1)
+        tp_rotated = generate_log2phy_map(global_expert_map, ep_rank=3, tp_size=2)
+
+        self.assertTrue(torch.equal(fallback, torch.tensor([2, 4, 6, 7], dtype=torch.int32)))
+        self.assertTrue(torch.equal(tp_rotated, torch.tensor([0, 4, 3, 7], dtype=torch.int32)))
+
     def test_init_eplb_config_without_eplb(self):
         self.vllm_config.additional_config = {"refresh": True}
         eplb_config = init_ascend_config(self.vllm_config).eplb_config

--- a/vllm_ascend/eplb/core/eplb_utils.py
+++ b/vllm_ascend/eplb/core/eplb_utils.py
@@ -16,7 +16,6 @@
 #
 # Todo: Once https://github.com/vllm-project/vllm/issues/22246 is merged in vllm. Remove eplb utils.
 import json
-from collections import defaultdict
 
 import numpy as np
 import torch
@@ -108,29 +107,23 @@ def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num
 
 
 def generate_log2phy_map(global_expert_map, ep_rank, tp_size: int | None = None):
-    log2phy_map = defaultdict(list)
-    valid_count = torch.sum(global_expert_map[0] != -1)
-    for rankid, map_per_rank in enumerate(global_expert_map):
-        for idx, val in enumerate(map_per_rank):
-            val = val.item()
-            if val != -1:
-                log2phy_map[idx].append(val + rankid * valid_count)
+    if not torch.is_tensor(global_expert_map):
+        global_expert_map = torch.stack(global_expert_map)
 
-    for key in log2phy_map:
-        num_of_duplications = len(log2phy_map[key])
-        if tp_size is not None and tp_size > 1:
-            tp_rank = ep_rank % tp_size
-            dp_like_rank = ep_rank // tp_size
-            replica_index = (tp_rank + dp_like_rank + key) % num_of_duplications
-        else:
-            replica_index = ep_rank % num_of_duplications
-        log2phy_map[key] = log2phy_map[key][replica_index]
+    valid = global_expert_map != -1
+    valid_count = valid[0].sum()
+    replica_counts = valid.sum(dim=0)
+    expert_ids = torch.arange(global_expert_map.shape[1], device=global_expert_map.device)
 
-    log2phy_map = torch.scatter(
-        torch.zeros(len(log2phy_map), dtype=torch.int32),
-        0,
-        torch.tensor(list(log2phy_map), dtype=torch.int64),
-        torch.tensor(list(log2phy_map.values()), dtype=torch.int32),
-    )
+    if tp_size is not None and tp_size > 1:
+        tp_rank = ep_rank % tp_size
+        dp_like_rank = ep_rank // tp_size
+        replica_indices = (tp_rank + dp_like_rank + expert_ids) % replica_counts
+    else:
+        replica_indices = ep_rank % replica_counts
 
-    return log2phy_map
+    replica_ordinals = valid.cumsum(dim=0) - 1
+    selected = valid & (replica_ordinals == replica_indices.unsqueeze(0))
+    rank_offsets = torch.arange(global_expert_map.shape[0], device=global_expert_map.device).unsqueeze(1)
+    physical_ids = global_expert_map + rank_offsets * valid_count
+    return torch.where(selected, physical_ids, 0).sum(dim=0).to(torch.int32)


### PR DESCRIPTION
## Summary

- replace nested Python loops and per-element `.item()` calls in `generate_log2phy_map` with tensorized replica selection
- preserve rank-order replica selection for both the fallback and TP-aware policies
- retain support for both a list of per-rank tensors and an already-stacked tensor

This is intentionally limited to one EPLB utility and its focused tests.

## Correctness and tests

Validated against vLLM-Ascend base `6003e3222b7a6d2f08753e03fe2aa44690da2dcf` and vLLM `54503ecec0f3ac31e5ecfc5f28652e4cc42307b5`.

- `ruff check vllm_ascend/eplb/core/eplb_utils.py tests/ut/eplb/core/a2/test_eplb_utils.py`
- `ruff format --check vllm_ascend/eplb/core/eplb_utils.py tests/ut/eplb/core/a2/test_eplb_utils.py`
- `python -m pytest -q tests/ut/eplb/core/a2/test_eplb_utils.py` (`5 passed`)
- fixed benchmark cases matched the previous implementation exactly for fallback and TP-aware selection across multiple ranks and replica counts

## Component benchmark

CPU-side `generate_log2phy_map` benchmark on aarch64, using 11 repeats and ten calls per sample:

| Ranks / experts / replicas | Baseline median | Vectorized median | Speedup |
|---|---:|---:|---:|
| 8 / 128 / 1 | 4475.5 us | 220.2 us | 20.32x |
| 8 / 128 / 2 | 6106.2 us | 222.5 us | 27.44x |
| 16 / 256 / 2 | 17164.9 us | 272.6 us | 62.96x |
| 32 / 256 / 4 | 33820.2 us | 353.7 us | 95.63x |

This measures only CPU control-plane map generation. I do not currently have a local MoE checkpoint compatible with the dynamic EPLB path, so this PR intentionally does not claim end-to-end serving improvement. It remains Draft pending upstream MoE/NPU CI or end-to-end validation.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
