### PR TITLE
[1/N][Refactor][Core] remove function find_longest_cache_hit_per_group in patch and support DSV4 decode partial group hits

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -5,8 +5,23 @@ from collections import defaultdict
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
 
+import torch
 from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import (
+    get_group_id,
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import EngineCoreOutput, FinishReason
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+)
 from vllm.v1.request import Request, RequestStatus
 
 from vllm_ascend.core.recompute_scheduler import (
@@ -110,3 +125,107 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
             client_index=request.client_index,
         )
     ]
+
+
+def test_dsv4_decode_node_observes_real_dense_local_cache_hit():
+    register_all_kvcache_specs(MagicMock())
+    init_none_hash(sha256)
+    hash_block_size = 4
+    kv_cache_config = KVCacheConfig(
+        num_blocks=800,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["dense_mla"],
+                MLAAttentionSpec(
+                    block_size=256,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.uint8,
+                    compress_ratio=4,
+                    model_version="deepseek_v4",
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_tail"],
+                SlidingWindowMLASpec(
+                    block_size=64,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.uint8,
+                    sliding_window=128,
+                    model_version="deepseek_v4",
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["c4_state"],
+                SlidingWindowMLASpec(
+                    block_size=4,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.uint8,
+                    sliding_window=8,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["c128_state"],
+                SlidingWindowMLASpec(
+                    block_size=8,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.uint8,
+                    sliding_window=128,
+                ),
+            ),
+        ],
+    )
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        scheduler_block_size=256,
+        hash_block_size=hash_block_size,
+        enable_caching=True,
+    )
+    block_hasher = get_request_block_hasher(hash_block_size, sha256)
+
+    def make_request(request_id: str, num_tokens: int) -> Request:
+        return Request(
+            request_id=request_id,
+            prompt_token_ids=[0] * num_tokens,
+            sampling_params=SamplingParams(max_tokens=1),
+            pooling_params=None,
+            block_hasher=block_hasher,
+        )
+
+    fill = make_request("fill", 1024)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
+    assert num_computed == 0
+    assert (
+        manager.allocate_slots(
+            fill,
+            fill.num_tokens,
+            num_new_computed_tokens=0,
+            new_computed_blocks=computed_blocks,
+        )
+        is not None
+    )
+    manager.free(fill)
+
+    non_dense_block_ids = {
+        block.block_id
+        for block in manager.block_pool.blocks
+        if block.block_hash is not None and get_group_id(block.block_hash) in {1, 2, 3}
+    }
+    assert non_dense_block_ids
+    manager.evict_blocks(non_dense_block_ids)
+
+    replay = make_request("replay", 1280)
+    replay.kv_transfer_params = {"do_remote_prefill": True}
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    scheduler.kv_cache_manager = manager
+
+    _, num_local, shared_prefix_boundary, hit_diverged = scheduler._get_computed_blocks_for_connector(replay)
+
+    assert num_local == 1024
+    assert shared_prefix_boundary == 0
+    assert hit_diverged

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -180,6 +180,7 @@ def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
         dcp_world_size=1,
         pcp_world_size=1,
         hash_block_size=block_size,
+        scheduler_block_size=logical_block_size,
         max_num_batched_tokens=logical_block_size,
     )
 

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -95,9 +95,43 @@ class RecomputeSchedulerOutput(SchedulerOutput):
 class RecomputeScheduler(Scheduler):
     running: list[Request]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_kv_producer = self.vllm_config.kv_transfer_config and self.vllm_config.kv_transfer_config.is_kv_producer
