### PR TITLE
[BugFix][Spec Decode] Isolate eager draft compilation config

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -224,6 +224,40 @@ class TestNPUPlatform(TestBase):
 
         self.assertEqual(observed_inputs, [77])
 
+    @patch("vllm_ascend.platform.refresh_block_size")
+    @patch("vllm_ascend.platform.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.platform.enable_sp", return_value=True)
+    @patch("vllm_ascend.ascend_config.init_ascend_config")
+    @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
+    def test_check_and_update_config_skips_sp_capture_sizes_without_cudagraph(
+        self,
+        mock_auto_detect,
+        mock_init_ascend,
+        _mock_enable_sp,
+        _mock_device_type,
+        _mock_refresh_block_size,
+    ):
+        mock_init_ascend.return_value = TestNPUPlatform.mock_vllm_ascend_config()
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.compilation_config.mode = CompilationMode.NONE
+        vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        vllm_config.compilation_config.cudagraph_capture_sizes = []
+        vllm_config.compilation_config.custom_ops = []
+        vllm_config.compilation_config.splitting_ops = []
+        vllm_config.model_config.enforce_eager = False
+        vllm_config.model_config.enable_sleep_mode = True
+        vllm_config.model_config.is_encoder_decoder = False
+        vllm_config.parallel_config.tensor_parallel_size = 16
+        vllm_config.parallel_config.worker_cls = "manual"
+        vllm_config.parallel_config.cp_kv_cache_interleave_size = 1
+        vllm_config.cache_config.block_size = 1
+        vllm_config._set_cudagraph_sizes = MagicMock()
+        vllm_config.update_sizes_for_sequence_parallelism = MagicMock(return_value=[])
+
+        self.platform.check_and_update_config(vllm_config)
+
+        vllm_config.update_sizes_for_sequence_parallelism.assert_not_called()
+
     def test_get_device_capability(self):
         self.assertIsNone(self.platform.get_device_capability(device_id=0))
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -506,6 +506,7 @@ class NPUPlatform(Platform):
         # is supported by vllm-ascend.
         if (
             vllm_config.parallel_config.tensor_parallel_size > 1
+            and compilation_config.cudagraph_mode != CUDAGraphMode.NONE
             and not vllm_config.model_config.enforce_eager
             and enable_sp(vllm_config)
         ):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -2,6 +2,7 @@
 import copy
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
+from dataclasses import replace
 from functools import partial
 from typing import Any, cast
 
@@ -83,12 +84,19 @@ _PREPARE_INPUTS_BLOCK_SIZE = 4
 # patch vllm_config to be in CompilationMode.NONE temporarily
 @contextmanager
 def _maybe_eager_context(vllm_config):
-    raw_compilation_config_mode = vllm_config.compilation_config.mode
-    vllm_config.compilation_config.mode = CompilationMode.NONE
+    target_compilation_config = vllm_config.compilation_config
+    draft_compilation_config = replace(
+        target_compilation_config,
+        mode=CompilationMode.NONE,
+    )
+    # Model layers use these registries even when compilation is disabled.
+    draft_compilation_config.static_forward_context = target_compilation_config.static_forward_context
+    draft_compilation_config.static_all_moe_layers = target_compilation_config.static_all_moe_layers
+    vllm_config.compilation_config = draft_compilation_config
     try:
         yield
     finally:
-        vllm_config.compilation_config.mode = raw_compilation_config_mode
+        vllm_config.compilation_config = target_compilation_config
 
 
 # split hidden states along dimension of sequence


### PR DESCRIPTION
### What this PR does / why we need it?

The original issue was an assertion failure when using an eager speculative draft with PIECEWISE CUDAGraph and FlashComm: `cudagraph_capture_sizes [] does not contain values that are multiples of tp_size 16`. The eager draft context changed the target model's shared `CompilationConfig` in place, and draft config initialization could then clear CUDAGraph capture sizes on the same object. As a result, the target model's PIECEWISE graph configuration was corrupted and the SP capture-size assertion failed.

`FULL_DECODE_ONLY` is not affected because it does not depend on compilation, so the upstream `check_and_update_config` path does not rewrite the related compilation fields when constructing the draft config. PIECEWISE depends on compilation and therefore exposes the shared `CompilationConfig` mutation.

The ideal fix is to resolve the draft-model compilation incompatibility and remove this eager workaround. Given the current time constraint, this PR takes a minimal approach: use a temporary copy of `CompilationConfig` while creating the eager draft, and skip SP capture-size validation when CUDAGraph mode is `NONE`.

This is correct because the target model keeps its original capture settings, while the runtime registries required by model layers remain shared with the draft. The original config object is restored after draft creation, including on exceptions.

### Does this PR introduce any user-facing change?

No. This PR introduces no configuration or parameter changes; it only fixes the incorrect handling of the existing configuration.

### How was this patch tested?

A regression test was added, and the fix passed manual acceptance testing.