### PR TITLE
[CI][UT] Add Minimax-M3 w8a8 weights e2e UT

### DIFF
--- a/.github/TEST_README.md
+++ b/.github/TEST_README.md
@@ -138,6 +138,7 @@ All E2E tests run on NPU. E2E routing is determined by directory or `_310p` file
 | `tests/e2e/pull_request/one_card/` | A2 NPU x1 |
 | `tests/e2e/pull_request/two_card/` | A3 NPU x2 |
 | `tests/e2e/pull_request/four_card/` | A3 NPU x4 |
+| `tests/e2e/pull_request/eight_card/` | A3 NPU x8 |
 | `*_310p.py` under one/two-card paths | 310P NPU x1 |
 | `*_310p.py` under four-card paths | 310P NPU x4 |
 
@@ -172,6 +173,7 @@ If `tests` points to a directory, `select_tests.py` scans `test_*.py` files and 
    - 1-card: `tests/e2e/pull_request/one_card/test_new_feature.py`
    - 2-card: `tests/e2e/pull_request/two_card/test_new_feature.py`
    - 4-card: `tests/e2e/pull_request/four_card/test_new_feature.py`
+   - 8-card: `tests/e2e/pull_request/eight_card/test_new_feature.py`
 
 2. Register it in `.github/workflows/scripts/test_config.yaml` for PR selective testing.
 

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -274,6 +274,7 @@
       "MiniMax/MiniMax-M2.5",
       "Eco-Tech/Qwen3.5-27B-w8a8-mtp",
       "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot",
+      "Eco-Tech/MiniMax-M3-w8a8",
       "vllm-ascend/MiniMax-M2.5-eagle-model-0318",
       "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp",
       "z-lab/Qwen3-8B-DFlash-b16",

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -19,7 +19,7 @@
 #     <module>/a3_4/       -> A3 NPU x4
 #     <module>/310p/       -> 310P NPU
 #   E2E (tests/e2e/):
-#     pull_request/{one_card,two_card,four_card}/  -> matched by card count
+#     pull_request/{one_card,two_card,four_card,eight_card}/ -> matched by card count
 #     *_310p.py files under one/two-card dirs      -> 310P NPU x1
 #     *_310p.py files under four-card dirs         -> 310P NPU x4
 #
@@ -298,6 +298,7 @@
   tests:
     - tests/ut/models/minimax_m3/test_minimax_m3.py
     - tests/e2e/pull_request/one_card/test_minimax_m3_sparse_attn.py
+    - tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py
     - tests/ut/models/minimax_m3/test_minimax_m3_vit.py
     - tests/ut/models/minimax_m3/test_msa_m3.py
 
@@ -786,6 +787,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/test_qwen3_5.py: 610
   tests/e2e/pull_request/four_card/test_qwen3_next.py: 1180
   tests/e2e/pull_request/four_card/test_graph_mode.py: 480
+  tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py: 1800
   tests/ut/attention/a2/test_attention_cp.py: 40
   tests/ut/attention/a2/test_attention_cp_precision.py: 30
   tests/ut/attention/a2/test_attention_v1.py: 30
@@ -837,6 +839,8 @@ runner_mapping:
   tests/e2e/pull_request/four_card:
     default: a3_x4
     310p: 310p_x4
+  tests/e2e/pull_request/eight_card:
+    default: a3_x8
   tests/ut/.+/a3_2:
     default: a3_x2
   tests/ut/.+/a2:
@@ -853,4 +857,5 @@ partition:
   a2_x1: 5
   a3_x2: 3
   a3_x4: 3
+  a3_x8: 1
   cpu_x0: 1

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -298,7 +298,7 @@
   tests:
     - tests/ut/models/minimax_m3/test_minimax_m3.py
     - tests/e2e/pull_request/one_card/test_minimax_m3_sparse_attn.py
-    - tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py
+    - tests/e2e/pull_request/eight_card/test_minimax_m3.py
     - tests/ut/models/minimax_m3/test_minimax_m3_vit.py
     - tests/ut/models/minimax_m3/test_msa_m3.py
 
