### PR TITLE
[Doc][BugFix] Update Atlas 310P startup configuration to disable npugraph_ex v0.24.0rc

### DIFF
--- a/docs/source/developer_guide/Design_Documents/npugraph_ex.md
+++ b/docs/source/developer_guide/Design_Documents/npugraph_ex.md
@@ -6,6 +6,10 @@ This is an optimization based on FX graphs, which can be considered an accelerat
 
 You can get its code [code](https://gitcode.com/Ascend/torchair)
 
+!!! note "Atlas inference products"
+
+    Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
+
 ## Default FX Graph Optimization
 
 ### FX Graph pass

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -49,6 +49,8 @@ This section guides you through container-based environment setup and large mode
 
     Atlas inference products use `float16`. Use the `-310p` image suffix for Ubuntu or `-310p-openeuler` for openEuler. Atlas inference products do not support `triton` or `triton-ascend`.
 
+    Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
+
     Atlas 200I Pro requires additional device nodes and driver mounts. See [Set up using Docker](installation.md#set-up-using-docker) for the complete container commands.
 
 ## Setup environment using container

--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -174,7 +174,8 @@ Run docker container to start the vLLM server on single-NPU:
     vllm serve Qwen/Qwen3-VL-8B-Instruct \
     --dtype float16 \
     --max_model_len 16384 \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}'
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}' \
+    --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'
     ```
 
     !!! note
@@ -183,6 +184,7 @@ Run docker container to start the vLLM server on single-NPU:
 
         - Only `float16` dtype is supported.
         - Graph compilation (`--compilation-config`) requires **CANN version >= 9.0.0**. If your CANN version is lower, replace `--compilation-config` with `--enforce-eager`.
+        - `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required because `enable_npugraph_ex` is not supported on Atlas inference products.
 
 Key Parameter Descriptions:
 

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -303,7 +303,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --max-num-seqs 32 \
         --served-model-name qwen3 \
         --dtype float16 \
-        --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+        --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,32]}' \
         --quantization ascend \
         --max-model-len 20480 \
@@ -325,7 +325,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --max-num-seqs 16 \
         --served-model-name qwen3 \
         --dtype float16 \
-        --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+        --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}' \
         --quantization ascend \
         --max-model-len 20480 \
@@ -347,7 +347,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --max-num-seqs 32 \
         --served-model-name qwen3 \
         --dtype float16 \
-        --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+        --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [16,32]}' \
         --quantization ascend \
         --max-model-len 20480 \

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -233,7 +233,7 @@ Single-node deployment runs both Prefill and Decode on the same node. `Qwen3.6-3
       --max-num-seqs 16 \
       --served-model-name qwen3.6 \
       --dtype float16 \
-      --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
+      --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}' \
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,8]}' \
       --quantization ascend \
       --max-model-len 20480 \
@@ -246,7 +246,7 @@ Single-node deployment runs both Prefill and Decode on the same node. `Qwen3.6-3
     - `--dtype float16` is used for Atlas inference products to match the Atlas inference execution path.
     - `--max-num-seqs 16` limits concurrent active requests to reduce KV cache and graph capture pressure on Atlas inference products.
     - `--gpu-memory-utilization` controls KV cache capacity. Reduce it if startup or runtime requests report OOM.
-    - `--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'` disables norm-quant fusion for the Atlas inference products serving path.
+    - `--additional-config` with `"ascend_compilation_config": {"enable_npugraph_ex": false}` is required because `enable_npugraph_ex` is not supported on Atlas inference products.
     - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}'` enables decode ACLGraph replay and explicitly limits capture sizes for Atlas inference products.
     - `--no-enable-prefix-caching` is the default recommendation for this Atlas inference products example to reduce memory pressure.
     - `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.

--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -123,6 +123,10 @@ This is most likely to appear in `PIECEWISE` or `FULL_AND_PIECEWISE` configurati
 
 As introduced in the [RFC](https://github.com/vllm-project/vllm-ascend/issues/4715), Npugraph_ex is a compile-time FX graph optimization layer that works together with ACLGraph. It optimizes the model's FX graph before ACLGraph captures it at runtime. Its performance benefits mainly come from fusing multiple operators into single kernels (e.g., add + rms_norm → npu_add_rms_norm) to reduce kernel launch overhead.
 
+!!! note "Atlas inference products"
+
+    Atlas inference products and Atlas 200I Pro do not support `enable_npugraph_ex`. Set --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}'.
+
 ### Default behavior
 
 Npugraph_ex is **enabled by default** when `cudagraph_mode` is `FULL` or `FULL_DECODE_ONLY`. It is automatically disabled in `PIECEWISE` or `NONE` modes.


### PR DESCRIPTION
### What this PR does / why we need it?
Add the 310P device to start the VLLM service requires the documentation for --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex":false}}. this modification has been merged into main, due to conflict cannot cherry-pick into v0.24.0, so a new PR happened.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
Local test
- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
