### PR TITLE
[Feature][Spec Decode] Align dspark/dflash draft fc with QuaRot-rotated target hidden states

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -286,6 +286,91 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
+    def _maybe_anti_rotate_fc(self) -> None:
+        """ Anti-rotate draft fc weights when the target is a QuaRot model.
+        The target's hidden states (fed to the draft via combine_hidden_states)
+        live in QuaRot's rotated space, while the draft fc projection was trained
+        in the unrotated space. Right-multiply fc.weight by the rotation matrix Q
+        (block-diagonal over the concatenated aux features) so the draft operates
+        in the same rotated space as the target.
+        """
+        if self.method not in ("dflash", "dspark"):
+            return
+        target_model_path = self.vllm_config.model_config.model
+        Q = self._load_quarot_rotation(target_model_path)
+        if Q is None:
+            return
+        draft_model = getattr(self.model, "model", None)
+        fc = getattr(draft_model, "fc", None) if draft_model is not None else None
+        if fc is None:
+            return
+        fc_weight = fc.weight
+        out_features, in_features = fc_weight.shape
+        H = Q.shape[0]
+        if in_features % H != 0:
+            logger.warning(
+                "[spec_decode/quarot] fc in_features=%d not divisible by Q dim=%d; "
+                "skipping fc anti-rotation.",
+                in_features,
+                H,
+            )
+            return
+        num_features = in_features // H
+        Q = Q.to(fc_weight.device).to(torch.float32)
+        # Apply Q to each H-sized block of the in_features axis (block-diagonal
+        # rotation) without materializing the mostly-zero block-diagonal matrix.
+        fc_f32 = fc_weight.data.to(torch.float32).reshape(out_features, num_features, H)
+        fc_rot = torch.matmul(fc_f32, Q)  # [out, num_features, H]
+        fc_weight.data = fc_rot.reshape(out_features, in_features).to(fc_weight.dtype)
+        logger.info(
+            "[spec_decode/quarot] Anti-rotated draft fc.weight with QuaRot Q "
+            "(num_features=%d, fc=%s).",
+            num_features,
+            tuple(fc_weight.shape),
+        )
+
+    @staticmethod
+    def _load_quarot_rotation(target_model_path: str):
+        """ Load QuaRot global_rotation Q from the target model dir.
+        Returns None when target is not a QuaRot model.
+        """
+        import json
+        from pathlib import Path
+        from safetensors.torch import load_file
+        desc_path = Path(target_model_path) / "quant_model_description.json"
+        if not desc_path.exists():
+            logger.info(
+                "[spec_decode/quarot] No QuaRot descriptor found at %s; "
+                "skipping draft fc anti-rotation (target treated as non-QuaRot). "
+                "If the target is a QuaRot model, make sure it is a local path.",
+                desc_path,
+            )
+            return None
+        try:
+            with open(desc_path) as f: desc = json.load(f)
+            if not desc.get("is_rot_used", False):
+                return None
+            rel = desc["optional"]["quarot"]["rotation_map"]["global_rotation"]
+        except (KeyError, ValueError, OSError) as e:
+            logger.warning("[spec_decode/quarot] is_rot_used=True but a key is missing in %s "
+                   "(verify schema: %s); skipping.", desc_path, e)
+            return None
+
+        q_path = Path(target_model_path) / rel
+        if not q_path.exists():
+            logger.warning("[spec_decode/quarot] is_rot_used=True but rotation file %s "
+                           "missing; skipping fc anti-rotation",
+                           q_path,
+            )
+            return None
+        try:
+            return load_file(q_path)["global_rotation"]
+        except Exception as e:
+            logger.warning(
+                "[spec_decode/quarot] Failed to load rotation %s: %s", q_path, e,
+            )
+            return None
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -316,6 +401,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         with self.maybe_eager_context:
             self.model = self._get_model()
