### PR TITLE
[Feature] Add RoPE switch support to MLA preprocess

### DIFF
--- a/csrc/mla_preprocess/mla_preprocess_torch_adpt.h
+++ b/csrc/mla_preprocess/mla_preprocess_torch_adpt.h
@@ -20,15 +20,20 @@
 #include "op_host/mla_preprocess.h"
 
 namespace vllm_ascend {
+constexpr int64_t MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK = 512;
+constexpr int64_t MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM = 64;
+
 std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &> mla_preprocess(
     const at::Tensor &hiddenState, const at::Tensor &wdqkv,
     const c10::optional<at::Tensor> &descale0, const at::Tensor &gamma1, const c10::optional<at::Tensor> &beta1, const at::Tensor &wuq,
-    const c10::optional<at::Tensor> &descale1, const at::Tensor &gamma2, const at::Tensor &cos, const at::Tensor &sin,
+    const c10::optional<at::Tensor> &descale1, const at::Tensor &gamma2,
+    const c10::optional<at::Tensor> &cos, const c10::optional<at::Tensor> &sin,
     const at::Tensor &wuk, const at::Tensor &kv_cache, const at::Tensor &kv_cache_rope, const at::Tensor &slotmapping,
     const c10::optional<at::Tensor> &quant_scale0, const c10::optional<at::Tensor> &quant_offset0, const c10::optional<at::Tensor> &bias0,
     const c10::optional<at::Tensor> &quant_scale1, const c10::optional<at::Tensor> &quant_offset1, const c10::optional<at::Tensor> &bias1,
     const c10::optional<at::Tensor> &ctkv_scale, const c10::optional<at::Tensor> &q_nope_scale,
-    c10::optional<c10::string_view> cache_mode, c10::optional<c10::string_view> quant_mode, c10::optional<bool> enable_inner_out, at::Tensor &q_out0,
+    c10::optional<c10::string_view> cache_mode, c10::optional<c10::string_view> quant_mode,
+    c10::optional<bool> enable_inner_out, at::Tensor &q_out0,
     at::Tensor &kv_cache_out0, at::Tensor &q_out1, at::Tensor &kv_cache_out1, at::Tensor &inner_out)
 {
     at::Tensor Descale0 =
@@ -79,7 +84,35 @@ std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
         enable_inner_out.has_value()
             ? enable_inner_out.value()
             : false;
-    
+    TORCH_CHECK(
+        cos.has_value() == sin.has_value(),
+        "mla_preprocess requires cos and sin to both be tensors or both be None.");
+    bool enableRope = cos.has_value();
+    // Use placeholder tensors because device kernels initialize RoPE input addresses unconditionally.
+    at::Tensor Cos =
+        cos.has_value()
+            ? cos.value()
+            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
+    at::Tensor Sin =
+        sin.has_value()
+            ? sin.value()
+            : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
+    int64_t kvLoraRank = wuk.size(2);
+    int64_t qkRopeHeadDim = kv_cache_rope.size(-1);
+    if (kvLoraRank != MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK ||
+        qkRopeHeadDim != MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM) {
+        TORCH_WARN_ONCE(
+            "mla_preprocess currently fully supports only kv_lora_rank=",
+            MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK,
+            " and qk_rope_head_dim=",
+            MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM,
+            ", but received kv_lora_rank=",
+            kvLoraRank,
+            " and qk_rope_head_dim=",
+            qkRopeHeadDim,
+             ". Inputs outside the fully supported configuration are allowed to continue, "
+             "but may produce accuracy issues.");
+    }
     auto [workspace_tensor, tiling, block_dim] = mlapo::mla_preprocess_tiling(
         hiddenState,
         wdqkv,
@@ -88,7 +121,8 @@ std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
         kv_cache_rope,
         cache_mode,
         quant_mode,
-        enableInnerOut
+        enableInnerOut,
+        enableRope
     );
 
     void *hidden_state_ptr = hiddenState.data_ptr();
@@ -101,8 +135,8 @@ std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
     void *quant_scale1_ptr = Quant_scale1.data_ptr();
     void *quant_offset1_ptr = Quant_offset1.data_ptr();
     void *gamma2_ptr = gamma2.data_ptr();
-    void *sin_ptr = sin.data_ptr();
-    void *cos_ptr = cos.data_ptr();
+    void *sin_ptr = Sin.data_ptr();
+    void *cos_ptr = Cos.data_ptr();
     void *kv_cache_ptr = kv_cache.data_ptr();
     void *slotmapping_ptr = slotmapping.data_ptr();
     void *wuq_ptr = wuq.data_ptr();

--- a/csrc/mla_preprocess/mla_preprocess_torch_adpt.h
+++ b/csrc/mla_preprocess/mla_preprocess_torch_adpt.h
@@ -97,7 +97,7 @@ std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
         sin.has_value()
             ? sin.value()
             : at::empty({1}, at::TensorOptions().dtype(at::kHalf).device(hiddenState.options().device()));
-    int64_t kvLoraRank = wuk.size(2);
+    int64_t kvLoraRank = wuk.size(-1);
     int64_t qkRopeHeadDim = kv_cache_rope.size(-1);
     if (kvLoraRank != MLA_PREPROCESS_FULLY_SUPPORTED_KV_LORA_RANK ||
         qkRopeHeadDim != MLA_PREPROCESS_FULLY_SUPPORTED_QK_ROPE_HEAD_DIM) {

--- a/csrc/mla_preprocess/op_host/mla_preprocess.h
+++ b/csrc/mla_preprocess/op_host/mla_preprocess.h
@@ -129,6 +129,7 @@ struct OpParam {
     QuantMode quantMode;
     caffe2::TypeMeta inDtype;
     bool enableInnerOut;
+    bool enableRope;
     // MLA dimensions derived from tensor shapes
     uint32_t qLoraRank;
     uint32_t qkNopeHeadDim;
@@ -565,6 +566,7 @@ void MlaPreprocessTiling::Init()
     tilingData->n = opParam.N;
     tilingData->hiddenStateDim = opParam.hiddenStateDim;
     tilingData->isWeightQuantized = opParam.isWeightQuantized;
+    tilingData->enableRope = static_cast<uint32_t>(opParam.enableRope);
     bool enDequant = (opParam.isWeightQuantized == 1);
     bool deqOnTheFly = false;
     if (enDequant && (opParam.inDtype == at::kBFloat16 || opParam.quantMode == QuantMode::PER_TOKEN_SYMM_QUANT)) {
@@ -660,7 +662,8 @@ std::tuple<at::Tensor, at::Tensor, uint32_t> mla_preprocess_tiling(
     const at::Tensor &kv_cache_rope,
     c10::optional<c10::string_view> cache_mode,
     c10::optional<c10::string_view> quant_mode,
-    bool enable_inner_out
+    bool enable_inner_out,
+    bool enable_rope
 )
 {
     auto cacheMode = get_op_mode(cache_mode_map, cache_mode, "krope_ctkv", "cache_mode");
@@ -697,6 +700,7 @@ std::tuple<at::Tensor, at::Tensor, uint32_t> mla_preprocess_tiling(
     opParam.quantMode = static_cast<QuantMode>(quantMode);
     opParam.inDtype = hiddenState.options().dtype();
     opParam.enableInnerOut = enable_inner_out;
+    opParam.enableRope = enable_rope;
     opParam.qLoraRank = qLoraRank;
     opParam.qkNopeHeadDim = qkNopeHeadDim;
     opParam.qkRopeHeadDim = qkRopeHeadDim;

--- a/csrc/mla_preprocess/op_host/tiling/mla_preprocess_tiling.h
+++ b/csrc/mla_preprocess/op_host/tiling/mla_preprocess_tiling.h
@@ -95,6 +95,7 @@ struct MlaTilingData {
     uint32_t hiddenStateDim{7168};
 
     uint32_t isWeightQuantized{1};
+    uint32_t enableRope{1};
 
     // Model-specific MLA dimensions (derived from tensor shapes)
     uint32_t mm1OutSize{2112};        // q_lora_rank + kv_lora_rank + qk_rope_head_dim

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
@@ -44,6 +44,7 @@ extern "C" __global__ __aicore__ void mla_preprocess(
     mlaTilingData.tilingKey = tilingData->tilingKey;
     mlaTilingData.n = tilingData->n;
     mlaTilingData.hiddenStateDim = tilingData->hiddenStateDim;
+    mlaTilingData.enableRope = tilingData->enableRope;
 
     mlaTilingData.mm1.numBatch = tilingData->mm1.numBatch;
     mlaTilingData.mm1.m = tilingData->mm1.m;

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
@@ -177,13 +177,10 @@ public:
             WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
             AscendC::DataCopy(inputQ, this->qGm_[qOffset],
                               {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
-            SET_FLAG(MTE2, V, EVENT_ID1);
-            WAIT_FLAG(MTE2, V, EVENT_ID1);
-
+            SET_FLAG(MTE2, MTE3, EVENT_ID1);
             uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
             uint64_t outQOffset2 = startHead * this->headDim;
-            SET_FLAG(V, MTE3, EVENT_ID1);
-            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(MTE2, MTE3, EVENT_ID1);
             if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
                 AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
                                   {loopN, headBlockLen, 0, concatBlockLen});

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16.hpp
@@ -45,6 +45,7 @@ public:
         headNumQ = ropeConcatParams.headNumQ;
         this->hiddenStrideRope_ = ropeConcatParams.hiddenStrideRope;
         this->qkNopeHeadDim_ = ropeConcatParams.qkNopeHeadDim;
+        this->enableRope_ = ropeConcatParams.enableRope;
         rotaryCoeff = ropeConcatParams.rotaryCoeff;
         ntokens = ropeConcatParams.ntokens;
         realCore = ropeConcatParams.realCore;
@@ -75,6 +76,10 @@ public:
     __aicore__ inline void Process()
     {
         if (blockIdx_ >= realCore) {
+            return;
+        }
+        if (enableRope_ == 0) {
+            ProcessRawQ();
             return;
         }
         uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
@@ -158,6 +163,37 @@ public:
         }
         WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
     }
+
+    __aicore__ inline void ProcessRawQ()
+    {
+        uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
+        SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        for (uint32_t zz = 0; zz < this->loopTime; ++zz) {
+            uint16_t loopN = (zz == this->loopTime - 1) ? this->lastLoopN : this->maxNPerLoopForUb;
+            uint64_t startHead = startCoreLineIndex + zz * this->maxNPerLoopForUb;
+            uint64_t qOffset = startHead * hiddenStrideRope_ + qkNopeHeadDim_;
+            AscendC::LocalTensor<QkDtype> inputQ = buf.GetBuffer<BufferType::ASCEND_UB, QkDtype>(0);
+
+            WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+            AscendC::DataCopy(inputQ, this->qGm_[qOffset],
+                              {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
+            SET_FLAG(MTE2, V, EVENT_ID1);
+            WAIT_FLAG(MTE2, V, EVENT_ID1);
+
+            uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
+            uint64_t outQOffset2 = startHead * this->headDim;
+            SET_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
+                AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
+                                  {loopN, headBlockLen, 0, concatBlockLen});
+            } else {
+                AscendC::DataCopy(this->outRopeConcatGm2_[outQOffset2], inputQ, loopN * this->headDim);
+            }
+            SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        }
+        WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+    }
     // tensor -1 -1 -1 1 1 1
     template <typename BUF_TYPE>
     __aicore__ inline void ExpandNeg(const AscendC::LocalTensor<BUF_TYPE> &tempBuf, uint32_t headNumTemp)
@@ -219,6 +255,7 @@ private:
 
     uint32_t hiddenStrideRope_{0};
     uint32_t qkNopeHeadDim_{0};
+    uint32_t enableRope_{1};
     uint32_t repeatSize_{0};
     uint32_t rotateStride_{0};  // this->headDim / rope conf
     uint32_t headDim;
@@ -2562,10 +2599,12 @@ private:
                 // quantMode == QuantMode::PER_TOKEN_SYMM_QUANT
                 AscendC::DataCopy(mmTensor, s2GmTensor[offset], AscendC::DataCopyParams(1, splitSizeOne_ / 8, 0, 0));
             }
-            AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
-            AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
+            if (mlaParams.enableRope != 0) {
+                AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+                AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+            }
             SET_FLAG(MTE2, V, EVENT_ID0);
             // ND
             uint64_t cacheStart = static_cast<uint64_t>(slotValue) * static_cast<uint64_t>(splitSizeOne_);
@@ -2635,30 +2674,43 @@ private:
             uint64_t revertOffset = splitRmsNormSizeTwo_ / 2;
             Cast(ropeKTensor, srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
                  splitRmsNormSizeTwo_);
-            Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Duplicate(calTensor, static_cast<float>(-1), revertOffset);
-            Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
-            AscendC::PipeBarrier<PIPE_V>();
-            Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE, splitRmsNormSizeTwo_);
-            Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
-                 splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
-            Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            if (std::is_same<T1, __bf16>::value) {
-                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_RINT,
+            if (mlaParams.enableRope != 0) {
+                Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Duplicate(calTensor, static_cast<float>(-1), revertOffset);
+                Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE,
                      splitRmsNormSizeTwo_);
+                Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
+                Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor,
+                    splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                if (std::is_same<T1, __bf16>::value) {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_RINT,
+                         splitRmsNormSizeTwo_);
+                } else {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_NONE,
+                         splitRmsNormSizeTwo_);
+                }
             } else {
-                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_NONE,
-                     splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                if (std::is_same<T1, __bf16>::value) {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKTensor, AscendC::RoundMode::CAST_RINT,
+                         splitRmsNormSizeTwo_);
+                } else {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKTensor, AscendC::RoundMode::CAST_NONE,
+                         splitRmsNormSizeTwo_);
+                }
             }
             AscendC::PipeBarrier<PIPE_V>();
             /* Rope K end */

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_nq.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_nq.hpp
@@ -177,13 +177,10 @@ public:
             WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
             AscendC::DataCopy(inputQ, this->qGm_[qOffset],
                               {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
-            SET_FLAG(MTE2, V, EVENT_ID1);
-            WAIT_FLAG(MTE2, V, EVENT_ID1);
-
+            SET_FLAG(MTE2, MTE3, EVENT_ID1);
             uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
             uint64_t outQOffset2 = startHead * this->headDim;
-            SET_FLAG(V, MTE3, EVENT_ID1);
-            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(MTE2, MTE3, EVENT_ID1);
             if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
                 AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
                                   {loopN, headBlockLen, 0, concatBlockLen});

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_nq.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_nq.hpp
@@ -56,6 +56,7 @@ public:
         concatSize = ropeConcatParams.concatSize;
         hiddenStrideRope_ = ropeConcatParams.hiddenStrideRope;
         qkNopeHeadDim_ = ropeConcatParams.qkNopeHeadDim;
+        enableRope_ = ropeConcatParams.enableRope;
         blockIdx_ = (blockIdx_ / 2) * 2 + static_cast<uint64_t>(GetSubBlockidx());
         loopTime = (blockIdx_ == realCore - 1) ? lastCoreLoopTime : preCoreLoopTime;
         lastLoopN = (blockIdx_ == realCore - 1) ? lastCoreLoopNLast : preCoreLoopNLast;
@@ -75,6 +76,10 @@ public:
     __aicore__ inline void Process()
     {
         if (blockIdx_ >= realCore) {
+            return;
+        }
+        if (enableRope_ == 0) {
+            ProcessRawQ();
             return;
         }
         uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
@@ -158,6 +163,37 @@ public:
         }
         WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
     }
+
+    __aicore__ inline void ProcessRawQ()
+    {
+        uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
+        SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        for (uint32_t zz = 0; zz < this->loopTime; ++zz) {
+            uint16_t loopN = (zz == this->loopTime - 1) ? this->lastLoopN : this->maxNPerLoopForUb;
+            uint64_t startHead = startCoreLineIndex + zz * this->maxNPerLoopForUb;
+            uint64_t qOffset = startHead * hiddenStrideRope_ + qkNopeHeadDim_;
+            AscendC::LocalTensor<QkDtype> inputQ = buf.GetBuffer<BufferType::ASCEND_UB, QkDtype>(0);
+
+            WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+            AscendC::DataCopy(inputQ, this->qGm_[qOffset],
+                              {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
+            SET_FLAG(MTE2, V, EVENT_ID1);
+            WAIT_FLAG(MTE2, V, EVENT_ID1);
+
+            uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
+            uint64_t outQOffset2 = startHead * this->headDim;
+            SET_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
+                AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
+                                  {loopN, headBlockLen, 0, concatBlockLen});
+            } else {
+                AscendC::DataCopy(this->outRopeConcatGm2_[outQOffset2], inputQ, loopN * this->headDim);
+            }
+            SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        }
+        WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+    }
     // tensor -1 -1 -1 1 1 1
     template <typename BUF_TYPE>
     __aicore__ inline void ExpandNeg(const AscendC::LocalTensor<BUF_TYPE> &tempBuf, uint32_t headNumTemp)
@@ -234,6 +270,7 @@ private:
     uint32_t concatSize;
     uint32_t hiddenStrideRope_;
     uint32_t qkNopeHeadDim_;
+    uint32_t enableRope_{1};
     uint32_t blockIdx_;
     uint32_t loopTime{0};
     uint32_t lastLoopN{0};
@@ -1054,10 +1091,12 @@ private:
             }
             AscendC::DataCopy(srcTensor, s3GmTensor[offset],
                               AscendC::DataCopyParams(1, mm1OutSize_ / BLOCK_SIZE_16, 0, 0));
-            AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
-            AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
+            if (mlaParams.enableRope != 0) {
+                AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+                AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+            }
             SET_FLAG(MTE2, V, EVENT_ID0);
             // ND
             uint64_t cacheStart = static_cast<uint64_t>(slotValue) * static_cast<uint64_t>(splitSizeOne_);
@@ -1094,26 +1133,34 @@ private:
             uint64_t revertOffset = splitRmsNormSizeTwo_ / 2;
             Cast(ropeKTensor, srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
                  splitRmsNormSizeTwo_);
-            Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Duplicate(calTensor, static_cast<float>(-1), revertOffset);
-            Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
-            AscendC::PipeBarrier<PIPE_V>();
-            Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE, splitRmsNormSizeTwo_);
-            Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
-                 splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
-            Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_RINT,
-                 splitRmsNormSizeTwo_);
+            if (mlaParams.enableRope != 0) {
+                Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Duplicate(calTensor, static_cast<float>(-1), revertOffset);
+                Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+                Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
+                Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor,
+                    splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_RINT,
+                     splitRmsNormSizeTwo_);
+            } else {
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKTensor, AscendC::RoundMode::CAST_RINT,
+                     splitRmsNormSizeTwo_);
+            }
             AscendC::PipeBarrier<PIPE_V>();
             /* Rope K end */
             SET_FLAG(V, MTE3, EVENT_ID0);

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
@@ -177,13 +177,10 @@ public:
             WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
             AscendC::DataCopy(inputQ, this->qGm_[qOffset],
                               {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
-            SET_FLAG(MTE2, V, EVENT_ID1);
-            WAIT_FLAG(MTE2, V, EVENT_ID1);
-
+            SET_FLAG(MTE2, MTE3, EVENT_ID1);
             uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
             uint64_t outQOffset2 = startHead * this->headDim;
-            SET_FLAG(V, MTE3, EVENT_ID1);
-            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(MTE2, MTE3, EVENT_ID1);
             if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
                 AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
                                   {loopN, headBlockLen, 0, concatBlockLen});

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_bf16_qdown.hpp
@@ -56,6 +56,7 @@ public:
         concatSize = ropeConcatParams.concatSize;
         hiddenStrideRope_ = ropeConcatParams.hiddenStrideRope;
         qkNopeHeadDim_ = ropeConcatParams.qkNopeHeadDim;
+        enableRope_ = ropeConcatParams.enableRope;
         blockIdx_ = (blockIdx_ / 2) * 2 + static_cast<uint64_t>(GetSubBlockidx());
         loopTime = (blockIdx_ == realCore - 1) ? lastCoreLoopTime : preCoreLoopTime;
         lastLoopN = (blockIdx_ == realCore - 1) ? lastCoreLoopNLast : preCoreLoopNLast;
@@ -75,6 +76,10 @@ public:
     __aicore__ inline void Process()
     {
         if (blockIdx_ >= realCore) {
+            return;
+        }
+        if (enableRope_ == 0) {
+            ProcessRawQ();
             return;
         }
         uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
@@ -158,6 +163,37 @@ public:
         }
         WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
     }
