### PR TITLE
[BugFix][v0.23.0] Pack SFA DSA-CP KV tensors into one all-gather

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -75,6 +75,42 @@ class TestAscendSFABackend(TestBase):
         self.assertIsNotNone(impl_cls)
 
 
+class TestAscendSFABytePackedGather(TestBase):
+    @patch("vllm_ascend.attention.sfa_v1.get_tp_group")
+    def test_byte_packed_gather_preserves_mixed_dtype_tensors(self, mock_get_tp_group):
+        mock_get_tp_group.return_value = SimpleNamespace(world_size=1)
+        sfa_kv = torch.arange(12, dtype=torch.float16).view(2, 6)
+        k_li = torch.arange(16, dtype=torch.int8).view(2, 1, 8)
+        k_li_scale = torch.arange(2, dtype=torch.float32).view(2, 1)
+
+        gathered, handle, metadata = AscendSFAImpl._all_gather_byte_packed_async(
+            [
+                ("sfa_kv", sfa_kv),
+                ("k_li", k_li),
+                ("k_li_scale", k_li_scale),
+            ],
+            async_op=True,
+        )
+
+        self.assertIsNone(handle)
+        self.assertEqual(gathered.dtype, torch.int8)
+        restored = AscendSFAImpl._restore_byte_gathered_tensors(gathered, metadata)
+        for name, expected in (("sfa_kv", sfa_kv), ("k_li", k_li), ("k_li_scale", k_li_scale)):
+            self.assertEqual(restored[name].shape, expected.shape)
+            self.assertEqual(restored[name].dtype, expected.dtype)
+            self.assertTrue(torch.equal(restored[name], expected))
+
+    def test_byte_packed_gather_rejects_mismatched_token_counts(self):
+        with self.assertRaisesRegex(RuntimeError, "different token counts"):
+            AscendSFAImpl._all_gather_byte_packed_async(
+                [
+                    ("sfa_kv", torch.zeros(2, 6, dtype=torch.float16)),
+                    ("k_li", torch.zeros(3, 8, dtype=torch.int8)),
+                ],
+                async_op=True,
+            )
+
+
 class TestAscendSFADeviceOperator(TestBase):
     def _make_common_inputs(self):
         ql_nope = torch.randn(3, 4, 8)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -80,6 +80,14 @@ if TYPE_CHECKING:
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
 
