### PR TITLE
[Refactor][Misc] Remove mix placement support

### DIFF
--- a/.agents/skills/vllm-ascend-release/references/ref-past-release-notes-highlight.md
+++ b/.agents/skills/vllm-ascend-release/references/ref-past-release-notes-highlight.md
@@ -61,7 +61,7 @@ We mainly focus on quality and performance improvement in this release. The spec
 - Eagle spec decode feature now works with full graph mode. [#5118](https://github.com/vllm-project/vllm-ascend/pull/5118)
 - Context Parallel(PCP&DCP) feature is more stable now. And it works for most case. Please try it out.
 - MTP and eagle spec decode feature now works in most cases. And it's suggested to use them in most cases.
-- EPLB feature more stable now. Many bugs have been fixed. Mix placement works now [#6086](https://github.com/vllm-project/vllm-ascend/pull/6086)
+- EPLB feature more stable now. Many bugs have been fixed.
 - Support kv nz feature for DeepSeek decode node in disagg-prefill scenario [#3072](https://github.com/vllm-project/vllm-ascend/pull/3072)
 
 ### Model Support

--- a/tests/ut/quantization/methods/test_moe_logical_experts.py
+++ b/tests/ut/quantization/methods/test_moe_logical_experts.py
@@ -12,12 +12,4 @@ def test_get_moe_num_logical_experts_uses_vllm_config_field():
 def test_get_moe_num_logical_experts_falls_back_for_older_configs():
     layer = SimpleNamespace(moe_config=SimpleNamespace())
 
-    assert (
-        get_moe_num_logical_experts(
-            layer,
-            num_experts=133,
-            global_redundant_expert_num=2,
-            num_shared_experts=3,
-        )
-        == 128
-    )
+    assert get_moe_num_logical_experts(layer, num_experts=130, global_redundant_expert_num=2) == 128

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -272,9 +272,6 @@ class AscendConfig:
         # Enable optimized reduce sampling scheme
         self.enable_reduce_sample = additional_config.get("enable_reduce_sample", False)
 
-        self.mix_placement = additional_config.get("mix_placement", False)
-        self._check_mix_placement()
-
         # Enable Block Verify and Entropy Verify in Rejection Sampler
         rejection_sampler_config = additional_config.get("rejection_sampler_config", {})
         self.rejection_sampler_config = RejectionSamplerConfig(rejection_sampler_config)
@@ -318,11 +315,6 @@ class AscendConfig:
             "Mooncake transfer would reinterpret bf16 bytes as int8. Please disable C8 KV cache quantization "
             "or use MooncakeLayerwiseConnector, which quantizes KV cache before transfer."
         )
-
-    def _check_mix_placement(self):
-        if self.mix_placement:
-            if self.enable_shared_expert_dp or self.multistream_overlap_shared_expert:
-                raise ValueError("Mix placement is not supported with shared expert DP or multistream overlap.")
 
     @staticmethod
     def _materialize_dump_config_to_file(dump_config: dict[str, Any]) -> str:

--- a/vllm_ascend/eplb/core/eplb_utils.py
+++ b/vllm_ascend/eplb/core/eplb_utils.py
@@ -43,41 +43,24 @@ def expert_file_to_tensor(expert_map_path, layer_id):
     return global_placement, physical_count
 
 
-def generate_global_placement(n_expert, ep_size, n_redundant, num_shared_experts):
-    n_expert -= num_shared_experts
+def generate_global_placement(n_expert, ep_size, n_redundant):
     if (n_expert + n_redundant) % ep_size != 0:
         raise ValueError("(n_expert + n_redundant) % ep_size must be 0")
-    if num_shared_experts == 0:
-        # Match vLLM's checkpoint-loading physical layout exactly:
-        # [all logical experts, redundant copies of logical experts 0..N].
-        # The flattened position is the global physical expert ID and must
-        # agree with RoutedExperts.make_expert_params_mapping.
-        physical_to_logical = np.concatenate((np.arange(n_expert), np.arange(n_redundant) % n_expert))
-        return torch.tensor(physical_to_logical.reshape(ep_size, -1), dtype=torch.int32)
-
-    # Shared-expert mix placement has a separate Ascend-only layout.
-    all_experts = np.arange(n_expert)
-    groups = np.array_split(all_experts, ep_size)
-    for i in range(n_redundant):
-        j = i % ep_size + 1
-        if len(groups[-j]) == 0:
-            groups[-j] = np.append(groups[-j], j)
-        else:
-            groups[-j] = np.append(groups[-j], (groups[-j][-1] + 1) % n_expert)
-    if num_shared_experts > 0:
-        for i, group in enumerate(groups):
-            groups[i] = np.append(group, n_expert + i % num_shared_experts)
-    return torch.tensor(groups, dtype=torch.int32)
+    # Match vLLM's checkpoint-loading physical layout exactly:
+    # [all logical experts, redundant copies of logical experts 0..N].
+    # The flattened position is the global physical expert ID and must
+    # agree with RoutedExperts.make_expert_params_mapping.
+    physical_to_logical = np.concatenate((np.arange(n_expert), np.arange(n_redundant) % n_expert))
+    return torch.tensor(physical_to_logical.reshape(ep_size, -1), dtype=torch.int32)
 
 
-def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num_shared_experts=1, tp_size=None):
+def init_eplb_config(eplb_config, layer_id, moe_config, tp_size=None):
     expert_map_path = eplb_config.expert_map_path
     n_experts = moe_config.num_experts
     ep_size = moe_config.ep_size
     global_placement = None
     eplb_enable = eplb_config.dynamic_eplb
     n_redundant = eplb_config.num_redundant_experts if eplb_enable else 0
-    num_shared_experts = num_shared_experts if mix_placement else 0
 
     if ep_size == 1:
         assert not eplb_enable, "EPLB must used in expert parallelism."
@@ -92,9 +75,7 @@ def init_eplb_config(eplb_config, layer_id, moe_config, mix_placement=False, num
         return None, expert_map, None, 0
 
     if global_placement is None:
-        global_placement = generate_global_placement(n_experts, ep_size, n_redundant, num_shared_experts)
-        if mix_placement:
-            n_redundant += ep_size - 1
+        global_placement = generate_global_placement(n_experts, ep_size, n_redundant)
     global_expert_map = []
     for rankid in range(ep_size):
         expert_map = torch.full((n_experts,), -1, dtype=torch.int32)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -78,7 +78,6 @@ from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache as VllmDeepseekV4SWACache
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
-from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
@@ -397,9 +396,7 @@ class DeepseekV4MoE(nn.Module):
         self.physical_expert_end = self.physical_expert_start + self.n_local_physical_experts
 
         self.is_rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
-        self.is_fusion_moe_shared_experts_enabled = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
-        self.is_fusion_moe_shared_experts_enabled = getattr(get_ascend_config(), "mix_placement", False)
-        if config.n_shared_experts is None or self.is_fusion_moe_shared_experts_enabled:
+        if config.n_shared_experts is None:
             self.shared_experts = None
         else:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
@@ -454,7 +451,7 @@ class DeepseekV4MoE(nn.Module):
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
-            n_shared_experts=config.n_shared_experts if self.is_fusion_moe_shared_experts_enabled else 0,
+            n_shared_experts=0,
             hash=layer_idx < config.num_hash_layers and not is_draft_layer,
             tid2eid=self.gate.tid2eid,
         )
@@ -1292,8 +1289,7 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts
-            + (self.config.n_shared_experts if getattr(get_ascend_config(), "mix_placement", False) else 0),
+            num_experts=self.config.n_routed_experts,
             num_redundant_experts=0,
         )
 