+    def _get_computed_blocks_for_connector(self, request: Request) -> tuple[KVCacheBlocks, int, int, bool]:
+        kv_cache_manager = self.kv_cache_manager
+        coordinator = kv_cache_manager.coordinator
+        if (
+            request.kv_transfer_params
+            and request.kv_transfer_params.get("do_remote_prefill")
+            and isinstance(coordinator, HybridKVCacheCoordinator)
+            and getattr(coordinator, "full_attention_group_id", None) is not None
+        ):
+            prefix_cache_lookup_enabled = kv_cache_manager.enable_caching and not request.skip_reading_prefix_cache
+            if not prefix_cache_lookup_enabled:
+                return kv_cache_manager.empty_kv_cache_blocks, 0, 0, False
+
+            fa_group_id = coordinator.full_attention_group_id
+            assert fa_group_id is not None
+            computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
+                request.block_hashes,
+                request.num_tokens - 1,
+            )
+            if not any(hit > per_group_hits[fa_group_id] for hit in per_group_hits):
+                num_local = per_group_hits[fa_group_id]
+                hit_diverged = min(per_group_hits) < num_local
+                if hit_diverged:
+                    blocks = kv_cache_manager.create_kv_cache_blocks(computed)
+                    logger.info(
+                        "[RecomputeScheduler] Partial-group cache candidate "
+                        "request_id=%s per_group_hits=%s full_attention_group_id=%d "
+                        "selected_local_tokens=%d",
+                        request.request_id,
+                        per_group_hits,
+                        fa_group_id,
+                        num_local,
+                    )
+                    return blocks, num_local, 0, True
+
+        blocks, num_local, shared_prefix_boundary = kv_cache_manager.get_computed_blocks(request)
+        return blocks, num_local, shared_prefix_boundary, False
 
     def _update_waiting_for_remote_kv(self, request: Request) -> None:
         """
@@ -480,44 +514,22 @@ class RecomputeScheduler(Scheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
-                num_uncached_common_prefix_tokens = 0
+                hit_diverged = False
+                partial_group_hit_selected = False
+                did_prefix_cache_lookup = False
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
+                    did_prefix_cache_lookup = True
                     # Get locally-cached tokens.
-                    if (
-                        self.connector is not None
-                        and not self.is_kv_producer
-                        and self.has_mamba_layers
-                        and isinstance(
-                            self.kv_cache_manager.coordinator,
-                            HybridKVCacheCoordinator,
-                        )
-                    ):
-                        computed_blocks, per_group_hits = (
-                            self.kv_cache_manager.coordinator.find_longest_cache_hit_per_group(
-                                request.block_hashes,
-                                request.num_tokens - 1,
-                            )
-                        )
-                        new_computed_blocks = self.kv_cache_manager.create_kv_cache_blocks(computed_blocks)
-                        # NOTE(ZhanqiuHu): For Mamba hybrid models,
-                        # num_new_local_computed_tokens should be the FA hit
-                        # length. This value is passed to the connector's
-                        # get_num_new_matched_tokens which computes:
-                        # external = total - local_computed.
-                        # Using the FA hit skips re-transferring FA blocks
-                        # already cached on D-side. The Mamba state (always
-                        # the last block) is transferred unconditionally by
-                        # _apply_prefix_caching in nixl/worker.py.
-                        num_new_local_computed_tokens = max(per_group_hits)
-                        if self.kv_cache_manager.log_stats:
-                            assert self.kv_cache_manager.prefix_cache_stats is not None
-                            self.kv_cache_manager.prefix_cache_stats.record(
-                                num_tokens=request.num_tokens,
-                                num_hits=num_new_local_computed_tokens,
-                                preempted=request.num_preemptions > 0,
-                            )
+                    if self.connector is not None:
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            request.shared_prefix_boundary,
+                            hit_diverged,
+                        ) = self._get_computed_blocks_for_connector(request)
+                        partial_group_hit_selected = hit_diverged
                     else:
                         computed_result = self.kv_cache_manager.get_computed_blocks(request)
                         (
@@ -525,15 +537,6 @@ class RecomputeScheduler(Scheduler):
                             num_new_local_computed_tokens,
                             request.shared_prefix_boundary,
                         ) = cast(tuple[KVCacheBlocks, int, int], computed_result)
-
-                    # In case of hybrid models, obtain a hint for the
-                    # Marconi-style APC admission logic.
-                    if self.has_mamba_layers:
-                        num_uncached_common_prefix_tokens = getattr(
-                            self.kv_cache_manager.coordinator,
-                            "num_uncached_common_prefix_tokens",
-                            0,
-                        )
 
                     # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
@@ -549,6 +552,25 @@ class RecomputeScheduler(Scheduler):
                             step_skipped_waiting.prepend_request(request)
                             continue
                         num_external_computed_tokens = ext_tokens
+                        selected_local_computed_tokens = num_new_local_computed_tokens
+                        if hit_diverged and num_external_computed_tokens == 0:
+                            (
+                                new_computed_blocks,
+                                num_new_local_computed_tokens,
+                                request.shared_prefix_boundary,
+                            ) = self.kv_cache_manager.get_computed_blocks(request)
+                            partial_group_hit_selected = False
+                        if hit_diverged:
+                            logger.info(
+                                "[RecomputeScheduler] Partial-group cache decision "
+                                "request_id=%s selected_local_tokens=%d "
+                                "external_tokens=%d final_local_tokens=%d fallback=%s",
+                                request_id,
+                                selected_local_computed_tokens,
+                                num_external_computed_tokens,
+                                num_new_local_computed_tokens,
+                                num_external_computed_tokens == 0,
+                            )
                         connector_prefix_cache_queries = request.num_tokens - num_new_local_computed_tokens
                         connector_prefix_cache_hits = num_external_computed_tokens
 
@@ -654,7 +676,6 @@ class RecomputeScheduler(Scheduler):
                         num_new_tokens,
                         num_new_local_computed_tokens,
                         num_external_computed_tokens,
-                        num_uncached_common_prefix_tokens,
                     )
                     if num_new_tokens == 0:
                         break
@@ -717,6 +738,20 @@ class RecomputeScheduler(Scheduler):
                             num_hits=connector_prefix_cache_hits,
                             preempted=request.num_preemptions > 0,
                         )
+
+                record_prefix_cache_stats = getattr(self.kv_cache_manager, "record_prefix_cache_stats", None)
+                if did_prefix_cache_lookup and record_prefix_cache_stats is not None:
+                    record_prefix_cache_stats(
+                        request,
+                        num_new_local_computed_tokens,
+                    )
+                elif partial_group_hit_selected and self.kv_cache_manager.log_stats:
+                    assert self.kv_cache_manager.prefix_cache_stats is not None
+                    self.kv_cache_manager.prefix_cache_stats.record(
+                        num_tokens=request.num_tokens,
+                        num_hits=num_new_local_computed_tokens,
+                        preempted=request.num_preemptions > 0,
+                    )
 
                 request = request_queue.pop_request()
                 if load_kv_async:
@@ -1044,6 +1079,7 @@ class RecomputeScheduler(Scheduler):
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
+            ec_transfer_params = None
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
 
@@ -1112,7 +1148,10 @@ class RecomputeScheduler(Scheduler):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
-                    kv_transfer_params = self._free_request(request)
+                    (
+                        kv_transfer_params,
+                        ec_transfer_params,
+                    ) = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -1142,6 +1181,7 @@ class RecomputeScheduler(Scheduler):
                         events=request.take_events(),
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -12,6 +12,7 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_coordinator import (
     HybridKVCacheCoordinator,
     KVCacheCoordinator,
+    SpecGroup,
 )
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
@@ -19,10 +20,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
     KVCacheBlock,
 )
-from vllm.v1.core.single_type_kv_cache_manager import (
-    SingleTypeKVCacheManager,
-    SlidingWindowManager,
-)
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -201,37 +199,37 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         Groups KV cache groups by their spec type for efficient batch processing
         during cache hit lookup.
         """
