### PR TITLE
[Doc][Misc]Unify the naming of Qwen3-30B-A3B and Qwen3-ASR-310 for Atlas 310P

### DIFF
--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -281,7 +281,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
     - `--max-num-seqs 16` limits concurrent active requests to reduce KV cache and graph capture pressure on Atlas inference products.
     - `--gpu-memory-utilization` controls KV cache capacity. Reduce it if startup or runtime requests report OOM.
     - `--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'` disables norm-quant fusion for the Atlas inference products serving path.
-    - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}'` enables decode ACLGraph replay and explicitly limits capture sizes for Atlas inference products.
+    - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,32]}'` enables decode ACLGraph replay and explicitly limits capture sizes for Atlas inference products.
     - `--no-enable-prefix-caching` is the default recommendation for this Atlas inference products example to reduce memory pressure.
     - `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.
     - To enable MTP speculative decoding, use --speculative_config '{"method": "mtp", "num_speculative_tokens": 1}'. We recommend setting num_speculative_tokens to 1.

--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -24,7 +24,13 @@ The following model variants are available. It is recommended to download the mo
 | -------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | Qwen3-30B-A3B (BF16) | Atlas 800I A3 (64G, 1\~2 cards)<br>Atlas 800I A2 (64G, 2\~4 cards) | [Download](https://www.modelscope.cn/models/Qwen/Qwen3-30B-A3B)          |
 | Qwen3-30B-A3B-W8A8   | Atlas 800I A3 (64G, 1\~2 cards)<br>Atlas 800I A2 (64G, 2\~4 cards)                               | [Download](https://www.modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8) |
-| Eagle3 Draft Model   | NA                                                                                               | [Download](https://huggingface.co/AngelSlim/Qwen3-a3B_eagle3)            |
+| Eagle3 Draft Model   | NA                                                                                               | [Download](https://modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8-QuaRot-310)            |
+
+**Quantized Versions for Atlas inference products:**
+
+| Model | Quantization | Hardware Requirement | Download |
+|-------|-------------|---------------------|----------|
+| Qwen3-30B-A3B-w8a8-QuaRot-310  |W8A8 | Atlas inference products (48G 2 cards)                                                                                               | [Download](https://modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8-QuaRot-310)            |
 
 These are the recommended numbers of cards, which can be adjusted according to the actual situation.
 
@@ -120,6 +126,32 @@ You can use the official all-in-one Docker image for Qwen3 MoE models.
         -v /usr/local/sbin:/usr/local/sbin \
         -it -d $IMAGE bash
     ```
+=== "Atlas inference products"
+
+    **Docker Run:**
+
+    ```bash
+
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
+
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=1g \
+        --net=host \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /root/.cache:/root/.cache \
+        -it $IMAGE bash
+    ```
 
 !!! tip
     The mounts above are the minimum required for NPU driver access. Add additional `-v` mounts (e.g., model weight paths, datasets) as needed for your environment.
@@ -162,6 +194,14 @@ If you prefer not to use the Docker image, you can build from source. Install vL
    pip install -e .
    ```
 
+!!! note
+
+    For Atlas inference products, source installation may pull in `triton` and `triton-ascend`. Uninstall them before running vLLM-Ascend on Atlas inference products:
+
+    ```bash
+    pip uninstall -y triton-ascend triton
+    ```   
+
 **Installation Verification:**
 
 ```bash
@@ -184,34 +224,67 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 
 > The following command is an example configuration. Adjust the parameters based on your actual scenario.
 
-**Atlas 800I A2/A3:**
+=== "Atlas 800I A2/A3"
 
