### PR TITLE
[BugFix][v0.24.0][cherry-pick] Dedupe load keys + document use_layerwise + lower load_gvas log

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -38,6 +38,7 @@ When `MultiConnector` is used, configure `kv_load_failure_policy` on the `MultiC
 | `backend` | Set the storage backend for kvpool (`mooncake`, `memcache`, `yuanrong`), with the default being `mooncake`. |
 | `consumer_is_to_put` | Whether Decode node put KV Cache into KV Pool. The default value is false. |
 | `consumer_is_to_load` | Whether Decode node load KV cache from KV Pool. The default value is false. |
+| `use_layerwise` | Enable layer-by-layer KV save/load. Only supported on the Prefill node and requires the `memcache` backend. The default value is false. |
 | `prefill_pp_size` | Prefill PP size, needs to be set when Prefill node enables PP. |
 | `prefill_pp_layer_partition` | Prefill PP layer partition, needs to be set when Prefill node enables PP. |
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -206,13 +206,15 @@ class LayerBatchBuilder:
         req_ids: list[str] = []
         is_last_chunks: list[bool | None] = []
         all_load_keys: list[str] = []
+        seen_load_req: set[int] = set()
         offset = 0
 
         for block_range in task.block_ranges:
             request = block_range.request
             req_ids.append(request.req_id)
             is_last_chunks.append(request.is_last_chunk)
-            if request.load_keys:
+            if request.load_keys and id(request) not in seen_load_req:
+                seen_load_req.add(id(request))
                 all_load_keys.extend(request.load_keys)
             block_ids_np, block_gvas_np = self._require_request_arrays(block_range, is_save)
             gva_block_offset = request.gva_block_offset if is_save else request.load_gva_block_offset
@@ -1574,7 +1576,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             self.max_transfer_bytes,
         )
         if layer_id <= 2 or res != 0:
-            logger.info(
+            logger.debug(
                 "load_thread: layer=%d groups=%d blocks=%d res=%d",
                 layer_id,
                 len(all_gvas),
@@ -1585,10 +1587,11 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             logger.error("Layerwise %d load batch_copy failed with return code %d", layer_id, res)
 
         if layer_id == self.final_layer_id and all_load_keys:
-            self.m_store.batch_remove_lease(all_load_keys)
+            unique_load_keys = list(dict.fromkeys(all_load_keys))
+            self.m_store.batch_remove_lease(unique_load_keys)
             logger.info(
                 "[KVPOOL] load_thread released %d leases after final layer %d",
-                len(all_load_keys),
+                len(unique_load_keys),
                 layer_id,
             )
         if layer_id == self.final_layer_id:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1291,7 +1291,7 @@ class KVPoolWorker:
                         )
                 all_group_load_keys.extend(valid_keys_for_lease)
 
-                logger.info(
+                logger.debug(
                     "load_gvas: req=%s group=%d eff_bs=%d load_blocks=[%d,%d) keys=%d valid_gvas=%d lease_fail=%d",
                     request.req_id,
                     group_id,


### PR DESCRIPTION
## What this PR does / why we need it?

Cherry-pick of #12797 onto `releases/v0.24.0rc`:

1. **fix(kv_pool)**: Dedupe lease keys in the layerwise load path. `build_shared` accumulated `request.load_keys` once per `(task, block_range)` and `load_thread` again per task, inflating `batch_remove_lease` key count to N x `add_lease` (N = block-range/task fan-out; observed 3x in PD-mixed kv_both, 6x in PD-disagg DP=4/TP=4). Dedupe by request in `build_shared` and at the final remove point so `remove` count matches `add` count.

2. **docs(kv_pool)**: Document `use_layerwise` in the KV Pool parameter table (enables layer-by-layer KV save/load, Prefill node only, memcache backend only).

3. **perf(kv_pool)**: Lower `load_gvas` log level from info to debug (hot-path noise).

## Does this PR introduce _any_ user-facing change?

No correctness change - `batch_remove_lease` on duplicate keys is idempotent in memcache; this only removes the inflated call count. New doc entry for `use_layerwise`. Log level change only.

## How was this patch tested?

- Verified `load_thread released N leases` == sum of per-group `load_gvas keys` (2849 == 2849) after fix (was 8547 == 3x before).
- Warmup + repeat requests: outputs consistent, no corruption; External prefix cache hit rate 0% -> 40.3% -> 53.7%.
- `ruff format --check` passed.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
