### PR TITLE
[CI] Add full ut protection for dspark

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -117,7 +117,7 @@ class _DSparkProposerTestBase:
         proposer._per_group_context_slot_mapping_buffers = {gid: slot.clone()}
         return proposer
 
-# fmt: off
+    # fmt: off
     @staticmethod
     def _invoke_set_inputs_first_pass(
         proposer,
@@ -163,6 +163,8 @@ class _DSparkProposerTestBase:
             num_rejected_tokens_gpu=num_rejected,
         )
         return num_query_total, token_indices, cad, extra, next_token_ids, target_hidden_states
+
+
 # fmt: on
 
 

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -117,6 +117,7 @@ class _DSparkProposerTestBase:
         proposer._per_group_context_slot_mapping_buffers = {gid: slot.clone()}
         return proposer
 
+# fmt: off
     @staticmethod
     def _invoke_set_inputs_first_pass(
         proposer,
@@ -162,6 +163,7 @@ class _DSparkProposerTestBase:
             num_rejected_tokens_gpu=num_rejected,
         )
         return num_query_total, token_indices, cad, extra, next_token_ids, target_hidden_states
+# fmt: on
 
 
 class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
@@ -344,6 +346,9 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
         assert proposer.sample_from_anchor is expected_sample_from_anchor
         assert proposer.num_query_per_req == expected_num_query_per_req
         assert proposer.max_query_tokens == expected_max_query_tokens