@@ -787,7 +787,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/test_qwen3_5.py: 610
   tests/e2e/pull_request/four_card/test_qwen3_next.py: 1180
   tests/e2e/pull_request/four_card/test_graph_mode.py: 480
-  tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py: 1800
+  tests/e2e/pull_request/eight_card/test_minimax_m3.py: 1800
   tests/ut/attention/a2/test_attention_cp.py: 40
   tests/ut/attention/a2/test_attention_cp_precision.py: 30
   tests/ut/attention/a2/test_attention_v1.py: 30

--- a/.github/workflows/scripts/test_select_tests.py
+++ b/.github/workflows/scripts/test_select_tests.py
@@ -138,7 +138,7 @@ def test_collect_paths_and_basic_path_helpers():
 
 def test_route_helpers():
     # Use a controlled runner_mapping that covers all convention directories
-    # documented in test_config.yaml (a2_2, a2, a3_4, a3_2, 310p). The real
+    # documented in test_config.yaml (a2_2, a2, a3_8, a3_4, a3_2, 310p). The real
     # config only defines a subset because the corresponding test directories
     # don't exist in the repo today, but the routing logic supports all of them.
     select_tests._load_runner_mapping(
@@ -146,12 +146,14 @@ def test_route_helpers():
             "runner_mapping": {
                 "tests/ut/.+/a2_2": {"default": "a2_x2"},
                 "tests/ut/.+/a2": {"default": "a2_x1"},
+                "tests/ut/.+/a3_8": {"default": "a3_x8"},
                 "tests/ut/.+/a3_4": {"default": "a3_x4"},
                 "tests/ut/.+/a3_2": {"default": "a3_x2"},
                 "tests/ut/.+/310p": {"default": "310p_x1"},
                 "tests/e2e/pull_request/one_card": {"default": "a2_x1", "310p": "310p_x1"},
                 "tests/e2e/pull_request/two_card": {"default": "a3_x2"},
                 "tests/e2e/pull_request/four_card": {"default": "a3_x4", "310p": "310p_x4"},
+                "tests/e2e/pull_request/eight_card": {"default": "a3_x8"},
             }
         }
     )
@@ -160,11 +162,13 @@ def test_route_helpers():
     assert select_tests._route_ut_dir("tests/ut/mod/a2_2/test_x.py") == (2, select_tests.NpuType.A2)
     assert select_tests._route_ut_dir("tests/ut/mod/a2_2/test_x.py::test_case") == (2, select_tests.NpuType.A2)
     assert select_tests._route_ut_dir("tests/ut/mod/a2/test_x.py") == (1, select_tests.NpuType.A2)
+    assert select_tests._route_ut_dir("tests/ut/mod/a3_8/test_x.py") == (8, select_tests.NpuType.A3)
     assert select_tests._route_ut_dir("tests/ut/mod/a3_4/test_x.py") == (4, select_tests.NpuType.A3)
     assert select_tests._route_ut_dir("tests/ut/mod/a3_2/test_x.py") == (2, select_tests.NpuType.A3)
     assert select_tests._route_ut_dir("tests/ut/mod/310p/test_x.py") == (1, select_tests.NpuType._310P)
     assert select_tests._route_ut_dir("tests/ut/_310p/test_x.py") == select_tests._DEFAULT_KEY
     assert select_tests._route_e2e_dir("tests/e2e/pull_request/four_card/") == (4, select_tests.NpuType.A3)
+    assert select_tests._route_e2e_dir("tests/e2e/pull_request/eight_card/") == (8, select_tests.NpuType.A3)
     assert select_tests._route_e2e_dir("tests/e2e/pull_request/two_card/") == (2, select_tests.NpuType.A3)
     assert select_tests._route_e2e_dir("tests/e2e/pull_request/one_card/") == (1, select_tests.NpuType.A2)
     assert select_tests._route_e2e_dir("tests/e2e/other/") is None
