### PR TITLE
[BugFix][Worker] Map A5 endpoint config to physical device

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -133,6 +133,45 @@ class TestUtils(TestBase):
         with mock.patch("torch.npu.current_stream") as mock_current_stream:
             self.assertEqual(utils.current_stream(), mock_current_stream())
 
+    def test_get_physical_device_id(self):
+        acl = mock.MagicMock()
+
+        def get_logic_device_id(user_device_id, logic_device_id):
+            self.assertEqual(user_device_id, 0)
+            logic_device_id._obj.value = 1
+            return 0
+
+        def get_physical_device_id(logic_device_id, physical_device_id):
+            self.assertEqual(logic_device_id.value, 1)
+            physical_device_id._obj.value = 6
+            return 0
+
+        acl.aclrtGetLogicDevIdByUserDevId.side_effect = get_logic_device_id
+        acl.aclrtGetPhyDevIdByLogicDevId.side_effect = get_physical_device_id
+
+        with mock.patch("ctypes.CDLL", return_value=acl):
+            self.assertEqual(utils._get_physical_device_id(0), 6)
+
+    def test_setup_ascend_local_comm_res_uses_runtime_physical_id(self):
+        kv_transfer_config = mock.MagicMock()
+        kv_transfer_config.kv_connector_extra_config = {
+            "ascend_local_comm_res_path": "/etc/hixl",
+        }
+
+        with (
+            mock.patch("vllm.platforms.current_platform") as mock_platform,
+            mock.patch("vllm_ascend.utils._get_physical_device_id", return_value=6) as mock_get_physical_device_id,
+            mock.patch.dict(os.environ, {"ASCEND_RT_VISIBLE_DEVICES": "0,1"}),
+            mock.patch("builtins.open", mock.mock_open(read_data='{"version":"1.3"}')) as mock_file,
+        ):
+            mock_platform.logical_device_id_to_visible_device_id.return_value = 0
+
+            utils.setup_ascend_local_comm_res(0, kv_transfer_config)
+
+            mock_platform.logical_device_id_to_visible_device_id.assert_called_once_with(0)
+            mock_get_physical_device_id.assert_called_once_with(0)
+            mock_file.assert_called_once_with("/etc/hixl/ub_endpoint_npu_6.json")
+
     def test_enable_dsa_cp_with_o_proj_tp_accepts_missing_kv_transfer(self):
         mock_vllm_config = mock.MagicMock()
         mock_vllm_config.kv_transfer_config = None

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import functools
 import json
 import math
@@ -541,30 +542,50 @@ def adapt_patch(is_global_patch: bool = False):
         from vllm_ascend.patch import worker  # noqa: F401
 
 
+def _get_physical_device_id(user_device_id: int) -> int:
+    acl = ctypes.CDLL("libascendcl.so")
+    logic_device_id = ctypes.c_int32()
+    physical_device_id = ctypes.c_int32()
+
+    get_logic_device_id = acl.aclrtGetLogicDevIdByUserDevId
+    get_logic_device_id.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_int32)]
+    get_logic_device_id.restype = ctypes.c_int
+    result = get_logic_device_id(user_device_id, ctypes.byref(logic_device_id))
+    if result != 0:
+        raise RuntimeError(f"aclrtGetLogicDevIdByUserDevId failed with error code {result}")
+
+    get_physical_device_id = acl.aclrtGetPhyDevIdByLogicDevId
+    get_physical_device_id.argtypes = [ctypes.c_int32, ctypes.POINTER(ctypes.c_int32)]
+    get_physical_device_id.restype = ctypes.c_int
+    result = get_physical_device_id(logic_device_id, ctypes.byref(physical_device_id))
+    if result != 0:
+        raise RuntimeError(f"aclrtGetPhyDevIdByLogicDevId failed with error code {result}")
+    return physical_device_id.value
+
+
 def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None) -> None:
-    """Load the local A5 endpoint config into ASCEND_LOCAL_COMM_RES."""
+    """Load the local A5 endpoint config into ASCEND_LOCAL_COMM_RES.
+
+    This is a temporary workaround for a HiXL transport dependency on 950DT
+    server/pod deployments. Endpoint resource selection should eventually be
+    handled by HiXL or its lower-level components. Ascend Runtime is used to
+    resolve the physical device ID so container device remapping does not affect
+    endpoint selection.
+    """
     if kv_transfer_config is None:
         return
