### PR TITLE
[BugFix][DSA-CP] Fix invalid local sequence lengths for graph padding

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_build_local_metadata_triton.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_build_local_metadata_triton.py
@@ -32,7 +32,12 @@ def _run_native(
 
     offset = query_start_loc[1:] - local_query_end
     local_seq_lens = torch.zeros(MAX_NUM_SEQS, dtype=torch.int32, device=query_start_loc.device)
-    local_seq_lens[:num_reqs] = (local_query_lens > 0) * (seq_lens - offset)
+    valid_local_req = (local_query_lens > 0) & (seq_lens > 0)
+    local_seq_lens[:num_reqs] = torch.where(
+        valid_local_req,
+        torch.clamp_min(seq_lens - offset, 0),
+        torch.zeros_like(seq_lens),
+    )
 
     start_pos = None
     if compute_start_pos:
@@ -149,6 +154,69 @@ def test_build_local_metadata_triton(
             )
         else:
             assert trt_sp is None and ref_sp is None
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton is not available")
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_build_local_metadata_triton_masks_graph_padding(device: str) -> None:
+    torch.set_default_device(device)
+
+    # TP8, graph size 80 and MTP3 produce 20 four-token request slots. With
+    # nine real requests, rank 6 splits a padded slot at its local boundary.
+    tp_size = 8
+    tp_rank = 6
+    num_input_tokens = 80
+    num_reqs = 20
+    num_actual_reqs = 9
+    tokens_per_rank = num_input_tokens // tp_size
+    local_start = tp_rank * tokens_per_rank
+    local_end = local_start + tokens_per_rank
+
+    query_start_loc = torch.arange(0, num_input_tokens + 1, 4, dtype=torch.int32, device=device)
+    seq_lens = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+    seq_lens[:num_actual_reqs] = torch.arange(
+        128,
+        128 + num_actual_reqs,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    trt_qsl, trt_sl, _ = _run_triton(
+        query_start_loc,
+        seq_lens,
+        local_start,
+        local_end,
+        num_reqs,
+        compute_start_pos=False,
+    )
+    ref_qsl, ref_sl, _ = _run_native(
+        query_start_loc,
+        seq_lens,
+        local_start,
+        local_end,
+        num_reqs,
+        compute_start_pos=False,
+    )
+
+    torch.testing.assert_close(
+        trt_qsl[: num_reqs + 1],
+        ref_qsl[: num_reqs + 1],
+        atol=DEFAULT_ATOL,
+        rtol=DEFAULT_RTOL,
+    )
+    torch.testing.assert_close(
+        trt_sl[:num_reqs],
+        ref_sl[:num_reqs],
+        atol=DEFAULT_ATOL,
+        rtol=DEFAULT_RTOL,
+    )
+    assert ref_sl[17].item() == 0
+    assert torch.all(trt_sl[:num_reqs] >= 0)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -844,10 +844,17 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             # For requests that cross the local slice boundary, offset removes the
             # tokens that live on later ranks so local_seq_lens matches local queries.
             offset = query_start_loc[1:] - local_query_end
+            valid_local_req = (local_query_lens > 0) & (seq_lens > 0)
+            safe_local_seq_lens = torch.clamp_min(seq_lens - offset, 0)
+            safe_local_seq_lens = torch.where(
+                valid_local_req,
+                safe_local_seq_lens,
+                torch.zeros_like(safe_local_seq_lens),
+            )
             if local_seq_lens is not None:
-                local_seq_lens[:num_reqs] = (local_query_lens > 0) * (seq_lens - offset)
+                local_seq_lens[:num_reqs] = safe_local_seq_lens
             else:
-                local_seq_lens = (local_query_lens > 0) * (seq_lens - offset)
+                local_seq_lens = safe_local_seq_lens
 
             if start_pos_out is not None:
                 seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]

--- a/vllm_ascend/ops/triton/dsa_cp.py
+++ b/vllm_ascend/ops/triton/dsa_cp.py
@@ -34,7 +34,7 @@ def build_local_metadata_triton(
     tl.store(local_query_start_loc_ptr + 1 + offsets, cum, mask=mask)
 
     offset = q_end - lqe
-    result = tl.where(lql > 0, seq_len - offset, 0)
+    result = tl.where((lql > 0) & (seq_len > 0), tl.maximum(seq_len - offset, 0), 0)
     tl.store(local_seq_lens_ptr + offsets, result, mask=mask)
 
     if COMPUTE_START_POS:


### PR DESCRIPTION
### What this PR does / why we need it?

In DSA-CP graph mode, graph padding keeps fixed query slots while padded requests have `seq_lens == 0`. With TP=8, graph capture size 80, MTP=3, and about nine active requests, a padded four-token slot can cross a rank-local token boundary. On TP rank 6, the padded interval `[68, 72)` is clipped by the local interval `[60, 70)`, so the previous `seq_lens - offset` calculation produced `-2`.

That negative local sequence length was passed to `KvQuantSparseAttnSharedKV` as `seqused_kv`. It caused severe latency degradation on individual TP ranks and a significant TPOT regression for specific request counts in graph mode.

This PR:
- masks graph-padding requests by requiring both a non-empty local query and a positive global sequence length;
- clamps the candidate local sequence length to zero so invalid negative values cannot reach the attention operator;
- keeps the PyTorch fallback and Triton implementation consistent;
- adds a regression test for the TP=8, graph-size=80, MTP=3 rank-6 boundary case.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. It fixes DSA-CP graph-mode latency for affected request counts.

### How was this patch tested?

Validated on Ascend hardware with TP=8, graph capture size 80, MTP=3, and about nine concurrent requests. The abnormal `KvQuantSparseAttnSharedKV` latency on individual ranks disappeared, and TPOT returned to the normal level.

A focused Triton metadata regression test was added for the graph-padding boundary case.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