-        attention_groups: list[tuple[KVCacheSpec, list[int], type[SingleTypeKVCacheManager]]] = []
-
+        self.attention_groups: list[SpecGroup] = []
         for i, g in enumerate(self.kv_cache_config.kv_cache_groups):
             manager_cls = self.single_type_managers[i].__class__
             spec = g.kv_cache_spec
+            use_eagle = i in self.eagle_group_ids
 
             # Try to find an existing group with the same spec
-            for existing_spec, group_ids, existing_cls in attention_groups:
-                if existing_spec == spec:
-                    assert manager_cls is existing_cls, "Expected same manager class for identical KV cache specs."
-                    group_ids.append(i)
+            for idx, group in enumerate(self.attention_groups):
+                if group.spec == spec:
+                    assert manager_cls is group.manager_cls, "Expected same manager class for identical KV cache specs."
+                    group.group_ids.append(i)
+                    if use_eagle and not group.use_eagle:
+                        self.attention_groups[idx] = group._replace(use_eagle=True)
                     break
             else:
-                attention_groups.append((spec, [i], manager_cls))
+                self.attention_groups.append(SpecGroup(spec, [i], manager_cls, use_eagle))
 
-        assert len(attention_groups) > 1, "HybridKVCacheCoordinator requires at least two attention groups."
+        assert len(self.attention_groups) > 1, "HybridKVCacheCoordinator requires at least two attention groups."
 
         # Put full attention first: its efficient left-to-right scan provides
         # a tighter initial bound, reducing work for subsequent groups.
