### PR TITLE
[main][Doc][Feature] Add info for eplb

### DIFF
--- a/docs/source/user_guide/feature_guide/expert_parallelism_load_balancer.md
+++ b/docs/source/user_guide/feature_guide/expert_parallelism_load_balancer.md
@@ -16,6 +16,9 @@ Expert balancing for MoE (Mixture of Experts) models in LLM (Large Language) ser
 All MOE models supported by vLLM-Ascend.
 But we have only verified the performance on deepseek-v3.1/r1 models.
 
+> [!IMPORTANT]
+> Ascend A5 does not support using EPLB with quant type "W4A8MXFP4", "W4A16", "W4A16MXFP4".
+
 ### MOE QuantType
 
 | QuantType                       | Supported Hardware          |
@@ -24,6 +27,17 @@ But we have only verified the performance on deepseek-v3.1/r1 models.
 | W4A8 (with fused MC2 enabled)   | A2, A3 |
 | MXFP4                           | Ascend 950 Products         |
 | MXFP8                           | Ascend 950 Products         |
+
+### Usage Recommendations
+
+EPLB is not recommended in the following scenarios because the load-balancing benefit may not offset its runtime overhead:
+
+- P node workloads with input sequences shorter than `1024` tokens.
+- D node workloads where the number of experts per die is `<= 8` (`<= 16` on 950DT), or where the per-die load is below `128` tokens.
+
+> [!WARNING]
+> Meeting the above conditions may lead to performance degradation.
+> When there are around 8 experts per die, the EPLB benefit may be comparable to its overhead. Benchmark the actual workload and enable EPLB only after confirming a performance gain.
 
 ## How to Use EPLB
 
@@ -49,6 +63,7 @@ We need to add environment variable `export DYNAMIC_EPLB="true"` to enable vLLM-
 | algorithm_execution_interval | Interval for executing the balancing algorithm. | 50 |
 | eplb_policy_type | EPLB policy type. | 2 |
 | num_redundant_experts | Number of redundant experts. | 0 |
+| eplb_heat_collection_stage | Request stage used to collect expert heat. Available values: `all`, `prefill`, and `decode`. | `all` |
 
 ```shell
 graph TB
@@ -96,7 +111,67 @@ The `eplb_policy_type` parameter selects the balancing algorithm used during dyn
 | `2` | SwiftBalanceEplb | Optimized for low-bandwidth environments. Supports intra-node and inter-node expert redundancy, joint optimization of expert placement. **(Recommended)** |
 | `3` | FlashLB | Statistical method using sliding-window mean/variance/covariance of expert loads. Uses FlashTree layered search for optimal replica allocation and `minimize_redeploy` for incremental adjustment. Best for high-frequency load fluctuations. |
 
+#### Selective Expert Heat Collection
+
+The `eplb_heat_collection_stage` option is intended for prefill-decode aggregation scenarios. Prefill requests usually process many tokens in one iteration, while decode requests usually process fewer tokens. As a result, the expert workload distribution can differ between the two stages. Collecting heat from both stages may hide the imbalance of the stage whose latency you want to optimize.
+
+> [!IMPORTANT]
+> Selective heat collection is currently implemented by the Ascend model runner V1. Dynamic EPLB, including this option, is not yet supported by the Ascend model runner V2.
+
+Use `eplb_heat_collection_stage` to select the stage whose expert heat contributes to EPLB:
+
+| Value | Behavior | Typical use |
+| ----- | -------- | ----------- |
+| `all` | Collect expert heat from both prefill and decode iterations. | General workloads; this is the default. |
+| `prefill` | Collect expert heat only from iterations classified as prefill. | Optimize prefill workload balance and TTFT. |
+| `decode` | Collect expert heat only from iterations classified as decode. | Optimize decode workload balance and TPOT. |
+
+Choose the stage according to the actual workload. The following values can be used as initial tuning guidance:
+
+- For workloads whose typical input sequence length is greater than `1024` tokens, start with `prefill`.
+- For workloads whose typical input sequence length is less than `1024` tokens but concurrency is greater than `1024`, try `decode` or `all`.
+- For other or mixed workloads, benchmark `all`, `prefill`, and `decode` against the target TTFT or TPOT before choosing a setting.
+
+These thresholds are empirical starting points rather than strict requirements. Production traffic distribution, concurrency, model configuration, and hardware topology can all affect the optimal stage.
+
+For example, to collect only prefill heat:
+
+```shell
+export DYNAMIC_EPLB="true"
+
+vllm serve Qwen/Qwen3-235B-A22 \
+  --tensor-parallel-size 16 \
+  --enable-expert-parallel \
+  --additional-config '{ "eplb_config": {
+    "dynamic_eplb": true,
+    "expert_heat_collection_interval": 600,
+    "algorithm_execution_interval": 50,
+    "eplb_policy_type": 2,
+    "num_redundant_experts": 16,
+    "eplb_heat_collection_stage": "prefill"
+  }}'
+```
+
+To collect only decode heat, set:
+
+```json
+{
+  "eplb_config": {
+    "dynamic_eplb": true,
+    "eplb_heat_collection_stage": "decode"
+  }
+}
+```
+
+> [!NOTE]
+> Stage selection applies to dynamic EPLB heat collection. Internally, vLLM-Ascend classifies each forward iteration by comparing its padded scheduled token count with the maximum expected token count of a decode iteration. An iteration above the threshold is treated as prefill; an iteration at or below the threshold is treated as decode. Classification is therefore performed per forward iteration rather than per individual request.
+
+When an iteration does not match the selected stage, its expert load is not accumulated and it does not advance the heat-collection interval. Once heat collection is complete, balancing calculation and layer-by-layer expert weight updates continue normally.
+
 ### Static EPLB
+
+> [!WARNING]
+> Static EPLB is scheduled for removal in v0.25.1.
 
 #### Initial Setup (Record Expert Map)
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the Expert Parallelism Load Balancer (EPLB) documentation to include:

A note that Ascend A5 does not support using EPLB with DeepSeek V4.
Documentation for the new eplb_heat_collection_stage parameter.
A warning that Static EPLB is scheduled for removal in v0.25.1.
### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.

### How was this patch tested?
Documentation-only update, no testing required.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
