### PR TITLE
[v0.23.0][BugFix] Fix AscendStore skip and retention lookup

### DIFF
--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -62,15 +62,9 @@ class FakeStore:
 
 
 class FakeTokenDatabase(ChunkedTokenDatabase):
-    def __init__(self, block_size=16, cache_family="default"):
+    def __init__(self, block_size=16):
         super().__init__([KeyMetadata("m", 0, 0, 0, 0)], [block_size], None)
-        self.set_group_buffers(
-            {0: [1000]},
-            {0: [block_size]},
-            {0: [1]},
-            group_cache_families={0: cache_family},
-            group_num_layers={0: 1},
-        )
+        self.set_group_buffers({0: [1000]}, {0: [block_size]}, {0: [1]}, group_num_layers={0: 1})
 
 
 class MaskedFakeTokenDatabase(FakeTokenDatabase):
@@ -169,15 +163,9 @@ class TestKVTransferThread(unittest.TestCase):
 
 
 class TestKVCacheStoreSendingThread(unittest.TestCase):
-    def _make_thread(
-        self,
-        exists_result=None,
-        kv_role="kv_producer",
-        enable_kv_event=False,
-        cache_family="default",
-    ):
+    def _make_thread(self, exists_result=None, kv_role="kv_producer", enable_kv_event=False):
         store = FakeStore(exists_result or [0, 0, 0, 0])
