### PR TITLE
[Doc]update qwen_3.5_397b/qwen3_vl_235b/qwen3_vl_30b doc, fill ascend 950DT info;update qwen_3.6_35b doc, change feature guide link and fill accuracy result

### DIFF
--- a/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
@@ -1,54 +1,51 @@
 # Qwen3-VL-235B-A22B-Instruct
 
-## Introduction
+## 1 Introduction
 
-The Qwen-VL(Vision-Language)series from Alibaba Cloud comprises a family of powerful Large Vision-Language Models (LVLMs) designed for comprehensive multimodal understanding. They accept images, text, and bounding boxes as input, and output text and detection boxes, enabling advanced functions like image detection, multi-modal dialogue, and multi-image reasoning.
+Qwen3-VL-235B-A22B-Instruct is a large-scale sparse MoE vision-language model in the Qwen3-VL family. It is designed for multimodal chat, image understanding, multi-image reasoning, OCR-like visual question answering, and long-context generation.
 
-This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, NPU deployment, accuracy and performance evaluation.
+This document describes the main validation steps for the model, including supported features, prerequisites, installation, single-node online deployment, multi-node deployment, Prefill-Decode (PD) disaggregation, functional verification, accuracy and performance evaluation, performance tuning, and FAQs.
 
-This tutorial uses the vLLM-Ascend `v0.11.0rc2` version for demonstration, showcasing the `Qwen3-VL-235B-A22B-Instruct` model as an example for multi-NPU deployment.
+The `Qwen3-VL-235B-A22B-Instruct` tutorial was introduced in the vLLM-Ascend validation cycle around `v0.12.0`. Use the current `vllm-ascend` documentation image placeholder or a later release for the examples below.
 
-## Supported Features
+## 2 Supported Features
 
-Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
+Refer to [Supported Features List](../../user_guide/support_matrix/supported_features.md) to get the model's supported feature matrix.
 
-Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
+Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
-## Environment Preparation
+## 3 Prerequisites
 
-### Model Weight
+### 3.1 Model Weight
 
-- `Qwen3-VL-235B-A22B-Instruct`(BF16 version): require 1 Atlas 800 A3 (64G × 16) node，2 Atlas 800 A2（64G × 8）nodes. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct/)
+- `Qwen3-VL-235B-A22B-Instruct` (BF16 version): requires 1 Atlas 800 A3 (64G x 16) node or 2 Atlas 800 A2 (64G x 8) nodes. [Model Weight](https://modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct/).
+- `Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot` (quantized version used by single-node validation): requires 1 Atlas 800 A3 (64G x 16) node. [Model Weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot).
+- `Qwen3-VL-235B-A22B-Instruct-w8a8-mxfp8` (quantized version): requires 1 Ascend 950DT (96G x 8) node. [Model Weight]#TODO
 
-It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
+It is recommended to download the model weight to a shared directory across multiple nodes.
 
-### Verify Multi-node Communication(Optional)
+### 3.2 Verify Multi-node Communication (Optional)
 
-If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).
+If you want to deploy the model in a multi-node environment, verify the communication environment according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).
 
-### Installation
+## 4 Installation
 
-=== "Use docker image"
+### 4.1 Docker Image Installation
 
-    For example, using images `quay.io/ascend/vllm-ascend:v0.11.0rc2`(for Atlas 800 A2) and `quay.io/ascend/vllm-ascend:v0.11.0rc2-a3`(for Atlas 800 A3).
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 
-    Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+=== "Ascend 950DT series"
+
+    Start the docker image on your each node.
 
     ```bash
-      # Update --device according to your device (Atlas A2: /dev/davinci[0-7] Atlas A3:/dev/davinci[0-15]).
-      # Update the vllm-ascend image according to your environment.
-      # Note you should download the weight to /root/.cache in advance.
-      # Update the vllm-ascend image
-      export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
-      export NAME=vllm-ascend
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-#TODO
+    export NAME=vllm-ascend
 
-      # Run the container using the defined variables
-      # Note: If you are running bridge network with docker, please expose available ports for multiple nodes communication in advance
-      docker run --rm \
+    docker run --rm \
       --name $NAME \
       --net=host \
-      --privileged=true \
-      --shm-size=500g \
+      --shm-size=1g \
       --device /dev/davinci0 \
       --device /dev/davinci1 \
       --device /dev/davinci2 \
@@ -58,41 +55,272 @@ If you want to deploy multi-node environment, you need to verify multi-node comm
       --device /dev/davinci6 \
       --device /dev/davinci7 \
       --device /dev/davinci_manager \
-      --device /dev/devmm_svm \
       --device /dev/hisi_hdc \
-      -v /usr/local/dcmi:/usr/local/dcmi \
-      -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
-      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-      -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      --device /dev/ummu \
+      --device /dev/uburma \
+      -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
       -v /etc/ascend_install.info:/etc/ascend_install.info \
-      -it $IMAGE bash
+      -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+      -v /etc/hixlep/:/etc/hixlep/ \
+      -v /root/.cache:/root/.cache \
+      -v /usr/local/sbin:/usr/local/sbin \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+      -v /usr/lib64:/usr/lib64 \
+      -itd $IMAGE bash
     ```
 
-=== "Build from source"
+=== "A3 series"
 
-    You can build all from source.
+    Start the docker image on each node.
 
