### PR TITLE
[Doc][Misc] Document Qwen3-Reranker chat template and simplify rerank API example

### DIFF
--- a/docs/source/tutorials/models/Qwen3-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-Reranker.md
@@ -113,14 +113,57 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 ## 5 Online Service Deployment
 
+### 5.1 Chat Template
+
+The Qwen3-Reranker model requires a specific chat template for proper formatting. Create a file named `qwen3_reranker.jinja` with the following content:
+
+```jinja
+<|im_start|>system
+Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>
+<|im_start|>user
+<Instruct>: {{
+    instruction
+    | default(
+        instruct
+        | default(
+            messages
+            | selectattr("role", "eq", "system")
+            | map(attribute="content")
+            | first
+            | default("Given a search query, retrieve relevant candidates that answer the query", true),
+            true
+        ),
+        true
+    )
+}}<Query>: {{
+    messages
+    | selectattr("role", "eq", "query")
+    | map(attribute="content")
+    | first
+}}
+<Document>: {{
+    messages
+    | selectattr("role", "eq", "document")
+    | map(attribute="content")
+    | first
+}}<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+```
+
+Save this file to a location of your choice (e.g., `./qwen3_reranker.jinja`).
+
 === "A3/A2 series"
 
     ```shell
     #!/bin/sh
-    vllm serve Qwen/Qwen3-VL-Reranker-2B \
+    vllm serve Qwen/Qwen3-Reranker-0.6B \
         --served-model-name Qwen/Qwen3-Reranker-0.6B \
         --runner pooling \
         --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
+        --chat-template ./qwen3_reranker.jinja \
         --port 8000 \
         --max-model-len 1024
     ```
@@ -133,6 +176,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
         --served-model-name Qwen/Qwen3-Reranker-0.6B \
         --runner pooling \
         --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
+        --chat-template ./qwen3_reranker.jinja \
         --compilation-config '{"cudagraph_capture_sizes": [1024,512]}' \
         --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
         --dtype float16 \
@@ -155,42 +199,21 @@ Once your server is started, you can verify by follow command:
 
 Service Verification:
 
-```python
-import requests
+When `--chat-template` is configured as above, you can send plain `query` and `documents` without manually building templates:
 
-url = "http://127.0.0.1:8000/v1/rerank"
-
-# Please use the query_template and document_template to format the query and
-# document for better reranker results.
-
-prefix = '<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
-suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
-
-query_template = "{prefix}<Instruct>: {instruction}\n<Query>: {query}\n"
-document_template = "<Document>: {doc}{suffix}"
-
-instruction = (
-    "Given a web search query, retrieve relevant passages that answer the query"
-)
-
-query = "What is the capital of China?"
-
-documents = [
+```bash
+curl http://127.0.0.1:8000/v1/rerank \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{
+  "model": "Qwen/Qwen3-Reranker-0.6B",
+  "query": "What is the capital of China?",
+  "documents": [
     "The capital of China is Beijing.",
-    "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.",
-]
-
-documents = [
-    document_template.format(doc=doc, suffix=suffix) for doc in documents
-]
-
-response = requests.post(url,
-                         json={
-                             "query": query_template.format(prefix=prefix, instruction=instruction, query=query),
-                             "documents": documents,
-                         }).json()
-
-print(response)
+    "Nanjing is a city of China.",
+    "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun."
+  ]
+}'
 ```
 
 Expected Result:
@@ -202,25 +225,33 @@ The service returns HTTP 200 OK with a JSON response containing the `relevance_s
     "id": "score-xxx",
     "model": "Qwen/Qwen3-Reranker-0.6B",
     "usage": {
-        "prompt_tokens": 193,
-        "total_tokens": 193
+        "prompt_tokens": 270,
+        "total_tokens": 270
     },
     "results": [
         {
             "index": 0,
             "document": {
-                "text": "<Document>: The capital of China is Beijing.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+                "text": "The capital of China is Beijing.",
                 "multi_modal": null
             },
-            "relevance_score": 0.9994981288909912
+            "relevance_score": 0.9691112041473389
         },
         {
             "index": 1,
             "document": {
-                "text": "<Document>: Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+                "text": "Nanjing is a city of China.",
                 "multi_modal": null
             },
-            "relevance_score": 0.00000506485957885161
+            "relevance_score": 0.25337138772010803
+        },
+        {
+            "index": 2,
+            "document": {
+                "text": "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.",
+                "multi_modal": null
+            },
+            "relevance_score": 0.01036941446363926
         }
     ]
 }


### PR DESCRIPTION
### What this PR does / why we need it?

The `Qwen3-Reranker` tutorial was outdated compared to `Qwen3-VL-Reranker`: it lacked chat template guidance, the A3/A2 serve example incorrectly referenced `Qwen3-VL-Reranker-2B`, and the functional verification section required users to manually build `query_template` / `document_template` in Python.

This PR updates `docs/source/tutorials/models/Qwen3-Reranker.md` to:

- Add section **5.1 Chat Template** with `qwen3_reranker.jinja`, aligned with the VL reranker doc layout
- Add `--chat-template ./qwen3_reranker.jinja` to A3/A2 and Atlas serve commands
- Fix the A3/A2 serve command to use `Qwen/Qwen3-Reranker-0.6B` instead of the VL model
- Replace the Python template-formatting example with a plain `/v1/rerank` curl request
- Update the expected JSON response with a 3-document ranking example and real `relevance_score` values

With `--chat-template` configured, users can send plain `query` and `documents` without manually constructing chat prompts.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only update.

### How was this patch tested?

- Reviewed the updated markdown for consistency with `Qwen3-VL-Reranker.md`
- Manually verified the rerank API example against a running `vllm serve` instance with `--chat-template ./qwen3_reranker.jinja`; the curl request and returned JSON match the documented example

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
