### PR TITLE
[Doc][BugFix] Fix Qwen3-VL-Embedding and Reranker user guides

### DIFF
--- a/docs/source/tutorials/models/Qwen3-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-Reranker.md
@@ -117,7 +117,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
     ```shell
     #!/bin/sh
-    vllm serve Qwen/Qwen3-VL-Reranker-2B \
+    vllm serve Qwen/Qwen3-Reranker-0.6B \
         --served-model-name Qwen/Qwen3-Reranker-0.6B \
         --runner pooling \
         --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
@@ -251,7 +251,7 @@ Here are two accuracy evaluation methods.
         os.environ["HF_DATASETS_CACHE"] = data_path
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
     
-        model = VllmCrossEncoderWrapper(f"/home/data/Qwen3-Reranker-0.6B",
+        model = VllmCrossEncoderWrapper(f"/root/.cache/Qwen3-Reranker-0.6B",
                                     revision="norm",
                                     dtype="float16",
                                     enforce_eager=True,
@@ -281,7 +281,7 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/cli/) for 
 Take the `serve` as an example. Run the code as follows.
 
 ```bash
-vllm bench serve --model Qwen/Qwen3-Reranker-0.6B --backend vllm-rerank  --prot 8000 --dataset-name random-rerank --endpoint /v1/rerank --random-input 200  --save-result --result-dir ./
+vllm bench serve --model Qwen/Qwen3-Reranker-0.6B --backend vllm-rerank  --port 8000 --dataset-name random-rerank --endpoint /v1/rerank --random-input 200  --save-result --result-dir ./
 ```
 
 After about several minutes, you can get the performance evaluation result.

--- a/docs/source/tutorials/models/Qwen3-VL-Embedding.md
+++ b/docs/source/tutorials/models/Qwen3-VL-Embedding.md
@@ -12,7 +12,7 @@ Refer to [supported features](../../user_guide/support_matrix/supported_models.m
 
 ### 3.1 Model Weight
 
-- `Qwen3-VL-Embedding-2B` [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-Embedding-8B)
+- `Qwen3-VL-Embedding-8B` [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-Embedding-8B)
 - `Qwen3-VL-Embedding-2B` [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-Embedding-2B)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`

--- a/docs/source/tutorials/models/Qwen3-VL-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-VL-Reranker.md
@@ -12,7 +12,7 @@ Refer to [supported features](../../user_guide/support_matrix/supported_models.m
 
 ### 3.1 Model Weight
 
-- `Qwen3-VL-Reranker-2B` [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-Reranker-8B)
+- `Qwen3-VL-Reranker-8B` [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-Reranker-8B)
 - `Qwen3-VL-Reranker-2B` [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-Reranker-2B)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
@@ -255,7 +255,7 @@ Here are two accuracy evaluation methods.
         os.environ["HF_DATASETS_CACHE"] = data_path
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
     
-        model = VllmCrossEncoderWrapper(f"/home/data/Qwen3-VL-Reranker-2B",
+        model = VllmCrossEncoderWrapper(f"/root/.cache/Qwen3-VL-Reranker-2B",
                                     revision="norm",
                                     dtype="float16",
                                     enforce_eager=True,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes several issues in the user guides for Qwen3-Reranker, Qwen3-VL-Embedding, and Qwen3-VL-Reranker:
- Corrects the model name in the download links for the 8B versions of Qwen3-VL-Embedding and Qwen3-VL-Reranker.
- Fixes the model name in the `vllm serve` command for Qwen3-Reranker.
- Updates the model cache paths to `/root/.cache/` to match the recommended directory.
- Fixes a typo in the benchmark command (`--prot` to `--port`).

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation changes only, no functional code changes.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
