### PR TITLE
[BugFix] Fix SFA DSA-CP prefill o_proj handling

### DIFF
--- a/docs/source/developer_guide/Design_Documents/context_parallel.md
+++ b/docs/source/developer_guide/Design_Documents/context_parallel.md
@@ -121,15 +121,15 @@ By predefining the maximum amount of KV cache processed per round, we sequential
 
 ![PCP-ChunkedPrefill](../../assets/cp/chunkedprefill.png)
 
-### SFA DSA-CP Mixed `o_proj` Path
+### SFA DSA-CP `o_proj` Path
 
-SFA DSA-CP mixed execution intentionally reuses the normal TP-sharded `o_proj`.
-This is part of the DSA-CP mixed data path, not a standalone user-facing `o_proj` TP switch.
-The mixed path is used when one instance may handle both decode-only and prefill/mixed batches, so `o_proj` must support two layouts at runtime:
+SFA DSA-CP execution intentionally reuses the normal TP-sharded `o_proj`.
+This applies both to a mixed-role instance and to a PD-disaggregated P node; it is not a standalone user-facing `o_proj` TP switch.
+The runtime path supports two layouts:
 
 - **Decode-only batches** keep the decode TP path.
   SFA outputs are exchanged with an all-to-all in the TP group, then the original TP-sharded `o_proj` runs normally.
-- **Prefill or mixed batches** produce SFA outputs that are not directly compatible with the TP-sharded `o_proj` input layout.
+- **Prefill or mixed batches**, including batches on a PD-disaggregated P node, produce SFA outputs that are not directly compatible with the TP-sharded `o_proj` input layout.
   Before `o_proj` forward, each rank all-gathers the TP-sharded `o_proj` weight and all input-sharded quantization parameters into temporary full-weight buffers.
   The full-weight `o_proj` forward runs once for that batch, and the module is then restored to the TP parameter aliases.
 
@@ -138,7 +138,7 @@ The storage invariant is that the original TP-sharded `o_proj` parameter remains
 `o_proj_full_*` tensors are reusable communication buffers for prefill/mixed full-gather execution only.
 They must not become a second persistent copy of the TP weight.
 
-This coupling preserves the existing decode TP behavior, supports prefill/mixed DSA-CP batches, and avoids adding an extra configuration path whose state can drift from DSA-CP mixed execution.
+This coupling preserves the existing decode TP behavior, supports prefill/mixed DSA-CP batches on both mixed-role and P-only instances, and avoids a persistent full-weight copy on every TP rank.
 
 ### Related Files
 

--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3_2-W8A8-EP.yaml
@@ -52,7 +52,7 @@ deployment:
           --gpu-memory-utilization 0.90
           --enforce-eager
           --no-enable-prefix-caching
-          --additional-config '{"enable_cpu_binding" : false, "enable_sfa_cp":false}'
+          --additional-config '{"enable_cpu_binding" : false, "enable_dsa_cp":true}'
           --tokenizer-mode deepseek_v32 
           --reasoning-parser deepseek_v3
           --kv-transfer-config
@@ -98,7 +98,7 @@ deployment:
           --gpu-memory-utilization 0.90
           --enforce-eager
           --no-enable-prefix-caching
-          --additional-config '{"enable_cpu_binding" : false, "enable_sfa_cp":false}'
+          --additional-config '{"enable_cpu_binding" : false, "enable_dsa_cp":false}'
           --tokenizer-mode deepseek_v32 
           --reasoning-parser deepseek_v3
           --kv-transfer-config

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -155,10 +155,22 @@ class TestUtils(TestBase):
         ):
             self.assertTrue(utils.enable_dsa_cp_with_o_proj_tp())
 
