### PR TITLE
[v0.23.0][BugFix] Preserve PP KV cache layers when filtering MTP

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -133,6 +133,30 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
 
+    def test_infer_cache_group_metadata_keeps_pp_layers_and_skips_mtp(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 2
+        worker.hf_config = MagicMock(num_hidden_layers=4)
+        caches = [MagicMock(), MagicMock(), MagicMock()]
+        for address, cache in zip((1000, 2000, 3000), caches):
+            cache.data_ptr.return_value = address
+        worker.kv_caches = {
+            "model.layers.2.self_attn": (caches[0],),
+            "model.layers.3.self_attn": (caches[1],),
+            "model.mtp.0.self_attn": (caches[2],),
+        }
+        worker._get_cache_block_metadata = MagicMock(return_value=(160, 160, 160, 1))
+        worker.group_kv_caches_base_addr = {}
+        worker.group_block_len = {}
+        worker.group_block_stride = {}
+        worker.group_num_layers = {}
+
+        worker._infer_cache_group_metadata(0, list(worker.kv_caches))
+
+        self.assertEqual(worker.group_kv_caches_base_addr[0], [1000, 2000])
+        self.assertEqual(worker.group_num_layers[0], 2)
+
 
 class TestKVPoolWorkerInit(unittest.TestCase):
     """Test KVPoolWorker initialization with mocked dependencies."""

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -613,7 +613,7 @@ class KVPoolWorker:
         physical_layers = set()
         for layer_name in layer_names:
             phys = self._extract_physical_layer_index(layer_name)
-            if phys >= self.num_layers:
+            if phys >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
                 continue
             physical_layers.add(phys)
             cache_or_caches = self.kv_caches[layer_name]


### PR DESCRIPTION
### What this PR does / why we need it?

`_infer_cache_group_metadata` compared globally indexed layer names with the pipeline rank-local `num_layers`. On nonzero PP ranks, this filtered regular attention layers together with MTP layers, leaving empty KV buffer metadata and causing Mooncake puts with `slice_length=0`.

Use the model's global `num_hidden_layers` as the MTP boundary. This keeps regular layers on every PP rank while preserving the MTP filtering introduced by #11829.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStore KV Pool keeps KV cache buffers on nonzero pipeline-parallel ranks instead of issuing invalid zero-length puts.

### How was this patch tested?

- Added a regression test covering globally indexed PP layers and MTP filtering.
- `TestKVPoolWorkerHelpers`: 15 tests passed.
- All changed-file pre-commit hooks passed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
