### PR TITLE
[CI] Pin dorny/paths-filter to v4.0.2 for reproducibility

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -152,7 +152,7 @@ jobs:
             *) echo "arch=$ARCH" >> $GITHUB_OUTPUT ;;
           esac
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@v4.0.2
         id: csrc-filter
         if: ${{ matrix.group.npu_type != 'cpu' }}
         with:

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -117,7 +117,7 @@ jobs:
           path: ./vllm-empty
           ref: ${{ steps.vllm.outputs.main_commit }}
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@v4.0.2
         id: filter
         with:
           filters: |
@@ -180,7 +180,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@v4.0.2
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary

Pins dorny/paths-filter from floating @v4 tag to specific @v4.0.2 release for CI reproducibility.

## Changes

- Updated dorny/paths-filter from @v4 to @v4.0.2 in .github/workflows/pr_test.yaml (2 instances)
- Updated dorny/paths-filter from @v4 to @v4.0.2 in .github/workflows/_selected_tests.yaml (1 instance)

## Testing

Verified by grep that all instances are updated to v4.0.2.
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
