### PR TITLE
[Feature] Add NPU frequency regulator operator for A5

### DIFF
--- a/csrc/common/aicpu/aclnn_frequency_regulator.h
+++ b/csrc/common/aicpu/aclnn_frequency_regulator.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef OP_API_INC_FREQUENCY_REGULATOR_
+#define OP_API_INC_FREQUENCY_REGULATOR_
+
+#include <string>
+
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief First-stage interface of aclnnFrequencyRegulator that calculates 
+ *        workspace size based on the specific compute flow.
+ * @domain aclnn_ops_infer
+ * @param [in] freq: The target frequency to be set (uint32_t).
+ * @param [in] out: The output tensor.
+ * @param [out] workspaceSize: workspace size to allocate on the NPU device side.
+ * @param [out] executor: op executor containing the operator compute flow.
+ * @return aclnnStatus: status code.
+ */
+__attribute__((visibility("default"))) aclnnStatus aclnnFrequencyRegulatorGetWorkspaceSize(
+    uint32_t freq,
+    aclTensor *out,
+    uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+/**
+ * @brief Second-stage interface of aclnnFrequencyRegulator to execute computation.
+ * @param [in] workspace: workspace memory address allocated on the NPU device side.
+ * @param [in] workspaceSize: workspace size allocated on the NPU device side, obtained from aclnnFrequencyRegulatorGetWorkspaceSize.
+ * @param [in] executor: op executor containing the operator compute flow.
+ * @param [in] stream: acl stream.
+ * @return aclnnStatus: status code.
+ */
+__attribute__((visibility("default"))) aclnnStatus aclnnFrequencyRegulator(
+    void *workspace,
+    uint64_t workspaceSize,
+    aclOpExecutor *executor,
+    aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OP_API_INC_FREQUENCY_REGULATOR_

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -49,6 +49,7 @@
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp"
+#include "common/aicpu/aclnn_frequency_regulator.h"
 #include <c10/core/Device.h>
 #include <c10/core/Scalar.h>
 #include <c10/util/Exception.h>
@@ -2050,6 +2051,14 @@ std::vector<int64_t> get_npu_storage_shape(const at::Tensor& tensor)
     return std::vector<int64_t>(desc.storage_sizes_.begin(), desc.storage_sizes_.end());
 }
 
+at::Tensor run_frequency_regulator(int64_t freq, const at::Tensor& tensor)
+{
+    auto out = at::empty({1}, at::TensorOptions().dtype(at::kUInt32).device(tensor.device()));
+    uint32_t freq_val = static_cast<uint32_t>(freq);
+    EXEC_NPU_CMD(aclnnFrequencyRegulator, freq_val, out);
+    return tensor;
+}
+
 
 } // namespace vllm_ascend
 
@@ -2747,5 +2756,10 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "store_kv_block(Tensor key_in, Tensor key_cache_in, Tensor group_len, Tensor group_key_idx,Tensor group_key_cache_idx, int block_size=0) -> ()"
     );
     ops.impl("store_kv_block", torch::kPrivateUse1, &vllm_ascend::store_kv_block);
+        
+    ops.def(
+        "run_frequency_regulator(int freq, Tensor device) -> Tensor"
+    );
+    ops.impl("run_frequency_regulator", torch::kPrivateUse1, &vllm_ascend::run_frequency_regulator);
 }
 #endif

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1124,6 +1124,11 @@ void kv_compress_epilog_meta(
     return;
 }
 
+at::Tensor run_frequency_regulator_meta(int64_t freq, const at::Tensor& tensor)
+{
+    return tensor;
+}
+
 std::tuple<at::Tensor, at::Tensor> npu_kv_quant_sparse_attn_sharedkv_meta(
     const at::Tensor& q,
     int64_t kv_quant_mode,
@@ -1623,6 +1628,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
      // store_kv_block
     ops.impl("store_kv_block_pre", &vllm_ascend::meta::store_kv_block_metadata);
     ops.impl("store_kv_block", &vllm_ascend::meta::store_kv_block);
+    // run_frequency_regulator
+    ops.impl("run_frequency_regulator", &vllm_ascend::meta::run_frequency_regulator_meta);
 }
 }
 #endif


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces a new custom operator on A5, aclnnFrequencyRegulator, designed to dynamically regulate the frequency of Ascend NPU devices during model execution. It includes the necessary C++ header definitions, the integration into the Torch binding layer, and the required meta kernel implementation to support proper operator registration and execution within the vLLM Ascend backend.

**Usage Example**
The operator is designed to be injected into the computation graph without altering the tensor values. It uses an existing tensor (e.g., `hidden_states`) to anchor the device context and prevent graph optimization passes from removing the operator.

hidden_states = torch.ops._C_ascend.run_frequency_regulator(1400, hidden_states)

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Tested via local compilation on A5 and execution to ensure the custom operator is properly registered and functions correctly within the vLLM Ascend backend.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