-```bash
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
-export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    ```bash
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+    export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
+    export HCCL_BUFFSIZE=1024
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=1
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-vllm serve your_model_path \
-    --served-model-name qwen3 \
-    --trust-remote-code \
-    --max-num-seqs 100 \
-    --max-model-len 40960 \
-    --max-num-batched-tokens 16384 \
-    --tensor-parallel-size 4 \
-    --enable-expert-parallel \
-    --quantization ascend \
-    --distributed_executor_backend "mp" \
-    --no-enable-prefix-caching \
-    --async-scheduling \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
-    --gpu-memory-utilization 0.95 \
-    --port 8000 \
-    --speculative-config '{"method": "eagle3", "model": "your_eagle3_model_path", "draft_tensor_parallel_size": 1, "num_speculative_tokens": 3}'
-```
+    vllm serve your_model_path \
+        --served-model-name qwen3 \
+        --trust-remote-code \
+        --max-num-seqs 100 \
+        --max-model-len 40960 \
+        --max-num-batched-tokens 16384 \
+        --tensor-parallel-size 4 \
+        --enable-expert-parallel \
+        --quantization ascend \
+        --distributed_executor_backend "mp" \
+        --no-enable-prefix-caching \
+        --async-scheduling \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
+        --gpu-memory-utilization 0.95 \
+        --port 8000 \
+        --speculative-config '{"method": "eagle3", "model": "your_eagle3_model_path", "draft_tensor_parallel_size": 1, "num_speculative_tokens": 3}'
+    ```
+
+=== "Atlas inference products"
+
+    ```bash
+    export VLLM_USE_MODELSCOPE=True
+    export ASCEND_RT_VISIBLE_DEVICES=0,1
+
+    vllm serve your_model_path  \
+        --host 127.0.0.1 \
+        --port 8000 \
+        --tensor-parallel-size 2 \
+        --max-num-seqs 32 \
+        --served_model_name qwen3 \
+        --dtype float16 \
+        --quantization ascend \
+        --max-model-len 16384 \
+        --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false,"enable_npu_graph_ex":false}}' \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,32]}' \
+        --no-enable-prefix-caching
+    ```
+
+    **Key parameters:**
+
+    - `--tensor-parallel-size 2` maps the model across two Atlas inference devices. Adjust it together with `ASCEND_RT_VISIBLE_DEVICES` according to the available devices and memory.
+    - `--dtype float16` is used for Atlas inference products to match the Atlas inference execution path.
+    - `--max-model-len 16384` is intentionally conservative. On Atlas inference products, large context lengths allocate large attention masks, so do not rely on automatic max-model-len detection.
+    - `--max-num-seqs 16` limits concurrent active requests to reduce KV cache and graph capture pressure on Atlas inference products.
+    - `--gpu-memory-utilization` controls KV cache capacity. Reduce it if startup or runtime requests report OOM.
+    - `--additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}'` disables norm-quant fusion for the Atlas inference products serving path.
+    - `--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16]}'` enables decode ACLGraph replay and explicitly limits capture sizes for Atlas inference products.
+    - `--no-enable-prefix-caching` is the default recommendation for this Atlas inference products example to reduce memory pressure.
+    - `--quantization ascend` enables Ascend quantization for the W8A8 model. Remove this option when deploying the BF16 model.
+    - To enable MTP speculative decoding, use --speculative_config '{"method": "mtp", "num_speculative_tokens": 1}'. We recommend setting num_speculative_tokens to 1.
 
 !!! note
 

--- a/docs/source/tutorials/models/Qwen3-ASR-1.7B.md
+++ b/docs/source/tutorials/models/Qwen3-ASR-1.7B.md
@@ -1,105 +1,204 @@
 # Qwen3-ASR-1.7B
 
-## Introduction
+## 1 Introduction
 
-The released Qwen3-ASR-1.7B is a lightweight, high-performance automatic speech recognition (ASR) model developed by the Qwen Team. It delivers industry-leading recognition accuracy across Chinese/English multi-scene speech, Chinese dialects, multilingual and singing voice scenarios, with native support for long audio and streaming inference, and deep optimization for Ascend NPU hardware.
+Qwen3-ASR-1.7B is a 1.7B-parameter automatic speech recognition (ASR) model from the Qwen team. It supports Chinese and English speech, Chinese dialects, multilingual speech, and singing voice transcription, and provides long-audio and streaming inference capabilities.
 
-This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node deployment, accuracy and performance evaluation.
+This document describes the supported features, environment preparation, single-node deployment, functional verification, and evaluation workflow for Qwen3-ASR-1.7B on Ascend NPUs.
 
-## Environment Preparation
+Qwen3-ASR-1.7B was introduced with upstream vLLM v0.19.0. Use a vLLM-Ascend image that matches your vLLM version, and refer to the support matrix for the current release status.
 
-### Model Weight
+## 2 Supported Features
 
-`Qwen3-ASR-1.7B`(BF16 version): requires 1 Ascend 910B (with 1 x 64G NPUs).
+Please refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) for the model support matrix.
 
