### PR TITLE
[Bugfix][SpecDecode] Fix GLM-5.2 DFlash acceptance for QuaRot targets

### DIFF
--- a/tests/ut/patch/worker/test_patch_dflash_quarot.py
+++ b/tests/ut/patch/worker/test_patch_dflash_quarot.py
@@ -1,0 +1,105 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm_ascend
+
+
+MODULE_PATH = (
+    Path(vllm_ascend.__file__).resolve().parent
+    / "patch"
+    / "worker"
+    / "patch_draft_quarot.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "dflash_quarot_module_under_test", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+patch_draft_quarot = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patch_draft_quarot)
+
+
+def test_transform_quarot_linear_weight_matches_block_diagonal():
+    torch.manual_seed(0)
+    rotation, _ = torch.linalg.qr(torch.randn(4, 4, dtype=torch.float32))
+    weight = torch.randn(3, 12, dtype=torch.float32)
+
+    actual = patch_draft_quarot.transform_quarot_linear_weight(
+        weight, rotation
+    )
+    expected = weight @ torch.block_diag(rotation, rotation, rotation)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_transform_quarot_linear_weight_rejects_invalid_width():
+    weight = torch.randn(3, 10)
+    rotation = torch.eye(4)
+
+    with pytest.raises(ValueError, match="multiple of the QuaRot hidden size"):
+        patch_draft_quarot.transform_quarot_linear_weight(weight, rotation)
+
+
+def test_dflash_wrapper_transforms_only_fc_weight(monkeypatch):
+    rotation = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+    fc_weight = torch.arange(16, dtype=torch.float32).reshape(2, 8)
+    other_weight = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+    captured = {}
+
+    monkeypatch.setattr(
+        patch_draft_quarot,
+        "get_rotataion_matrix",
+        lambda _: rotation,
+    )
+
+    def original_load_weights(_self, weights):
+        captured.update(dict(weights))
+        return {"loaded": True}
+
+    load_weights = patch_draft_quarot.make_dflash_load_weights(
+        "unused.safetensors", original_load_weights
+    )
+    result = load_weights(
+        object(),
+        [("fc.weight", fc_weight), ("model.layers.0.weight", other_weight)],
+    )
+
+    expected_fc = fc_weight @ torch.block_diag(
+        rotation, rotation, rotation, rotation
+    )
+    torch.testing.assert_close(captured["fc.weight"], expected_fc)
+    torch.testing.assert_close(captured["model.layers.0.weight"], other_weight)
+    assert result == {"loaded": True}
+
+
+def test_dflash_wrapper_requires_fc_weight(monkeypatch):
+    monkeypatch.setattr(
+        patch_draft_quarot,
+        "get_rotataion_matrix",
+        lambda _: torch.eye(2),
+    )
+
+    def original_load_weights(_self, weights):
+        list(weights)
+
+    load_weights = patch_draft_quarot.make_dflash_load_weights(
+        "unused.safetensors", original_load_weights
+    )
+
+    with pytest.raises(RuntimeError, match="did not provide fc.weight"):
+        load_weights(object(), [("model.layers.0.weight", torch.eye(2))])
+
+
+def test_non_quarot_target_leaves_dflash_loader_unchanged():
+    target_config = SimpleNamespace(
+        model_config=SimpleNamespace(model="unused"),
+        quant_config=SimpleNamespace(quant_description={}),
+    )
+    original = patch_draft_quarot.DFlashQwen3ForCausalLM.load_weights
+
+    patch_draft_quarot.patch_load_weights(target_config)
+
+    assert patch_draft_quarot.DFlashQwen3ForCausalLM.load_weights is original

--- a/tests/ut/patch/worker/test_patch_dflash_quarot.py
+++ b/tests/ut/patch/worker/test_patch_dflash_quarot.py
@@ -7,16 +7,8 @@ import torch
 
 import vllm_ascend
 
-
-MODULE_PATH = (
-    Path(vllm_ascend.__file__).resolve().parent
-    / "patch"
-    / "worker"
-    / "patch_draft_quarot.py"
-)
-SPEC = importlib.util.spec_from_file_location(
-    "dflash_quarot_module_under_test", MODULE_PATH
-)
+MODULE_PATH = Path(vllm_ascend.__file__).resolve().parent / "patch" / "worker" / "patch_draft_quarot.py"
+SPEC = importlib.util.spec_from_file_location("dflash_quarot_module_under_test", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 patch_draft_quarot = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(patch_draft_quarot)
@@ -27,9 +19,7 @@ def test_transform_quarot_linear_weight_matches_block_diagonal():
     rotation, _ = torch.linalg.qr(torch.randn(4, 4, dtype=torch.float32))
     weight = torch.randn(3, 12, dtype=torch.float32)
 
-    actual = patch_draft_quarot.transform_quarot_linear_weight(
-        weight, rotation
-    )
+    actual = patch_draft_quarot.transform_quarot_linear_weight(weight, rotation)
     expected = weight @ torch.block_diag(rotation, rotation, rotation)
 
     torch.testing.assert_close(actual, expected)
@@ -59,17 +49,13 @@ def test_dflash_wrapper_transforms_only_fc_weight(monkeypatch):
         captured.update(dict(weights))
         return {"loaded": True}
 
-    load_weights = patch_draft_quarot.make_dflash_load_weights(
-        "unused.safetensors", original_load_weights
-    )
+    load_weights = patch_draft_quarot.make_dflash_load_weights("unused.safetensors", original_load_weights)
     result = load_weights(
         object(),
         [("fc.weight", fc_weight), ("model.layers.0.weight", other_weight)],
     )
 
-    expected_fc = fc_weight @ torch.block_diag(
-        rotation, rotation, rotation, rotation
-    )
+    expected_fc = fc_weight @ torch.block_diag(rotation, rotation, rotation, rotation)
     torch.testing.assert_close(captured["fc.weight"], expected_fc)
     torch.testing.assert_close(captured["model.layers.0.weight"], other_weight)
     assert result == {"loaded": True}
@@ -85,9 +71,7 @@ def test_dflash_wrapper_requires_fc_weight(monkeypatch):
     def original_load_weights(_self, weights):
         list(weights)
 
-    load_weights = patch_draft_quarot.make_dflash_load_weights(
-        "unused.safetensors", original_load_weights
-    )
+    load_weights = patch_draft_quarot.make_dflash_load_weights("unused.safetensors", original_load_weights)
 
     with pytest.raises(RuntimeError, match="did not provide fc.weight"):
         load_weights(object(), [("model.layers.0.weight", torch.eye(2))])

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM projectx
+import inspect
 import sys
 from collections.abc import Mapping
 from math import lcm
@@ -37,6 +38,7 @@ from vllm_ascend.utils import vllm_version_is
 USE_MULTI_GROUPS_KV_CACHE = True
 
 _orig_get_kv_cache_coordinator = vllm.v1.core.kv_cache_coordinator.get_kv_cache_coordinator
+_ORIG_KV_COORDINATOR_PARAMS = inspect.signature(_orig_get_kv_cache_coordinator).parameters
 
 
 def _select_kv_token_budget(
@@ -44,7 +46,9 @@ def _select_kv_token_budget(
     max_in_flight_tokens: int | None,
     max_num_batched_tokens: int | None,
 ) -> int:
-    token_budget = max_num_batched_tokens if vllm_version_is("0.25.1") else max_in_flight_tokens
+    token_budget = max_num_batched_tokens
+    if token_budget is None:
+        token_budget = max_in_flight_tokens
     return token_budget if token_budget is not None else max_model_len
 
 
@@ -507,7 +511,7 @@ def get_kv_cache_coordinator(
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
         )
-        if vllm_version_is("0.25.1"):
+        if "max_num_batched_tokens" in _ORIG_KV_COORDINATOR_PARAMS:
             orig_kwargs["max_num_batched_tokens"] = token_budget
         else:
             orig_kwargs["max_in_flight_tokens"] = token_budget

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -190,5 +190,5 @@ def make_dflash_load_weights(rotation_path, original_load_weights):
             raise RuntimeError("DFlash checkpoint did not provide fc.weight; target QuaRot rotation was not applied")
         return result
 
-    load_weights._vllm_ascend_quarot_wrapper = True
+    load_weights._vllm_ascend_quarot_wrapper = True  # type: ignore[attr-defined]
     return load_weights

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -80,9 +80,7 @@ def compute_rotataion_matrix3(Q):
 
 def transform_quarot_linear_weight(weight, rotation):
     if weight.ndim != 2 or rotation.ndim != 2:
-        raise ValueError(
-            f"Expected 2D weight and rotation, got {weight.shape=} {rotation.shape=}"
-        )
+        raise ValueError(f"Expected 2D weight and rotation, got {weight.shape=} {rotation.shape=}")
     hidden_size = rotation.shape[0]
     if rotation.shape[1] != hidden_size or weight.shape[1] % hidden_size != 0:
         raise ValueError(
@@ -94,9 +92,7 @@ def transform_quarot_linear_weight(weight, rotation):
     rotation_fp32 = rotation.to(device=weight.device, dtype=torch.float32)
     for start in range(0, weight.shape[1], hidden_size):
         end = start + hidden_size
-        output[:, start:end] = torch.matmul(
-            weight[:, start:end].to(torch.float32), rotation_fp32
-        ).to(weight.dtype)
+        output[:, start:end] = torch.matmul(weight[:, start:end].to(torch.float32), rotation_fp32).to(weight.dtype)
     return output
 
 
@@ -111,9 +107,7 @@ def patch_load_weights(target_vllm_config):
     Eagle3LlamaForCausalLM.load_weights = make_load_weights(target_model_path, rotation_path)
     original_dflash_load_weights = DFlashQwen3ForCausalLM.load_weights
     if not getattr(original_dflash_load_weights, "_vllm_ascend_quarot_wrapper", False):
-        DFlashQwen3ForCausalLM.load_weights = make_dflash_load_weights(
-            rotation_path, original_dflash_load_weights
-        )
+        DFlashQwen3ForCausalLM.load_weights = make_dflash_load_weights(rotation_path, original_dflash_load_weights)
 
 
 def make_load_weights(target_model_path, rotation_path):
@@ -182,13 +176,10 @@ def make_dflash_load_weights(rotation_path, original_load_weights):
             nonlocal transformed_fc
             for name, loaded_weight in weights:
                 if name == "fc.weight" or name.endswith(".fc.weight"):
-                    loaded_weight = transform_quarot_linear_weight(
-                        loaded_weight, rotation
-                    )
+                    loaded_weight = transform_quarot_linear_weight(loaded_weight, rotation)
                     transformed_fc = True
                     logger.info(
-                        "Applied target QuaRot rotation to DFlash fc.weight: "
-                        "shape=%s, rotation=%s",
+                        "Applied target QuaRot rotation to DFlash fc.weight: shape=%s, rotation=%s",
                         tuple(loaded_weight.shape),
                         rotation_path,
                     )
@@ -196,10 +187,7 @@ def make_dflash_load_weights(rotation_path, original_load_weights):
 
         result = original_load_weights(self, transformed_weights())
         if not transformed_fc:
-            raise RuntimeError(
-                "DFlash checkpoint did not provide fc.weight; target QuaRot "
-                "rotation was not applied"
-            )
+            raise RuntimeError("DFlash checkpoint did not provide fc.weight; target QuaRot rotation was not applied")
         return result
 
     load_weights._vllm_ascend_quarot_wrapper = True

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import torch
 from safetensors.torch import load_file
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     process_eagle_weight,
@@ -77,6 +78,28 @@ def compute_rotataion_matrix3(Q):
     return torch.block_diag(Q, Q, Q)
 
 
+def transform_quarot_linear_weight(weight, rotation):
+    if weight.ndim != 2 or rotation.ndim != 2:
+        raise ValueError(
+            f"Expected 2D weight and rotation, got {weight.shape=} {rotation.shape=}"
+        )
+    hidden_size = rotation.shape[0]
+    if rotation.shape[1] != hidden_size or weight.shape[1] % hidden_size != 0:
+        raise ValueError(
+            "DFlash fc input width must be a multiple of the QuaRot hidden size: "
+            f"weight={tuple(weight.shape)}, rotation={tuple(rotation.shape)}"
+        )
+
+    output = torch.empty_like(weight)
+    rotation_fp32 = rotation.to(device=weight.device, dtype=torch.float32)
+    for start in range(0, weight.shape[1], hidden_size):
+        end = start + hidden_size
+        output[:, start:end] = torch.matmul(
+            weight[:, start:end].to(torch.float32), rotation_fp32
+        ).to(weight.dtype)
+    return output
+
+
 def patch_load_weights(target_vllm_config):
     target_model_path = Path(target_vllm_config.model_config.model)
     rotation_path = get_rotation_path(target_vllm_config)
@@ -86,6 +109,11 @@ def patch_load_weights(target_vllm_config):
         return
 
     Eagle3LlamaForCausalLM.load_weights = make_load_weights(target_model_path, rotation_path)
+    original_dflash_load_weights = DFlashQwen3ForCausalLM.load_weights
+    if not getattr(original_dflash_load_weights, "_vllm_ascend_quarot_wrapper", False):
+        DFlashQwen3ForCausalLM.load_weights = make_dflash_load_weights(
+            rotation_path, original_dflash_load_weights
+        )
 
 
 def make_load_weights(target_model_path, rotation_path):
@@ -142,4 +170,37 @@ def make_load_weights(target_model_path, rotation_path):
         )
         loader.load_weights(model_weights.items())
 
+    return load_weights
+
+
+def make_dflash_load_weights(rotation_path, original_load_weights):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        rotation = get_rotataion_matrix(rotation_path)
+        transformed_fc = False
+
+        def transformed_weights():
+            nonlocal transformed_fc
+            for name, loaded_weight in weights:
+                if name == "fc.weight" or name.endswith(".fc.weight"):
+                    loaded_weight = transform_quarot_linear_weight(
+                        loaded_weight, rotation
+                    )
+                    transformed_fc = True
+                    logger.info(
+                        "Applied target QuaRot rotation to DFlash fc.weight: "
+                        "shape=%s, rotation=%s",
+                        tuple(loaded_weight.shape),
+                        rotation_path,
+                    )
+                yield name, loaded_weight
+
+        result = original_load_weights(self, transformed_weights())
+        if not transformed_fc:
+            raise RuntimeError(
+                "DFlash checkpoint did not provide fc.weight; target QuaRot "
+                "rotation was not applied"
+            )
+        return result
+
+    load_weights._vllm_ascend_quarot_wrapper = True
     return load_weights

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -413,6 +413,20 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         " embed_tokens weights. Keeping separate embedding weights"
                         " from the target model."
                     )
+            elif self.method == "dflash":
+                if not getattr(self.model, "has_own_embed_tokens", True):
+                    share_embeddings = True
+                    logger.info(
+                        "[spec_decode/base] Detected DFlash model without its own"
+                        " embed_tokens. Sharing target model embedding weights with"
+                        " the draft model."
+                    )
+                else:
+                    logger.info(
+                        "[spec_decode/base] Detected DFlash model with its own"
+                        " embed_tokens. Keeping the checkpoint embedding weights"
+                        " in the unrotated draft space."
+                    )
             elif self.method == "dspark":
                 if not getattr(self.model, "has_own_embed_tokens", True):
                     share_embeddings = True

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -10,6 +10,8 @@ from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 from vllm_ascend.utils import vllm_version_is
 
+_SLOT_MAPPING_KERNEL_PARAMS = frozenset(getattr(_compute_slot_mapping_kernel, "arg_names", ()))
+
 
 class BlockTable:
     def __init__(
@@ -167,10 +169,13 @@ class BlockTable:
                 "PAD_ID": PAD_SLOT_ID,
                 "BLOCK_SIZE": 1024,
             }
-            if not vllm_version_is("0.25.1"):
+            if {
+                "KV_CACHE_BLOCK_SIZE",
+                "BLOCKS_PER_KV_BLOCK",
+            }.issubset(_SLOT_MAPPING_KERNEL_PARAMS):
                 # vLLM #40996 split physical KV blocks into kernel blocks in
-                # the slot-mapping kernel. These are required constexprs on
-                # main; the v0.25.1 kernel does not accept them.
+                # the slot-mapping kernel. Pass these constexprs only when the
+                # installed vLLM kernel exposes them.
                 kernel_kwargs.update(
                     KV_CACHE_BLOCK_SIZE=self.physical_block_size,
                     BLOCKS_PER_KV_BLOCK=self.blocks_per_phys_block,

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -8,8 +8,6 @@ from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.block_table import _compute_slot_mapping_kernel
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
-from vllm_ascend.utils import vllm_version_is
-
 _SLOT_MAPPING_KERNEL_PARAMS = frozenset(getattr(_compute_slot_mapping_kernel, "arg_names", ()))
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes near-zero speculative token acceptance when a GLM-5.2 DFlash checkpoint is used with a QuaRot-quantized GLM-5.2 target on Ascend.

The DFlash path was active before this fix: draft, draft-token, and accepted-token counters all increased. However, the drafter accepted almost no tokens. A pre-fix all-eager diagnostic run measured only **0.0637%** token acceptance and an average accepted length of **1.0096**, which made DFlash effectively unusable.

After this fix, two post-fix `1k input / 300 output / concurrency 1` validation runs measured:

| Run | Drafts | Draft tokens | Accepted tokens | Token acceptance | Accepted length |
| --- | ---: | ---: | ---: | ---: | ---: |
| Post-fix run 1 | 141 | 2,115 | 458 | **21.65%** | **4.248** |
| Post-fix run 2 | 134 | 2,010 | 470 | **23.38%** | **4.507** |
| Checkpoint README reference | - | - | - | - | 4.44 |

The second run reaches an average accepted length of `4.507`, which is consistent with the checkpoint README reference of `4.44`. This confirms that the near-zero-acceptance problem was an inference integration bug rather than a corrupt DFlash checkpoint.

#### Root cause

The quantized GLM-5.2 target produces auxiliary hidden states in a QuaRot-rotated hidden basis. The DFlash checkpoint's `fc.weight`, embedding, and LM head remain in the original hidden basis.

Let the original hidden state be `h`, and let the target expose the rotated hidden state:

```text
h_rot = h @ Q
```

The original DFlash linear projection computes `y = h @ W.T`. Feeding `h_rot` directly to the unmodified checkpoint weight computes in the wrong basis. To preserve the original projection, the DFlash weight must be transformed as `W_rot = W @ Q`. Then:

```text
h_rot @ W_rot.T
  = h @ Q @ (W @ Q).T
  = h @ Q @ Q.T @ W.T
  = h @ W.T
```

DFlash concatenates multiple target hidden-state chunks into the input of `fc.weight`. The PR therefore applies `W @ Q` **independently to every hidden-sized input chunk** instead of constructing one large block-diagonal matrix. The multiplication is performed in FP32 and cast back to the checkpoint dtype.

There is a second basis mismatch in **embedding handling**. The existing proposer could share the target embedding with DFlash. For this checkpoint, the target embedding belongs to the rotated target space while the DFlash embedding and LM head form a matched pair in the original draft space. The fix keeps the DFlash checkpoint's own embedding and LM head whenever the model provides them.

#### Changes in this PR

| File | Change |
| --- | --- |
| `vllm_ascend/patch/worker/patch_draft_quarot.py` | Add DFlash QuaRot load-time transformation. Transform only `fc.weight`, process every hidden-sized chunk, preserve dtype, avoid duplicate wrapping, fail fast if a QuaRot DFlash checkpoint does not provide `fc.weight`. |
| `vllm_ascend/spec_decode/llm_base_proposer.py` | Keep DFlash checkpoint embedding weights when the draft model owns `embed_tokens`; share the target embedding only for a DFlash model that does not provide its own embedding. |
| `tests/ut/patch/worker/test_patch_dflash_quarot.py` | Five focused unit tests for the blockwise transform, invalid dimensions, selective `fc.weight` transformation, missing-weight failure, and the non-QuaRot no-op path. |
| `vllm_ascend/patch/platform/patch_kv_cache_coordinator.py` | Select the KV token-budget argument from the installed vLLM function signature instead of relying only on a version string. |
| `vllm_ascend/worker/block_table.py` | Pass slot-mapping KV block constexprs only when the installed vLLM kernel exposes those arguments. |

The last two files are compatibility fixes for the selected vLLM commit and are kept in a separate commit from the DFlash correctness change.

#### Diff size

```text
Runtime code: 4 files, +89/-5
Unit test:    1 file,  +105/-0
Total:        5 files, +194/-5
```

The DFlash-specific runtime change is `+75/-0`. The selected-vLLM compatibility change is `+14/-5`. vLLM itself is not modified.

#### Why `num_speculative_tokens=15`

The checkpoint declares a DFlash block size of 16. The current proposer schedules `num_query_per_req = 1 + num_speculative_tokens`. The GLM SFA fused-attention path supports at most 16 query rows. Therefore `1 (anchor) + 15 (spec) = 16 rows` is the working configuration.

#### Diagnosis summary

The following alternatives were checked before identifying the QuaRot mismatch:

| Hypothesis | Result |
| --- | --- |
| DFlash path was not active | Ruled out (draft & acceptance counters increased) |
| ModelSlim BF16 repack damaged the checkpoint | Ruled out (60 keys/shapes/dtypes/values identical; original checkpoint also reproduced near-zero acceptance) |
| ACL Graph caused the low acceptance | Ruled out (target eager + draft eager still 0.0637%) |
| W4A8C8 alone caused the low acceptance | Ruled out as primary cause (W8A8 target also near zero) |
| Sharing only the wrong vocabulary tensor was the complete explanation | Ruled out (keeping checkpoint embed + LM head together did not recover acceptance without the FC basis fix) |
| Prompt length exceeded the checkpoint training limit | Ruled out (~1k input tokens) |
| Target auxiliary hidden states and DFlash FC used different QuaRot bases | **Confirmed.** Load-time FC transform + preserving DFlash vocabulary weights restored accepted length to the checkpoint reference range. |

### Does this PR introduce _any_ user-facing change?

Yes, as a correctness fix for GLM-5.2 DFlash speculative decoding with a QuaRot-quantized target.

After this change:

- GLM-5.2 DFlash checkpoints can consume auxiliary target hidden states from the QuaRot target in the correct hidden basis.
- A DFlash model that provides its own embedding keeps the checkpoint embedding and LM head instead of mixing a rotated target embedding with an unrotated draft LM head.
- A missing `fc.weight` in a QuaRot DFlash checkpoint produces an explicit error instead of silently running with invalid acceptance.
- Non-QuaRot target configurations keep the existing DFlash load path unchanged.

There is no new CLI option and no OpenAI-compatible API change.

### How was this patch tested?

#### Model configuration

| Item | Value |
| --- | --- |
| Target | GLM-5.2 W4A8C8 with QuaRot metadata and rotation matrix |
| DFlash checkpoint | [`UCloud-org/GLM-5.2-FP8-DFlash`](https://huggingface.co/UCloud-org/GLM-5.2-FP8-DFlash) rev `2261b3c3` |
| Speculative method | `dflash`, `num_speculative_tokens=15` |
| Parallelism | TP8 with expert parallelism enabled |
| Execution mode | Target eager and DFlash drafter eager (correctness gate, no ACLGraph) |

The `FP8` part of the DFlash repository name identifies the target used to train the drafter. The DFlash checkpoint tensors themselves are BF16 and do not need a numerical FP8-to-BF16 conversion.

#### Unit test

```bash
python -m pytest -q \
  --confcutdir=tests/ut/patch/worker \
  tests/ut/patch/worker/test_patch_dflash_quarot.py
```

Result: `5 passed`.

The five test cases verify:

1. Blockwise `W @ Q` equals multiplication by an explicit block-diagonal rotation matrix.
2. Invalid FC widths are rejected.
3. Only `fc.weight` is transformed; unrelated weights remain unchanged.
4. A QuaRot DFlash checkpoint without `fc.weight` fails explicitly.
5. A non-QuaRot target leaves the DFlash loader unchanged.

#### Service startup command (reproduction template)

```bash
export VLLM_USE_V1=1
export HCCL_OP_EXPANSION_MODE=AIV
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
export VLLM_ASCEND_ENABLE_FUSED_MC2=0

vllm serve <PATH_TO_GLM_5.2_w4a8c8> \
  --served-model-name GLM-5.2 \
  --tensor-parallel-size 8 \
  --enable-expert-parallel \
  --seed 1024 \
  --trust-remote-code \
  --max-model-len 8192 \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 16 \
  --gpu-memory-utilization 0.95 \
  --quantization ascend \
  --safetensors-load-strategy lazy \
  --no-enable-prefix-caching \
  --enforce-eager \
  --speculative-config \
    '{"method":"dflash","model":"<PATH_TO_GLM-5.2-FP8-DFlash>","num_speculative_tokens":15,"enforce_eager":true}'
```

The eager/eager configuration is intentional for the correctness gate. It removes ACL Graph capture and replay from the acceptance diagnosis. Graph performance can be evaluated separately after this correctness fix is merged.

#### AISBench validation shape

- Input length: 1,012 tokens
- Output length: 300 tokens
- Data num: 1 · Concurrency: 1
- Repeats: 2

Prometheus counters were captured before and after each run:

```text
token acceptance = accepted_tokens / draft_tokens
accepted length = 1 + accepted_tokens / drafts
```

#### Online correctness results

| Stage | Test shape | Drafts | Draft tokens | Accepted tokens | Token acceptance | Accepted length |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Pre-fix diagnostic | ~1k input / 32 output / 16 requests / c16 | 523 | 7,845 | 5 | **0.0637%** | **1.0096** |
| Post-fix run 1 | 1,012 input / 300 output / 1 request / c1 | 141 | 2,115 | 458 | **21.65%** | **4.248** |
| Post-fix run 2 | 1,012 input / 300 output / 1 request / c1 | 134 | 2,010 | 470 | **23.38%** | **4.507** |
| Checkpoint README | published reference | - | - | - | - | 4.44 |

The pre-fix and post-fix rows use different request shapes and are presented as a diagnosis-to-validation comparison rather than a strict throughput A/B. The key correctness signal is that two post-fix runs are repeatable and recover the checkpoint's published accepted-length range.

#### Post-fix single-request gate

Single-request correctness gate only (not a formal throughput benchmark):

| Run | Output TPS | Average TTFT | Average TPOT | E2E duration |
| --- | ---: | ---: | ---: | ---: |
| Post-fix run 1 | 10.70 tok/s | 716.3 ms | 91.4 ms | 28.03 s |
| Post-fix run 2 | 10.04 tok/s | 687.9 ms | 97.7 ms | 29.89 s |

No DFlash-vs-MTP speedup claim is made from this c1 gate. A strict performance comparison must use the same code revision, service lifecycle, warm-up, request set, concurrency, and graph mode for both DFlash and MTP.

#### Reviewer checklist

- [x] The branch is based on the documented vLLM-Ascend commit.
- [x] vLLM is unmodified.
- [x] DFlash QuaRot transformation is restricted to `fc.weight`.
- [x] Non-QuaRot targets retain the existing load behavior.
- [x] DFlash checkpoint embedding and LM head remain paired when available.
- [x] Missing QuaRot DFlash `fc.weight` fails explicitly.
- [x] Focused unit tests pass.
- [x] Two online validation runs recover the expected accepted-length range.
- [x] No sensitive environment information is committed.
- [ ] Run the repository's complete CI matrix in the upstream build environment.
- [ ] Run a strict post-fix DFlash-vs-MTP multi-concurrency performance A/B if a performance claim is required.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