-
-    visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
-    if visible_devices is None:
-        from vllm_ascend.cpu_binding import DeviceInfo
-
-        devices = sorted([int(x) for x in DeviceInfo.get_npu_map_info()])
-    else:
-        devices = [int(x) for x in visible_devices.split(",") if x.strip()]
 
     extra_config = kv_transfer_config.kv_connector_extra_config or {}
     local_comm_res_path = extra_config.get("ascend_local_comm_res_path")
     if not local_comm_res_path:
         return
 
-    if not devices:
-        raise ValueError("No NPU devices found or specified in ASCEND_RT_VISIBLE_DEVICES.")
-    if local_rank < 0 or local_rank >= len(devices):
-        raise ValueError(f"local_rank {local_rank} is out of bounds for the available NPU devices: {devices}")
+    # Inline import avoids a circular dependency with vllm_ascend.platform.
+    from vllm.platforms import current_platform
 
-    local_comm_res_file = os.path.join(local_comm_res_path, f"ub_endpoint_npu_{devices[local_rank]}.json")
+    visible_device_index = current_platform.logical_device_id_to_visible_device_id(local_rank)
+    endpoint_device_id = _get_physical_device_id(visible_device_index)
+    local_comm_res_file = os.path.join(local_comm_res_path, f"ub_endpoint_npu_{endpoint_device_id}.json")
     try:
         with open(local_comm_res_file) as f:
             data = json.load(f)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -453,6 +453,9 @@ class NPUWorker(WorkerBase):
         torch.npu.empty_cache()
 
         if get_ascend_device_type() == AscendDeviceType.A5:
+            # Temporary workaround for a HiXL transport dependency on 950DT
+            # server/pod deployments. HiXL should eventually select its local
+            # endpoint resource without requiring vLLM Ascend to configure it.
             setup_ascend_local_comm_res(self.local_rank, self.vllm_config.kv_transfer_config)
 
         # take current memory snapshot


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes the device ID mapping issue introduced by #9690.

`setup_ascend_local_comm_res` previously used vLLM's logical `local_rank` to select a per-device endpoint file. Logical, user-visible, and physical NPU IDs can differ in containers, especially when only later host devices are mounted.

This PR performs the complete mapping inside `setup_ascend_local_comm_res`:

1. Resolve `local_rank` to the user-visible device ID.
2. Use `aclrtGetLogicDevIdByUserDevId` to obtain the Ascend logical device ID.
3. Use `aclrtGetPhyDevIdByLogicDevId` to obtain the physical NPU ID.
4. Load the endpoint file matching that physical ID.

This makes endpoint selection independent of `ASCEND_RT_VISIBLE_DEVICES`, container mount ordering, and `npu-smi` enumeration.

> [!IMPORTANT]
> This approach has an architectural compromise: it introduces direct `ctypes` calls to `libascendcl.so` and depends on low-level CANN Runtime APIs from framework code. This increases implementation and runtime dependency complexity, couples vLLM Ascend to the AscendCL ABI and supported CANN versions, and places user/logical/physical device conversion in a layer that should not ideally own it. The mapping and endpoint selection should ultimately be provided by HiXL or another lower-level runtime component.

This remains a temporary workaround for the HiXL transport dependency on 950DT server/pod deployments. A higher-level alternative is available in #12959; it avoids the direct AscendCL dependency but requires `ASCEND_RT_VISIBLE_DEVICES` to remain unset when a container mounts only a subset of host NPUs.

### Does this PR introduce _any_ user-facing change?

Yes. A5/950DT workers now load the endpoint configuration matching the physical NPU they actually use after container device remapping.

### How was this patch tested?

- Ruff format and lint passed.
- Python compilation passed.
- Added unit coverage for the Runtime user-to-logical-to-physical mapping and endpoint selection with a misleading visible-device environment variable.
- Local test execution requires the NPU test environment and is left to CI.

- vLLM version:
- vLLM main:
