### PR TITLE
fix trace for pull kv time

### DIFF
--- a/tools/trace/parse_logs.py
+++ b/tools/trace/parse_logs.py
@@ -17,6 +17,15 @@ _VLLM_INTERNAL_REQUEST_ID_RE = re.compile(
     r"^(?P<external>.+)-[0-9a-fA-F]{8}$"
 )
 
+# Map role-sensitive actions to the field name used in time_analysis.xlsx.
+# Actions not listed here keep their original names for every role.
+_ACTION_ROLE_MAP: dict[str, dict[str, str]] = {
+    "Add need pulling sequence": {
+        "prefill": "prefill_Add need pulling sequence",
+        "decode": "Add need pulling sequence",
+    },
+}
+
 
 def _normalize_request_id(request_id):
     # vLLM V1 may rewrite EngineCore request IDs as "<external>-<8 hex>".
@@ -226,13 +235,19 @@ def _get_step_line(
                             role, ip = role.split("_")
                             action = action.strip()
                             timestamp = float(timestamp)
+                            request_role[request_id][role] = ip
+                            role_action_map = _ACTION_ROLE_MAP.get(action)
+                            if role_action_map is not None:
+                                mapped_action = role_action_map.get(role)
+                                if mapped_action is None:
+                                    continue
+                                action = mapped_action
                             # min value
                             if (
                                 action not in data_by_request[request_id]
                                 or timestamp < data_by_request[request_id][action]
                             ):
                                 data_by_request[request_id][action] = timestamp
-                            request_role[request_id][role] = ip
                             if (
                                 action not in action_timestamps
                                 or timestamp < action_timestamps[action]
@@ -351,6 +366,7 @@ def _get_action_map() -> dict:
         "Prefill add waiting queue": "prefill 请求添加到waiting队列",
         "try to schedule in waiting queue": "首次尝试加入running队列",
         "fail to add result of kv insufficient": "首次kv不足加入失败",
+        "prefill_Add need pulling sequence": "prefill添加到need pulling队列",
         "Prefill get new_blocks": "P侧申请完成KV",
         "success add to seq groups": "成功加入running队列",
         "Prefill start execute_model": "P开始execute model",

--- a/tools/trace/process_trace_model.py
+++ b/tools/trace/process_trace_model.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import os
+
+import pandas as pd
 
 pd.set_option("display.max_rows", None)
 pd.set_option("display.max_columns", None)
@@ -69,19 +70,37 @@ with pd.ExcelWriter(dst, engine="openpyxl") as writer:
     result_ta = pd.DataFrame()
     result_ta["request p_node"] = df_ta["P_NODE"]
     result_ta["request d_node"] = df_ta["D_NODE"]
-    result_ta["tokenizer排队耗时(ms)"] = (df_ta["Get prefill engine request and start pickle"] - df_ta["PD api server get request"]) * 1000
-    result_ta["tokenizer耗时(ms)"] = (df_ta["Finish process request in prefill engine"] - df_ta["Get prefill engine request and start pickle"]) * 1000
-    result_ta["waiting队列耗时(ms)"] = (df_ta["Prefill add waiting queue"] - df_ta["Start process request in prefill engine"]) * 1000
-    result_ta["schedule耗时(ms)"] = (df_ta["success add to seq groups"] - df_ta["try to schedule in waiting queue"]) * 1000
+    result_ta["tokenizer排队耗时(ms)"] = (
+        df_ta["Get prefill engine request and start pickle"]
+        - df_ta["PD api server get request"]
+    ) * 1000
+    result_ta["tokenizer耗时(ms)"] = (
+        df_ta["Finish process request in prefill engine"]
+        - df_ta["Get prefill engine request and start pickle"]
+    ) * 1000
+    result_ta["waiting队列耗时(ms)"] = (
+        df_ta["Prefill add waiting queue"]
+        - df_ta["Start process request in prefill engine"]
+    ) * 1000
+    result_ta["schedule耗时(ms)"] = (
+        df_ta["success add to seq groups"]
+        - df_ta["try to schedule in waiting queue"]
+    ) * 1000
     result_ta["pull kv耗时(ms)"] = (df_ta["Finish pull kv"] - df_ta["Start pull kv"]) * 1000
-    result_ta["pull kv排队耗时(ms)"] = (df_ta["Add need pulling sequence"] - df_ta["Start to dispatch decode request"]) * 1000
+    result_ta["pull kv排队耗时(ms)"] = (
+        df_ta["Start pull kv"] - df_ta["Add need pulling sequence"]
+    ) * 1000
 
     avg_row_ta = {"来源": "time_analysis"}
     for col in result_ta.columns:
         if col not in ("request p_node", "request d_node"):
             avg_row_ta[col] = result_ta[col].mean()
 
-    result_ta.loc[len(result_ta)] = {"request p_node": "平均值", "request d_node": "", **{col: avg_row_ta[col] for col in avg_row_ta if col != "来源"}}
+    result_ta.loc[len(result_ta)] = {
+        "request p_node": "平均值",
+        "request d_node": "",
+        **{col: avg_row_ta[col] for col in avg_row_ta if col != "来源"},
+    }
 
     result_ta.to_excel(writer, sheet_name="time_analysis", index=False)
     print(f"[time_analysis] Done! Rows: {len(result_ta)}")


### PR DESCRIPTION
**What this PR does / why we need it?**

This PR improves PD trace analysis by distinguishing the duplicated `Add need pulling sequence` action emitted by Prefill and Decode nodes.

- Keeps the existing `Add need pulling sequence` field for Decode-side timing, preserving compatibility with existing Pull KV queue calculations.
- Adds `prefill_Add need pulling sequence` for Prefill-side timing.
- Uses a role-based action mapping so additional role-specific trace actions can be added without introducing more hard-coded condition branches.
- Keeps Pull KV queue latency calculated from Decode-side timestamps:

  ```python
  Start pull kv - Add need pulling sequence
  ```

This prevents Prefill KV-pool load events from being mixed with Decode PD KV-pull events.

**Does this PR introduce any user-facing change?**

No runtime or inference behavior is changed.

The only change is to the trace analysis output: `time_analysis.xlsx` now includes the additional `prefill_Add need pulling sequence` field. The existing `Add need pulling sequence` field remains the Decode-side value, so existing downstream Pull KV latency calculations remain compatible.

**How was this patch tested?**

enable mooncake store kv pool
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
