### PR TITLE
[BugFix][Refactor] Fix `sp` in dspark

### DIFF
--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -23,7 +23,10 @@ from types import SimpleNamespace
 import pytest
 from vllm.config import CUDAGraphMode
 
-from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.spec_decode.llm_base_proposer import (
+    AscendSpecDecodeBaseProposer,
+    _disable_flash_comm_v1_context,
+)
 
 # CUDAGraphMode values whose ``has_full_cudagraphs()`` is True: FULL plus the
 # two composite modes that mix FULL with NONE / PIECEWISE.
@@ -110,3 +113,45 @@ class TestDisablePaddedDrafterBatchWithFullGraph:
         )
 
         proposer._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
+
+
+class TestDisableFlashCommV1Context:
+    """``_disable_flash_comm_v1_context`` temporarily clears
+    ``forward_context.flash_comm_v1_enabled`` while MarkovHead runs -- MarkovHead
+    operates in the all-gathered full space, so SP's reduce-scatter must not
+    split ``markov_emb`` -- then restores the original value on exit, including
+    on exception. See commit c62ef687b ([BugFix] Fix `sp` in dspark).
+    """
+
+    @staticmethod
+    def _patch_forward_context(monkeypatch, flash_comm_v1_enabled: bool):
+        ctx = SimpleNamespace(flash_comm_v1_enabled=flash_comm_v1_enabled)
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.get_forward_context",
+            lambda: ctx,
+        )
+        return ctx
+
+    def test_clears_while_inside_when_sp_on(self, monkeypatch):
+        ctx = self._patch_forward_context(monkeypatch, True)
+        with _disable_flash_comm_v1_context():
+            assert ctx.flash_comm_v1_enabled is False
+
+    def test_restores_true_on_exit(self, monkeypatch):
+        ctx = self._patch_forward_context(monkeypatch, True)
+        with _disable_flash_comm_v1_context():
+            pass
+        assert ctx.flash_comm_v1_enabled is True
+
+    def test_restores_false_on_exit(self, monkeypatch):
+        """SP already off -> clearing is a no-op, original False preserved."""
+        ctx = self._patch_forward_context(monkeypatch, False)
+        with _disable_flash_comm_v1_context():
+            assert ctx.flash_comm_v1_enabled is False
+        assert ctx.flash_comm_v1_enabled is False
+
+    def test_restores_on_exception(self, monkeypatch):
+        ctx = self._patch_forward_context(monkeypatch, True)
+        with pytest.raises(RuntimeError, match="boom"), _disable_flash_comm_v1_context():
+            raise RuntimeError("boom")
+        assert ctx.flash_comm_v1_enabled is True

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -23,10 +23,8 @@ from types import SimpleNamespace
 import pytest
 from vllm.config import CUDAGraphMode
 
-from vllm_ascend.spec_decode.llm_base_proposer import (
-    AscendSpecDecodeBaseProposer,
-    _disable_flash_comm_v1_context,
-)
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.spec_decode.utils import _disable_flash_comm_v1_context
 
 # CUDAGraphMode values whose ``has_full_cudagraphs()`` is True: FULL plus the
 # two composite modes that mix FULL with NONE / PIECEWISE.
@@ -127,7 +125,7 @@ class TestDisableFlashCommV1Context:
     def _patch_forward_context(monkeypatch, flash_comm_v1_enabled: bool):
         ctx = SimpleNamespace(flash_comm_v1_enabled=flash_comm_v1_enabled)
         monkeypatch.setattr(
-            "vllm_ascend.spec_decode.llm_base_proposer.get_forward_context",
+            "vllm_ascend.spec_decode.utils.get_forward_context",
             lambda: ctx,
         )
         return ctx

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
 from collections.abc import Callable
-from contextlib import AbstractContextManager, contextmanager, nullcontext
-from dataclasses import replace
+from contextlib import AbstractContextManager, nullcontext
 from functools import partial
 from typing import Any, cast
 
@@ -10,8 +9,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
-from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
@@ -54,60 +52,16 @@ from vllm_ascend.models.deepseek_v4_dspark import DSparkDeepseekV4ForCausalLM
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-from vllm_ascend.spec_decode.utils import SlidingWindowAdapter
+from vllm_ascend.spec_decode.utils import (
+    SlidingWindowAdapter,
+    _disable_flash_comm_v1_context,
+    _maybe_eager_context,
+    patch_tensor_parallel_group,
+)
 from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