+
+class _ByteGatherPart(NamedTuple):
+    name: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    num_bytes_per_row: int
+
+
 O_PROJ_ACLNN_INPUT_PARAMS = (
     "aclnn_input_scale",
     "aclnn_input_scale_reciprocal",
@@ -1184,6 +1192,70 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             return attn_output, True
 
+    @staticmethod
+    def _flatten_for_byte_gather(tensor: torch.Tensor) -> tuple[torch.Tensor, int]:
+        if tensor.dim() == 0:
+            raise RuntimeError("Byte-packed all-gather requires tensors with a token dimension.")
+        tensor = tensor.contiguous()
+        num_rows = tensor.shape[0]
+        num_bytes_per_row = tensor.element_size()
+        for dim in tensor.shape[1:]:
+            num_bytes_per_row *= dim
+        return tensor.view(torch.int8).view(num_rows, num_bytes_per_row), num_bytes_per_row
+
+    @classmethod
+    def _all_gather_byte_packed_async(
+        cls,
+        parts: list[tuple[str, torch.Tensor]],
+        async_op: bool,
+    ) -> tuple[torch.Tensor, torch.distributed.Work | None, tuple[_ByteGatherPart, ...]]:
+        if not parts:
+            raise RuntimeError("Byte-packed all-gather requires at least one tensor.")
+
+        packed_parts = []
+        metadata = []
+        expected_num_rows: int | None = None
+        for name, tensor in parts:
+            num_rows = tensor.shape[0]
+            if expected_num_rows is None:
+                expected_num_rows = num_rows
+            elif num_rows != expected_num_rows:
+                raise RuntimeError(
+                    "Cannot byte-pack KV tensors with different token counts: "
+                    f"expected {expected_num_rows}, got {num_rows} for {name}."
+                )
+
+            packed_tensor, num_bytes_per_row = cls._flatten_for_byte_gather(tensor)
+            packed_parts.append(packed_tensor)
+            metadata.append(
+                _ByteGatherPart(
+                    name=name,
+                    shape=tuple(tensor.shape),
+                    dtype=tensor.dtype,
+                    num_bytes_per_row=num_bytes_per_row,
+                )
+            )
+
+        packed_input = torch.cat(packed_parts, dim=1) if len(packed_parts) > 1 else packed_parts[0]
+        gathered, handle = all_gather_async(
+            packed_input,
+            get_tp_group(),
+            async_op=async_op,
+        )
+        return gathered, handle, tuple(metadata)
+
+    @staticmethod
+    def _restore_byte_gathered_tensors(
+        gathered: torch.Tensor,
+        metadata: tuple[_ByteGatherPart, ...],
+    ) -> dict[str, torch.Tensor]:
+        chunks = torch.split(gathered, [part.num_bytes_per_row for part in metadata], dim=1)
+        num_rows = gathered.shape[0]
+        restored = {}
+        for part, chunk in zip(metadata, chunks):
+            restored[part.name] = chunk.contiguous().view(part.dtype).view(num_rows, *part.shape[1:])
+        return restored
+
     def _get_full_kv(self, k, attn_metadata):
         return k
 
@@ -1702,7 +1774,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                 assert k_nope is not None
                 async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
                 kv_ag_handles = []
-                # support all_gather kv async for communication calculation overlap
+                # Pack all KV-related tensors into one byte stream so DSA-CP only
+                # submits one KV all-gather while still preserving original dtypes.
                 if self.enable_sparse_sfa_c8:
                     assert knope_scale is not None
                     fused_kv_parts = [
@@ -1715,37 +1788,25 @@ class AscendSFAImpl(MLAAttentionImpl):
                         k_pe.view(-1, k_pe.shape[-1]),
                         k_nope.view(-1, k_nope.shape[-1]),
                     ]
-                    if self.has_indexer and not self.enable_sparse_li_c8:
-                        assert k_li is not None
-                        fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
 
                 fused_kv_input = torch.cat(fused_kv_parts, dim=1)
-                fused_kv_no_split, kv_ag_handle = all_gather_async(
-                    fused_kv_input,
-                    get_tp_group(),
+                kv_gather_parts = [("sfa_kv", fused_kv_input)]
+                if self.has_indexer:
+                    assert k_li is not None
+                    k_li_gather_input = k_li
+                    if not self.enable_sparse_sfa_c8 and not self.enable_sparse_li_c8:
+                        k_li_gather_input = k_li.view(-1, k_li.shape[-1])
+                    kv_gather_parts.append(("k_li", k_li_gather_input))
+                if self.has_indexer and self.enable_sparse_li_c8:
+                    assert k_li_scale is not None
+                    kv_gather_parts.append(("k_li_scale", k_li_scale))
+
+                kv_gathered_bytes, kv_ag_handle, kv_gather_metadata = self._all_gather_byte_packed_async(
+                    kv_gather_parts,
                     async_op=async_op,
                 )
                 if kv_ag_handle is not None:
                     kv_ag_handles.append(kv_ag_handle)
-
-                if self.has_indexer and (self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8):
-                    assert k_li is not None
-                    k_li, kv_ag_handle = all_gather_async(
-                        k_li,
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                    if kv_ag_handle is not None:
-                        kv_ag_handles.append(kv_ag_handle)
-                if self.has_indexer and self.enable_sparse_li_c8:
-                    assert k_li_scale is not None
-                    k_li_scale, kv_ag_handle = all_gather_async(
-                        k_li_scale,
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
-                    if kv_ag_handle is not None:
-                        kv_ag_handles.append(kv_ag_handle)
 
             ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
             q_pe = self.rope_single(q_pe, cos, sin)
@@ -1754,6 +1815,12 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.enable_dsa_cp:
                 for kv_ag_handle in kv_ag_handles:
                     kv_ag_handle.wait()
+                kv_gather_outputs = self._restore_byte_gathered_tensors(kv_gathered_bytes, kv_gather_metadata)
+                fused_kv_no_split = kv_gather_outputs["sfa_kv"]
+                if self.has_indexer:
+                    k_li = kv_gather_outputs["k_li"]
+                    if self.enable_sparse_li_c8:
+                        k_li_scale = kv_gather_outputs["k_li_scale"]
 
                 if self.enable_dsa_cp_with_layer_shard:
                     for layer in self.layer_sharding_kwargs or []:
@@ -1784,16 +1851,6 @@ class AscendSFAImpl(MLAAttentionImpl):
                         )
                         k_pe = None
                         k_nope = None
-                    elif not self.has_indexer:
-                        k_pe, k_nope = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank],
-                            dim=-1,
-                        )
-                    elif not self.enable_sparse_li_c8:
-                        k_pe, k_nope, k_li = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
-                            dim=-1,
-                        )
                     else:
                         k_pe, k_nope = fused_kv_no_split.split(
                             [self.qk_rope_head_dim, self.kv_lora_rank],


### PR DESCRIPTION
### What this PR does / why we need it?
In rare cases, issuing consecutive KV all-gathers can lead to first-forward correctness issues. For example, GLM5.2 can produce severely garbled output during the first forward pass when DSA_CP is enabled.

This PR packs the SFA KV payload, indexer KV payload, and indexer scale payload into one byte stream, submits a single KV all-gather, and restores each tensor to its original dtype and shape before the existing cache writes. This avoids multiple KV-related all-gather launches while preserving the separate o_proj weight gather path.

Main-branch PR: #12868

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- python compile check for vllm_ascend/attention/sfa_v1.py and tests/ut/attention/a2/test_sfa_v1.py
- git diff --check
- Added unit coverage for mixed-dtype byte pack/restore and mismatched token-count validation

Local torch/torch_npu execution was not run in this workspace.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
