### PR TITLE
[Ops][BugFix] Refactor DeepSeek V4 configuration override in speculative config

### DIFF
--- a/tests/ut/patch/platform/test_patch_speculative_config.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.patch.platform.patch_speculative_config import hf_config_override
+
+
+def _make_cfg(model_type: str, *, n_predict: int = 1, architectures: list[str] | None = None):
+    cfg = SimpleNamespace(
+        model_type=model_type,
+        architectures=list(architectures or ["DummyForCausalLM"]),
+        num_nextn_predict_layers=n_predict,
+    )
+
+    def update(mapping=None, **kwargs):
+        data = dict(mapping or {})
+        data.update(kwargs)
+        for key, value in data.items():
+            setattr(cfg, key, value)
+
+    cfg.update = update
+    return cfg
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_arch"),
+    [
+        ("deepseek_v3", "DeepSeekMTPModel"),
+        ("deepseek_v32", "DeepSeekMTPModel"),
+        ("glm_moe_dsa", "DeepSeekMTPModel"),
+        ("deepseek_v4", "DeepSeekV4MTPModel"),
+        ("deepseek_mtp", "DeepSeekMTPModel"),
+    ],
+)
+def test_hf_config_override_deepseek_family(model_type: str, expected_arch: str):
+    cfg = _make_cfg(model_type, n_predict=2)
+
+    out = hf_config_override(cfg)
+
+    assert out.model_type == "deepseek_mtp"
+    assert out.architectures == [expected_arch]
+    assert out.n_predict == 2

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -16,15 +16,15 @@ else:
 
 def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
     initial_architecture = hf_config.architectures[0]
-    if hf_config.model_type in ("deepseek_v3", "deepseek_v32", "deepseek_v4", "glm_moe_dsa"):
-        target_model_type = hf_config.model_type
+    if hf_config.model_type in ("deepseek_v3", "deepseek_v32", "glm_moe_dsa"):
         hf_config.model_type = "deepseek_mtp"
     if hf_config.model_type == "deepseek_mtp":
-        if target_model_type == "deepseek_v4":
-            hf_config.update({"architectures": ["DeepSeekV4MTPModel"]})
-        else:
-            n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
-            hf_config.update({"n_predict": n_predict, "architectures": ["DeepSeekMTPModel"]})
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["DeepSeekMTPModel"]})
+    if hf_config.model_type == "deepseek_v4":
+        hf_config.model_type = "deepseek_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["DeepSeekV4MTPModel"]})
     if hf_config.model_type in ("pangu_ultra_moe"):
         hf_config.model_type = "pangu_ultra_moe_mtp"
     if hf_config.model_type == "pangu_ultra_moe_mtp":


### PR DESCRIPTION
### What this PR does / why we need it?
- Align `hf_config_override` with upstream: handle `deepseek_v4` separately (https://github.com/vllm-project/vllm/blob/main/vllm/config/speculative.py , line 331)
- Avoid `NameError` when draft config is already `deepseek_mtp` (unbound `target_model_type`)
- Add unit tests for deepseek/glm MTP remap paths

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Unit tests: `tests/ut/patch/platform/test_patch_speculative_config.py`

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
