### PR TITLE
[Doc][Feature] Adapt IQuest-Coder-V1-40B-Instruct to Ascend NPU

### DIFF
--- a/docs/source/tutorials/models/IQuest-Coder-V1-40B-Instruct.md
+++ b/docs/source/tutorials/models/IQuest-Coder-V1-40B-Instruct.md
@@ -1,0 +1,175 @@
+# IQuest-Coder-V1-40B-Instruct
+
+## Introduction
+
+IQuest-Coder-V1 is a family of code large language models built on a LLaMA-style
+architecture with Grouped-Query Attention (GQA). The 40B-Instruct variant has
+80 layers, `hidden_size=5120`, `num_attention_heads=40`, `num_key_value_heads=8`,
+`head_dim=128`, `intermediate_size=27648`, `vocab_size=76800` and a 128K token
+context (`max_position_embeddings=131072`). Its weights use the standard LLaMA
+tensor naming, and the optional OLMo (`clip_qkv`) / Qwen2 (`sliding_window`)
+enhancements are **disabled** in this config, so inference behaviour is identical
+to a standard LLaMA + GQA model.
+
+This tutorial shows how to run IQuest-Coder-V1-40B-Instruct on Ascend NPUs with
+vLLM-Ascend. It requires **vllm-ascend >= 0.18.0rc1**.
+
+## Supported Features
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md)
+to get the model's supported feature matrix.
+
+Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the
+feature's configuration.
+
+## Environment Preparation
+
+### Model Weight
+
+- `IQuest-Coder-V1-40B-Instruct` (BF16, ~80 GB): requires **2 × Atlas 800 A2 (64 GB)**
+  cards for tensor-parallel-size = 2. A single 64 GB card cannot hold the ~80 GB
+  of weights, so **single-card deployment is not supported** for the BF16 model.
+  [Download model weight](https://modelscope.cn/models/IQuestLab/IQuest-Coder-V1-40B-Instruct)
+
+It is recommended to download the model weight (via the ModelScope or
+HuggingFace repo linked above) to a local directory of your choice.
+
+### NPU device selection
+
+Ascend runtime logical device IDs are controlled via `ASCEND_RT_VISIBLE_DEVICES`.
+For example, to restrict the process to the last four physical NPUs (4, 5, 6, 7):
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
+```
+
+> Note: the runtime renumbers the listed physical devices to logical 0..N-1.
+> `tensor_parallel_size` must divide both `num_attention_heads` (40) and
+> `num_key_value_heads` (8), so the valid values are **1 / 2 / 4 / 8**. With the
+> last-four cards you can use TP=2 (or TP=4 if all four are present).
+
+### Verify Multi-node Communication (Optional)
+
+If you want to deploy a multi-node environment, verify multi-node communication
+according to [verify multi-node communication environment](../../installation.md#verify-multi-node-communication).
+
+### Installation
+
+You can use our official docker image for supporting IQuest-Coder-V1-40B-Instruct.
+Currently, we provide the all-in-one images.
+[Download images](https://quay.io/repository/ascend/vllm-ascend?tab=tags)
+
+#### Docker Pull (by tag)
+
+```{code-block} bash
+   :substitutions:
+
+docker pull quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+
+```
+
+#### Docker run
+
+```{code-block} bash
+   :substitutions:
+
+# Update --device according to your device (Atlas A2: /dev/davinci[0-7]).
+# Update the vllm-ascend image according to your environment.
+# Download the model weights to a local directory before running.
+export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|
+docker run --rm \
+    --name vllm-ascend-env \
+    --shm-size=1g \
+    --net=host \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --entrypoint /bin/bash \
+    $IMAGE
+```
+
+## Quick Start
+
+### 1. Architecture registration (already in vllm-ascend)
+
+IQuest-Coder-V1-40B-Instruct declares a custom architecture name
+`IQuestCoderForCausalLM` that is not part of vLLM's built-in registry. vllm-ascend
+ships a platform patch
+(`vllm_ascend/patch/platform/patch_iquestcoder_config.py`) that aliases it to
+`LlamaForCausalLM`. After importing vllm-ascend the model loads natively — **no
+`--hf-overrides` needed**.
+
+If you are on an older vllm-ascend without the patch, you can still force the
+mapping with:
+
+```bash
+--hf-overrides '{"architectures":["LlamaForCausalLM"],"model_type":"llama"}'
+```
+
+### 2. Start the OpenAI-compatible server
+
+```bash
+# Use 2 NPUs (TP=2) for the 40B BF16 model.
+export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
+
+vllm serve IQuestLab/IQuest-Coder-V1-40B-Instruct \
+    --tensor-parallel-size 2 \
+    --trust-remote-code \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.9
+```
+
+For a local weight path, replace the model id with the directory path where
+you saved the weights.
+
+### 3. Query the server
+
+```bash
+curl http://localhost:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "IQuestLab/IQuest-Coder-V1-40B-Instruct",
+      "prompt": "def quicksort(arr):",
+      "max_tokens": 128,
+      "temperature": 0.0
+    }'
+```
+
+### 4. Verified behaviour
+
+On Atlas 800 A2 (910B3), with the settings above:
+
+- **Eager mode**: ~22 s to generate a short code sample; model loads in ~70 s,
+  ~37 GB weights per card, ~114 K tokens of KV cache at `max-model-len=2048`.
+- **ACL graph mode**: same workload generates in ~4 s (graph replay captures
+  LlamaForCausalLM, 80 layers).
+
+Both modes produce correct code and correct answers (e.g. `O(log n)` for binary
+search complexity).
+
+> Note: vLLM reports `Using a slow tokenizer` because the model ships a non-fast
+> `IQuestCoderTokenizer`. This is benign; generation quality is unaffected.
+
+## Accuracy and Performance Evaluation
+
+The e2e accuracy config is at
+`tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml`. Run it with:
+
+```bash
+pytest tests/e2e/models/test_lm_eval_correctness.py \
+    --config tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml \
+    --tp-size 2
+```
+
+It evaluates `humaneval` and `mbpp` (pass@1) on Ascend. The metric thresholds in
+the yaml are preliminary estimates for the Instruct variant on bf16; the nightly
+accuracy run confirms the final numbers.
+
+## Known Limitations
+
+- **Single-card BF16 is unsupported** — the 40B weights (~80 GB) exceed a single
+  64 GB card. Use TP>=2 (or a quantized W8A8 variant for single-card).
+- **Long context KV cache is large**: at 128 K tokens, KV cache per card is
+  substantial; reduce `--max-model-len` for higher concurrency on 2 cards.
+- **Slow tokenizer**: convert to a fast tokenizer if throughput is critical.

--- a/docs/source/tutorials/models/IQuest-Coder-V1-40B-Instruct.md
+++ b/docs/source/tutorials/models/IQuest-Coder-V1-40B-Instruct.md
@@ -1,0 +1,170 @@
+# IQuest-Coder-V1-40B-Instruct
+
+## Introduction
+
+IQuest-Coder-V1 is a family of code large language models built on a LLaMA-style
+architecture with Grouped-Query Attention (GQA). The 40B-Instruct variant has
+80 layers, `hidden_size=5120`, `num_attention_heads=40`, `num_key_value_heads=8`,
+`head_dim=128`, `intermediate_size=27648`, `vocab_size=76800` and a 128K token
+context (`max_position_embeddings=131072`). Its weights use the standard LLaMA
+tensor naming, and the optional OLMo (`clip_qkv`) / Qwen2 (`sliding_window`)
+enhancements are **disabled** in this config, so inference behaviour is identical
+to a standard LLaMA + GQA model.
+
+This tutorial shows how to run IQuest-Coder-V1-40B-Instruct on Ascend NPUs with
+vLLM-Ascend. It requires **vllm-ascend >= 0.18.0rc1**.
+
+## Supported Features
+
+Refer to [supported features](../../user_guide/support_matrix/supported_models.md)
+to get the model's supported feature matrix.
+
+Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the
+feature's configuration.
+
+## Environment Preparation
+
+### Model Weight
+
+- `IQuest-Coder-V1-40B-Instruct` (BF16, ~80 GB): requires **2 × Atlas 800 A2 (64 GB)**
+  cards for tensor-parallel-size = 2. A single 64 GB card cannot hold the ~80 GB
+  of weights, so **single-card deployment is not supported** for the BF16 model.
+  [Download model weight](https://modelscope.cn/models/IQuestLab/IQuest-Coder-V1-40B-Instruct)
+
+It is recommended to download the model weight (via the ModelScope or
+HuggingFace repo linked above) to a local directory of your choice.
+
+### NPU device selection
+
+Ascend runtime logical device IDs are controlled via `ASCEND_RT_VISIBLE_DEVICES`.
+For example, to restrict the process to the last four physical NPUs (4, 5, 6, 7):
+
+```bash
+export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
+```
+
+> Note: the runtime renumbers the listed physical devices to logical 0..N-1.
+> `tensor_parallel_size` must divide both `num_attention_heads` (40) and
+> `num_key_value_heads` (8), so the valid values are **1 / 2 / 4 / 8**. With the
+> last-four cards you can use TP=2 (or TP=4 if all four are present).
+
+### Verify Multi-node Communication (Optional)
+
+If you want to deploy a multi-node environment, verify multi-node communication
+according to [verify multi-node communication environment](../../getting_started/installation.md#installation-multi-node-interconnect).
+
+### Installation
+
+You can use our official docker image for supporting IQuest-Coder-V1-40B-Instruct.
+Currently, we provide the all-in-one images.
+[Download images](https://quay.io/repository/ascend/vllm-ascend?tab=tags)
+
+#### Docker Pull (by tag)
+
+```bash
+docker pull quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+```
+
+#### Docker run
+
+```bash
+# Update --device according to your device (Atlas A2: /dev/davinci[0-7]).
+# Update the vllm-ascend image according to your environment.
+# Download the model weights to a local directory before running.
+export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+docker run --rm \
+    --name vllm-ascend-env \
+    --shm-size=1g \
+    --net=host \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --entrypoint /bin/bash \
+    $IMAGE
+```
+
+## Quick Start
+
+### 1. Architecture registration (already in vllm-ascend)
+
+IQuest-Coder-V1-40B-Instruct declares a custom architecture name
+`IQuestCoderForCausalLM` that is not part of vLLM's built-in registry. vllm-ascend
+ships a platform patch
+(`vllm_ascend/patch/platform/patch_iquestcoder_config.py`) that aliases it to
+`LlamaForCausalLM`. After importing vllm-ascend the model loads natively — **no
+`--hf-overrides` needed**.
+
+If you are on an older vllm-ascend without the patch, you can still force the
+mapping with:
+
+```bash
+--hf-overrides '{"architectures":["LlamaForCausalLM"],"model_type":"llama"}'
+```
+
+### 2. Start the OpenAI-compatible server
+
+```bash
+# Use 2 NPUs (TP=2) for the 40B BF16 model.
+export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
+
+vllm serve IQuestLab/IQuest-Coder-V1-40B-Instruct \
+    --tensor-parallel-size 2 \
+    --trust-remote-code \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.9
+```
+
+For a local weight path, replace the model id with the directory path where
+you saved the weights.
+
+### 3. Query the server
+
+```bash
+curl http://localhost:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "IQuestLab/IQuest-Coder-V1-40B-Instruct",
+      "prompt": "def quicksort(arr):",
+      "max_tokens": 128,
+      "temperature": 0.0
+    }'
+```
+
+### 4. Verified behaviour
+
+On Atlas 800 A2 (910B3), with the settings above:
+
+- **Eager mode**: ~22 s to generate a short code sample; model loads in ~70 s,
+  ~37 GB weights per card, ~114 K tokens of KV cache at `max-model-len=2048`.
+- **ACL graph mode**: same workload generates in ~4 s (graph replay captures
+  LlamaForCausalLM, 80 layers).
+
+Both modes produce correct code and correct answers (e.g. `O(log n)` for binary
+search complexity).
+
+> Note: vLLM reports `Using a slow tokenizer` because the model ships a non-fast
+> `IQuestCoderTokenizer`. This is benign; generation quality is unaffected.
+
+## Accuracy and Performance Evaluation
+
+The e2e accuracy config is at
+`tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml`. Run it with:
+
+```bash
+pytest tests/e2e/models/test_lm_eval_correctness.py \
+    --config tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml \
+    --tp-size 2
+```
+
+It evaluates `humaneval` and `mbpp` (pass@1) on Ascend. The metric thresholds in
+the yaml are preliminary estimates for the Instruct variant on bf16; the nightly
+accuracy run confirms the final numbers.
+
+## Known Limitations
+
+- **Single-card BF16 is unsupported** — the 40B weights (~80 GB) exceed a single
+  64 GB card. Use TP>=2 (or a quantized W8A8 variant for single-card).
+- **Long context KV cache is large**: at 128 K tokens, KV cache per card is
+  substantial; reduce `--max-model-len` for higher concurrency on 2 cards.
+- **Slow tokenizer**: convert to a fast tokenizer if throughput is critical.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,3 +1,5 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
+
+- [IQuest-Coder-V1-40B-Instruct](IQuest-Coder-V1-40B-Instruct.md)

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,3 +1,9 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
+
+:::{toctree}
+:maxdepth: 1
+
+IQuest-Coder-V1-40B-Instruct
+:::

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -254,6 +254,7 @@ nav:
         - tutorials/models/Qwen2.5-Math-RM-72B.md
         - tutorials/models/InternVL3.5.md
         - tutorials/models/Dots3-Note.md
+        - tutorials/models/IQuest-Coder-V1-40B-Instruct.md
     - Feature Tutorials:
         - tutorials/features/index.md
         - tutorials/features/pd_colocated_mooncake_multi_instance.md

--- a/tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml
+++ b/tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml
@@ -1,0 +1,41 @@
+# Accuracy / e2e config for IQuest-Coder-V1-40B-Instruct on Ascend (Atlas A2 / 910B3)
+#
+# The model is a LLaMA-family model (GQA, head_dim=128, standard LLaMA weight
+# naming; clip_qkv and sliding_window are both disabled in its config). It is
+# served as `LlamaForCausalLM` via the vllm-ascend registry alias
+# (vllm_ascend/patch/platform/patch_iquestcoder_config.py), so NO `--hf-overrides`
+# is required. The custom config & tokenizer classes still need
+# `trust_remote_code: true`.
+#
+# NOTE: the `value` fields below are *preliminary estimates* for the Instruct
+# variant on Ascend 910B3 (bf16). Replace them with the numbers measured by the
+# nightly accuracy run (the e2e harness asserts |measured - value| within RTOL=0.05).
+# Measurement command (run inside the vllm-ascend repo):
+#   pytest tests/e2e/models/test_lm_eval_correctness.py \
+#     --config tests/e2e/models/configs/IQuest-Coder-V1-40B-Instruct.yaml --tp-size 2
+model_name: "IQuestLab/IQuest-Coder-V1-40B-Instruct"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 2
+  dtype: auto
+  max_model_len: 4096
+  gpu_memory_utilization: 0.9
+  trust_remote_code: true
+  enforce_eager: true
+
+tasks:
+- name: "humaneval"
+  metrics:
+  - name: "pass_at_1"
+    value: 0.84
+- name: "mbpp"
+  metrics:
+  - name: "pass_at_1"
+    value: 0.89
+
+num_fewshot: 0
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -12,3 +12,4 @@ Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml
 Qwen3-ASR-1.7B.yaml
+IQuest-Coder-V1-40B-Instruct.yaml

--- a/tests/e2e/models/configs/accuracy_groups_a2.json
+++ b/tests/e2e/models/configs/accuracy_groups_a2.json
@@ -1,0 +1,8 @@
+{
+  "nightly": [
+    "IQuest-Coder-V1-40B-Instruct.yaml"
+  ],
+  "pr-only": [
+    "IQuest-Coder-V1-40B-Instruct.yaml"
+  ]
+}

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -45,3 +45,5 @@ import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 
 import vllm_ascend.patch.platform.patch_fused_moe  # noqa
 import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
+
+import vllm_ascend.patch.platform.patch_iquestcoder_config  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -48,6 +48,7 @@ import vllm_ascend.patch.platform.patch_eplb  # noqa
 import vllm_ascend.patch.platform.patch_fused_moe  # noqa
 import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
 import vllm_ascend.patch.platform.patch_glm5next_config  # noqa
+import vllm_ascend.patch.platform.patch_iquestcoder_config  # noqa
 
 # ** File: platform/patch_kv_cache_utils.py **
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_iquestcoder_config.py
+++ b/vllm_ascend/patch/platform/patch_iquestcoder_config.py
@@ -1,0 +1,37 @@
+# mypy: ignore-errors
+"""Register IQuestCoderForCausalLM as an alias of LlamaForCausalLM.
+
+IQuest-Coder-V1 is a LLaMA-family model (GQA, ``head_dim=128``, standard LLaMA
+weight naming, ``clip_qkv``/``sliding_window`` both disabled). Its ``config.json``
+declares a custom architecture name ``IQuestCoderForCausalLM`` that is not part of
+vLLM's built-in registry, so vLLM refuses to load it out of the box.
+
+Because the weights, attention layout and all core operators are identical to
+LLaMA, we alias the architecture to the existing ``LlamaForCausalLM``
+implementation. After this patch the model can be served / evaluated **without**
+``--hf-overrides``::
+
+    vllm serve IQuestLab/IQuest-Coder-V1-40B-Instruct --tensor-parallel-size 2 \\
+        --trust-remote-code
+
+Note: the model still ships a custom ``configuration_iquestcoder`` config class and
+an ``IQuestCoderTokenizer`` tokenizer class, so ``--trust-remote-code`` is still
+required at load time.
+"""
+
+from vllm.logger import logger
+from vllm.model_executor.models.registry import ModelRegistry
+
+
+def _patch_iquestcoder_registry_alias() -> None:
+    try:
+        ModelRegistry.register_model(
+            "IQuestCoderForCausalLM",
+            "vllm.model_executor.models.llama:LlamaForCausalLM",
+        )
+        logger.info("Registered IQuestCoderForCausalLM -> LlamaForCausalLM alias.")
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning("Failed to register IQuestCoderForCausalLM alias: %s", e)
+
+
+_patch_iquestcoder_registry_alias()


### PR DESCRIPTION
### What
Register IQuest-Coder-V1-40B-Instruct (a LLaMA-family 40B code model) as
LlamaForCausalLM via a vllm-ascend registry alias, and add the e2e test
config plus tutorial doc.

### User-facing change
- IQuestLab/IQuest-Coder-V1-40B-Instruct can now be served on Ascend NPU
  out of the box (no --hf-overrides needed), only --trust-remote-code.
- Requires tensor_parallel_size >= 2; a single 910B3 (64GB) card cannot hold
  the 40B weights.

### How tested
- Verified both Eager and ACLGraph modes on Atlas A2 / 910B3 with TP=2
  (NPU devices 4 and 6) generate correct code (fibonacci, quicksort,
  linked-list, binary-search complexity).

Fixes #10662
Fixes #9079

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
