### PR TITLE
[Performance] Optimize AscendStore key construction and miss path

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -140,7 +140,7 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         hashes = [bytes([idx % 251]) * 32 for idx in range(128)]
 
         result = list(
-            db.process_tokens_with_block_ids(
+            db.process_token_key_strings_with_block_ids(
                 128 * 128,
                 hashes,
                 [1000, 1001, 1002, 1003],
@@ -148,11 +148,11 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         )
 
         self.assertEqual(
-            [start for start, _, _, _ in result],
+            [start for start, _, _, _, _ in result],
             [124 * 128, 125 * 128, 126 * 128, 127 * 128],
         )
         self.assertEqual(
-            [block_id for _, _, _, block_id in result],
+            [block_id for _, _, _, _, block_id in result],
             [1000, 1001, 1002, 1003],
         )
 
@@ -170,11 +170,71 @@ class TestChunkedTokenDatabase(unittest.TestCase):
 
     def test_get_block_hashes_selects_terminal_str_hashes(self):
         result = get_block_hashes(["a", "b", "c", "d"], group_block_size=32, hash_block_size=16)
-        self.assertEqual(result, ["b", "d"])
+        self.assertEqual(list(result), ["b", "d"])
 
     def test_get_block_hashes_selects_terminal_byte_hashes(self):
         result = get_block_hashes([b"a", b"b", b"c", b"d"], group_block_size=32, hash_block_size=16)
-        self.assertEqual(result, [b"b", b"d"])
+        self.assertEqual(list(result), [b"b", b"d"])
+
+    def test_key_strings_match_pool_keys(self):
+        hashes = ["aaa", "bbb", "ccc"]
+        pool_keys = list(self.db.process_tokens(40, hashes))
+        self.assertEqual(
+            list(self.db.process_token_key_strings(40, hashes)),
+            [
+                (start, end, key.to_string(), hash_val)
+                for (start, end, key), hash_val in zip(pool_keys, hashes, strict=True)
+            ],
+        )
+
+        block_ids = [5, 6]
+        self.assertEqual(
+            list(self.db.process_token_key_strings_with_block_ids(32, hashes, block_ids)),
+            [
+                (start, end, key.to_string(), hash_val, block_id)
+                for (start, end, key), hash_val, block_id in zip(pool_keys[:2], hashes[:2], block_ids, strict=True)
+            ],
+        )
+
+    def test_direct_keys_preserve_multigroup_layerwise_key_semantics(self):
+        group_metadata = [
+            KeyMetadata("llama", 0, 0, 0, 0),
+            KeyMetadata("llama", 1, 0, 0, 0),
+        ]
+        db = ChunkedTokenDatabase(group_metadata, block_size=[16, 32], partitions=None, hash_block_size=16)
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [160], 1: [320]},
+            group_cache_families={0: "c1", 1: "c2"},
+            group_num_layers={0: 2, 1: 2},
+        )
+        hashes = ["a", "b", "c", "d"]
+
+        pool_key_result = list(db.process_tokens(64, hashes, kv_cache_group_id=1))
+        direct_key_result = list(db.process_token_key_strings(64, hashes, kv_cache_group_id=1))
+
+        self.assertEqual(len(pool_key_result), 1)
+        self.assertEqual(
+            direct_key_result[0][:3],
+            (pool_key_result[0][0], pool_key_result[0][1], pool_key_result[0][2].to_string()),
+        )
+        layer_key = pool_key_result[0][2].split_layers(2)[1]
+        self.assertIn("@group:1@cache_role:kv@cache_family:c2@layer_id:1", layer_key.to_string())
+
+    def test_key_strings_pre_shard_after_filtering(self):
+        hashes = ["a", "b", "c", "d"]
+        store_mask = [True, False, True, True]
+        result = list(
+            self.db.process_token_key_strings_with_block_ids(
+                64,
+                hashes,
+                [10, 11, 12, 13],
+                chunk_filter=lambda start: store_mask[start // 16],
+                shard_rank=1,
+                shard_size=2,
+            )
+        )
+        self.assertEqual([(start, end, block_id) for start, end, _, _, block_id in result], [(32, 48, 12)])
 
     def test_prepare_value(self):
         addr, size, block_id = self.db.prepare_value(0, 16, [5, 6, 7])

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -182,6 +182,24 @@ class TestAscendStoreCoordinator(unittest.TestCase):
 
         self.assertEqual(masks, ([False, False, False, True],))
 
+    def test_lookup_mask_uses_reachability_without_retention(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _sliding_spec(block_size=128, sliding_window=256))],
+            scheduler_block_size=512,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c1"],
+            retention_interval=256,
+        )
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+            return_value=[False, False, False, True],
+        ) as reachable:
+            masks = coord.lookup_mask(512)
+
+        self.assertEqual(masks, ([False, False, False, True],))
+        self.assertIsNone(reachable.call_args.kwargs["retention_interval"])
+
     def test_store_mask_propagates_eagle_to_same_spec_siblings(self):
         calls = []
 

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -239,8 +239,8 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t._handle_request(req)
         events = t.get_kv_events()
         self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].block_hashes, [b"h1"])
-        self.assertEqual(events[0].parent_block_hash, b"h0")
+        self.assertEqual(events[0].block_hashes, [maybe_convert_block_hash(b"h1")])
+        self.assertEqual(events[0].parent_block_hash, maybe_convert_block_hash(b"h0"))
 
     def test_handle_request_consumer_role(self):
         t, store = self._make_thread([0], kv_role="kv_consumer")

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -653,16 +653,20 @@ class TestKVTransferTpMismatchDispatch(unittest.TestCase):
         )
         return t, store
 
-    def test_sending_dispatches_to_worker_when_tp_mismatch(self):
+    def test_sending_tp_mismatch_completes_request_lifecycle(self):
         worker = MagicMock()
         worker.tp_mismatch = True
         t, _ = self._make_sending(worker=worker)
+        worker._store_kv_tp_mismatch.side_effect = lambda req: t.dec_stored_request(req.req_id)
         req = ReqMeta(
             req_id="r1", token_len_chunk=16, block_ids_by_group=[[0]], block_hashes=[b"h0"], current_event=None
         )
+        t.add_stored_request("r1")
         t.request_queue.put(req)
         t._handle_request(req)
         worker._store_kv_tp_mismatch.assert_called_once_with(req)
+        self.assertIsNone(t.get_stored_request_count("r1"))
+        self.assertEqual(t.get_and_clear_finished_requests(), {"r1"})
 
     def test_sending_normal_path_when_worker_none(self):
         # worker=None -> tp_mismatch dispatch skipped, normal store path runs.

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -24,11 +24,11 @@ import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm.distributed.kv_events import BlockStored
 from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    ChunkedTokenDatabase,
     KeyMetadata,
     LayerMultiBlockReqMeta,
     LayerPoolKey,
     LoadSpec,
-    PoolKey,
     ReqMeta,
 )
 
@@ -61,42 +61,10 @@ class FakeStore:
         self.get_calls.append((list(keys), list(addrs), list(sizes)))
 
 
-class FakeKey:
-    def __init__(self, val):
-        self._val = val
-
-    def to_string(self):
-        return self._val
-
-
-class FakeTokenDatabase:
+class FakeTokenDatabase(ChunkedTokenDatabase):
     def __init__(self, block_size=16):
-        self.block_size = block_size
-        self.group_block_len = [[block_size, block_size]]
-        self.group_kv_caches_base_addr = [[0, block_size]]
-        self.group_block_stride = {0: [block_size, block_size]}
-
-    def process_tokens(self, token_len, block_hashes, mask_num=0):
-        meta = KeyMetadata("m", 0, 0, 0, 0)
-        for i, h in enumerate(block_hashes):
-            start = i * self.block_size
-            if start >= token_len:
-                break
-            end = min(start + self.block_size, token_len)
-            if start < mask_num:
-                continue
-            yield start, end, PoolKey(meta, f"k{i}")
-
-    def prepare_value(self, start, end, block_ids):
-        block_id = block_ids[start // self.block_size]
-        return [1000 + block_id], [end - start], block_id
-
-    def prepare_value_layer(self, start, end, block_ids, layer_id):
-        block_id = block_ids[start // self.block_size]
-        return [2000 + layer_id * 100 + block_id], [end - start], block_id
-
-    def decode_adaptor_prefill_pp(self, keys, addrs, sizes):
-        return keys, addrs, sizes
+        super().__init__([KeyMetadata("m", 0, 0, 0, 0)], [block_size], None)
+        self.set_group_buffers({0: [1000]}, {0: [block_size]}, {0: [1]}, group_num_layers={0: 1})
 
 
 class MaskedFakeTokenDatabase(FakeTokenDatabase):
@@ -113,7 +81,7 @@ class MaskedFakeTokenDatabase(FakeTokenDatabase):
     def mask_allows_chunk(self, masks, kv_cache_group_id, start):
         if masks is None:
             return True
-        block_idx = start // self.block_size
+        block_idx = start // self.get_block_size(kv_cache_group_id)
         return block_idx < len(masks[kv_cache_group_id]) and masks[kv_cache_group_id][block_idx]
 
 
@@ -256,14 +224,14 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         self.assertEqual(len(store.put_calls), 0)
 
     def test_handle_request_with_kv_event(self):
-        t, store = self._make_thread([0], enable_kv_event=True)
+        t, store = self._make_thread([1, 0, 1], enable_kv_event=True)
         req = ReqMeta(
             req_id="r1",
-            token_len_chunk=16,
-            block_ids=[0],
-            block_hashes=[b"h0"],  # type: ignore[arg-type]
+            token_len_chunk=48,
+            block_ids=[0, 1, 2],
+            block_hashes=[b"h0", b"h1", b"h2"],  # type: ignore[arg-type]
             current_event=None,
-            token_ids=list(range(16)),
+            token_ids=list(range(48)),
             original_block_size=16,
         )
         t.add_stored_request("r1")
@@ -271,6 +239,8 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t._handle_request(req)
         events = t.get_kv_events()
         self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].block_hashes, [b"h1"])
+        self.assertEqual(events[0].parent_block_hash, b"h0")
 
     def test_handle_request_consumer_role(self):
         t, store = self._make_thread([0], kv_role="kv_consumer")
