### PR TITLE
[CI] Avoid gitleaks false positive in EAGLE test docstring

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -53,11 +53,10 @@ useDefault = true
 [[allowlists]]
 paths = ["^vllm-empty/"]
 
-# Allow tilingKey generic-api-key false positives in specified files
+# Allow tilingKey generic-api-key false positives in the specified file
 [[allowlists]]
 paths = [
-    "^csrc/notify_dispatch/op_host/notify_dispatch_tiling.cpp",
-    "^tests/ut/spec_decode/test_eagle_proposer.py"
+    "^csrc/notify_dispatch/op_host/notify_dispatch_tiling.cpp"
 ]
 rules = ["generic-api-key"]
 

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -4035,12 +4035,12 @@ class TestEagleProposerSetInputsFirstPass:
         Expected output layout:
         Request 0 (6 output slots = 4 - 1 + 3):
         - idx 0-2: shifted tokens [11, 12, 100]
-        - idx 3-4: parallel_drafting_tokens, is_masked=True
+        - idx 3-4: masked parallel drafting tokens
         - idx 5: padding_token, is_rejected=True
         Request 1 (6 output slots = 4 - 1 + 3):
         - idx 6-8: shifted tokens [21, 22, 23]
         - idx 9: bonus token 200
-        - idx 10-11: parallel_drafting_tokens, is_masked=True
+        - idx 10-11: masked parallel drafting tokens
         """
         num_speculative_tokens = 3
         block_size = BLOCK_SIZE


### PR DESCRIPTION
### What this PR does / why we need it?

Rewords two entries in the EAGLE proposer test docstring to avoid false positives from the `generic-api-key` gitleaks rule.

This uses the same wording as PR #12592:

- `parallel_drafting_tokens, is_masked=True`
- becomes `masked parallel drafting tokens`

The failing file is `tests/ut/spec_decode/a2/test_eagle_proposer.py`, which is distinct from the stale allowlist path `tests/ut/spec_decode/test_eagle_proposer.py`.

The stale path is also removed from `.gitleaks.toml`; the active A2 test is intentionally not allowlisted because the docstring is fixed at the source.

### Does this PR introduce _any_ user-facing change?

No. This is a test docstring and CI configuration cleanup.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