+
+        self._maybe_anti_rotate_fc()
 
         # Find draft layers (attention layers added by draft model)
         all_attn_layers = get_layers_from_vllm_config(


### PR DESCRIPTION
### What this PR does / why we need it?

When the target model is quantized with QuaRot, a global orthogonal (Hadamard)
rotation is applied to the residual stream, so the target's hidden states live
in a *rotated* space. A dspark/dflash draft model's first projection (`fc`) is
trained against *un-rotated* hidden states. Without adaptation, the draft
receives rotated hidden states from the target (fed in through
`combine_hidden_states`) and emits mismatched logits, which collapses the
speculative acceptance rate.

This PR makes the Ascend spec-decode draft proposer QuaRot-aware: at draft-model
load time it right-multiplies the draft `fc.weight` by the QuaRot rotation matrix
`Q` (applied block-diagonally over the concatenated aux-feature blocks) so the
draft operates in the same rotated space as the target.

Why it is needed: a dspark/dflash draft on Ascend cannot be paired with a
QuaRot-quantized target without this alignment; acceptance drops to near zero
otherwise.

The logic applies to both `dflash` and `dspark` draft methods (single code path,
gated by `if self.method not in ("dflash", "dspark"): return`). It is validated
in this PR with `dflash`.

Changes are confined to `vllm_ascend/spec_decode/llm_base_proposer.py`:

- New static method `_load_quarot_rotation(target_model_path)`:
  - Reads `quant_model_description.json` from the target model directory.
  - If `is_rot_used` is true, loads the `global_rotation` matrix from the
    safetensors file referenced by
    `optional.quarot.rotation_map.global_rotation`.
  - Returns `None` for non-QuaRot targets, so the whole feature is a graceful
    no-op for ordinary models. Missing descriptor / missing rotation file /
    schema mismatch are logged and treated as "not QuaRot".

- New method `_maybe_anti_rotate_fc()`:
  - Runs only for the `dflash` / `dspark` methods.
  - Validates `fc.in_features % Q.shape[0] == 0` (logs and skips otherwise).
  - Applies the block-diagonal rotation cheaply: reshapes `fc.weight` to
    `[out, num_features, H]`, batched-multiplies by `Q` (`[H, H]`), reshapes
    back. No large block-diagonal matrix is materialized, so it is NPU-memory
    friendly even for large hidden sizes. Math is done in float32 and cast back
    to the original dtype; bias is untouched (Q is orthogonal).

- `load_model()` calls `self._maybe_anti_rotate_fc()` right after the draft
  model is loaded and *before* ACL graph capture, so the rotated weights are
  baked into the captured graph.

Safe by default: for any non-QuaRot target the rotation descriptor is absent and
the code returns early, so existing dspark/dflash/eagle/mtp paths are unchanged.

### Does this PR introduce _any_ user-facing change?

No public API or CLI change, and no new environment variable. The behavior is
identical for all existing setups. The only observable difference is that a
dspark/dflash draft model is now automatically adapted when the target model is
detected as QuaRot (presence of `quant_model_description.json` with
`is_rot_used=true` under the target model directory). For non-QuaRot targets the
change is a no-op.

### How was this patch tested?

Validated end-to-end on Ascend NPU with **GLM-5.2-w4a8** (QuaRot, W4A8 target)
paired with **GLM-5.2-FP8-DFlash** (draft), using only the code in this PR
(no extra patches).

1. Apply this PR (the `llm_base_proposer.py` change).
2. Launch DFlash spec decode with a QuaRot-quantized target and its DFlash
   draft, e.g.:

   ```bash
   vllm serve <path/to/quarot-target> \
       --speculative-config '{"method":"dflash","model":"<path/to/dflash-draft>","num_speculative_tokens":7}' \
       # ... remaining args
   ```

   During startup, confirm the rotation actually ran:

   ```
   [spec_decode/quarot] Anti-rotated draft fc.weight with QuaRot Q (num_features=N, fc=...)
   ```

   - If this line appears, the DFlash draft has the `fc` layer and it was rotated
     (the PR took effect).
   - If it does NOT appear (and there is also no `not divisible` / `No QuaRot
     descriptor found` message), the DFlash draft has no `fc` attribute and the
     rotation was silently skipped -- the target layer name in
     `_maybe_anti_rotate_fc` would need adjusting.

Results (GLM-5.2-w4a8 target + GLM-5.2-FP8-DFlash draft, GSM8K dataset,
num_speculative_tokens=7, 200 requests, max concurrency 10):

Without the fc anti-rotation, speculative decoding is effectively broken
(acceptance ~0.6%, almost no draft tokens accepted). With this PR it becomes
functional:

| Metric                          | Before (no rotation) | After (this PR) |
|---------------------------------|----------------------|-----------------|
| Acceptance rate (%)             | 0.60                 | 8.51            |
| Acceptance length               | 1.04                 | 1.60            |

Per-position acceptance (%):

| Position | Before (no rotation) | After (this PR) |
|----------|----------------------|-----------------|
| 0        | 4.21                 | 37.47           |
| 1        | 0.02                 | 13.85           |
| 2        | 0.00                 | 5.30            |
| 3        | 0.00                 | 1.98            |
| 4        | 0.00                 | 0.72            |
| 5        | 0.00                 | 0.23            |
| 6        | 0.00                 | 0.06            |

The modest absolute acceptance is expected for a W4A8-quantized target, where
target-side quantization noise limits how closely the draft can match; the point
of this PR is that spec decoding goes from non-functional to functional.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