-    - Install `vllm-ascend`, refer to [set up using python](../../installation.md#set-up-using-python).
+    ```bash
 
-If you want to deploy multi-node environment, you need to set up environment on each node.
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=512g \
+        --net=host \
+        --privileged=true \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci2 \
+        --device /dev/davinci3 \
+        --device /dev/davinci4 \
+        --device /dev/davinci5 \
+        --device /dev/davinci6 \
+        --device /dev/davinci7 \
+        --device /dev/davinci8 \
+        --device /dev/davinci9 \
+        --device /dev/davinci10 \
+        --device /dev/davinci11 \
+        --device /dev/davinci12 \
+        --device /dev/davinci13 \
+        --device /dev/davinci14 \
+        --device /dev/davinci15 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
+        -it $IMAGE bash
+    ```
 
-## Deployment
+=== "A2 series"
 
-### Multi-node Deployment with MP (Recommended)
+    Start the docker image on each node.
 
-Assume you have Atlas 800 A3 (64G*16) nodes (or 2* A2), and want to deploy the `Qwen3-VL-235B-A22B-Instruct` model across multiple nodes.
+    ```bash
 
-Node 0
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=512g \
+        --net=host \
+        --privileged=true \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci2 \
+        --device /dev/davinci3 \
+        --device /dev/davinci4 \
+        --device /dev/davinci5 \
+        --device /dev/davinci6 \
+        --device /dev/davinci7 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
+        -it $IMAGE bash
+    ```
+
+After starting the container, run the following command to verify the installation:
+
+```bash
+docker ps | grep vllm-ascend
+```
+
+Expected result: The container is listed with status `Up`. You can also verify the vllm-ascend version inside the container:
+
+```bash
+pip show vllm-ascend
+```
+
+Expected result: The version information is displayed, matching the pulled image version.
+
+### 4.2 Source Code Installation
+
+If you prefer not to use the Docker image, you can build from source. Install vLLM from source first:
+
+1. Clone and install vLLM:
+
+   ```bash
+   git clone https://github.com/vllm-project/vllm.git
+   cd vllm
+   pip install -e .
+   ```
+
+2. Clone and install the vLLM-Ascend repository:
+
+   ```bash
+   git clone https://github.com/vllm-project/vllm-ascend.git
+   cd vllm-ascend
+   pip install -e .
+   ```
+
+**Installation Verification:**
+
+```bash
+pip show vllm vllm-ascend
+```
+
+Expected result: The version information for both packages is displayed, confirming a successful installation.
+
+!!! note
+
+    If deploying a multi-node environment, set up the environment on each node.
+
+For more details, please refer to the [Installation Guide](../../installation.md).
+
+## 5 Online Service Deployment
+
+### 5.1 Single-Node Online Deployment
+
+Single-node deployment runs both Prefill and Decode on the same node. The W8A8 version needs `--quantization ascend`.
+
+=== "Ascend 950DT series"
+
+    Run the following script to execute online inference on 1 Ascend 950DT (96G x 8). The quantized version (`Qwen3-VL-235B-A22B-Instruct-w8a8-mxfp8`) can be deployed on a single Ascend 950DT node.
+
+    ```shell
+    #!/bin/sh
+
+    # Load model from ModelScope to speed up download.
+    export VLLM_USE_MODELSCOPE=True
+
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=400
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=100
+    export TASK_QUEUE_ENABLE=1
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+    vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-mxfp8 \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --distributed-executor-backend mp \
+      --data-parallel-size 1 \
+      --tensor-parallel-size 8 \
+      --enable-expert-parallel \
+      --seed 1024 \
+      --quantization ascend \
+      --served-model-name qwen3-vl-235b \
+      --max-num-seqs 32 \
+      --max-model-len 32768 \
+      --max-num-batched-tokens 8192 \
+      --trust-remote-code \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0 \
+      --limit-mm-per-prompt.image 1 \
+      --limit-mm-per-prompt.video 0 \
+      --gpu-memory-utilization 0.9 \
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+    ```
+
+=== "A3 series"
+
+    Run the following script to start online serving on 1 Atlas 800 A3 (64G x 16) node. The W8A8 example is suitable for functional validation and image-only online serving.
+
+    ```shell
+    #!/bin/sh
+
+    # Load model from ModelScope to speed up download.
+    export VLLM_USE_MODELSCOPE=True
+
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=1536
+    export OMP_NUM_THREADS=1
+    export OMP_PROC_BIND=false
+    export TASK_QUEUE_ENABLE=1
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+    export VLLM_ASCEND_BALANCE_SCHEDULING=1
+
+    vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --served-model-name qwen3-vl-235b \
+      --quantization ascend \
+      --data-parallel-size 4 \
+      --tensor-parallel-size 4 \
+      --enable-expert-parallel \
+      --seed 1024 \
+      --max-num-seqs 32 \
+      --max-model-len 32768 \
+      --max-num-batched-tokens 16384 \
+      --trust-remote-code \
+      --gpu-memory-utilization 0.92 \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0 \
+      --limit-mm-per-prompt.image 1 \
+      --limit-mm-per-prompt.video 0 \
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,24,32]}'
+    ```
+
+=== "A2 series"
+
+    For W8A8 deployment on A2, 2 Atlas 800 A2 (64G x 8) nodes are required. Refer to [Section 5.2](#52-multi-node-deployment-with-mp-recommended-for-bf16) for multi-node MP deployment.
+
+Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
+
+**Key parameters:**
+
+- `--data-parallel-size 4` and `--tensor-parallel-size 4` map the 16 NPUs on one A3 node into four DP groups, each with TP4.
+- `--enable-expert-parallel` enables expert parallelism for MoE layers. Do not mix MoE tensor parallelism and expert parallelism in the same MoE layer.
+- `--max-model-len` is the maximum input plus output length for a single request. Multimodal inputs consume text tokens and visual tokens, so increase it only when enough KV cache is available.
+- `--max-num-seqs` is the maximum number of active requests scheduled by each DP group. For performance tests, set `--max-num-seqs * --data-parallel-size` greater than or equal to the test concurrency.
+- `--max-num-batched-tokens` is the maximum number of tokens processed in one scheduler step. A larger value can improve prefill efficiency but consumes more activation memory.
+- `--gpu-memory-utilization` controls how much HBM vLLM can use to calculate KV cache capacity. A higher value increases KV cache size but can trigger OOM if runtime memory is higher than the profile run.
+- `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.
+- `--limit-mm-per-prompt.image 1` and `--limit-mm-per-prompt.video 0` reserve multimodal capacity for one image per request and disable video inputs to save memory.
+- `--mm-processor-cache-gb 0` disables the multimodal processor cache. Increase it only when your workload benefits from reused media preprocessing and you have enough host memory.
+- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full decode ACLGraph replay to reduce dispatch overhead.
+
+### 5.2 Multi-Node Deployment with MP (Recommended for BF16)
+
+Multi-node MP deployment uses vLLM data parallelism across nodes and tensor parallelism within each node. It is recommended for the BF16 model on 2 Atlas 800 A2 (64G x 8) nodes, or for long-context validation where one node does not provide enough HBM headroom.
+
+Assume you have 2 Atlas 800 A2 nodes and want to deploy `Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot` across them. Replace `nic_name`, `local_ip`, and `node0_ip` with the actual network interface and IP addresses in your environment.
+
+Run the following script on node 0.
 
 ```shell
 #!/bin/sh
-# Load model from ModelScope to speed up download
+
 export VLLM_USE_MODELSCOPE=True
-# To reduce memory fragmentation and avoid out of memory
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-# this obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
+
+# Get these values through ifconfig.
+# nic_name is the network interface name corresponding to local_ip.
 nic_name="xxxx"
 local_ip="xxxx"
 
@@ -106,39 +334,48 @@ export HCCL_BUFFSIZE=1024
 export TASK_QUEUE_ENABLE=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 
-vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
---host 0.0.0.0 \
---port 8000 \
---data-parallel-size 2 \
---api-server-count 2 \
---data-parallel-size-local 1 \
---data-parallel-address $local_ip \
---data-parallel-rpc-port 13389 \
---seed 1024 \
---served-model-name qwen3 \
---tensor-parallel-size 8 \
---enable-expert-parallel \
---max-num-seqs 16 \
---max-model-len 262144 \
---max-num-batched-tokens 4096 \
---trust-remote-code \
---gpu-memory-utilization 0.9 \
+vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --quantization ascend \
+  --data-parallel-size 2 \
+  --api-server-count 2 \
+  --data-parallel-size-local 1 \
+  --data-parallel-address $local_ip \
+  --data-parallel-rpc-port 13389 \
+  --seed 1024 \
+  --served-model-name qwen3-vl-235b \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel \
+  --max-num-seqs 16 \
+  --max-model-len 262144 \
+  --max-num-batched-tokens 4096 \
+  --trust-remote-code \
+  --gpu-memory-utilization 0.9 \
+  --no-enable-prefix-caching \
+  --mm-processor-cache-gb 0 \
+  --limit-mm-per-prompt.image 1 \
+  --limit-mm-per-prompt.video 0 \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+  --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
 ```
 
-Node1
+Common Issues Tip: If node 1 cannot join the service or HCCL initialization times out, refer to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication) and [Public FAQs](../../faqs.md). Make sure the network interface names, IP addresses, and RPC ports are consistent across nodes.
+
+Run the following script on node 1.
 
 ```shell
 #!/bin/sh
-# Load model from ModelScope to speed up download
+
 export VLLM_USE_MODELSCOPE=True
-# To reduce memory fragmentation and avoid out of memory
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-# this is obtained through ifconfig
-# nic_name is the network interface name corresponding to local_ip of the current node
+
+# Get these values through ifconfig.
+# nic_name is the network interface name corresponding to local_ip.
 nic_name="xxxx"
 local_ip="xxxx"
 
-# The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+# The value of node0_ip must be consistent with local_ip on node 0.
 node0_ip="xxxx"
 
 export HCCL_IF_IP=$local_ip
@@ -151,44 +388,34 @@ export HCCL_BUFFSIZE=1024
 export TASK_QUEUE_ENABLE=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 
-vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
---host 0.0.0.0 \
---port 8000 \
---headless \
---data-parallel-size 2 \
---data-parallel-size-local 1 \
---data-parallel-start-rank 1 \
---data-parallel-address $node0_ip \
---data-parallel-rpc-port 13389 \
---seed 1024 \
---tensor-parallel-size 8 \
---served-model-name qwen3 \
---max-num-seqs 16 \
---max-model-len 262144 \
---max-num-batched-tokens 4096 \
---enable-expert-parallel \
---trust-remote-code \
---gpu-memory-utilization 0.9 \
+vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --quantization ascend \
+  --headless \
+  --data-parallel-size 2 \
+  --data-parallel-size-local 1 \
+  --data-parallel-start-rank 1 \
+  --data-parallel-address $node0_ip \
+  --data-parallel-rpc-port 13389 \
+  --seed 1024 \
+  --tensor-parallel-size 8 \
+  --served-model-name qwen3-vl-235b \
+  --max-num-seqs 16 \
+  --max-model-len 262144 \
+  --max-num-batched-tokens 4096 \
+  --enable-expert-parallel \
+  --trust-remote-code \
+  --gpu-memory-utilization 0.9 \
+  --no-enable-prefix-caching \
+  --mm-processor-cache-gb 0 \
+  --limit-mm-per-prompt.image 1 \
+  --limit-mm-per-prompt.video 0 \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+  --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
 ```
 
-The parameters are explained as follows:
-
-- `--max-model-len` represents the context length, which is the maximum value of the input plus output for a single request.
-- `--max-num-seqs` indicates the maximum number of requests that each DP group is allowed to process. If the number of requests sent to the service exceeds this limit, the excess requests will remain in a waiting state and will not be scheduled. Note that the time spent in the waiting state is also counted in metrics such as TTFT and TPOT. Therefore, when testing performance, it is generally recommended that `--max-num-seqs` * `--data-parallel-size` >= the actual total concurrency.
-- `--max-num-batched-tokens` represents the maximum number of tokens that the model can process in a single step. Currently, vLLM v1 scheduling enables ChunkPrefill/SplitFuse by default, which means:
-    - (1) If the input length of a request is greater than `--max-num-batched-tokens`, it will be divided into multiple rounds of computation according to `--max-num-batched-tokens`;
-    - (2) Decode requests are prioritized for scheduling, and prefill requests are scheduled only if there is available capacity.
-    - Generally, if `--max-num-batched-tokens` is set to a larger value, the overall latency will be lower, but the pressure on GPU memory (activation value usage) will be greater.
-- `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Its essential function is to calculate the available kv_cache size. During the warm-up phase (referred to as profile run in vLLM), vLLM records the peak GPU memory usage during an inference process with an input size of `--max-num-batched-tokens`. The available kv_cache size is then calculated as: `--gpu-memory-utilization` * HBM size - peak GPU memory usage. Therefore, the larger the value of `--gpu-memory-utilization`, the more kv_cache can be used. However, since the GPU memory usage during the warm-up phase may differ from that during actual inference (e.g., due to uneven EP load), setting `--gpu-memory-utilization` too high may lead to OOM (Out of Memory) issues during actual inference. The default value is `0.9`.
-- `--enable-expert-parallel` indicates that EP is enabled. Note that vLLM does not support a mixed approach of ETP and EP; that is, MoE can either use pure EP or pure TP.
-- `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
-- `--quantization` "ascend" indicates that quantization is used. To disable quantization, remove this option.
-- `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are "cudagraph_mode" and "cudagraph_capture_sizes", which have the following meanings:
-"cudagraph_mode": represents the specific graph mode. Currently, "PIECEWISE" and "FULL_DECODE_ONLY" are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, "FULL_DECODE_ONLY" is recommended.
-- "cudagraph_capture_sizes": represents different levels of graph modes. The default value is [1, 2, 4, 8, 16, 24, 32, 40,..., `--max-num-seqs`]. In the graph mode, the input for graphs at different levels is fixed, and inputs between levels are automatically padded to the next level. Currently, the default setting is recommended. Only in some scenarios is it necessary to set this separately to achieve optimal performance.
-- `export VLLM_ASCEND_ENABLE_FLASHCOMM1=1` indicates that Flashcomm1 optimization is enabled. Currently, this optimization is only supported for MoE in scenarios where tp_size > 1.
-
-If the service starts successfully, the following information will be displayed on node 0:
+If the service starts successfully, the following information is displayed on node 0:
 
 ```shell
 INFO:     Started server process [44610]
@@ -199,70 +426,318 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete.
 ```
 
-### Multi-node Deployment with Ray
+**Key parameters for MP deployment:**
 
-- refer to [Ray Distributed (Qwen/Qwen3-235B-A22B)](../features/ray.md).
+- `--data-parallel-size` is the global DP size across all nodes. In the example, 2 DP ranks are used.
+- `--data-parallel-size-local` is the number of DP ranks on the current node. In the example, each A2 node has 1 local DP rank.
+- `--data-parallel-start-rank` is the first DP rank on the current node. Node 0 starts from 0 by default, and node 1 starts from 1.
+- `--data-parallel-address` must point to the master DP node. Use node 0 `local_ip` on node 0 and `node0_ip` on other nodes.
+- `--data-parallel-rpc-port` is the DP RPC port. Use the same value on all nodes and ensure the port is available.
+- `--api-server-count` controls how many API server processes are started on the master node.
+- `--headless` starts a worker node without exposing an API server. Use it on non-master nodes.
+- `--tensor-parallel-size 8` maps one TP group to the 8 NPUs on each A2 node.
+- `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` bind HCCL, Gloo, and TP communication to the selected network.
 
-### Prefill-Decode Disaggregation
+### 5.3 Multi-Node PD Separation Deployment
 
-- refer to [Prefill-Decode Disaggregation Mooncake Verification](../features/pd_disaggregation_mooncake_multi_node.md)
+PD disaggregation separates Prefill and Decode into different service groups. Prefill nodes process large prompt chunks, Decode nodes serve token generation, and a proxy forwards requests between them. This mode is suitable for production serving scenarios where prefill and decode resource ratios need to be tuned separately.
 
-## Functional Verification
+We recommend using Mooncake for deployment. Refer to [Mooncake](../features/pd_disaggregation_mooncake_multi_node.md) for the general PD disaggregation workflow and request forwarding setup.
 
-Once your server is started, you can query the model with input prompts:
+The following example matches the validated A3 two-node topology for `Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot`:
 
-```shell  
-curl http://<node0_ip>:<port>/v1/chat/completions \
+- 1 Prefill node: 1 Atlas 800 A3 (64G x 16), DP2 + TP8 + EP.
+- 1 Decode node: 1 Atlas 800 A3 (64G x 16), DP4 + TP4 + EP + full decode ACLGraph.
+
+#### 5.3.1 Prefill Node
+
+Create `run_p.sh` on the prefill node.
+
+```shell
+#!/bin/bash
+
+export VLLM_USE_MODELSCOPE=True
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_BUFFSIZE=1024
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export TASK_QUEUE_ENABLE=1
+
+vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --quantization ascend \
+  --data-parallel-size 2 \
+  --data-parallel-size-local 2 \
+  --tensor-parallel-size 8 \
+  --seed 1024 \
+  --served-model-name qwen3-vl-235b \
+  --enable-expert-parallel \
+  --max-num-seqs 32 \
+  --max-model-len 8192 \
+  --max-num-batched-tokens 8192 \
+  --trust-remote-code \
+  --no-enable-prefix-caching \
+  --gpu-memory-utilization 0.9 \
+  --kv-transfer-config \
+  '{"kv_connector":"MooncakeConnectorV1",
+    "kv_role":"kv_producer",
+    "kv_port":"30000",
+    "kv_connector_extra_config":{
+      "prefill":{"dp_size":2,"tp_size":8},
+      "decode":{"dp_size":4,"tp_size":4}
+    }
+  }'
+```
+
+Common Issues Tip: If the prefill service is not ready for a long time, check whether the model path is shared, all 16 NPUs are visible, and the Mooncake `kv_port` is available.
+
+#### 5.3.2 Decode Node
+
+Create `run_d.sh` on the decode node.
+
+```shell
+#!/bin/bash
+
+export VLLM_USE_MODELSCOPE=True
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_BUFFSIZE=1024
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+export TASK_QUEUE_ENABLE=1
+
+vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --quantization ascend \
+  --data-parallel-size 4 \
+  --data-parallel-size-local 4 \
+  --tensor-parallel-size 4 \
+  --seed 1024 \
+  --served-model-name qwen3-vl-235b \
+  --enable-expert-parallel \
+  --max-num-seqs 32 \
+  --max-model-len 8192 \
+  --max-num-batched-tokens 8192 \
+  --trust-remote-code \
+  --no-enable-prefix-caching \
+  --gpu-memory-utilization 0.9 \
+  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+  --kv-transfer-config \
+  '{"kv_connector":"MooncakeConnectorV1",
+    "kv_role":"kv_consumer",
+    "kv_port":"30200",
+    "kv_connector_extra_config":{
+      "prefill":{"dp_size":2,"tp_size":8},
+      "decode":{"dp_size":4,"tp_size":4}
+    }
+  }'
+```
+
+**Key parameters for PD disaggregation:**
+
+- Prefill uses `--data-parallel-size 2`, `--data-parallel-size-local 2`, and `--tensor-parallel-size 8`.
+- Decode uses `--data-parallel-size 4`, `--data-parallel-size-local 4`, and `--tensor-parallel-size 4`.
+- `--max-num-batched-tokens` is set to 8192 on both sides in this validation topology. Increase the prefill value only if activation memory is sufficient.
+- `--kv-transfer-config` sets the Mooncake connector. `kv_role` is `kv_producer` on prefill and `kv_consumer` on decode.
+- `kv_connector_extra_config.prefill.dp_size/tp_size` and `decode.dp_size/tp_size` must match the actual global DP and TP layout.
+- `--no-enable-prefix-caching` disables prefix caching. For PD disaggregation, first validate the service without prefix caching before enabling additional cache features.
+- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` is recommended on decode nodes to reduce decode dispatch overhead.
+  
+Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
+
+Service Verification:
+
+```shell
+curl http://<server_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-    "model": "qwen3",
-    "messages": [
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": [
-        {"type": "image_url", "image_url": {"url": "https://modelscope.oss-cn-beijing.aliyuncs.com/resource/qwen.png"}},
-        {"type": "text", "text": "What is the text in the illustration?"}
-    ]}
-    ]
+        "model": "qwen3-vl-235b",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Who are you?"
+            }
+        ],
+        "max_tokens": 256,
+        "temperature": 0
     }'
 ```
 
