### PR TITLE
[Doc] update MindIE-Motor repository links

### DIFF
--- a/docs/source/user_guide/deployment_guide/using_mindie_motor.md
+++ b/docs/source/user_guide/deployment_guide/using_mindie_motor.md
@@ -2,8 +2,8 @@
 
 ## 1. Overview
 
-[MindIE-Motor](https://gitcode.com/Ascend/MindIE-PyMotor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
+[MindIE-Motor](https://gitcode.com/Ascend/MindIE-Motor) provides one-click deployment for **prefill–decode (PD) disaggregation** and **PD aggregation** on Ascend NPUs with vLLM-Ascend. It uses **high-performance scheduling and load balancing**, together with **RAS (Reliability, Availability and Serviceability) capabilities**, to build inference services that are fast and highly stable.
 
 ## 2. Getting Started
 
-For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-PyMotor/blob/master/docs/zh/user_guide/README.md).
+For quick deployment instructions, refer to the [MindIE-Motor Quick Start](https://gitcode.com/Ascend/MindIE-Motor/blob/master/docs/zh/user_guide/README.md).


### PR DESCRIPTION
### What this PR does / why we need it?

Update MindIE-Motor documentation links in `using_mindie_motor.md` from the old `MindIE-PyMotor` repository to the current repository:
https://gitcode.com/Ascend/MindIE-Motor

No code logic changes.

### Does this PR introduce _any_ user-facing change?

Documentation links only.

### How was this patch tested?

Link targets verified.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