@@ -1307,8 +1303,6 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
         self.model._set_aux_hidden_state_layers(layers)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        rocm_aiter_moe_shared_expert_enabled = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
-        rocm_aiter_moe_shared_expert_enabled = getattr(get_ascend_config(), "mix_placement", False)
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
@@ -1321,8 +1315,7 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts
-            + (self.config.n_shared_experts if rocm_aiter_moe_shared_expert_enabled else 0),
+            num_experts=self.config.n_routed_experts,
             num_redundant_experts=self.num_redundant_experts,
         )
 
@@ -1387,8 +1380,6 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 loaded_params.add(name)
                 continue
 
-            is_fusion_moe_shared_experts_layer = rocm_aiter_moe_shared_expert_enabled and ("mlp.shared_experts" in name)
-
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
@@ -1400,8 +1391,6 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 # will then be updated below in expert_params_mapping
                 # for mlp.experts[0].gate_gate_up_proj, which breaks load.
                 if ("mlp.experts." in name) and name not in params_dict:
-                    continue
-                if is_fusion_moe_shared_experts_layer:
                     continue
                 name_mapped = name.replace(weight_name, param_name)
 
@@ -1425,105 +1414,49 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
                 break
             else:
                 is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
 
-                # Special handling: when AITER fusion_shared_experts is enabled,
-                # checkpoints may provide a single widened shared_experts tensor
-                # without explicit expert indices
-                # (e.g. ...mlp.shared_experts.gate_proj.weight).
-                # For models with multiple shared experts, split that tensor
-                # evenly into per-shared-expert slices and load them into
-                # appended expert slots mlp.experts.{n_routed_experts + j}.*
-                # accordingly.
-                num_chunks = 1
-                if is_fusion_moe_shared_experts_layer:
-                    num_chunks = getattr(self.config, "n_shared_experts", 1) or 1
-                    # Determine split axis based on op type
-                    # gate/up: ColumnParallel → split along dim 0
-                    # down: RowParallel → split along dim 1
-                    split_dim = 1 if "down_proj.weight" in name else 0
-                    total = loaded_weight.shape[split_dim]
-                    assert total % num_chunks == 0, (
-                        f"Shared expert weight dim {total} not divisible by num_chunks {num_chunks}"
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    if is_pp_missing_parameter(name_mapped, self):
+                        continue
+
+                    param = params_dict[name_mapped]
+                    weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+                    success = weight_loader(
+                        param,
+                        loaded_weight,
+                        name_mapped,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        return_success=True,
                     )
-                    chunk_size = total // num_chunks
+                    if success:
+                        name = name_mapped
+                        break
+                else:
+                    if is_expert_weight:
+                        continue
 
-                for j in range(num_chunks):
-                    chunk_name = name
-                    weight_to_load = loaded_weight
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
 
-                    if is_fusion_moe_shared_experts_layer:
-                        if split_dim == 0:
-                            weight_to_load = loaded_weight[j * chunk_size : (j + 1) * chunk_size, :]
-                        else:
-                            weight_to_load = loaded_weight[:, j * chunk_size : (j + 1) * chunk_size]
-                        # Synthesize an expert-style name so expert mapping
-                        # can route it
-                        chunk_name = name.replace(
-                            "mlp.shared_experts",
-                            f"mlp.experts.{self.config.n_routed_experts + j}",
-                        )
+                    # Remapping the name of FP8 kv-scale.
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
 
-                    # Use expert_params_mapping to locate the destination
-                    # param and delegate to its expert-aware weight_loader
-                    # with expert_id.
-                    for mapping in expert_params_mapping:
-                        param_name, weight_name, expert_id, shard_id = mapping
-                        if weight_name not in chunk_name:
-                            continue
+                    if is_pp_missing_parameter(name, self):
+                        continue
 
-                        # Anyway, this is an expert weight and should not be
-                        # attempted to load as other weights later
-                        is_expert_weight = True
-
-                        # Do not modify `name` since the loop may continue here
-                        # Instead, create a new variable
-                        name_mapped = chunk_name.replace(weight_name, param_name)
-
-                        if is_pp_missing_parameter(name_mapped, self):
-                            continue
-
-                        param = params_dict[name_mapped]
-                        # We should ask the weight loader to return success or
-                        # not here since otherwise we may skip experts with
-                        # other available replicas.
-                        weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
-                        success = weight_loader(
-                            param,
-                            weight_to_load,
-                            name_mapped,
-                            shard_id=shard_id,
-                            expert_id=expert_id,
-                            return_success=True,
-                        )
-                        if success:
-                            if not is_fusion_moe_shared_experts_layer:
-                                name = name_mapped
-                            else:
-                                loaded_params.add(name_mapped)
-                            break
-                    else:
-                        if is_expert_weight:
-                            # We've checked that this is an expert weight
-                            # However it's not mapped locally to this rank
-                            # So we simply skip it
-                            continue
-
-                        # Skip loading extra bias for GPTQ models.
-                        if name.endswith(".bias") and name not in params_dict:
-                            continue
-
-                        # Remapping the name of FP8 kv-scale.
-                        name = maybe_remap_kv_scale_name(name, params_dict)
-                        if name is None:
-                            continue
-
-                        if is_pp_missing_parameter(name, self):
-                            continue
-
-                        param = params_dict[name]
-                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                        weight_loader(param, loaded_weight)
-            if not is_fusion_moe_shared_experts_layer:
-                loaded_params.add(name)
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
 
         return loaded_params

--- a/vllm_ascend/models/deepseek_v4_mtp.py
+++ b/vllm_ascend/models/deepseek_v4_mtp.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Iterable
 import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
@@ -22,7 +21,6 @@ from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.utils import enable_dsa_cp
 
 from .deepseek_v4 import (
@@ -250,8 +248,6 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
         return self.model.compute_logits(hidden_states, spec_step_idx)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        rocm_aiter_moe_shared_expert_enabled = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
-        rocm_aiter_moe_shared_expert_enabled = getattr(get_ascend_config(), "mix_placement", False)
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
@@ -262,8 +258,7 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts
-            + (self.config.n_shared_experts if rocm_aiter_moe_shared_expert_enabled else 0),
+            num_experts=self.config.n_routed_experts,
             num_redundant_experts=self.num_redundant_experts,
         )
 
@@ -341,7 +336,6 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
                 loaded_params.add(name)
                 continue
 
-            is_fusion_moe_shared_experts_layer = rocm_aiter_moe_shared_expert_enabled and ("mlp.shared_experts" in name)
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
@@ -353,8 +347,6 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
                 # will then be updated below in expert_params_mapping
                 # for mlp.experts[0].gate_gate_up_proj, which breaks load.
                 if ("mlp.experts." in name) and name not in params_dict:
-                    continue
-                if is_fusion_moe_shared_experts_layer:
                     continue
                 name_mapped = name.replace(weight_name, param_name)
 
@@ -374,107 +366,44 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Special handling: when AITER fusion_shared_experts is enabled,
-                # checkpoints may provide a single widened shared_experts tensor
-                # without explicit expert indices
-                # (e.g. ...mlp.shared_experts.gate_proj.weight).
-                # For models with multiple shared experts, split that tensor
-                # evenly into per-shared-expert slices and load them into
-                # appended expert slots mlp.experts.{n_routed_experts + j}.*
-                # accordingly.
-                num_chunks = 1
-                if is_fusion_moe_shared_experts_layer:
-                    num_chunks = getattr(self.config, "n_shared_experts", 1) or 1
-                    # Determine split axis based on op type
-                    # gate/up: ColumnParallel → split along dim 0
-                    # down: RowParallel → split along dim 1
-                    split_dim = 1 if "down_proj.weight" in name else 0
-                    total = loaded_weight.shape[split_dim]
-                    assert total % num_chunks == 0, (
-                        f"Shared expert weight dim {total} not divisible by num_chunks {num_chunks}"
+                is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    param = params_dict[name_mapped]
+                    weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+                    success = weight_loader(
+                        param,
+                        loaded_weight,
+                        name_mapped,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        return_success=True,
                     )
-                    chunk_size = total // num_chunks
+                    if success:
+                        name = name_mapped
+                        break
+                else:
+                    if is_expert_weight:
+                        continue
 
-                for j in range(num_chunks):
-                    chunk_name = name
-                    weight_to_load = loaded_weight
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
 
-                    if is_fusion_moe_shared_experts_layer:
-                        if split_dim == 0:
-                            weight_to_load = loaded_weight[j * chunk_size : (j + 1) * chunk_size, :]
-                        else:
-                            weight_to_load = loaded_weight[:, j * chunk_size : (j + 1) * chunk_size]
-                        # Synthesize an expert-style name so expert mapping
-                        # can route it
-                        chunk_name = name.replace(
-                            "mlp.shared_experts",
-                            f"mlp.experts.{self.config.n_routed_experts + j}",
-                        )
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
 
-                    # Use expert_params_mapping to locate the destination
-                    # param and delegate to its expert-aware weight_loader
-                    # with expert_id.
-                    is_expert_weight = False
-                    for mapping in expert_params_mapping:
-                        param_name, weight_name, expert_id, shard_id = mapping
-                        if weight_name not in chunk_name:
-                            continue
-
-                        # Anyway, this is an expert weight and should not be
-                        # attempted to load as other weights later
-                        is_expert_weight = True
-
-                        # Do not modify `name` since the loop may continue here
-                        # Instead, create a new variable
-                        name_mapped = chunk_name.replace(weight_name, param_name)
-
-                        param = params_dict[name_mapped]
-                        # We should ask the weight loader to return success or
-                        # not here since otherwise we may skip experts with
-                        # other available replicas.
-                        weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
-                        success = weight_loader(
-                            param,
-                            weight_to_load,
-                            name_mapped,
-                            shard_id=shard_id,
-                            expert_id=expert_id,
-                            return_success=True,
-                        )
-                        if success:
-                            if not is_fusion_moe_shared_experts_layer:
-                                name = name_mapped
-                            else:
-                                loaded_params.add(name_mapped)
-                            break
-                    else:
-                        if is_expert_weight:
-                            # We've checked that this is an expert weight
-                            # However it's not mapped locally to this rank
-                            # So we simply skip it
-                            continue
-
-                        # Skip loading extra bias for GPTQ models.
-                        if name.endswith(".bias") and name not in params_dict:
-                            continue
-
-                        name = maybe_remap_kv_scale_name(name, params_dict)
-                        if name is None:
-                            continue
-
-                        # # According to DeepSeek-V3 Technical Report, MTP modules
-                        # # shares embedding layer. We only load the first weights.
-                        # if (
-                        #     spec_layer != self.model.mtp_start_layer_idx
-                        #     and ".layers" not in name
-                        # ):
-                        #     continue
-
-                        param = params_dict[name]
-                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                        weight_loader(param, loaded_weight)
-            if not is_fusion_moe_shared_experts_layer:
-                loaded_params.add(name)
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
         return loaded_params
 
     def _rewrite_spec_layer_name(self, spec_layer: int, name: str) -> str:

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -39,9 +39,6 @@ def select_experts(
     routed_scaling_factor=1.0,
     e_score_correction_bias: torch.Tensor | None = None,
     indices_type: torch.dtype | None = None,
-    mix_placement: bool = False,
-    num_logical_experts: int = -1,
-    num_shared_experts: int = 0,
     num_experts: int = -1,
     input_ids: torch.Tensor | None = None,
     tid2eid: torch.Tensor | None = None,
@@ -111,23 +108,6 @@ def select_experts(
         # Apply routed scaling factor to weights
         if routed_scaling_factor != 1.0:
             topk_weights = topk_weights * routed_scaling_factor
-    if mix_placement:
-        shared_expert_routing_factor = 1.0 if is_support_npu_moe_gating_top_k else (1 / routed_scaling_factor)
-        batch_size = topk_ids.shape[0]
-        pad_shared_expert_ids = torch.arange(
-            num_logical_experts, num_logical_experts + num_shared_experts, dtype=topk_ids.dtype, device=topk_ids.device
-        ).repeat(batch_size, 1)
-
-        pad_shared_expert_weights = torch.full(
-            (topk_weights.shape[0], num_shared_experts),
-            shared_expert_routing_factor,
-            dtype=topk_weights.dtype,
-            device=topk_weights.device,
-        )
-
-        topk_ids = torch.cat([topk_ids, pad_shared_expert_ids], dim=1)
-        topk_weights = torch.cat([topk_weights, pad_shared_expert_weights], dim=1)
-
     return topk_weights, topk_ids
 
 

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -180,14 +180,10 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         zero_expert_num = getattr(layer, "zero_expert_num", 0)
         zero_expert_type = getattr(layer, "zero_expert_type", None)
         input_ids = getattr(get_forward_context(), "input_ids", None)
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         topk_weights, topk_ids = select_experts(
             hidden_states=x,
@@ -389,8 +385,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         self.multistream_overlap_shared_expert = (
             ascend_config.multistream_overlap_shared_expert and shared_experts is not None
         )
-        mix_placement = getattr(ascend_config, "mix_placement", False)
-
         # EPLB initialization (Ascend-specific; mirrors old AscendFusedMoE logic).
         AscendMoERunner.moe_counter += 1
         self.moe_instance_id = AscendMoERunner.moe_counter
@@ -402,7 +396,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # Ascend's placement builder operates on logical expert IDs, so give it
         # a shallow config view with the logical count.
         placement_moe_config = copy(moe_config)
-        placement_moe_config.num_experts = moe_config.num_logical_experts + (n_shared_experts if mix_placement else 0)
+        placement_moe_config.num_experts = moe_config.num_logical_experts
         allocated_redundancy = moe_config.num_experts - moe_config.num_logical_experts
         if eplb_config.num_redundant_experts not in (0, allocated_redundancy):
             raise ValueError(
@@ -420,8 +414,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             placement_eplb_config,
             AscendMoERunner.moe_counter,
             placement_moe_config,
-            mix_placement,
-            n_shared_experts,
             tp_size=vllm_config.parallel_config.tensor_parallel_size,
         )
 

--- a/vllm_ascend/quantization/methods/base.py
+++ b/vllm_ascend/quantization/methods/base.py
@@ -29,14 +29,13 @@ def get_moe_num_logical_experts(
     layer: torch.nn.Module,
     num_experts: int,
     global_redundant_expert_num: int = 0,
-    num_shared_experts: int = 0,
 ) -> int:
     moe_config = getattr(layer, "moe_config", None)
     num_logical_experts = getattr(moe_config, "num_logical_experts", None)
     if num_logical_experts is not None:
         return int(num_logical_experts)
 
-    return int(num_experts - global_redundant_expert_num - num_shared_experts)
+    return int(num_experts - global_redundant_expert_num)
 
 
 class AscendLinearScheme(ABC):

--- a/vllm_ascend/quantization/methods/w4a16.py
+++ b/vllm_ascend/quantization/methods/w4a16.py
@@ -271,14 +271,10 @@ class AscendW4A16FusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, (
             "Number of global experts mismatch (excluding redundancy): "

--- a/vllm_ascend/quantization/methods/w4a16_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a16_mxfp4.py
@@ -136,14 +136,10 @@ class AscendW4A16MXFP4FusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, (
             "Number of global experts mismatch (excluding redundancy): "

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -193,14 +193,10 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: Any | None = None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
         topk_weights, topk_ids = select_experts(

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -511,14 +511,10 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, (
             "Number of global experts mismatch (excluding redundancy): "

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -166,14 +166,10 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
         topk_weights, topk_ids = select_experts(

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -236,15 +236,10 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
     ) -> torch.Tensor:
         zero_expert_num = getattr(layer, "zero_expert_num", 0)
         zero_expert_type = getattr(layer, "zero_expert_type", None)
-        n_shared_experts = getattr(layer, "n_shared_experts", 0)
-        mix_placement = getattr(layer, "mix_placement", False)
-        if n_shared_experts is None:
-            n_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=n_shared_experts,
         )
         if zero_expert_num == 0 or zero_expert_type is None:
             assert router_logits.shape[1] == num_logical_experts, (
@@ -268,9 +263,6 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             scoring_func=scoring_func,
             routed_scaling_factor=routed_scaling_factor,
             e_score_correction_bias=e_score_correction_bias,
-            mix_placement=mix_placement,
-            num_logical_experts=router_logits.shape[1],
-            num_shared_experts=n_shared_experts,
             num_experts=num_logical_experts,
             tid2eid=tid2eid,
         )

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -261,14 +261,10 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
         num_logical_experts = get_moe_num_logical_experts(
             layer,
             num_experts,
             global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
         )
         assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
         topk_weights, topk_ids = select_experts(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -34,7 +34,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size, tensor_model_parallel_all_gather
@@ -3766,14 +3765,6 @@ class NPUModelRunner(GPUModelRunner):
     def load_model(self) -> None:
         load_model_start_time = time.perf_counter()
         logger.info("Starting to load model %s...", self.model_config.model)
-
-        if self.ascend_config.mix_placement:
-            # TODO: Enabling the mix placement in deepseek_v2.py
-            # remove this part after the mix placement merged into vllm
-            def mock_true():
-                return True
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = mock_true
-            rocm_aiter_ops.is_fused_moe_enabled = mock_true
 
         with DeviceMemoryProfiler() as m:  # noqa: SIM117
             if self.eplb_enable:


### PR DESCRIPTION
### What this PR does / why we need it?

Remove the `mix_placement` feature path and its related shared-expert-as-routed-expert handling:

- Remove `AscendConfig.mix_placement` parsing and validation.
- Remove shared-expert mixed placement logic from EPLB placement generation.
- Remove router top-k padding for shared experts.
- Remove DeepSeek V4/MTP shared expert weight loading into appended routed expert slots.
- Restore MoE logical expert fallback calculation to only subtract redundant experts.
- Remove mix placement text from the release helper highlight. Formal release notes are intentionally not modified.

### Does this PR introduce _any_ user-facing change?

Yes. The `mix_placement` additional_config option and its behavior are removed.

### How was this patch tested?

- `python -m py_compile vllm_ascend/ascend_config.py vllm_ascend/eplb/core/eplb_utils.py vllm_ascend/models/deepseek_v4.py vllm_ascend/models/deepseek_v4_mtp.py vllm_ascend/ops/fused_moe/experts_selector.py vllm_ascend/ops/fused_moe/fused_moe.py vllm_ascend/quantization/methods/base.py vllm_ascend/quantization/methods/w4a16.py vllm_ascend/quantization/methods/w4a16_mxfp4.py vllm_ascend/quantization/methods/w4a4_mxfp4.py vllm_ascend/quantization/methods/w4a8.py vllm_ascend/quantization/methods/w4a8_mxfp4.py vllm_ascend/quantization/methods/w8a8_dynamic.py vllm_ascend/quantization/methods/w8a8_mxfp8.py vllm_ascend/worker/model_runner_v1.py tests/ut/quantization/methods/test_moe_logical_experts.py`
- `git diff --check HEAD~1..HEAD`
- `git grep -n "mix_placement\|Mix placement\|mix placement\|mixed placement\|Unified Placement\|fusion_shared_experts\|is_fusion_moe_shared_experts" -- . ':!docs/source/user_guide/release_notes.md' ':!docs/source/locale/zh_CN/LC_MESSAGES/user_guide/release_notes.po'`

Attempted `pytest -q tests/ut/eplb/core/a2/test_eplb_utils.py`, but the local environment has an incompatible installed vLLM package: `ImportError: cannot import name 'MoERunner' from 'vllm.model_executor.layers.fused_moe.layer'`.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
