### PR TITLE
[Doc] Add single-node Atlas 800 A2 (64G x 8) deployment guide for GLM-5.2-w4a8c8

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -161,7 +161,6 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export HCCL_BUFFSIZE=200
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 export VLLM_ASCEND_ENABLE_FUSED_MC2=0
 vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
 --host 0.0.0.0 \
@@ -182,7 +181,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
 --gpu-memory-utilization 0.96 \
 --quantization ascend \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"enable_dsa_cp": true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"enable_balance_scheduling": true,"multistream_overlap_shared_expert":true}' \
+--additional-config '{"enable_flashcomm1": true,"enable_dsa_cp": true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"enable_balance_scheduling": true,"multistream_overlap_shared_expert":true}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 
 ```

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -151,6 +151,47 @@ The parameters are explained as follows:
 
 - For single-node deployment, we recommend using `dp1tp16` and turn off expert parallel in low-latency scenarios.
 
+#### Single Atlas 800 A2 (64G × 8) node
+
+- Quantized model `GLM-5.2-w4a8c8` can also be deployed on **1 Atlas 800 A2 (64G × 8)** node. A single A2 node only has 8 NPUs (an A3 node has 16), so use `dp1tp8` with expert parallel instead of `dp2tp8`, and reduce `max-num-seqs` / `max-model-len` to fit the smaller HBM.
+
+```shell
+export HCCL_OP_EXPANSION_MODE="AIV"
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+export HCCL_BUFFSIZE=200
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+export VLLM_ASCEND_ENABLE_FUSED_MC2=0
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w4a8c8 \
+--host 0.0.0.0 \
+--port 8077 \
+--api-server-count 1 \
+--data-parallel-size 1 \
+--enable-expert-parallel \
+--tensor-parallel-size 8 \
+--seed 1024 \
+--served-model-name glm-5 \
+--tool-call-parser glm47 \
+--reasoning-parser glm45 \
+--enable-auto-tool-choice \
+--max-num-seqs 4 \
+--max-model-len 16384 \
+--max-num-batched-tokens 2048 \
+--trust-remote-code \
+--gpu-memory-utilization 0.96 \
+--quantization ascend \
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+--additional-config '{"enable_dsa_cp": true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true,"enable_balance_scheduling": true,"multistream_overlap_shared_expert":true}' \
+--speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
+
+```
+
+**Notice:**
+
+- Use image `v0.23.0rc1` or later. With `v0.22.1rc1` the model fails to load with `KeyError: model.layers.X.self_attn.indexer.wq_b.weight`, because GLM-5.2 DSA uses a "shared indexer": only "full" layers store an independent indexer weight while "shared" layers reuse the previous full layer's indexer, so the quant description has no key for shared layers.
+- On a single A2 node the weights take ~54.7 GB/card, leaving little HBM for KV cache. If startup fails with a KV-cache `ValueError` (it prints a suggested maximum length), lower `max-model-len` further or raise `gpu-memory-utilization`.
+
 ### Multi-node Deployment
 
 If you want to deploy multi-node environment, you need to verify multi-node communication according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).


### PR DESCRIPTION
### What this PR does / why we need it?

The current GLM-5.2 tutorial only documents single-node deployment on **1 Atlas 800 A3 (64G × 16)** using `dp2tp8`. This PR adds a verified single-node deployment guide for the quantized `GLM-5.2-w4a8c8` on **1 Atlas 800 A2 (64G × 8)**.

Since an A2 node has only 8 NPUs (compared to 16 on A3), the standard `dp2tp8` configuration does not fit. This guide introduces a `dp1tp8` configuration with expert parallel enabled, and reduces `max-num-seqs` / `max-model-len` to fit the smaller HBM. It also documents two critical pitfalls (image version requirement and HBM limits for KV cache) found during bring-up.

Fixes #

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change: it adds a `#### Single Atlas 800 A2 (64G × 8) node` section under *Single-node Deployment* in `docs/source/tutorials/models/GLM5.2.md`, with a full `vllm serve` script and two notices.

### How was this patch tested?

Verified on real hardware: **1× Atlas 800 A2, 8× 910B, 64GB/card**, with `dp1tp8 + EP`, `max-num-seqs=4`, `max-model-len=16384`, `gpu-memory-utilization=0.96`, MTP (`deepseek_mtp`, 3 tokens). The service starts and serves correctly (`/v1/models` returns 200, inference correct).

**Performance** (`vllm bench serve`, random dataset, `--ignore-eos`)

Context length (concurrency=4, output=128):

| input len | total tput (tok/s) | mean TTFT (ms) | mean TPOT (ms) |
|-----------|-------------------:|---------------:|---------------:|
| 512       | 228.5              | 1128.7         | 77.4           |
| 2048      | 726.8              | 1239.0         | 78.0           |
| 4096      | 1252.1             | 2297.2         | 80.8           |
| 8192      | 1418.7             | 7710.2         | 105.9          |
| 12288     | 1550.5             | 16199.1        | 92.8           |

Concurrency (input=1024, output=128):

| concurrency | out tput (tok/s) | total tput (tok/s) | mean TTFT (ms) | mean TPOT (ms) |
|-------------|-----------------:|-------------------:|---------------:|---------------:|
| 1           | 14.9             | 134.1              | 630.5          | 62.7           |
| 2           | 27.2             | 245.0              | 851.1          | 64.4           |
| 4           | 45.6             | 410.1              | 1095.9         | 74.4           |
| 8           | 44.9             | 404.4              | 9399.2         | 82.3           |

At concurrency 8 throughput plateaus and TTFT rises sharply because `max-num-seqs=4` caps the running batch on a single A2 node (extra requests queue).

**Accuracy** (GSM8K 5-shot via `lm_eval` `local-completions` against the OpenAI-compatible endpoint, full 1319 samples):

| metric | score | stderr |
|--------|------:|-------:|
| exact_match, strict-match     | 0.9477 | 0.0061 |
| exact_match, flexible-extract | 0.9469 | 0.0062 |

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/54503ecec0f3ac31e5ecfc5f28652e4cc42307b5
