### PR TITLE
[BugFix] accuracy issue under SP and DP

### DIFF
--- a/tests/ut/ops/test_register_custom_ops.py
+++ b/tests/ut/ops/test_register_custom_ops.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.ops import register_custom_ops
+
+
+@patch.object(register_custom_ops._EXTRA_CTX, "flash_comm_v1_enabled", False)
+@patch("vllm_ascend.ops.register_custom_ops.enable_sp_by_pass", return_value=True)
+@patch("vllm_ascend.ops.register_custom_ops.get_tensor_model_parallel_world_size", return_value=4)
+@patch("vllm_ascend.ops.register_custom_ops.get_ep_group")
+def test_fake_ep_communication_uses_ep_world_size(
+    mock_get_ep_group,
+    mock_get_tp_world_size,
+    mock_enable_sp_by_pass,
+):
+    """SP-pass fake communication must model the dp4/tp4 EP group."""
+    mock_get_ep_group.return_value = MagicMock(world_size=16)
+    input_ = torch.empty(16, 8)
+
+    gathered = register_custom_ops._maybe_all_gather_and_maybe_unpad_fake(input_, True, is_ep_comm=True)
+    reduced = register_custom_ops._maybe_pad_and_reduce_fake(gathered, is_ep_comm=True)
+
+    assert gathered.shape == (256, 8)
+    assert reduced.shape == input_.shape
+    mock_get_tp_world_size.assert_not_called()

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -105,35 +105,19 @@ def _maybe_pad_and_reduce_impl(x: torch.Tensor, is_ep_comm: bool = False) -> tor
 
 
 def _maybe_all_gather_and_maybe_unpad_fake(x: torch.Tensor, label: bool, is_ep_comm: bool = False) -> torch.Tensor:
-    flash_comm_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (
-        enable_sp_by_pass() and is_ep_comm
-    )
+    flash_comm_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (enable_sp_by_pass() and is_ep_comm)
     if flash_comm_enabled and label:
-        world_size = (
-            get_ep_group().world_size
-            if is_ep_comm
-            else get_tensor_model_parallel_world_size()
-        )
-        return torch.empty(
-            (x.shape[0] * world_size, *x.shape[1:]), device=x.device, dtype=x.dtype
-        )
+        world_size = get_ep_group().world_size if is_ep_comm else get_tensor_model_parallel_world_size()
+        return torch.empty((x.shape[0] * world_size, *x.shape[1:]), device=x.device, dtype=x.dtype)
 
     return x
 
 
 def _maybe_pad_and_reduce_fake(x: torch.Tensor, is_ep_comm: bool = False) -> torch.Tensor:
-    flash_comm_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (
-        enable_sp_by_pass() and is_ep_comm
-    )
+    flash_comm_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (enable_sp_by_pass() and is_ep_comm)
     if flash_comm_enabled:
-        world_size = (
-            get_ep_group().world_size
-            if is_ep_comm
-            else get_tensor_model_parallel_world_size()
-        )
-        return torch.empty(
-            (x.shape[0] // world_size, *x.shape[1:]), device=x.device, dtype=x.dtype
-        )
+        world_size = get_ep_group().world_size if is_ep_comm else get_tensor_model_parallel_world_size()
+        return torch.empty((x.shape[0] // world_size, *x.shape[1:]), device=x.device, dtype=x.dtype)
 
     return x
 

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -105,18 +105,34 @@ def _maybe_pad_and_reduce_impl(x: torch.Tensor, is_ep_comm: bool = False) -> tor
 
 
 def _maybe_all_gather_and_maybe_unpad_fake(x: torch.Tensor, label: bool, is_ep_comm: bool = False) -> torch.Tensor:
-    if _EXTRA_CTX.flash_comm_v1_enabled and label:
+    flash_comm_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (
+        enable_sp_by_pass() and is_ep_comm
+    )
+    if flash_comm_enabled and label:
+        world_size = (
+            get_ep_group().world_size
+            if is_ep_comm
+            else get_tensor_model_parallel_world_size()
+        )
         return torch.empty(
-            (x.shape[0] * get_tensor_model_parallel_world_size(), *x.shape[1:]), device=x.device, dtype=x.dtype
+            (x.shape[0] * world_size, *x.shape[1:]), device=x.device, dtype=x.dtype
         )
 
     return x
 
 
 def _maybe_pad_and_reduce_fake(x: torch.Tensor, is_ep_comm: bool = False) -> torch.Tensor:
-    if _EXTRA_CTX.flash_comm_v1_enabled or enable_sp_by_pass():
+    flash_comm_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (
+        enable_sp_by_pass() and is_ep_comm
+    )
+    if flash_comm_enabled:
+        world_size = (
+            get_ep_group().world_size
+            if is_ep_comm
+            else get_tensor_model_parallel_world_size()
+        )
         return torch.empty(
-            (x.shape[0] // get_tensor_model_parallel_world_size(), *x.shape[1:]), device=x.device, dtype=x.dtype
+            (x.shape[0] // world_size, *x.shape[1:]), device=x.device, dtype=x.dtype
         )
 
     return x


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes an accuracy issue when sequence parallelism (SP) is enabled together with data parallelism (DP) and expert parallelism (EP).
For MoE communication, the real custom-op path uses the EP group when is_ep_comm=True. However, the fake implementations used during torch.compile shape propagation always used the TP group size. With dp=4 and tp=4, the real EP world size is 16 while the fake path used 4, causing inconsistent tensor shapes between the compiled graph and runtime communication.
This patch makes the fake all-gather and reduce-scatter implementations select the EP group world size for EP communication, matching the real execution path.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Verified with Qwen3-VL-235B-A22B-Instruct under the following configurations:
SP disabled, dp=4, tp=4: normal output.
SP enabled, dp=1, tp=16: normal output.
SP enabled, dp=4, tp=4: normal output after this fix.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
