### PR TITLE
[v0.23.0][BugFix] Restrict FP8 quantization detection to A5 devices only

### DIFF
--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -129,7 +129,7 @@ def detect_quantization_method(model: str, revision: str | None = None) -> str |
                     return COMPRESSED_TENSORS_METHOD
             if isinstance(quant_cfg, dict):
                 quant_method = quant_cfg.get("quant_method", "")
-                if quant_method == FP8_METHOD:
+                if quant_method == FP8_METHOD and get_ascend_device_type() == AscendDeviceType.A5:
                     return FP8_METHOD
         except (json.JSONDecodeError, OSError):
             pass


### PR DESCRIPTION
## Summary
- Add A5 device type check to FP8 quantization detection in `quantization/utils.py`
- FP8 quantization is only supported on Ascend A5 devices; this prevents incorrect FP8 detection on non-A5 hardware

Fixes #12685

## Test plan
- [x] Verify FP8 quantization is correctly disabled on non-A5 Ascend devices
- [ ] Verify FP8 quantization still works on A5 devices
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
