### PR TITLE
[CI] Update operations_per_run parameter for stale and wait-feedback …

### DIFF
--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -38,6 +38,13 @@ jobs:
           # Process issues with the 'resolved' label
           any-of-labels: 'resolved'
 
+          # Increase the operations budget so older (least-recently-updated)
+          # issues are still reached before the per-run quota is exhausted.
+          # The action processes issues newest-updated-first; with the default
+          # of 30, stale-eligible issues sitting at the tail of the list (e.g.
+          # ones that have had no activity for weeks) never get processed.
+          operations-per-run: 200
+
           # Mark as stale after a period of inactivity
           days-before-stale: 7
           stale-issue-label: 'stale'
@@ -64,6 +71,10 @@ jobs:
         with:
           # Process issues with the 'wait-feedback' label
           any-of-labels: 'wait-feedback'
+
+          # See note above: default operations-per-run (30) is too small and
+          # causes the oldest wait-feedback issues to starve at the queue tail.
+          operations-per-run: 200
 
           # Mark as stale after a period of inactivity
           days-before-stale: 7


### PR DESCRIPTION
### What this PR does / why we need it?
Increase the `operations_per_run` parameter from the default 30 to 200 to enable the automatic closure of repository issues historically labeled as `stale` or `wait-feedback`.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Simply increasing the parameter from 30 to 200 does not affect functionality or other aspects..