-
-
-@contextmanager
-def patch_tensor_parallel_group(tp_group):
-    """Temporarily swap the global TP group for draft-model spec decode.
-
-    vllm-ascend local implementation for swapping the global TP group so the
-    draft model can run with a TP degree that differs from the target model.
-    """
-    old_tp_group = _ps.get_tp_group()
-    _ps._TP_STATE_PATCHED = True
-    _ps._TP = tp_group
-    try:
-        yield
-    finally:
-        _ps._TP_STATE_PATCHED = False
-        _ps._TP = old_tp_group
-
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
-
-
-# TODO: Remove it when the bug of fx-graph is solved
-# patch vllm_config to be in CompilationMode.NONE temporarily
-@contextmanager
-def _maybe_eager_context(vllm_config):
-    target_compilation_config = vllm_config.compilation_config
-    draft_compilation_config = replace(
-        target_compilation_config,
-        mode=CompilationMode.NONE,
-    )
-    # Model layers use these registries even when compilation is disabled.
-    draft_compilation_config.static_forward_context = target_compilation_config.static_forward_context
-    draft_compilation_config.static_all_moe_layers = target_compilation_config.static_all_moe_layers
-    vllm_config.compilation_config = draft_compilation_config
-    try:
-        yield
-    finally:
-        vllm_config.compilation_config = target_compilation_config
-
-
-# `sp` should be disabled when running MarkovHead
-@contextmanager
-def _disable_flash_comm_v1_context():
-    forward_context = get_forward_context()
-    _raw_flash_comm_v1 = forward_context.flash_comm_v1_enabled
-    try:
-        forward_context.flash_comm_v1_enabled = False
-        yield
-    finally:
-        forward_context.flash_comm_v1_enabled = _raw_flash_comm_v1
 
 
 # split hidden states along dimension of sequence

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -98,6 +98,18 @@ def _maybe_eager_context(vllm_config):
         vllm_config.compilation_config = target_compilation_config
 
 
+# `sp` should be disabled when running MarkovHead
+@contextmanager
+def _disable_flash_comm_v1_context():
+    forward_context = get_forward_context()
+    _raw_flash_comm_v1 = forward_context.flash_comm_v1_enabled
+    try:
+        forward_context.flash_comm_v1_enabled = False
+        yield
+    finally:
+        forward_context.flash_comm_v1_enabled = _raw_flash_comm_v1
+
+
 # split hidden states along dimension of sequence
 def split_inputs_tp_to_sp(hidden_states, out):
     # tp and sp share the same group
@@ -1191,16 +1203,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
                 # The MarkovHead performs bias correction on logits.
                 # The ConfidenceHead predicts the expected acceptance length of tokens(Not yet achieved).
-                raw_logits = self.model.compute_logits(sample_hidden_states)
-                logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
-                num_blk = logits.shape[0]
-                draft_token_ids = self._dspark_draft_buffer[:num_blk]
-                draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
-                for idx in range(self.num_speculative_tokens):
-                    markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
-                    logits_bias = self.model.markov_bias(markov_emb)
-                    logits[:, idx].add_(logits_bias)
-                    draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
+
+                # `sample_hidden_states` has been all-gathered to full.
+                # `markov_emb` should also be full to match it.
+                # We changed `flash_comm_v1_enabled` to avoid `markov_emb` from being split.
+                with _disable_flash_comm_v1_context():
+                    raw_logits = self.model.compute_logits(sample_hidden_states)
+                    logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
+                    num_blk = logits.shape[0]
+                    draft_token_ids = self._dspark_draft_buffer[:num_blk]
+                    draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
+                    for idx in range(self.num_speculative_tokens):
+                        markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
+                        logits_bias = self.model.markov_bias(markov_emb)
+                        logits[:, idx].add_(logits_bias)
+                        draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable():

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from contextlib import contextmanager
+from dataclasses import replace
+
 import numpy as np
 import torch