-`Qwen3-ASR-1.7B`(BF16 version): requires 1 Ascend 310P (with 1 x 48G NPUs).
-[Download model weight](https://modelscope.cn/models/Qwen/Qwen3-ASR-1.7B).
+Please refer to the [Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration information.
 
-It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
+## 3 Prerequisites
 
-### Installation
+### 3.1 Model Weight
 
-`Qwen3-ASR-1.7B` is supported in `vllm-ascend`.
+The BF16 model can be deployed with one Ascend 910B 64 GB NPU or one Ascend Atlas inference products 48 GB NPU. Download the model weights from [ModelScope](https://modelscope.cn/models/Qwen/Qwen3-ASR-1.7B).
 
-You can use our official docker image to run `Qwen3-ASR-1.7B` directly.
+Download the weights to a directory that is accessible from the deployment environment. For multi-node deployments, use a shared directory; for example, `/root/.cache/`.
+
+## 4 Installation
+
+### 4.1 Docker Image Installation
+
+Use the vLLM-Ascend Docker image that corresponds to your hardware. Replace the model-weight mount with the path used in your environment.
+
+=== "Atlas A2 inference products"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=1g \
+        --net host \
+        --device /dev/davinci0 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /root/.cache:/root/.cache \
+        -it -d $IMAGE bash
+    ```
+
+=== "Atlas inference products"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
+
+    docker run --rm \
+        --name vllm-ascend \
+        --shm-size=10g \
+        --net host \
+        --device /dev/davinci0 \
+        --device /dev/davinci_manager \
+        --device /dev/devmm_svm \
+        --device /dev/hisi_hdc \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /root/.cache:/root/.cache \
+        -it -d $IMAGE bash
+    ```
+
+Verify that the container is running and that the installed package version matches the image tag:
 
 ```bash
-export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
-docker run --rm \
-  --name vllm-ascend \
-  --shm-size=1g \
-  --device /dev/davinci0 \
-  --device /dev/davinci_manager \
-  --device /dev/devmm_svm \
-  --device /dev/hisi_hdc \
-  -v /usr/local/dcmi:/usr/local/dcmi \
-  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
-  -v /etc/ascend_install.info:/etc/ascend_install.info \
-  -v /root/.cache:/root/.cache \
-  -v /data/vllm-workspace/models:/data/vllm-workspace/models \
-  -p 8000:8000 \
-  -it $IMAGE bash
+docker ps --filter name=vllm-ascend
+pip show vllm vllm-ascend
 ```
 
-In addition, if you don't want to use the docker image as above, you can also build all from source:
+Expected result: `docker ps` lists the container with status `Up`, and `pip show` displays version information for both packages.
 
-- Install `vllm-ascend` from source, refer to [installation](../../installation.md).
+### 4.2 Source Code Installation
 
-## Deployment
+f you prefer to build from source instead of using the Docker image, install vLLM-Ascend following the [Installation Guide](../../installation.md).
 
-### Atlas 300I A2 2UP
+!!! note
 
-```shell
-vllm serve "Qwen/Qwen3-ASR-1.7B" \
-  --tensor-parallel-size 1 \
-  --max-model-len 4096 \
-  --gpu-memory-utilization 0.9 \
-  --enforce-eager \
-  --port 8000
+    For Atlas inference products, source installation may pull in `triton` and `triton-ascend`. Uninstall them before running vLLM-Ascend on Atlas inference products:
+
+    ```bash
+    pip uninstall -y triton-ascend triton
+    ```
+
+To verify the source installation:
+
+```bash
+pip show vllm-ascend
 ```
 
-### Atlas 300I DUO
+## 5 Online Service Deployment
 
-```shell
-vllm serve "Qwen/Qwen3-ASR-1.7B" \
-  --tensor-parallel-size 1 \
-  --gpu_memory_utilization 0.9 \
-  --dtype float16 \
-  --max_model_len 4096 \
-  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
-  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,4]}' \
-  --port 8000
-```
+### 5.1 Single-Node Online Deployment
 
-## Functional Verification
+Single-node deployment runs both audio prefill and decoding on one NPU, making it suitable for development, testing, and small-scale ASR services. Replace `your_model_path` with the local model directory, or use `Qwen/Qwen3-ASR-1.7B` to download the model through the configured model hub.
 
-Once your server is started, you can query the model with input prompts:
+=== "Atlas A2 inference products"
 
-```shell
-curl http://localhost:8000/v1/chat/completions
-    -H "Content-Type: application/json"
+    ```shell
+    vllm serve your_model_path \
+      --served-model-name qwen3-asr \
+      --tensor-parallel-size 1 \
+      --max-model-len 4096 \
+      --gpu-memory-utilization 0.9 \
+      --enforce-eager \
+      --port 8000
+    ```
+
+=== "Atlas inference products"
+
+    ```shell
+    vllm serve your_model_path \
+      --served-model-name qwen3-asr \
+      --tensor-parallel-size 1 \
+      --gpu-memory-utilization 0.9 \
+      --dtype float16 \
+      --max-model-len 4096 \
+      --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false,"enable_npu_graph_ex":false}}' \
+      --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,4]}' \
+      --port 8000
+    ```
+
+    !!! note
+
+        - `--tensor-parallel-size 1` uses one NPU. Increase it only after confirming that the hardware and deployment topology support the chosen parallel configuration.
+        - `--max-model-len 4096` limits the maximum sequence length. On Atlas 300I DUO, always specify a conservative value explicitly; automatic detection can allocate an oversized attention mask and cause an out-of-memory error.
+        - `--gpu-memory-utilization 0.9` sets the fraction of device memory available to the vLLM executor. Lower this value if other workloads share the NPU.
+        - `--enforce-eager` disables graph execution. It is used in the Atlas 300I A2 2UP example for compatibility.
+
+When the service starts successfully, the log contains `Application startup complete`. If startup fails, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html).
+
+## 6 Functional Verification
+
+After the service is started, the model can be invoked by sending a prompt.
+
+**Chat Completions API:**
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
     -d '{
-    "messages": [
-    {"role": "user", "content": [
-        {"type": "audio_url",
-        "audio_url":
-        {"url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"}}
-    ]}
-    ]
-}'
+        "model": "qwen3-asr",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "audio_url",
+                        "audio_url": {
+                            "url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"
+                        }
+                    }
+                ]
+            }
+        ]
+    }'
 ```
 
-## Accuracy Evaluation
+Replace `localhost`, `8000`, and `qwen3-asr` with the address, port, and `--served-model-name` used by your deployment. Expected result: HTTP 200 and a JSON response containing the transcription in the `choices` field.
 
-After all samples were processed, transcription quality was measured using:
+## 7 Accuracy Evaluation
 
-- WER (Word Error Rate) for word-level recognition accuracy
-- CER (Character Error Rate) for character-level recognition accuracy
+Evaluate transcription quality with Word Error Rate (WER) for word-level recognition and Character Error Rate (CER) for character-level recognition.
 
-### Remarks
+## 8 Performance Evaluation
 
-This result reflects end-to-end serving performance, including audio preprocessing, request construction, API communication, inference, and response parsing. Actual performance may vary depending on hardware, concurrency, audio length, and deployment configuration.
+Measure ASR serving performance with audio samples that represent the production workload. Record at least the audio duration, request concurrency, end-to-end latency, real-time factor, and throughput. This ensures that audio preprocessing, request construction, API communication, inference, and response parsing are included in the result.
 
-Further benchmarking is recommended for latency distribution, concurrent throughput, long-audio scenarios, and system resource utilization.
+Actual performance varies with hardware, audio duration, concurrency, and deployment configuration. Evaluate short audio, long audio, and concurrent requests separately before selecting a production configuration.
+
+## 9 Performance Tuning
+
+The following settings are starting points rather than globally optimal configurations. Tune them according to audio duration, concurrency, latency requirements, and available NPU memory.
+
+| Scenario | Recommended Starting Point | Key Considerations |
+| --- | --- | --- |
+| Low latency | `--tensor-parallel-size 1`, `--max-model-len 4096` | Use short audio inputs and avoid sharing the NPU with other workloads. |
+| High throughput | Increase request concurrency after establishing the latency baseline | Monitor NPU memory and end-to-end latency; do not use synthetic text-only requests as a proxy for ASR traffic. |
+| Long audio | Increase `--max-model-len` only as required | On Atlas inference products, keep the value conservative because attention-mask memory grows with the configured maximum length. |
+
+For general parameter tuning, refer to the [Performance Tuning Guide](../../developer_guide/performance_and_debug/optimization_and_tuning.md).
+
+## 10 FAQ
+
+For common environment, installation, and general parameter issues, see the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html). This section covers model- and hardware-specific guidance.
+
+### Atlas inference products runs out of memory during startup
+
+**Symptom:** The server fails with an out-of-memory error while initializing attention.
+
+**Cause:** On Atlas inference products, an automatically detected large context length can create a full causal attention mask whose memory consumption grows quadratically with `max_model_len`.
+
+**Solution:** Always set `--max-model-len` explicitly to a conservative value, such as `4096`, and increase it only after verifying available NPU memory.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the documentation for Qwen3-30B-A3B and Qwen3-ASR-1.7B models, adding support and instructions for Atlas inference products (such as Atlas 300I DUO / 310P).

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation changes, no code execution changes.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
