### PR TITLE
[CI]test: enable V2 model runner in e2e server env

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -273,7 +273,6 @@ class RemoteOpenAIServer:
         # the current process might initialize npu,
         # to be safe, we should use spawn method
         env["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-        env["VLLM_VERSION"] = "0.25.0"
         env["VLLM_USE_V2_MODEL_RUNNER"] = "1"
         if env_dict is not None:
             env.update(env_dict)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -44,6 +44,8 @@ import pytest
 import requests
 import torch
 from modelscope import snapshot_download  # type: ignore[import-untyped]
+
+from tests.e2e.env_logging import log_full_environment
 from PIL import Image
 from requests.exceptions import RequestException
 from torch import nn
@@ -277,6 +279,7 @@ class RemoteOpenAIServer:
         if env_dict is not None:
             env.update(env_dict)
         logger.info("Starting server with command: %s", " ".join(server_cmd))
+        log_full_environment(env, logger, prefix="[server] ")
         self.proc: subprocess.Popen = subprocess.Popen(
             server_cmd,
             env=env,
@@ -593,6 +596,7 @@ class RemotePDServer(RemoteOpenAIServer):
         env = os.environ.copy()
         if env_dict is not None:
             env.update(env_dict)
+        log_full_environment(env, logger, prefix=log_prefix)
         proc = subprocess.Popen(
             server_cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, bufsize=1
         )
@@ -749,6 +753,7 @@ class RemoteEPDServer(RemoteOpenAIServer):
         env = os.environ.copy()
         if env_dict is not None:
             env.update(env_dict)
+        log_full_environment(env, logger, prefix=log_prefix)
         proc = subprocess.Popen(
             server_cmd,
             env=env,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -273,6 +273,8 @@ class RemoteOpenAIServer:
         # the current process might initialize npu,
         # to be safe, we should use spawn method
         env["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+        env["VLLM_VERSION"] = "0.25.0"
+        env["VLLM_USE_V2_MODEL_RUNNER"] = "1"
         if env_dict is not None:
             env.update(env_dict)
         logger.info("Starting server with command: %s", " ".join(server_cmd))

--- a/tests/e2e/env_logging.py
+++ b/tests/e2e/env_logging.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import os
+import shlex
+
+LOG_FULL_ENV_VAR = "VLLM_ASCEND_LOG_FULL_ENV"
+
+SENSITIVE_ENV_TOKENS = ("TOKEN", "SECRET", "PASSWORD", "ACCESS_KEY")
+
+
+def is_full_env_logging_enabled() -> bool:
+    return os.getenv(LOG_FULL_ENV_VAR, "0") == "1"
+
+
+def mask_env_value(key: str, value: str) -> str:
+    if any(token in key.upper() for token in SENSITIVE_ENV_TOKENS):
+        return "***"
+    return value
+
+
+def log_full_environment(env: dict[str, str], logger: logging.Logger, *, prefix: str = "") -> None:
+    if not is_full_env_logging_enabled():
+        return
+    logger.info("%sFull environment (%d vars):", prefix, len(env))
+    for key in sorted(env):
+        logger.info("%sENV %s=%s", prefix, key, mask_env_value(key, str(env[key])))
+
+
+def format_env_prefix(env: dict[str, str]) -> list[str]:
+    return [f"{key}={shlex.quote(mask_env_value(key, str(value)))}" for key, value in sorted(env.items())]

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
@@ -16,6 +16,7 @@ from tests.e2e.nightly.multi_node.external_dp.scripts.external_dp_config import 
     ExternalDPConfig,
     RankInfo,
 )
+from tests.e2e.env_logging import format_env_prefix, log_full_environment
 from tests.e2e.nightly.multi_node.scripts.benchmark_results import (
     build_task_entry,
     extract_hardware,
@@ -30,22 +31,17 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from tests.e2e.nightly.multi_node.external_dp.scripts.runtime import ServerCommand
 
-SENSITIVE_ENV_TOKENS = ("TOKEN", "SECRET", "PASSWORD", "ACCESS_KEY")
-
-
 def format_server_cmd(cmd: list[str], env: dict[str, str] | None = None) -> str:
-    env_parts: list[str] = []
-    for key, value in sorted((env or {}).items()):
-        display_value = "***" if any(token in key.upper() for token in SENSITIVE_ENV_TOKENS) else str(value)
-        env_parts.append(f"{key}={shlex.quote(display_value)}")
+    env_parts = format_env_prefix(env or {})
     return " ".join([*env_parts, shlex.join(cmd)])
 
 
 def start_logged_process(cmd: list[str], env: dict[str, str], log_file: Path) -> subprocess.Popen:
     log_file.parent.mkdir(parents=True, exist_ok=True)
     merged_env = {**os.environ, **env}
+    log_full_environment(merged_env, logger, prefix=f"[{log_file.name}] ")
     with log_file.open("ab") as f:
-        f.write(f"Starting command: {format_server_cmd(cmd, env)}\n".encode())
+        f.write(f"Starting command: {format_server_cmd(cmd, merged_env)}\n".encode())
         f.flush()
         return subprocess.Popen(
             cmd,

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
@@ -10,7 +10,6 @@ env_common: &env_common
   OMP_NUM_THREADS: 1
   HCCL_BUFFSIZE: 1024
   SERVER_PORT: 8080
-  DYNAMIC_EPLB: true
 disaggregated_prefill:
   enabled: true
   prefiller_host_index: [0]
@@ -29,6 +28,9 @@ deployment:
         --tensor-parallel-size 8
         --seed 1024
         --enable-expert-parallel
+        --enable-eplb
+        --eplb-config
+        '{"window_size": 50, "step_interval": 5, "use_async": false}'
         --max-num-seqs 16
         --max-model-len 8192
         --max-num-batched-tokens 8192
@@ -51,8 +53,6 @@ deployment:
                   }
             }
         }'
-        --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5}}'
 
   -
     envs:
@@ -70,6 +70,9 @@ deployment:
         --max-model-len 8192
         --max-num-batched-tokens 8192
         --enable-expert-parallel
+        --enable-eplb
+        --eplb-config
+        '{"window_size": 600, "step_interval": 50, "use_async": false}'
         --trust-remote-code
         --no-enable-prefix-caching
         --gpu-memory-utilization 0.9
@@ -88,6 +91,4 @@ deployment:
                   }
             }
         }'
-        --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":600,"algorithm_execution_interval":50}}'
 benchmarks:

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/multi_node_config.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/multi_node_config.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import regex as re
 
+from tests.e2e.env_logging import log_full_environment
 from tests.e2e.nightly.multi_node.scripts.utils import (
     get_available_port,
     get_net_interface,
@@ -152,7 +153,9 @@ class ProxyLauncher:
         ]
 
         logger.info("Launching proxy: %s", " ".join(cmd))
-        self.process = subprocess.Popen(cmd, env={**os.environ, **self.envs})
+        proxy_env = {**os.environ, **self.envs}
+        log_full_environment(proxy_env, logger, prefix="[proxy] ")
+        self.process = subprocess.Popen(cmd, env=proxy_env)
         return self
 
     def __exit__(self, exc_type, exc, tb):

--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2.6-w4a8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2.6-w4a8-A3.yaml
@@ -12,7 +12,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "800"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--quantization"
@@ -30,6 +29,9 @@ test_cases:
       - "2"
       - "--no-enable-prefix-caching"
       - "--enable-expert-parallel"
+      - "--enable-eplb"
+      - "--eplb-config"
+      - '{"window_size": 600, "step_interval": 50, "use_async": false}'
       - "--max-num-seqs"
       - "24"
       - "--max-model-len"
@@ -44,7 +46,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"enable_fused_mc2":1,"scheduler_config":{"enable_balance_scheduling":true},"enable_mlapo":true}'
+      - '{"ascend_compilation_config":{"enable_static_kernel":false},"enable_fused_mc2":1,"scheduler_config":{"enable_balance_scheduling":true},"enable_mlapo":true}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-235B-A22B-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-235B-A22B-W8A8.yaml
@@ -72,11 +72,11 @@ test_cases:
     model: "vllm-ascend/Qwen3-235B-A22B-W8A8"
     envs:
       <<: *envs