-        self.attention_groups = sorted(
-            attention_groups,
-            key=lambda x: not isinstance(x[0], FullAttentionSpec),
-        )
+        self.attention_groups.sort(key=lambda group: not isinstance(group.spec, FullAttentionSpec))
 
-        # Attention-group indices (into ``self.attention_groups``) that
-        # contain at least one EAGLE/MTP KV cache group.
-        self.eagle_attn_group_indices: set[int] = {
-            i
-            for i, (_, group_ids, _) in enumerate(self.attention_groups)
-            if any(gid in self.eagle_group_ids for gid in group_ids)
-        }
+        # Dense reference group for per-group lookups (None when the model
+        # has no full-attention layers): full attention is downward-closed,
+        # so any group reporting a longer per-group hit implies the union of
+        # per-group hits is not consistent at a single boundary (#46453).
+        first = self.attention_groups[0]
+        self.full_attention_group_id: int | None = (
+            first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
+        )
 
         # Propagate the eagle bit to every manager in an eagle-containing
         # attention group, mirroring upstream
@@ -251,9 +249,10 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # ``_annotate_eagle_groups_deepseek_v4`` flags only the single group
         # holding the MTP layer, so iterating ``eagle_group_ids`` alone would
         # miss its same-spec siblings.
-        for idx in self.eagle_attn_group_indices:
-            for gid in self.attention_groups[idx][1]:
-                self.single_type_managers[gid].use_eagle = True
+        for group in self.attention_groups:
+            if group.use_eagle:
+                for gid in group.group_ids:
+                    self.single_type_managers[gid].use_eagle = True
 
         # The LCM of the block sizes of all attention types.
         # The cache hit length must be a multiple of the LCM of the block sizes
@@ -261,7 +260,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # each attention type. Requiring this because we don't support partial
         # block cache hit yet.
         # NOTE: use 16k as the alignment tokens for model with compress ratio
-        block_sizes = [self._get_effective_block_size(spec) for spec, _, _ in self.attention_groups]
+        block_sizes = [self._get_effective_block_size(group.spec) for group in self.attention_groups]
         self.lcm_block_size = lcm(*block_sizes)
 
     def find_longest_cache_hit(
@@ -299,7 +298,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # Simple hybrid (1 full attn + 1 other): one iteration suffices.
         # Full attn is always first if it exists.
         is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
-            self.attention_groups[0][0], FullAttentionSpec
+            self.attention_groups[0].spec, FullAttentionSpec
         )
 
         # Attention-group indices whose EAGLE drop is verified at the current
@@ -309,8 +308,13 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         while True:
             curr_hit_length = hit_length
-            for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
-                effective_block_size = self._get_effective_block_size(spec)
+            for idx, (
+                spec,
+                group_ids,
+                manager_cls,
+                use_eagle,
+            ) in enumerate(self.attention_groups):
+                group_block_size = self._get_effective_block_size(spec)
                 first_group_id = group_ids[0]
                 cached_blocks = hit_blocks_by_group[first_group_id]
                 if isinstance(spec, FullAttentionSpec) and cached_blocks is not None:
@@ -320,33 +324,32 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     curr_hit_length = min(curr_hit_length, hit_length_by_group[first_group_id])
                     continue
 
-                use_eagle = idx in self.eagle_attn_group_indices and idx not in eagle_verified
+                drop_eagle_block = use_eagle and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                if use_eagle and not isinstance(spec, MambaSpec):
+                if drop_eagle_block and not isinstance(spec, MambaSpec):
                     # Eagle needs to match one more block and then pop the last.
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits
                         and manager_cls.supports_fine_grained_hash_lookup
-                        and effective_block_size > self.hash_block_size
-                        else effective_block_size
+                        and group_block_size > self.hash_block_size
+                        else group_block_size
                     )
                     _max_length = min(curr_hit_length + eagle_margin, max_cache_hit_length)
-                eagle_kwarg = {"drop_eagle_block": use_eagle}
                 hit_result = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
-                    **eagle_kwarg,
+                    drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self._cache_hit_alignment_tokens,
                     dcp_world_size=self.dcp_world_size,
                     pcp_world_size=1,
                 )
                 hit_blocks, _new_hit_length = hit_result
-                if use_eagle:
+                if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
@@ -364,62 +367,24 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        # NOTE(zxr): for deepseek-v4, there is two fullattn groups, but
-        # in this function, only the first fullattn group is truncate by
-        # the belowing codes(c4), c128 layer does not truncate, which may
-        # have prefix cache block hit.
-        # Due to slidingwindow attn, deepseek-v4 decode node can't have
-        # any prefix cache hit, because `hit_length` of SWA is 0.
-        spec, group_ids, _ = self.attention_groups[0]
-        if isinstance(spec, FullAttentionSpec):
-            num_blocks = cdiv(hit_length, self._get_effective_block_size(spec))
-            for group_id in group_ids:
+        # Truncate all full attention groups to the final hit_length.
+        # NOTE(zxr): DeepSeek-V4 has two full-attention groups, C4 and
+        # C128. Truncate both groups with their own effective block sizes
+        # so neither group keeps prefix-cache blocks beyond final hit_length.
+        for group in self.attention_groups:
+            if not isinstance(group.spec, FullAttentionSpec):
+                continue
+            num_blocks = cdiv(
+                hit_length,
+                self._get_effective_block_size(group.spec),
+            )
+            for group_id in group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
                     hit_length_by_group[group_id] = hit_length
 
         cache_hit_blocks = tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group)
         return cache_hit_blocks, hit_length, longest_hit_length - hit_length