+
+
+# fmt: off
 class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
     """``set_per_group_attn_metadata`` stores the runner-provided per-group
     block table / slot mapping into the read-only dicts the proposer consults
@@ -680,3 +685,4 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         kv_cache_config = SimpleNamespace(kv_cache_groups=[non_overlapping_group])
         with pytest.raises(RuntimeError, match="registered draft attention groups"):
             proposer.initialize_attn_backend(kv_cache_config)
+# fmt: on

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -27,6 +27,8 @@ import numpy as np
 import pytest
 import torch
 
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
@@ -114,6 +116,52 @@ class _DSparkProposerTestBase:
         proposer._per_group_query_slot_mapping_buffers = {gid: slot.clone()}
         proposer._per_group_context_slot_mapping_buffers = {gid: slot.clone()}
         return proposer
+
+    @staticmethod
+    def _invoke_set_inputs_first_pass(
+        proposer,
+        *,
+        num_reqs,
+        block_size,
+        seq_len=128,
+        context=None,
+        num_rejected=None,
+        with_optional_attrs=False,
+    ):
+        """Drive ``set_inputs_first_pass`` with a configurable cad.
+
+        ``context`` sets ``query_start_loc_cpu[num_reqs]`` so the proposer
+        copies ``context`` rows of target hidden states (0 by default).
+        Returns ``(num_query_total, token_indices, cad, extra,
+        next_token_ids, target_hidden_states)``.
+        """
+        next_token_ids = torch.arange(1, num_reqs + 1, dtype=torch.int64)
+        target_hidden_states = torch.arange(
+            num_reqs * 8, dtype=torch.float32
+        ).reshape(num_reqs, 8)
+        query_start_loc_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
+        if context is not None:
+            query_start_loc_cpu[num_reqs] = context
+        cad = SimpleNamespace(
+            num_reqs=num_reqs,
+            query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=torch.full((num_reqs,), seq_len, dtype=torch.int32),
+            max_seq_len=seq_len,
+        )
+        if with_optional_attrs:
+            cad.actual_seq_lengths_q = [0] * num_reqs
+            cad.decode_token_per_req = 0
+        num_query_total, token_indices, cad, extra = proposer.set_inputs_first_pass(
+            target_token_ids=torch.zeros(num_reqs, dtype=torch.int64),
+            next_token_ids=next_token_ids,
+            target_positions=torch.zeros(num_reqs, dtype=torch.int32),
+            target_hidden_states=target_hidden_states,
+            token_indices_to_sample=None,
+            cad=cad,
+            num_rejected_tokens_gpu=num_rejected,
+        )
+        return num_query_total, token_indices, cad, extra, next_token_ids, target_hidden_states
 
 
 class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
@@ -296,3 +344,339 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
         assert proposer.sample_from_anchor is expected_sample_from_anchor
         assert proposer.num_query_per_req == expected_num_query_per_req
         assert proposer.max_query_tokens == expected_max_query_tokens
+class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
+    """``set_per_group_attn_metadata`` stores the runner-provided per-group
+    block table / slot mapping into the read-only dicts the proposer consults
+    during ``set_inputs_first_pass``."""
+
+    def test_stores_block_table_and_slot_mapping(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        # a gid not pre-populated by _make_proposer (which only seeds gid=0)
+        gid = 7
+        block_table = torch.zeros((num_reqs, 16), dtype=torch.int32)
+        slot_mapping = torch.full((max_num_tokens,), 42, dtype=torch.int32)
+
+        proposer.set_per_group_attn_metadata(gid, block_table, slot_mapping)
+
+        assert proposer._per_group_block_tables[gid] is block_table
+        assert proposer._per_group_slot_mappings[gid] is slot_mapping
+
+    def test_overwrites_existing_gid(self):
+        num_reqs, block_size, max_num_tokens = 2, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        gid = 0  # already populated by _make_proposer
+        old_block_table = proposer._per_group_block_tables[gid]
+        new_block_table = torch.ones((num_reqs, 16), dtype=torch.int32)
+        new_slot_mapping = torch.ones(max_num_tokens, dtype=torch.int32)
+
+        proposer.set_per_group_attn_metadata(gid, new_block_table, new_slot_mapping)
+
+        assert proposer._per_group_block_tables[gid] is new_block_table
+        assert proposer._per_group_slot_mappings[gid] is new_slot_mapping
+        assert proposer._per_group_block_tables[gid] is not old_block_table
+
+
+class TestDSparkInitValidation:
+    """``AscendDSparkProposer.__init__`` rejects probabilistic draft sampling
+    (unsupported on the v1 model runner) and, for the greedy path, allocates
+    the DSpark-specific draft/seed buffers and overrides the DFlash
+    query-token / cudagraph defaults."""
+
+    @staticmethod
+    def _make_vllm_config(
+        *,
+        num_speculative_tokens,
+        max_batch_size,
+        max_num_tokens,
+        draft_sample_method,
+        hidden_size=8,
+    ):
+        speculative_config = SimpleNamespace(
+            num_speculative_tokens=num_speculative_tokens,
+            draft_sample_method=draft_sample_method,
+            draft_model_config=SimpleNamespace(get_hidden_size=lambda: hidden_size),
+        )
+        return SimpleNamespace(speculative_config=speculative_config)
+
+    @staticmethod
+    def _stub_dflash_init(
+        monkeypatch,
+        *,
+        num_speculative_tokens,
+        max_batch_size,
+        max_num_tokens,
+        dtype,
+        device,
+    ):
+        """Replace the heavy DFlash/Eagle base init with a stub that only sets
+        the attributes DSpark's ``__init__`` subsequently reads."""
+
+        def _stub(self, vllm_config, device, runner=None):
+            self.num_speculative_tokens = num_speculative_tokens
+            self.max_batch_size = max_batch_size
+            self.max_num_tokens = max_num_tokens
+            self.dtype = dtype
+            self.device = device
+            # present so the ``del`` in DSpark.__init__ succeeds
+            self.hidden_size = 0
+            self.hidden_states = None
+            self._dflash_hidden_states = None
+
+        monkeypatch.setattr(AscendDflashProposer, "__init__", _stub)
+
+    def test_probabilistic_rejected(self, monkeypatch):
+        device = torch.device("cpu")
+        self._stub_dflash_init(
+            monkeypatch,
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            dtype=torch.float32,
+            device=device,
+        )
+        vllm_config = self._make_vllm_config(
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            draft_sample_method="probabilistic",
+        )
+        with pytest.raises(ValueError, match="probabilistic"):
+            AscendDSparkProposer(vllm_config, device)
+
+    def test_greedy_allocates_dspark_buffers(self, monkeypatch):
+        device = torch.device("cpu")
+        num_spec, max_batch, max_num_tokens, hidden = 5, 16, 256, 8
+        self._stub_dflash_init(
+            monkeypatch,
+            num_speculative_tokens=num_spec,
+            max_batch_size=max_batch,
+            max_num_tokens=max_num_tokens,
+            dtype=torch.float32,
+            device=device,
+        )
+        vllm_config = self._make_vllm_config(
+            num_speculative_tokens=num_spec,
+            max_batch_size=max_batch,
+            max_num_tokens=max_num_tokens,
+            draft_sample_method="greedy",
+            hidden_size=hidden,
+        )
+        proposer = AscendDSparkProposer(vllm_config, device)
+
+        blk = 1 + num_spec
+        max_query_tokens = max_batch * num_spec
+        # DSpark-specific draft / seed buffers.
+        assert proposer._dspark_draft_buffer.shape == (max_batch, blk)
+        assert proposer._dspark_draft_buffer.dtype == torch.int64
+        assert proposer._dspark_seed_buffer.shape == (max_batch,)
+        assert proposer._dspark_seed_buffer.dtype == torch.int64
+        # hidden_size / hidden states come from the draft model config.
+        assert proposer.hidden_size == hidden
+        assert proposer.hidden_states.shape == (max_num_tokens, hidden)
+        assert proposer._dflash_hidden_states.shape == (max_num_tokens, hidden)
+        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
+        assert proposer.use_cuda_graph is False
+        # anchor-first: N query tokens per request, no bonus token (unlike
+        # DFlash's 1+N).
+        assert proposer.max_query_tokens == max_query_tokens
+        assert proposer.positions.shape == (max_query_tokens,)
+        assert proposer.positions.dtype == torch.int32
+        assert proposer._slot_mapping_buffer.shape == (max_query_tokens,)
+        # per-group bookkeeping dicts start empty / None.
+        assert proposer._per_group_block_tables == {}
+        assert proposer._per_group_slot_mappings == {}
+        assert proposer._context_slot_mapping_buffers is None
+
+
+class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
+    """``set_inputs_first_pass`` returns the anchor-first query budget and
+    rewrites the common attention metadata into the DSpark cross-attention
+    shape (N query tokens per request, non-causal, chunked-prefill state)."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_kernel(self, monkeypatch):
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer."
+            "copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+            MagicMock(),
+        )
+
+    def test_return_value_and_token_indices(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        num_query_total, token_indices, _cad, extra = (
+            self._invoke_set_inputs_first_pass(
+                proposer, num_reqs=num_reqs, block_size=block_size
+            )[:4]
+        )
+        assert num_query_total == num_reqs * block_size
+        assert token_indices.shape == (num_reqs * block_size,)
+        assert token_indices.dtype == torch.int32
+        # 4th return slot is unused (no per-group attn metadata tuple here).
+        assert extra is None
+
+    def test_seed_buffer_copied_from_next_tokens(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size
+        )
+        expected = torch.arange(1, num_reqs + 1, dtype=torch.int64)
+        assert torch.equal(proposer._dspark_seed_buffer[:num_reqs], expected)
+        assert torch.all(proposer._dspark_seed_buffer[num_reqs:] == 0)
+
+    def test_context_hidden_states_copied(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size, context=num_reqs
+        )
+        assert proposer._dflash_num_context == num_reqs
+        expected = torch.arange(num_reqs * 8, dtype=torch.float32).reshape(num_reqs, 8)
+        assert torch.equal(proposer._dflash_hidden_states[:num_reqs], expected)
+
+    def test_cad_rewritten_to_cross_attention_shape(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        num_query_total, _, cad, _ = self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size, with_optional_attrs=True
+        )[:4]
+        # token budgets reflect anchor-first (N per request, no bonus).
+        assert cad.num_actual_tokens == num_query_total
+        assert cad.num_input_tokens == num_query_total
+        assert cad.max_query_len == block_size
+        assert cad.max_seq_len == 128 + block_size
+        # attention is non-causal cross-attention over the draft query block.
+        assert cad.causal is False
+        assert cad.attn_mask is None
+        assert cad.attn_state == AscendAttentionState.ChunkedPrefill
+        # positions is the full buffer (DSA slices it), not a pre-slice.
+        assert cad.positions is proposer.positions
+        # slot mapping is a slice of the primary group's query buffer (shares
+        # storage from offset 0); a fresh slice is not identity-equal, so check
+        # the underlying storage and length instead.
+        assert (
+            cad.slot_mapping.data_ptr()
+            == proposer._per_group_query_slot_mapping_buffers[0].data_ptr()
+        )
+        assert cad.slot_mapping.shape[0] == num_query_total
+        # optional attrs the proposer rewrites when present.
+        assert cad.actual_seq_lengths_q == [block_size] * num_reqs
+        assert cad.decode_token_per_req == block_size
+
+    def test_cad_query_start_loc_and_seq_lens(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size
+        )[:4]
+        expected_qsl = torch.arange(num_reqs + 1, dtype=torch.int32) * block_size
+        assert torch.equal(cad.query_start_loc, expected_qsl)
+        assert torch.equal(cad.query_start_loc_cpu, expected_qsl)
+        # seq_lens grow by block_size when no tokens were rejected.
+        assert torch.equal(cad.seq_lens, torch.full((num_reqs,), 128 + block_size, dtype=torch.int32))
+
+
+class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
+    """The ``has_num_rejected`` branch must shrink ``seq_lens`` by the rejected
+    token count before adding the draft block size, and flag the kernel."""
+
+    def test_seq_lens_subtracts_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer."
+            "copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+            MagicMock(),
+        )
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        rejected = torch.full((num_reqs,), 2, dtype=torch.int32)
+        _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size, num_rejected=rejected
+        )[:4]
+        # effective = seq_lens(128) - rejected(2) = 126; then + block_size(5) = 131.
+        assert torch.equal(
+            cad.seq_lens, torch.full((num_reqs,), 128 - 2 + block_size, dtype=torch.int32)
+        )
+
+    def test_kernel_called_with_has_num_rejected(self, monkeypatch):
+        kernel = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer."
+            "copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+            kernel,
+        )
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size
+        )
+        rejected = torch.full((num_reqs,), 2, dtype=torch.int32)
+        self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size, num_rejected=rejected
+        )
+        # The proposer calls the kernel as ``kernel[1,](...)`` (Triton-style
+        # grid indexing), so the call lands on the indexed sub-mock.
+        sub = kernel[1,]
+        assert sub.called
+        kwargs = sub.call_args.kwargs
+        assert kwargs["HAS_NUM_REJECTED"] is True
+        assert kwargs["num_rejected_tokens_ptr"] is rejected
+        assert kwargs["SAMPLE_FROM_ANCHOR"] is True
+
+
+class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
+    """``initialize_attn_backend`` raises clearly when the draft model does not
+    expose the DSpark layer-name API, or when no draft attention groups can be
+    built from the kv-cache groups."""
+
+    @staticmethod
+    def _make_proposer_for_init():
+        proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
+        proposer.vllm_config = SimpleNamespace()
+        proposer.device = torch.device("cpu")
+        return proposer
+
+    def test_model_without_draft_layer_names_raises(self, monkeypatch):
+        # get_layers_from_vllm_config is called first; stub it so the model
+        # check is what actually fails.
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *a, **k: {},
+        )
+        proposer = self._make_proposer_for_init()
+        # model lacks get_draft_kv_cache_layer_names entirely.
+        proposer.model = SimpleNamespace()
+
+        kv_cache_config = SimpleNamespace(kv_cache_groups=[])
+        with pytest.raises(RuntimeError, match="get_draft_kv_cache_layer_names"):
+            proposer.initialize_attn_backend(kv_cache_config)
+
+    def test_no_draft_attn_groups_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *a, **k: {},
+        )
+        proposer = self._make_proposer_for_init()
+        # draft layer names exist, but no kv-cache group names overlap them.
+        proposer.model = SimpleNamespace(get_draft_kv_cache_layer_names=lambda: {"L0"})
+
+        non_overlapping_group = SimpleNamespace(layer_names=["OTHER_LAYER"])
+        kv_cache_config = SimpleNamespace(kv_cache_groups=[non_overlapping_group])
+        with pytest.raises(RuntimeError, match="registered draft attention groups"):
+            proposer.initialize_attn_backend(kv_cache_config)

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -406,7 +406,10 @@ class TestDSparkInitValidation:
         speculative_config = SimpleNamespace(
             num_speculative_tokens=num_speculative_tokens,
             draft_sample_method=draft_sample_method,
-            draft_model_config=SimpleNamespace(get_hidden_size=lambda: hidden_size),
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(),
+                get_hidden_size=lambda: hidden_size
+            ),
         )
         return SimpleNamespace(speculative_config=speculative_config)
 
@@ -429,6 +432,7 @@ class TestDSparkInitValidation:
             self.max_num_tokens = max_num_tokens
             self.dtype = dtype
             self.device = device
+            self.draft_model_config = vllm_config.speculative_config.draft_model_config
             # present so the ``del`` in DSpark.__init__ succeeds
             self.hidden_size = 0
             self.hidden_states = None


### PR DESCRIPTION
### What this PR does / why we need it?
Add more dspark functions in ut to make sure the safety of them. Using ut has monitored more potential threats that may arise.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ut and tests

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