@@ -178,6 +182,10 @@ def test_route_helpers():
     )
     assert select_tests._route_e2e_file("tests/e2e/pull_request/two_card/test_x.py::test_case") == (
         2,
+        select_tests.NpuType.A3,
+    )
+    assert select_tests._route_e2e_file("tests/e2e/pull_request/eight_card/test_x.py::test_case") == (
+        8,
         select_tests.NpuType.A3,
     )
 
@@ -657,7 +665,8 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
     e2e_one_card = test_root / "e2e" / "pull_request" / "one_card"
     e2e_two_card = test_root / "e2e" / "pull_request" / "two_card"
     e2e_four_card = test_root / "e2e" / "pull_request" / "four_card"
-    for path in (e2e_one_card, e2e_two_card, e2e_four_card):
+    e2e_eight_card = test_root / "e2e" / "pull_request" / "eight_card"
+    for path in (e2e_one_card, e2e_two_card, e2e_four_card, e2e_eight_card):
         path.mkdir(parents=True)
     one_a = e2e_one_card / "test_one_a.py"
     one_b = e2e_one_card / "test_one_b.py"
@@ -665,7 +674,8 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
     two_a = e2e_two_card / "test_two_a.py"
     two_b = e2e_two_card / "test_two_b.py"
     four_a = e2e_four_card / "test_four_a.py"
-    for path in (one_a, one_b, one_310p, two_a, two_b, four_a):
+    eight_a = e2e_eight_card / "test_eight_a.py"
+    for path in (one_a, one_b, one_310p, two_a, two_b, four_a, eight_a):
         path.write_text("")
 
     # Module with ``optional: false`` would normally pull in the entire e2e
@@ -679,6 +689,7 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
                 "tests/e2e/pull_request/one_card",
                 "tests/e2e/pull_request/two_card",
                 "tests/e2e/pull_request/four_card",
+                "tests/e2e/pull_request/eight_card",
             ],
         },
     ]
@@ -686,6 +697,7 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
         "tests/e2e/pull_request/one_card": {"default": "a2_x1", "310p": "310p_x1"},
         "tests/e2e/pull_request/two_card": {"default": "a3_x2"},
         "tests/e2e/pull_request/four_card": {"default": "a3_x4", "310p": "310p_x4"},
+        "tests/e2e/pull_request/eight_card": {"default": "a3_x8"},
     }
     config_path = tmp_path / "config.yaml"
     _write_two_doc_config(config_path, config_modules, {"runner_mapping": runner_mapping})
@@ -696,6 +708,7 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
                 "a2-runner": {"chip": "a2", "npu_num": 1},
                 "a3-runner-2": {"chip": "a3", "npu_num": 2},
                 "a3-runner-4": {"chip": "a3", "npu_num": 4},
+                "a3-runner-8": {"chip": "a3", "npu_num": 8},
                 "310p-runner": {"chip": "310p", "npu_num": 1},
             }
         )
@@ -711,6 +724,7 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
     rel_two_a = "tests/e2e/pull_request/two_card/test_two_a.py"
     rel_two_b = "tests/e2e/pull_request/two_card/test_two_b.py"
     rel_four_a = "tests/e2e/pull_request/four_card/test_four_a.py"
+    rel_eight_a = "tests/e2e/pull_request/eight_card/test_eight_a.py"
     rel_e2e_one = "tests/e2e/pull_request/one_card"
     rel_ut_file = "tests/ut/test_ut.py"
     rel_missing = "tests/e2e/pull_request/one_card/does_not_exist.py"