@@ -372,6 +342,42 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t._handle_request(req)
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
+
+    def test_handle_request_skips_known_kvpool_hit_prefix(self):
+        t, store = self._make_thread([0, 0])
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[0, 1, 2, 3],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=31,
+                kvpool_store_skip_tokens=32,
+                can_load=True,
+            ),
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        keys, addrs, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(addrs, [[1002], [1003]])
+
+    def test_save_exception_cleans_queue_lifecycle(self):
+        t, store = self._make_thread([0])
+        store.put = MagicMock(side_effect=RuntimeError("put failed"))
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertEqual(t.request_queue.unfinished_tasks, 0)
+        self.assertNotIn("r1", t.stored_requests)
 
 
 class TestKVCacheStoreRecvingThread(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -343,17 +343,18 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
 
-    def test_handle_request_skips_known_kvpool_hit_prefix(self):
+    def test_handle_request_skips_compressed_hit_in_raw_token_domain(self):
         t, store = self._make_thread([0, 0])
+        t.token_database.group_cache_families["kv"][0] = "c4"
         req = ReqMeta(
             req_id="r1",
-            token_len_chunk=64,
-            block_ids=[0, 1, 2, 3],
-            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            token_len_chunk=128,
+            block_ids=[0, 1],
+            block_hashes=[f"h{i}" for i in range(8)],
             load_spec=LoadSpec(
                 vllm_cached_tokens=0,
-                kvpool_cached_tokens=31,
-                kvpool_store_skip_tokens=32,
+                kvpool_cached_tokens=63,
+                kvpool_store_skip_tokens=64,
                 can_load=True,
             ),
         )
@@ -361,8 +362,8 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         keys, addrs, _ = store.put_calls[0]
-        self.assertEqual(len(keys), 2)
-        self.assertEqual(addrs, [[1002], [1003]])
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(addrs, [[1001]])
 
     def test_save_exception_cleans_queue_lifecycle(self):
         t, store = self._make_thread([0])

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -444,7 +444,10 @@ class TestLookupKeyClient(unittest.TestCase):
         mock_socket.recv.return_value = (32).to_bytes(4, "big")
 
         client = LookupKeyClient(config)
-        client.encoder.encode.side_effect = [[b"hashes"], [b"groups"]]
+        # Replace the concrete encoder so multipart framing can be asserted deterministically.
+        mock_encoder = MagicMock()
+        mock_encoder.encode.side_effect = [[b"hashes"], [b"groups"]]
+        client.encoder = mock_encoder
         result = client.lookup(64, [b"\xaa\xbb"], hbm_hit_tokens=16)
         self.assertEqual(result, 32)
         mock_socket.send_multipart.assert_called_once()

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -128,6 +128,12 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(need, 32)  # 48 - 16
         self.assertFalse(is_async)
         self.assertIn("r1", scheduler.load_specs)
+        mock_client_cls.return_value.lookup.assert_called_once_with(
+            64,
+            request.block_hashes,
+            [0],
+            hbm_hit_tokens=16,
+        )
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_all_hit(self, mock_client_cls):
@@ -144,6 +150,20 @@ class TestKVPoolScheduler(unittest.TestCase):
 
         need, _ = scheduler.get_num_new_matched_tokens(request, 0)
         self.assertEqual(need, 63)
+        self.assertEqual(scheduler.load_specs["r1"].kvpool_cached_tokens, 63)
+        self.assertEqual(scheduler.load_specs["r1"].kvpool_store_skip_tokens, 64)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_get_num_new_matched_tokens_full_hbm_hit_skips_external_lookup(self, mock_client_cls):
+        scheduler = KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
+        request = MagicMock()
+        request.prompt_token_ids = list(range(64))
+        request.num_tokens = 64
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 4
+
+        self.assertEqual(scheduler.get_num_new_matched_tokens(request, 64), (0, False))
+        mock_client_cls.return_value.lookup.assert_not_called()
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_less_than_computed(self, mock_client_cls):
@@ -424,9 +444,12 @@ class TestLookupKeyClient(unittest.TestCase):
         mock_socket.recv.return_value = (32).to_bytes(4, "big")
 
         client = LookupKeyClient(config)
-        result = client.lookup(64, [b"\xaa\xbb"])
+        client.encoder.encode.side_effect = [[b"hashes"], [b"groups"]]
+        result = client.lookup(64, [b"\xaa\xbb"], hbm_hit_tokens=16)
         self.assertEqual(result, 32)
         mock_socket.send_multipart.assert_called_once()
+        frames = mock_socket.send_multipart.call_args.args[0]
+        self.assertEqual(int.from_bytes(frames[2], "big"), 16)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.make_zmq_socket")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.zmq")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -106,21 +106,23 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hits = [[16, 32, 48], [32, 48], [16, 32], [32, 48, 64]]
         self.assertEqual(32, cls._max_intersection_hit_position(hits))
 
-    def test_external_coordinator_lookup_disables_eagle_drop(self):
+    def test_external_coordinator_lookup_uses_reachable_masks(self):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
         worker.hash_block_size = 128
         worker.num_kv_cache_groups = 1
         worker.cache_coordinator = MagicMock()
+        worker.cache_coordinator.lcm_block_size = 128
+        worker.cache_coordinator.lookup_mask.return_value = ([True],)
+        worker.cache_coordinator.store_mask.return_value = ([True],)
         worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
         worker.m_store = MagicMock()
         worker.m_store.exists.return_value = [1]
 
-        key = MagicMock()
-        key.chunk_hash = "ab" * 32
-        key.to_string.return_value = "key"
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens.return_value = [(0, 128, key)]
+        worker.token_database.get_block_size.return_value = 128
+        worker.token_database.group_cache_families = {"kv": {0: "default"}}
+        worker.token_database.process_token_key_strings.return_value = [(0, 128, "key", "ab" * 32)]
 
         hit = worker._lookup_with_coordinator(
             128,
@@ -131,8 +133,11 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         )
 
         self.assertEqual(hit, 128)
+        worker.cache_coordinator.lookup_mask.assert_called_once_with(128)
+        worker.cache_coordinator.store_mask.assert_called_once_with(128, None)
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
+        worker.token_database.process_tokens.assert_not_called()
 
 
 class TestKVPoolWorkerInit(unittest.TestCase):
@@ -578,7 +583,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.start_load_kv(meta)
         # No get called since no load_spec
 
-    def test_wait_for_save(self):
+    def test_wait_for_save_enqueues_async(self):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()
 
@@ -594,6 +599,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.wait_for_save(meta)
         worker.kv_send_thread.add_stored_request.assert_called_with("r1")
         worker.kv_send_thread.add_request.assert_called_once()
+        worker.kv_send_thread.request_queue.join.assert_not_called()
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1579,11 +1579,7 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         )
         rank = worker.metadata[0].head_or_tp_rank  # = 1 for tp_rank=1
 
-        class FakeKey:
-            def to_string(self):
-                return f"model@head_or_tp_rank:{rank}@pp_rank:0@k0"
-
-        out = worker._make_sub_key_str(FakeKey(), effective_rank=3)
+        out = worker._make_sub_key_str(f"model@head_or_tp_rank:{rank}@pp_rank:0@k0", effective_rank=3)
         self.assertIn("@head_or_tp_rank:3", out)
         self.assertNotIn(f"@head_or_tp_rank:{rank}", out)
 
@@ -1612,19 +1608,15 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         worker.group_block_stride = {0: [16]}
         worker.sub_size_bytes = 2
 
