### PR TITLE
[v0.26.0rc][Attention][Feature] Cache inverse RoPE sine in DSA-CP

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,5 +1,5 @@
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, TypeVar
 
 import torch
@@ -74,6 +74,7 @@ class DSACPMetadata:
     num_tokens_pad: int
     local_sin: torch.Tensor = None
     local_cos: torch.Tensor = None
+    local_sin_neg: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -1241,10 +1242,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
         req_metadata = attn_metadata.req_metadata
         cp_metadata = req_metadata.cp_metadata
         num_tokens = local_attn_output.shape[0]
+        local_sin = cp_metadata.local_sin[layer_name]
+        sin_neg = cp_metadata.local_sin_neg.get(id(local_sin))
+        if sin_neg is None:
+            sin_neg = -local_sin
+            cp_metadata.local_sin_neg[id(local_sin)] = sin_neg
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             local_attn_output.unsqueeze(1),
             cp_metadata.local_cos[layer_name],
-            -cp_metadata.local_sin[layer_name],
+            sin_neg,
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, TypeVar
 
 import torch
@@ -80,6 +80,7 @@ class DSACPMetadata:
     num_tokens_pad: int
     local_sin: torch.Tensor = None
     local_cos: torch.Tensor = None
+    local_sin_neg: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -1798,10 +1799,15 @@ class AscendDSACPImpl(DSAAttentionImpl):
         req_metadata = attn_metadata.req_metadata
         cp_metadata = req_metadata.cp_metadata
         num_tokens = local_attn_output.shape[0]
+        local_sin = cp_metadata.local_sin[layer_name]
+        sin_neg = cp_metadata.local_sin_neg.get(id(local_sin))
+        if sin_neg is None:
+            sin_neg = -local_sin
+            cp_metadata.local_sin_neg[id(local_sin)] = sin_neg
         torch.ops._C_ascend.inplace_partial_rotary_mul(
             local_attn_output.unsqueeze(1),
             cp_metadata.local_cos[layer_name],
-            -cp_metadata.local_sin[layer_name],
+            sin_neg,
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )


### PR DESCRIPTION
This PR caches the inverse local RoPE sine tensor used by `_restore_tp_head_layout()` in DSA context parallelism, avoiding repeated `-local_sin` computation and `Neg` kernel launches across attention layers that share the same RoPE tensor. On DeepSeek-V4-Flash with TP8 and an 8196-token chunked-prefill request, the inverse-RoPE `Neg` count decreased from 86 to 8 per rank, while its average device time decreased from 419.465 us to 38.281 us, saving approximately 381 us per rank without introducing new NPU operators or changing the `InplacePartialRotaryMul` execution path.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