@@ -740,11 +754,11 @@ def test_explicit_e2e_tests_runs_only_specified_paths(tmp_path, monkeypatch, cap
     assert test_groups[0]["tests"].split() == [rel_one_a]
 
     # 2. Multiple files spanning different runners.
-    test_groups, _, _ = run_explicit(rel_one_a, rel_two_a, rel_four_a)
+    test_groups, _, _ = run_explicit(rel_one_a, rel_two_a, rel_four_a, rel_eight_a)
     npu_keys = {(g["npu_type"], g["num_npus"]) for g in test_groups}
-    assert npu_keys == {("a2", 1), ("a3", 2), ("a3", 4)}
+    assert npu_keys == {("a2", 1), ("a3", 2), ("a3", 4), ("a3", 8)}
     selected = {t for g in test_groups for t in g["tests"].split()}
-    assert selected == {rel_one_a, rel_two_a, rel_four_a}
+    assert selected == {rel_one_a, rel_two_a, rel_four_a, rel_eight_a}
 
     # 3. _310p suffix overrides the default runner.
     test_groups, _, _ = run_explicit(rel_one_310p)

--- a/tests/e2e/generate_coverage_html.py
+++ b/tests/e2e/generate_coverage_html.py
@@ -114,6 +114,8 @@ def _detect_card_count(rel_path: str) -> int:
             return 2
         if p == "four_card":
             return 4
+        if p == "eight_card":
+            return 8
     return 1
 
 

--- a/tests/e2e/pull_request/eight_card/__init__.py
+++ b/tests/e2e/pull_request/eight_card/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#

--- a/tests/e2e/pull_request/eight_card/test_minimax_m3.py
+++ b/tests/e2e/pull_request/eight_card/test_minimax_m3.py
@@ -27,8 +27,7 @@ import regex as re
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 
-# Eco-Tech/MiniMax-M3-w8a8
-MINIMAX_M3_MODEL_PATH = Path(os.environ.get("MINIMAX_M3_MODEL_PATH", "Eco-Tech/MiniMax-M3-w8a8"))
+MINIMAX_M3_MODEL_PATH = os.environ.get("MINIMAX_M3_MODEL_PATH", "Eco-Tech/MiniMax-M3-w8a8")
 GSM8K_QUESTION = "Ali had $21. Leila gave him half of her $100. How much does Ali have now?"
 GSM8K_ANSWER = "71"
 MAX_TOKENS = 512
@@ -89,13 +88,12 @@ def _configure_jemalloc() -> None:
     },
 )
 @wait_until_npu_memory_free()