-        class FakeKey:
-            def __init__(self, i):
-                self.i = i
-
-            def to_string(self):
-                return f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k{self.i}"
-
-        def fake_process_tokens_with_block_ids(token_len, block_hashes, block_ids, mask_num=0):
-            yield 0, 4, FakeKey(0), block_ids[0]
-            yield 4, 8, FakeKey(1), block_ids[1]
+        def fake_process_token_key_strings_with_block_ids(token_len, block_hashes, block_ids, mask_num=0):
+            prefix = f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0"
+            yield 0, 4, f"{prefix}@k0", block_hashes[0], block_ids[0]
+            yield 4, 8, f"{prefix}@k1", block_hashes[1], block_ids[1]
 
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens_with_block_ids.side_effect = fake_process_tokens_with_block_ids
+        worker.token_database.process_token_key_strings_with_block_ids.side_effect = (
+            fake_process_token_key_strings_with_block_ids
+        )
 
         keys, addrs, sizes, block_ids = worker._build_tp_mismatch_keys_and_addrs(
             block_hashes=[b"h0", b"h1"], block_ids=[10, 11], token_len=8, mask_num=0
@@ -1646,16 +1638,9 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         worker.group_block_stride = {0: [16]}
         worker.sub_size_bytes = 2
 
-        class FakeKey:
-            def __init__(self, i):
-                self.i = i
-
-            def to_string(self):
-                return f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k{self.i}"
-
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens_with_block_ids.return_value = [
-            (4, 8, FakeKey(1), 10),
+        worker.token_database.process_token_key_strings_with_block_ids.return_value = [
+            (4, 8, f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k1", b"h1", 10),
         ]
 
         keys, addrs, sizes, block_ids = worker._build_tp_mismatch_keys_and_addrs(
@@ -1678,12 +1663,10 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         worker.m_store = MagicMock()
         worker.m_store.get.return_value = [0]  # success
 
-        class FakeKey:
-            def to_string(self):
-                return f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k0"
-
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens_with_block_ids.side_effect = lambda *a, **kw: iter([(0, 4, FakeKey(), 5)])
+        worker.token_database.process_token_key_strings_with_block_ids.side_effect = lambda *a, **kw: iter(
+            [(0, 4, f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k0", b"h0", 5)]
+        )
 
         worker._load_kv_tp_mismatch(block_hashes=[b"h0"], block_ids=[5], token_len=4, mask_num=0)
         worker.m_store.get.assert_called_once()
@@ -1708,12 +1691,10 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         worker.m_store = MagicMock()
         worker.enable_kv_events = False
 
-        class FakeKey:
-            def to_string(self):
-                return f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k0"
-
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens_with_block_ids.side_effect = lambda *a, **kw: iter([(0, 4, FakeKey(), 5)])
+        worker.token_database.process_token_key_strings_with_block_ids.side_effect = lambda *a, **kw: iter(
+            [(0, 4, f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k0", b"h0", 5)]
+        )
 
         send_thread = MagicMock()
         send_thread.is_stored_request.return_value = True
@@ -1741,12 +1722,10 @@ class TestKVPoolWorkerTpMismatch(unittest.TestCase):
         worker.m_store.put.side_effect = RuntimeError("put failed")
         worker.enable_kv_events = False
 
-        class FakeKey:
-            def to_string(self):
-                return f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k0"
-
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens_with_block_ids.side_effect = lambda *a, **kw: iter([(0, 4, FakeKey(), 5)])
+        worker.token_database.process_token_key_strings_with_block_ids.side_effect = lambda *a, **kw: iter(
+            [(0, 4, f"m@head_or_tp_rank:{worker.metadata[0].head_or_tp_rank}@pp_rank:0@k0", b"h0", 5)]
+        )
 
         send_thread = MagicMock()
         send_thread.is_stored_request.return_value = True

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -106,7 +106,7 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hits = [[16, 32, 48], [32, 48], [16, 32], [32, 48, 64]]
         self.assertEqual(32, cls._max_intersection_hit_position(hits))
 
-    def test_external_coordinator_lookup_uses_reachable_masks(self):
+    def test_external_coordinator_lookup_uses_only_lookup_mask(self):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
         worker.hash_block_size = 128
@@ -114,7 +114,7 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.cache_coordinator = MagicMock()
         worker.cache_coordinator.lcm_block_size = 128
         worker.cache_coordinator.lookup_mask.return_value = ([True],)
-        worker.cache_coordinator.store_mask.return_value = ([True],)
+        worker.cache_coordinator.store_mask.return_value = ([False],)
         worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
         worker.m_store = MagicMock()
         worker.m_store.exists.return_value = [1]
@@ -122,7 +122,9 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.token_database = MagicMock()
         worker.token_database.get_block_size.return_value = 128
         worker.token_database.group_cache_families = {"kv": {0: "default"}}
-        worker.token_database.process_token_key_strings.return_value = [(0, 128, "key", "ab" * 32)]
+        worker.token_database.process_token_key_strings.side_effect = (
+            lambda *args, chunk_filter, **kwargs: [(0, 128, "key", "ab" * 32)] if chunk_filter(0) else []
+        )
 
         hit = worker._lookup_with_coordinator(
             128,
@@ -134,7 +136,8 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
 
         self.assertEqual(hit, 128)
         worker.cache_coordinator.lookup_mask.assert_called_once_with(128)
-        worker.cache_coordinator.store_mask.assert_called_once_with(128, None)
+        worker.cache_coordinator.store_mask.assert_not_called()
+        worker.m_store.exists.assert_called_once_with(["key"])
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
         worker.token_database.process_tokens.assert_not_called()

--- a/tests/ut/distributed/mooncake/test_mooncake_kv_transfer.py
+++ b/tests/ut/distributed/mooncake/test_mooncake_kv_transfer.py
@@ -8,19 +8,13 @@ if not hasattr(torch, "npu"):
     torch.npu = SimpleNamespace(Event=object)  # type: ignore[attr-defined]
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
     ReqMeta,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import (
     KVCacheStoreSendingThread,
 )
-
-
-class _FakeKey:
-    def __init__(self, value: str):
-        self._value = value
-
-    def to_string(self) -> str:
-        return self._value
 
 
 class _FakeStore:
@@ -39,27 +33,11 @@ class _FakeStore:
         self.put_calls.append((list(keys), list(addrs), list(sizes)))
 
 
-class _FakeTokenDatabase:
-    # KVTransferThread base __init__ reads len(token_database.group_block_len[0]).
-    group_block_len = {0: [16]}
-
-    def process_tokens(self, token_len, block_hashes):
-        for i, _ in enumerate(block_hashes):
-            yield i * 16, (i + 1) * 16, _FakeKey(f"k{i}")
-
-    def prepare_value(self, start, end, block_ids):
-        block_id = start // 16
-        return [1000 + block_id], [end - start], block_id
-
-    def prepare_value_layer(self, start, end, block_ids, layer_id):
-        block_id = start // 16
-        return [2000 + layer_id * 100 + block_id], [end - start], block_id
-
-
 class TestKVTransferMissingKeyPut(unittest.TestCase):
     def test_sending_thread_only_puts_missing_keys(self):
         store = _FakeStore(exists_result=[1, 0, 1, 0])
-        token_db = _FakeTokenDatabase()
+        token_db = ChunkedTokenDatabase([KeyMetadata("m", 0, 0, 0, 0)], [16], None)
+        token_db.set_group_buffers({0: [1000]}, {0: [16]}, {0: [1]})
         thread = KVCacheStoreSendingThread(
             m_store=store,
             token_database=token_db,
@@ -86,7 +64,7 @@ class TestKVTransferMissingKeyPut(unittest.TestCase):
 
         self.assertEqual(len(store.put_calls), 1)
         put_keys, put_addrs, put_sizes = store.put_calls[0]
-        self.assertEqual(put_keys, ["k1", "k3"])
+        self.assertEqual(len(put_keys), 2)
         self.assertEqual(put_addrs, [[1001], [1003]])
         self.assertEqual(put_sizes, [[16], [16]])
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -304,13 +304,14 @@ class LookupKeyServer:
                 all_frames = self.socket.recv_multipart(copy=False)
                 token_len = int.from_bytes(all_frames[0], byteorder="big")
                 kv_group_ids = self.decoder.decode([all_frames[1]])
-                hash_frames = all_frames[2:]
-                hashes_str = self.decoder.decode(hash_frames)
+                hbm_hit_tokens = int.from_bytes(all_frames[2], byteorder="big")
+                hashes_str = self.decoder.decode(all_frames[3:])
                 result = self.pool_worker.lookup_scheduler(
                     token_len,
                     hashes_str,
                     kv_group_ids,
                     use_layerwise=False,
+                    hbm_hit_tokens=hbm_hit_tokens,
                 )
                 logger.debug(
                     "KV pool lookup response token_len=%d groups=%s hit_tokens=%d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -277,10 +277,32 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self._key_prefix_cache: dict[tuple[int, str, str], str] = {}
         self.cache_coordinator: Any | None = None
 
-    def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:
-        self.cache_coordinator = cache_coordinator
+    def _get_key_prefix(
+        self,
+        kv_cache_group_id: int,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+    ) -> str:
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_key = (kv_cache_group_id, cache_role, cache_family)
+        prefix = self._key_prefix_cache.get(cache_key)
+        if prefix is None:
+            group_metadata = self.metadata[kv_cache_group_id]
+            prefix = (
+                f"{group_metadata.model_name}"
+                f"@pcp{group_metadata.pcp_rank}@dcp{group_metadata.dcp_rank}"
+                f"@head_or_tp_rank:{group_metadata.head_or_tp_rank}"
+                f"@pp_rank:{group_metadata.pp_rank}"
+                f"@group:{kv_cache_group_id}"
+                f"@cache_role:{cache_role}"
+                f"@cache_family:{cache_family}@"
+            )
+            self._key_prefix_cache[cache_key] = prefix
+        return prefix
 
     def store_mask(
         self,
@@ -362,6 +384,7 @@ class ChunkedTokenDatabase:
             self.group_block_stride = group_block_stride or {}
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
+            self._key_prefix_cache.clear()
         if group_num_layers is not None:
             self.group_num_layers[cache_role] = group_num_layers.copy()
 
@@ -439,6 +462,64 @@ class ChunkedTokenDatabase:
             size_list.append(size)
         return addr_list, size_list, block_id
 
+    def _iter_token_chunks(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+        block_ids: list[int] | None = None,
+        skip_null_blocks: bool = False,
+        chunk_filter: Callable[[int], bool] | None = None,
+        shard_rank: int | None = None,
+        shard_size: int | None = None,
+    ) -> Iterable[tuple[int, int, BlockHash | str, int | None]]:
+        if not block_hashes:
+            return
+        base_block_size = self.get_block_size(kv_cache_group_id)
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        effective_block_size = base_block_size * cache_family_ratio
+        grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        if not grouped_hashes:
+            return
+        num_logical_blocks = min(len(grouped_hashes), cdiv(token_len, effective_block_size)) if token_len > 0 else 0
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0) if block_ids is not None else 0
+        candidate_index = 0
+
+        for chunk_id in range(num_logical_blocks):
+            start_token = chunk_id * effective_block_size
+            end_token = min(start_token + effective_block_size, token_len)
+            if start_token < mask_num:
+                continue
+            start_idx = start_token // cache_family_ratio
+            end_idx = end_token // cache_family_ratio
+            if end_idx <= start_idx:
+                continue
+            if chunk_filter is not None and not chunk_filter(start_idx):
+                continue
+            block_id = None
+            if block_ids is not None:
+                block_idx = start_idx // base_block_size - block_id_offset
+                if block_idx < 0 or block_idx >= len(block_ids):
+                    continue
+                block_id = block_ids[block_idx]
+                if skip_null_blocks and block_id <= 0:
+                    continue
+            shard_allows = (
+                shard_rank is None
+                or shard_size is None
+                or shard_size <= 1
+                or candidate_index % shard_size == shard_rank
+            )
+            candidate_index += 1
+            if not shard_allows:
+                continue
+            yield start_idx, end_idx, grouped_hashes[chunk_id], block_id
+
     def process_tokens(
         self,
         token_len: int,
@@ -449,50 +530,45 @@ class ChunkedTokenDatabase:
         cache_family: str | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
-        if not block_hashes:
-            return
-        group_block_size = self.get_block_size(kv_cache_group_id)
-        if cache_family is None:
-            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
-        cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
-        group_block_size *= cache_family_ratio
-        block_hashes = get_block_hashes(
+        for start, end, hash_val, _ in self._iter_token_chunks(
+            token_len,
             block_hashes,
-            group_block_size,
-            self.hash_block_size,
-        )
-        if not block_hashes:
-            return
-        if not isinstance(block_hashes[0], str):
-            block_hashes = [
-                h.hex() if not isinstance(h, str) else h  # type: ignore[union-attr]
-                for h in block_hashes
-            ]
-        start_idx = 0
-        for chunk_id, hash_val in enumerate(block_hashes):
-            start_idx = chunk_id * group_block_size
-            if start_idx >= token_len:
-                break
-            end_idx = min(start_idx + group_block_size, token_len)
-            if start_idx < mask_num:
-                continue
-            else:
-                start_idx //= cache_family_ratio
-                end_idx //= cache_family_ratio
-                if end_idx <= start_idx:
-                    continue
-                yield (
-                    start_idx,
-                    end_idx,
-                    self._make_key_by_hash(
-                        hash_val,
-                        kv_cache_group_id=kv_cache_group_id,
-                        cache_role=cache_role,
-                        cache_family=cache_family,
-                    ),
-                )
+            mask_num,
+            kv_cache_group_id,
+            cache_role,
+            cache_family,
+        ):
+            yield (
+                start,
+                end,
+                self._make_key_by_hash(
+                    block_hash_to_str(hash_val),
+                    kv_cache_group_id=kv_cache_group_id,
+                    cache_role=cache_role,
+                    cache_family=cache_family,
+                ),
+            )
 
-    def process_tokens_with_block_ids(
+    def process_token_key_strings(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        chunk_filter: Callable[[int], bool] | None = None,
+    ) -> Iterable[tuple[int, int, str, BlockHash | str]]:
+        """Yield cache key strings directly without materializing PoolKey objects."""
+        prefix = self._get_key_prefix(kv_cache_group_id)
+        for start, end, hash_val, _ in self._iter_token_chunks(
+            token_len,
+            block_hashes,
+            mask_num,
+            kv_cache_group_id,
+            chunk_filter=chunk_filter,
+        ):
+            yield start, end, prefix + block_hash_to_str(hash_val), hash_val
+
+    def process_token_key_strings_with_block_ids(
         self,
         token_len: int,
         block_hashes: BlockHashList | list[str],
@@ -500,48 +576,25 @@ class ChunkedTokenDatabase:
         mask_num: int = 0,
         kv_cache_group_id: int = 0,
         skip_null_blocks: bool = False,
-        cache_role: str = "kv",
-        cache_family: str | None = None,
-    ) -> Iterable[tuple[int, int, PoolKey, int]]:
-        all_chunks = list(
-            self.process_tokens(
-                token_len,
-                block_hashes,
-                0,
-                kv_cache_group_id=kv_cache_group_id,
-                cache_role=cache_role,
-                cache_family=cache_family,
-            )
-        )
-        if not all_chunks:
-            return
-
-        group_block_size = self.get_block_size(kv_cache_group_id)
-        # Sliding-window groups can expose only live tail block ids while keys
-        # still use logical chunk positions from the full prefix.
-        num_logical_blocks = all_chunks[-1][0] // group_block_size + 1
-        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
-        chunks = all_chunks
-        if mask_num:
-            chunks = list(
-                self.process_tokens(
-                    token_len,
-                    block_hashes,
-                    mask_num,
-                    kv_cache_group_id=kv_cache_group_id,
-                    cache_role=cache_role,
-                    cache_family=cache_family,
-                )
-            )
-
-        for start_idx, end_idx, key in chunks:
-            block_idx = start_idx // group_block_size - block_id_offset
-            if block_idx < 0 or block_idx >= len(block_ids):
-                continue
-            block_id = block_ids[block_idx]
-            if skip_null_blocks and block_id <= 0:
-                continue
-            yield start_idx, end_idx, key, block_id
+        chunk_filter: Callable[[int], bool] | None = None,
+        shard_rank: int | None = None,
+        shard_size: int | None = None,
+    ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
+        """Yield cache key strings and resolved block ids without PoolKey allocation."""
+        prefix = self._get_key_prefix(kv_cache_group_id)
+        for start, end, hash_val, block_id in self._iter_token_chunks(
+            token_len,
+            block_hashes,
+            mask_num,
+            kv_cache_group_id,
+            block_ids=block_ids,
+            skip_null_blocks=skip_null_blocks,
+            chunk_filter=chunk_filter,
+            shard_rank=shard_rank,
+            shard_size=shard_size,
+        ):
+            assert block_id is not None
+            yield start, end, prefix + block_hash_to_str(hash_val), hash_val, block_id
 
     def decode_adaptor_prefill_pp(self, key, addr, size, kv_cache_group_id: int = 0, cache_role: str = "kv"):
         if self.partitions is None or len(self.partitions) == 1:
@@ -586,24 +639,37 @@ def get_block_hashes(
     block_hashes: BlockHashList | list[str],
     group_block_size: int,
     hash_block_size: int,
-) -> BlockHashList | list[str]:
+) -> Sequence[BlockHash | str]:
     if group_block_size == hash_block_size:
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
-    scale_factor = group_block_size // hash_block_size
-    # Both supported lanes use chained hashes. The last fine-grained hash
-    # already identifies the complete larger block.
-    return [
-        block_hashes[idx + scale_factor - 1]
-        for idx in range(0, len(block_hashes) // scale_factor * scale_factor, scale_factor)
-    ]
+    return _LazyGroupedBlockHashList(block_hashes, group_block_size // hash_block_size)
+
+
+class _LazyGroupedBlockHashList(Sequence[BlockHash | str]):
+    def __init__(self, block_hashes: Sequence[BlockHash | str], scale_factor: int) -> None:
+        self._block_hashes = block_hashes
+        self._scale_factor = scale_factor
+        self._length = len(block_hashes) // scale_factor
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return [self[idx] for idx in range(*index.indices(self._length))]
+        if index < 0:
+            index += self._length
+        if index < 0 or index >= self._length:
+            raise IndexError(index)
+        return self._block_hashes[(index + 1) * self._scale_factor - 1]
 
 
 def block_hash_to_str(block_hash: BlockHash | str) -> str:
     return block_hash if isinstance(block_hash, str) else block_hash.hex()
 
 
-def _block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
+def block_hash_to_bytes(block_hash: BlockHash | str) -> bytes:
     if isinstance(block_hash, str):
         if len(block_hash) == 64:
             try:
@@ -623,6 +689,8 @@ class LoadSpec:
     kvpool_cached_tokens: int
     # Whether the scheduler allow us to load the tokens
     can_load: bool
+    # Raw KVPool hit length used to avoid storing an already pooled prefix.
+    kvpool_store_skip_tokens: int | None = None
 
     token_len: int = 0
 
@@ -805,7 +873,6 @@ class ReqMeta:
     kv_cache_group_ids: list[int] | None = None
     kv_cache_families_by_group: list[str] | None = None
     skip_null_blocks_by_group: list[bool] | None = None
-    disable_tp_key_sharding: bool = False
     num_prompt_tokens: int | None = None
 
     # The following parameters are only used for kv event generation
@@ -828,7 +895,6 @@ class ReqMeta:
         kv_cache_group_ids: list[int] | None = None,
         kv_cache_families_by_group: list[str] | None = None,
         skip_null_blocks_by_group: list[bool] | None = None,
-        disable_tp_key_sharding: bool = False,
         num_prompt_tokens: int | None = None,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
@@ -869,7 +935,6 @@ class ReqMeta:
         self.kv_cache_group_ids = kv_cache_group_ids
         self.kv_cache_families_by_group = kv_cache_families_by_group
         self.skip_null_blocks_by_group = skip_null_blocks_by_group
-        self.disable_tp_key_sharding = disable_tp_key_sharding
         self.num_prompt_tokens = num_prompt_tokens
         self.token_ids = token_ids
         self.original_block_size = original_block_size
@@ -1090,7 +1155,7 @@ class LayerMultiBlockReqMeta:
     ends: list[int]
     block_ids_by_group: list[list[int]]
     layer_id: int
-    block_hashes: list[Any] = field(default_factory=list)
+    block_hashes: Sequence[Any] = field(default_factory=list)
     is_last_chunk: bool | None = True
     current_event: torch.npu.Event | None = None
     token_ids: list[int] | None = None
@@ -1110,7 +1175,7 @@ class LayerMultiBlockReqMeta:
         block_ids: list[int] | list[list[int]] | None = None,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
-        block_hashes: list[Any] | None = None,
+        block_hashes: Sequence[Any] | None = None,
         kv_cache_group_id: int = 0,
     ) -> None:
         self.req_id = req_id

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -17,7 +17,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
-    _block_hash_to_bytes,
+    block_hash_to_bytes,
     get_block_hashes,
 )
 from vllm_ascend.utils import vllm_version_is
@@ -48,7 +48,7 @@ class ExternalCachedBlockPool:
     ) -> list[KVCacheBlock] | None:
         if self._exists is None:
             return [self._present_block] * len(group_ids)
-        h = _block_hash_to_bytes(block_hash)
+        h = block_hash_to_bytes(block_hash)
         if all((group_id, h) in self._exists for group_id in group_ids):
             return [self._present_block] * len(group_ids)
         return None
@@ -178,19 +178,20 @@ class AscendStoreCoordinator:
             for group_id, mask in enumerate(masks)
         )
 
-    def store_mask(
+    def _reachable_masks(
         self,
         aligned_token_len: int,
-        num_prompt_tokens: int | None = None,
-    ) -> tuple[list[bool], ...]:
+        retention_interval: int | None,
+        num_prompt_tokens: int | None,
+    ) -> list[tuple[int, list[bool] | None]]:
         assert aligned_token_len % self.lcm_block_size == 0, (
             f"aligned_token_len ({aligned_token_len}) must be a multiple of lcm_block_size ({self.lcm_block_size})"
         )
-        masks: list[list[bool]] = []
+        masks: list[tuple[int, list[bool] | None]] = []
         for group_id, spec in enumerate(self.group_effective_specs):
             num_chunks = aligned_token_len // self.group_effective_block_sizes[group_id]
             if not _uses_reachable_mask(self.group_cache_families[group_id]):
-                masks.append([True] * num_chunks)
+                masks.append((num_chunks, None))
                 continue
             manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
             mask = _reachable_block_mask(
@@ -200,11 +201,29 @@ class AscendStoreCoordinator:
                 alignment_tokens=self.lcm_block_size,
                 kv_cache_spec=spec,
                 use_eagle=group_id in self.eagle_reachable_group_ids,
-                retention_interval=self.retention_interval,
+                retention_interval=retention_interval,
                 num_prompt_tokens=num_prompt_tokens,
             )
-            masks.append([True] * num_chunks if mask is None else mask)
-        return tuple(masks)
+            masks.append((num_chunks, mask))
+        return masks
+
+    def store_mask(
+        self,
+        aligned_token_len: int,
+        num_prompt_tokens: int | None = None,
+    ) -> tuple[list[bool], ...]:
+        masks = self._reachable_masks(aligned_token_len, self.retention_interval, num_prompt_tokens)
+        return tuple([True] * num_chunks if mask is None else mask for num_chunks, mask in masks)
+
+    def lookup_mask(
+        self,
+        aligned_token_len: int,
+    ) -> tuple[list[bool] | None, ...]:
+        masks = self._reachable_masks(aligned_token_len, None, None)
+        for num_chunks, mask in masks:
+            if mask is not None:
+                assert len(mask) == num_chunks
+        return tuple(None if mask is None or all(mask) else mask for _, mask in masks)
 
     def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: KVCacheSpec) -> BlockHashList:
         if not vllm_version_is("0.25.1"):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -660,8 +660,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
     def _handle_request(self, req_meta: ReqMeta):
         req_id = req_meta.req_id
         tracked_request = False
+        tp_mismatch = self.worker is not None and getattr(self.worker, "tp_mismatch", False)
         try:
-            if self.worker is not None and getattr(self.worker, "tp_mismatch", False):
+            if tp_mismatch:
+                with self.done_task_lock:
+                    tracked_request = req_id in self.stored_requests
                 self.worker._store_kv_tp_mismatch(req_meta)
                 return
             with self.done_task_lock:
@@ -672,7 +675,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
         except Exception:
             logger.exception("Failed to store KV cache for request %s", req_id)
         finally:
-            remaining = self.dec_stored_request(req_id) if tracked_request else None
+            # The TP-mismatch worker owns the decrement.
+            remaining = None
+            if tracked_request:
+                remaining = self.get_stored_request_count(req_id) if tp_mismatch else self.dec_stored_request(req_id)
             if tracked_request and remaining == 0:
                 self.delete_finished_stored_request(req_id)
                 self.set_finished_request(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -25,7 +25,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerTransferTask,
     ReqMeta,
     SharedBlockData,
-    get_block_hashes,
 )
 # isort: on
 
@@ -369,6 +368,8 @@ class KVTransferThread(threading.Thread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 self.stored_requests[req_id] -= 1
+                return self.stored_requests[req_id]
+            return None
 
     def try_finish_and_delete_stored_request(self, req_id: str) -> bool:
         with self.done_task_lock:
@@ -478,6 +479,7 @@ class KVTransferThread(threading.Thread):
         self.m_store.set_device()
         self.ready_event.set()
         while True:
+            request_data = None
             try:
                 request_data = self.request_queue.get()
                 if request_data is None:
@@ -486,6 +488,8 @@ class KVTransferThread(threading.Thread):
                     continue
                 self._handle_request(request_data)
             except Exception as e:
+                if request_data is not None:
+                    self._handle_request_exception(request_data)
                 logger.error(
                     "Error in KVCacheTransferThread(%s). type=%s, error=%s. Check thread state and request processing.",
                     self.name,
@@ -494,6 +498,10 @@ class KVTransferThread(threading.Thread):
                 )
 
     def _handle_request(self, req_meta: Any):
+        pass
+
+    def _handle_request_exception(self, request_data: Any):
+        """Allow subclasses to complete queue/request bookkeeping on errors."""
         pass
 
     def lookup(
@@ -535,45 +543,6 @@ class KVTransferThread(threading.Thread):
         skip_flags = req_meta.skip_null_blocks_by_group
         return group_id < len(skip_flags) and skip_flags[group_id] if skip_flags else False
 
-    def _process_tokens_with_block_ids(
-        self,
-        token_len: int,
-        block_hashes,
-        block_ids: list[int],
-        mask_num: int = 0,
-        kv_cache_group_id: int = 0,
-        skip_null_blocks: bool = False,
-        cache_role: str = "kv",
-    ):
-        process_with_block_ids = getattr(self.token_database, "process_tokens_with_block_ids", None)
-        if process_with_block_ids is not None:
-            return process_with_block_ids(
-                token_len,
-                block_hashes,
-                block_ids,
-                mask_num,
-                kv_cache_group_id=kv_cache_group_id,
-                skip_null_blocks=skip_null_blocks,
-                cache_role=cache_role,
-            )
-
-        def iter_with_legacy_process_tokens():
-            try:
-                token_iter = self.token_database.process_tokens(token_len, block_hashes, mask_num)
-            except TypeError:
-                token_iter = self.token_database.process_tokens(token_len, block_hashes)
-            group_block_size = self._get_block_size(kv_cache_group_id)
-            for start, end, key in token_iter:
-                block_idx = start // group_block_size
-                if block_idx >= len(block_ids):
-                    continue
-                block_id = block_ids[block_idx]
-                if skip_null_blocks and cache_role == "kv" and block_id <= 0:
-                    continue
-                yield start, end, key, block_id
-
-        return iter_with_legacy_process_tokens()
-
     def _prepare_value(
         self,
         start: int,
@@ -613,33 +582,6 @@ class KVTransferThread(threading.Thread):
             )
         except TypeError:
             return self.token_database.decode_adaptor_prefill_pp(keys, addrs, sizes)
-
-    def _store_mask(self, req_meta: ReqMeta) -> tuple[list[bool], ...] | None:
-        store_mask = getattr(self.token_database, "store_mask", None)
-        if store_mask is None:
-            return None
-        try:
-            return store_mask(req_meta.token_len_chunk, req_meta.num_prompt_tokens)
-        except AssertionError as exc:
-            logger.debug("Skip AscendStore store mask for unaligned request %s: %s", req_meta.req_id, exc)
-            return None
-
-    def _load_mask(self, req_meta: ReqMeta, token_len: int) -> tuple[list[bool], ...] | None:
-        load_mask = getattr(self.token_database, "load_mask", None)
-        if load_mask is None:
-            return None
-        return load_mask(req_meta.block_hashes, token_len)
-
-    def _mask_allows_chunk(
-        self,
-        masks: tuple[list[bool], ...] | None,
-        group_id: int,
-        start: int,
-    ) -> bool:
-        mask_allows_chunk = getattr(self.token_database, "mask_allows_chunk", None)
-        if mask_allows_chunk is None:
-            return True
-        return mask_allows_chunk(masks, group_id, start)
 
 
 class KVCacheStoreSendingThread(KVTransferThread):
@@ -690,16 +632,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 self.stored_requests[req_id] -= 1
+                return self.stored_requests[req_id]
+            return None
 
     def delete_finished_stored_request(self, req_id: str):
         with self.done_task_lock:
-            if req_id in self.stored_requests:
-                del self.stored_requests[req_id]
-
-    def mark_completed_events(self, event_id: int | None) -> None:
-        if event_id is not None:
-            with self.completed_events_lock:
-                self.completed_events[event_id] = 1
+            self.stored_requests.pop(req_id, None)
 
     def get_completed_events(self):
         if not self.completed_events:
@@ -709,158 +647,212 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.completed_events.clear()
         return completed_events
 
+    def _handle_request_exception(self, request_data: Any):
+        req_id = getattr(request_data, "req_id", None)
+        if req_id is not None:
+            with self.done_task_lock:
+                tracked_request = req_id in self.stored_requests
+            if tracked_request:
+                self.dec_stored_request(req_id)
+        self.request_queue.task_done()
+
     def _handle_request(self, req_meta: ReqMeta):
-        if self.worker is not None and getattr(self.worker, "tp_mismatch", False):
-            try:
+        req_id = req_meta.req_id
+        tracked_request = False
+        try:
+            if self.worker is not None and getattr(self.worker, "tp_mismatch", False):
                 self.worker._store_kv_tp_mismatch(req_meta)
-            finally:
-                self.request_queue.task_done()
-            return
+                return
+            with self.done_task_lock:
+                tracked_request = req_id in self.stored_requests
+            if not tracked_request:
+                return
+            self._handle_stored_request(req_meta)
+        except Exception:
+            logger.exception("Failed to store KV cache for request %s", req_id)
+        finally:
+            remaining = self.dec_stored_request(req_id) if tracked_request else None
+            if tracked_request and remaining == 0:
+                self.delete_finished_stored_request(req_id)
+                self.set_finished_request(req_id)
+            if req_meta.event_id is not None:
+                with self.completed_events_lock:
+                    self.completed_events[req_meta.event_id] = 1
+            self.request_queue.task_done()
+
+    def _handle_stored_request(self, req_meta: ReqMeta):
+        """Build and store the request's missing, mask-eligible KV chunks."""
         token_len = req_meta.token_len_chunk
         req_id = req_meta.req_id
         current_event = req_meta.current_event
         try:
-            if req_id not in self.stored_requests:
-                self.request_queue.task_done()
-                return
+            store_masks = self.token_database.store_mask(token_len, req_meta.num_prompt_tokens)
+        except AssertionError as exc:
+            logger.debug("Skip AscendStore store mask for unaligned request %s: %s", req_id, exc)
+            store_masks = None
+        load_spec = req_meta.load_spec
+        skip_start = load_spec.vllm_cached_tokens if load_spec is not None else 0
+        skip_end = (
+            (
+                load_spec.kvpool_store_skip_tokens
+                if load_spec.kvpool_store_skip_tokens is not None
+                else load_spec.kvpool_cached_tokens
+            )
+            if load_spec is not None
+            else 0
+        )
 
-            store_masks = self._store_mask(req_meta)
-            for group_id in req_meta.kv_cache_group_ids or [0]:
-                starts = []
-                ends = []
-                keys = []
-                block_hashes = []
-                key_block_ids = []
-                block_ids = req_meta.block_ids_by_group[group_id]
-                group_block_size = self._get_block_size(group_id)
-                group_block_hashes = get_block_hashes(
-                    req_meta.block_hashes,
-                    group_block_size,
-                    getattr(self.token_database, "hash_block_size", group_block_size),
+        def should_skip(start: int, end: int) -> bool:
+            return skip_end > skip_start and start >= skip_start and end <= skip_end
+
+        for group_id in req_meta.kv_cache_group_ids or [0]:
+            group_block_size = self._get_block_size(group_id)
+            group_store_mask = (
+                list(store_masks[group_id]) if store_masks is not None and group_id < len(store_masks) else None
+            )
+            if group_store_mask is not None:
+                skipped_chunks = 0
+                for chunk_id, allowed in enumerate(group_store_mask):
+                    start = chunk_id * group_block_size
+                    if allowed and should_skip(start, start + group_block_size):
+                        group_store_mask[chunk_id] = False
+                        skipped_chunks += 1
+                if skipped_chunks:
+                    logger.debug(
+                        "KV pool put skipped %d pooled chunks for request %s group %d",
+                        skipped_chunks,
+                        req_id,
+                        group_id,
+                    )
+                if not group_store_mask or not any(group_store_mask):
+                    continue
+
+            starts: list[int] = []
+            ends: list[int] = []
+            keys: list[str] = []
+            key_block_ids: list[int] = []
+            block_ids = req_meta.block_ids_by_group[group_id]
+            skip_null_blocks = self._skip_null_blocks(req_meta, group_id)
+            align_state_group = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
+
+            def chunk_filter(
+                start: int,
+                group_block_size=group_block_size,
+                group_store_mask=group_store_mask,
+            ) -> bool:
+                block_idx = start // group_block_size
+                mask_allows = group_store_mask is None or (
+                    block_idx < len(group_store_mask) and group_store_mask[block_idx]
                 )
+                chunk_start = block_idx * group_block_size
+                return mask_allows and not should_skip(chunk_start, chunk_start + group_block_size)
 
-                for start, end, key, block_id in self._process_tokens_with_block_ids(
-                    token_len,
-                    req_meta.block_hashes,
+            pre_shard = self.dcp_size <= 1 and not align_state_group
+            iterator = self.token_database.process_token_key_strings_with_block_ids(
+                token_len,
+                req_meta.block_hashes,
+                block_ids,
+                kv_cache_group_id=group_id,
+                skip_null_blocks=skip_null_blocks,
+                chunk_filter=chunk_filter,
+                shard_rank=self.tp_rank % self.put_step if pre_shard else None,
+                shard_size=self.put_step if pre_shard else None,
+            )
+            for start, end, key, _block_hash, block_id in iterator:
+                starts.append(start)
+                ends.append(end)
+                keys.append(key)
+                key_block_ids.append(block_id)
+
+            if not keys:
+                continue
+            exists_states = self.lookup(keys)
+            missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
+            if not missing_indices:
+                continue
+            starts = [starts[index] for index in missing_indices]
+            ends = [ends[index] for index in missing_indices]
+            keys = [keys[index] for index in missing_indices]
+            key_block_ids = [key_block_ids[index] for index in missing_indices]
+
+            logger.debug(
+                "Storing KV cache for %d out of %d blocks for request %s in group %d",
+                len(keys),
+                token_len // group_block_size,
+                req_id,
+                group_id,
+            )
+            logger.debug(
+                "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
+                req_id,
+                group_id,
+                token_len,
+                len(keys),
+                keys[:3],
+            )
+
+            addrs = []
+            sizes = []
+            stored_events: list[BlockStored] = []
+            all_hashes = (
+                [
+                    maybe_convert_block_hash(block_hash)
+                    for _, _, _, block_hash in self.token_database.process_token_key_strings(
+                        token_len,
+                        req_meta.block_hashes,
+                        kv_cache_group_id=group_id,
+                    )
+                ]
+                if self.enable_kv_event
+                else []
+            )
+            for index, start in enumerate(starts):
+                addr, size, _ = self._prepare_value(
+                    start,
+                    ends[index],
                     block_ids,
                     kv_cache_group_id=group_id,
-                    skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
-                ):
-                    if not self._mask_allows_chunk(store_masks, group_id, start):
-                        continue
-                    starts.append(start)
-                    ends.append(end)
-                    keys.append(key.to_string())
-                    block_hashes.append(group_block_hashes[start // group_block_size])
-                    key_block_ids.append(block_id)
-
-                if (
-                    not self.dcp_size > 1
-                    and not req_meta.disable_tp_key_sharding
-                    and not self.group_uses_align_state[group_id]
-                ):
-                    starts = starts[self.tp_rank % self.put_step :: self.put_step]
-                    ends = ends[self.tp_rank % self.put_step :: self.put_step]
-                    keys = keys[self.tp_rank % self.put_step :: self.put_step]
-                    block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
-                    key_block_ids = key_block_ids[self.tp_rank % self.put_step :: self.put_step]
-
-                if not keys:
-                    continue
-
-                exists_states = self.lookup(keys)
-                missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
-
-                if not missing_indices:
-                    continue
-
-                starts = [starts[index] for index in missing_indices]
-                ends = [ends[index] for index in missing_indices]
-                keys = [keys[index] for index in missing_indices]
-                block_hashes = [block_hashes[index] for index in missing_indices]
-                key_block_ids = [key_block_ids[index] for index in missing_indices]
-
-                logger.debug(
-                    "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
-                    len(keys),
-                    token_len // group_block_size,
-                    len(missing_indices),
-                    req_id,
-                    group_id,
+                    block_id=key_block_ids[index],
                 )
-                logger.debug(
-                    "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
-                    req_id,
-                    group_id,
-                    token_len,
-                    len(keys),
-                    keys[:3],
-                )
-
-                addrs = []
-                sizes = []
-                stored_events: list[BlockStored] = []
-                all_hashes = [maybe_convert_block_hash(bh) for bh in group_block_hashes]
-                for index, start in enumerate(starts):
-                    addr, size, _ = self._prepare_value(
-                        start,
-                        ends[index],
-                        block_ids,
-                        kv_cache_group_id=group_id,
-                        block_id=key_block_ids[index],
+                addrs.append(addr)
+                sizes.append(size)
+                if self.enable_kv_event:
+                    token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
+                    block_size = (
+                        req_meta.original_block_size[group_id]
+                        if isinstance(req_meta.original_block_size, list)
+                        else req_meta.original_block_size
                     )
-                    addrs.append(addr)
-                    sizes.append(size)
-
-                    # Create KV event
-                    if self.enable_kv_event:
-                        token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
-                        block_size = (
-                            req_meta.original_block_size[group_id]
-                            if isinstance(req_meta.original_block_size, list)
-                            else req_meta.original_block_size
+                    if block_size is not None:
+                        block_idx = start // group_block_size
+                        if block_idx >= len(all_hashes):
+                            continue
+                        current_hash = all_hashes[block_idx]
+                        parent_hash = all_hashes[block_idx - 1] if block_idx > 0 else None
+                        stored_event = BlockStored(
+                            block_hashes=[current_hash],
+                            parent_block_hash=parent_hash,
+                            token_ids=token_ids,
+                            block_size=block_size,
+                            lora_id=None,
+                            medium="cpu",
+                            lora_name=None,
                         )
-                        if block_size is not None:
-                            block_idx = start // group_block_size
-                            if block_idx >= len(all_hashes):
-                                continue
-                            current_hash = all_hashes[block_idx]
-                            parent_hash = all_hashes[block_idx - 1] if block_idx > 0 else None
-                            stored_event = BlockStored(
-                                block_hashes=[current_hash],
-                                parent_block_hash=parent_hash,
-                                token_ids=token_ids,
-                                block_size=block_size,
-                                lora_id=None,
-                                medium="cpu",
-                                lora_name=None,
-                            )
-                            stored_events.append(stored_event)
-                            logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+                        stored_events.append(stored_event)
+                        logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
 
-                if self.kv_role == "kv_consumer":
-                    keys, addrs, sizes = self._decode_adaptor_prefill_pp(
-                        keys,
-                        addrs,
-                        sizes,
-                        kv_cache_group_id=group_id,
-                    )
-
-                if current_event is not None:
-                    current_event.synchronize()
-                self.m_store.put(keys, addrs, sizes)
-
-                # TODO Query specific replica info to update the event
-                if self.enable_kv_event and stored_events is not None:
-                    self.update_kv_event(stored_events)
-        finally:
-            # always free blocks
-            self.mark_completed_events(req_meta.event_id)
-        self.dec_stored_request(req_id)
-        if self.stored_requests.get(req_id, -1) == 0:
-            self.delete_finished_stored_request(req_id)
-            self.set_finished_request(req_id)
-        self.request_queue.task_done()
+            if self.kv_role == "kv_consumer":
+                keys, addrs, sizes = self._decode_adaptor_prefill_pp(
+                    keys,
+                    addrs,
+                    sizes,
+                    kv_cache_group_id=group_id,
+                )
+            if current_event is not None:
+                current_event.synchronize()
+            self.m_store.put(keys, addrs, sizes)
+            if self.enable_kv_event and stored_events:
+                self.update_kv_event(stored_events)
 
 
 class KVCacheStoreRecvingThread(KVTransferThread):
@@ -918,21 +910,30 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             key_list = []
             block_id_list: list[int] = []
             group_ids = req_meta.kv_cache_group_ids or [0]
-            load_masks = self._load_mask(req_meta, token_len)
+            load_masks = self.token_database.load_mask(req_meta.block_hashes, token_len)
             for group_id in group_ids:
                 block_ids = req_meta.block_ids_by_group[group_id]
                 group_block_size = self._get_block_size(group_id)
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
-                for start, end, key, block_id in self._process_tokens_with_block_ids(
+
+                def chunk_filter(start: int, group_id=group_id) -> bool:
+                    return self.token_database.mask_allows_chunk(load_masks, group_id, start)
+
+                for (
+                    start,
+                    end,
+                    key,
+                    _block_hash,
+                    block_id,
+                ) in self.token_database.process_token_key_strings_with_block_ids(
                     token_len,
                     req_meta.block_hashes,
                     block_ids,
                     mask_num,
                     kv_cache_group_id=group_id,
                     skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                    chunk_filter=chunk_filter,
                 ):
-                    if not self._mask_allows_chunk(load_masks, group_id, start):
-                        continue
                     addr, size, block_id = self._prepare_value(
                         start,
                         end,
@@ -940,7 +941,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                         kv_cache_group_id=group_id,
                         block_id=block_id,
                     )
-                    key_list.append(key.to_string())
+                    key_list.append(key)
                     addr_list.append(addr)
                     size_list.append(size)
                     block_id_list.append(block_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -18,6 +18,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend im
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
+    infer_cache_family_ratio,
     LayerBatchReqMeta,
     LayerBlockRange,
     LayerLoadTask,
@@ -707,14 +708,16 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
+            cache_family = self.token_database.group_cache_families["kv"].get(group_id)
+            raw_group_block_size = group_block_size * infer_cache_family_ratio(cache_family)
             group_store_mask = (
                 list(store_masks[group_id]) if store_masks is not None and group_id < len(store_masks) else None
             )
             if group_store_mask is not None:
                 skipped_chunks = 0
                 for chunk_id, allowed in enumerate(group_store_mask):
-                    start = chunk_id * group_block_size
-                    if allowed and should_skip(start, start + group_block_size):
+                    start = chunk_id * raw_group_block_size
+                    if allowed and should_skip(start, start + raw_group_block_size):
                         group_store_mask[chunk_id] = False
                         skipped_chunks += 1
                 if skipped_chunks:
@@ -739,13 +742,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 start: int,
                 group_block_size=group_block_size,
                 group_store_mask=group_store_mask,
+                raw_group_block_size=raw_group_block_size,
             ) -> bool:
                 block_idx = start // group_block_size
                 mask_allows = group_store_mask is None or (
                     block_idx < len(group_store_mask) and group_store_mask[block_idx]
                 )
-                chunk_start = block_idx * group_block_size
-                return mask_allows and not should_skip(chunk_start, chunk_start + group_block_size)
+                chunk_start = block_idx * raw_group_block_size
+                return mask_allows and not should_skip(chunk_start, chunk_start + raw_group_block_size)
 
             pre_shard = self.dcp_size <= 1 and not align_state_group
             iterator = self.token_database.process_token_key_strings_with_block_ids(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -93,6 +93,8 @@ class KVPoolScheduler:
             "consumer_is_to_put", False
         )
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get("load_async", False)
+        retention_interval = getattr(envs, "VLLM_PREFIX_CACHE_RETENTION_INTERVAL", None)
+        self.retention_interval = retention_interval if isinstance(retention_interval, int) else None
         self.save_decode_cache = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "save_decode_cache", False
         )
@@ -512,14 +514,22 @@ class KVPoolScheduler:
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_load:
             return 0, False
 
+        prompt_token_len = len(request.prompt_token_ids)
+        if (
+            self.retention_interval is not None
+            and not self.use_layerwise
+            and prompt_token_len < 2 * self.retention_interval
+        ):
+            return 0, False
+
         if self.use_gva_layerwise:
-            token_len = len(request.prompt_token_ids)
+            token_len = prompt_token_len
             num_external_hit_tokens = self._get_layerwise_gva_hit_tokens(request, token_len, num_computed_tokens)
         else:
             if self._discard_partial_chunks:
-                token_len = self._floor_to_cache_transfer_granularity(len(request.prompt_token_ids))
+                token_len = self._floor_to_cache_transfer_granularity(prompt_token_len)
             else:
-                token_len = len(request.prompt_token_ids)
+                token_len = prompt_token_len
 
             if token_len < self.cache_transfer_granularity:
                 return 0, False
@@ -529,17 +539,21 @@ class KVPoolScheduler:
                     request, token_len, num_computed_tokens, include_layers=True
                 )
             else:
+                if num_computed_tokens >= token_len:
+                    return 0, False
                 if self.client is None:
                     self.client = LookupKeyClient(self.vllm_config)
                 num_external_hit_tokens = self.client.lookup(
                     token_len,
                     request.block_hashes,
                     self.kv_cache_group_ids,
+                    hbm_hit_tokens=num_computed_tokens,
                 )
 
         if num_external_hit_tokens == 0:
             return 0, False
 
+        store_skip_tokens = num_external_hit_tokens
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 
@@ -567,6 +581,7 @@ class KVPoolScheduler:
             vllm_cached_tokens=num_computed_tokens,
             kvpool_cached_tokens=num_external_hit_tokens,
             can_load=force_layerwise_load,
+            kvpool_store_skip_tokens=store_skip_tokens,
         )
         logger.info(
             "KV pool load spec created req=%s vllm_cached=%d kvpool_cached=%d "
@@ -1115,13 +1130,18 @@ class LookupKeyClient:
         token_len: int,
         block_hashes: list[BlockHash],
         kv_cache_group_ids: list[int] | None = None,
+        hbm_hit_tokens: int = 0,
     ) -> int:
         kv_cache_group_ids = kv_cache_group_ids or [0]
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
         kv_group_frames = self.encoder.encode(kv_cache_group_ids)
-        token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [token_len_bytes] + list(kv_group_frames) + list(hash_frames)
+        all_frames = [
+            token_len.to_bytes(4, byteorder="big"),
+            *kv_group_frames,
+            hbm_hit_tokens.to_bytes(4, byteorder="big"),
+            *hash_frames,
+        ]
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1648,13 +1648,13 @@ class KVPoolWorker:
             for layer_id in range(self.num_layers):
                 yield
 
-    def _make_sub_key_str(self, base_key, effective_rank: int) -> str:
-        """Rewrite ``@head_or_tp_rank:<local>`` in base_key.to_string() to ``<effective_rank>``.
+    def _make_sub_key_str(self, base_key: str, effective_rank: int) -> str:
+        """Rewrite ``@head_or_tp_rank:<local>`` in base_key to ``<effective_rank>``.
 
         Under TP mismatch, both sides address the pool at the effective_tp_size
         namespace rather than the local TP rank.
         """
-        return self._replace_key_field(base_key.to_string(), "head_or_tp_rank", effective_rank)
+        return self._replace_key_field(base_key, "head_or_tp_rank", effective_rank)
 
     def _build_strided_addrs(self, block_id: int, token_count: int, sub_idx: int) -> tuple[list[int], list[int]]:
         """Build per-token (addr, size) pairs into local KV cache memory for one
@@ -1699,7 +1699,7 @@ class KVPoolWorker:
         all_addrs: list[list[int]] = []
         all_sizes: list[list[int]] = []
         all_block_ids: list[int] = []
-        for start, end, base_key, block_id in self.token_database.process_tokens_with_block_ids(
+        for start, end, base_key, _, block_id in self.token_database.process_token_key_strings_with_block_ids(
             token_len,
             block_hashes,
             block_ids,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2003,7 +2003,6 @@ class KVPoolWorker:
             * self.cache_coordinator.lcm_block_size
         )
         lookup_masks = self.cache_coordinator.lookup_mask(aligned_len)
-        store_masks = self.cache_coordinator.store_mask(aligned_len, None)
 
         for group_id in kv_cache_group_ids:
             keys: list[str] = []
@@ -2022,18 +2021,14 @@ class KVPoolWorker:
                 )
             lookup_start = hbm_hit_tokens // effective_block_size * effective_block_size
             lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
-            store_mask = store_masks[group_id] if store_masks is not None and group_id < len(store_masks) else None
 
             def chunk_filter(
                 start: int,
                 base_block_size=base_block_size,
                 lookup_mask=lookup_mask,
-                store_mask=store_mask,
             ) -> bool:
                 chunk_idx = start // base_block_size
-                if lookup_mask is not None and (chunk_idx >= len(lookup_mask) or not lookup_mask[chunk_idx]):
-                    return False
-                return store_mask is None or (chunk_idx < len(store_mask) and store_mask[chunk_idx])
+                return lookup_mask is None or (chunk_idx < len(lookup_mask) and lookup_mask[chunk_idx])
 
             for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
                 token_len,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -38,6 +38,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
+    block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
     get_cache_family_granularity,
@@ -288,7 +289,7 @@ class KVPoolWorker:
             self.metadata, self.grouped_block_size, partitions, self.use_hybrid, self.hash_block_size
         )
         self.cache_coordinator = self._build_cache_coordinator(vllm_config)
-        self.token_database.set_cache_coordinator(self.cache_coordinator)
+        self.token_database.cache_coordinator = self.cache_coordinator
 
     def _init_backend(self, parallel_config, extra_config) -> None:
         backend = backend_map.get(self.backend.lower())
@@ -868,16 +869,25 @@ class KVPoolWorker:
                 group_block_size = self.grouped_block_size[group_id]
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
                 skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
-                for start, end, key, block_id in self.token_database.process_tokens_with_block_ids(
+
+                def chunk_filter(start: int, group_id=group_id, load_masks=load_masks) -> bool:
+                    return self.token_database.mask_allows_chunk(load_masks, group_id, start)
+
+                for (
+                    start,
+                    end,
+                    key,
+                    _block_hash,
+                    block_id,
+                ) in self.token_database.process_token_key_strings_with_block_ids(
                     token_len,
                     request.block_hashes,
                     block_ids,
                     mask_num,
                     kv_cache_group_id=group_id,
                     skip_null_blocks=skip_null,
+                    chunk_filter=chunk_filter,
                 ):
-                    if not self.token_database.mask_allows_chunk(load_masks, group_id, start):
-                        continue
                     addr, size, block_id = self.token_database.prepare_value(
                         start,
                         end,
@@ -885,7 +895,7 @@ class KVPoolWorker:
                         kv_cache_group_id=group_id,
                         block_id=block_id,
                     )
-                    key_list.append(key.to_string())
+                    key_list.append(key)
                     addr_list.append(addr)
                     size_list.append(size)
                     block_id_list.append(block_id)
@@ -1485,35 +1495,20 @@ class KVPoolWorker:
 
     def wait_for_save(self, connector_metadata: AscendConnectorMetadata):
         current_event = None
-        has_save_request = False
-        for request in connector_metadata.requests:
-            can_save = request.can_save
-            if can_save is None or not can_save:
-                continue
-            current_event = torch.npu.Event()
-            current_event.record()
-            break
+        assert self.kv_send_thread is not None
+        send_thread = self.kv_send_thread
 
         for request in connector_metadata.requests:
             can_save = request.can_save
             if can_save is None or not can_save:
                 continue
-
+            if current_event is None:
+                current_event = torch.npu.Event()
+                current_event.record()
             request.skip_null_blocks_by_group = self.group_uses_align_state
             request.current_event = current_event
-            self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                request.req_id
-            )
-            self.kv_send_thread.add_request(  # type: ignore[union-attr]
-                request,
-            )
-            has_save_request = True
-
-        if has_save_request:
-            # vLLM expects wait_for_save() to make stores visible before the
-            # request is reported as finished. Without this barrier a following
-            # identical prompt can lookup before Mooncake put() has completed.
-            self.kv_send_thread.request_queue.join()  # type: ignore[union-attr]
+            send_thread.add_stored_request(request.req_id)
+            send_thread.add_request(request)
 
     def retrieve_layer(
         self,
@@ -1856,6 +1851,32 @@ class KVPoolWorker:
         if ensure_initialized is not None:
             ensure_initialized()
 
+    def _build_lookup_keys(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        group_id: int,
+        use_layerwise: bool,
+    ) -> tuple[list[str], list[int], list[int]]:
+        keys: list[str] = []
+        starts: list[int] = []
+        ends: list[int] = []
+        if use_layerwise:
+            for start, end, pool_key in self.token_database.process_tokens(
+                token_len, block_hashes, kv_cache_group_id=group_id
+            ):
+                keys.extend(item.to_string() for item in pool_key.split_layers(self.num_layers))
+                starts.append(start)
+                ends.append(end)
+        else:
+            for start, end, key_string, _ in self.token_database.process_token_key_strings(
+                token_len, block_hashes, kv_cache_group_id=group_id
+            ):
+                keys.append(key_string)
+                starts.append(start)
+                ends.append(end)
+        return keys, starts, ends
+
     def lookup(
         self,
         token_len: int,
@@ -1881,23 +1902,7 @@ class KVPoolWorker:
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
-                end = 0
-                keys: list[str] = []
-                starts = []
-                ends = []
-                for start, end, key in self.token_database.process_tokens(
-                    token_len,
-                    block_hashes,
-                    kv_cache_group_id=group_id,
-                ):
-                    if use_layerwise:
-                        keys_multi_layer = key.split_layers(self.num_layers)
-                        for layer_key in keys_multi_layer:
-                            keys.append(layer_key.to_string())
-                    else:
-                        keys.append(key.to_string())
-                    starts.append(start)
-                    ends.append(end)
+                keys, starts, ends = self._build_lookup_keys(token_len, block_hashes, group_id, use_layerwise)
 
                 if not keys:
                     hits.append(0)
@@ -1917,7 +1922,7 @@ class KVPoolWorker:
                             hit_end = ends[index]
                             break
                 else:
-                    hit_end = end
+                    hit_end = ends[-1]
                     for index, value in enumerate(res):  # type: ignore[arg-type]
                         if value != 1:
                             hit_end = 0
@@ -1972,15 +1977,6 @@ class KVPoolWorker:
                     expanded.append(self._replace_key_field(tp_key, "pp_rank", pp_rank))
         return expanded
 
-    @staticmethod
-    def _chunk_hash_to_bytes(chunk_hash: str) -> bytes:
-        if len(chunk_hash) == 64:
-            try:
-                return bytes.fromhex(chunk_hash)
-            except ValueError:
-                pass
-        return chunk_hash.encode("utf-8")
-
     def _expand_lookup_key_variants(self, key: str, group_id: int, include_all_ranks: bool) -> list[str]:
         if not include_all_ranks:
             return [key]
@@ -1993,6 +1989,7 @@ class KVPoolWorker:
         kv_cache_group_ids: list[int],
         use_layerwise: bool,
         include_all_ranks: bool,
+        hbm_hit_tokens: int = 0,
     ) -> int | None:
         if self.cache_coordinator is None or use_layerwise:
             return None
@@ -2000,18 +1997,54 @@ class KVPoolWorker:
             return None
 
         exists: set[tuple[int, bytes]] = set()
+        aligned_len = (
+            (token_len + self.cache_coordinator.lcm_block_size - 1)
+            // self.cache_coordinator.lcm_block_size
+            * self.cache_coordinator.lcm_block_size
+        )
+        lookup_masks = self.cache_coordinator.lookup_mask(aligned_len)
+        store_masks = self.cache_coordinator.store_mask(aligned_len, None)
+
         for group_id in kv_cache_group_ids:
             keys: list[str] = []
-            chunk_hashes: list[str] = []
+            chunk_hashes: list[BlockHash | str] = []
             variant_counts: list[int] = []
-            for _, _, key in self.token_database.process_tokens(
+            base_block_size = self.token_database.get_block_size(group_id)
+            cache_family = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+            effective_block_size = get_cache_family_granularity(base_block_size, cache_family)
+            if hbm_hit_tokens:
+                grouped_hashes = get_block_hashes(
+                    block_hashes, effective_block_size, self.token_database.hash_block_size
+                )
+                exists.update(
+                    (group_id, block_hash_to_bytes(chunk_hash))
+                    for chunk_hash in grouped_hashes[: hbm_hit_tokens // effective_block_size]
+                )
+            lookup_start = hbm_hit_tokens // effective_block_size * effective_block_size
+            lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
+            store_mask = store_masks[group_id] if store_masks is not None and group_id < len(store_masks) else None
+
+            def chunk_filter(
+                start: int,
+                base_block_size=base_block_size,
+                lookup_mask=lookup_mask,
+                store_mask=store_mask,
+            ) -> bool:
+                chunk_idx = start // base_block_size
+                if lookup_mask is not None and (chunk_idx >= len(lookup_mask) or not lookup_mask[chunk_idx]):
+                    return False
+                return store_mask is None or (chunk_idx < len(store_mask) and store_mask[chunk_idx])
+
+            for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
                 token_len,
                 block_hashes,
+                mask_num=lookup_start,
                 kv_cache_group_id=group_id,
+                chunk_filter=chunk_filter,
             ):
-                variants = self._expand_lookup_key_variants(key.to_string(), group_id, include_all_ranks)
+                variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
                 keys.extend(variants)
-                chunk_hashes.append(key.chunk_hash)
+                chunk_hashes.append(chunk_hash)
                 variant_counts.append(len(variants))
 
             if not keys:
@@ -2021,7 +2054,7 @@ class KVPoolWorker:
             for chunk_hash, count in zip(chunk_hashes, variant_counts, strict=True):
                 values = res[offset : offset + count]  # type: ignore[index]
                 if values and all(value == 1 for value in values):
-                    exists.add((group_id, self._chunk_hash_to_bytes(chunk_hash)))
+                    exists.add((group_id, block_hash_to_bytes(chunk_hash)))
                 offset += count
 
             logger.debug(
@@ -2054,6 +2087,7 @@ class KVPoolWorker:
         block_hashes: list[BlockHash],
         kv_cache_group_ids: list[int] | None = None,
         use_layerwise: bool = False,
+        hbm_hit_tokens: int = 0,
     ) -> int:
         """
         Checks the existence of KV cache of the tokens from the cache engine.
@@ -2070,26 +2104,12 @@ class KVPoolWorker:
                 kv_cache_group_ids,
                 use_layerwise,
                 include_all_ranks=True,
+                hbm_hit_tokens=hbm_hit_tokens,
             )
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
-                keys: list[str] = []
-                starts = []
-                ends = []
-                for start, end, key in self.token_database.process_tokens(
-                    token_len,
-                    block_hashes,
-                    kv_cache_group_id=group_id,
-                ):
-                    if use_layerwise:
-                        keys_multi_layer = key.split_layers(self.num_layers)
-                        for layer_key in keys_multi_layer:
-                            keys.append(layer_key.to_string())
-                    else:
-                        keys.append(key.to_string())
-                    starts.append(start)
-                    ends.append(end)
+                keys, starts, ends = self._build_lookup_keys(token_len, block_hashes, group_id, use_layerwise)
 
                 if not keys:
                     return 0


### PR DESCRIPTION
### What this PR does / why we need it?

This ports #12783 from `releases/v0.23.0` to the latest `main`.

- Generates serialized non-layerwise keys directly, caches immutable prefixes, and selects grouped chained hashes lazily.
- Centralizes token/chunk iteration and removes duplicated key-building paths.
- Propagates HBM hit tokens through lookup and avoids redundant external lookups and stores.
- Applies hybrid-cache lookup/store/load masks before key construction.
- Keeps store-policy masks out of lookup candidate filtering; backend `exists()` determines whether each reachable candidate was stored.
- Pre-shards filtered keys automatically when applicable.
- Uses asynchronous save by default and removes the old wait-mode lifecycle.
- Keeps the layerwise `PoolKey` transfer path unchanged.
- Preserves main-only TP-mismatch dispatch and invalid-block fallback behavior.
- Uses serialized keys in the main-only TP-mismatch path.
- Publishes TP-mismatch async-save completion so delayed KV blocks are released.
- Compares compressed-cache store-skip ranges in raw-token units.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStore now selects the optimized key construction, mask handling, pre-sharding, and asynchronous save paths automatically. The cache key format is unchanged. Because save is asynchronous, a following identical lookup may race with save visibility.

### How was this patch tested?

- Repository hooks passed for the changed Python files: ruff check/format, codespell, typos, custom Python checks, and DCO validation.
- 93 targeted AscendStore/Mooncake unit tests passed; 10 existing deprecated layerwise tests were skipped.
- 6 targeted scheduler/worker tests covering HBM-hit propagation, full-HBM short-circuiting, lookup framing, reachable masks, and asynchronous save passed.
- 16 TP-mismatch worker tests, 5 TP-mismatch dispatch tests, and 13 store-thread tests passed, including async-save lifecycle and compressed-cache raw-token-domain regressions.
- 14 pool-worker helper tests passed, including lookup/store mask separation.
- Python syntax compilation and `git diff --check` passed.
- The local gitleaks hook was skipped because `upstream/main` tracks `.github/workflows/scripts/gitleaks.sh` without the executable bit; CI/NPU validation is required.

### Co-authors

- Pz1116 <zpbzpb123123@gmail.com>
- zmc1997 <742133686@qq.com>

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