-
-    def find_longest_cache_hit_per_group(
-        self,
-        block_hashes: list[BlockHash],
-        max_cache_hit_length: int,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], tuple[int, ...]]:
-        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
-            return block_hashes
-
-        num_groups = len(self.kv_cache_config.kv_cache_groups)
-        hit_blocks_by_group: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
-        hit_length_by_group: list[int] = [0] * num_groups
-
-        for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
-            # The connector transfers Mamba state separately; report only the
-            # independently reusable attention-group prefixes on this path.
-            if isinstance(spec, MambaSpec):
-                continue
-
-            hit_result = manager_cls.find_longest_cache_hit(
-                block_hashes=_get_block_hashes(spec),
-                max_length=max_cache_hit_length,
-                kv_cache_group_ids=group_ids,
-                block_pool=self.block_pool,
-                kv_cache_spec=spec,
-                drop_eagle_block=idx in self.eagle_attn_group_indices,
-                alignment_tokens=self._cache_hit_alignment_tokens,
-                dcp_world_size=self.dcp_world_size,
-                pcp_world_size=1,
-            )
-            hit_blocks, group_hit_length = hit_result
-            for group_id, blocks in zip(group_ids, hit_blocks, strict=True):
-                hit_blocks_by_group[group_id] = blocks
-                hit_length_by_group[group_id] = group_hit_length
-
-        return (
-            tuple(hit_blocks_by_group),
-            tuple(hit_length_by_group),
-        )
 
 
 def get_kv_cache_coordinator(


### PR DESCRIPTION
### What this PR does / why we need it?

#### Problem

Hybrid models can have different decode-node prefix-cache hit lengths across KV cache groups. The existing all-group reconciliation uses a boundary that every group can satisfy. For remote-prefill P/D serving, a sliding-window, Mamba/state, or MTP/EAGLE group may report a shorter hit, often zero, even when a reusable full-attention prefix is already present on the decode node. That collapses the decode-node local hit and causes the connector to request KV that the full-attention group already has.

Align to https://github.com/vllm-project/vllm/pull/48425 and https://github.com/vllm-project/vllm/pull/45804

This affects the two target layouts in this PR:

- Qwen3.5 + MTP: the full-attention group can hit while the Mamba/state and MTP groups remain shorter.
- DeepSeek-V4 + MTP: the C4 and C128 full-attention groups can hit while the remaining hybrid groups report zero. The C128 group must also be truncated with its own effective boundary.

#### Solution requirements

The implementation follows these requirements:

1. Apply partial-group selection only to remote-prefill requests handled by a hybrid KV cache coordinator on the decode node.
2. Keep the normal cache-off and non-connector paths unchanged. Local lookup must still honor `enable_prefix_caching` and `skip_reading_prefix_cache`.
3. Use the first full-attention group as the dense reference group. Its hit is downward-closed and is the safe local boundary used by the decode scheduler.
4. Query the upstream per-group lookup API and select the dense reference hit only when no other group reports a hit longer than the reference. A longer non-reference hit means the per-group union is not consistent at one boundary and must not be selected as a partial-group hit.
5. Treat the result as a partial-group candidate only when at least one other group is shorter than the dense reference group.
6. Ask the KV connector only for the remaining external tokens. If the connector reports zero external tokens for a divergent candidate, fall back to the normal all-group-consistent lookup rather than accepting an incomplete local-only boundary.
7. Preserve MTP/EAGLE semantics when grouping identical cache specs and when dropping the EAGLE block during lookup.
8. Truncate every DeepSeek-V4 full-attention group, including C4 and C128, to the reconciled hit length using that group's own effective block size. No full-attention group may retain blocks beyond the final safe boundary.
9. Record prefix-cache statistics through the current vLLM interface and keep structured candidate/decision logs for mechanism validation.
10. Do not add a product feature flag. Cache-off/cache-on remains controlled by the existing decode-node `--enable-prefix-caching` setting.


### Does this PR introduce _any_ user-facing change?

Yes, it changes decode-node cache behavior for hybrid remote-prefill serving when decode-node prefix caching is enabled:

- The decode node can reuse a safe full-attention local prefix even when other hybrid groups have shorter hits.
- The connector transfers only the remaining KV tokens.
- Cache-off behavior, request/response APIs, and model configuration interfaces do not change.

### How was this patch tested?

#### Qwen3.5 P/D configuration

Model: `/mnt/weight/Qwen3.5-35B-A3B-w8a8-mtp`

| Item | Prefill node | Decode node |
|---|---|---|
| Devices | `0,1,2,3` | `4,5,6,7` |
| Parallelism | TP2, DP2, EP enabled | TP2, DP2, EP enabled |
| Service port | `30060` | `30050` |
| Prefix caching | Enabled | Cache-off: disabled; cache-on: enabled |
| KV connector | `MooncakeConnectorV1`, `kv_producer`, port `23010` | `MooncakeConnectorV1`, `kv_consumer`, port `36010` |
| Hybrid KV manager | Enabled | Enabled |
| MTP | Enabled, one speculative token | Enabled, one speculative token |
| Maximum model length | `32768` | `32768` |
| Maximum sequences | `64` | `64` |
| Maximum batched tokens | `4096` | `2048` |
| Execution | Eager | Eager + recompute scheduler |
| Other key settings | CPU binding, fused MC2 disabled, seed 1024 | CPU binding, fused MC2 disabled, seed 1024 |

The load-balancing proxy listened on port `8010` and routed prefill to `30060` and decode to `30050`.

#### DeepSeek-V4 P/D configuration

Model: `/mnt/weight/DeepSeek-V4-Flash-w8a8-mtp`

| Item | Prefill node | Decode node |
|---|---|---|
| Devices | `0-7` | `8-15` |
| Parallelism | TP8 | TP8 |
| Service port | `30060` | `30050` |
| Prefix caching | Enabled | Cache-off: disabled; cache-on: enabled |
| KV connector | `MooncakeHybridConnector`, `kv_producer`, port `23010` | `MooncakeHybridConnector`, `kv_consumer`, port `36010` |
| Hybrid KV manager | Enabled, block size 32 | Enabled, block size 32 |
| KV cache | FP8, `18360985190` bytes | FP8, `18360985190` bytes |
| MTP | Enabled, one speculative token | Enabled, one speculative token |
| Maximum model length | `132096` | `132096` |
| Maximum sequences | `16` | `60` |
| Maximum batched tokens | `8192` | `120` |
| Execution | Eager | Async scheduling + `FULL_DECODE_ONLY` graph |
| Other key settings | DeepSeek-V4 tokenizer/tool/reasoning parsers, 128-thread loader, CPU binding, fused MC2 disabled | Same parsers/loader, recompute scheduler, NPU graph extension, CPU binding, fused MC2 disabled |

The load-balancing proxy listened on port `8010` and routed prefill to `30060` and decode to `30050`.

#### Partial-group mechanism validation

| Model | Cache-off decode node | Cache-on decode node |
|---|---|---|
| Qwen3.5 + MTP | Local prefix-cache hit rate `0.0%`; no partial-group decision | 508 candidates and 508 decisions; `per_group_hits=(14336, 0, 0, 0)`; `selected_local_tokens=14336`; all `fallback=False`; observed local hit rate about `80.8%-83.5%` |
| DeepSeek-V4 + MTP | Local prefix-cache hit rate `0.0%`; no partial-group decision | 452 candidates and 452 decisions; all `fallback=False`; observed local hit rate increased from `49.8%` to `97.8%` |

DeepSeek-V4 additionally demonstrated both 131K and canonical-prefix boundaries:

```text
131K workload:  per_group_hits=(131584, 131072, 0, 0, 0, 0)
                 selected_local_tokens=131584
                 external_tokens=3

Canonical GPQA: per_group_hits=(10880, 8192, 0, 0, 0, 0)
```

The second full-attention group is truncated to `131072` or `8192`, both exact multiples of 4096, while the zero-hit hybrid groups no longer collapse the decode-node local hit to zero.

#### Performance comparison

https://github.com/vllm-project/vllm/pull/45804#issuecomment-5076112373

#### Accuracy comparison: GPQA canonical only

| Model | Cache-off | Cache-on | Accuracy delta | Paired answer changes |
|---|---:|---:|---:|---|
| Qwen3.5 + MTP, 64 workers | `162/198 = 81.82%` | `162/198 = 81.82%` | `0.00 pp` | 7 wrong-to-correct, 7 correct-to-wrong, 19 predictions changed |
| DeepSeek-V4 + MTP, 16 workers | `144/198 = 72.73%` | `146/198 = 73.74%` | `+1.01 pp` | 9 wrong-to-correct, 7 correct-to-wrong, 22 predictions changed |

Both cache states completed `198/198` requests with zero request errors. Prompt hashes and request hashes matched for all paired samples. Because generated reasoning is not token-for-token deterministic across repeated high-concurrency runs, GPQA is treated as a regression check; the score difference is reported but is not attributed as a cache-quality improvement.

#### Main/v0.26.0 sunset plan

This PR targets the vLLM main/v0.26.0 interface. It does not retain a v0.25.1 compatibility path.

The duplicated Ascend implementation of `find_longest_cache_hit_per_group()` is already removed in favor of the upstream API. The remaining Ascend-specific patch can be retired incrementally:

1. When upstream vLLM truncates every full-attention group with its own effective block size, remove the corresponding coordinator override from `patch_kv_cache_coordinator.py`.
2. When upstream remote-prefill scheduling natively supports safe dense-reference partial-group selection and zero-external fallback, remove `_get_computed_blocks_for_connector()` and the partial-group branch from `RecomputeScheduler`.
