### PR TITLE
[BugFix][GLM-5.2][SpecDecode] Use forward_native for DSpark draft query RoPE on Ascend (stacked on #11066)

### DIFF
--- a/tests/ut/compilation/a2/test_acl_graph.py
+++ b/tests/ut/compilation/a2/test_acl_graph.py
@@ -33,6 +33,7 @@ from vllm_ascend.compilation.acl_graph import (
     GraphParams,
     get_draft_graph_params,
     get_graph_params,
+    reset_graph_params,
     set_draft_graph_params,
     set_graph_params,
     update_draft_graph_params_workspaces,
@@ -808,6 +809,26 @@ class TestSleepGraphParams(TestBase):
 
 
 class TestDraftGraphParams(TestBase):
+    def test_reset_graph_params(self):
+        graph_params = GraphParams(
+            events={},
+            workspaces={},
+            handles={},
+            attn_params={},
+        )
+        with (
+            patch("vllm_ascend.compilation.acl_graph._graph_params", graph_params),
+            patch("vllm_ascend.compilation.acl_graph._draft_graph_params", graph_params),
+            patch(
+                "vllm_ascend.compilation.acl_graph._draft_graph_prefill_params",
+                graph_params,
+            ),
+        ):
+            reset_graph_params()
+            self.assertIsNone(acl_graph._graph_params)
+            self.assertIsNone(acl_graph._draft_graph_params)
+            self.assertIsNone(acl_graph._draft_graph_prefill_params)
+
     def test_set_draft_graph_params(self):
         with patch("vllm_ascend.compilation.acl_graph._draft_graph_params", new=None):
             set_draft_graph_params([4])

--- a/tests/ut/test_dspark_graph_inputs.py
+++ b/tests/ut/test_dspark_graph_inputs.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+import torch
+from vllm.config import CUDAGraphMode
+
+import vllm_ascend.spec_decode.dflash_proposer as dflash_module
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+
+class _ContextRecorder:
+    def __init__(self):
+        self.calls = 0
+
+    def precompute_and_store_context_kv(self, hidden_states, positions, slot_mapping):
+        self.calls += 1
+        self.hidden_states = hidden_states
+        self.positions = positions
+        self.slot_mapping = slot_mapping
+
+
+def _make_proposer():
+    return SimpleNamespace(
+        _dflash_num_context=3,
+        _dflash_hidden_states=torch.zeros(16, 4),
+        _context_positions_buffer=torch.zeros(16, dtype=torch.int32),
+        _context_slot_mapping_buffer=torch.zeros(16, dtype=torch.int32),
+        input_ids=torch.zeros(16, dtype=torch.int32),
+        positions=torch.zeros(16, dtype=torch.int32),
+        model=_ContextRecorder(),
+        _use_dspark_block_contract=lambda: True,
+    )
+
+
+def test_dspark_eager_precomputes_actual_context(monkeypatch):
+    proposer = _make_proposer()
+    monkeypatch.setattr(
+        dflash_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE),
+    )
+
+    model_inputs = AscendDflashProposer.build_model_inputs_first_pass(
+        proposer,
+        num_input_tokens=8,
+    )
+
+    assert proposer.model.calls == 1
+    assert proposer.model.hidden_states.shape[0] == 3
+    assert proposer.model.positions.shape[0] == 3
+    assert proposer.model.slot_mapping.shape[0] == 3
+    assert model_inputs["input_ids"].shape[0] == 8
+    assert model_inputs["positions"].shape[0] == 8
+
+
+def test_dspark_graph_precomputes_fixed_padded_context(monkeypatch):
+    proposer = _make_proposer()
+    monkeypatch.setattr(
+        dflash_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.FULL),
+    )
+
+    model_inputs = AscendDflashProposer.build_model_inputs_first_pass(
+        proposer,
+        num_input_tokens=8,
+    )
+
+    assert proposer.model.calls == 1
+    assert proposer.model.hidden_states.shape[0] == 8
+    assert proposer.model.positions.shape[0] == 8
+    assert proposer.model.slot_mapping.shape[0] == 8
+    assert model_inputs["input_ids"].shape[0] == 8
+    assert model_inputs["positions"].shape[0] == 8

--- a/tests/ut/test_dspark_graph_inputs.py
+++ b/tests/ut/test_dspark_graph_inputs.py
@@ -1,10 +1,14 @@
+from dataclasses import dataclass
 from types import SimpleNamespace
 
+import numpy as np
 import torch
-from vllm.config import CUDAGraphMode
+from vllm.config import CompilationMode, CUDAGraphMode
 
+import vllm_ascend.spec_decode as spec_decode_module
 import vllm_ascend.spec_decode.dflash_proposer as dflash_module
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 
 
 class _ContextRecorder:
@@ -71,3 +75,186 @@ def test_dspark_graph_precomputes_fixed_padded_context(monkeypatch):
     assert proposer.model.slot_mapping.shape[0] == 8
     assert model_inputs["input_ids"].shape[0] == 8
     assert model_inputs["positions"].shape[0] == 8