-def test_minimax_m3_online_gsm8k_one_case() -> None:
-    assert MINIMAX_M3_MODEL_PATH.exists(), f"MiniMax-M3 model is not available: {MINIMAX_M3_MODEL_PATH}"
+def test_minimax_m3_gsm8k_one_case() -> None:
     _configure_jemalloc()
 
     example_prompts = [GSM8K_PROMPT_TEMPLATE.format(question=GSM8K_QUESTION)]
     with VllmRunner(
-        str(MINIMAX_M3_MODEL_PATH),
+        MINIMAX_M3_MODEL_PATH,
         max_model_len=10240,
         max_num_seqs=8,
         max_num_batched_tokens=8192,

--- a/tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py
+++ b/tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py
@@ -1,0 +1,136 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import regex as re
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+# Eco-Tech/MiniMax-M3-w8a8
+MINIMAX_M3_MODEL_PATH = Path(os.environ.get("MINIMAX_M3_MODEL_PATH", "Eco-Tech/MiniMax-M3-w8a8"))
+GSM8K_QUESTION = "Ali had $21. Leila gave him half of her $100. How much does Ali have now?"
+GSM8K_ANSWER = "71"
+MAX_TOKENS = 512
+
+GSM8K_PROMPT_TEMPLATE = (
+    'Answer the following question.The last line of the response should follow this format: "answer:$ANSWER" '
+    "(without quotes), where ANSWER is a number. Let's think step by step.\n\nQuestion: {question}"
+)
+
+ANSWER_RE = re.compile(r"answer\s*:\s*\$?\s*(-?\d+(?:\.\d+)?)", re.IGNORECASE)
+NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+os.environ["HCCL_OP_EXPANSION_MODE"] = "AIV"
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["PYTORCH_NPU_ALLOC_CONF"] = "expandable_segments:True"
+os.environ["VLLM_DISABLE_COMPILE_CACHE"] = "0"
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+
+def _extract_predicted_answer(text: str) -> str:
+    matches = ANSWER_RE.findall(text)
+    if matches:
+        return _normalize_number(matches[-1])
+
+    numbers = NUMBER_RE.findall(text)
+    assert numbers, f"No numeric answer found in model output: {text!r}"
+    return _normalize_number(numbers[-1])
+
+
+def _normalize_number(value: str) -> str:
+    normalized = value.strip().replace(",", "").rstrip(".")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    return normalized
+
+
+def _configure_jemalloc() -> None:
+    jemalloc_path = "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2"
+    if Path(jemalloc_path).exists():
+        ld_preload = os.environ.get("LD_PRELOAD", "")
+        os.environ["LD_PRELOAD"] = f"{jemalloc_path}:{ld_preload}" if ld_preload else jemalloc_path
+
+
+@pytest.mark.e2e_model(str(MINIMAX_M3_MODEL_PATH))
+@pytest.mark.e2e_coverage(
+    arch="multimodal",
+    feature="flashcomm1,aclgraph",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="W8A8",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_ASCEND_ENABLE_FLASHCOMM1": "1",
+    },
+)
+@wait_until_npu_memory_free()
+def test_minimax_m3_online_gsm8k_one_case() -> None:
+    assert MINIMAX_M3_MODEL_PATH.exists(), f"MiniMax-M3 model is not available: {MINIMAX_M3_MODEL_PATH}"
+    _configure_jemalloc()
+
+    example_prompts = [GSM8K_PROMPT_TEMPLATE.format(question=GSM8K_QUESTION)]
+    with VllmRunner(
+        str(MINIMAX_M3_MODEL_PATH),
+        max_model_len=10240,
+        max_num_seqs=8,
+        max_num_batched_tokens=8192,
+        dtype="auto",
+        tensor_parallel_size=8,
+        enable_expert_parallel=True,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.95,
+        quantization="ascend",
+        long_prefill_token_threshold=2048,
+        limit_mm_per_prompt={"image": 1},
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+        },
+        additional_config={
+            "enable_cpu_binding": True,
+            "enable_reduce_sample": True,
+            "ascend_compilation_config": {
+                "enable_static_kernel": True,
+                "fuse_norm_quant": False,
+            },
+            "multistream_overlap_shared_expert": False,
+            "weight_nz_mode": 2,
+            "enable_flashcomm1": True,
+            "enable_shared_expert_dp": True,
+        },
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(example_prompts, MAX_TOKENS)
+
+        assert len(outputs) == len(example_prompts)
+        output_ids, output_str = outputs[0]
+        assert len(output_str) > 0
+        assert len(output_ids) > 0
+        actual_answer = _extract_predicted_answer(output_str)
+        assert actual_answer == GSM8K_ANSWER, (
+            f"MiniMax-M3 GSM8K answer mismatch for question={GSM8K_QUESTION!r}: "
+            f"expected={GSM8K_ANSWER!r}, actual={actual_answer!r}, output={output_str!r}"
+        )


### PR DESCRIPTION
  ### What this PR does / why we need it?

  This PR adds an eight-card e2e UT for MiniMax-M3 W8A8.

  The new test verifies MiniMax-M3 with TP8 + EP + flashcomm1 + ACLGraph by running one fixed GSM8K case through `VllmRunner.generate_greedy`. The GSM8K prompt
  is hardcoded from `/workspace/benchmark/ais_bench/datasets/gsm8k/test.jsonl`, and the test checks that the generated answer matches the expected result.

  This PR also adds `eight_card` routing support so the test can be selected together with the MiniMax-M3 / MSA sparse attention test group and run on an A3 x8
  runner.

  ### Does this PR introduce _any_ user-facing change?

  No. This is a CI/test-only change.

  ### How was this patch tested?

  - `python -m py_compile tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py`
  - `ruff check tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py .github/workflows/scripts/test_select_tests.py tests/e2e/
  generate_coverage_html.py`
  - `ruff format --check tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py .github/workflows/scripts/test_select_tests.py tests/e2e/
  generate_coverage_html.py`
  - `pytest -q .github/workflows/scripts/test_select_tests.py`

  Local NPU e2e command was also attempted:

  ```bash
  pytest -sv tests/e2e/pull_request/eight_card/test_minimax_m3_online_gsm8k.py
```

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
