### PR TITLE
[Doc][Misc] Fix decoder code block rendering

### DIFF
--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
@@ -409,6 +409,7 @@ Modify `run_dp_template.sh` on each node.
                  }
           }
       }'
+    ```
 
 === "Decoder node 2"
 
@@ -631,6 +632,7 @@ Modify `run_dp_template.sh` on each node.
                  }
           }
       }'
+    ```
 
 === "Decoder node 2"
 


### PR DESCRIPTION
### What this PR does / why we need it?

Closes the missing Markdown code fences after the Layerwise and non-layerwise Decoder node 1 examples in the multi-node Mooncake PD disaggregation tutorial.

Without the closing fences, MkDocs treats the following tab markup and shell variables as malformed Markdown and MathJax content, causing the decoder script to appear garbled.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation rendering fix only.

### How was this patch tested?

- `git diff --check`
- `markdownlint`
- `ruff check`
- `ruff format`
- `codespell`
- `typos`
- Shell lint and documentation-related pre-commit hooks

The full `bash format.sh ci` run reached unrelated local environment failures: the gitleaks helper is not executable in this checkout, and two Python hooks cannot resolve the macOS `python` shim. All checks relevant to this Markdown-only change passed.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