-      DYNAMIC_EPLB: "true"
     server_cmd: *server_cmd
     server_cmd_extra:
-      - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": "true", "expert_heat_collection_interval": 600, "algorithm_execution_interval": 50, "num_redundant_experts": 16, "eplb_policy_type": 2}}'
+      - "--enable-eplb"
+      - "--eplb-config"
+      - '{"window_size": 600, "step_interval": 50, "use_async": false, "num_redundant_experts": 16}'
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
     benchmarks:

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -974,20 +974,6 @@
 #           to override them, then delete the patch file `worker/patch_rejection_sampler.py`.
 #       2. make these functions as costom op, then remove AscendRejectionSampler
 #
-# ** 18.1. File: worker/patch_topk_topp_sampler.py**
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.v1.sample.ops.topk_topp_sampler.apply_top_k_top_p`
-#    Why:
-#       Temporarily force the PyTorch path by disabling the upstream
-#       `current_platform.is_cpu()` and `HAS_TRITON and batch>=8` branches
-#       for Ascend nightly validation.
-#    How：
-#       Replace `apply_top_k_top_p` so it always calls `apply_top_k_top_p_pytorch`.
-#    Related PR (if no, explain why):
-#       Experimental patch for nightly; not intended as a long-term Ascend change.
-#    Future Plan:
-#       Remove this patch once the upstream sampling path is confirmed or fixed.
-#
 # ** 19. File: worker/patch_routed_experts_capture.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.layers.fused_moe.routed_experts_capturer.RoutedExpertsCapturer.capture`
@@ -1217,6 +1203,23 @@
 #    Future Plan:
 #       Remove this patch once vLLM selects the Triton libdevice through a
 #       backend-dispatch mechanism.
+#
+# ** 28.1. File: worker/patch_v2/patch_topk_topp_sampler.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.sample.ops.topk_topp_sampler.apply_top_k_top_p`
+#   2. `vllm.v1.worker.gpu.sample.states.apply_top_k_top_p`
+#    Why:
+#       V2 nightly validation: force the PyTorch path by disabling upstream
+#       `current_platform.is_cpu()` and `HAS_TRITON and batch>=8` branches.
+#       V2 SamplingStates binds apply_top_k_top_p at import time, so both the
+#       source module and that local name must be rebound.
+#    How：
+#       Replace both bindings so they always call `apply_top_k_top_p_pytorch`.
+#       Loaded after `patch_v2/patch_triton.py` under HAS_TRITON.
+#    Related PR (if no, explain why):
+#       Experimental patch for V2 nightly; not intended as a long-term Ascend change.
+#    Future Plan:
+#       Remove this patch once the upstream V2 sampling path is confirmed or fixed.
 #
 # ** 29. File: worker/patch_v2/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -974,6 +974,20 @@
 #           to override them, then delete the patch file `worker/patch_rejection_sampler.py`.
 #       2. make these functions as costom op, then remove AscendRejectionSampler
 #
+# ** 18.1. File: worker/patch_topk_topp_sampler.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.sample.ops.topk_topp_sampler.apply_top_k_top_p`
+#    Why:
+#       Temporarily force the PyTorch path by disabling the upstream
+#       `current_platform.is_cpu()` and `HAS_TRITON and batch>=8` branches
+#       for Ascend nightly validation.
+#    How：
+#       Replace `apply_top_k_top_p` so it always calls `apply_top_k_top_p_pytorch`.
+#    Related PR (if no, explain why):
+#       Experimental patch for nightly; not intended as a long-term Ascend change.
+#    Future Plan:
+#       Remove this patch once the upstream sampling path is confirmed or fixed.
+#
 # ** 19. File: worker/patch_routed_experts_capture.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.layers.fused_moe.routed_experts_capturer.RoutedExpertsCapturer.capture`

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1207,14 +1207,15 @@
 # ** 28.1. File: worker/patch_v2/patch_topk_topp_sampler.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.sample.ops.topk_topp_sampler.apply_top_k_top_p`