-## Accuracy Evaluation
+Expected Result:
 
-Here are two accuracy evaluation methods.
+The service returns HTTP 200 OK with a JSON response containing the `choices` field.
+
+## 6 Functional Verification
+
+After the server is started, send a request to verify basic multimodal functionality. For single-node and MP deployment, use the API endpoint on node 0. For PD disaggregation, use the proxy endpoint from the Mooncake deployment guide.
+
+```shell
+curl http://<server_ip>:<port>/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-vl-235b",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": "https://modelscope.oss-cn-beijing.aliyuncs.com/resource/qwen.png"}},
+        {"type": "text", "text": "What is the text in the illustration?"}
+      ]}
+    ],
+    "max_completion_tokens": 100,
+    "temperature": 0
+  }'
+```
+
+Expected result: the HTTP status is 200 and the JSON response contains a `choices` field with generated text, for example text similar to `TONGYI Qwen`.
+
+## 7 Accuracy Evaluation
 
 ### Using AISBench
 
 1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
 
-2. After execution, you can get the result, here is the result of `Qwen3-VL-235B-A22B-Instruct` in `vllm-ascend:0.11.0rc2` for reference only.
+2. After execution, you can get the result.
 
-| dataset  | version | metric   | mode | vllm-api-general-chat |
-| -------- | ------- | -------- | ---- | --------------------- |
-| aime2024 | -       | accuracy | gen  |             93        |
+| dataset | version | metric | mode | vllm-api-general-chat |
+| ------- | ------- | ------ | ---- | --------------------- |
+| textvqa-lite | - | accuracy | gen | 83 |
+| aime2024 | - | accuracy | gen | 93 |
 
-## Performance
+## 8 Performance Evaluation
 
-### Using AISBench
+### 8.1 Using AISBench
 
-Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
+Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details. For multimodal performance, use a dataset with image payloads, such as TextVQA-style requests, instead of random text-only prompts.
 
-### Using vLLM Benchmark
+### 8.2 Using vLLM Benchmark
 
