### PR TITLE
[Cherry-pick][releases/v0.23.0][BugFix][DSA-CP] Fix invalid local sequence lengths for graph padding (from #12840)

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -754,10 +754,17 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # For requests that cross the local slice boundary, offset removes the
         # tokens that live on later ranks so local_seq_lens matches local queries.
         offset = query_start_loc[1:] - local_query_end
+        valid_local_req = (local_query_lens > 0) & (seq_lens > 0)
+        safe_local_seq_lens = torch.clamp_min(seq_lens - offset, 0)
+        safe_local_seq_lens = torch.where(
+            valid_local_req,
+            safe_local_seq_lens,
+            torch.zeros_like(safe_local_seq_lens),
+        )
         if local_seq_lens is not None:
-            local_seq_lens[:num_reqs] = (local_query_lens > 0) * (seq_lens - offset)
+            local_seq_lens[:num_reqs] = safe_local_seq_lens
         else:
-            local_seq_lens = (local_query_lens > 0) * (seq_lens - offset)
+            local_seq_lens = safe_local_seq_lens
 
         # RoPE tables are generated on the padded global positions first, then
         # sliced to this rank so local tokens keep their original positions.


### PR DESCRIPTION
### What this PR does / why we need it?

Cherry-pick of #12840 to `releases/v0.23.0`.

In DSA-CP graph mode, graph padding keeps fixed query slots while padded requests have `seq_lens == 0`. With TP=8, graph capture size 80, MTP=3, and about nine active requests, a padded four-token slot can cross a rank-local token boundary. On TP rank 6, the previous local sequence length calculation could produce `-2`.

The invalid value was passed to `KvQuantSparseAttnSharedKV` as `seqused_kv`, causing severe latency degradation on individual TP ranks and a significant TPOT regression for specific request counts.

This backport masks graph-padding requests and clamps candidate local sequence lengths to zero before they reach the attention operator. This release branch uses the PyTorch metadata path and does not contain the Triton metadata kernel added on main.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. It fixes DSA-CP graph-mode latency for affected request counts.

### How was this patch tested?

Validated on Ascend hardware with TP=8, graph capture size 80, MTP=3, and about nine concurrent requests. The abnormal `KvQuantSparseAttnSharedKV` latency on individual ranks disappeared, and TPOT returned to the normal level.

Main PR: #12840
Main commit: `a8c6e2a744df79558bf40551868adf2e11b1de21`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
