### PR TITLE
[BugFix](kv_pool): finalize non-last PP stages with MTP

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -773,6 +773,16 @@ class NPUModelRunner(GPUModelRunner):
             device=self.device,
         ).unsqueeze(1)
 
+    def _should_defer_kv_connector_finalize(self) -> bool:
+        if self.speculative_config is None:
+            return False
+
+        pp = get_pp_group()
+        # Non-last PP ranks return their intermediate tensors without running
+        # the draft model. Finalize their connector after the target forward so
+        # every PP rank stores its local layers in the external KV pool.
+        return pp.is_last_rank or self.broadcast_pp_output
+
     def _update_states(self, scheduler_output: "SchedulerOutput") -> Callable | None:
         # Temporary rewind guard for KV-load-failure recompute.
         # This can be removed after the upstream fix is merged.
@@ -2314,7 +2324,7 @@ class NPUModelRunner(GPUModelRunner):
         has_encoder_input = self.model_config.is_encoder_decoder and num_encoder_reqs > 0
 
         # Run forward pass
-        clear_kv_metadata = self.speculative_config is None
+        defer_kv_connector_finalize = self._should_defer_kv_connector_finalize()
         with (
             record_function_or_nullcontext("forward"),
             set_ascend_forward_context(
@@ -2335,7 +2345,7 @@ class NPUModelRunner(GPUModelRunner):
             self.maybe_get_kv_connector_output(
                 scheduler_output,
                 **(
-                    {"defer_finalize": not clear_kv_metadata}
+                    {"defer_finalize": defer_kv_connector_finalize}
                 ),
             ) as kv_connector_output,
         ):


### PR DESCRIPTION
### What this PR does / why we need it?
When MTP/speculative decoding is enabled, KV connector finalization is deferred until after the draft model runs. The existing logic set defer_finalize=True for all PP ranks whenever speculative_config is present:

```
clear_kv_metadata = self.speculative_config is None
# ...
{"defer_finalize": not clear_kv_metadata}
```
This is correct for the last PP rank, which runs both the target model and the draft model. However, non-last PP ranks return intermediate activations after the target forward pass and never enter the draft path. As a result, their KV connector is never finalized and AscendStore PUT never runs on those ranks.

In a PP + KV Pool setup, each PP rank must store its local layer blocks in the external pool. When only the last PP rank PUTs keys, pool lookup fails because it requires keys from all TP × PP ranks. This leads to:

- AscendStore PUT failures or incomplete key coverage (only @pp_rank:0 or last-rank keys)

- External prefix cache hit rate stuck at 0% on the producer node

- Full prefill on every request despite repeated prefixes

This PR introduces _should_defer_kv_connector_finalize() to make the defer decision rank-aware:

- Non-last PP ranks: defer_finalize=False → finalize immediately after target forward → AscendStore PUT runs for their local layers

- Last PP rank (or ranks with broadcast_pp_output): defer_finalize=True → unchanged behavior, finalize after draft model as before

- No speculative decoding: defer_finalize=False → unchanged behavior

---
### Does this PR introduce any user-facing change?
No API or CLI changes.

Behavioral fix for users running PP + MTP/speculative decoding + external KV connector (e.g. AscendStore KV Pool): non-last PP ranks now correctly store their KV blocks to the external pool. Users should see improved external prefix cache hit rates and reduced redundant prefill when the same prefixes are reused across requests.

No impact on deployments without speculative decoding, without PP, or without an external KV connector.

---
### How was this patch tested?
Manual integration testing on Ascend NPU with the following setup:
Tested on Ascend NPU with 2P2D (P: PP=2/TP=8, D: DP=4/TP=4), MultiConnector (Mooncake + AscendStore), MTP, and GLM-5.
Before fix:

- Only last PP rank PUT keys to AscendStore; non-last rank keys missing

- Mooncake/AscendStore PUT errors (key's slice length=0 / incomplete rank coverage)

- External prefix cache hit rate: 0% on producer node with 50% prefix-overlap dataset

- GPU KV cache usage grew linearly (full prefill every request)

After fix:

- Verified AscendStore keys are PUT from both PP ranks (@pp_rank:0 and @pp_rank:1)

- External prefix cache hit rate improves on repeated-prefix workloads

- No regression observed on the last PP rank draft-model finalize path

Unit tests were not added in this PR because the fix is specific to the interaction between PP rank scheduling, MTP defer-finalize logic, and the external KV connector lifecycle. A follow-up test can mock _should_defer_kv_connector_finalize() per PP rank if desired.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