-Run performance evaluation of `Qwen3-VL-235B-A22B-Instruct` as an example.
-
-Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
+Run performance evaluation of `Qwen3-VL-235B-A22B-Instruct` as an example. Refer to [vLLM benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
 
 There are three `vllm bench` subcommands:
 
-- `latency`: Benchmark the latency of a single batch of requests.
-- `serve`: Benchmark the online serving throughput.
-- `throughput`: Benchmark offline inference throughput.
+- `latency`: benchmark the latency of a single batch of requests.
+- `serve`: benchmark online serving throughput.
+- `throughput`: benchmark offline inference throughput.
 
-Take the `serve` as an example. Run the code as follows.
+Take `serve` as an example:
 
 ```shell
 export VLLM_USE_MODELSCOPE=True
-vllm bench serve --model Qwen/Qwen3-VL-235B-A22B-Instruct  --dataset-name random --random-input 200 --num-prompts 200 --request-rate 1 --save-result --result-dir ./
+
+vllm bench serve \
+  --model Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+  --served-model-name qwen3-vl-235b \
+  --dataset-name random \
+  --random-input 200 \
+  --num-prompts 200 \
+  --request-rate 1 \
+  --save-result \
+  --result-dir ./
 ```
 
-After about several minutes, you can get the performance evaluation result.
+After several minutes, you can get the performance evaluation result. This random benchmark is useful for serving pipeline validation; use AISBench or a custom multimodal dataset for image-token performance.
+
+## 9 Performance Tuning
+
+### 9.1 Recommended Configurations
+
+> **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on hardware type, maximum input/output length, image resolution, request concurrency, prefix cache hit rate, quantization, and prefill/decode ratio. Tune the parameters in Section 9.2 based on your actual workload.
+
+#### Table 1: Scenario Overview
+
+| Scenario | Deployment Mode | *Total NPUs | Weight Version | Key Considerations |
+| -------- | --------------- | ---------- | -------------- | ------------------ |
+| Functional validation | Single-node online serving | 16 A3 NPUs | W8A8 | Use shorter context, disable video, and set `--mm-processor-cache-gb 0` to reduce memory pressure. |
+| Long context | Multi-node MP | 16 A3 NPUs | W8A8 | Use TP across each node and DP across nodes. Lower image count or context length if OOM occurs. |
+| Low latency | 1P1D PD disaggregation | 32 A3 NPUs | W8A8 | Separate prefill and decode resources and enable full decode ACLGraph on decode nodes. |
+
+> `*Total NPUs` indicates the total number of NPUs used across all nodes. 1 node = 1 Atlas 800 A3 server (64G × 16 NPUs).
+
+#### Table 2: Detailed Node Configuration
+
+| Scenario | Node Role | NPUs | TP | DP | Max Num Seqs | Max Model Len | Max Num Batched Tokens | Prefix Cache | Main Optimizations |
+| -------- | --------- | ---- | -- | -- | ------------ | ------------- | ---------------------- | ------------ | ------------------ |
+| Functional validation | Single node | 16 | 4 | 4 | 32 | 32768 | 16384 | Off | W8A8, FullGraph, FlashComm1, Fused MC2 |
+| Long context | MP node | 8 per node | 8 | 1 per node, 2 global | 16 per DP | 262144 | 4096 | Off | FullGraph, FlashComm1, CPU binding |
+| Low latency | Prefill node | 16 | 8 | 2 | 32 | 8192 | 8192 | Off | Mooncake KV producer, EP |
+| Low latency | Decode node | 16 | 4 | 4 | 32 | 8192 | 8192 | Off | Mooncake KV consumer, FullGraph, EP |
+
+> For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
+
+### 9.2 Tuning Guidelines
+
+#### 9.2.1 General Tuning Reference
+
+Please refer to the [Public Performance Tuning Documentation](../../developer_guide/performance_and_debug/optimization_and_tuning.md) for tuning methods.
+
+Please refer to the [Feature Guide](../../user_guide/support_matrix/feature_matrix.md) for detailed feature descriptions.
+
+#### 9.2.2 Recommended tuning order
+
+1. Set the deployment topology first. Use single-node deployment for validation, MP deployment for simple multi-node serving, and PD disaggregation when prefill and decode need different resource ratios.
+2. Choose the maximum context length with `--max-model-len`. Multimodal requests consume KV cache for both text tokens and visual tokens, so reduce image resolution, image count, `--max-num-seqs`, or context length if OOM occurs.
+3. Tune multimodal limits. Use `--limit-mm-per-prompt.image` and `--limit-mm-per-prompt.video` to match your request shape. Disable video with `--limit-mm-per-prompt.video 0` for image-only services.
+4. Tune `--max-num-batched-tokens`. Larger values usually improve prefill throughput but increase activation memory. Decode-heavy workloads usually need smaller values.
+5. Tune `--max-num-seqs` according to service concurrency. Requests above this value wait in the queue and the waiting time is counted in TTFT and TPOT.
+6. Tune `--gpu-memory-utilization`. Increase it to provide more KV cache, but leave headroom for runtime memory fluctuation, image preprocessing, and expert imbalance.
+7. Tune ACLGraph capture. `FULL_DECODE_ONLY` is recommended for decode. If you set `cudagraph_capture_sizes` manually, include common decode batch sizes.
+
+### 9.3 Model-Specific Optimizations
+
+| Optimization | Enablement | Benefit | Notes |
+| ------------ | ---------- | ------- | ----- |
+| Multimodal prompt limits | `--limit-mm-per-prompt.image`, `--limit-mm-per-prompt.video` | Avoids reserving memory for unused media types. | Disable video for image-only serving. |
+| Multimodal processor cache | `--mm-processor-cache-gb` | Caches processed media features when repeated media appears. | Set to 0 for memory-constrained validation. |
+| Full decode ACLGraph | `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` | Reduces operator dispatch overhead and stabilizes decode performance. | Recommended for decode-heavy serving. |
+| FlashComm1 | `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` or `--additional-config '{"enable_flashcomm1":true}'` | Reduces communication overhead in large TP and high-concurrency scenarios. | May not help low-concurrency workloads. |
+| Fused MC2 | `VLLM_ASCEND_ENABLE_FUSED_MC2=1` | Enables MoE fused operators to improve MoE efficiency. | Compare with disabled state if accuracy or performance regresses. |
+| Prefix caching | `--enable-prefix-caching` | Improves repeated-prefix workloads. | Validate HBM usage first. For PD, start with prefix caching disabled. |
+| Asynchronous scheduling | `--async-scheduling` | Can improve high-concurrency throughput. | Disable and compare for latency-sensitive workloads. |
+| PD disaggregation | `--kv-transfer-config` | Separates prefill and decode resources. | Ensure producer/consumer DP and TP sizes match the actual topology. |
+
+## 10 FAQ
+
+For common environment, installation, and general parameter issues, refer to [Public FAQs](../../faqs.md). This section only covers model-specific issues for Qwen3-VL-235B-A22B-Instruct.
+
+### Q1: Why does the service report OOM during startup or soon after accepting requests?
+
+**Phenomenon:** The service fails during profile run, or it starts successfully but reports OOM when real traffic arrives.
+
+**Cause:** Qwen3-VL-235B-A22B-Instruct has high weight, KV cache, and multimodal preprocessing memory requirements. Large `--max-model-len`, large `--max-num-seqs`, large `--max-num-batched-tokens`, high image resolution, too many images per prompt, or high `--gpu-memory-utilization` can leave insufficient HBM headroom.
+
+**Solution:** Use the W8A8 model with `--quantization ascend` when possible, lower `--max-model-len`, lower `--max-num-seqs`, lower `--max-num-batched-tokens`, lower image/video limits, or reduce `--gpu-memory-utilization`. Keep `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True`.
+
+### Q2: Why does multi-node MP deployment hang during initialization?
+
+**Phenomenon:** One node waits for other ranks, HCCL initialization times out, or the headless node exits.
+
+**Cause:** Network interface names, IP addresses, DP ranks, or RPC ports are inconsistent across nodes.
+
+**Solution:** Verify multi-node communication first. Ensure `HCCL_IF_IP`, `GLOO_SOCKET_IFNAME`, `TP_SOCKET_IFNAME`, and `HCCL_SOCKET_IFNAME` match the selected NIC. Ensure all nodes use the same `--data-parallel-rpc-port`, non-master nodes use `--headless`, and `--data-parallel-start-rank` does not overlap.
+
+### Q3: Why is video disabled in the image-only examples?
+
+**Phenomenon:** The service reserves more memory than expected, or startup OOM occurs even when requests only contain images.
+
+**Cause:** Allowing video inputs can reserve memory for long visual embeddings and preprocessing paths that are not needed by image-only workloads.
+
+**Solution:** Use `--limit-mm-per-prompt.video 0` for image-only serving. Enable video only when your workload needs it, and lower `--max-model-len` or request concurrency if needed.
+
+### Q4: Why does enabling prefix caching not improve performance?
+
+**Phenomenon:** Prefix caching is enabled, but throughput or latency does not improve.
+
+**Cause:** Prefix caching only helps when requests share reusable prefixes. Random prompts, unique images, or low cache hit rates may add memory pressure without visible gains.
+
+**Solution:** Enable prefix caching for repeated-prefix workloads. For random benchmark datasets, memory-constrained long-context workloads, or PD validation, compare with `--no-enable-prefix-caching`.
+
+### Q5: Why does PD disaggregation fail to transfer KV cache?
+
+**Phenomenon:** Requests reach the proxy or prefill service, but decode nodes do not produce output or report KV transfer errors.
+
+**Cause:** The Mooncake connector ports, producer/consumer roles, or `kv_connector_extra_config` DP/TP sizes do not match the actual topology.
+
+**Solution:** Check `kv_role`, `kv_port`, and the prefill/decode DP/TP sizes on all nodes. Start from the validated topology in Section 5.4, then change one dimension at a time.

--- a/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
@@ -1,196 +1,488 @@
 # Qwen3-VL-30B-A3B-Instruct
 
-## Introduction
+## 1 Introduction
 
-The Qwen-VL (Vision-Language) series from Alibaba Cloud comprises a family of powerful Large Vision-Language Models (LVLMs) designed for comprehensive multimodal understanding. They accept images, text, and bounding boxes as input, and output text and detection boxes, enabling advanced functions like image detection, multi-modal dialogue, and multi-image reasoning.
+Qwen3-VL-30B-A3B-Instruct is a sparse MoE vision-language model in the Qwen3-VL family, with about 30B total parameters and about 3B activated parameters per token. It is suitable for image understanding, video understanding, multimodal dialogue, and long-context online serving on Ascend hardware.
 
-This document will show the main verification steps of the `Qwen3-VL-30B-A3B-Instruct`.
+This document describes the main validation steps for the model, including supported features, prerequisites, installation, image and video online deployment, offline inference, functional verification, accuracy and performance evaluation, performance tuning, and FAQs.
 
-## Supported Features
+The `Qwen3-VL-30B-A3B-Instruct` tutorial was introduced for the `vllm-ascend` `v0.13.0` validation cycle. Use `v0.13.0` or later for this model. The examples below use the version placeholder configured by the documentation build system.
 
-- Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
-- Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
+## 2 Supported Features
 
-## Environment Preparation
+Refer to [Supported Features List](../../user_guide/support_matrix/supported_features.md) to get the model's supported feature matrix.
 
-### Prepare Model Weights
+Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
-Running this model requires 1 Atlas 800I A2 (64G × 8) node or 1 Atlas 800 A3 (64G × 16) node.
+## 3 Prerequisites
 
-Download model weight at [ModelScope Website](https://modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Instruct) or download by below command:
+### 3.1 Model Weight
+
+- `Qwen3-VL-30B-A3B-Instruct` (BF16 version): requires 1 Atlas 800 A3 (64G x 16) node or 1 Atlas 800 A2 (64G x 8) node. [Model Weight](https://modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Instruct).
+- `Qwen3-VL-30B-A3B-Instruct-w8a8-mxfp8` (quantized version): requires 1 Ascend 950DT (96G x 8) node. [Model Weight]#TODO
+
+It is recommended to download the model weight to a shared directory across multiple nodes.
+
+## 4 Installation
+
+### 4.1 Docker Image Installation
+
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+
+=== "Ascend 950DT series"
+
+    Start the docker image on your each node.
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-#TODO
+    export NAME=vllm-ascend
+
+    docker run --rm \
+      --name $NAME \
+      --net=host \
+      --shm-size=1g \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci2 \
+      --device /dev/davinci3 \
+      --device /dev/davinci4 \
+      --device /dev/davinci5 \
+      --device /dev/davinci6 \
+      --device /dev/davinci7 \
+      --device /dev/davinci_manager \
+      --device /dev/hisi_hdc \
+      --device /dev/ummu \
+      --device /dev/uburma \
+      -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+      -v /etc/hixlep/:/etc/hixlep/ \
+      -v /root/.cache:/root/.cache \
+      -v /usr/local/sbin:/usr/local/sbin \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+      -v /usr/lib64:/usr/lib64 \
+      -itd $IMAGE bash
+    ```
+
+=== "A3 series"
+
+    Start the docker image on each node.
+
+    ```bash
+
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=512g \
+        --net=host \
+        --privileged=true \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci2 \
+        --device /dev/davinci3 \
+        --device /dev/davinci4 \
+        --device /dev/davinci5 \
+        --device /dev/davinci6 \
+        --device /dev/davinci7 \
+        --device /dev/davinci8 \
+        --device /dev/davinci9 \
+        --device /dev/davinci10 \
+        --device /dev/davinci11 \
+        --device /dev/davinci12 \
+        --device /dev/davinci13 \
+        --device /dev/davinci14 \
+        --device /dev/davinci15 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
+        -it $IMAGE bash
+    ```
+
+=== "A2 series"
+
+    Start the docker image on each node.
+
+    ```bash
+
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=512g \
+        --net=host \
+        --privileged=true \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci2 \
+        --device /dev/davinci3 \
+        --device /dev/davinci4 \
+        --device /dev/davinci5 \
+        --device /dev/davinci6 \
+        --device /dev/davinci7 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /etc/hccn.conf:/etc/hccn.conf \
+        -v /root/.cache:/root/.cache \
+        -it $IMAGE bash
+    ```
+
+After starting the container, run the following command to verify the installation:
 
 ```bash
-pip install modelscope
-modelscope download --model Qwen/Qwen3-VL-30B-A3B-Instruct
+docker ps | grep vllm-ascend
 ```
 
-It is recommended to download the model weights to the shared directory of multiple nodes, such as `/root/.cache/`.
-
-### Installation
-
-Run docker container:
+Expected result: The container is listed with status `Up`. You can also verify the vllm-ascend version inside the container:
 
 ```bash
-# Update the vllm-ascend image
-export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
-
-docker run --rm \
---name vllm-ascend \
---shm-size=1g \
---net=host \
---device /dev/davinci0 \
---device /dev/davinci1 \
---device /dev/davinci_manager \
---device /dev/devmm_svm \
---device /dev/hisi_hdc \
--v /usr/local/dcmi:/usr/local/dcmi \
--v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
--v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
--v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
--v /etc/ascend_install.info:/etc/ascend_install.info \
--v /root/.cache:/root/.cache \
--v /data:/data \
--v <path/to/your/media>:/media \
--it $IMAGE bash
+pip show vllm-ascend
 ```
 
-Setup environment variables:
+Expected result: The version information is displayed, matching the pulled image version.
+
+### 4.2 Source Code Installation
+
+If you prefer not to use the Docker image, you can build from source. Install vLLM from source first:
+
+1. Clone and install vLLM:
+
+   ```bash
+   git clone https://github.com/vllm-project/vllm.git
+   cd vllm
+   pip install -e .
+   ```
+
+2. Clone and install the vLLM-Ascend repository:
+
+   ```bash
+   git clone https://github.com/vllm-project/vllm-ascend.git
+   cd vllm-ascend
+   pip install -e .
+   ```
+
+**Installation Verification:**
 
 ```bash
-# Load model from ModelScope to speed up download
-export VLLM_USE_MODELSCOPE=True
-
-# Set `max_split_size_mb` to reduce memory fragmentation and avoid out of memory
-export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:256
+pip show vllm vllm-ascend
 ```
+
+Expected result: The version information for both packages is displayed, confirming a successful installation.
 
 !!! note
 
-    `max_split_size_mb` prevents the native allocator from splitting blocks larger than this size (in MB). This can reduce fragmentation and may allow some borderline workloads to complete without running out of memory. You can find more details [<u>here</u>](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/800alpha003/apiref/envref/envref_07_0061.html).
+    If deploying a multi-node environment, set up the environment on each node.
 
-## Deployment
+For more details, please refer to the [Installation Guide](../../installation.md).
 
-### Online Serving
+## 5 Online Service Deployment
 
-=== "Image Inputs"
+### 5.1 Single-Node Online Deployment
 
-    Run the following command inside the container to start the vLLM server on multi-NPU:
+Single-node deployment runs both Prefill and Decode on the same node. The following examples are suitable for image-only online serving.
 
-    ```bash
-    vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
-    --tensor-parallel-size 2 \
-    --enable-expert-parallel \
-    --limit-mm-per-prompt.video 0 \
-    --max-model-len 128000
-    ```
+=== "Ascend 950DT series"
 
-    !!! note
-
-        vllm-ascend supports Expert Parallelism (EP) via `--enable-expert-parallel`, which allows experts in MoE models to be deployed on separate GPUs for better throughput.
-
-        It's highly recommended to specify `--limit-mm-per-prompt.video 0` if your inference server will only process image inputs since enabling video inputs consumes more memory reserved for long video embeddings.
-
-        You can set `--max-model-len` to preserve memory. By default the model's context length is 262K, but `--max-model-len 128000` is good for most scenarios.
-
-    If your service starts successfully, you can see the info shown below:
-
-    ```bash
-    INFO:     Started server process [746077]
-    INFO:     Waiting for application startup.
-    INFO:     Application startup complete.
-    ```
-
-    Once your server is started, you can query the model with input prompts:
-
-    ```bash
-    curl http://localhost:8000/v1/chat/completions \
-        -H "Content-Type: application/json" \
-        -d '{
-        "model": "Qwen/Qwen3-VL-30B-A3B-Instruct",
-        "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": [
-                {"type": "image_url", "image_url": {"url": "https://modelscope.oss-cn-beijing.aliyuncs.com/resource/qwen.png"}},
-                {"type": "text", "text": "What is the text in the illustration?"}
-            ]}
-        ],
-        "max_completion_tokens": 100
-        }'
-    ```
-
-    If you query the server successfully, you can see the info shown below (client):
-
-    ```bash
-    {"id":"chatcmpl-974cb7a7a746a13e","object":"chat.completion","created":1766569357,"model":"/root/.cache/modelscope/hub/models/Qwen/Qwen3-VL-30B-A3B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"The text in the illustration is \"TONGYI Qwen\".","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":107,"total_tokens":122,"completion_tokens":15,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
-    ```
-
-    Logs of the vllm server:
-
-    ```bash
-    INFO 12-24 09:42:37 [acl_graph.py:187] Replaying aclgraph
-    INFO:     127.0.0.1:54946 - "POST /v1/chat/completions HTTP/1.1" 200 OK
-    INFO 12-24 09:42:41 [loggers.py:257] Engine 000: Avg prompt throughput: 10.7 tokens/s, Avg generation throughput: 1.5 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
-    ```
-
-=== "Video Inputs"
-
-    Run the following command inside the container to start the vLLM server on multi-NPU:
+    Run the following script to execute online inference on 1 Ascend 950DT (96G x 8). The quantized version (`Qwen3-VL-30B-A3B-Instruct-w8a8-mxfp8`) can be deployed on a single Ascend 950DT node. The W8A8 version needs `--quantization ascend`.
 
     ```shell
+    #!/bin/sh
+
+    # Load model from ModelScope to speed up download.
+    export VLLM_USE_MODELSCOPE=True
+
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=400
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=100
+    export TASK_QUEUE_ENABLE=1
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+
+    vllm serve Eco-Tech/Qwen3-VL-30B-A3B-Instruct-w8a8-mxfp8 \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --distributed-executor-backend mp \
+      --data-parallel-size 1 \
+      --tensor-parallel-size 8 \
+      --enable-expert-parallel \
+      --seed 1024 \
+      --quantization ascend \
+      --served-model-name qwen3-vl-30b \
+      --max-num-seqs 32 \
+      --max-model-len 32768 \
+      --max-num-batched-tokens 8192 \
+      --trust-remote-code \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0 \
+      --limit-mm-per-prompt.image 1 \
+      --limit-mm-per-prompt.video 0 \
+      --gpu-memory-utilization 0.9 \
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+    ```
+
+=== "A3 series"
+
+    Run the following script to start image-only serving on 1 Atlas 800 A3 (64G x 16) node.
+
+    ```shell
+    #!/bin/sh
+
+    # Load model from ModelScope to speed up download.
+    export VLLM_USE_MODELSCOPE=True
+
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=1024
+    export OMP_NUM_THREADS=1
+    export OMP_PROC_BIND=false
+    export TASK_QUEUE_ENABLE=1
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+    export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+
     vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
-    --tensor-parallel-size 2 \
-    --enable-expert-parallel \
-    --max-model-len 128000 \
-    --allowed-local-media-path /media
+      --host 0.0.0.0 \
+      --port 8000 \
+      --served-model-name qwen3-vl-30b \
+      --data-parallel-size 1 \
+      --tensor-parallel-size 2 \
+      --enable-expert-parallel \
+      --seed 1024 \
+      --max-num-seqs 32 \
+      --max-model-len 32768 \
+      --max-num-batched-tokens 16384 \
+      --gpu-memory-utilization 0.9 \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0 \
+      --limit-mm-per-prompt.image 1 \
+      --limit-mm-per-prompt.video 0 \
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,24,32]}'
     ```
 
-    !!! note
+=== "A2 series"
 
-        vllm-ascend supports Expert Parallelism (EP) via `--enable-expert-parallel`, which allows experts in MoE models to be deployed on separate GPUs for better throughput.
+    The A3 series script above also works on 1 Atlas 800 A2 (64G x 8) node with `--tensor-parallel-size 2`.
 
-        You can set `--max-model-len` to preserve memory. By default the model's context length is 262K, but `--max-model-len 128000` is good for most scenarios.
+Key Parameter Descriptions:
 
-        Set `--allowed-local-media-path /media` to use your local video that located at `/media`, since directly download the video during serving can be extremely slow due to network issues.
+- `--tensor-parallel-size 2` maps the model to two NPUs. Increase TP only after validating memory, communication, and throughput on your hardware.
+- `--enable-expert-parallel` enables expert parallelism for MoE layers. Do not mix MoE tensor parallelism and expert parallelism in the same MoE layer.
+- `--max-model-len` is the maximum input plus output length for a single request. By default, the model can support long context, but `128000` is a practical validation value for many image/video workloads.
+- `--max-num-seqs` is the maximum number of active requests scheduled by each DP group. Video requests consume more memory, so the video example uses a smaller value.
+- `--max-num-batched-tokens` is the maximum number of tokens processed in one scheduler step. A larger value can improve prefill efficiency but consumes more activation memory.
+- `--gpu-memory-utilization` controls how much HBM vLLM can use to calculate KV cache capacity. Increase it only after confirming the service is stable.
+- `--limit-mm-per-prompt.video 0` disables video inputs and saves memory for image-only serving.
+- `--allowed-local-media-path /media` allows requests to use local files such as `file:///media/test.mp4`.
+- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full decode ACLGraph replay to reduce dispatch overhead.
 