-    def test_enable_dsa_cp_with_o_proj_tp_rejects_single_role_pd(self):
+    def test_enable_dsa_cp_with_o_proj_tp_accepts_kv_producer(self):
         mock_vllm_config = mock.MagicMock()
         mock_vllm_config.kv_transfer_config = mock.MagicMock(
             kv_role="kv_producer", is_kv_producer=True, is_kv_consumer=False
+        )
+
+        with (
+            mock.patch("vllm.config.get_current_vllm_config", return_value=mock_vllm_config),
+            mock.patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+        ):
+            self.assertTrue(utils.enable_dsa_cp_with_o_proj_tp())
+
+    def test_enable_dsa_cp_with_o_proj_tp_rejects_kv_consumer(self):
+        mock_vllm_config = mock.MagicMock()
+        mock_vllm_config.kv_transfer_config = mock.MagicMock(
+            kv_role="kv_consumer", is_kv_producer=False, is_kv_consumer=True
         )
 
         with (

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -503,7 +503,7 @@ class AscendSFAImpl(MLAAttentionImpl):
     understand this class
     """
 
-    # Supports forward using the all-gather o_proj weight for decode requests when Sharded CP is enabled.
+    # Reusable full-weight gather buffers for DSA-CP prefill/mixed requests.
     o_proj_full_pools: dict[tuple[str, int | None, torch.dtype, int, tuple[int, ...]], torch.Tensor] = {}
 
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
@@ -638,12 +638,11 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.enable_dsa_cp = enable_dsa_cp()
         self.enable_sp = enable_sp()
 
-        # SFA DSA-CP mixed deployments keep o_proj in the existing TP layout.
-        # Decode can use the TP-sharded o_proj directly after an activation
-        # all-to-all, while prefill/mixed batches temporarily gather the TP
-        # shards into a full-weight buffer because their SFA output is not
-        # TP-sharded. This is part of the DSA-CP mixed-mode data path rather
-        # than an independent user-facing feature switch.
+        # SFA DSA-CP deployments keep o_proj in the existing TP layout. Decode
+        # can use the TP-sharded o_proj after an activation all-to-all, while
+        # prefill/mixed batches (including a PD-disaggregated P node)
+        # temporarily gather the TP shards into a full-weight buffer because
+        # their SFA output is not TP-sharded.
         self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
 
         if self.enable_dsa_cp:
@@ -968,8 +967,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         """
         Initialize TP-mode aliases and Full-mode buffers for DSA-CP o_proj.
 
-        In SFA DSA-CP mixed execution, the same model instance can run both
-        decode-only and prefill/mixed batches:
+        In SFA DSA-CP execution:
         - Decode-only batches all-to-all the SFA output in the TP group, then
           run the original TP-sharded o_proj.
         - Prefill/mixed batches produce SFA output that is not directly
@@ -1662,7 +1660,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         num_input_tokens = attn_metadata.num_input_tokens
         output_padded = output
 
-        # all-gather o_proj weight for prefill stage of PD mix node
+        # Asynchronously all-gather o_proj for DSA-CP prefill. This applies to
+        # both a mixed-role instance and a PD-disaggregated P node.
         o_proj_full_handle = None
         o_proj_full_param_handles = None
         # Prefill/mixed DSA-CP computes o_proj with a temporary full weight.
@@ -1954,7 +1953,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         attn_output = self._v_up_proj(attn_output)
 
         if self.enable_dsa_cp_with_o_proj_tp:
-            # SFA DSA-CP mixed mode keeps o_proj weight sharded in the TP domain:
+            # SFA DSA-CP keeps o_proj weight sharded in the TP domain:
             # 1. prefill/mixed: gather TP shards into a temporary full weight.
             # 2. decode-only: all-to-all hidden states, then run TP o_proj.
             result, require_o_proj_forward = self._handle_o_proj_weight_switch_and_forward(
@@ -1965,6 +1964,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                 should_shard_weight=full_gather_o_proj_enabled,
             )
             if not require_o_proj_forward:
+                # The full-weight prefill path completes o_proj internally,
+                # but a pure P node must still publish this layer's KV cache.
+                maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
                 return result
             attn_output = result
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1404,10 +1404,12 @@ def enable_dsa_cp_with_o_proj_tp() -> bool:
     vllm_config = get_current_vllm_config()
     kv_transfer_config = vllm_config.kv_transfer_config
 
-    # In PD-mixed mode, keep the original TP o_proj weight when:
+    # Keep the original TP o_proj weight when:
     # 1) KV pooling is disabled, or
-    # 2) KV pooling is enabled with kv_role == "kv_both".
-    return kv_transfer_config is None or kv_transfer_config.kv_role == "kv_both"
+    # 2) KV pooling is enabled on a prefill producer (including kv_both).
+    # DSA-CP prefill produces a full-head attention output, so the runtime
+    # asynchronously gathers a temporary full o_proj weight for the forward.
+    return kv_transfer_config is None or kv_transfer_config.is_kv_producer
 
 
 def check_gdn_layer(vllm_config) -> bool:


### PR DESCRIPTION
## What this PR does

- Enables the TP-resident `o_proj` path for DSA-CP prefill producers, including PD-disaggregated P-only instances.
- Keeps `o_proj` persistently TP-sharded and asynchronously gathers a temporary full weight plus input-sharded quantization parameters for prefill/mixed forward passes.
- Preserves the existing consumer/decode role gating.
- Ensures the full-weight prefill path still publishes the layer KV cache before returning.
- Updates the SFA DSA-CP design documentation and role-gating unit coverage.

## Why this change is needed

DSA-CP prefill produces a full-head attention output on each TP rank. After layer sharding support was removed, a P-only instance could retain a TP-sharded `o_proj` while bypassing the existing full-weight gather path, creating an input/weight shape mismatch. Treating every KV producer as eligible for the TP-resident `o_proj` path restores the intended async full-weight gather behavior without adding a persistent full-weight copy on every rank.

## User impact

PD-disaggregated P nodes using SFA v1 with DSA-CP can apply `o_proj` to full-head prefill outputs using the existing asynchronous gather path. Decode-only consumers keep their previous behavior.

## Validation

- `git diff --check`
- `python -m py_compile vllm_ascend/utils.py vllm_ascend/attention/sfa_v1.py tests/ut/test_utils.py tests/ut/attention/test_sfa_o_proj_tp.py`
- Commit sign-off hook passed

NPU-dependent tests were not run locally, per repository guidance.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