-#   2. `vllm.v1.worker.gpu.sample.states.apply_top_k_top_p`
+#   2. `vllm.v1.worker.gpu.sample.sampler.apply_top_k_top_p`
+#   3. `vllm.v1.worker.gpu.sample.states.apply_top_k_top_p`
 #    Why:
 #       V2 nightly validation: force the PyTorch path by disabling upstream
 #       `current_platform.is_cpu()` and `HAS_TRITON and batch>=8` branches.
-#       V2 SamplingStates binds apply_top_k_top_p at import time, so both the
-#       source module and that local name must be rebound.
+#       V2 binds apply_top_k_top_p at import time in sampler (hot path) and
+#       states, so the source module and both local names must be rebound.
 #    How：
-#       Replace both bindings so they always call `apply_top_k_top_p_pytorch`.
+#       Replace all three bindings so they always call `apply_top_k_top_p_pytorch`.
 #       Loaded after `patch_v2/patch_triton.py` under HAS_TRITON.
 #    Related PR (if no, explain why):
 #       Experimental patch for V2 nightly; not intended as a long-term Ascend change.

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -37,6 +37,7 @@ if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PA
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa
+import vllm_ascend.patch.worker.patch_topk_topp_sampler  # noqa
 
 import vllm_ascend.patch.worker.patch_kimi_k25  # noqa
 import vllm_ascend.patch.worker.patch_eagle3_init  # noqa

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -22,6 +22,9 @@ from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_
 if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
     import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
+    # After patch_v2.patch_triton imports sample.states; rebind its
+    # import-time apply_top_k_top_p for V2 nightly.
+    import vllm_ascend.patch.worker.patch_v2.patch_topk_topp_sampler  # noqa
 
 
 import vllm_ascend.patch.worker.patch_distributed  # noqa
@@ -37,7 +40,6 @@ if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PA
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa
 import vllm_ascend.patch.worker.patch_rejection_sampler  # noqa
-import vllm_ascend.patch.worker.patch_topk_topp_sampler  # noqa
 
 import vllm_ascend.patch.worker.patch_kimi_k25  # noqa
 import vllm_ascend.patch.worker.patch_eagle3_init  # noqa

--- a/vllm_ascend/patch/worker/patch_topk_topp_sampler.py
+++ b/vllm_ascend/patch/worker/patch_topk_topp_sampler.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import vllm.v1.sample.ops.topk_topp_sampler as topk_topp_sampler
+
+
+def apply_top_k_top_p(
+    logits: torch.Tensor, k: torch.Tensor | None, p: torch.Tensor | None
+) -> torch.Tensor:
+    """Same as upstream apply_top_k_top_p, with CPU/Triton branches disabled.
+
+    Equivalent to commenting out these two upstream blocks:
+      - if current_platform.is_cpu(): ...
+      - if HAS_TRITON and logits.shape[0] >= 8: ...
+    Always falls through to the PyTorch implementation.
+    """
+    if p is None and k is None:
+        return logits
+
+    # Disabled on Ascend (commented out upstream branches):
+    # if current_platform.is_cpu():
+    #     if HAS_TRITON:
+    #         return apply_top_k_top_p_triton(logits, k, p)
+    #     return apply_top_k_top_p_pytorch(logits, k, p, allow_cpu_sync=True)
+    #
+    # if HAS_TRITON and logits.shape[0] >= 8:
+    #     return apply_top_k_top_p_triton(logits, k, p)
+
+    # Use pytorch sort implementation.
+    return topk_topp_sampler.apply_top_k_top_p_pytorch(logits, k, p)
+
+
+topk_topp_sampler.apply_top_k_top_p = apply_top_k_top_p

--- a/vllm_ascend/patch/worker/patch_v2/patch_topk_topp_sampler.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_topk_topp_sampler.py
@@ -15,6 +15,7 @@
 
 import torch
 import vllm.v1.sample.ops.topk_topp_sampler as topk_topp_sampler