-    If your service start successfully, you can see the info shown below:
+Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 
-    ```bash
-    INFO:     Started server process [746077]
-    INFO:     Waiting for application startup.
-    INFO:     Application startup complete.
-    ```
+Service Verification:
 
-    Once your server is started, you can query the model with input prompts:
-
-    ```bash
-    curl http://localhost:8000/v1/chat/completions \
-        -H "Content-Type: application/json" \
-        -d '{
-        "model": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+```shell
+curl http://<server_ip>:<port>/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3-vl-30b",
         "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": [
-                {"type": "video_url", "video_url": {"url": "file:///media/test.mp4"}},
-                {"type": "text", "text": "What is in this video?"}
-            ]}
+            {
+                "role": "user",
+                "content": "Who are you?"
+            }
         ],
-        "max_completion_tokens": 100
-        }'
-    ```
+        "max_tokens": 256,
+        "temperature": 0
+    }'
+```
 
-    If you query the server successfully, you can see the info shown below (client):
+Expected Result:
 
-    ```bash
-    {"id":"chatcmpl-a03c6d6e40267738","object":"chat.completion","created":1766569752,"model":"/root/.cache/modelscope/hub/models/Qwen/Qwen3-VL-30B-A3B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"The video shows a standard test pattern, which is a series of vertical bars in various colors (red, green, blue, yellow, magenta, cyan, and white) arranged in a circular pattern on a black background. This is a common visual used in television broadcasting to calibrate and test equipment. The pattern remains static throughout the video.","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":196,"total_tokens":266,"completion_tokens":70,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
-    ```
+The service returns HTTP 200 OK with a JSON response containing the `choices` field.
 
-    Logs of the vllm server:
+## 6 Functional Verification
 
-    ```bash
-    INFO:     127.0.0.1:49314 - "POST /v1/chat/completions HTTP/1.1" 200 OK
-    INFO 12-24 09:49:22 [loggers.py:257] Engine 000: Avg prompt throughput: 19.6 tokens/s, Avg generation throughput: 7.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 33.3%
-    ```
+After the server is started, send a request to verify basic multimodal functionality.
 
-### Offline Inference
+```shell
+curl http://<server_ip>:<port>/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-vl-30b",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": "https://modelscope.oss-cn-beijing.aliyuncs.com/resource/qwen.png"}},
+        {"type": "text", "text": "What is the text in the illustration?"}
+      ]}
+    ],
+    "max_completion_tokens": 100,
+    "temperature": 0
+  }'
+```
 
-The usage of offline inference with `Qwen3-VL-30B-A3B-Instruct` is totally the same as that of `Qwen3-VL-8B-Instruct`, find more details at [Qwen3-VL-8B-Instruct](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen-VL-Dense.html#offline-inference).
+Expected result: the HTTP status is 200 and the JSON response contains a `choices` field with generated text, for example text similar to `TONGYI Qwen`.
+
+## 7 Accuracy Evaluation
+
+### Using AISBench
+
+1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
+
+2. After execution, you can get the result.
+
+| dataset | version | metric | mode | result |
+| ------- | ------- | ------ | ---- | ------ |
+| mmmu_val | - | acc,none | gen | 0.58 |
+
+## 8 Performance Evaluation
+
+### 8.1 Using AISBench
+
+Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details. For image or video performance, use a dataset with real multimodal payloads instead of random text-only prompts.
+
+### 8.2 Using vLLM Benchmark
+
+Run performance evaluation of `Qwen3-VL-30B-A3B-Instruct` as an example. Refer to [vLLM benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
+
+There are three `vllm bench` subcommands:
+
+- `latency`: benchmark the latency of a single batch of requests.
+- `serve`: benchmark online serving throughput.
+- `throughput`: benchmark offline inference throughput.
+
+Take `serve` as an example:
+
+```shell
+export VLLM_USE_MODELSCOPE=True
+
+vllm bench serve \
+  --model Qwen/Qwen3-VL-30B-A3B-Instruct \
+  --served-model-name qwen3-vl-30b \
+  --dataset-name random \
+  --random-input 200 \
+  --num-prompts 200 \
+  --request-rate 1 \
+  --save-result \
+  --result-dir ./
+```
+
+After several minutes, you can get the performance evaluation result. This random benchmark is useful for serving pipeline validation; use AISBench or a custom multimodal dataset for image/video-token performance.
+
+## 9 Performance Tuning
+
+### 9.1 Recommended Configurations
+
+> **Note**: The following configurations are validated in specific test environments and are for reference only. The optimal configuration depends on hardware type, image resolution, video length, maximum input/output length, request concurrency, prefix cache hit rate, and prefill/decode ratio. Tune the parameters in Section 9.2 based on your actual workload.
+
+#### Table 1: Scenario Overview
+
+| Scenario | Deployment Mode | *Total NPUs | Weight Version | Key Considerations |
+| -------- | --------------- | ---------- | -------------- | ------------------ |
+| Image-only serving | Single-node online serving | 2 or more NPUs | BF16 | Disable video, tune context length, and keep enough KV cache for visual tokens. |
+| Video serving | Single-node online serving | 2 or more NPUs | BF16 | Use local media paths, lower concurrency, and reduce video length or frame sampling if OOM occurs. |
+| Functional graph validation | Single-node PP | 2 NPUs | BF16 | Use shorter context and explicit capture sizes to validate full decode ACLGraph behavior. |
+
+> `*Total NPUs` indicates the total number of NPUs used across all nodes. 1 node = 1 Atlas 800 A3 server (64G × 16 NPUs).
+
+#### Table 2: Detailed Node Configuration
+
+| Scenario | Node Role | NPUs | TP | PP | Max Num Seqs | Max Model Len | Max Num Batched Tokens | Prefix Cache | Main Optimizations |
+| -------- | --------- | ---- | -- | -- | ------------ | ------------- | ---------------------- | ------------ | ------------------ |
+| Image-only serving | Single node | 2 or more | 2 | 1 | 16 | 128000 | 4096 | Workload dependent | FullGraph, EP, video disabled |
+| Video serving | Single node | 2 or more | 2 | 1 | 8 | 128000 | 4096 | Workload dependent | FullGraph, EP, local media path |
+| Graph validation | Single node | 2 | 1 | 2 | Tune by test | 4096 | 1024 | Off | FullGraph capture sizes |
+
+> For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
+
+### 9.2 Tuning Guidelines
+
+#### 9.2.1 General Tuning Reference
+
+Please refer to the [Public Performance Tuning Documentation](../../developer_guide/performance_and_debug/optimization_and_tuning.md) for tuning methods.
+
+Please refer to the [Feature Guide](../../user_guide/support_matrix/feature_matrix.md) for detailed feature descriptions.
+
+#### 9.2.2 Recommended tuning order
+
+1. Start from image-only serving. Add video only after the image path is stable.
+2. Choose the maximum context length with `--max-model-len`. Multimodal requests consume KV cache for both text tokens and visual tokens, so reduce image resolution, video length, request concurrency, or context length if OOM occurs.
+3. Tune multimodal limits. Use `--limit-mm-per-prompt.image` and `--limit-mm-per-prompt.video` to match your request shape.
+4. Tune `--max-num-batched-tokens`. Larger values usually improve prefill throughput but increase activation memory. Video-heavy workloads usually need conservative values.
+5. Tune `--max-num-seqs` according to service concurrency. Video requests are more memory intensive than image requests, so start with a smaller value.
+6. Tune `--gpu-memory-utilization`. Increase it to provide more KV cache, but leave headroom for runtime memory fluctuation and media preprocessing.
+7. Tune ACLGraph capture. `FULL_DECODE_ONLY` is recommended for decode. If you set `cudagraph_capture_sizes` manually, include common decode batch sizes.
+
+### 9.3 Model-Specific Optimizations
+
+| Optimization | Enablement | Benefit | Notes |
+| ------------ | ---------- | ------- | ----- |
+| Multimodal prompt limits | `--limit-mm-per-prompt.image`, `--limit-mm-per-prompt.video` | Avoids reserving memory for unused media types. | Disable video for image-only serving. |
+| Local media access | `--allowed-local-media-path /media` | Avoids slow network video downloads during serving. | Use `file:///media/...` in requests. |
+| Full decode ACLGraph | `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` | Reduces operator dispatch overhead and stabilizes decode performance. | Recommended for decode-heavy serving. |
+| Expert parallelism | `--enable-expert-parallel` | Improves MoE serving throughput. | Do not mix MoE tensor parallelism and expert parallelism in the same MoE layer. |
+| Prefix caching | `--enable-prefix-caching` | Improves repeated-prefix workloads. | Random prompts or unique media may not benefit. |
+| Asynchronous scheduling | `--async-scheduling` | Can improve high-concurrency throughput. | Disable and compare for latency-sensitive workloads. |
+| Pipeline parallel validation | `--pipeline-parallel-size 2` | Provides another two-card validation layout. | Use shorter context and lower batch tokens for functional tests. |
+
+## 10 FAQ
+
+For common environment, installation, and general parameter issues, refer to [Public FAQs](../../faqs.md). This section only covers model-specific issues for Qwen3-VL-30B-A3B-Instruct.
+
+### Q1: Why does the service report OOM during startup?
+
+**Phenomenon:** The service fails during profile run or exits before accepting requests.
+
+**Cause:** Long context, high image resolution, video inputs, large `--max-num-seqs`, large `--max-num-batched-tokens`, or high `--gpu-memory-utilization` can leave insufficient HBM headroom.
+
+**Solution:** Start with image-only serving, set `--limit-mm-per-prompt.video 0`, reduce `--max-model-len`, lower `--max-num-seqs`, lower `--max-num-batched-tokens`, or reduce `--gpu-memory-utilization`. Keep `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True`.
+
+### Q2: Why is video disabled in the image-only command?
+
+**Phenomenon:** The service reserves more memory than expected even when requests only contain images.
+
+**Cause:** Allowing video inputs can reserve memory for long visual embeddings and preprocessing paths.
+
+**Solution:** Use `--limit-mm-per-prompt.video 0` for image-only serving. Enable video only when the workload needs it.
+
+### Q3: Why does the video request fail with a local file path?
+
+**Phenomenon:** The request reports that the file is not allowed or cannot be found.
+
+**Cause:** The server can only access local media paths that are mounted into the container and allowed by `--allowed-local-media-path`.
+
+**Solution:** Mount the host media directory to `/media`, start the server with `--allowed-local-media-path /media`, and use a request URL like `file:///media/test.mp4`.
+
+### Q4: Why does enabling prefix caching not improve performance?
+
+**Phenomenon:** Prefix caching is enabled, but throughput or latency does not improve.
+
+**Cause:** Prefix caching only helps when requests share reusable prefixes. Unique images, unique videos, or random prompts may add memory pressure without visible gains.
+
+**Solution:** Enable prefix caching for repeated-prefix workloads. For random benchmarks or memory-constrained video workloads, compare with prefix caching disabled.
+
+### Q5: Why does multimodal accuracy evaluation fail to insert image tokens?
+
+**Phenomenon:** Evaluation fails because image placeholders cannot be found in the prompt.
+
+**Cause:** Qwen3-VL multimodal tasks rely on the model chat template to insert image placeholder tokens before multimodal processing.
+
+**Solution:** Enable chat template application in the evaluation configuration. For lm_eval-based multimodal tasks, set `apply_chat_template` to true.

--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -1,4 +1,4 @@
-# Qwen3.5-397B-A17B Deployment Tutorial
+# Qwen3.5-397B-A17B
 
 ## 1 Introduction
 
@@ -6,24 +6,27 @@ Qwen3.5-397B-A17B is a large-scale Qwen3.5 MoE model that combines multimodal ca
 
 This document describes the main validation steps for the model, including supported features, prerequisites, installation, single-node online deployment, multi-node deployment, Prefill-Decode (PD) disaggregation, functional verification, accuracy and performance evaluation, performance tuning, and FAQs.
 
-The `Qwen3.5-397B-A17B` model is first supported in `vllm-ascend:v0.17.0rc1`. Use `v0.17.0rc1` or later for this model. The examples below use the version placeholder configured by the documentation build system.
+The `Qwen3.5-397B-A17B` model is first supported in `vllm-ascend:v0.17.0rc1`. Use `v0.17.0rc1` or later for this model. For Ascend95DT, the model is supported from `vllm-ascend:v0.23.0rc1`. The examples below use the version placeholder configured by the documentation build system.
 
 ## 2 Supported Features
 
-Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix, including BF16, W8A8 quantization, chunked prefill, automatic prefix caching, speculative decoding, asynchronous scheduling, tensor parallelism, expert parallelism, data parallelism, PD disaggregation, and ACLGraph support.
+Refer to [supported features](../../user_guide/support_matrix/supported_features.md) to get the model's supported feature matrix, including BF16, W8A8 quantization, chunked prefill, automatic prefix caching, speculative decoding, asynchronous scheduling, tensor parallelism, expert parallelism, data parallelism, PD disaggregation, and ACLGraph support.
 
 Refer to [feature guide](../../user_guide/feature_guide/index.md) to get feature configuration details.
 
-!!! note
-
-    The support matrix records the maximum verified capability for this model. The startup examples in this document use practical validation settings for online serving and performance testing. Adjust `--max-model-len`, `--max-num-seqs`, and `--max-num-batched-tokens` based on your service workload and available KV cache.
+:::{note}
+The support matrix records the maximum verified capability for this model. The startup examples in this document use practical validation settings for online serving and performance testing. Adjust `--max-model-len`, `--max-num-seqs`, and `--max-num-batched-tokens` based on your service workload and available KV cache.
+:::
 
 ## 3 Prerequisites
 
 ### 3.1 Model Weight
 
-- `Qwen3.5-397B-A17B` (BF16 version): requires 2 Atlas 800 A3 (64G x 16) nodes or 4 Atlas 800 A2 (64G x 8) nodes. [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3.5-397B-A17B).
+- `Qwen3.5-397B-A17B` (BF16 version): requires 2 Ascend 950DT(96G x 8) nodes or 2 Atlas 800 A3 (64G x 16) nodes or 4 Atlas 800 A2 (64G x 8) nodes. [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3.5-397B-A17B).
 - `Qwen3.5-397B-A17B-w8a8` (quantized version): requires 1 Atlas 800 A3 (64G x 16) node or 2 Atlas 800 A2 (64G x 8) nodes. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp).
+- `Qwen3.5-397B-A17B-w4a8` (quantized version): requires 1 Atlas 800 A3 (64G x 16) node or 2 Atlas 800 A2 (64G x 8) nodes. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-397B-A17B-w4a8-mtp).
+- `Qwen3.5-397B-A17B-w8a8-mxfp8` (quantized version): requires 1 Ascend 950DT(96G x 8) node. [Download model weight]#TODO
+- `Qwen3.5-397B-A17B-w4a4-mxfp4` (quantized version): requires 1 Ascend 950DT(96G x 8) node. [Download model weight]#TODO
 
 It is recommended to download the model weight to a shared directory across multiple nodes, such as `/root/.cache/`, so that all serving nodes can load the same path.
 
