### PR TITLE
[BugFix][WeightTransfer] Sync source stream in packed_broadcast_producer before packing

### DIFF
--- a/vllm_ascend/distributed/weight_transfer/packed_tensor.py
+++ b/vllm_ascend/distributed/weight_transfer/packed_tensor.py
@@ -39,6 +39,7 @@ def packed_broadcast_producer(
     target_packed_tensor_size = buffer_size_bytes
 
     streams = [torch.npu.Stream() for _ in range(num_buffers)]
+    source_stream = torch.npu.current_stream()
     buffer_idx = 0
 
     packing_tensor_list: list[list[torch.Tensor]] = [[] for _ in range(num_buffers)]
@@ -50,6 +51,9 @@ def packed_broadcast_producer(
         # Synchronize the current stream (waits for previous
         # iteration's work on this buffer to finish)
         streams[buffer_idx].synchronize()
+        # Source tensors may have been produced asynchronously on the caller's
+        # stream. Wait before the packing stream reads them in torch.cat.
+        streams[buffer_idx].wait_stream(source_stream)
         # Start tasks for the new buffer in a new stream
         with torch.npu.stream(streams[buffer_idx]):
             # Initialize the packing tensor list and sizes


### PR DESCRIPTION
### What this PR does / why we need it?

`packed_broadcast_producer` runs the `torch.cat` packing on dedicated NPU
streams (`streams[buffer_idx]`), but the source tensors it reads may still be
in flight on the caller's current stream — e.g. weights that were just
produced asynchronously by the model / weight-sync path. The producer only
calls `streams[buffer_idx].synchronize()` (which waits for the *previous*
iteration on that buffer), so nothing orders the packing stream after the
stream that produced the source tensors.

As a result `torch.cat` on the packing stream can read the source tensors
before their producing kernels finish, yielding stale/garbage packed weights
that are then broadcast to the workers.

This PR captures the caller's stream via `torch.npu.current_stream()` and makes
each packing stream `wait_stream()` on it (after `synchronize()`, before the
`torch.cat`). This mirrors the existing `default_stream` handling already used
in `packed_broadcast_consumer`.

### Does this PR introduce any user-facing change?

No. Correctness fix only; no API or behavior change beyond removing the race.

### How was this patch tested?

Validated in a colocated Qwen3-VL GRPO weight-sync run on Ascend NPU, where the
race intermittently produced corrupted broadcast weights before this change and
consistently correct weights after.

Signed-off-by: Meihan-chen <zr010426ztt@outlook.com>
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