-        db = FakeTokenDatabase(cache_family=cache_family)
+        db = FakeTokenDatabase()
         t = KVCacheStoreSendingThread(
             m_store=store,
             token_database=db,
@@ -355,29 +343,9 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
 
-    def test_handle_request_skips_known_kvpool_hit_prefix(self):
-        t, store = self._make_thread([0, 0])
-        req = ReqMeta(
-            req_id="r1",
-            token_len_chunk=64,
-            block_ids=[0, 1, 2, 3],
-            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
-            load_spec=LoadSpec(
-                vllm_cached_tokens=0,
-                kvpool_cached_tokens=31,
-                kvpool_store_skip_tokens=32,
-                can_load=True,
-            ),
-        )
-        t.add_stored_request("r1")
-        t.request_queue.put(req)
-        t._handle_request(req)
-        keys, addrs, _ = store.put_calls[0]
-        self.assertEqual(len(keys), 2)
-        self.assertEqual(addrs, [[1002], [1003]])
-
     def test_handle_request_skips_compressed_hit_in_raw_token_domain(self):
-        t, store = self._make_thread([0, 0], cache_family="c4")
+        t, store = self._make_thread([0, 0])
+        t.token_database.group_cache_families["kv"][0] = "c4"
         req = ReqMeta(
             req_id="r1",
             token_len_chunk=128,
@@ -396,27 +364,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, addrs, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
         self.assertEqual(addrs, [[1001]])
-
-    def test_handle_request_skips_compressed_hit_after_local_prefix(self):
-        t, store = self._make_thread([0, 0, 0], cache_family="c4")
-        req = ReqMeta(
-            req_id="r1",
-            token_len_chunk=192,
-            block_ids=[0, 1, 2],
-            block_hashes=[f"h{i}" for i in range(12)],
-            load_spec=LoadSpec(
-                vllm_cached_tokens=64,
-                kvpool_cached_tokens=127,
-                kvpool_store_skip_tokens=128,
-                can_load=True,
-            ),
-        )
-        t.add_stored_request("r1")
-        t.request_queue.put(req)
-        t._handle_request(req)
-        keys, addrs, _ = store.put_calls[0]
-        self.assertEqual(len(keys), 2)
-        self.assertEqual(addrs, [[1000], [1002]])
 
     def test_save_exception_cleans_queue_lifecycle(self):
         t, store = self._make_thread([0])

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -62,9 +62,15 @@ class FakeStore:
 
 
 class FakeTokenDatabase(ChunkedTokenDatabase):
-    def __init__(self, block_size=16):
+    def __init__(self, block_size=16, cache_family="default"):
         super().__init__([KeyMetadata("m", 0, 0, 0, 0)], [block_size], None)
-        self.set_group_buffers({0: [1000]}, {0: [block_size]}, {0: [1]}, group_num_layers={0: 1})
+        self.set_group_buffers(
+            {0: [1000]},
+            {0: [block_size]},
+            {0: [1]},
+            group_cache_families={0: cache_family},
+            group_num_layers={0: 1},
+        )
 
 
 class MaskedFakeTokenDatabase(FakeTokenDatabase):
@@ -163,9 +169,15 @@ class TestKVTransferThread(unittest.TestCase):
 
 
 class TestKVCacheStoreSendingThread(unittest.TestCase):
-    def _make_thread(self, exists_result=None, kv_role="kv_producer", enable_kv_event=False):
+    def _make_thread(
+        self,
+        exists_result=None,
+        kv_role="kv_producer",
+        enable_kv_event=False,
+        cache_family="default",
+    ):
         store = FakeStore(exists_result or [0, 0, 0, 0])
-        db = FakeTokenDatabase()
+        db = FakeTokenDatabase(cache_family=cache_family)
         t = KVCacheStoreSendingThread(
             m_store=store,
             token_database=db,
@@ -363,6 +375,48 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, addrs, _ = store.put_calls[0]
         self.assertEqual(len(keys), 2)
         self.assertEqual(addrs, [[1002], [1003]])
+
+    def test_handle_request_skips_compressed_hit_in_raw_token_domain(self):
+        t, store = self._make_thread([0, 0], cache_family="c4")
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=128,
+            block_ids=[0, 1],
+            block_hashes=[f"h{i}" for i in range(8)],
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=63,
+                kvpool_store_skip_tokens=64,
+                can_load=True,
+            ),
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        keys, addrs, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(addrs, [[1001]])
+
+    def test_handle_request_skips_compressed_hit_after_local_prefix(self):
+        t, store = self._make_thread([0, 0, 0], cache_family="c4")
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=192,
+            block_ids=[0, 1, 2],
+            block_hashes=[f"h{i}" for i in range(12)],
+            load_spec=LoadSpec(
+                vllm_cached_tokens=64,
+                kvpool_cached_tokens=127,
+                kvpool_store_skip_tokens=128,
+                can_load=True,
+            ),
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        keys, addrs, _ = store.put_calls[0]
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(addrs, [[1000], [1002]])
 
     def test_save_exception_cleans_queue_lifecycle(self):
         t, store = self._make_thread([0])

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -106,14 +106,14 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hits = [[16, 32, 48], [32, 48], [16, 32], [32, 48, 64]]
         self.assertEqual(32, cls._max_intersection_hit_position(hits))
 
-    def test_external_coordinator_lookup_uses_reachable_masks(self):
+    def test_external_coordinator_lookup_uses_only_lookup_mask(self):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
         worker.num_kv_cache_groups = 1
         worker.cache_coordinator = MagicMock()
         worker.cache_coordinator.lcm_block_size = 128
         worker.cache_coordinator.lookup_mask.return_value = ([True],)
-        worker.cache_coordinator.store_mask.return_value = ([True],)
+        worker.cache_coordinator.store_mask.return_value = ([False],)
         worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
         worker.m_store = MagicMock()
         worker.m_store.exists.return_value = [1]
@@ -121,7 +121,9 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.token_database = MagicMock()
         worker.token_database.get_block_size.return_value = 128
         worker.token_database.group_cache_families = {"kv": {0: "default"}}
-        worker.token_database.process_token_key_strings.return_value = [(0, 128, "key", "ab" * 32)]
+        worker.token_database.process_token_key_strings.side_effect = (
+            lambda *args, chunk_filter, **kwargs: [(0, 128, "key", "ab" * 32)] if chunk_filter(0) else []
+        )
 
         hit = worker._lookup_with_coordinator(
             128,
@@ -133,7 +135,8 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
 
         self.assertEqual(hit, 128)
         worker.cache_coordinator.lookup_mask.assert_called_once_with(128)
-        worker.cache_coordinator.store_mask.assert_called_once_with(128, None)
+        worker.cache_coordinator.store_mask.assert_not_called()
+        worker.m_store.exists.assert_called_once_with(["key"])
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
         worker.token_database.process_tokens.assert_not_called()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -678,15 +678,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
             else 0
         )
 
-        def should_skip_group_chunk(start: int, end: int, cache_family_ratio: int) -> bool:
-            raw_start = start * cache_family_ratio
-            raw_end = end * cache_family_ratio
-            return skip_end > skip_start and raw_start >= skip_start and raw_end <= skip_end
+        def should_skip(start: int, end: int) -> bool:
+            return skip_end > skip_start and start >= skip_start and end <= skip_end
 
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
-            cache_family = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
-            cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+            cache_family = self.token_database.group_cache_families["kv"].get(group_id)
+            raw_group_block_size = group_block_size * infer_cache_family_ratio(cache_family)
 
             group_store_mask = (
                 list(store_masks[group_id]) if store_masks is not None and group_id < len(store_masks) else None
@@ -694,8 +692,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if group_store_mask is not None:
                 skipped_chunks = 0
                 for chunk_id, allowed in enumerate(group_store_mask):
-                    start = chunk_id * group_block_size
-                    if allowed and should_skip_group_chunk(start, start + group_block_size, cache_family_ratio):
+                    start = chunk_id * raw_group_block_size
+                    if allowed and should_skip(start, start + raw_group_block_size):
                         group_store_mask[chunk_id] = False
                         skipped_chunks += 1
                 if skipped_chunks:
@@ -720,16 +718,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 start: int,
                 group_block_size=group_block_size,
                 group_store_mask=group_store_mask,
-                cache_family_ratio=cache_family_ratio,
+                raw_group_block_size=raw_group_block_size,
             ) -> bool:
                 block_idx = start // group_block_size
                 mask_allows = group_store_mask is None or (
                     block_idx < len(group_store_mask) and group_store_mask[block_idx]
                 )
-                chunk_start = block_idx * group_block_size
-                return mask_allows and not should_skip_group_chunk(
-                    chunk_start, chunk_start + group_block_size, cache_family_ratio
-                )
+                chunk_start = block_idx * raw_group_block_size
+                return mask_allows and not should_skip(chunk_start, chunk_start + raw_group_block_size)
 
             pre_shard = self.dcp_size <= 1 and not align_state_group
             iterator = self.token_database.process_token_key_strings_with_block_ids(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -18,6 +18,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend im
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
+    infer_cache_family_ratio,
     LayerBatchReqMeta,
     LayerBlockRange,
     LayerLoadTask,
@@ -677,11 +678,16 @@ class KVCacheStoreSendingThread(KVTransferThread):
             else 0
         )
 
-        def should_skip(start: int, end: int) -> bool:
-            return skip_end > skip_start and start >= skip_start and end <= skip_end
+        def should_skip_group_chunk(start: int, end: int, cache_family_ratio: int) -> bool:
+            raw_start = start * cache_family_ratio
+            raw_end = end * cache_family_ratio
+            return skip_end > skip_start and raw_start >= skip_start and raw_end <= skip_end
 
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
+            cache_family = self.token_database.group_cache_families.get("kv", {}).get(group_id, "default")
+            cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+
             group_store_mask = (
                 list(store_masks[group_id]) if store_masks is not None and group_id < len(store_masks) else None
             )
@@ -689,7 +695,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 skipped_chunks = 0
                 for chunk_id, allowed in enumerate(group_store_mask):
                     start = chunk_id * group_block_size
-                    if allowed and should_skip(start, start + group_block_size):
+                    if allowed and should_skip_group_chunk(start, start + group_block_size, cache_family_ratio):
                         group_store_mask[chunk_id] = False
                         skipped_chunks += 1
                 if skipped_chunks:
@@ -714,13 +720,16 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 start: int,
                 group_block_size=group_block_size,
                 group_store_mask=group_store_mask,
+                cache_family_ratio=cache_family_ratio,
             ) -> bool:
                 block_idx = start // group_block_size
                 mask_allows = group_store_mask is None or (
                     block_idx < len(group_store_mask) and group_store_mask[block_idx]
                 )
                 chunk_start = block_idx * group_block_size
-                return mask_allows and not should_skip(chunk_start, chunk_start + group_block_size)
+                return mask_allows and not should_skip_group_chunk(
+                    chunk_start, chunk_start + group_block_size, cache_family_ratio
+                )
 
             pre_shard = self.dcp_size <= 1 and not align_state_group
             iterator = self.token_database.process_token_key_strings_with_block_ids(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1766,7 +1766,6 @@ class KVPoolWorker:
             * self.cache_coordinator.lcm_block_size
         )
         lookup_masks = self.cache_coordinator.lookup_mask(aligned_len)
-        store_masks = self.cache_coordinator.store_mask(aligned_len, None)
 
         for group_id in kv_cache_group_ids:
             keys: list[str] = []
@@ -1785,18 +1784,14 @@ class KVPoolWorker:
                 )
             lookup_start = hbm_hit_tokens // effective_block_size * effective_block_size
             lookup_mask = lookup_masks[group_id] if lookup_masks is not None and group_id < len(lookup_masks) else None