@@ -35,43 +38,120 @@ If you want to deploy the model in a multi-node environment, verify the communic
 
 ### 4.1 Docker Image Installation
 
-Select an image based on your machine type. For example, use `quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}` for Atlas 800 A2 and `quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3` for Atlas 800 A3.
+Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 
-Refer to [using docker](../../installation.md#set-up-using-docker) for the complete installation guide.
+The `Qwen3.5-397B-A17B` model is first supported in `vllm-ascend:v0.17.0rc1`. Use `v0.17.0rc1` or later for this model.For Ascend95DT, the model is supported from `vllm-ascend:v0.23.0rc1`.
 
-```bash
+=== "Ascend 950DT series"
 
-# Update --device according to your device.
-# Atlas A2: /dev/davinci[0-7]
-# Atlas A3: /dev/davinci[0-15]
-# Download the model weight to /root/.cache in advance.
-export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
-export NAME=vllm-ascend
+    Start the docker image on your each node.
 
-docker run --rm \
-  --name $NAME \
-  --net=host \
-  --shm-size=1g \
-  --device /dev/davinci0 \
-  --device /dev/davinci1 \
-  --device /dev/davinci2 \
-  --device /dev/davinci3 \
-  --device /dev/davinci4 \
-  --device /dev/davinci5 \
-  --device /dev/davinci6 \
-  --device /dev/davinci7 \
-  --device /dev/davinci_manager \
-  --device /dev/devmm_svm \
-  --device /dev/hisi_hdc \
-  -v /usr/local/dcmi:/usr/local/dcmi \
-  -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
-  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
-  -v /etc/ascend_install.info:/etc/ascend_install.info \
-  -v /root/.cache:/root/.cache \
-  -it $IMAGE bash
-```
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-#TODO
+    export NAME=vllm-ascend
+
+    docker run --rm \
+      --name $NAME \
+      --net=host \
+      --shm-size=1g \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci2 \
+      --device /dev/davinci3 \
+      --device /dev/davinci4 \
+      --device /dev/davinci5 \
+      --device /dev/davinci6 \
+      --device /dev/davinci7 \
+      --device /dev/davinci_manager \
+      --device /dev/hisi_hdc \
+      --device /dev/ummu \
+      --device /dev/uburma \
+      -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+      -v /etc/hixlep/:/etc/hixlep/ \
+      -v /root/.cache:/root/.cache \
+      -v /usr/local/sbin:/usr/local/sbin \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+      -v /usr/lib64:/usr/lib64 \
+      -itd $IMAGE bash
+    ```
+
+=== "A3 series"
+
+    Start the docker image on your each node.
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    export NAME=vllm-ascend
+
+    docker run --rm \
+      --name $NAME \
+      --net=host \
+      --shm-size=1g \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci2 \
+      --device /dev/davinci3 \
+      --device /dev/davinci4 \
+      --device /dev/davinci5 \
+      --device /dev/davinci6 \
+      --device /dev/davinci7 \
+      --device /dev/davinci8 \
+      --device /dev/davinci9 \
+      --device /dev/davinci10 \
+      --device /dev/davinci11 \
+      --device /dev/davinci12 \
+      --device /dev/davinci13 \
+      --device /dev/davinci14 \
+      --device /dev/davinci15 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /root/.cache:/root/.cache \
+      -it $IMAGE bash
+    ```
+
+=== "A2 series"
+
+    Start the docker image on your each node.
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+    export NAME=vllm-ascend
+
+    docker run --rm \
+      --name $NAME \
+      --net=host \
+      --shm-size=1g \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci2 \
+      --device /dev/davinci3 \
+      --device /dev/davinci4 \
+      --device /dev/davinci5 \
+      --device /dev/davinci6 \
+      --device /dev/davinci7 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /root/.cache:/root/.cache \
+      -it $IMAGE bash
+    ```
 
 After entering the container, verify that vLLM and vLLM-Ascend can be imported:
 
@@ -93,46 +173,97 @@ If you want to deploy a multi-node service, install the same version of vLLM and
 
 Single-node deployment runs both Prefill and Decode on the same node. It is suitable for functional validation, long-context single-cluster serving, and W8A8 deployment on 1 Atlas 800 A3 (64G x 16) node. The W8A8 version needs `--quantization ascend`.
 
-Run the following script to execute online 128K inference on 1 Atlas 800 A3 (64G x 16).
+=== "Ascend 950DT series"
 
-```shell
-#!/bin/sh
+    Run the following script to execute online inference on 1 Ascend 950DT (96G x 8). The quantized versions (`Qwen3.5-397B-A17B-w8a8-mxfp8` and `Qwen3.5-397B-A17B-w4a4-mxfp4`) can be deployed on a single Ascend 950DT node.
 
-# Load model from ModelScope to speed up download.
-export VLLM_USE_MODELSCOPE=True
+    ```shell
+    #!/bin/sh
 
-# Reduce memory fragmentation and avoid out-of-memory errors.
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    # Load model from ModelScope to speed up download.
+    export VLLM_USE_MODELSCOPE=True
 
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_BUFFSIZE=1024
-export OMP_NUM_THREADS=1
-export TASK_QUEUE_ENABLE=1
-echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-sysctl -w vm.swappiness=0
-sysctl -w kernel.numa_balancing=0
-sysctl kernel.sched_migration_cost_ns=50000
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
-  --host 0.0.0.0 \
-  --port 8000 \
-  --data-parallel-size 1 \
-  --tensor-parallel-size 16 \
-  --enable-expert-parallel \
-  --seed 1024 \
-  --quantization ascend \
-  --served-model-name qwen3.5 \
-  --max-num-seqs 128 \
-  --max-model-len 133000 \
-  --max-num-batched-tokens 16384 \
-  --trust-remote-code \
-  --gpu-memory-utilization 0.90 \
-  --enable-prefix-caching \
-  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
-  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_cpu_binding":true, "enable_fused_mc2":1, "enable_flashcomm1":true}'
-```
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=400
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=100
+    export TASK_QUEUE_ENABLE=1
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+    export VLLM_ASCEND_ENABLE_PREFETCH_MLP=1
+    export HCCL_INTRA_PCIE_ENABLE=1
+    export HCCL_INTRA_ROCE_ENABLE=0
+
+    vllm serve Eco-Tech/Qwen3.5-397B-A17B-w4a4-mxfp4 \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --distributed-executor-backend mp \
+      --data-parallel-size 1 \
+      --tensor-parallel-size 8 \
+      --enable-expert-parallel \
+      --seed 1024 \
+      --quantization ascend \
+      --served-model-name qwen3.5 \
+      --max-num-seqs 128 \
+      --max-model-len 133000 \
+      --max-num-batched-tokens 8192 \
+      --trust-remote-code \
+      --enable-prefix-caching \
+      --gpu-memory-utilization 0.95 \
+      --async-scheduling \
+      --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}' \
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+      --additional-config '{"enable_cpu_binding":true}'
+    ```
+
+=== "A3 series"
+
+    Run the following script to execute online 128K inference on 1 Atlas 800 A3 (64G x 16).
+
+    ```shell
+    #!/bin/sh
+
+    # Load model from ModelScope to speed up download.
+    export VLLM_USE_MODELSCOPE=True
+
+    # Reduce memory fragmentation and avoid out-of-memory errors.
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export HCCL_BUFFSIZE=1024
+    export OMP_NUM_THREADS=1
+    export TASK_QUEUE_ENABLE=1
+    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+    sysctl -w vm.swappiness=0
+    sysctl -w kernel.numa_balancing=0
+    sysctl kernel.sched_migration_cost_ns=50000
+    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+
+    vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --data-parallel-size 1 \
+      --tensor-parallel-size 16 \
+      --enable-expert-parallel \
+      --seed 1024 \
+      --quantization ascend \
+      --served-model-name qwen3.5 \
+      --max-num-seqs 128 \
+      --max-model-len 133000 \
+      --max-num-batched-tokens 16384 \
+      --trust-remote-code \
+      --gpu-memory-utilization 0.90 \
+      --enable-prefix-caching \
+      --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}' \
+      --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+      --additional-config '{"enable_cpu_binding":true}'
+    ```
+
+=== "A2 series"
+
+    For W8A8 deployment, 2 Atlas 800 A2 (64G x 8) nodes are required. Refer to [Section 5.2](#52-multi-node-deployment-with-mp-recommended) for multi-node MP deployment.
 
 Common Issues Tip: If the service fails to start, HBM is insufficient, or requests are not scheduled as expected, refer to [FAQs](../../faqs.md) first, and then check the model-specific FAQ in Section 10.
 
@@ -148,7 +279,7 @@ Common Issues Tip: If the service fails to start, HBM is insufficient, or reques
 - `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.
 - `--speculative-config` enables Qwen3.5 MTP speculative decoding. Reduce `num_speculative_tokens` or remove this option if the workload is sensitive to first-token latency or if MTP is unstable in your environment.
 - `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full decode ACLGraph replay to reduce dispatch overhead.
-- `--additional-config` enables Ascend-specific optimizations. `enable_fused_mc2` enables MoE fused operators, `enable_flashcomm1` enables FlashComm1, and `enable_cpu_binding` enables Ascend-native CPU binding.
+- `--additional-config` enables Ascend-specific optimizations. `enable_cpu_binding` enables Ascend-native CPU binding.
 
 ### 5.2 Multi-Node Deployment with MP (Recommended)
 
@@ -197,7 +328,7 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --gpu-memory-utilization 0.9 \
   --no-enable-prefix-caching \
   --quantization ascend \
-  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
+  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}' \
   --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
   --additional-config '{"enable_cpu_binding":true, "multistream_overlap_shared_expert": true}'
 ```
@@ -249,7 +380,7 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --gpu-memory-utilization 0.9 \
   --no-enable-prefix-caching \
   --quantization ascend \