+import vllm.v1.worker.gpu.sample.states as states
 
 
 def apply_top_k_top_p(
@@ -26,6 +27,10 @@ def apply_top_k_top_p(
       - if current_platform.is_cpu(): ...
       - if HAS_TRITON and logits.shape[0] >= 8: ...
     Always falls through to the PyTorch implementation.
+
+    V2 model runner imports apply_top_k_top_p into
+    ``vllm.v1.worker.gpu.sample.states`` at import time, so both the source
+    module and that local binding must be rebound for nightly to take effect.
     """
     if p is None and k is None:
         return logits
@@ -44,3 +49,5 @@ def apply_top_k_top_p(
 
 
 topk_topp_sampler.apply_top_k_top_p = apply_top_k_top_p
+# V2 SamplingStates.apply_top_k_top_p uses this import-time binding.
+states.apply_top_k_top_p = apply_top_k_top_p

--- a/vllm_ascend/patch/worker/patch_v2/patch_topk_topp_sampler.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_topk_topp_sampler.py
@@ -17,6 +17,9 @@ import torch
 import vllm.v1.sample.ops.topk_topp_sampler as topk_topp_sampler
 import vllm.v1.worker.gpu.sample.sampler as gpu_sampler
 import vllm.v1.worker.gpu.sample.states as states
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 def apply_top_k_top_p(
@@ -33,6 +36,16 @@ def apply_top_k_top_p(
     ``Sampler.sample``) and ``gpu.sample.states`` at import time, so the source
     module and both local bindings must be rebound for nightly to take effect.
     """
+    # Log at entry so we can tell the patched function was invoked even when
+    # k/p are both None (early return) or when temperature fails earlier.
+    logger.info_once(
+        "[patch_topk_topp] Ascend V2 patch invoked: forcing apply_top_k_top_p_pytorch "
+        "(batch=%s, has_k=%s, has_p=%s)",
+        logits.shape[0] if logits is not None else None,
+        k is not None,
+        p is not None,
+    )
+
     if p is None and k is None:
         return logits
 
@@ -54,3 +67,7 @@ topk_topp_sampler.apply_top_k_top_p = apply_top_k_top_p
 gpu_sampler.apply_top_k_top_p = apply_top_k_top_p
 # V2 SamplingStates.apply_top_k_top_p uses this import-time binding.
 states.apply_top_k_top_p = apply_top_k_top_p
+logger.info_once(
+    "[patch_topk_topp] Ascend V2 patch loaded: rebound apply_top_k_top_p on "
+    "topk_topp_sampler, gpu.sample.sampler, and gpu.sample.states"
+)

--- a/vllm_ascend/patch/worker/patch_v2/patch_topk_topp_sampler.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_topk_topp_sampler.py
@@ -15,6 +15,7 @@
 
 import torch
 import vllm.v1.sample.ops.topk_topp_sampler as topk_topp_sampler
+import vllm.v1.worker.gpu.sample.sampler as gpu_sampler
 import vllm.v1.worker.gpu.sample.states as states
 
 
@@ -28,9 +29,9 @@ def apply_top_k_top_p(
       - if HAS_TRITON and logits.shape[0] >= 8: ...
     Always falls through to the PyTorch implementation.
 
-    V2 model runner imports apply_top_k_top_p into
-    ``vllm.v1.worker.gpu.sample.states`` at import time, so both the source
-    module and that local binding must be rebound for nightly to take effect.
+    V2 imports apply_top_k_top_p into ``gpu.sample.sampler`` (hot path in
+    ``Sampler.sample``) and ``gpu.sample.states`` at import time, so the source
+    module and both local bindings must be rebound for nightly to take effect.
     """
     if p is None and k is None:
         return logits
@@ -49,5 +50,7 @@ def apply_top_k_top_p(
 
 
 topk_topp_sampler.apply_top_k_top_p = apply_top_k_top_p
+# V2 Sampler.sample() hot path uses this import-time binding.
+gpu_sampler.apply_top_k_top_p = apply_top_k_top_p
 # V2 SamplingStates.apply_top_k_top_p uses this import-time binding.
 states.apply_top_k_top_p = apply_top_k_top_p


### PR DESCRIPTION
Set VLLM_VERSION=0.25.0 and VLLM_USE_V2_MODEL_RUNNER=1 when starting RemoteOpenAIServer.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