-            store_mask = store_masks[group_id] if store_masks is not None and group_id < len(store_masks) else None
 
             def chunk_filter(
                 start: int,
                 base_block_size=base_block_size,
                 lookup_mask=lookup_mask,
-                store_mask=store_mask,
             ) -> bool:
                 chunk_idx = start // base_block_size
-                if lookup_mask is not None and (chunk_idx >= len(lookup_mask) or not lookup_mask[chunk_idx]):
-                    return False
-                return store_mask is None or (chunk_idx < len(store_mask) and store_mask[chunk_idx])
+                return lookup_mask is None or (chunk_idx < len(lookup_mask) and lookup_mask[chunk_idx])
 
             for _, _, key_string, chunk_hash in self.token_database.process_token_key_strings(
                 token_len,


### PR DESCRIPTION
### What this PR does / why we need it?

This is a follow-up to #12783.

- Scheduler-provided AscendStore skip bounds are raw token counts, while compressed cache families such as `c4` and `c128` iterate store chunks in the physical cache domain. Convert each group chunk range back to raw token positions before applying the store-skip filter.
- Coordinator lookup previously intersected `lookup_mask` with `store_mask(..., None)`. For sparse retention, the latter lacks the prompt length needed to include the replay-boundary key, so a valid stored key could be filtered before key construction and `exists()`. Use only `lookup_mask` for lookup candidates and let `exists()` determine whether each candidate was stored.

### Does this PR introduce _any_ user-facing change?

No. It prevents compressed AscendStore groups from skipping KV chunks outside the cached raw-token interval and preserves retention replay cache hits.

### How was this patch tested?

- All pre-commit hooks passed.
- AscendStore KV transfer CPU/mock unit tests: 32 passed, 10 skipped.
- AscendStore pool worker CPU/mock unit tests: 65 passed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