-  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
+  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}' \
   --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
   --additional-config '{"enable_cpu_binding":true, "multistream_overlap_shared_expert": true}'
 ```
@@ -286,18 +417,18 @@ For Ray-based distributed deployment, refer to [Ray Distributed (Qwen/Qwen3-235B
 
 Common Issues Tip: If Ray workers cannot discover each other, check Ray cluster status first, then verify the same HCCL and network interface settings used in MP deployment.
 
-### 5.4 Prefill-Decode Disaggregation
+### 5.4 Prefill-Decode Disaggregation (A3)
 
 PD disaggregation separates Prefill and Decode into different service groups. Prefill nodes process large prompt chunks, Decode nodes serve token generation, and a proxy forwards requests between them. This mode is suitable for production serving scenarios where prefill and decode resource ratios need to be tuned separately.
 
 We recommend using Mooncake for deployment. Refer to [Mooncake](../features/pd_disaggregation_mooncake_multi_node.md) for the general PD disaggregation workflow.
 
-Take Atlas 800 A3 (64G x 16) as an example. We recommend deploying 1P1D with 3 nodes for `Qwen3.5-397B-A17B-w8a8-mtp`:
+For Atlas 800 A3 (64G x 16), we recommend deploying 1P1D with 2 nodes for `Qwen3.5-397B-A17B-w8a8-mtp`:
 
 - 1 Prefill node: 1 Atlas 800 A3 (64G x 16).
-- 2 Decode nodes: 2 Atlas 800 A3 (64G x 16).
+- 1 Decode node: 1 Atlas 800 A3 (64G x 16).
 
-Deploy `run_p.sh`, `run_d0.sh`, and `run_d1.sh` on the corresponding nodes, and deploy a proxy script on the prefill master node to forward requests.
+Deploy `run_p.sh` and `run_d.sh` on the corresponding nodes, and deploy a proxy script on the prefill master node to forward requests.
 
 #### 5.4.1 Prefill Node
 
@@ -337,13 +468,13 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --port 30060 \
   --no-enable-prefix-caching \
   --enable-expert-parallel \
-  --data-parallel-size 8 \
-  --data-parallel-size-local 8 \
+  --data-parallel-size 1 \
+  --data-parallel-size-local 1 \
   --api-server-count 1 \
   --data-parallel-address ${IP_ADDRESS} \
   --max-num-seqs 64 \
   --data-parallel-rpc-port 6884 \
-  --tensor-parallel-size 2 \
+  --tensor-parallel-size 16 \
   --seed 1024 \
   --distributed-executor-backend mp \
   --served-model-name qwen3.5 \
@@ -353,21 +484,21 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --quantization ascend \
   --no-disable-hybrid-kv-cache-manager \
   --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
-  --additional-config '{"enable_cpu_binding": true, "enable_fused_mc2":1}' \
+  --additional-config '{"enable_cpu_binding": true}' \
   --gpu-memory-utilization 0.9 \
   --enforce-eager \
   --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
+  '{"kv_connector": "MooncakeLayerwiseConnector",
     "kv_role": "kv_producer",
     "kv_port": "23010",
     "kv_connector_extra_config": {
       "prefill": {
-        "dp_size": 8,
-        "tp_size": 2
+        "dp_size": 1,
+        "tp_size": 16
       },
       "decode": {
-        "dp_size": 16,
-        "tp_size": 2
+        "dp_size": 1,
+        "tp_size": 16
       }
     }
   }'
@@ -375,9 +506,9 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
 
 Common Issues Tip: If the prefill service is not ready for a long time, check whether the model path is shared, `ASCEND_RT_VISIBLE_DEVICES` contains all 16 NPUs, and the Mooncake `kv_port` is available.
 
-#### 5.4.2 Decode Node 0
+#### 5.4.2 Decode Node
 
-Create `run_d0.sh` on the first decode node.
+Create `run_d.sh` on the decode node.
 
 ```shell
 #!/bin/bash
@@ -391,12 +522,8 @@ unset http_proxy
 nic_name="xxx"
 local_ip="xxx"
 
-# The value of node0_ip must be consistent with local_ip on the first decode node.
-node0_ip="xxxx"
-
 export VLLM_ENGINE_READY_TIMEOUT_S=30000
 export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-export MASTER_IP_ADDRESS=$node0_ip
 export IP_ADDRESS=$local_ip
 export NETWORK_CARD_NAME=$nic_name
 export HCCL_IF_IP=$IP_ADDRESS
@@ -417,14 +544,13 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --port 30050 \
   --no-enable-prefix-caching \
   --enable-expert-parallel \
-  --data-parallel-size 16 \
-  --data-parallel-size-local 8 \
-  --data-parallel-start-rank 0 \
+  --data-parallel-size 1 \
+  --data-parallel-size-local 1 \
   --api-server-count 1 \
-  --data-parallel-address ${MASTER_IP_ADDRESS} \
+  --data-parallel-address ${IP_ADDRESS} \
   --max-num-seqs 32 \
   --data-parallel-rpc-port 6884 \
-  --tensor-parallel-size 2 \
+  --tensor-parallel-size 16 \
   --seed 1024 \
   --distributed-executor-backend mp \
   --served-model-name qwen3.5 \
@@ -433,149 +559,265 @@ vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
   --trust-remote-code \
   --quantization ascend \
   --no-disable-hybrid-kv-cache-manager \
-  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
-  --additional-config '{"recompute_scheduler_enable": true, "enable_cpu_binding": true, "enable_fused_mc2":1}' \
+  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3}' \
+  --additional-config '{"recompute_scheduler_enable": true, "enable_cpu_binding": true}' \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
   --gpu-memory-utilization 0.96 \
   --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
+  '{"kv_connector": "MooncakeLayerwiseConnector",
     "kv_buffer_device": "npu",
     "kv_role": "kv_consumer",
     "kv_port": "36010",
     "kv_connector_extra_config": {
       "prefill": {
-        "dp_size": 8,
-        "tp_size": 2
+        "dp_size": 1,
+        "tp_size": 16
       },
       "decode": {
-        "dp_size": 16,
-        "tp_size": 2
+        "dp_size": 1,
+        "tp_size": 16
       }
     }
   }'
 ```
 
-Common Issues Tip: If decode node 0 fails to initialize, check that `MASTER_IP_ADDRESS` points to decode node 0 itself, `--data-parallel-start-rank` is 0, and `kv_connector_extra_config.decode.dp_size` matches the global decode DP size.
-
-#### 5.4.3 Decode Node 1
-
-Create `run_d1.sh` on the second decode node.
-
-```shell
-#!/bin/bash
-
-unset ftp_proxy
-unset https_proxy
-unset http_proxy
-
-# Get these values through ifconfig.
-# nic_name is the network interface name corresponding to local_ip.
-nic_name="xxx"
-local_ip="xxx"
-
-# The value of node0_ip must be consistent with local_ip on the first decode node.
-node0_ip="xxxx"
-
-export VLLM_ENGINE_READY_TIMEOUT_S=30000
-export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-export MASTER_IP_ADDRESS=$node0_ip
-export IP_ADDRESS=$local_ip
-export NETWORK_CARD_NAME=$nic_name
-export HCCL_IF_IP=$IP_ADDRESS
-export GLOO_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export TP_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export HCCL_SOCKET_IFNAME=$NETWORK_CARD_NAME
-export VLLM_USE_V1=1
-export HCCL_BUFFSIZE=1536
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
-export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
-export VLLM_TORCH_PROFILER_WITH_STACK=0
-export TASK_QUEUE_ENABLE=1
-export HCCL_OP_EXPANSION_MODE="AIV"
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
-
-vllm serve Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp \
-  --host ${IP_ADDRESS} \
-  --port 30050 \
-  --headless \
-  --no-enable-prefix-caching \
-  --enable-expert-parallel \
-  --data-parallel-size 16 \
-  --data-parallel-size-local 8 \
-  --data-parallel-start-rank 8 \
-  --data-parallel-address ${MASTER_IP_ADDRESS} \
-  --max-num-seqs 32 \
-  --data-parallel-rpc-port 6884 \
-  --tensor-parallel-size 2 \
-  --seed 1024 \
-  --distributed-executor-backend mp \
-  --served-model-name qwen3.5 \
-  --max-model-len 16384 \
-  --max-num-batched-tokens 128 \
-  --trust-remote-code \
-  --quantization ascend \
-  --no-disable-hybrid-kv-cache-manager \
-  --speculative-config '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}' \
-  --additional-config '{"recompute_scheduler_enable": true, "enable_cpu_binding": true, "enable_fused_mc2":1}' \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --gpu-memory-utilization 0.96 \
-  --kv-transfer-config \
-  '{"kv_connector": "MooncakeConnectorV1",
-    "kv_buffer_device": "npu",
-    "kv_role": "kv_consumer",
-    "kv_port": "36010",
-    "kv_connector_extra_config": {
-      "prefill": {
-        "dp_size": 8,
-        "tp_size": 2
-      },
-      "decode": {
-        "dp_size": 16,
-        "tp_size": 2
-      }
-    }
-  }'
-```
-
-Common Issues Tip: If decode node 1 cannot join decode node 0, check that `--headless` is set, `--data-parallel-start-rank` is 8, and `--data-parallel-address` points to decode node 0.
+Common Issues Tip: If the decode node fails to initialize, check that `--tensor-parallel-size` is 16, `--data-parallel-size-local` matches the global decode DP size (1), and `kv_connector_extra_config.decode.dp_size` matches the global decode DP size.
 
 **Key parameters for PD disaggregation:**
 
 - `--distributed-executor-backend mp` uses multiprocessing on each node for the local workers.
-- Prefill uses `--data-parallel-size 8`, `--data-parallel-size-local 8`, and `--tensor-parallel-size 2`. This creates 8 local DP groups, each with TP2.
-- Decode uses `--data-parallel-size 16`, `--data-parallel-size-local 8`, and `--tensor-parallel-size 2`. Decode node 0 starts from DP rank 0 and decode node 1 starts from DP rank 8.
-- `--data-parallel-address` and `--data-parallel-rpc-port` define the DP control plane. For decode nodes, the address must point to decode node 0.
-- `--max-num-batched-tokens` is larger on the prefill node and smaller on decode nodes because prefill is prompt-token intensive while decode is latency sensitive.
-- `recompute_scheduler_enable` sends requests back to the prefill side to recompute KV cache when decode KV cache is insufficient. Enable it only on decode nodes in PD mode.
-- `--kv-transfer-config` sets the Mooncake V1 connector. `kv_role` is `kv_producer` on prefill and `kv_consumer` on decode.
+- Prefill uses `--data-parallel-size 1`, `--data-parallel-size-local 1`, and `--tensor-parallel-size 16`. This creates 1 DP group with TP16.
+- Decode uses `--data-parallel-size 1`, `--data-parallel-size-local 1`, and `--tensor-parallel-size 16`. This creates 1 local DP groups, each with TP16 .
+- `--data-parallel-address` and `--data-parallel-rpc-port` define the DP control plane.
+- `--max-num-batched-tokens` is larger on the prefill node and smaller on the decode node because prefill is prompt-token intensive while decode is latency sensitive.
+- `recompute_scheduler_enable` sends requests back to the prefill side to recompute KV cache when decode KV cache is insufficient. Enable it only on the decode node in PD mode.
+- `--kv-transfer-config` sets the Mooncake connector. `kv_role` is `kv_producer` on prefill and `kv_consumer` on decode.
 - `kv_connector_extra_config.prefill.dp_size/tp_size` and `decode.dp_size/tp_size` must match the actual global DP and TP layout.
 - `--no-enable-prefix-caching` disables prefix caching. For PD disaggregation, the D-node prefix-cache known issue is tracked in [#7944](https://github.com/vllm-project/vllm-ascend/issues/7944).
 - `VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT` is the timeout in seconds for automatically releasing the prefiller KV cache for a request.
-- `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'` is recommended on decode nodes to reduce decode dispatch overhead.
+- `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'` is recommended on the decode node to reduce decode dispatch overhead.
 
-#### 5.4.4 Request Forwarding
+### 5.5 Prefill-Decode Disaggregation (Ascend 950DT series)
 