+
+    __aicore__ inline void ProcessRawQ()
+    {
+        uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
+        SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        for (uint32_t zz = 0; zz < this->loopTime; ++zz) {
+            uint16_t loopN = (zz == this->loopTime - 1) ? this->lastLoopN : this->maxNPerLoopForUb;
+            uint64_t startHead = startCoreLineIndex + zz * this->maxNPerLoopForUb;
+            uint64_t qOffset = startHead * hiddenStrideRope_ + qkNopeHeadDim_;
+            AscendC::LocalTensor<QkDtype> inputQ = buf.GetBuffer<BufferType::ASCEND_UB, QkDtype>(0);
+
+            WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+            AscendC::DataCopy(inputQ, this->qGm_[qOffset],
+                              {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
+            SET_FLAG(MTE2, V, EVENT_ID1);
+            WAIT_FLAG(MTE2, V, EVENT_ID1);
+
+            uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
+            uint64_t outQOffset2 = startHead * this->headDim;
+            SET_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
+                AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
+                                  {loopN, headBlockLen, 0, concatBlockLen});
+            } else {
+                AscendC::DataCopy(this->outRopeConcatGm2_[outQOffset2], inputQ, loopN * this->headDim);
+            }
+            SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        }
+        WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+    }
     // tensor -1 -1 -1 1 1 1
     template <typename BUF_TYPE>
     __aicore__ inline void ExpandNeg(const AscendC::LocalTensor<BUF_TYPE> &tempBuf, uint32_t headNumTemp)
