### PR TITLE
[Ops][Feature] adapt hixlep endpoint selection for Motor colocated P/D

### DIFF
--- a/docs/source/user_guide/deployment_guide/using_mindie_motor.md
+++ b/docs/source/user_guide/deployment_guide/using_mindie_motor.md
@@ -2,8 +2,8 @@
 
 ## 1. Overview
 
-[MindIE-Motor](https://gitcode.com/Ascend/MindIE-PyMotor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
+[MindIE-Motor](https://gitcode.com/Ascend/MindIE-Motor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
 
 ## 2. Getting Started
 
-For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-PyMotor/blob/master/docs/zh/user_guide/README.md).
+For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-Motor/blob/master/docs/zh/user_guide/README.md).

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -546,13 +546,28 @@ def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None)
     if kv_transfer_config is None:
         return
 
-    visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
-    if visible_devices is None:
-        from vllm_ascend.cpu_binding import DeviceInfo
-
-        devices = sorted([int(x) for x in DeviceInfo.get_npu_map_info()])
+    # ASCEND_VISIBLE_DEVICES is set only when using MindIE Motor.
+    visible_devices = os.getenv("ASCEND_VISIBLE_DEVICES")
+    if visible_devices:
+        physical_devices = sorted(
+            int(x) for x in visible_devices.split(",") if x.strip())
+        rt_visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
+        if rt_visible_devices:
+            logical_devices = [int(x) for x in rt_visible_devices.split(",") if x.strip()]
+            if logical_devices and all(0 <= x < len(physical_devices) for x in logical_devices):
+                devices = [physical_devices[x] for x in logical_devices]
+            else:
+                devices = logical_devices
+        else:
+            devices = physical_devices
     else:
-        devices = [int(x) for x in visible_devices.split(",") if x.strip()]
+        visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
+        if visible_devices is None:
+            from vllm_ascend.cpu_binding import DeviceInfo
+
+            devices = sorted([int(x) for x in DeviceInfo.get_npu_map_info()])
+        else:
+            devices = [int(x) for x in visible_devices.split(",") if x.strip()]
 
     extra_config = kv_transfer_config.kv_connector_extra_config or {}
     local_comm_res_path = extra_config.get("ascend_local_comm_res_path")


### PR DESCRIPTION
Suggested PR Title:

```markdown
[Ops][Feature] adapt hixlep endpoint selection for Motor colocated P/D
```

Suggested PR Summary:

```markdown
### What this PR does / why we need it?

This is an adaptation for the MindIE Motor / K8s scenario where Prefill and Decode are colocated on one node but each Pod only mounts a subset of NPUs.

In that setup, device-plugin injects `ASCEND_VISIBLE_DEVICES` as the Pod physical NPU list, while each DP/endpoint process gets remapped `ASCEND_RT_VISIBLE_DEVICES` as logical indices (`0..N-1`). hixlep endpoint files are named by physical id (`ub_endpoint_npu_{phys}.json`). Selecting files only from RT logical ids makes Decode collide with Prefill endpoint files.

This PR updates `setup_ascend_local_comm_res` so that when `ASCEND_VISIBLE_DEVICES` is present, RT indices are mapped into that physical list (`VISIBLE[RT]`). If `ASCEND_VISIBLE_DEVICES` is absent, the original RT / DeviceInfo path is left unchanged for Docker/script launches.

Also updates `using_mindie_motor.md` links from MindIE-PyMotor to https://gitcode.com/Ascend/MindIE-Motor.

### Does this PR introduce _any_ user-facing change?

No for existing Docker/script users that only set `ASCEND_RT_VISIBLE_DEVICES`.
Motor/K8s colocated Prefill-Decode with subset NPUs becomes able to select the correct physical hixlep endpoint files.
Doc links now point to the MindIE-Motor repository.

### How was this patch tested?

- Motor colocated Prefill/Decode: Prefill LocalCommRes `npu_0..3`, Decode `npu_4..7`.
- Both sides initialize the adxl engine successfully.
- Path without `ASCEND_VISIBLE_DEVICES` behaves as before.
```

### What this PR does / why we need it?

This is an adaptation for the MindIE Motor / K8s scenario where Prefill and Decode are colocated on one node but each Pod only mounts a subset of NPUs.

This PR updates `setup_ascend_local_comm_res` so that when `ASCEND_VISIBLE_DEVICES` is present, RT indices are mapped into that physical list (`VISIBLE[RT]`). If `ASCEND_VISIBLE_DEVICES` is absent, the original RT / DeviceInfo path is left unchanged.

Also updates `using_mindie_motor.md` links from MindIE-PyMotor to https://gitcode.com/Ascend/MindIE-Motor.

Target branch: `releases/v0.24.0rc`

### Does this PR introduce _any_ user-facing change?

No for existing Docker/script users that only set `ASCEND_RT_VISIBLE_DEVICES`.
Doc links now point to the MindIE-Motor repository.

### How was this patch tested?

- Motor colocated Prefill/Decode: Prefill LocalCommRes `npu_0..3`, Decode `npu_4..7`.
- Both sides initialize the adxl engine successfully.
- Path without `ASCEND_VISIBLE_DEVICES` behaves as before.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