-Run a proxy server on the same node as the prefiller service instance. You can get the proxy program in the repository examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py).
+For Ascend 950DT (96G x 8), we recommend deploying 1P1D with 2 nodes for `Qwen3.5-397B-A17B-w4a4-mxfp4`:
+
+- 1 Prefill node: 1 Ascend 950DT (96G x 8). Runs an independent service with DP=1, TP=8.
+- 1 Decode node: 1 Ascend 950DT (96G x 8). Forms a global DP=1 group, with 1 local DP rank (TP=8).
+
+The prefill service pushes KV cache to the decode node via the Mooncake p2p connector.
+
+Deploy `run_p.sh` and `run_d.sh` on the corresponding nodes, and deploy a proxy script on the prefill master node to forward requests.
+
+#### 5.5.1 Prefill Node
+
+Create `run_p.sh` on the prefill node.
 
 ```shell
+#!/bin/bash
+
 unset ftp_proxy
 unset https_proxy
 unset http_proxy
-python3 load_balance_proxy_server_example.py \
-  --prefiller-hosts 141.xx.xx.1 \
-  --prefiller-ports 30060 \
-  --decoder-hosts 141.xx.xx.2 141.xx.xx.3 \
-  --decoder-ports 30050 30050 \
-  --host 141.xx.xx.1 \
-  --port 8010
+
+source /root/.bashrc
+export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+
+# Get these values through ifconfig.
+# nic_name is the network interface name corresponding to local_ip.
+nic_name="xxx"
+local_ip="xxx"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+export HCCL_ALGO=level0:fullmesh
+export VLLM_RPC_TIMEOUT=3600000
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+export HCCL_EXEC_TIMEOUT=204
+export HCCL_CONNECT_TIMEOUT=180
+export HCCL_BUFFSIZE=300
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=10
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export TASK_QUEUE_ENABLE=1
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export DYNAMIC_EPLB="true"
+
+vllm serve Eco-Tech/Qwen3.5-397B-A17B-w4a4-mxfp4 \
+  --host 0.0.0.0 \
+  --port 30060 \
+  --no-enable-prefix-caching \
+  --enable-expert-parallel \
+  --data-parallel-size 1 \
+  --data-parallel-size-local 1 \
+  --data-parallel-address $local_ip \
+  --data-parallel-rpc-port 6884 \
+  --tensor-parallel-size 8 \
+  --seed 1024 \
+  --distributed-executor-backend mp \
+  --served-model-name qwen3.5 \
+  --max-model-len 133000 \
+  --max-num-batched-tokens 8192 \
+  --max-num-seqs 64 \
+  --trust-remote-code \
+  --gpu-memory-utilization 0.95 \
+  --quantization ascend \
+  --async-scheduling \
+  --enforce-eager \
+  --speculative-config '{"num_speculative_tokens": 1, "method": "qwen3_5_mtp", "enforce_eager": true}' \
+  --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true}' \
+  --kv-transfer-config \
+  '{"kv_connector": "MooncakeConnector",
+    "kv_role": "kv_producer",
+    "kv_port": "30100",
+    "engine_id": "1",
+    "kv_connector_module_path": "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector",
+    "kv_connector_extra_config": {
+      "prefill": {
+        "dp_size": 1,
+        "tp_size": 8
+      },
+      "decode": {
+        "dp_size": 1,
+        "tp_size": 8
+      },
+      "ascend_local_comm_res_path": "/etc/hixlep"
+    }
+  }'
 ```
 
-For example:
+Common Issues Tip: If the prefill service is not ready for a long time, check whether `ASCEND_RT_VISIBLE_DEVICES` contains all 8 NPUs, the Mooncake `kv_port` is available, and `ascend_local_comm_res_path` points to a writable shared path.
+
+#### 5.5.2 Decode Node
+
+Create `run_d.sh` on the decode node.
 
 ```shell
-cd vllm-ascend/examples/disaggregated_prefill_v1/
-bash proxy.sh
+#!/bin/bash
+
+unset ftp_proxy
+unset https_proxy
+unset http_proxy
+
+source /root/.bashrc
+export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics && mkdir -p $PROMETHEUS_MULTIPROC_DIR
+export HCCL_DFS_CONFIG="task_exception:off,inconsistent_check:off"
+
+# Get these values through ifconfig.
+# nic_name is the network interface name corresponding to local_ip.
+nic_name="xxx"
+local_ip="xxx"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+export HCCL_ALGO=level0:fullmesh
+export VLLM_RPC_TIMEOUT=3600000
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+export HCCL_EXEC_TIMEOUT=200
+export HCCL_CONNECT_TIMEOUT=1800
+export HCCL_BUFFSIZE=1200
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=10
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export TASK_QUEUE_ENABLE=1
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export DYNAMIC_EPLB="true"
+
+vllm serve Eco-Tech/Qwen3.5-397B-A17B-w4a4-mxfp4 \
+  --host 0.0.0.0 \
+  --port 30050 \
+  --no-enable-prefix-caching \
+  --enable-expert-parallel \
+  --data-parallel-size 1 \
+  --data-parallel-size-local 1 \
+  --api-server-count 1 \
+  --data-parallel-address $local_ip \
+  --data-parallel-rpc-port 6884 \
+  --tensor-parallel-size 8 \
+  --seed 1024 \
+  --distributed-executor-backend mp \
+  --served-model-name qwen3.5 \
+  --max-model-len 133000 \
+  --max-num-batched-tokens 240 \
+  --max-num-seqs 64 \
+  --trust-remote-code \
+  --gpu-memory-utilization 0.95 \
+  --quantization ascend \
+  --async-scheduling \
+  --speculative-config '{"num_speculative_tokens": 3, "method": "qwen3_5_mtp"}' \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+  --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "recompute_scheduler_enable": true, "ascend_compilation_config": {"enable_npugraph_ex": false}}' \
+  --kv-transfer-config \
+  '{"kv_connector": "MooncakeConnector",
+    "kv_role": "kv_consumer",
+    "kv_port": "30300",
+    "engine_id": "3",
+    "kv_connector_module_path": "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector",
+    "kv_connector_extra_config": {
+      "prefill": {
+        "dp_size": 1,
+        "tp_size": 8
+      },
+      "decode": {
+        "dp_size": 1,
+        "tp_size": 8
+      },
+      "ascend_local_comm_res_path": "/etc/hixlep"
+    }
+  }'
 ```
+
+Common Issues Tip: If decode node 0 fails to initialize, check that `--data-parallel-start-rank` is 0, `--tensor-parallel-size` is 8, and `kv_connector_extra_config.decode.dp_size` matches the global decode DP size (1).
+
+### 5.6 Request Forwarding
+
+Run a proxy server on the same node as the prefiller service instance. You can get the proxy program in the repository examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py).
+
+=== "A3 series"
+
+    For A3 PD disaggregation (1P1D), the proxy forwards requests to 1 prefill node and 1 decode node. Use the layerwise proxy script.
+
+    ```shell
+    unset ftp_proxy
+    unset https_proxy
+    unset http_proxy
+    python3 load_balance_proxy_server_example.py \
+      --prefiller-hosts 141.xx.xx.1 \
+      --prefiller-ports 30060 \
+      --decoder-hosts 141.xx.xx.2 \
+      --decoder-ports 30050 \
+      --host 141.xx.xx.1 \
+      --port 8010
+    ```
+
+    For example:
+
+    ```shell
+    cd vllm-ascend/examples/disaggregated_prefill_v1/
+    bash proxy.sh
+    ```
+
+=== "Ascend 950DT series"
+
+    For Ascend 950DT PD disaggregation (1P1D), the proxy forwards requests to 1 prefill node and 1 decode node. Use the layerwise proxy script.
+
+    ```shell
+    unset ftp_proxy
+    unset https_proxy
+    unset http_proxy
+    python3 load_balance_proxy_layerwise_server_example.py \
+      --prefiller-hosts 141.xx.xx.1 \
+      --prefiller-ports 30060 \
+      --decoder-hosts 141.xx.xx.2 \
+      --decoder-ports 30050 \
+      --host 141.xx.xx.1 \
+      --port 8010
+    ```
 
 Common Issues Tip: If requests reach the proxy but no output is returned, check that the proxy host list includes all healthy prefill and decode endpoints, and verify that the service verification request in Section 6 succeeds through the proxy port.
 
@@ -664,15 +906,20 @@ The following configurations are validated in specific test environments and are
 | Scenario | Deployment Mode | Total NPUs | Weight Version | Key Considerations |
 | -------- | --------------- | ---------- | -------------- | ------------------ |
 | Long context | Single-node online serving | 16 A3 NPUs | W8A8 MTP | Use larger `--max-model-len` and reserve enough KV cache. Lower `--max-num-seqs` if OOM occurs. |
+| Long context | Single-node online serving | 8 Ascend 950DT NPUs | W4A4 MXFP4 MTP | Use TP=8 and reserve enough KV cache for 133K context. Lower `--max-num-seqs` if OOM occurs. |
 | High throughput | Multi-node MP | 16 A2 NPUs | W8A8 MTP | Increase concurrency through DP and tune `--max-num-batched-tokens` for prefill throughput. |
 | Low latency | 1P1D PD disaggregation | 48 A3 NPUs | W8A8 MTP | Use separate prefill and decode DP/TP layouts and enable full decode ACLGraph on decode nodes. |
+| Low latency | 1P1D PD disaggregation | 16 Ascend 950DT NPUs | W4A4 MXFP4 MTP | Use one 8-NPU prefill node and one 8-NPU decode node. Enable full decode ACLGraph on the decode node. |
 
 | Scenario | Node Role | NPUs | TP | DP | Max Num Seqs | Max Model Len | Max Num Batched Tokens | MTP Tokens | Prefix Cache | Main Optimizations |
 | -------- | --------- | ---- | -- | -- | ------------ | ------------- | ---------------------- | ---------- | ------------ | ------------------ |
 | Long context | Single node | 16 | 16 | 1 | 128 | 133000 | 16384 | 3 | On | FullGraph, FlashComm1, Fused MC2, CPU binding |
+| Long context | Single Ascend 950DT node | 8 | 8 | 1 | 128 | 133000 | 8192 | 3 | On | Full decode ACLGraph, FlashComm1, shared expert overlap, CPU binding, async scheduling |
 | High throughput | MP node | 8 per node | 8 | 1 per node, 2 global | 16 per DP | 32768 | 4096 | 3 | Off | FullGraph, shared expert overlap, CPU binding |
 | Low latency | Prefill node | 16 | 2 | 8 | 64 | 16384 | 4096 | 3 | Off | Recompute scheduler, Fused MC2, CPU binding |
 | Low latency | Decode node | 16 per node | 2 | 8 per node, 16 global | 32 | 16384 | 128 | 3 | Off | FullGraph, recompute scheduler, Fused MC2, CPU binding |
+| Low latency | Ascend 950DT prefill node | 8 | 8 | 1 | 64 | 133000 | 8192 | 1 | Off | Recompute scheduler, shared expert overlap, CPU binding, async scheduling |
+| Low latency | Ascend 950DT decode node | 8 | 8 | 1 | 64 | 133000 | 240 | 3 | Off | Full decode ACLGraph, recompute scheduler, shared expert overlap, CPU binding, async scheduling |
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -1,4 +1,4 @@
-# Qwen3.6-35B-A3B Deployment Tutorial
+# Qwen3.6-35B-A3B
 
 ## 1 Introduction
 
@@ -10,7 +10,7 @@ The `Qwen3.6-35B-A3B` model is first supported in `vllm-ascend:v0.18.0rc1`. Use 
 
 ## 2 Supported Features
 
-Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix, including BF16, W8A8 quantization, chunked prefill, automatic prefix caching, asynchronous scheduling, tensor parallelism, expert parallelism, and ACLGraph support.
+Refer to [supported features](../../user_guide/support_matrix/supported_features.md) to get the model's supported feature matrix, including BF16, W8A8 quantization, chunked prefill, automatic prefix caching, asynchronous scheduling, tensor parallelism, expert parallelism, and ACLGraph support.
 
 Refer to [feature guide](../../user_guide/feature_guide/index.md) to get feature configuration details.
 
@@ -233,7 +233,7 @@ Single-node deployment runs both Prefill and Decode on the same node. `Qwen3.6-3
       --max-num-seqs 16 \
       --served-model-name qwen3.6 \
       --dtype float16 \
-      --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
+      --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": false}}' \
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
       --quantization ascend \
       --max-model-len 20480 \
@@ -278,6 +278,11 @@ Here are two accuracy evaluation methods.
 ### 7.1 Using AISBench
 
 Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details. After execution, you can get the accuracy result of `Qwen3.6-35B-A3B-w8a8`.
+
+| dataset | version | metric | mode | vllm-api-general-chat |
+| ------- | ------- | ------ | ---- | --------------------- |
+| mmmu | - | accuracy | gen | 83.3 |
+| gpqa | - | accuracy | gen | 83.3 |
 
 ### 7.2 Using Language Model Evaluation Harness
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the deployment guide for the Qwen3.5-397B-A17B model on Ascend hardware, specifically adding support and configuration details for the Ascend 950DT series. It includes single-node deployment scripts, multi-node deployment with MP, and Prefill-Decode (PD) disaggregation configurations.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only change, no testing required.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