+import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
+from vllm.config import CompilationMode
+from vllm.forward_context import get_forward_context
 
 
 def update_num_computed_tokens_for_batch_change(
@@ -163,3 +169,51 @@ class SlidingWindowAdapter:
             if src is not None:
                 _windowed_cpu = src - ((src + k_future - w).clamp(min=0) // b) * b
                 setattr(common_attn_metadata, name, _windowed_cpu)
+
+
+@contextmanager
+def patch_tensor_parallel_group(tp_group):
+    """Temporarily swap the global TP group for draft-model spec decode.
+
+    vllm-ascend local implementation for swapping the global TP group so the
+    draft model can run with a TP degree that differs from the target model.
+    """
+    old_tp_group = _ps.get_tp_group()
+    _ps._TP_STATE_PATCHED = True
+    _ps._TP = tp_group
+    try:
+        yield
+    finally:
+        _ps._TP_STATE_PATCHED = False
+        _ps._TP = old_tp_group
+
+
+# TODO: Remove it when the bug of fx-graph is solved
+# patch vllm_config to be in CompilationMode.NONE temporarily
+@contextmanager
+def _maybe_eager_context(vllm_config):
+    target_compilation_config = vllm_config.compilation_config
+    draft_compilation_config = replace(
+        target_compilation_config,
+        mode=CompilationMode.NONE,
+    )
+    # Model layers use these registries even when compilation is disabled.
+    draft_compilation_config.static_forward_context = target_compilation_config.static_forward_context
+    draft_compilation_config.static_all_moe_layers = target_compilation_config.static_all_moe_layers
+    vllm_config.compilation_config = draft_compilation_config
+    try:
+        yield
+    finally:
+        vllm_config.compilation_config = target_compilation_config
+
+
+# `sp` should be disabled when running MarkovHead
+@contextmanager
+def _disable_flash_comm_v1_context():
+    forward_context = get_forward_context()
+    _raw_flash_comm_v1 = forward_context.flash_comm_v1_enabled
+    try:
+        forward_context.flash_comm_v1_enabled = False
+        yield
+    finally:
+        forward_context.flash_comm_v1_enabled = _raw_flash_comm_v1


### PR DESCRIPTION
### What this PR does / why we need it?

Enable `sp` in `DSpark` will cause a `shape-mismatch` error near `MarkovHead`.

`self.model.markov_embed` is out of the `draft_model_forward`, but the result of `self.model.markov_embed` is erroneously split by `sp`. It will cause a `shape-mismatch` error when calculating `draft_logits`.

We fixed it by disabling `flash_comm_v1_enabled` temporarily when calculating `draft_logits`.

**Additional Notes:**

`DSpark` requires `num_spec >= 5`, and `sp` must be set to `num_spec + 1`.

Therefore, the test requires at least 8 cards to run.

That is too many cards for an end-to-end test, so we only added a unit test.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Command to start a server:

```shell
set -euo pipefail

MODEL=/mnt/a800_weight/DeepSeek-V4-Flash-DSpark-re-w4a8
SERVED_NAME=deepseek-v4-flash-dspark
 
export HCCL_OP_EXPANSION_MODE=AIV
export TASK_QUEUE_ENABLE=1
export CPU_AFFINITY_CONF=1
export VLLM_ENGINE_READY_TIMEOUT_S=7200
 
export LCCL_DETERMINISTIC=1
export HCCL_DETERMINISTIC=true
export ATB_MATMUL_SHUFFLE_K_ENABLE=0
export ATB_LLM_LCOC_ENABLE=0

export VLLM_ASCEND_ENABLE_FLASHCOMM1=1

rm -rf /root/.cache/vllm/torch_compile_cache/*
vllm serve "${MODEL}" \
    --served-model-name "${SERVED_NAME}" \
    --host 0.0.0.0 --port 9898 \
    --tensor-parallel-size 8 \
    --data-parallel-size 2 \
    --enable-expert-parallel \
    --max-model-len 8192 \
    --max-num-seqs 16 \
    --speculative-config '{"method":"dspark","num_speculative_tokens":7,"enforce_eager":true}' \
    --async-scheduling \
    --additional-config '{"enable_cpu_binding": true}' \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
```

Command to test with a dataset:

```shell
ais_bench --models vllm_api_general_chat --datasets gsm8k_gen_4_shot_cot_chat_prompt --mode all --dump-eval-details --merge-ds --num-prompts 30
```

The acceptance-length of the `sp` enabled config:

```text
# tp8 dp1
num_drafts=717.0
num_accepted_tokens_per_pos=[664.0, 579.0, 496.0, 406.0, 328.0, 243.0, 166.0, 0]
acceptance_per_pos=[0.9260808926080892, 0.8075313807531381, 0.691771269177127, 0.5662482566248257, 0.45746164574616455, 0.3389121338912134, 0.2315202231520223, 0.0]
acceptance_len=5.01952580195258

# tp8 dp2
num_drafts=739.0
num_accepted_tokens_per_pos=[667.0, 588.0, 503.0, 430.0, 345.0, 257.0, 174.0, 0]
acceptance_per_pos=[0.9025710419485792, 0.7956698240866035, 0.6806495263870095, 0.5818673883626523, 0.4668470906630582, 0.34776725304465494, 0.2354533152909337, 0.0]
acceptance_len=5.010825439783491
```

The acceptance-length of the norm config:

```text
num_drafts=756.0
num_accepted_tokens_per_pos=[685.0, 600.0, 517.0, 437.0, 345.0, 260.0, 163.0, 0]
acceptance_per_pos=[0.906084656084656, 0.7936507936507936, 0.6838624338624338, 0.578042328042328, 0.45634920634920634, 0.3439153439153439, 0.2156084656084656, 0.0]
acceptance_len=4.977513227513228
```

The above tests show that `sp` with `DSpark` is fine now.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
