### PR TITLE
[Doc] Add Memcache SSD cache configuration

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -497,30 +497,6 @@ ock.mmc.local_service.dram.size = 1GB
 | `ock.mmc.local_service.protocol` | `device_rdma` (supported for A2 and A3 when device ROCE available, recommended for A2), `device_sdma` (supported for A3 when HCCS available, recommended for A3). Currently does not support heterogeneous protocol setting.|
 | `ock.mmc.local_service.dram.size` | Sets the size of the memory occupied by the master. The configured value is the size of the memory occupied by each card. |
 
-### Enable Memcache SSD Cache
-
-* Requires Memcache installed with the UBS IO runtime.
-
-#### Configuration
-
-Starting from the `mmc-local.conf` configured in [Configuring the memcache Config File](#configuring-the-memcache-config-file), add the following SSD cache fields:
-
-```shell
-ock.mmc.local_service.storage.enabled = true
-ubsio.disk.path = /dev/nvmexn1:/dev/nvmexn2:/dev/nvmexn3:/dev/nvmexn4:/dev/nvmexn5:/dev/nvmexn6:/dev/nvmexn7:/dev/nvmexn8
-ubsio.mem.size_in_gb = 10
-ubsio.standalone.device_count = 8
-```
-
-| Field | Description |
-| :--- | :--- |
-| `ock.mmc.local_service.storage.enabled` | Set to `true` to enable SSD caching. |
-| `ubsio.disk.path` | **Required when SSD caching is enabled. The configured SSDs or partitions must be exclusively used by UBS IO and must not have any mount points.** Separate multiple paths with colons (`:`). |
-| `ubsio.mem.size_in_gb` | UBS IO memory pool size in GB. Adjust it based on the remaining host memory. |
-| `ubsio.standalone.device_count` | Number of local services whose `ock.mmc.local_service.dram.size` is not `0`. |
-
-For disk partitioning, capacity, eviction watermarks, and other UBS IO parameters, see the [DRAM + SSD Multi-level Pooling Configuration Guide](https://gitcode.com/Ascend/memcache/wiki/DRAM%20+%20SSD%20%E5%A4%9A%E7%BA%A7%E6%B1%A0%E5%8C%96%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97.md).
-
 ### Run Memcache Master
 
 Starting the MetaService service.
@@ -745,6 +721,47 @@ echo "vLLM started. Log file: log_mix.log"
 ```
 
 #### [2. Run Inference](#2-run-inference)
+
+### Enable Memcache SSD Cache
+
+* Requires `memcache_hybrid >= 1.2.0`.
+* Requires UBS IO. Starting from `memcache_hybrid 1.2.0`, UBS IO is built into Memcache and does not need to be installed separately.
+
+#### Configuration
+
+Starting from the `mmc-local.conf` configured in [Configuring the memcache Config File](#configuring-the-memcache-config-file), add the following SSD cache fields:
+
+```shell
+ock.mmc.local_service.storage.enabled = true
+ubsio.disk.path = /dev/nvmexn1:/dev/nvmexn2:/dev/nvmexn3:/dev/nvmexn4:/dev/nvmexn5:/dev/nvmexn6:/dev/nvmexn7:/dev/nvmexn8
+ubsio.mem.size_in_gb = 10
+ubsio.standalone.device_count = 8
+```
+
+When starting vLLM, explicitly set `UBSIO_CONFIG_PATH` to the same file as `MMC_LOCAL_CONFIG_PATH`:
+
+```shell
+export UBSIO_CONFIG_PATH=${MMC_LOCAL_CONFIG_PATH}
+```
+
+| Field | Description |
+| :--- | :--- |
+| `ock.mmc.local_service.storage.enabled` | Set to `true` to enable SSD caching. |
+| `ubsio.disk.path` | **Required when SSD caching is enabled. The configured SSDs or partitions must be exclusively used by UBS IO and must not have any mount points.** Separate multiple paths with colons (`:`). |
+| `ubsio.mem.size_in_gb` | Per-process UBS IO memory pool size in GB. The recommended value is `10`. The supported range is an integer from `0` to `1024`; SSD caching requires at least `5` GB per process. The total allocation must not exceed the node memory available after reserving memory for the operating system, vLLM, and the Memcache DRAM pool. |
+| `ubsio.standalone.device_count` | Number of local services whose `ock.mmc.local_service.dram.size` is not `0`. |
+
+When adjusting the recommended value, calculate the maximum permitted per-process value by dividing the node memory available to UBS IO by the number of DRAM-enabled local services, rounding down, and capping the result at `1024`:
+
+```text
+maximum ubsio.mem.size_in_gb = min(1024, floor(available node memory for UBS IO (GB) / number of DRAM-enabled local services))
+```
+
+For example, if `200` GB is available to UBS IO and four local services have DRAM enabled, the upper limit is `50` GB per process, so the recommended value `ubsio.mem.size_in_gb = 10` is valid. If the calculated upper limit is less than `5`, free more node memory or reduce the number of DRAM-enabled local services.
+
+For SSD caching, `10` GB per process is generally sufficient and does not need to be configured much larger. If you want to use the L2.5 memory caching capability, increase `ubsio.mem.size_in_gb` within the limits above and adjust [`ubsio.wcache.evict_water_level`](https://gitcode.com/Ascend/memcache/wiki/DRAM%20+%20SSD%20%E5%A4%9A%E7%BA%A7%E6%B1%A0%E5%8C%96%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97.md#ubsiowcacheevict_water_level) accordingly.
+
+For disk partitioning, capacity, eviction watermarks, and other UBS IO parameters, see the [DRAM + SSD Multi-level Pooling Configuration Guide](https://gitcode.com/Ascend/memcache/wiki/DRAM%20+%20SSD%20%E5%A4%9A%E7%BA%A7%E6%B1%A0%E5%8C%96%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97.md).
 
 ## Example of using Yuanrong as a KV Pool backend
 

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -497,6 +497,30 @@ ock.mmc.local_service.dram.size = 1GB
 | `ock.mmc.local_service.protocol` | `device_rdma` (supported for A2 and A3 when device ROCE available, recommended for A2), `device_sdma` (supported for A3 when HCCS available, recommended for A3). Currently does not support heterogeneous protocol setting.|
 | `ock.mmc.local_service.dram.size` | Sets the size of the memory occupied by the master. The configured value is the size of the memory occupied by each card. |
 
+### Enable Memcache SSD Cache
+
+* Requires Memcache installed with the UBS IO runtime.
+
+#### Configuration
+
+Starting from the `mmc-local.conf` configured in [Configuring the memcache Config File](#configuring-the-memcache-config-file), add the following SSD cache fields:
+
+```shell
+ock.mmc.local_service.storage.enabled = true
+ubsio.disk.path = /dev/nvmexn1:/dev/nvmexn2:/dev/nvmexn3:/dev/nvmexn4:/dev/nvmexn5:/dev/nvmexn6:/dev/nvmexn7:/dev/nvmexn8
+ubsio.mem.size_in_gb = 10
+ubsio.standalone.device_count = 8
+```
+
+| Field | Description |
+| :--- | :--- |
+| `ock.mmc.local_service.storage.enabled` | Set to `true` to enable SSD caching. |
+| `ubsio.disk.path` | **Required when SSD caching is enabled. The configured SSDs or partitions must be exclusively used by UBS IO and must not have any mount points.** Separate multiple paths with colons (`:`). |
+| `ubsio.mem.size_in_gb` | UBS IO memory pool size in GB. Adjust it based on the remaining host memory. |
+| `ubsio.standalone.device_count` | Number of local services whose `ock.mmc.local_service.dram.size` is not `0`. |
+
+For disk partitioning, capacity, eviction watermarks, and other UBS IO parameters, see the [DRAM + SSD Multi-level Pooling Configuration Guide](https://gitcode.com/Ascend/memcache/wiki/DRAM%20+%20SSD%20%E5%A4%9A%E7%BA%A7%E6%B1%A0%E5%8C%96%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97.md).
+
 ### Run Memcache Master
 
 Starting the MetaService service.


### PR DESCRIPTION
### What this PR does / why we need it?

- Adds the minimum UBS IO configuration required to enable Memcache SSD caching.
- Documents that configured SSDs or partitions must be dedicated to UBS IO and must not have mount points.
- Links to the detailed DRAM + SSD multi-level pooling configuration guide.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

- Ran `git diff --check`.
- Verified that Markdown code fences are balanced.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