@@ -234,6 +270,7 @@ private:
     uint32_t concatSize;
     uint32_t hiddenStrideRope_;
     uint32_t qkNopeHeadDim_;
+    uint32_t enableRope_{1};
     uint32_t blockIdx_;
     uint32_t loopTime{0};
     uint32_t lastLoopN{0};
@@ -2583,10 +2620,12 @@ private:
                 // quantMode == QuantMode::PER_TOKEN_SYMM_QUANT
                 AscendC::DataCopy(mmTensor, s2GmTensor[offset], AscendC::DataCopyParams(1, splitSizeOne_ / 8, 0, 0));
             }
-            AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
-            AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
+            if (mlaParams.enableRope != 0) {
+                AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+                AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+            }
             SET_FLAG(MTE2, V, EVENT_ID0);
             // ND
             uint64_t cacheStart = static_cast<uint64_t>(slotValue) * static_cast<uint64_t>(splitSizeOne_);
@@ -2656,30 +2695,43 @@ private:
             uint64_t revertOffset = splitRmsNormSizeTwo_ / 2;
             Cast(ropeKTensor, srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
                  splitRmsNormSizeTwo_);
-            Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Duplicate(calTensor, static_cast<float>(-1), revertOffset);
-            Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
-            AscendC::PipeBarrier<PIPE_V>();
-            Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE, splitRmsNormSizeTwo_);
-            Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
-                 splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
-            Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            if (std::is_same<T1, __bf16>::value) {
-                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_RINT,
+            if (mlaParams.enableRope != 0) {
+                Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Duplicate(calTensor, static_cast<float>(-1), revertOffset);
+                Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE,
                      splitRmsNormSizeTwo_);
+                Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
+                Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor,
+                    splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                if (std::is_same<T1, __bf16>::value) {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_RINT,
+                         splitRmsNormSizeTwo_);
+                } else {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_NONE,
+                         splitRmsNormSizeTwo_);
+                }
             } else {
-                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_NONE,
-                     splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                if (std::is_same<T1, __bf16>::value) {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKTensor, AscendC::RoundMode::CAST_RINT,
+                         splitRmsNormSizeTwo_);
+                } else {
+                    Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKTensor, AscendC::RoundMode::CAST_NONE,
+                         splitRmsNormSizeTwo_);
+                }
             }
             AscendC::PipeBarrier<PIPE_V>();
             /* Rope K end */

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_fp16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_fp16.hpp
@@ -58,6 +58,7 @@ public:
         concatSize = ropeConcatParams.concatSize;
         hiddenStrideRope_ = ropeConcatParams.hiddenStrideRope;
         qkNopeHeadDim_ = ropeConcatParams.qkNopeHeadDim;