+
+
+class _KernelRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def __getitem__(self, grid):
+        assert grid == (1,)
+
+        def launch(**kwargs):
+            self.calls.append(kwargs)
+
+        return launch
+
+
+def test_dspark_input_preparation_uses_device_kernel(monkeypatch):
+    kernel = _KernelRecorder()
+    monkeypatch.setattr(
+        dflash_module,
+        "copy_and_expand_dflash_inputs_kernel_single_grid",
+        kernel,
+    )
+    proposer = SimpleNamespace(
+        num_speculative_tokens=2,
+        max_query_tokens=12,
+        use_cuda_graph=True,
+        _dflash_hidden_states=torch.zeros(12, 4),
+        _context_positions_buffer=torch.zeros(12, dtype=torch.int32),
+        _context_slot_mapping_buffer=torch.zeros(12, dtype=torch.int32),
+        input_ids=torch.zeros(12, dtype=torch.int32),
+        positions=torch.zeros(12, dtype=torch.int32),
+        _slot_mapping_buffer=torch.zeros(12, dtype=torch.int32),
+        parallel_drafting_token_id=99,
+        kernel_block_size=4,
+        device=torch.device("cpu"),
+        arange_dflash=torch.arange(32, dtype=torch.int32),
+        token_arange_np=np.arange(32, dtype=np.int32),
+    )
+    cad = SimpleNamespace(
+        num_reqs=2,
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([5, 13], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([5, 13], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([5, 13], dtype=torch.int32),
+        block_table_tensor=torch.tensor(
+            [[10, 11, 12, 13], [20, 21, 22, 23]],
+            dtype=torch.int32,
+        ),
+        slot_mapping=torch.arange(5, dtype=torch.int32),
+        actual_seq_lengths_q=[2, 3],
+        decode_token_per_req=1,
+        max_query_len=3,
+        max_seq_len=13,
+        positions=None,
+        positions_cpu=torch.empty(0, dtype=torch.int32),
+        causal=True,
+        attn_mask=object(),
+        attn_state=None,
+    )
+
+    result = AscendDflashProposer._set_dspark_inputs_first_pass(
+        proposer,
+        target_token_ids=torch.arange(5, dtype=torch.int32),
+        next_token_ids=torch.tensor([7, 8], dtype=torch.int32),
+        target_positions=torch.tensor([3, 4, 10, 11, 12], dtype=torch.int32),
+        target_hidden_states=torch.ones(5, 4),
+        cad=cad,
+        num_rejected_tokens_gpu=torch.tensor([1, 0], dtype=torch.int32),
+    )
+
+    assert result[0] == 6
+    assert len(kernel.calls) == 1
+    assert kernel.calls[0]["RECOMPUTE_CONTEXT_SLOTS"] is True
+    torch.testing.assert_close(
+        cad.query_start_loc,
+        torch.tensor([0, 3, 6], dtype=torch.int32),
+    )
+    torch.testing.assert_close(cad.seq_lens, torch.tensor([7, 16], dtype=torch.int32))
+    torch.testing.assert_close(
+        cad._seq_lens_cpu,
+        torch.tensor([7, 16], dtype=torch.int32),
+    )
+    assert cad.actual_seq_lengths_q == [3, 3]
+    assert cad.max_seq_len == 16
+
+
+def test_dspark_padded_graph_metadata_uses_static_sentinels():
+    def adjust_tensor(tensor, desired_size):
+        if tensor.shape[0] >= desired_size:
+            return tensor[:desired_size]
+        padding = torch.zeros(
+            desired_size - tensor.shape[0],
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        return torch.cat((tensor, padding))
+
+    proposer = SimpleNamespace(
+        num_speculative_tokens=2,
+        _adjust_tensor=adjust_tensor,
+    )
+    cad = SimpleNamespace(
+        seq_lens=torch.tensor([7, 16, 0], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([7, 16], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([7, 16], dtype=torch.int32),
+        actual_seq_lengths_q=[3, 3],
+    )
+
+    AscendDSparkProposer._stabilize_padded_graph_metadata(
+        proposer,
+        cad,
+        actual_num_reqs=2,
+        padded_num_reqs=3,
+    )
+
+    torch.testing.assert_close(
+        cad.seq_lens,
+        torch.tensor([7, 16, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        cad._seq_lens_cpu,
+        torch.tensor([7, 16, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        cad.seq_lens_cpu,
+        torch.tensor([7, 16, 1], dtype=torch.int32),
+    )
+    assert cad.actual_seq_lengths_q == [3, 3, 3]
+
+
+def test_dspark_draft_config_disables_inner_compile(monkeypatch):
+    @dataclass
+    class FakeCompilationConfig:
+        mode: CompilationMode
+
+    @dataclass
+    class FakeVllmConfig:
+        compilation_config: FakeCompilationConfig
+
+    base_config = FakeVllmConfig(
+        compilation_config=FakeCompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+        )
+    )
+    monkeypatch.setattr(
+        AscendDflashProposer,
+        "_create_draft_vllm_config",
+        lambda self: base_config,
+    )
+    proposer = object.__new__(AscendDSparkProposer)
+    proposer.use_cuda_graph = True
+
+    draft_config = AscendDSparkProposer._create_draft_vllm_config(proposer)
+
+    assert draft_config.compilation_config.mode == CompilationMode.NONE
+    assert base_config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+
+def test_dspark_checkpoint_selects_dedicated_proposer(monkeypatch):
+    monkeypatch.setattr(
+        spec_decode_module,
+        "AscendDSparkProposer",
+        lambda vllm_config, device, runner: "dspark",
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    architectures=["DSparkDraftModel"],
+                )
+            )
+        )
+    )
+
+    proposer = spec_decode_module.get_spec_decode_method(
+        "dflash",
+        vllm_config,
+        torch.device("cpu"),
+        runner=None,
+    )
+
+    assert proposer == "dspark"

--- a/tests/ut/test_dspark_quarot.py
+++ b/tests/ut/test_dspark_quarot.py
@@ -1,0 +1,66 @@
+import json
+
+import pytest
+import torch
+
+from vllm_ascend.models.dspark_quarot import (
+    resolve_quarot_rotation_path,
+    transform_fc_weight_for_quarot,
+)
+from vllm_ascend.models.qwen3_dspark import DSparkQwen3ForCausalLM
+
+
+def test_transform_fc_weight_matches_runtime_unrotate():
+    torch.manual_seed(7)
+    hidden_size = 8
+    num_features = 5
+    output_size = 6
+
+    rotation, _ = torch.linalg.qr(torch.randn(hidden_size, hidden_size))
+    fc_weight = torch.randn(output_size, num_features * hidden_size)
+    rotated_hidden = torch.randn(4, num_features * hidden_size)
+
+    hidden_chunks = rotated_hidden.view(4, num_features, hidden_size)
+    unrotated_hidden = torch.matmul(hidden_chunks, rotation.T).reshape(4, -1)
+    expected = torch.nn.functional.linear(unrotated_hidden, fc_weight)
+
+    transformed_weight = transform_fc_weight_for_quarot(fc_weight, rotation)
+    actual = torch.nn.functional.linear(rotated_hidden, transformed_weight)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_resolve_quarot_rotation_path(tmp_path):
+    rotation_path = tmp_path / "optional" / "quarot.safetensors"
+    rotation_path.parent.mkdir()
+    rotation_path.touch()
+    description = {
+        "is_rot_used": True,
+        "optional": {
+            "quarot": {
+                "rotation_map": {
+                    "global_rotation": "optional/quarot.safetensors",
+                }
+            }
+        },
+    }
+    (tmp_path / "quant_model_description.json").write_text(
+        json.dumps(description),
+        encoding="utf-8",
+    )
+
+    assert resolve_quarot_rotation_path(tmp_path) == rotation_path
+
+
+def test_transform_fc_weight_rejects_mismatched_width():
+    with pytest.raises(ValueError, match="multiple"):
+        transform_fc_weight_for_quarot(torch.randn(3, 10), torch.eye(4))
+
+
+def test_dspark_quarot_load_requires_fc_weight(tmp_path):
+    model = object.__new__(DSparkQwen3ForCausalLM)
+    torch.nn.Module.__init__(model)
+    model._quarot_rotation_path = tmp_path / "quarot.safetensors"
+
+    with pytest.raises(ValueError, match="did not provide fc.weight"):
+        model.load_weights([])

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -7,7 +7,12 @@ import torch
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, KVCacheTensor
 
+import vllm_ascend.worker.model_runner_v1 as model_runner_module
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+def test_sfa_dcp_replicated_indexer_helper_is_imported():
+    assert callable(model_runner_module.enable_sfa_dcp_replicated_indexer)
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -16,6 +16,7 @@
 #
 
 _GLOBAL_PATCH_APPLIED = False
+_DSPARK_SPECULATORS_PATCH_APPLIED = False
 
 
 def _ensure_global_patch():
@@ -35,9 +36,67 @@ def _ensure_global_patch():
     _GLOBAL_PATCH_APPLIED = True
 
 
+def _ensure_dspark_speculators_patch():
+    """Register GLM-5.2 DSpark speculators config through vLLM-Ascend.
+
+    vLLM 0.23 knows DFlash but does not know the speculators
+    ``speculators_model_type=dspark`` config used by GLM-5.2. Keep the source
+    change in vLLM-Ascend by extending vLLM's runtime registry from the plugin
+    entrypoint, instead of patching files under the vLLM package.
+    """
+    global _DSPARK_SPECULATORS_PATCH_APPLIED
+    if _DSPARK_SPECULATORS_PATCH_APPLIED:
+        return
+
+    from vllm.transformers_utils.configs.speculators import algos
+    from vllm.transformers_utils.configs.speculators.base import SpeculatorsConfig
+
+    if "dspark" not in algos.SUPPORTED_SPECULATORS_TYPES:
+
+        def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
+            algos.update_dflash(config_dict, pre_trained_config)
+            pre_trained_config["architectures"] = ["DSparkDraftModel"]
+            aux_offset = int(config_dict.get("aux_hidden_state_layer_offset", 0) or 0)
+            if aux_offset:
+                aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
+                pre_trained_config["eagle_aux_hidden_state_layer_ids"] = [
+                    i + aux_offset for i in aux_layer_ids
+                ]
+
+            dflash_config = pre_trained_config.setdefault("dflash_config", {})
+            dflash_config["source_speculators_model_type"] = "dspark"
+            dflash_config["markov_rank"] = config_dict.get("markov_rank", 0)
+            dflash_config["enable_confidence_head"] = config_dict.get(
+                "enable_confidence_head", False
+            )
+            dflash_config["confidence_head_with_markov"] = config_dict.get(
+                "confidence_head_with_markov", False
+            )
+
+        algos.SUPPORTED_SPECULATORS_TYPES["dspark"] = update_dspark
+
+    original = SpeculatorsConfig.build_vllm_speculative_config
+    if not getattr(original, "_ascend_dspark_patched", False):
+
+        def build_vllm_speculative_config(cls, config_dict: dict) -> dict:
+            result = original(config_dict)
+            if result.get("method") == "dspark":
+                result["method"] = "dflash"
+                result["parallel_drafting"] = True
+            return result
+
+        build_vllm_speculative_config._ascend_dspark_patched = True
+        SpeculatorsConfig.build_vllm_speculative_config = classmethod(
+            build_vllm_speculative_config
+        )
+
+    _DSPARK_SPECULATORS_PATCH_APPLIED = True
+
+
 def register():
     """Register the NPU platform."""
 
+    _ensure_dspark_speculators_patch()
     return "vllm_ascend.platform.NPUPlatform"
 
 
@@ -70,6 +129,8 @@ def register_service_profiling():
 
 
 def register_model():
+    _ensure_dspark_speculators_patch()
+
     from .models import register_model
 
     register_model()

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -309,6 +309,13 @@ class GraphParams:
 _graph_params: GraphParams | None = None
 
 
+def reset_graph_params():
+    global _graph_params, _draft_graph_params, _draft_graph_prefill_params
+    _graph_params = None
+    _draft_graph_params = None
+    _draft_graph_prefill_params = None
+
+
 def set_graph_params(aclgraph_capture_sizes: list[int]):
     global _graph_params
     if _graph_params is not None:

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -110,6 +110,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Enable the experimental GLM DSpark draft ACLGraph path.
+    # Truthy values: "1", "true", "yes", "on". Default: "0". Non-sensitive.
+    "VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH": lambda: (
+        os.getenv("VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH", "0").lower() in ("1", "true", "yes", "on")
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -5,6 +5,7 @@ def register_model():
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
+    ModelRegistry.register_model("DSparkDraftModel", "vllm_ascend.models.qwen3_dspark:DSparkQwen3ForCausalLM")
     ModelRegistry.register_model(
         "LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM"
     )

--- a/vllm_ascend/models/dspark_quarot.py
+++ b/vllm_ascend/models/dspark_quarot.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+from safetensors.torch import load_file
+
+
+def resolve_quarot_rotation_path(model_path: str | Path) -> Path | None:
+    model_root = Path(model_path)
+    description_path = model_root / "quant_model_description.json"
+    if not description_path.is_file():
+        return None
+
+    with description_path.open(encoding="utf-8") as description_file:
+        description = json.load(description_file)
+
+    if not description.get("is_rot_used", False):
+        return None
+
+    try:
+        relative_path = description["optional"]["quarot"]["rotation_map"][
+            "global_rotation"
+        ]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            f"QuaRot is enabled but no global rotation is configured in {description_path}"
+        ) from exc
+
+    rotation_path = model_root / relative_path
+    if not rotation_path.is_file():
+        raise FileNotFoundError(
+            f"QuaRot global rotation does not exist: {rotation_path}"
+        )
+    return rotation_path
+
+
+def load_quarot_rotation(rotation_path: str | Path) -> torch.Tensor:
+    state = load_file(str(rotation_path), device="cpu")
+    try:
+        rotation = state["global_rotation"]
+    except KeyError as exc:
+        raise KeyError(
+            f"QuaRot file {rotation_path} does not contain 'global_rotation'"
+        ) from exc
+    return rotation
+
+
+@torch.inference_mode()
+def transform_fc_weight_for_quarot(
+    fc_weight: torch.Tensor,
+    rotation: torch.Tensor,
+    *,
+    target_device: torch.device | str | None = None,
+) -> torch.Tensor:
+    if fc_weight.ndim != 2:
+        raise ValueError(f"Expected a 2-D fc weight, got shape={tuple(fc_weight.shape)}")
+    if rotation.ndim != 2 or rotation.shape[0] != rotation.shape[1]:
+        raise ValueError(
+            f"Expected a square rotation matrix, got shape={tuple(rotation.shape)}"
+        )
+
+    hidden_size = rotation.shape[0]
+    if fc_weight.shape[1] % hidden_size != 0:
+        raise ValueError(
+            "FC input width must be a multiple of the QuaRot hidden size: "
+            f"fc={tuple(fc_weight.shape)}, rotation={tuple(rotation.shape)}"
+        )
+
+    device = (
+        torch.device(target_device) if target_device is not None else fc_weight.device
+    )
+    transformed = torch.empty(
+        fc_weight.shape,
+        dtype=fc_weight.dtype,
+        device=device,
+    )
+    rotation_device = rotation.to(device=device, dtype=torch.float32)
+
+    for start in range(0, fc_weight.shape[1], hidden_size):
+        weight_chunk = fc_weight[:, start : start + hidden_size].to(
+            device=device,
+            dtype=torch.float32,
+        )
+        transformed_chunk = torch.matmul(weight_chunk, rotation_device)
+        transformed[:, start : start + hidden_size].copy_(
+            transformed_chunk.to(dtype=fc_weight.dtype)
+        )
+
+    return transformed

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -298,7 +298,12 @@ class DFlashQwen3Attention(nn.Module):
         q = self.q_norm(q.view(*q_shape[:-1], q_shape[-1] // self.head_dim, self.head_dim)).view(q_shape)
         k = self.k_norm(k.view(*k_shape[:-1], k_shape[-1] // self.head_dim, self.head_dim)).view(k_shape)
 
-        q, k = self.rotary_emb(positions, q, k)
+        # Ascend: the platform-dispatched rotary path returns non-norm-preserving
+        # Q/K for this draft shape (bf16, NeoX-style, head_dim=rotary_dim=192),
+        # collapsing DSpark acceptance. Call the rotary object's native
+        # implementation (still executed on NPU) until the dispatched backend
+        # is fixed for this shape.
+        q, k = self.rotary_emb.forward_native(positions, q, k)
 
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -1,0 +1,969 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from collections.abc import Iterable
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import Qwen3Config
+
+from vllm import _custom_ops as ops
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.multimodal.inputs import NestedTensors
+from vllm.transformers_utils.config import set_default_rope_theta
+from vllm.v1.attention.backend import AttentionType
+
+from vllm.model_executor.models.qwen2 import Qwen2MLP as Qwen3MLP
+from vllm.model_executor.models.qwen3 import Qwen3ForCausalLM
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    get_draft_quant_config,
+    maybe_prefix,
+    process_eagle_weight,
+)
+
+logger = init_logger(__name__)
+
+
+def _rms_norm_into(
+    out: torch.Tensor,
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> None:
+    try:
+        ops.rms_norm(out, input_tensor, weight, epsilon)
+    except AttributeError:
+        variance = input_tensor.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
+        normalized = input_tensor * torch.rsqrt(variance.to(input_tensor.dtype) + epsilon)
+        out.copy_(normalized * weight)
+
+
+def _apply_rotary_native_inplace(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox_style: bool,
+) -> None:
+    positions = positions.flatten()
+    num_tokens = positions.shape[0]
+    cos_sin = cos_sin_cache.index_select(0, positions)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+
+    x_shape = x.shape
+    x_view = x.view(num_tokens, -1, head_size)
+    rotary_dim = cos.shape[-1] * 2
+    x_rot = x_view[..., :rotary_dim]
+    x_pass = x_view[..., rotary_dim:]
+
+    cos = cos.unsqueeze(-2).to(x_rot.dtype)
+    sin = sin.unsqueeze(-2).to(x_rot.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x_rot, 2, dim=-1)
+    else:
+        x1 = x_rot[..., ::2]
+        x2 = x_rot[..., 1::2]
+
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        out_rot = torch.cat((o1, o2), dim=-1)
+    else:
+        out_rot = torch.stack((o1, o2), dim=-1).flatten(-2)
+
+    if x_pass.shape[-1] > 0:
+        out = torch.cat((out_rot, x_pass), dim=-1)
+    else:
+        out = out_rot
+    x.copy_(out.reshape(x_shape))
+
+
+def _rotary_embedding_inplace(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor | None,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox_style: bool,
+) -> None:
+    try:
+        ops.rotary_embedding(
+            positions,
+            query,
+            key,
+            head_size,
+            cos_sin_cache,
+            is_neox_style,
+        )
+    except AttributeError:
+        _apply_rotary_native_inplace(
+            query,
+            positions,
+            head_size,
+            cos_sin_cache,
+            is_neox_style,
+        )
+        if key is not None:
+            _apply_rotary_native_inplace(
+                key,
+                positions,
+                head_size,
+                cos_sin_cache,
+                is_neox_style,
+            )
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        markov_rank: int,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(
+            vocab_size,
+            markov_rank,
+            prefix=maybe_prefix(prefix, "markov_w1"),
+        )
+        self.markov_w2 = ParallelLMHead(
+            vocab_size,
+            markov_rank,
+            prefix=maybe_prefix(prefix, "markov_w2"),
+        )
+        self.logits_processor = LogitsProcessor(vocab_size)
+
+    def forward(self, token_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        markov_embed = self.markov_w1(token_ids.long())
+        markov_logits = self.logits_processor(self.markov_w2, markov_embed)
+        return markov_logits, markov_embed
+
+
+class DSparkConfidenceHead(nn.Module):
+    def __init__(
+        self,
+        input_size: int,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.proj = ReplicatedLinear(
+            input_size,
+            1,
+            bias=True,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "proj"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        markov_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if markov_embeds is not None:
+            hidden_states = torch.cat([hidden_states, markov_embeds], dim=-1)
+        logits = self.proj(hidden_states)
+        if isinstance(logits, tuple):
+            logits = logits[0]
+        return logits.squeeze(-1)
+
+
+class DFlashQwen3Attention(nn.Module):
+    """Attention for DFlash speculative decoding.
+
+    Context KVs are pre-inserted into the KV cache before the forward pass.
+    This layer handles only query tokens via standard attention.
+    Adapted from Qwen3Attention."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_parameters: dict,
+        max_position: int = 4096 * 32,
+        head_dim: int | None = None,
+        rms_norm_eps: float = 1e-06,
+        attention_bias: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        attn_type: str = AttentionType.DECODER,
+    ) -> None:
+        super().__init__()
+        self.layer_name = prefix
+        self.hidden_size = hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim or hidden_size // self.total_num_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=attention_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=attention_bias,  # DFlash has o_proj bias when using attention bias
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        rope_interleave = os.getenv("DSPARK_ROPE_INTERLEAVE", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            max_position=max_position,
+            is_neox_style=not rope_interleave,
+            rope_parameters=rope_parameters,
+        )
+        if rope_interleave:
+            logger.warning_once(
+                "[spec_decode/dspark] using interleaved draft RoPE "
+                "(is_neox_style=False)"
+            )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+            attn_type=attn_type,
+        )
+        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """DFlash attention assumes that the KV cache is already populated
+        with the context K/V from the target model's hidden states. This forward op
+        computes attention for the query tokens only.
+        See also: precompute_and_store_context_kv"""
+        qkv = F.linear(hidden_states, self.qkv_proj.weight, self.qkv_proj.bias)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        # Per-head RMSNorm
+        q_shape, k_shape = q.shape, k.shape
+        q = self.q_norm(
+            q.view(*q_shape[:-1], q_shape[-1] // self.head_dim, self.head_dim)
+        ).view(q_shape)
+        k = self.k_norm(
+            k.view(*k_shape[:-1], k_shape[-1] // self.head_dim, self.head_dim)
+        ).view(k_shape)
+
+        q, k = self.rotary_emb(positions, q, k)
+
+        attn_output = self.attn(q, k, v)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class DFlashQwen3DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        config: Qwen3Config,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        set_default_rope_theta(config, default_theta=1000000)
+        attn_type = AttentionType.DECODER
+
+        self.self_attn = DFlashQwen3Attention(
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            max_position=config.max_position_embeddings,
+            num_kv_heads=config.num_key_value_heads,
+            rms_norm_eps=config.rms_norm_eps,
+            attention_bias=getattr(config, "attention_bias", False),
+            head_dim=getattr(config, "head_dim", None),
+            cache_config=cache_config,
+            quant_config=quant_config,
+            rope_parameters=config.rope_parameters,
+            prefix=f"{prefix}.self_attn",
+            attn_type=attn_type,
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is not None:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        else:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+@support_torch_compile
+class DFlashQwen3Model(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.vocab_size = self.config.vocab_size
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        drafter_config = getattr(self.config, "eagle_config", {})
+        drafter_config.update(getattr(self.config, "dflash_config", {}))
+
+        if drafter_config is not None and "use_aux_hidden_state" in drafter_config:
+            self.use_aux_hidden_state = drafter_config["use_aux_hidden_state"]
+        else:
+            self.use_aux_hidden_state = True
+
+        current_vllm_config = get_current_vllm_config()
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                DFlashQwen3DecoderLayer(
+                    current_vllm_config,
+                    config=self.config,
+                    cache_config=current_vllm_config.cache_config,
+                    quant_config=self.quant_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        if self.use_aux_hidden_state:
+            num_features_to_use = self.config.num_hidden_layers
+            if "target_layer_ids" in drafter_config:
+                num_features_to_use = len(drafter_config["target_layer_ids"])
+            elif "layer_ids" in drafter_config:
+                num_features_to_use = len(drafter_config["layer_ids"])
+            if hasattr(self.config, "target_hidden_size"):
+                fc_input_size = self.config.target_hidden_size * num_features_to_use
+            else:
+                fc_input_size = self.config.hidden_size * num_features_to_use
+            self.fc = ReplicatedLinear(
+                input_size=fc_input_size,
+                output_size=self.config.hidden_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "fc"),
+                return_bias=False,
+            )
+        self.hidden_norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+        self.norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def _build_fused_kv_buffers(self) -> None:
+        """Build fused weight buffers for precompute_and_store_context_kv.
+
+        Must be called after weights are loaded. Stacks the KV-projection
+        weights, K-norm weights, and RoPE parameters from every attention
+        layer so that precompute_and_store_context_kv can run one fused
+        GEMM for all layers at once. Also aliases the weight of the hidden_norm.
+        """
+        layers_attn = [layer.self_attn for layer in self.layers]
+        attn0 = layers_attn[0]
+        has_bias = attn0.qkv_proj.bias is not None
+
+        self._hidden_norm_weight = self.hidden_norm.weight.data
+
+        # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+        self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+        if has_bias:
+            kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
+            self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
+        else:
+            self._fused_kv_bias = None
+
+        # K-norm weights: list of [head_dim] tensors, one per layer.
+        self._k_norm_weights = [a.k_norm.weight.data for a in layers_attn]
+
+        # RoPE parameters
+        self._rope_head_size = attn0.rotary_emb.head_size
+        self._rope_cos_sin_cache = attn0.rotary_emb.cos_sin_cache
+        self._rope_is_neox = attn0.rotary_emb.is_neox_style
+        # Validation that RoPE params are the same across all layers
+        for attn in layers_attn[1:]:
+            assert (
+                attn.rotary_emb.head_size == self._rope_head_size
+                and attn.rotary_emb.is_neox_style == self._rope_is_neox
+            ), "All layers must have the same RoPE parameters for DFlash precomputation"
+
+        # Layer metadata
+        self._num_attn_layers = len(layers_attn)
+        self._kv_size = attn0.kv_size
+        self._head_dim = attn0.head_dim
+        self._num_kv_heads = attn0.num_kv_heads
+        self._rms_norm_eps = attn0.q_norm.variance_epsilon
+        # Validation that all layers have the same attention config
+        for attn in layers_attn[1:]:
+            assert (
+                attn.kv_size == self._kv_size
+                and attn.head_dim == self._head_dim
+                and attn.num_kv_heads == self._num_kv_heads
+                and attn.q_norm.variance_epsilon == self._rms_norm_eps
+            ), "All layers must have the same attn config for DFlash precomputation"
+
+        # References to inner Attention layers for direct cache writes
+        self._attn_layers = [layer.self_attn.attn for layer in self.layers]
+
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor | None = None,
+    ) -> None:
+        """Precompute K/V for context states write them into each layer's KV cache.
+
+        Input context states are projected to K/V, normed, and have RoPE applied.
+        Since the context shape is different than the query shape, we can't rely on the
+        regular forward pass to apply torch.compile and CUDA graphs to this section.
+        As such, this function is optimized to minimize the number of torch ops present:
+        we use fused vLLM kernels for RMSNorm and RoPE, fuse the GEMM into one
+        large projection, and avoid cloning buffers (with .contiguous()) where possible.
+
+        When context_slot_mapping is None (e.g. during dummy_run) only
+        the computation runs, and no K/V is written to cache.
+        """
+        if not hasattr(self, "_num_attn_layers"):
+            logger.warning_once(
+                "DFlash buffer initialization was skipped. If dummy weights are not "
+                "in use, this may indicate an error in weight loading."
+            )
+            self._build_fused_kv_buffers()
+
+        num_ctx = context_states.shape[0]
+        L = self._num_attn_layers
+        kv = self._kv_size
+        hd = self._head_dim
+        nkv = self._num_kv_heads
+
+        # --- Fused KV projection (one GEMM for all layers) ---
+        normed_context_states = torch.empty_like(context_states)
+        _rms_norm_into(
+            normed_context_states,
+            context_states,
+            self._hidden_norm_weight,
+            self._rms_norm_eps,
+        )
+        all_kv_flat = F.linear(
+            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
+        )
+        # Single contiguous copy that separates K/V and transposes to
+        # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
+        # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
+        all_kv = (
+            all_kv_flat.view(num_ctx, L, 2, nkv, hd).permute(2, 1, 0, 3, 4).contiguous()
+        )
+        all_k = all_kv[0]  # [L, num_ctx, nkv, hd], contiguous
+        all_v = all_kv[1]  # [L, num_ctx, nkv, hd], contiguous
+
+        # --- Per-layer RMSNorm K (3D: [num_ctx, nkv, hd] per layer) ---
+        all_k_normed = torch.empty_like(all_k)
+        for i in range(L):
+            _rms_norm_into(
+                all_k_normed[i],
+                all_k[i],
+                self._k_norm_weights[i],
+                self._rms_norm_eps,
+            )
+
+        # --- Fused RoPE across all layers ---
+        # View as [L * num_ctx, kv] so RoPE sees one big batch (no copy).
+        # In-place RoPE: pass K as the "query" arg with key=None.
+        all_k_flat = all_k_normed.view(L * num_ctx, kv)
+        positions_repeated = context_positions.repeat(L)
+        cos_sin_cache = self._rope_cos_sin_cache
+        if (
+            cos_sin_cache.device != all_k_flat.device
+            or cos_sin_cache.dtype != all_k_flat.dtype
+        ):
+            cos_sin_cache = cos_sin_cache.to(
+                device=all_k_flat.device,
+                dtype=all_k_flat.dtype,
+            )
+        _rotary_embedding_inplace(
+            positions_repeated,
+            all_k_flat,
+            None,
+            self._rope_head_size,
+            cos_sin_cache,
+            self._rope_is_neox,
+        )
+
+        if context_slot_mapping is None:
+            return
+
+        # --- Per-layer cache insert ---
+        all_k_final = all_k_flat.view(L, num_ctx, nkv, hd)
+        if context_slot_mapping.ndim == 1:
+            valid_context = context_slot_mapping >= 0
+        else:
+            valid_context = (context_slot_mapping >= 0).all(dim=-1)
+
+        if (
+            os.getenv("DSPARK_LOGITS_DEBUG", "0").lower() in ("1", "true", "yes", "on")
+            and getattr(self, "_dspark_context_kv_debug_count", 0) < 4
+        ):
+            self._dspark_context_kv_debug_count = (
+                getattr(self, "_dspark_context_kv_debug_count", 0) + 1
+            )
+            logger.warning(
+                "[spec_decode/dspark] context kv debug #%d: rows=%d valid_rows=%d "
+                "slot_tail=%s",
+                self._dspark_context_kv_debug_count,
+                int(context_slot_mapping.shape[0]),
+                int(valid_context.detach().to(torch.int32).sum().cpu().item()),
+                context_slot_mapping[-8:].detach().cpu().tolist(),
+            )
+
+        context_slot_mapping = context_slot_mapping[valid_context].to(torch.int32).contiguous()
+        if context_slot_mapping.numel() == 0:
+            return
+        for i in range(L):
+            attn = self._attn_layers[i]
+            kv_cache = attn.kv_cache
+            attn.impl.do_kv_cache_update(
+                attn,
+                all_k_final[i][valid_context].contiguous(),
+                all_v[i][valid_context].contiguous(),
+                kv_cache,
+                context_slot_mapping,
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if input_embeds is None:
+            input_embeds = self.embed_input_ids(input_ids)
+
+        hidden_states = input_embeds
+
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "midlayer." in name:
+                name = name.replace("midlayer.", "layers.0.")
+            if "scale" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            self.config.draft_vocab_size = getattr(self.config, "vocab_size", None)
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+        self.model = DFlashQwen3Model(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+            start_layer_id=target_layer_num,
+        )
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+        target_vocab_size = vllm_config.model_config.get_vocab_size()
+        if self.config.draft_vocab_size != target_vocab_size:
+            self.draft_id_to_target_id = nn.Parameter(
+                torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
+                requires_grad=False,
+            )
+        else:
+            self.draft_id_to_target_id = None
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: NestedTensors | None = None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model(input_ids, positions, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if self.draft_id_to_target_id is None:
+            return logits
+
+        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+        targets = base + self.draft_id_to_target_id
+        logits_new = logits.new_full(
+            (logits.shape[0], self.config.vocab_size),
+            float("-inf"),
+        )
+        logits_new[:, targets] = logits
+        return logits_new
+
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor | None = None,
+    ) -> None:
+        """Precompute projected + RoPE'd K/V and write to cache."""
+        self.model.precompute_and_store_context_kv(
+            context_states, context_positions, context_slot_mapping
+        )
+
+    def combine_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.model.use_aux_hidden_state:
+            return hidden_states
+        needs_squeeze = hidden_states.dim() == 1
+        if needs_squeeze:
+            hidden_states = hidden_states.unsqueeze(0)
+        result = self.model.fc(hidden_states)
+        if needs_squeeze:
+            result = result.squeeze(0)
+        return result
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        for name, loaded_weight in weights:
+            assert "mask_hidden" not in name, (
+                "DFlash should use mask_token_id to embed the padding hidden state"
+            )
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())
+        self.model._build_fused_kv_buffers()
+
+
+class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
+    """DSpark speculators draft model on top of the DFlash Qwen3 backbone.
+
+    The GLM-5.2 DSpark checkpoint uses the speculators DSpark format:
+    DFlash backbone weights plus Markov and confidence heads.  vLLM-Ascend's
+    DFlash proposer already builds the parallel query hidden states; this class
+    adds the DSpark token refinement step.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        markov_rank = int(
+            getattr(
+                self.config,
+                "markov_rank",
+                getattr(self.config, "dspark_markov_rank", 256),
+            )
+        )
+        self.confidence_head_with_markov = bool(
+            getattr(self.config, "confidence_head_with_markov", True)
+        )
+        self.enable_confidence_head = bool(
+            getattr(self.config, "enable_confidence_head", True)
+        )
+        self.markov_head = DSparkMarkovHead(
+            self.config.vocab_size,
+            markov_rank,
+            prefix=maybe_prefix(prefix, "markov_head"),
+        )
+        if self.enable_confidence_head:
+            confidence_input_size = self.config.hidden_size
+            if self.confidence_head_with_markov:
+                confidence_input_size += markov_rank
+            self.confidence_head = DSparkConfidenceHead(
+                confidence_input_size,
+                prefix=maybe_prefix(prefix, "confidence_head"),
+            )
+        else:
+            self.confidence_head = None
+        self.last_confidence_logits: torch.Tensor | None = None
+
+    def compute_dspark_draft_tokens(
+        self,
+        anchor_token_ids: torch.Tensor,
+        proposal_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, num_speculative_tokens, hidden_size = proposal_hidden_states.shape
+        base_logits = self.compute_logits(
+            proposal_hidden_states.reshape(batch_size * num_speculative_tokens, hidden_size)
+        ).view(batch_size, num_speculative_tokens, -1)
+
+        prev_token_ids = anchor_token_ids.long()
+        draft_token_ids: list[torch.Tensor] = []
+        markov_embeds: list[torch.Tensor] = []
+        disable_markov_bias = os.getenv("DSPARK_DISABLE_MARKOV_BIAS", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        debug_logits = (
+            os.getenv("DSPARK_LOGITS_DEBUG", "0").lower() in ("1", "true", "yes", "on")
+            and get_tensor_model_parallel_rank() == 0
+            and getattr(self, "_dspark_logits_debug_count", 0) < 2
+            and batch_size > 0
+        )
+        debug_steps: list[dict[str, object]] = []
+        for step_idx in range(num_speculative_tokens):
+            markov_logits, markov_embed = self.markov_head(prev_token_ids)
+            if disable_markov_bias:
+                markov_logits = torch.zeros_like(markov_logits)
+            step_logits = base_logits[:, step_idx, :] + markov_logits
+            next_token_ids = step_logits.argmax(dim=-1)
+            draft_token_ids.append(next_token_ids)
+            markov_embeds.append(markov_embed)
+            if debug_logits:
+                k = min(5, int(step_logits.shape[-1]))
+                base_vals, base_ids = torch.topk(base_logits[0, step_idx].float(), k=k)
+                markov_vals, markov_ids = torch.topk(markov_logits[0].float(), k=k)
+                final_vals, final_ids = torch.topk(step_logits[0].float(), k=k)
+                debug_steps.append(
+                    {
+                        "step": int(step_idx),
+                        "prev": int(prev_token_ids[0].detach().cpu().item()),
+                        "sampled": int(next_token_ids[0].detach().cpu().item()),
+                        "base_ids": [int(x) for x in base_ids.detach().cpu().tolist()],
+                        "base_vals": [round(float(x), 4) for x in base_vals.detach().cpu().tolist()],
+                        "markov_ids": [int(x) for x in markov_ids.detach().cpu().tolist()],
+                        "markov_vals": [round(float(x), 4) for x in markov_vals.detach().cpu().tolist()],
+                        "final_ids": [int(x) for x in final_ids.detach().cpu().tolist()],
+                        "final_vals": [round(float(x), 4) for x in final_vals.detach().cpu().tolist()],
+                    }
+                )
+            prev_token_ids = next_token_ids
+
+        if self.confidence_head is not None:
+            markov_embed_tensor = torch.stack(markov_embeds, dim=1)
+            confidence_markov = (
+                markov_embed_tensor if self.confidence_head_with_markov else None
+            )
+            self.last_confidence_logits = self.confidence_head(
+                proposal_hidden_states,
+                confidence_markov,
+            )
+
+        if debug_logits:
+            self._dspark_logits_debug_count = getattr(self, "_dspark_logits_debug_count", 0) + 1
+            logger.warning(
+                "[spec_decode/dspark] logits debug #%d: anchor=%s hidden_shape=%s "
+                "base_shape=%s hidden_abs_mean=%.6f disable_markov_bias=%s "
+                "draft_first=%s steps=%s",
+                self._dspark_logits_debug_count,
+                int(anchor_token_ids[0].detach().cpu().item()),
+                tuple(proposal_hidden_states.shape),
+                tuple(base_logits.shape),
+                float(proposal_hidden_states.detach().float().abs().mean().cpu().item()),
+                disable_markov_bias,
+                [int(x) for x in torch.stack(draft_token_ids, dim=1)[0].detach().cpu().tolist()],
+                debug_steps,
+            )
+
+        return torch.stack(draft_token_ids, dim=1)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        for name, loaded_weight in weights:
+            assert "mask_hidden" not in name, (
+                "DSpark should use mask_token_id to embed the padding hidden state"
+            )
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif name.startswith(("markov_head.", "confidence_head.")):
+                pass
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        if not self.enable_confidence_head:
+            skip_substrs.append("confidence_head.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())
+        self.model._build_fused_kv_buffers()

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -596,15 +596,14 @@ class DFlashQwen3Model(nn.Module):
 
         # --- Per-layer cache insert ---
         all_k_final = all_k_flat.view(L, num_ctx, nkv, hd)
-        if context_slot_mapping.ndim == 1:
-            valid_context = context_slot_mapping >= 0
-        else:
-            valid_context = (context_slot_mapping >= 0).all(dim=-1)
-
         if (
             os.getenv("DSPARK_LOGITS_DEBUG", "0").lower() in ("1", "true", "yes", "on")
             and getattr(self, "_dspark_context_kv_debug_count", 0) < 4
         ):
+            if context_slot_mapping.ndim == 1:
+                valid_context = context_slot_mapping >= 0
+            else:
+                valid_context = (context_slot_mapping >= 0).all(dim=-1)
             self._dspark_context_kv_debug_count = (
                 getattr(self, "_dspark_context_kv_debug_count", 0) + 1
             )
@@ -617,16 +616,17 @@ class DFlashQwen3Model(nn.Module):
                 context_slot_mapping[-8:].detach().cpu().tolist(),
             )
 
-        context_slot_mapping = context_slot_mapping[valid_context].to(torch.int32).contiguous()
-        if context_slot_mapping.numel() == 0:
-            return
+        # Keep the cache-update inputs fixed-shape for ACL graph capture.
+        # DeviceOperator.reshape_and_cache treats negative slot ids as padding,
+        # matching the upstream DFlash graph path.
+        context_slot_mapping = context_slot_mapping.to(torch.int32).contiguous()
         for i in range(L):
             attn = self._attn_layers[i]
             kv_cache = attn.kv_cache
             attn.impl.do_kv_cache_update(
                 attn,
-                all_k_final[i][valid_context].contiguous(),
-                all_v[i][valid_context].contiguous(),
+                all_k_final[i].contiguous(),
+                all_v[i].contiguous(),
                 kv_cache,
                 context_slot_mapping,
             )

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -48,6 +48,12 @@ from vllm.model_executor.models.utils import (
     process_eagle_weight,
 )
 
+from vllm_ascend.models.dspark_quarot import (
+    load_quarot_rotation,
+    resolve_quarot_rotation_path,
+    transform_fc_weight_for_quarot,
+)
+
 logger = init_logger(__name__)
 
 
@@ -817,6 +823,21 @@ class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
+        target_model_config = (
+            getattr(
+                vllm_config.speculative_config,
+                "target_model_config",
+                None,
+            )
+            or vllm_config.model_config
+        )
+        target_model_path = getattr(target_model_config, "model", "")
+        self._quarot_rotation_path = resolve_quarot_rotation_path(target_model_path)
+        if self._quarot_rotation_path is not None:
+            logger.info(
+                "[spec_decode/dspark] detected target QuaRot rotation: %s",
+                self._quarot_rotation_path,
+            )
         markov_rank = int(
             getattr(
                 self.config,
@@ -933,10 +954,29 @@ class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
         model_weights = {}
         includes_draft_id_mapping = False
         includes_embed_tokens = False
+        rotation = None
+        transformed_quarot_fc = False
         for name, loaded_weight in weights:
             assert "mask_hidden" not in name, (
                 "DSpark should use mask_token_id to embed the padding hidden state"
             )
+            if name == "fc.weight" and self._quarot_rotation_path is not None:
+                if rotation is None:
+                    rotation = load_quarot_rotation(self._quarot_rotation_path)
+                loaded_weight = transform_fc_weight_for_quarot(
+                    loaded_weight,
+                    rotation,
+                    target_device=self.model.fc.weight.device,
+                )
+                transformed_quarot_fc = True
+                logger.info(
+                    "[spec_decode/dspark] transformed fc.weight for QuaRot: "
+                    "rotation=%s fc_shape=%s blocks=%d device=%s",
+                    self._quarot_rotation_path,
+                    tuple(loaded_weight.shape),
+                    loaded_weight.shape[1] // rotation.shape[0],
+                    loaded_weight.device,
+                )
             if "t2d" in name:
                 continue
             if "d2t" in name:
@@ -950,6 +990,12 @@ class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
                 includes_embed_tokens = True
             model_weights[name] = loaded_weight
             process_eagle_weight(self, name)
+
+        if self._quarot_rotation_path is not None and not transformed_quarot_fc:
+            raise ValueError(
+                "Target model uses QuaRot, but the DSpark checkpoint did not "
+                "provide fc.weight for the required load-time transformation"
+            )
 
         skip_substrs = []
         if not includes_draft_id_mapping:

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -8,7 +8,6 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from transformers import Qwen3Config
-
 from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
@@ -16,7 +15,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.logger import init_logger
+from vllm.logger import logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -35,10 +34,6 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
-from vllm.multimodal.inputs import NestedTensors
-from vllm.transformers_utils.config import set_default_rope_theta
-from vllm.v1.attention.backend import AttentionType
-
 from vllm.model_executor.models.qwen2 import Qwen2MLP as Qwen3MLP
 from vllm.model_executor.models.qwen3 import Qwen3ForCausalLM
 from vllm.model_executor.models.utils import (
@@ -47,14 +42,15 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
     process_eagle_weight,
 )
+from vllm.multimodal.inputs import NestedTensors
+from vllm.transformers_utils.config import set_default_rope_theta
+from vllm.v1.attention.backend import AttentionType
 
 from vllm_ascend.models.dspark_quarot import (
     load_quarot_rotation,
     resolve_quarot_rotation_path,
     transform_fc_weight_for_quarot,
 )
-
-logger = init_logger(__name__)
 
 
 def _rms_norm_into(
@@ -271,10 +267,7 @@ class DFlashQwen3Attention(nn.Module):
             rope_parameters=rope_parameters,
         )
         if rope_interleave:
-            logger.warning_once(
-                "[spec_decode/dspark] using interleaved draft RoPE "
-                "(is_neox_style=False)"
-            )
+            logger.warning_once("[spec_decode/dspark] using interleaved draft RoPE (is_neox_style=False)")
         self.attn = Attention(
             self.num_heads,
             self.head_dim,
@@ -302,12 +295,8 @@ class DFlashQwen3Attention(nn.Module):
 
         # Per-head RMSNorm
         q_shape, k_shape = q.shape, k.shape
-        q = self.q_norm(
-            q.view(*q_shape[:-1], q_shape[-1] // self.head_dim, self.head_dim)
-        ).view(q_shape)
-        k = self.k_norm(
-            k.view(*k_shape[:-1], k_shape[-1] // self.head_dim, self.head_dim)
-        ).view(k_shape)
+        q = self.q_norm(q.view(*q_shape[:-1], q_shape[-1] // self.head_dim, self.head_dim)).view(q_shape)
+        k = self.k_norm(k.view(*k_shape[:-1], k_shape[-1] // self.head_dim, self.head_dim)).view(k_shape)
 
         q, k = self.rotary_emb(positions, q, k)
 
@@ -353,9 +342,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
             prefix=f"{prefix}.mlp",
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
-        )
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
     def forward(
         self,
@@ -546,15 +533,11 @@ class DFlashQwen3Model(nn.Module):
             self._hidden_norm_weight,
             self._rms_norm_eps,
         )
-        all_kv_flat = F.linear(
-            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
-        )
+        all_kv_flat = F.linear(normed_context_states, self._fused_kv_weight, self._fused_kv_bias)
         # Single contiguous copy that separates K/V and transposes to
         # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
         # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
-        all_kv = (
-            all_kv_flat.view(num_ctx, L, 2, nkv, hd).permute(2, 1, 0, 3, 4).contiguous()
-        )
+        all_kv = all_kv_flat.view(num_ctx, L, 2, nkv, hd).permute(2, 1, 0, 3, 4).contiguous()
         all_k = all_kv[0]  # [L, num_ctx, nkv, hd], contiguous
         all_v = all_kv[1]  # [L, num_ctx, nkv, hd], contiguous
 
@@ -574,10 +557,7 @@ class DFlashQwen3Model(nn.Module):
         all_k_flat = all_k_normed.view(L * num_ctx, kv)
         positions_repeated = context_positions.repeat(L)
         cos_sin_cache = self._rope_cos_sin_cache
-        if (
-            cos_sin_cache.device != all_k_flat.device
-            or cos_sin_cache.dtype != all_k_flat.dtype
-        ):
+        if cos_sin_cache.device != all_k_flat.device or cos_sin_cache.dtype != all_k_flat.dtype:
             cos_sin_cache = cos_sin_cache.to(
                 device=all_k_flat.device,
                 dtype=all_k_flat.dtype,
@@ -604,12 +584,9 @@ class DFlashQwen3Model(nn.Module):
                 valid_context = context_slot_mapping >= 0
             else:
                 valid_context = (context_slot_mapping >= 0).all(dim=-1)
-            self._dspark_context_kv_debug_count = (
-                getattr(self, "_dspark_context_kv_debug_count", 0) + 1
-            )
+            self._dspark_context_kv_debug_count = getattr(self, "_dspark_context_kv_debug_count", 0) + 1
             logger.warning(
-                "[spec_decode/dspark] context kv debug #%d: rows=%d valid_rows=%d "
-                "slot_tail=%s",
+                "[spec_decode/dspark] context kv debug #%d: rows=%d valid_rows=%d slot_tail=%s",
                 self._dspark_context_kv_debug_count,
                 int(context_slot_mapping.shape[0]),
                 int(valid_context.detach().to(torch.int32).sum().cpu().item()),
@@ -691,9 +668,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self.config = vllm_config.speculative_config.draft_model_config.hf_config
         if getattr(self.config, "draft_vocab_size", None) is None:
             self.config.draft_vocab_size = getattr(self.config, "vocab_size", None)
-        target_layer_num = vllm_config.model_config.get_num_layers(
-            vllm_config.parallel_config
-        )
+        target_layer_num = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
         self.model = DFlashQwen3Model(
             vllm_config=vllm_config,
             prefix=maybe_prefix(prefix, "model"),
@@ -706,9 +681,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        self.logits_processor = LogitsProcessor(
-            self.config.draft_vocab_size, scale=logit_scale
-        )
+        self.logits_processor = LogitsProcessor(self.config.draft_vocab_size, scale=logit_scale)
         target_vocab_size = vllm_config.model_config.get_vocab_size()
         if self.config.draft_vocab_size != target_vocab_size:
             self.draft_id_to_target_id = nn.Parameter(
@@ -758,9 +731,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         context_slot_mapping: torch.Tensor | None = None,
     ) -> None:
         """Precompute projected + RoPE'd K/V and write to cache."""
-        self.model.precompute_and_store_context_kv(
-            context_states, context_positions, context_slot_mapping
-        )
+        self.model.precompute_and_store_context_kv(context_states, context_positions, context_slot_mapping)
 
     def combine_hidden_states(
         self,
@@ -781,9 +752,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         includes_draft_id_mapping = False
         includes_embed_tokens = False
         for name, loaded_weight in weights:
-            assert "mask_hidden" not in name, (
-                "DFlash should use mask_token_id to embed the padding hidden state"
-            )
+            assert "mask_hidden" not in name, "DFlash should use mask_token_id to embed the padding hidden state"
             if "t2d" in name:
                 continue
             if "d2t" in name:
@@ -845,12 +814,8 @@ class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
                 getattr(self.config, "dspark_markov_rank", 256),
             )
         )
-        self.confidence_head_with_markov = bool(
-            getattr(self.config, "confidence_head_with_markov", True)
-        )
-        self.enable_confidence_head = bool(
-            getattr(self.config, "enable_confidence_head", True)
-        )
+        self.confidence_head_with_markov = bool(getattr(self.config, "confidence_head_with_markov", True))
+        self.enable_confidence_head = bool(getattr(self.config, "enable_confidence_head", True))
         self.markov_head = DSparkMarkovHead(
             self.config.vocab_size,
             markov_rank,
@@ -924,9 +889,7 @@ class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
 
         if self.confidence_head is not None:
             markov_embed_tensor = torch.stack(markov_embeds, dim=1)
-            confidence_markov = (
-                markov_embed_tensor if self.confidence_head_with_markov else None
-            )
+            confidence_markov = markov_embed_tensor if self.confidence_head_with_markov else None
             self.last_confidence_logits = self.confidence_head(
                 proposal_hidden_states,
                 confidence_markov,
@@ -957,9 +920,7 @@ class DSparkQwen3ForCausalLM(DFlashQwen3ForCausalLM):
         rotation = None
         transformed_quarot_fc = False
         for name, loaded_weight in weights:
-            assert "mask_hidden" not in name, (
-                "DSpark should use mask_token_id to embed the padding hidden state"
-            )
+            assert "mask_hidden" not in name, "DSpark should use mask_token_id to embed the padding hidden state"
             if name == "fc.weight" and self._quarot_rotation_path is not None:
                 if rotation is None:
                     rotation = load_quarot_rotation(self._quarot_rotation_path)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -93,19 +93,12 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
     total_input_tokens,  # tl.int32
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
+    RECOMPUTE_CONTEXT_SLOTS: tl.constexpr = False,
 ):
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
         ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
         num_ctx = ctx_end - ctx_start
-
-        for j in range(0, num_ctx):
-            ctx_pos_idx = ctx_start + j
-            pos = tl.load(target_positions_ptr + ctx_pos_idx)
-            tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
-
-            slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
-            tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
 
         if HAS_NUM_REJECTED:
             num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
@@ -114,9 +107,30 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
             num_rejected = 0
             valid_ctx_end = ctx_end
 
+        for j in range(0, num_ctx):
+            ctx_pos_idx = ctx_start + j
+            pos = tl.load(target_positions_ptr + ctx_pos_idx)
+            tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
+
+            if RECOMPUTE_CONTEXT_SLOTS:
+                block_num_ctx = tl.maximum(
+                    0,
+                    tl.minimum(pos // block_size, block_table_stride - 1),
+                )
+                block_id_ctx = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_ctx).to(tl.int64)
+                slot = block_id_ctx * block_size + (pos % block_size)
+                slot = tl.where(ctx_pos_idx < valid_ctx_end, slot, -1)
+            else:
+                slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
+            tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
+
         seq_len = tl.load(seq_lens_ptr + req_idx)
         effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+        if RECOMPUTE_CONTEXT_SLOTS:
+            last_pos_idx = tl.maximum(ctx_start, valid_ctx_end - 1)
+        else:
+            last_pos_idx = valid_ctx_end - 1
+        last_pos = tl.load(target_positions_ptr + last_pos_idx)
 
         for q_idx in range(0, num_query_per_req):
             query_pos = last_pos + 1 + q_idx
@@ -124,8 +138,16 @@ def copy_and_expand_dflash_inputs_kernel_single_grid(
 
             tl.store(out_query_positions_ptr + query_out_idx, query_pos)
 
-            query_cache_pos = effective_seq_len + q_idx
+            if RECOMPUTE_CONTEXT_SLOTS:
+                query_cache_pos = query_pos
+            else:
+                query_cache_pos = effective_seq_len + q_idx
             block_num_q = query_cache_pos // block_size
+            if RECOMPUTE_CONTEXT_SLOTS:
+                block_num_q = tl.maximum(
+                    0,
+                    tl.minimum(block_num_q, block_table_stride - 1),
+                )
             block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
             slot_q = block_id_q * block_size + (query_cache_pos % block_size)
             tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)

--- a/vllm_ascend/spec_decode/__init__.py
+++ b/vllm_ascend/spec_decode/__init__.py
@@ -20,10 +20,12 @@
 
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 from vllm_ascend.spec_decode.extract_hidden_states_proposer import (
     AscendExtractHiddenStatesProposer,
 )
+from vllm_ascend.spec_decode.llm_base_proposer import _is_dspark_draft_model
 from vllm_ascend.spec_decode.medusa_proposer import AscendMedusaProposer
 from vllm_ascend.spec_decode.ngram_proposer import AscendNgramProposer
 from vllm_ascend.spec_decode.ngram_proposer_npu import AscendNgramProposerNPU
@@ -46,6 +48,9 @@ def get_spec_decode_method(method, vllm_config, device, runner):
             return AscendStep3p5MTPProposer(vllm_config, device, runner)
         return AscendEagleProposer(vllm_config, device, runner)
     elif method == "dflash":
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None and _is_dspark_draft_model(speculative_config.draft_model_config):
+            return AscendDSparkProposer(vllm_config, device, runner)
         return AscendDflashProposer(vllm_config, device, runner)
     elif method == "draft_model":
         return AscendDraftModelProposer(vllm_config, device, runner)

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -1,8 +1,10 @@
+import os
 from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
@@ -10,6 +12,8 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+
+logger = init_logger(__name__)
 
 
 class AscendDflashProposer(AscendEagleProposer):
@@ -60,6 +64,163 @@ class AscendDflashProposer(AscendEagleProposer):
 
         self.parallel_drafting_hidden_state_tensor = None
 
+    def _use_dspark_block_contract(self) -> bool:
+        spec_config = self.vllm_config.speculative_config
+        draft_model_config = getattr(spec_config, "draft_model_config", None)
+        hf_config = getattr(draft_model_config, "hf_config", None)
+        if hf_config is None:
+            return False
+        architectures = getattr(hf_config, "architectures", []) or []
+        if "DSparkDraftModel" in architectures:
+            return True
+        if getattr(hf_config, "speculators_model_type", None) == "dspark":
+            return True
+        dflash_config = getattr(hf_config, "dflash_config", None) or {}
+        return dflash_config.get("source_speculators_model_type") == "dspark"
+
+    def _set_dspark_inputs_first_pass(
+        self,
+        target_token_ids: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        cad: CommonAttentionMetadata,
+        num_rejected_tokens_gpu: torch.Tensor | None,
+    ) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
+        batch_size = cad.num_reqs
+        num_context = target_token_ids.shape[0]
+        num_query_per_req = 1 + self.num_speculative_tokens
+        num_query_total = batch_size * num_query_per_req
+
+        self._dflash_num_context = num_context
+        self._dflash_hidden_states[:num_context] = target_hidden_states
+
+        token_indices_to_sample = torch.empty(
+            batch_size * self.num_speculative_tokens,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        self.input_ids[:num_query_total].fill_(self.parallel_drafting_token_id)
+        self.positions[:num_query_total].zero_()
+        self._slot_mapping_buffer[:num_query_total].fill_(-1)
+        self._context_positions_buffer[:num_context].fill_(-1)
+        self._context_slot_mapping_buffer[:num_context].fill_(-1)
+
+        old_query_start_loc = cad.query_start_loc
+        old_block_table = cad.block_table_tensor
+        block_stride = old_block_table.stride(0)
+        cache_block_size = self.kernel_block_size
+        has_num_rejected = num_rejected_tokens_gpu is not None
+        new_seq_lens = torch.empty(batch_size, dtype=torch.int32, device=self.device)
+        step_offsets = self.arange_dflash[:num_query_per_req].to(torch.int32)
+        sample_offsets = self.arange_dflash[: self.num_speculative_tokens].to(torch.int32)
+
+        if target_positions.dim() != 1:
+            raise NotImplementedError("DSpark DFlash proposer only supports 1-D positions")
+
+        for req_idx in range(batch_size):
+            ctx_start = int(old_query_start_loc[req_idx].item())
+            ctx_end = int(old_query_start_loc[req_idx + 1].item())
+            valid_ctx_end = ctx_end
+            if has_num_rejected:
+                rejected = int(num_rejected_tokens_gpu[req_idx].item())
+                valid_ctx_end = max(ctx_start, ctx_end - rejected)
+
+            if ctx_end > ctx_start:
+                ctx_slice = slice(ctx_start, ctx_end)
+                ctx_positions = target_positions[ctx_slice].to(torch.int32)
+                self._context_positions_buffer[ctx_slice].copy_(ctx_positions)
+
+                valid_count = max(0, valid_ctx_end - ctx_start)
+                if valid_count > 0:
+                    valid_positions = ctx_positions[:valid_count].long()
+                    ctx_block_nums = torch.clamp(
+                        valid_positions // cache_block_size,
+                        min=0,
+                        max=block_stride - 1,
+                    )
+                    ctx_block_ids = old_block_table[req_idx, ctx_block_nums]
+                    ctx_slots = ctx_block_ids.to(torch.int32) * cache_block_size + (
+                        valid_positions.to(torch.int32) % cache_block_size
+                    )
+                    self._context_slot_mapping_buffer[
+                        ctx_start:valid_ctx_end
+                    ].copy_(ctx_slots)
+
+            last_pos_idx = max(ctx_start, valid_ctx_end - 1)
+            last_valid_pos = target_positions[last_pos_idx].to(torch.int32)
+            query_base = req_idx * num_query_per_req
+            query_slice = slice(query_base, query_base + num_query_per_req)
+            query_positions = last_valid_pos + 1 + step_offsets
+
+            self.positions[query_slice].copy_(query_positions)
+            self.input_ids[query_base] = next_token_ids[req_idx].to(self.input_ids.dtype)
+            sample_base = req_idx * self.num_speculative_tokens
+            token_indices_to_sample[
+                sample_base : sample_base + self.num_speculative_tokens
+            ].copy_(query_base + 1 + sample_offsets)
+
+            q_block_nums = torch.clamp(
+                query_positions.long() // cache_block_size,
+                min=0,
+                max=block_stride - 1,
+            )
+            q_block_ids = old_block_table[req_idx, q_block_nums]
+            q_slots = q_block_ids.to(torch.int32) * cache_block_size + (
+                query_positions.to(torch.int32) % cache_block_size
+            )
+            self._slot_mapping_buffer[query_slice].copy_(q_slots)
+            new_seq_lens[req_idx] = query_positions[-1] + 1
+
+        query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
+        new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
+
+        cad.query_start_loc = new_query_start_loc
+        cad.seq_lens = new_seq_lens
+        cad.query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * num_query_per_req
+        ).to(torch.int32)
+        if getattr(cad, "_seq_lens_cpu", None) is not None:
+            cad._seq_lens_cpu = new_seq_lens.detach().cpu()
+        if getattr(cad, "seq_lens_cpu", None) is not None:
+            cad.seq_lens_cpu = new_seq_lens.detach().cpu()
+
+        if hasattr(cad, "actual_seq_lengths_q"):
+            cad.actual_seq_lengths_q = [num_query_per_req] * batch_size
+        if hasattr(cad, "decode_token_per_req"):
+            cad.decode_token_per_req = num_query_per_req
+
+        cad.num_actual_tokens = num_query_total
+        cad.max_query_len = num_query_per_req
+        cad.max_seq_len = int(new_seq_lens.max().item()) if batch_size else 0
+        cad.positions = self.positions[:num_query_total]
+        if getattr(cad, "positions_cpu", None) is not None:
+            cad.positions_cpu = cad.positions.detach().cpu()
+        cad.slot_mapping = query_slot_mapping
+        cad.causal = False
+        cad.attn_mask = None
+        cad.attn_state = AscendAttentionState.ChunkedPrefill
+
+        if os.getenv("DSPARK_LOGITS_DEBUG", "0").lower() in ("1", "true", "yes", "on"):
+            debug_count = getattr(self, "_dspark_prepared_input_debug_count", 0)
+            if debug_count < 4 and batch_size > 0:
+                self._dspark_prepared_input_debug_count = debug_count + 1
+                logger.warning(
+                    "[spec_decode/dspark] prepared input debug #%d: "
+                    "input_ids=%s positions=%s seq_lens=%s query_slots=%s "
+                    "context_positions_tail=%s context_slots_tail=%s",
+                    debug_count + 1,
+                    self.input_ids[:num_query_total].detach().cpu().tolist(),
+                    self.positions[:num_query_total].detach().cpu().tolist(),
+                    new_seq_lens.detach().cpu().tolist(),
+                    query_slot_mapping.detach().cpu().tolist(),
+                    self._context_positions_buffer[:num_context][-8:].detach().cpu().tolist(),
+                    self._context_slot_mapping_buffer[:num_context][-8:].detach().cpu().tolist(),
+                )
+
+        return num_query_total, token_indices_to_sample, cad, None
+
     def set_inputs_first_pass(
         self,
         target_token_ids: torch.Tensor,
@@ -78,6 +239,16 @@ class AscendDflashProposer(AscendEagleProposer):
         # Q from query embeddings (bonus + mask tokens).
         batch_size = cad.num_reqs
         num_context = target_token_ids.shape[0]
+        use_dspark = self._use_dspark_block_contract()
+        if use_dspark:
+            return self._set_dspark_inputs_first_pass(
+                target_token_ids=target_token_ids,
+                next_token_ids=next_token_ids,
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                cad=cad,
+                num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+            )
         num_query_per_req = 1 + self.num_speculative_tokens
         num_query_total = batch_size * num_query_per_req
 
@@ -120,7 +291,6 @@ class AscendDflashProposer(AscendEagleProposer):
             batch_size=batch_size,
             HAS_NUM_REJECTED=has_num_rejected,
         )
-
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
         new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
 

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -4,7 +4,7 @@ from typing import Any
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import get_forward_context
-from vllm.logger import init_logger
+from vllm.logger import logger
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
@@ -12,8 +12,6 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
-
-logger = init_logger(__name__)
 
 
 class AscendDflashProposer(AscendEagleProposer):

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -93,6 +93,16 @@ class AscendDflashProposer(AscendEagleProposer):
         num_query_total = batch_size * num_query_per_req
 
         self._dflash_num_context = num_context
+        if self.use_cuda_graph:
+            # The captured graph reads a fixed context slice matching its
+            # token descriptor. Clear the full decode capacity before copying
+            # live rows so shorter accepted windows cannot reuse old K/V input.
+            self._dflash_hidden_states[: self.max_query_tokens].zero_()
+            self._context_positions_buffer[: self.max_query_tokens].zero_()
+            self._context_slot_mapping_buffer[: self.max_query_tokens].fill_(-1)
+        else:
+            self._context_positions_buffer[:num_context].fill_(-1)
+            self._context_slot_mapping_buffer[:num_context].fill_(-1)
         self._dflash_hidden_states[:num_context] = target_hidden_states
 
         token_indices_to_sample = torch.empty(
@@ -101,12 +111,16 @@ class AscendDflashProposer(AscendEagleProposer):
             device=self.device,
         )
 
-        self.input_ids[:num_query_total].fill_(self.parallel_drafting_token_id)
-        self.positions[:num_query_total].zero_()
-        self._slot_mapping_buffer[:num_query_total].fill_(-1)
-        self._context_positions_buffer[:num_context].fill_(-1)
-        self._context_slot_mapping_buffer[:num_context].fill_(-1)
-
+        if self.use_cuda_graph:
+            # Graph dispatch can pad beyond the live query count. Initialize
+            # every graph-visible row so replay never consumes stale inputs.
+            self.input_ids.fill_(self.parallel_drafting_token_id)
+            self.positions.zero_()
+            self._slot_mapping_buffer.fill_(-1)
+        else:
+            self.input_ids[:num_query_total].fill_(self.parallel_drafting_token_id)
+            self.positions[:num_query_total].zero_()
+            self._slot_mapping_buffer[:num_query_total].fill_(-1)
         old_query_start_loc = cad.query_start_loc
         old_block_table = cad.block_table_tensor
         block_stride = old_block_table.stride(0)
@@ -425,6 +439,12 @@ class AscendDflashProposer(AscendEagleProposer):
         num_input_tokens: int,
     ) -> dict[str, Any]:
         num_context = self._dflash_num_context
+        forward_context = get_forward_context()
+        if (
+            self._use_dspark_block_contract()
+            and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+        ):
+            num_context = num_input_tokens
 
         self.model.precompute_and_store_context_kv(
             self._dflash_hidden_states[:num_context],

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -122,70 +122,48 @@ class AscendDflashProposer(AscendEagleProposer):
             self.positions[:num_query_total].zero_()
             self._slot_mapping_buffer[:num_query_total].fill_(-1)
         old_query_start_loc = cad.query_start_loc
-        old_block_table = cad.block_table_tensor
-        block_stride = old_block_table.stride(0)
-        cache_block_size = self.kernel_block_size
         has_num_rejected = num_rejected_tokens_gpu is not None
-        new_seq_lens = torch.empty(batch_size, dtype=torch.int32, device=self.device)
-        step_offsets = self.arange_dflash[:num_query_per_req].to(torch.int32)
-        sample_offsets = self.arange_dflash[: self.num_speculative_tokens].to(torch.int32)
 
         if target_positions.dim() != 1:
             raise NotImplementedError("DSpark DFlash proposer only supports 1-D positions")
 
-        for req_idx in range(batch_size):
-            ctx_start = int(old_query_start_loc[req_idx].item())
-            ctx_end = int(old_query_start_loc[req_idx + 1].item())
-            valid_ctx_end = ctx_end
-            if has_num_rejected:
-                rejected = int(num_rejected_tokens_gpu[req_idx].item())
-                valid_ctx_end = max(ctx_start, ctx_end - rejected)
+        copy_and_expand_dflash_inputs_kernel_single_grid[1,](
+            next_token_ids_ptr=next_token_ids,
+            target_positions_ptr=target_positions,
+            context_slot_mapping_ptr=cad.slot_mapping,
+            out_input_ids_ptr=self.input_ids,
+            out_context_positions_ptr=self._context_positions_buffer,
+            out_query_positions_ptr=self.positions,
+            out_context_slot_mapping_ptr=self._context_slot_mapping_buffer,
+            out_query_slot_mapping_ptr=self._slot_mapping_buffer,
+            out_token_indices_ptr=token_indices_to_sample,
+            block_table_ptr=cad.block_table_tensor,
+            block_table_stride=cad.block_table_tensor.stride(0),
+            query_start_loc_ptr=old_query_start_loc,
+            seq_lens_ptr=cad.seq_lens,
+            num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
+            parallel_drafting_token_id=self.parallel_drafting_token_id,
+            block_size=self.kernel_block_size,
+            num_query_per_req=num_query_per_req,
+            num_speculative_tokens=self.num_speculative_tokens,
+            total_input_tokens=num_context,
+            batch_size=batch_size,
+            HAS_NUM_REJECTED=has_num_rejected,
+            RECOMPUTE_CONTEXT_SLOTS=True,
+        )
 
-            if ctx_end > ctx_start:
-                ctx_slice = slice(ctx_start, ctx_end)
-                ctx_positions = target_positions[ctx_slice].to(torch.int32)
-                self._context_positions_buffer[ctx_slice].copy_(ctx_positions)
-
-                valid_count = max(0, valid_ctx_end - ctx_start)
-                if valid_count > 0:
-                    valid_positions = ctx_positions[:valid_count].long()
-                    ctx_block_nums = torch.clamp(
-                        valid_positions // cache_block_size,
-                        min=0,
-                        max=block_stride - 1,
-                    )
-                    ctx_block_ids = old_block_table[req_idx, ctx_block_nums]
-                    ctx_slots = ctx_block_ids.to(torch.int32) * cache_block_size + (
-                        valid_positions.to(torch.int32) % cache_block_size
-                    )
-                    self._context_slot_mapping_buffer[
-                        ctx_start:valid_ctx_end
-                    ].copy_(ctx_slots)
-
-            last_pos_idx = max(ctx_start, valid_ctx_end - 1)
-            last_valid_pos = target_positions[last_pos_idx].to(torch.int32)
-            query_base = req_idx * num_query_per_req
-            query_slice = slice(query_base, query_base + num_query_per_req)
-            query_positions = last_valid_pos + 1 + step_offsets
-
-            self.positions[query_slice].copy_(query_positions)
-            self.input_ids[query_base] = next_token_ids[req_idx].to(self.input_ids.dtype)
-            sample_base = req_idx * self.num_speculative_tokens
-            token_indices_to_sample[
-                sample_base : sample_base + self.num_speculative_tokens
-            ].copy_(query_base + 1 + sample_offsets)
-
-            q_block_nums = torch.clamp(
-                query_positions.long() // cache_block_size,
-                min=0,
-                max=block_stride - 1,
-            )
-            q_block_ids = old_block_table[req_idx, q_block_nums]
-            q_slots = q_block_ids.to(torch.int32) * cache_block_size + (
-                query_positions.to(torch.int32) % cache_block_size
-            )
-            self._slot_mapping_buffer[query_slice].copy_(q_slots)
-            new_seq_lens[req_idx] = query_positions[-1] + 1
+        last_position_indices = old_query_start_loc[1:] - 1
+        if has_num_rejected:
+            last_position_indices = last_position_indices - num_rejected_tokens_gpu
+        last_position_indices = torch.maximum(
+            last_position_indices,
+            old_query_start_loc[:-1],
+        )
+        last_valid_positions = target_positions.index_select(
+            0,
+            last_position_indices.long(),
+        ).to(torch.int32)
+        new_seq_lens = last_valid_positions + num_query_per_req + 1
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
         new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req
@@ -207,7 +185,7 @@ class AscendDflashProposer(AscendEagleProposer):
 
         cad.num_actual_tokens = num_query_total
         cad.max_query_len = num_query_per_req
-        cad.max_seq_len = int(new_seq_lens.max().item()) if batch_size else 0
+        cad.max_seq_len += num_query_per_req
         cad.positions = self.positions[:num_query_total]
         if getattr(cad, "positions_cpu", None) is not None:
             cad.positions_cpu = cad.positions.detach().cpu()
@@ -440,10 +418,7 @@ class AscendDflashProposer(AscendEagleProposer):
     ) -> dict[str, Any]:
         num_context = self._dflash_num_context
         forward_context = get_forward_context()
-        if (
-            self._use_dspark_block_contract()
-            and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
-        ):
+        if self._use_dspark_block_contract() and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
             num_context = num_input_tokens
 
         self.model.precompute_and_store_context_kv(

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -1,0 +1,45 @@
+from copy import copy
+from dataclasses import replace
+
+from vllm.config import CompilationMode, VllmConfig
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+
+class AscendDSparkProposer(AscendDflashProposer):
+    """DSpark-specific graph configuration on top of the DFlash proposer."""
+
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        draft_vllm_config = super()._create_draft_vllm_config()
+        if not self.use_cuda_graph:
+            return draft_vllm_config
+
+        draft_compilation_config = copy(draft_vllm_config.compilation_config)
+        draft_compilation_config.mode = CompilationMode.NONE
+        return replace(
+            draft_vllm_config,
+            compilation_config=draft_compilation_config,
+        )
+
+    def _stabilize_padded_graph_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        actual_num_reqs: int,
+        padded_num_reqs: int,
+    ) -> None:
+        if padded_num_reqs <= actual_num_reqs:
+            return
+
+        common_attn_metadata.seq_lens[actual_num_reqs:padded_num_reqs].fill_(1)
+        for attr_name in ("_seq_lens_cpu", "seq_lens_cpu"):
+            seq_lens_cpu = getattr(common_attn_metadata, attr_name, None)
+            if seq_lens_cpu is None:
+                continue
+            seq_lens_cpu = self._adjust_tensor(seq_lens_cpu, padded_num_reqs)
+            seq_lens_cpu[actual_num_reqs:padded_num_reqs].fill_(1)
+            setattr(common_attn_metadata, attr_name, seq_lens_cpu)
+
+        if hasattr(common_attn_metadata, "actual_seq_lengths_q"):
+            query_len = 1 + self.num_speculative_tokens
+            common_attn_metadata.actual_seq_lengths_q = [query_len] * padded_num_reqs

--- a/vllm_ascend/spec_decode/eagle_proposer.py
+++ b/vllm_ascend/spec_decode/eagle_proposer.py
@@ -10,3 +10,6 @@ from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBasePropos
 class AscendEagleProposer(EagleProposer, AscendSpecDecodeBaseProposer):
     def __init__(self, vllm_config: VllmConfig, device: torch.device, runner=None):
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, True, runner=runner)
+
+    def compute_draft_token_ids(self, hidden_states: torch.Tensor):
+        return AscendSpecDecodeBaseProposer.compute_draft_token_ids(self, hidden_states)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -142,6 +142,21 @@ def _is_glm_model(model_config) -> bool:
     return "glm" in str(model_type).lower()
 
 
+def _is_dspark_draft_model(model_config) -> bool:
+    if model_config is None:
+        return False
+    hf_config = getattr(model_config, "hf_config", None)
+    if hf_config is None:
+        return False
+    architectures = getattr(hf_config, "architectures", []) or []
+    if "DSparkDraftModel" in architectures:
+        return True
+    if getattr(hf_config, "speculators_model_type", None) == "dspark":
+        return True
+    dflash_config = getattr(hf_config, "dflash_config", None) or {}
+    return dflash_config.get("source_speculators_model_type") == "dspark"
+
+
 class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
     _runnable: ACLGraphWrapper | Callable
 
@@ -216,14 +231,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.use_cuda_graph = self.runner._use_aclgraph() and not self.speculative_config.enforce_eager
         self._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
 
-        # GLM series models: speculative decoding does not yet support running
-        # the draft model in graph mode. Force the draft model to always use
-        # eager mode. This is equivalent to the user adding
-        # `"enforce_eager": true` to the `--speculative-config`, and keeps
-        # the target model's graph-mode setting untouched.
-        # TODO(lilinsiman): Remove this code segment after future versions of the GLM
-        # series models support graph input for speculative inference.
-        if _is_glm_model(self.vllm_config.model_config):
+        # Preserve the upstream GLM force-eager default. Validated DSpark paths
+        # can opt into draft graph capture explicitly while other GLM draft
+        # methods remain protected.
+        enable_glm_dspark_draft_graph = (
+            _is_dspark_draft_model(draft_model_config)
+            and os.getenv("VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH", "0").lower()
+            in ("1", "true", "yes", "on")
+        )
+        if _is_glm_model(self.vllm_config.model_config) and not enable_glm_dspark_draft_graph:
             if self.use_cuda_graph:
                 logger.warning(
                     "GLM series models with speculative decoding currently do "
@@ -233,6 +249,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     "speculative decoding will be added in a future release. "
                 )
             self.use_cuda_graph = False
+        elif enable_glm_dspark_draft_graph and self.use_cuda_graph:
+            logger.warning(
+                "VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH is enabled; "
+                "attempting experimental ACL graph capture for the DSpark "
+                "draft model."
+            )
 
         # TODO: Remove it when the bug of fx-graph is solved
         self.maybe_eager_context: AbstractContextManager[Any] = nullcontext()

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
+import os
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
@@ -46,7 +47,6 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
@@ -292,6 +292,92 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
+    def _maybe_unrotate_dspark_aux_hidden(self, target_hidden_states: torch.Tensor) -> torch.Tensor:
+        mode = os.getenv("DSPARK_AUX_UNROTATE", "0").lower()
+        if mode not in ("1", "true", "yes", "on", "qt", "q_t", "transpose", "q"):
+            return target_hidden_states
+
+        hidden_size = self.hidden_size
+        if target_hidden_states.shape[-1] % hidden_size != 0:
+            logger.warning_once(
+                "[spec_decode/dspark] skip aux unrotate: hidden shape %s is not "
+                "a multiple of hidden_size=%d",
+                tuple(target_hidden_states.shape),
+                hidden_size,
+            )
+            return target_hidden_states
+
+        rotation = getattr(self, "_dspark_aux_rotation", None)
+        if rotation is None:
+            rotation_path = os.getenv("DSPARK_AUX_ROTATION_PATH", "")
+            if not rotation_path:
+                model_path = getattr(self.vllm_config.model_config, "model", "")
+                rotation_path = os.path.join(
+                    model_path,
+                    "optional",
+                    "quarot.safetensors",
+                )
+            try:
+                from safetensors.torch import load_file
+
+                rotation_state = load_file(rotation_path)
+                if "global_rotation" in rotation_state:
+                    rotation = rotation_state["global_rotation"]
+                elif "rot.weight" in rotation_state:
+                    rotation = rotation_state["rot.weight"]
+                else:
+                    raise KeyError(
+                        "rotation file must contain 'global_rotation' or 'rot.weight'; "
+                        f"found keys={list(rotation_state.keys())}"
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[spec_decode/dspark] failed to load aux rotation from %s: %r",
+                    rotation_path,
+                    exc,
+                )
+                return target_hidden_states
+            if tuple(rotation.shape) != (hidden_size, hidden_size):
+                logger.warning(
+                    "[spec_decode/dspark] skip aux unrotate: rotation shape %s "
+                    "does not match hidden_size=%d",
+                    tuple(rotation.shape),
+                    hidden_size,
+                )
+                return target_hidden_states
+            rotation = rotation.to(
+                device=target_hidden_states.device,
+                dtype=target_hidden_states.dtype,
+            )
+            self._dspark_aux_rotation = rotation
+
+        # F.linear(x, Q) computes x @ Q.T. This matches the existing Eagle
+        # QuaRot patch's fc.weight @ Q transformation, but keep x @ Q as a
+        # diagnostic switch in case a checkpoint uses the opposite convention.
+        weight = rotation.t() if mode == "q" else rotation
+        num_features = target_hidden_states.shape[-1] // hidden_size
+        original_shape = target_hidden_states.shape
+        chunks = target_hidden_states.reshape(-1, num_features, hidden_size)
+        unrotated = torch.stack(
+            [F.linear(chunks[:, i, :], weight) for i in range(num_features)],
+            dim=1,
+        ).reshape(original_shape)
+
+        debug_count = getattr(self, "_dspark_aux_unrotate_debug_count", 0)
+        if debug_count < 4:
+            self._dspark_aux_unrotate_debug_count = debug_count + 1
+            logger.warning(
+                "[spec_decode/dspark] aux unrotate debug #%d: mode=%s shape=%s "
+                "features=%d before_abs_mean=%.6f after_abs_mean=%.6f",
+                debug_count + 1,
+                mode,
+                tuple(target_hidden_states.shape),
+                num_features,
+                float(target_hidden_states.detach().float().abs().mean().cpu().item()),
+                float(unrotated.detach().float().abs().mean().cpu().item()),
+            )
+        return unrotated
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -469,16 +555,34 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # target lm_head ([target_vocab_size, hidden]) makes the draft emit
             # logits over the wrong vocabulary, so the verifier rejects almost
             # every speculative token. Keep the draft's own lm_head in that case.
+            draft_model = self.get_model()
+            draft_is_dspark = callable(getattr(draft_model, "compute_dspark_draft_tokens", None))
+            share_dspark_target_lm_head = (
+                draft_is_dspark
+                and os.getenv("DSPARK_SHARE_TARGET_LM_HEAD", "0").lower()
+                in ("1", "true", "yes", "on")
+            )
             draft_has_own_lm_head = (
                 self.method == "dflash" and getattr(self.model, "draft_id_to_target_id", None) is not None
-            )
+            ) or (draft_is_dspark and not share_dspark_target_lm_head)
             if draft_has_own_lm_head:
-                logger.info(
-                    "[spec_decode/base] DFlash draft uses d2t vocab remapping;"
-                    " keeping the draft's own lm_head instead of sharing the target"
-                    " lm_head."
-                )
+                if draft_is_dspark:
+                    logger.info(
+                        "[spec_decode/base] DSpark draft provides its own lm_head;"
+                        " keeping it instead of sharing the target lm_head."
+                    )
+                else:
+                    logger.info(
+                        "[spec_decode/base] DFlash draft uses d2t vocab remapping;"
+                        " keeping the draft's own lm_head instead of sharing the target"
+                        " lm_head."
+                    )
             else:
+                if share_dspark_target_lm_head:
+                    logger.warning(
+                        "[spec_decode/base] DSPARK_SHARE_TARGET_LM_HEAD=1;"
+                        " sharing target lm_head with DSpark draft for debug."
+                    )
                 logger.info("[spec_decode/base] Loading EAGLE/DFLASH LM head weights from the target model.")
                 if hasattr(model, "lm_head"):
                     self.model.lm_head = model.lm_head
@@ -534,6 +638,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if isinstance(self.model, ACLGraphWrapper):
             return self.model.unwrap()
         return self.model
+
+    def _get_dspark_draft_model(self) -> nn.Module | None:
+        draft_model = self.get_model()
+        if callable(getattr(draft_model, "compute_dspark_draft_tokens", None)):
+            return draft_model
+        nested_model = getattr(draft_model, "model", None)
+        if callable(getattr(nested_model, "compute_dspark_draft_tokens", None)):
+            return nested_model
+        return None
 
     def shallow_copy_metadata(self, attn_metadata):
         # Currently, new objects will be assigned to the lists in attn_metadata
@@ -632,7 +745,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
                 extra_attn_metadata_args: dict = {}
                 if self.use_compress:
-                    extra_attn_metadata_args.update(
+                    extra_attn_metadata_args = dict(
                         prefill_ratio_to_sas_metadata=dict(),
                         decode_ratio_to_sas_metadata=dict(),
                         common_ratio_to_sas_metadata=dict(),
@@ -759,16 +872,43 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             token_indices_to_sample = common_attn_metadata.query_start_loc[1:] - 1
 
         if self.method in ("eagle3", "dflash"):
+            draft_model = self.get_model()
             assert isinstance(
-                self.get_model(),
+                draft_model,
                 (
                     Eagle3LlamaForCausalLM,
                     DFlashQwen3ForCausalLM,
                     Eagle3VwnLlamaForCausalLM,
                     Eagle3DeepseekV2ForCausalLM,
                 ),
-            )
+            ) or callable(getattr(draft_model, "compute_dspark_draft_tokens", None))
+            if callable(getattr(draft_model, "compute_dspark_draft_tokens", None)):
+                target_hidden_states = self._maybe_unrotate_dspark_aux_hidden(target_hidden_states)
+                debug_count = getattr(self, "_dspark_hidden_input_debug_count", 0)
+                if debug_count < 4:
+                    self._dspark_hidden_input_debug_count = debug_count + 1
+                    draft_inner = getattr(draft_model, "model", None)
+                    fc = getattr(draft_inner, "fc", None)
+                    fc_weight = getattr(fc, "weight", None)
+                    logger.warning(
+                        "[spec_decode/dspark] hidden input debug #%d: "
+                        "target_hidden_shape=%s draft_use_aux=%s fc_weight_shape=%s",
+                        debug_count + 1,
+                        tuple(target_hidden_states.shape),
+                        getattr(draft_inner, "use_aux_hidden_state", None),
+                        tuple(fc_weight.shape) if fc_weight is not None else None,
+                    )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
+            if callable(getattr(draft_model, "compute_dspark_draft_tokens", None)):
+                debug_count = getattr(self, "_dspark_hidden_output_debug_count", 0)
+                if debug_count < 4:
+                    self._dspark_hidden_output_debug_count = debug_count + 1
+                    logger.warning(
+                        "[spec_decode/dspark] hidden output debug #%d: "
+                        "combined_hidden_shape=%s",
+                        debug_count + 1,
+                        tuple(target_hidden_states.shape),
+                    )
             assert target_hidden_states.shape[-1] == self.hidden_size
 
         num_tokens, token_indices_to_sample, common_attn_metadata, long_seq_args = self.set_inputs_first_pass(
@@ -953,11 +1093,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor.clone()
 
-        metadata_has_prefill = bool(getattr(attn_metadata_i, "num_prefills", 0))
-        is_prefill_batch = num_prefill_reqs > 0 or metadata_has_prefill
         if self.pcp_size * self.dcp_size > 1:
-            is_decode_only_batch = num_decode_reqs > 0 and not is_prefill_batch
-            if self.num_speculative_tokens > 1 and is_decode_only_batch:
+            if self.num_speculative_tokens > 1 and not attn_metadata_i.num_prefills:
                 # For pcp/dcp, tokens are split across different cp ranks,
                 # so we can not simply update slot_mapping by += 1.
                 # Instead, we pre-allocate mtp slot_mapping in model_runner
@@ -1037,6 +1174,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         token_indices_to_sample_len = token_indices_to_sample.shape[0]
+        self._token_indices_to_sample_len = token_indices_to_sample_len
         self.token_indices_to_sample[:token_indices_to_sample_len].copy_(token_indices_to_sample)
         self.token_indices_to_sample[token_indices_to_sample_len:].fill_(0)
 
@@ -1067,7 +1205,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "inputs_embeds": inputs_embeds,
                 "multi_steps_attn_metadata": multi_steps_attn_metadata,
                 "num_tokens": num_tokens,
-                "is_prefill": is_prefill_batch,
+                "is_prefill": attn_metadata_i.num_prefills,
             }
             run_draft = partial(self._runnable, **model_inputs)
 
@@ -1080,6 +1218,97 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         return draft_token_ids
 
     def compute_draft_token_ids(self, hidden_states: torch.Tensor):
+        draft_model = self._get_dspark_draft_model()
+        compute_dspark_draft_tokens = getattr(draft_model, "compute_dspark_draft_tokens", None)
+        if callable(compute_dspark_draft_tokens) and self.num_speculative_tokens > 0:
+            num_rows = hidden_states.shape[0]
+            num_valid_rows = getattr(self, "_token_indices_to_sample_len", num_rows)
+            if num_valid_rows > num_rows:
+                num_valid_rows = num_rows
+            if num_valid_rows % self.num_speculative_tokens == 0:
+                hidden_states = hidden_states[:num_valid_rows]
+                batch_size = num_valid_rows // self.num_speculative_tokens
+                sample_indices = self.token_indices_to_sample[:num_valid_rows].long()
+                sample_input_ids = torch.index_select(
+                    self.input_ids,
+                    dim=0,
+                    index=sample_indices,
+                ).view(batch_size, self.num_speculative_tokens)
+                anchor_indices = sample_indices.view(
+                    batch_size, self.num_speculative_tokens
+                )[:, 0] - 1
+                anchor_indices = torch.where(
+                    anchor_indices >= 0,
+                    anchor_indices,
+                    torch.zeros_like(anchor_indices),
+                )
+                anchor_token_ids = torch.index_select(
+                    self.input_ids,
+                    dim=0,
+                    index=anchor_indices,
+                )
+                proposal_hidden_states = hidden_states.view(
+                    batch_size,
+                    self.num_speculative_tokens,
+                    hidden_states.shape[-1],
+                )
+                draft_token_ids = compute_dspark_draft_tokens(
+                    anchor_token_ids,
+                    proposal_hidden_states,
+                )
+                debug_limit = int(os.getenv("DSPARK_DEBUG_PROPOSER", "4") or "0")
+                debug_count = getattr(self, "_dspark_debug_proposer_count", 0)
+                if debug_count < debug_limit and batch_size > 0:
+                    sample_positions = torch.index_select(
+                        self.positions,
+                        dim=0,
+                        index=sample_indices,
+                    ).view(batch_size, self.num_speculative_tokens)
+                    is_dummy_sample = bool(
+                        torch.all(sample_input_ids[0] == 0).detach().cpu().item()
+                        and torch.all(sample_positions[0] == 0).detach().cpu().item()
+                    )
+                    if is_dummy_sample:
+                        return draft_token_ids.reshape(-1)
+                    self._dspark_debug_proposer_count = debug_count + 1
+                    confidence_logits = getattr(
+                        draft_model,
+                        "last_confidence_logits",
+                        None,
+                    )
+                    confidence_first = None
+                    if confidence_logits is not None and confidence_logits.numel() > 0:
+                        confidence_first = (
+                            confidence_logits[0]
+                            .detach()
+                            .float()
+                            .sigmoid()
+                            .cpu()
+                            .view(-1)
+                            .tolist()
+                        )
+                    logger.warning(
+                        "[spec_decode/dspark] proposal debug #%d: "
+                        "anchor_index_first=%d sample_indices_first=%s "
+                        "sample_input_ids_first=%s "
+                        "sample_positions_first=%s anchor_first=%s draft_first=%s "
+                        "hidden_shape=%s hidden_abs_mean=%.6f confidence_first=%s",
+                        debug_count + 1,
+                        int(anchor_indices[0].detach().cpu().item()),
+                        sample_indices[: self.num_speculative_tokens]
+                        .detach()
+                        .cpu()
+                        .tolist(),
+                        sample_input_ids[0].detach().cpu().tolist(),
+                        sample_positions[0].detach().cpu().tolist(),
+                        int(anchor_token_ids[0].detach().cpu().item()),
+                        draft_token_ids[0].detach().cpu().tolist(),
+                        tuple(proposal_hidden_states.shape),
+                        float(proposal_hidden_states.detach().float().abs().mean().cpu().item()),
+                        confidence_first,
+                    )
+                return draft_token_ids.reshape(-1)
+
         if self.method in ("eagle3", "dflash"):
             logits = self.model.logits_processor(self.model.lm_head, hidden_states)
             if not hasattr(self.model, "draft_id_to_target_id") or self.model.draft_id_to_target_id is None:
@@ -1195,7 +1424,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 
-        if get_ascend_config().enable_reduce_sample:
+        use_dspark_draft = self._get_dspark_draft_model() is not None
+        if get_ascend_config().enable_reduce_sample or use_dspark_draft:
             if self.method in ("eagle3", "dflash", "mtp"):
                 draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                 if lmhead_tp_enable():
@@ -1357,7 +1587,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
 
             sample_hidden_states = last_hidden_states[token_indices_to_sample]
-            if get_ascend_config().enable_reduce_sample:
+            use_dspark_draft = self._get_dspark_draft_model() is not None
+            if get_ascend_config().enable_reduce_sample or use_dspark_draft:
                 if self.method in ("eagle3", "dflash", "mtp"):
                     draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                     if lmhead_tp_enable() and num_indices < draft_token_ids.shape[0]:
@@ -1740,7 +1971,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             slot_indices += self.pcp_size
             slot_mapping = mtp_slot_mapping[slot_indices]
             self.slot_mapping_group[draft_index][: batch_size * self.pcp_size] = slot_mapping
-            self.slot_mapping_group[draft_index][batch_size * self.pcp_size :].fill_(PADDING_SLOT_ID)
             common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_index]
         else:
             # NOTE: In vllm, `block_size = attn_metadata_builder.kv_cache_spec.block_size`.
@@ -1800,22 +2030,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         if self.pcp_size * self.dcp_size > 1:
-            if isinstance(attn_metadata_builder, AscendSFADCPMetadataBuilder):
-                assert attn_metadata.dcp_context is not None
-                dcp_seq_lens = attn_metadata.dcp_context.seq_lens
-                sfa_cp_seq_len = cp_seq_len.to(
-                    device=dcp_seq_lens.device,
-                    dtype=dcp_seq_lens.dtype,
-                    non_blocking=True,
-                )
-                dcp_seq_lens[: sfa_cp_seq_len.shape[0]].copy_(sfa_cp_seq_len, non_blocking=True)
-                dcp_seq_lens[sfa_cp_seq_len.shape[0] :].fill_(0)
+            kv_cache_spec = self.draft_attn_groups[0].kv_cache_spec
+            if isinstance(kv_cache_spec, AscendMLAAttentionSpec):
+                attn_metadata.decode.cp_seq_len = cp_seq_len
             else:
-                kv_cache_spec = self.draft_attn_groups[0].kv_cache_spec
-                if isinstance(kv_cache_spec, AscendMLAAttentionSpec):
-                    attn_metadata.decode.cp_seq_len = cp_seq_len
-                else:
-                    attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp = num_computed_tokens_of_pcp_dcp.numpy()
+                attn_metadata.decode_meta.num_computed_tokens_of_pcp_dcp = num_computed_tokens_of_pcp_dcp.numpy()
 
         return common_attn_metadata, attn_metadata
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -43,6 +43,7 @@ from vllm.v1.spec_decode.utils import (
 )
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
+from vllm_ascend import envs
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
@@ -235,9 +236,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # can opt into draft graph capture explicitly while other GLM draft
         # methods remain protected.
         enable_glm_dspark_draft_graph = (
-            _is_dspark_draft_model(draft_model_config)
-            and os.getenv("VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH", "0").lower()
-            in ("1", "true", "yes", "on")
+            _is_dspark_draft_model(draft_model_config) and envs.VLLM_ASCEND_ENABLE_GLM_DSPARK_DRAFT_GRAPH
         )
         if _is_glm_model(self.vllm_config.model_config) and not enable_glm_dspark_draft_graph:
             if self.use_cuda_graph:
@@ -314,6 +313,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
+    def _stabilize_padded_graph_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        actual_num_reqs: int,
+        padded_num_reqs: int,
+    ) -> None:
+        return
+
     def _maybe_unrotate_dspark_aux_hidden(self, target_hidden_states: torch.Tensor) -> torch.Tensor:
         mode = os.getenv("DSPARK_AUX_UNROTATE", "0").lower()
         if mode not in ("1", "true", "yes", "on", "qt", "q_t", "transpose", "q"):
@@ -322,8 +329,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         hidden_size = self.hidden_size
         if target_hidden_states.shape[-1] % hidden_size != 0:
             logger.warning_once(
-                "[spec_decode/dspark] skip aux unrotate: hidden shape %s is not "
-                "a multiple of hidden_size=%d",
+                "[spec_decode/dspark] skip aux unrotate: hidden shape %s is not a multiple of hidden_size=%d",
                 tuple(target_hidden_states.shape),
                 hidden_size,
             )
@@ -361,8 +367,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 return target_hidden_states
             if tuple(rotation.shape) != (hidden_size, hidden_size):
                 logger.warning(
-                    "[spec_decode/dspark] skip aux unrotate: rotation shape %s "
-                    "does not match hidden_size=%d",
+                    "[spec_decode/dspark] skip aux unrotate: rotation shape %s does not match hidden_size=%d",
                     tuple(rotation.shape),
                     hidden_size,
                 )
@@ -579,10 +584,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # every speculative token. Keep the draft's own lm_head in that case.
             draft_model = self.get_model()
             draft_is_dspark = callable(getattr(draft_model, "compute_dspark_draft_tokens", None))
-            share_dspark_target_lm_head = (
-                draft_is_dspark
-                and os.getenv("DSPARK_SHARE_TARGET_LM_HEAD", "0").lower()
-                in ("1", "true", "yes", "on")
+            share_dspark_target_lm_head = draft_is_dspark and os.getenv("DSPARK_SHARE_TARGET_LM_HEAD", "0").lower() in (
+                "1",
+                "true",
+                "yes",
+                "on",
             )
             draft_has_own_lm_head = (
                 self.method == "dflash" and getattr(self.model, "draft_id_to_target_id", None) is not None
@@ -926,8 +932,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if debug_count < 4:
                     self._dspark_hidden_output_debug_count = debug_count + 1
                     logger.warning(
-                        "[spec_decode/dspark] hidden output debug #%d: "
-                        "combined_hidden_shape=%s",
+                        "[spec_decode/dspark] hidden output debug #%d: combined_hidden_shape=%s",
                         debug_count + 1,
                         tuple(target_hidden_states.shape),
                     )
@@ -983,6 +988,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # is run in eager mode currently, which means `_pad_query_start_loc_for_fia` is not called,
             # while draft model is run in graph model, which means we should pad the `query_start_loc`.
             # Need to be fixed in the future.
+            actual_num_reqs = common_attn_metadata.num_reqs
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
@@ -1005,6 +1011,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
             if self.method == "dflash":
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+                self._stabilize_padded_graph_metadata(
+                    common_attn_metadata,
+                    actual_num_reqs,
+                    num_reqs_padded,
+                )
             else:
                 common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
@@ -1256,9 +1267,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     dim=0,
                     index=sample_indices,
                 ).view(batch_size, self.num_speculative_tokens)
-                anchor_indices = sample_indices.view(
-                    batch_size, self.num_speculative_tokens
-                )[:, 0] - 1
+                anchor_indices = sample_indices.view(batch_size, self.num_speculative_tokens)[:, 0] - 1
                 anchor_indices = torch.where(
                     anchor_indices >= 0,
                     anchor_indices,
@@ -1281,11 +1290,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # Graph capture cannot execute the host synchronizations used
                 # by proposal debugging. Keep debugging opt-in for eager runs
                 # and disable it unconditionally for the graph path.
-                debug_limit = (
-                    0
-                    if self.use_cuda_graph
-                    else int(os.getenv("DSPARK_DEBUG_PROPOSER", "0") or "0")
-                )
+                debug_limit = 0 if self.use_cuda_graph else int(os.getenv("DSPARK_DEBUG_PROPOSER", "0") or "0")
                 debug_count = getattr(self, "_dspark_debug_proposer_count", 0)
                 if debug_count < debug_limit and batch_size > 0:
                     sample_positions = torch.index_select(
@@ -1307,15 +1312,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     )
                     confidence_first = None
                     if confidence_logits is not None and confidence_logits.numel() > 0:
-                        confidence_first = (
-                            confidence_logits[0]
-                            .detach()
-                            .float()
-                            .sigmoid()
-                            .cpu()
-                            .view(-1)
-                            .tolist()
-                        )
+                        confidence_first = confidence_logits[0].detach().float().sigmoid().cpu().view(-1).tolist()
                     logger.warning(
                         "[spec_decode/dspark] proposal debug #%d: "
                         "anchor_index_first=%d sample_indices_first=%s "
@@ -1324,10 +1321,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         "hidden_shape=%s hidden_abs_mean=%.6f confidence_first=%s",
                         debug_count + 1,
                         int(anchor_indices[0].detach().cpu().item()),
-                        sample_indices[: self.num_speculative_tokens]
-                        .detach()
-                        .cpu()
-                        .tolist(),
+                        sample_indices[: self.num_speculative_tokens].detach().cpu().tolist(),
                         sample_input_ids[0].detach().cpu().tolist(),
                         sample_positions[0].detach().cpu().tolist(),
                         int(anchor_token_ids[0].detach().cpu().item()),

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1278,7 +1278,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     anchor_token_ids,
                     proposal_hidden_states,
                 )
-                debug_limit = int(os.getenv("DSPARK_DEBUG_PROPOSER", "4") or "0")
+                # Graph capture cannot execute the host synchronizations used
+                # by proposal debugging. Keep debugging opt-in for eager runs
+                # and disable it unconditionally for the graph path.
+                debug_limit = (
+                    0
+                    if self.use_cuda_graph
+                    else int(os.getenv("DSPARK_DEBUG_PROPOSER", "0") or "0")
+                )
                 debug_count = getattr(self, "_dspark_debug_proposer_count", 0)
                 if debug_count < debug_limit and batch_size > 0:
                     sample_positions = torch.index_select(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -148,6 +148,7 @@ from vllm_ascend.utils import (
     calc_split_factor,
     check_gdn_layer,
     embedding_tp_enable,
+    enable_sfa_dcp_replicated_indexer,
     enable_sp,
     enable_sp_by_pass,
     get_ascend_device_type,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -17,6 +17,7 @@
 # Adapted from vllm-project/vllm/vllm/worker/gpu_model_runner.py
 #
 
+import gc
 import logging
 import math
 import sys
@@ -105,19 +106,15 @@ from vllm.v1.worker.utils import AttentionGroup, select_common_block_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
-from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
 from vllm_ascend.attention.mla_v1 import AscendMLABackend
-from vllm_ascend.attention.utils import (
-    AscendCommonAttentionMetadata,
-    get_sfa_qsfa_packed_head_dim,
-    using_paged_attention,
-)
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, using_paged_attention
 
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm_ascend.compilation.acl_graph import (
     ACLGraphWrapper,
+    reset_graph_params,
     set_draft_graph_params,
     set_graph_params,
     update_full_graph_params,
@@ -151,7 +148,6 @@ from vllm_ascend.utils import (
     calc_split_factor,
     check_gdn_layer,
     embedding_tp_enable,
-    enable_sfa_dcp_replicated_indexer,
     enable_sp,
     enable_sp_by_pass,
     get_ascend_device_type,
@@ -164,7 +160,6 @@ from vllm_ascend.utils import (
     set_potential_max_tokens,
     set_weight_prefetch_method,
     should_skip_allreduce_across_dp_group,
-    sparse_kv_cache_has_indexer,
     vllm_version_is,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
@@ -368,14 +363,19 @@ class NPUModelRunner(GPUModelRunner):
         )
         if self.use_sparse:
             if get_ascend_device_type() == AscendDeviceType.A5 and self.ascend_config.enable_sparse_c8:
-                # A5 sparse C8 uses the same merged/packed KV layout as SFA QSFA.
+                # A5 sparse C8: kv_lora and k_rope are merged into a single CKV FP8 tensor.
                 # qk_rope_head_dim = 0 signals the merged layout.
-                packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
-                    self.model_config.hf_text_config.kv_lora_rank,
-                    self.model_config.hf_text_config.qk_rope_head_dim,
-                )
+                # ckv_dim = kv_lora_rank                    (fp8, 1 byte/elem)
+                #         + qk_rope_head_dim * 2             (bf16→fp8: 2/1 bytes)
+                #         + 4 * 4                            (quant_scale metadata:
+                #                                              4 = kv_lora_rank / tile_size(128),
+                #                                              4 = float32→fp8: 4/1 bytes)
+                A5_CKV_SCALE_METADATA_BYTES = 4 * 4
+                ckv = self.model_config.hf_text_config.kv_lora_rank
+                rope = self.model_config.hf_text_config.qk_rope_head_dim
+                a5_ckv_dim = ckv + rope * 2 + A5_CKV_SCALE_METADATA_BYTES
                 self.sparse_head_dim = (
-                    packed_kv_head_dim,
+                    a5_ckv_dim,
                     0,
                     self.model_config.hf_text_config.index_head_dim,
                 )
@@ -386,8 +386,8 @@ class NPUModelRunner(GPUModelRunner):
                     self.model_config.hf_text_config.index_head_dim,
                 )
         # dsa c8
-        self.use_sparse_c8 = self.ascend_config.enable_sparse_c8
-        if self.use_sparse_c8:
+        self.use_sparse_c8_indexer = self.ascend_config.enable_sparse_c8
+        if self.use_sparse_c8_indexer:
             if get_ascend_device_type() == AscendDeviceType.A5:
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
@@ -2097,9 +2097,7 @@ class NPUModelRunner(GPUModelRunner):
         # TODO(Ronald1995): deepcopy is expensive when there is a large
         # number of requests, optimize it later.
         if ((
-            self.use_async_scheduling
-            and self.num_spec_tokens
-            and self._draft_token_ids is None  # type: ignore[has-type]
+            self.use_async_scheduling and self.num_spec_tokens and self._draft_token_ids is None  # type: ignore[has-type]
         ) or (
             # NOTE: This branch specifically triggers a deepcopy during the prefill phase 
             # only for PCP (Parallel Context Processing) + Multi-Modal (MM) scenarios. 
@@ -3354,11 +3352,7 @@ class NPUModelRunner(GPUModelRunner):
 
             # add kvcomp_metadata into common_attn_metadata
             if (for_cudagraph_capture
-                    and not isinstance(builder, (
-                        AscendDSAMetadataBuilder,
-                        AscendDSACPMetadataBuilder,
-                        AscendSFADCPMetadataBuilder,
-                    ))):
+                    and not isinstance(builder, (AscendDSAMetadataBuilder, AscendDSACPMetadataBuilder))):
                 attn_metadata_i = builder.build_for_cudagraph_capture(common_attn_metadata)
             else:
                 attn_metadata_i = builder.build(
@@ -3667,10 +3661,6 @@ class NPUModelRunner(GPUModelRunner):
                 for_cudagraph_capture=is_graph_capturing,
                 num_scheduled_tokens_np=num_scheduled_tokens,
             )
-            if not is_graph_capturing:
-                for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):
-                    blk_table = self.input_batch.block_table[kv_cache_gid]
-                    blk_table.slot_mapping.gpu.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
@@ -3960,7 +3950,11 @@ class NPUModelRunner(GPUModelRunner):
 
         self.debugger.step(**kwargs)
 
-    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+    def initialize_kv_cache(
+        self,
+        kv_cache_config: KVCacheConfig,
+        is_profiling: bool = False,
+    ) -> None:
         """
         Initialize KV cache based on `kv_cache_config`.
         Args:
@@ -3974,7 +3968,7 @@ class NPUModelRunner(GPUModelRunner):
         self.may_add_encoder_only_layers_to_kv_cache_config()
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
-        self.initialize_attn_backend(kv_cache_config)
+        self.initialize_attn_backend(kv_cache_config, is_profiling=is_profiling)
         self.use_hybrid_blocks = len(self.attn_groups) > 1
         # NOTE: Currently, we determine whether we need `num_accepted_tokens` through `MambaSpec`.
         self.need_accepted_tokens = any(
@@ -4000,7 +3994,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.kernel_block_sizes, list) else self.kernel_block_sizes)
             self.drafter.initialize_attn_backend(kv_cache_config, block_size)
 
-        if has_kv_transfer_group():
+        if has_kv_transfer_group() and not is_profiling:
             get_kv_transfer_group().register_kv_caches(kv_caches)
 
         if self.model_config.enable_return_routed_experts:
@@ -4272,53 +4266,28 @@ class NPUModelRunner(GPUModelRunner):
                     # and rope head dim.
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     assert isinstance(current_kv_cache_spec, AttentionSpec)
+                    use_sparse_kv_spec = self.use_sparse and isinstance(
+                        current_kv_cache_spec, AscendMLAAttentionSpec
+                    )
 
-                    dsa_k_tensor_split_factor = None
-                    if self.use_sparse:
+                    if use_sparse_kv_spec:
                         # for deepseek v3.2, we split the kv cache according to the corresponding ratio
                         kv_cache_spec = layer_kv_cache_spec[layer_name]
                         current_sparse_c8 = kv_cache_spec_uses_sparse_c8(kv_cache_spec)
-                        assert isinstance(kv_cache_spec, AscendMLAAttentionSpec)
-                        assert kv_cache_spec.sparse_head_dim is not None
-                        has_indexer_cache = sparse_kv_cache_has_indexer(kv_cache_spec)
-
-                        if current_sparse_c8:
-                            assert kv_cache_tensor.size % kv_cache_spec.page_size_bytes == 0
-                            num_blocks = kv_cache_tensor.size // kv_cache_spec.page_size_bytes
-                            num_heads = kv_cache_spec.block_size * kv_cache_spec.num_kv_heads
-                            packed_kv_head_dim, _, index_head_dim = kv_cache_spec.sparse_head_dim
-                            k_tensor_split_factor = 1.0
-                            k_tensor_size = (
-                                num_blocks
-                                * num_heads
-                                * packed_kv_head_dim
-                                * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
-                            )
-                            v_tensor_size = None
-                            if has_indexer_cache:
-                                dsa_k_tensor_size = (
-                                    num_blocks
-                                    * num_heads
-                                    * index_head_dim
-                                    * get_dtype_size(kv_cache_spec.c8_k_cache_dtype)
-                                )
-                                dsa_k_scale_tensor_size = (
-                                    num_blocks
-                                    * num_heads
-                                    * get_dtype_size(kv_cache_spec.c8_k_scale_cache_dtype)
-                                )
-                            else:
-                                dsa_k_tensor_size = None
-                                dsa_k_scale_tensor_size = None
-                            dsa_k_tensor_split_factor = None
-                        elif has_indexer_cache:
-                            sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
+                        sparse_kv_cache_ratio = kv_cache_spec.sparse_kv_cache_ratio
+                        
+                        # A5 sparse C8: (ckv_ratio, qli_ratio, qli_scale_ratio, None)
+                        # A3 sparse C8: (k_ratio, v_ratio, qli_ratio, qli_scale_ratio)
+                        if current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                            k_tensor_split_factor = sparse_kv_cache_ratio[0]  # ckv
+                            v_tensor_split_factor = None  # merged
+                            dsa_k_tensor_split_factor = sparse_kv_cache_ratio[1]  # qli_tensor
+                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[2]  # qli_scale
+                        else:
                             k_tensor_split_factor = sparse_kv_cache_ratio[0]
                             v_tensor_split_factor = sparse_kv_cache_ratio[1]
                             dsa_k_tensor_split_factor = sparse_kv_cache_ratio[2]
-                        else:
-                            k_dim, v_dim, _ = kv_cache_spec.sparse_head_dim
-                            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor([k_dim, v_dim])
+                            dsa_k_scale_tensor_split_factor = sparse_kv_cache_ratio[3] if current_sparse_c8 else None
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
@@ -4333,19 +4302,19 @@ class NPUModelRunner(GPUModelRunner):
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
 
-                    if not (self.use_sparse and current_sparse_c8):
-                        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                        v_tensor_size = (
-                            int(kv_cache_tensor.size // v_tensor_split_factor)
-                            if v_tensor_split_factor is not None
-                            else None
-                        )
-                        dsa_k_tensor_size = None
-                        dsa_k_scale_tensor_size = None
+                    k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
+                    if v_tensor_split_factor is not None:
+                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                    else:
+                        v_tensor_size = None
+                    dsa_k_tensor_size = None
+                    dsa_k_scale_tensor_size = None
                     #### for deepseek sparse attention
-                    if self.use_sparse and has_indexer_cache and not current_sparse_c8:
-                        assert dsa_k_tensor_split_factor is not None
+                    if use_sparse_kv_spec:
                         dsa_k_tensor_size = int(kv_cache_tensor.size // dsa_k_tensor_split_factor)
+                    if use_sparse_kv_spec and current_sparse_c8:
+                        dsa_k_scale_tensor_size = int(kv_cache_tensor.size // dsa_k_scale_tensor_split_factor)
+
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
                     # the target dtype in _reshape_kv_cache_tensors.
@@ -4362,7 +4331,9 @@ class NPUModelRunner(GPUModelRunner):
                             alignment,
                         )
 
-                    if self.use_sparse and dsa_k_tensor_size is not None:
+                    if use_sparse_kv_spec:
+                        assert dsa_k_tensor_size is not None
+
                         if current_sparse_c8:
                             assert dsa_k_scale_tensor_size is not None
 
@@ -4373,7 +4344,7 @@ class NPUModelRunner(GPUModelRunner):
                                 dsa_k_tensor_size=dsa_k_tensor_size,
                                 dsa_k_scale_tensor_size=dsa_k_scale_tensor_size,
                                 alignment=alignment,
-                                scale_dtype=current_kv_cache_spec.c8_k_scale_cache_dtype,
+                                scale_dtype=current_kv_cache_spec.scale_dtype,
                             )
                         else:
                             dsa_k_tensor = self._allocate_int8_cache_tensor(
@@ -4384,27 +4355,19 @@ class NPUModelRunner(GPUModelRunner):
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the attn kvcache for all shared layers
                         if "attn" in layer_name_inner and "linear_attn" not in layer_name_inner:
-                            if self.use_sparse:
+                            if use_sparse_kv_spec:
                                 if current_sparse_c8:
-                                    if has_indexer_cache:
-                                        # Sparse C8 with indexer: packed KV, indexer K, and indexer K scale.
+                                    if get_ascend_device_type() == AscendDeviceType.A5:
                                         kv_cache_raw_tensors[layer_name_inner] = (
                                             k_tensor, dsa_k_tensor, dsa_k_scale_tensor
                                         )
                                     else:
-                                        # Sparse C8 without indexer: packed KV only.
-                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor,)
-                                else:
-                                    if has_indexer_cache:
-                                        # Sparse non-C8 with indexer: regular K/V plus indexer K.
                                         kv_cache_raw_tensors[layer_name_inner] = (
-                                            k_tensor, v_tensor, dsa_k_tensor
+                                            k_tensor, v_tensor, dsa_k_tensor, dsa_k_scale_tensor
                                         )
-                                    else:
-                                        # Sparse non-C8 without indexer: regular K/V only.
-                                        kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
+                                else:
+                                    kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor, dsa_k_tensor)
                             else:
-                                # Dense attention: regular K/V only.
                                 kv_cache_raw_tensors[layer_name_inner] = (k_tensor, v_tensor)
         layer_names = set()
         for group in kv_cache_config.kv_cache_groups:
@@ -4533,41 +4496,45 @@ class NPUModelRunner(GPUModelRunner):
 
                     kv_caches[layer_name] = kv_cache
                 elif isinstance(current_kv_cache_spec, AttentionSpec):
+                    use_sparse_kv_spec = self.use_sparse and isinstance(
+                        current_kv_cache_spec, AscendMLAAttentionSpec
+                    )
+                    current_sparse_c8 = False
                     # cache_only_layers (extract_hidden_states) are allocated
                     # as a single tensor by the branch at the top of
                     # _allocate_kv_cache_tensors; route them to the dedicated
-                    current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
-                    has_indexer_cache = sparse_kv_cache_has_indexer(current_kv_cache_spec)
-                    raw_dsa_k_tensor = None
-                    raw_dsa_k_scale_tensor = None
-                    if self.use_sparse and has_indexer_cache and "cache_only_layers" not in layer_name:
-                        assert isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
-                        assert current_kv_cache_spec.sparse_head_dim is not None
+                    # elif branch below before the sparse branch tries to
+                    # unpack them as a (k, v, dsa_k[, scale]) tuple.
+                    if use_sparse_kv_spec and "cache_only_layers" not in layer_name:
+                        current_sparse_c8 = kv_cache_spec_uses_sparse_c8(current_kv_cache_spec)
                         if current_sparse_c8:
-                            raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
-                                kv_cache_raw_tensors[layer_name]  # type: ignore
-                            )
-                            assert raw_dsa_k_tensor is not None
-                            assert raw_dsa_k_scale_tensor is not None
-                            sum_page_size_bytes = (
-                                raw_k_tensor.numel()
-                                + raw_dsa_k_tensor.numel()
-                                + raw_dsa_k_scale_tensor.numel()
-                            )
+                            if get_ascend_device_type() == AscendDeviceType.A5:
+                                raw_k_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = kv_cache_raw_tensors[  # type: ignore
+                                    layer_name]
+                                assert raw_dsa_k_tensor is not None
+                                assert raw_dsa_k_scale_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel()
+                                    + raw_dsa_k_tensor.numel()
+                                    + raw_dsa_k_scale_tensor.numel()
+                                )
+                            else:
+                                raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor, raw_dsa_k_scale_tensor = (
+                                    kv_cache_raw_tensors[layer_name]  # type: ignore
+                                )
+                                assert raw_dsa_k_tensor is not None
+                                assert raw_dsa_k_scale_tensor is not None
+                                sum_page_size_bytes = (
+                                    raw_k_tensor.numel()
+                                    + raw_v_tensor.numel()
+                                    + raw_dsa_k_tensor.numel()
+                                    + raw_dsa_k_scale_tensor.numel()
+                                )
                         else:
                             raw_k_tensor, raw_v_tensor, raw_dsa_k_tensor = kv_cache_raw_tensors[  # type: ignore
                                 layer_name]
                             assert raw_dsa_k_tensor is not None
                             sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel() + raw_dsa_k_tensor.numel()
-                    elif self.use_sparse and "cache_only_layers" not in layer_name:
-                        assert isinstance(current_kv_cache_spec, AscendMLAAttentionSpec)
-                        assert current_kv_cache_spec.sparse_head_dim is not None
-                        if current_sparse_c8:
-                            (raw_k_tensor,) = kv_cache_raw_tensors[layer_name]  # type: ignore
-                            sum_page_size_bytes = raw_k_tensor.numel()
-                        else:
-                            raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name]  # type: ignore
-                            sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
                     elif (
                         self.use_hybrid_blocks
                         and self.hybrid_with_attn_and_mamba
@@ -4688,15 +4655,19 @@ class NPUModelRunner(GPUModelRunner):
                             num_kv_heads,
                             k_dim,
                         )
-                        if self.use_sparse and current_sparse_c8:
-                            assert current_kv_cache_spec.sparse_head_dim is not None
+                        if use_sparse_kv_spec and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
+                            # A5 sparse C8: CKV tensor = kv_lora(fp8) + k_rope(bf16→fp8) + quant_scale_metadata
+                            #   kv_lora_rank                    : fp8, 1 byte/elem
+                            #   qk_rope_head_dim * 2            : bf16→fp8 ratio (2/1 bytes)
+                            #   4 * 4                           : quant_scale (4 elements × float32→fp8 ratio)
                             k_shape = (
                                 mla_num_blocks,
                                 mla_block_size,
                                 num_kv_heads,
-                                current_kv_cache_spec.sparse_head_dim[0],
+                                self.model_config.hf_text_config.kv_lora_rank
+                                + self.model_config.hf_text_config.qk_rope_head_dim * 2
+                                + 4 * 4,
                             )
-                            v_dim = 0
                         v_shape = (
                             mla_num_blocks,
                             mla_block_size,
@@ -4708,20 +4679,20 @@ class NPUModelRunner(GPUModelRunner):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
-
-                    if self.use_sparse and current_sparse_c8:
+                    
+                    # A5 sparse C8: ckv uses float8_e4m3fn
+                    if use_sparse_kv_spec and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         k_cache_dtype = self.c8_k_cache_dtype
-
+                    
                     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-                    if self.use_sparse and current_sparse_c8:
+                    if use_sparse_kv_spec and current_sparse_c8 and get_ascend_device_type() == AscendDeviceType.A5:
                         v_cache = None
                     else:
                         v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
 
-                    if self.use_sparse and has_indexer_cache:
-                        assert raw_dsa_k_tensor is not None
+                    if use_sparse_kv_spec:
                         dsa_k_cache_shape = (
-                            num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                            num_blocks,
                             current_kv_cache_spec.block_size,
                             current_kv_cache_spec.num_kv_heads,
                             self.model_config.hf_text_config.index_head_dim,
@@ -4731,7 +4702,7 @@ class NPUModelRunner(GPUModelRunner):
                             dsa_k_cache = raw_dsa_k_tensor.view(self.c8_k_cache_dtype).view(dsa_k_cache_shape)
                             # dsa_k_scale
                             dsa_k_scale_cache_shape = (
-                                num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                                num_blocks,
                                 current_kv_cache_spec.block_size,
                                 current_kv_cache_spec.num_kv_heads,
                                 1,
@@ -4752,8 +4723,6 @@ class NPUModelRunner(GPUModelRunner):
                             # dsa_k
                             dsa_k_cache = raw_dsa_k_tensor.view(current_kv_cache_spec.dtype).view(dsa_k_cache_shape)
                             kv_caches[layer_name] = (k_cache, v_cache, dsa_k_cache)
-                    elif self.use_sparse and current_sparse_c8:
-                        kv_caches[layer_name] = (k_cache,)
                     else:
                         kv_caches[layer_name] = (k_cache, v_cache)
                 elif isinstance(current_kv_cache_spec, MambaSpec):
@@ -4853,10 +4822,9 @@ class NPUModelRunner(GPUModelRunner):
             if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
                 mamba_blocks_per_req = (
                     max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
-                ) 
+                ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
 
                 max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
-                max_num_blocks_per_req += kv_cache_group.kv_cache_spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
 
         if (block_sizes != [self.cache_config.block_size]
@@ -4889,7 +4857,11 @@ class NPUModelRunner(GPUModelRunner):
                 cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             )
 
-    def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        is_profiling: bool = False,
+    ) -> None:
         """
         Initialize the attention backends and attention metadata builders.
         """
@@ -4951,7 +4923,11 @@ class NPUModelRunner(GPUModelRunner):
             attention_backend_maps.append(attn_backends[0])
             attention_backend_list.append(attn_backends[1])
 
-        self._check_and_update_cudagraph_mode(attention_backend_list, kv_cache_config.kv_cache_groups)
+        self._check_and_update_cudagraph_mode(
+            attention_backend_list,
+            kv_cache_config.kv_cache_groups,
+            is_profiling=is_profiling,
+        )
 
         for i, attn_backend_map in enumerate(attention_backend_maps):
             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
@@ -5023,45 +4999,14 @@ class NPUModelRunner(GPUModelRunner):
 
             elif isinstance(attn_module, MLAAttention):
                 if self.use_sparse:
-                    impl = attn_module.impl
-                    has_indexer = bool(getattr(impl, "has_indexer", False))
-                    use_sparse_c8_sfa_for_layer = bool(getattr(impl, "use_sparse_c8_sfa", False))
-                    use_sparse_c8_indexer_for_layer = bool(getattr(impl, "use_sparse_c8_indexer", False))
-
-                    if use_sparse_c8_sfa_for_layer:
-                        packed_kv_head_dim = get_sfa_qsfa_packed_head_dim(
-                            self.model_config.hf_text_config.kv_lora_rank,
-                            self.model_config.hf_text_config.qk_rope_head_dim,
-                        )
-                        sparse_head_dim = (
-                            packed_kv_head_dim,
-                            0,
-                            (
-                                self.model_config.hf_text_config.index_head_dim
-                                if use_sparse_c8_indexer_for_layer
-                                else 0
-                            ),
-                        )
-                    elif has_indexer:
-                        sparse_head_dim = self.sparse_head_dim
-                    else:
-                        # Layers that reuse another layer's top-k indices only
-                        # need the MLA latent and RoPE caches.
-                        sparse_head_dim = (
-                            self.model_config.hf_text_config.kv_lora_rank,
-                            self.model_config.hf_text_config.qk_rope_head_dim,
-                            0,
-                        )
-
                     kv_cache_spec[layer_name] = AscendMLAAttentionSpec(
                         block_size=self.block_size,
                         num_kv_heads=1,
-                        head_size=sum(sparse_head_dim),
-                        sparse_head_dim=sparse_head_dim,
+                        head_size=sum(self.sparse_head_dim),
+                        sparse_head_dim=self.sparse_head_dim,
                         dtype=self.kv_cache_dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
-                        cache_sparse_c8=use_sparse_c8_sfa_for_layer,
-                        sfa_dcp_replicated_indexer_size=self.sfa_dcp_replicated_indexer_size,
+                        cache_sparse_c8=self.ascend_config.is_sparse_c8_layer(layer_name),
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     if getattr(attn_module.impl, "fa_quant_layer", False):
@@ -5120,6 +5065,7 @@ class NPUModelRunner(GPUModelRunner):
         self,
         attention_backends: list[set[type[AttentionBackend]]],
         kv_cache_groups: list[KVCacheGroupSpec],
+        is_profiling: bool = False,
     ) -> None:
         min_cg_support = AttentionCGSupport.ALWAYS
         min_cg_attn_backend = None
@@ -5144,6 +5090,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.parallel_config.tensor_parallel_size,
                 self.kv_cache_config,
                 self.max_num_reqs,
+                is_profiling=is_profiling,
             )
             self.cudagraph_dispatcher.initialize_cudagraph_keys(
                 cudagraph_mode, self.uniform_decode_query_len
@@ -5172,10 +5119,34 @@ class NPUModelRunner(GPUModelRunner):
 
         # NOTE: Since aclgraph_batch_sizes cannot be determined until here,
         # we set the graph params right before initializing the keys.
+        # Profiling still runs real graph warmup/capture paths, so the NPU-side
+        # graph params must exist there as well.
         if self.use_aclgraph:
             set_graph_params(capture_sizes)
             if self.speculative_config:
                 set_draft_graph_params(capture_sizes)
+
+    def profile_cudagraph_memory(self) -> int:
+        parent_module_name = _get_gpu_model_runner_module_name(self)
+        with _torch_cuda_wrapper(), _replace_gpu_model_runner_function_wrapper(parent_module_name):
+            result = GPUModelRunner.profile_cudagraph_memory(self)
+
+        reset_graph_params()
+
+        # NOTE: This is a serious problem that we maintain two extra copies of the KV cache as the instance
+        # variable of the attention layers, when they are local variables in the upstream vLLM code.
+        # We have to manually clear them here to release memory after profiling. 
+        for layer in self.compilation_config.static_forward_context.values():
+            if hasattr(layer, "impl"):
+                if hasattr(layer.impl, "key_cache"):
+                    layer.impl.key_cache = None
+                if hasattr(layer.impl, "value_cache"):
+                    layer.impl.value_cache = None
+
+        gc.collect()
+        torch.accelerator.empty_cache()
+
+        return result
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""
@@ -5307,16 +5278,23 @@ def _replace_gpu_model_runner_function_wrapper(target_module_name):
     _encoder_mgr_orig = _vllm_encoder_cudagraph.EncoderCudaGraphManager
     _vllm_encoder_cudagraph.EncoderCudaGraphManager = EncoderAclGraphManager
     target_module = None
+    original_attrs = {}
     try:
         target_module = sys.modules[target_module_name]
+        if hasattr(target_module, "graph_capture"):
+            original_attrs["graph_capture"] = target_module.graph_capture
         setattr(target_module, "graph_capture", graph_capture)  # noqa: B010
+        if hasattr(target_module, "CUDAGraphWrapper"):
+            original_attrs["CUDAGraphWrapper"] = target_module.CUDAGraphWrapper
+            setattr(target_module, "CUDAGraphWrapper", ACLGraphWrapper)  # noqa: B010
         yield
     except Exception as e:
         raise RuntimeError(f"NPUModelRunner failed, error is {e}")
     finally:
         _vllm_encoder_cudagraph.EncoderCudaGraphManager = _encoder_mgr_orig
         if target_module is not None:
-            setattr(target_module, "graph_capture", graph_capture)  # noqa: B010
+            for attr_name, attr_value in original_attrs.items():
+                setattr(target_module, attr_name, attr_value)  # noqa: B010
 
 
 # TODO: remove it when flash_comm1 is removed


### PR DESCRIPTION
> **Stacked on #11066** (`Liuchenbing-2026:dspark` @ `fabc77a9`): this branch contains #11066's commits plus **one new commit on top — only the last commit is under review here**. Happy to rebase once #11066 lands, or to retarget the fix onto whichever GLM-5.2 DSpark line settles post-#11431.

### What this PR does / why we need it?

Fixes a global acceptance collapse of GLM-5.2 DSpark on Ascend A3 caused by the
platform-dispatched rotary path returning non-norm-preserving Q/K for the draft
attention shape (bf16, NeoX-style, head_dim=rotary_dim=192). Root-cause evidence
chain (same-worker dispatched-vs-native A/B, two fresh-process reproductions,
token-level causality, cache exoneration) is in #12723

The change is a single line in the draft attention forward: call
`self.rotary_emb.forward_native(positions, q, k)` instead of the dispatched
`self.rotary_emb(positions, q, k)`. `forward_native` still executes on the NPU
(as unfused tensor ops); this is a correctness fix, not a performance
optimization. A shape-gated fix in the Ascend rotary backend itself would be the
long-term solution.

### Does this PR introduce any user-facing change?

No. Same API, same weights, same config. Only the draft query RoPE execution
path changes.

### How was this patch tested?

E2E on Ascend A3 (16 dies, DP2/TP8/EP, eager, k=7, GLM-5.2 w8a8 target,
bf16 DSpark draft), identical requests before/after:

| metric | before | after |
|---|---:|---:|
| accept_len, 8 serial requests | 3.055556 | **5.547692** |
| accept_len, 32 requests / concurrency 8 | 2.910313 | **5.429936** |

40/40 requests HTTP 200, hard counters consistent (`draft_tokens = 7 × drafts`),
post-run health check green. Offline accept_len for the same checkpoint on the
same question domain is ~5.6, i.e. online now matches offline capability.

End-to-end throughput comparison (no-spec vs MTP-5 vs DSpark) is **in
progress**; numbers will be posted in this thread. A NeoX-192 bf16
norm-preservation unit test (production path vs `forward_native` within
tolerance) is planned — note a plain-CPU CI cannot reproduce the corrupted
dispatch, so the numerical regression test belongs in NPU e2e/hardware CI.
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
