### PR TITLE
[Performance] 9.1.0 CANN supports the mla_prolog operator

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -669,7 +669,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         # PD decode consumers with sparse C8 can use mla_prolog_v3 to write the packed KV cache.
         # TODO: Re-enable after the community CANN baseline upgrades from 9.0 to 9.1.
         # npu_mla_prolog_v3 depends on CANN 9.1 and is not available in the current community CANN 9.0.
-        sfa_prolog_v3_supported = False
+        sfa_prolog_v3_supported = torch.version.cann == "9.1.0"
         self.enable_sfa_prolog_v3 = (
             sfa_prolog_v3_supported
             and self.is_kv_consumer

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -669,6 +669,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         # PD decode consumers with sparse C8 can use mla_prolog_v3 to write the packed KV cache.
         # TODO: Re-enable after the community CANN baseline upgrades from 9.0 to 9.1.
         # npu_mla_prolog_v3 depends on CANN 9.1 and is not available in the current community CANN 9.0.
+        cann_version = getattr(torch.version, "cann", None)
+        if cann_version is not None:
+            from packaging.version import Version
+            sfa_prolog_v3_supported = Version(cann_version) >= Version("9.1.0")
+        else:
+            sfa_prolog_v3_supported = False
         sfa_prolog_v3_supported = torch.version.cann == "9.1.0"
         self.enable_sfa_prolog_v3 = (
             sfa_prolog_v3_supported

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -672,10 +672,10 @@ class AscendSFAImpl(MLAAttentionImpl):
         cann_version = getattr(torch.version, "cann", None)
         if cann_version is not None:
             from packaging.version import Version
+
             sfa_prolog_v3_supported = Version(cann_version) >= Version("9.1.0")
         else:
             sfa_prolog_v3_supported = False
-        sfa_prolog_v3_supported = torch.version.cann == "9.1.0"
         self.enable_sfa_prolog_v3 = (
             sfa_prolog_v3_supported
             and self.is_kv_consumer


### PR DESCRIPTION
### What this PR does / why we need it?
9.1.0 CANN supports the mla_prolog operator

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
vLLM version: v0.23.0

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