+        enableRope_ = ropeConcatParams.enableRope;
         blockIdx_ = (blockIdx_ / 2) * 2 + static_cast<uint64_t>(GetSubBlockidx());
         loopTime = (blockIdx_ == realCore - 1) ? lastCoreLoopTime : preCoreLoopTime;
         lastLoopN = (blockIdx_ == realCore - 1) ? lastCoreLoopNLast : preCoreLoopNLast;
@@ -77,6 +78,10 @@ public:
     __aicore__ inline void Process()
     {
         if (blockIdx_ >= realCore) return;
+        if (enableRope_ == 0) {
+            ProcessRawQ();
+            return;
+        }
         uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
         // [maxNPerLoopForUb,head_dim] 的 neg
         AscendC::LocalTensor<float> negLocal =
@@ -163,6 +168,39 @@ public:
         }
         WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
     }
+
+    __aicore__ inline void ProcessRawQ()
+    {
+        uint64_t startCoreLineIndex = this->blockIdx_ * this->nlCoreRun;
+        SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        for (uint32_t zz = 0; zz < this->loopTime; ++zz) {
+            uint16_t loopN = (zz == this->loopTime - 1) ? this->lastLoopN : this->maxNPerLoopForUb;
+            uint64_t startHead = startCoreLineIndex + zz * this->maxNPerLoopForUb;
+            uint64_t qOffset = startHead * hiddenStrideRope_ + qkNopeHeadDim_;
+            AscendC::LocalTensor<QkDtype> inputQ = buf.GetBuffer<BufferType::ASCEND_UB, QkDtype>(0);
+
+            SET_FLAG(S, MTE2, EVENT_ID1);
+            WAIT_FLAG(S, MTE2, EVENT_ID1);
+            WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+            AscendC::DataCopy(inputQ, this->qGm_[qOffset],
+                              {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
+            SET_FLAG(MTE2, V, EVENT_ID1);
+            WAIT_FLAG(MTE2, V, EVENT_ID1);
+
+            uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
+            uint64_t outQOffset2 = startHead * this->headDim;
+            SET_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
+                AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
+                                  {loopN, headBlockLen, 0, concatBlockLen});
+            } else {
+                AscendC::DataCopy(this->outRopeConcatGm2_[outQOffset2], inputQ, loopN * this->headDim);
+            }
+            SET_FLAG(MTE3, MTE2, EVENT_ID1);
+        }
+        WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
+    }
     // tensor -1 -1 -1 1 1 1
     template <typename BUF_TYPE>
     __aicore__ inline void ExpandNeg(const AscendC::LocalTensor<BUF_TYPE> &tempBuf, uint32_t headNumTemp)
@@ -242,6 +280,7 @@ private:
     uint32_t concatSize;
     uint32_t hiddenStrideRope_;
     uint32_t qkNopeHeadDim_;
+    uint32_t enableRope_{1};
     uint32_t blockIdx_;
     uint32_t loopTime{0};   // The number of current data rounds
     uint32_t lastLoopN{0};  // The number of lines currently processed by tails kernel
@@ -2181,10 +2220,12 @@ private:
                 continue;
             }
             AscendC::DataCopy(srcTensor, s3GmTensor[offset], splitSizeOne_);
-            AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
-            AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
-                              splitRmsNormSizeTwo_);
+            if (mlaParams.enableRope != 0) {
+                AscendC::DataCopy(sinTensor, sin1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+                AscendC::DataCopy(cosTensor, cos1GmTensor[(row_work * vectorBlockIdx + loop) * splitRmsNormSizeTwo_],
+                                  splitRmsNormSizeTwo_);
+            }
             SET_FLAG(MTE2, V, EVENT_ID0);
             // ND
             uint64_t cacheStart = static_cast<uint64_t>(slotValue) * static_cast<uint64_t>(splitSizeOne_);
@@ -2237,26 +2278,34 @@ private:
             uint64_t revertOffset = splitRmsNormSizeTwo_ / 2;
             Cast(ropeKTensor, srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
                  splitRmsNormSizeTwo_);
-            Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset], AscendC::RoundMode::CAST_NONE,
-                 revertOffset);
-            Duplicate(calTensor, static_cast<float>(-1), revertOffset);
-            Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
-            AscendC::PipeBarrier<PIPE_V>();
-            Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE, splitRmsNormSizeTwo_);
-            Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
-                 splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
-            Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
-            AscendC::PipeBarrier<PIPE_V>();
-            Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_NONE,
-                 splitRmsNormSizeTwo_);
+            if (mlaParams.enableRope != 0) {
+                Cast(ropeKRevertTensor[revertOffset], srcTensor[splitRmsNormSizeOne_],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Cast(ropeKRevertTensor, srcTensor[splitRmsNormSizeOne_ + revertOffset],
+                     AscendC::RoundMode::CAST_NONE, revertOffset);
+                Duplicate(calTensor, static_cast<float>(-1), revertOffset);
+                Duplicate(calTensor[revertOffset], static_cast<float>(1), revertOffset);
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(calTensor[splitRmsNormSizeTwo_], cosTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+                Cast(calTensor[splitRmsNormSizeTwo_ * 2], sinTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKTensor, calTensor[splitRmsNormSizeTwo_], ropeKTensor, splitRmsNormSizeTwo_);
+                Mul(ropeKRevertTensor, calTensor[splitRmsNormSizeTwo_ * 2], ropeKRevertTensor,
+                    splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Mul(ropeKRevertTensor, calTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Add(ropeKRevertTensor, ropeKTensor, ropeKRevertTensor, splitRmsNormSizeTwo_);
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKRevertTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+            } else {
+                AscendC::PipeBarrier<PIPE_V>();
+                Cast(outTmpTensor[splitRmsNormSizeOne_], ropeKTensor, AscendC::RoundMode::CAST_NONE,
+                     splitRmsNormSizeTwo_);
+            }
             /* Rope K end */
             // reshapeAndcache
             SET_FLAG(V, MTE3, EVENT_ID0);

--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_fp16.hpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_mix_fp16.hpp
@@ -184,13 +184,10 @@ public:
             WAIT_FLAG(MTE3, MTE2, EVENT_ID1);
             AscendC::DataCopy(inputQ, this->qGm_[qOffset],
                               {loopN, headBlockLen, static_cast<uint16_t>(qkNopeHeadDim_ / 16), 0});
-            SET_FLAG(MTE2, V, EVENT_ID1);
-            WAIT_FLAG(MTE2, V, EVENT_ID1);
-
+            SET_FLAG(MTE2, MTE3, EVENT_ID1);
             uint64_t outQOffset = startHead * outLineOffset + this->concatSize;
             uint64_t outQOffset2 = startHead * this->headDim;
-            SET_FLAG(V, MTE3, EVENT_ID1);
-            WAIT_FLAG(V, MTE3, EVENT_ID1);
+            WAIT_FLAG(MTE2, MTE3, EVENT_ID1);
             if constexpr (CacheMode == CACHE_MODE_KVCACHE) {
                 AscendC::DataCopy(this->outRopeConcatGm_[outQOffset], inputQ,
                                   {loopN, headBlockLen, 0, concatBlockLen});

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2146,7 +2146,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     ops.def(
         "mla_preprocess(Tensor hiddenState, Tensor wdqkv,"
         "               Tensor? descale0, Tensor gamma1, Tensor? beta1, Tensor wuq, Tensor? descale1,"
-        "               Tensor gamma2, Tensor cos, Tensor sin, Tensor wuk, Tensor kv_cache,"
+        "               Tensor gamma2, Tensor? cos, Tensor? sin, Tensor wuk, Tensor kv_cache,"
         "               Tensor kv_cache_rope, Tensor slotmapping, Tensor? quant_scale0,"
         "               Tensor? quant_offset0, Tensor? bias0, Tensor? quant_scale1, Tensor? quant_offset1,"
         "               Tensor? bias1, Tensor? ctkv_scale, Tensor? q_nope_scale, str? cache_mode,"

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -66,8 +66,8 @@ std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
     const at::Tensor &wuq,
     const c10::optional<at::Tensor> &descale1,
     const at::Tensor &gamma2,
-    const at::Tensor &cos,
-    const at::Tensor &sin,
+    const c10::optional<at::Tensor> &cos,
+    const c10::optional<at::Tensor> &sin,
     const at::Tensor &wuk,
     const at::Tensor &kv_cache,
     const at::Tensor &kv_cache_rope,
@@ -90,6 +90,9 @@ std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
     at::Tensor &inner_out
     )
 {
+    TORCH_CHECK(
+        cos.has_value() == sin.has_value(),
+        "mla_preprocess requires cos and sin to both be tensors or both be None.");
     return {q_out0, kv_cache_out0, q_out1, kv_cache_out1, inner_out};
 }
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess.py
@@ -11,8 +11,10 @@ enable_custom_op()
 
 @pytest.mark.skip(reason="Failure of an individual operator use case causes failures of other operators.")
 @pytest.mark.parametrize("cache_mode", ["krope_ctkv", "nzcache"])
+@pytest.mark.parametrize("enable_rope", [True, False])
 @torch.inference_mode()
-def test_mla_preprocess_kernel(cache_mode: str):
+def test_mla_preprocess_kernel(cache_mode: str, enable_rope: bool):
+    """Exercise MLA preprocess cache modes with RoPE enabled and disabled."""
     token_num = 1
     head_num = 2
     N_7168 = 7168
@@ -72,6 +74,7 @@ def test_mla_preprocess_kernel(cache_mode: str):
     )
     q_nope_old = q_nope_out.clone()
     q_rope_old = q_rope_out.clone()
+    kv_cache_rope_old = kv_cache_rope.clone()
 
     torch.ops._C_ascend.mla_preprocess(
         hidden_states,
@@ -82,8 +85,8 @@ def test_mla_preprocess_kernel(cache_mode: str):
         wuq,
         de_scale1,
         gamma2,
-        cos,
-        sin,
+        cos if enable_rope else None,
+        sin if enable_rope else None,
         wuk,
         kv_cache,
         kv_cache_rope,
@@ -107,6 +110,7 @@ def test_mla_preprocess_kernel(cache_mode: str):
     )
     assert not torch.equal(q_nope_out, q_nope_old)
     assert not torch.equal(q_rope_out, q_rope_old)
+    assert not torch.equal(kv_cache_rope, kv_cache_rope_old)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_nq.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_nq.py
@@ -10,8 +10,9 @@ enable_custom_op()
 
 
 @pytest.mark.skip(reason="Failure of an individual operator use case causes failures of other operators.")
+@pytest.mark.parametrize("enable_rope", [True, False])
 @torch.inference_mode()
-def test_mla_preprocess_kernel():
+def test_mla_preprocess_kernel(enable_rope: bool):
     token_num = 1
     head_num = 2
     N_7168 = 7168
@@ -56,6 +57,7 @@ def test_mla_preprocess_kernel():
     )
     q_nope_old = q_nope_out.clone()
     q_rope_old = q_rope_out.clone()
+    kv_cache_rope_old = kv_cache_rope.clone()
 
     torch.ops._C_ascend.mla_preprocess(
         hidden_states,
@@ -66,8 +68,8 @@ def test_mla_preprocess_kernel():
         wuq,
         None,
         gamma2,
-        cos,
-        sin,
+        cos if enable_rope else None,
+        sin if enable_rope else None,
         wuk,
         kv_cache,
         kv_cache_rope,
@@ -91,6 +93,7 @@ def test_mla_preprocess_kernel():
     )
     assert not torch.equal(q_nope_out, q_nope_old)
     assert not torch.equal(q_rope_out, q_rope_old)
+    assert not torch.equal(kv_cache_rope, kv_cache_rope_old)
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_qdown.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_preprocess_qdown.py
@@ -11,8 +11,10 @@ enable_custom_op()
 
 @pytest.mark.skip(reason="Failure of an individual operator use case causes failures of other operators.")
 @pytest.mark.parametrize("cache_mode", ["krope_ctkv", "nzcache"])
+@pytest.mark.parametrize("enable_rope", [True, False])
 @torch.inference_mode()
-def test_mla_preprocess_kernel(cache_mode: str):
+def test_mla_preprocess_kernel(cache_mode: str, enable_rope: bool):
+    """Exercise MLA QDown cache modes with RoPE enabled and disabled."""
     token_num = 1
     head_num = 2
     N_7168 = 7168
@@ -73,6 +75,7 @@ def test_mla_preprocess_kernel(cache_mode: str):
 
     q_nope_old = q_nope_out.clone()
     q_rope_old = q_rope_out.clone()
+    kv_cache_rope_old = kv_cache_rope.clone()
     q_down_old = q_down.clone()
 
     torch.ops._C_ascend.mla_preprocess(
@@ -84,8 +87,8 @@ def test_mla_preprocess_kernel(cache_mode: str):
         wuq,
         de_scale1,
         gamma2,
-        cos,
-        sin,
+        cos if enable_rope else None,
+        sin if enable_rope else None,
         wuk,
         kv_cache,
         kv_cache_rope,
@@ -109,6 +112,7 @@ def test_mla_preprocess_kernel(cache_mode: str):
     )
     assert not torch.equal(q_nope_out, q_nope_old)
     assert not torch.equal(q_rope_out, q_rope_old)
+    assert not torch.equal(kv_cache_rope, kv_cache_rope_old)
     assert not torch.equal(q_down, q_down_old)
 
     gc.collect()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves the `mla_preprocess` custom operator in the following areas:

- Makes `cos` and `sin` optional in the Torch interface.
  - Passing both tensors keeps the existing Q/K RoPE behavior unchanged.
  - Passing both as `None` disables only the Q-RoPE and K-RoPE mathematical operations.
  - The original unrotated Q-rope and K-rope data is still written to all outputs and KV caches using the existing layouts and copy lengths.
  - Mixed inputs, where only one of `cos` or `sin` is `None`, are rejected.
- Propagates the RoPE state through the Torch adapter, host tiling, device tiling, and all four kernels:
  - FP16
  - BF16
  - BF16 QDown
  - BF16 NoQuant
- Adds support for KV cache tensors that are non-contiguous on dimension 0 while requiring the remaining dimensions to remain contiguous.
- Adds BF16 per-token symmetric quantization support for the corresponding cache and inner-output configurations.
- Fixes UB out-of-bounds and temporary-buffer overlap risks in the quantization and RoPE paths.
- Adds warnings for configurations where `kv_lora_rank != 512` or `qk_rope_head_dim != 64`. Execution is allowed, but accuracy is not currently guaranteed.
- Updates MLA preprocess nightly tests to cover both RoPE-enabled and RoPE-disabled paths.
- Adds English and Chinese documentation for the Torch and ACLNN interfaces, supported modes, shape constraints, and RoPE control behavior.

These changes are needed to support callers that do not require fused RoPE, paged/non-contiguous cache views, and BF16 per-token quantization without changing the semantics of MatMul, Dequant, RMSNorm, Quant, Q-nope, CTKV, or inner output.

### Does this PR introduce *any* user-facing change?

Yes.

The Torch interface now accepts optional `cos` and `sin` tensors:

- `cos` and `sin` are both tensors: RoPE is enabled, preserving the existing behavior.
- `cos=None` and `sin=None`: RoPE is disabled.
- Only one is `None`: an error is reported.

Existing calls that pass both tensors remain backward compatible. No additional public `enable_rope` argument is introduced.

The operator also supports dimension-0 non-contiguous KV caches and additional BF16 per-token symmetric quantization configurations.

### How was this patch tested?

The custom kernels were built and installed with:

```bash
export COMPILE_CUSTOM_KERNELS=1
export CMAKE_BUILD_TYPE=Release
export MAX_JOBS=16
unset SOC_VERSION
python -m pip install --no-build-isolation --no-deps -v -e .
```
The local test file is as follows: 
[mla_preprocess_enable_rope_test.zip](https://github.com/user-attachments/files/30369639/mla_preprocess_enable_rope_test.zip)
The external MLA preprocess accuracy and performance matrix was executed with:
cd /test_script/mla_preprocess_enable_rope_test
bash run.sh
Result:
115/115 configurations passed
230/230 RoPE flag runs passed
Each configuration was tested with both RoPE states. The matrix covers:
FP16 and BF16
Quant, NoQuant, and QDown paths
CPU Golden and NPU small-operator Golden comparisons
Contiguous and dimension-0 non-contiguous cache layouts
Inner output enabled and disabled
Performance smoke tests for all four kernel implementations, using 100 iterations for each RoPE state
The repository nightly MLA preprocess test cases were also updated to cover both enabled and disabled RoPE behavior.


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
