### PR TITLE
[Backport][v0.24.0rc][Feature] Add CANN MegaMoe fused MC2 support for A3

### DIFF
--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -280,14 +280,18 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
             )
         return layer
 
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
     @patch("torch.Tensor.npu", new=lambda self: self)
-    def test_process_weights_after_loading(self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz):
+    def test_process_weights_after_loading(
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz, mock_get_ascend_config
+    ):
         mock_npu_quantize.return_value = torch.Tensor()
         mock_npu_format_cast.side_effect = identity
         mock_maybe_trans_nz.side_effect = identity
+        mock_get_ascend_config.return_value.enable_fused_mc2 = 0
         # old quant version weight
         layer = self.build_layer(is_new_quant_version=False)
         self.quant_method.process_weights_after_loading(layer)
@@ -334,16 +338,18 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.assertEqual(result["w13_weight_scale"].dtype, torch.bfloat16)
         self.assertEqual(result["w2_weight_scale"].dtype, torch.bfloat16)
 
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
     @patch("torch_npu.npu_quantize")
     @patch("torch.Tensor.npu", new=lambda self: self)
     def test_process_weights_after_loading_compressed_tensors(
-        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz, mock_get_ascend_config
     ):
         mock_npu_quantize.return_value = torch.Tensor()
         mock_npu_format_cast.side_effect = identity
         mock_maybe_trans_nz.side_effect = identity
+        mock_get_ascend_config.return_value.enable_fused_mc2 = 0
 
         layer = self.build_layer(is_new_quant_version=False)
         self.quant_method.quant_method = COMPRESSED_TENSORS_METHOD

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -29,12 +29,14 @@ def _make_vllm_config(
     cudagraph_capture_sizes: list[int] | None = None,
     max_cudagraph_capture_size: int = 0,
     max_num_batched_tokens: int = 0,
+    hidden_size: int = 2048,
 ):
     hf_text_config_attrs: dict[str, object] = {"top_k_experts": top_k_experts}
     if quant_type is not None:
         hf_text_config_attrs["quantize"] = quant_type
     if num_experts_per_tok is not None:
         hf_text_config_attrs["num_experts_per_tok"] = num_experts_per_tok
+    hf_text_config_attrs["hidden_size"] = hidden_size
 
     model_config = SimpleNamespace(
         hf_text_config=SimpleNamespace(**hf_text_config_attrs),
@@ -66,13 +68,18 @@ def _patch_select_moe_comm_method_deps(
     capacity: int = 128,
     ep_world_size: int = 8,
     enable_fused_mc2: int = 0,
+    enable_prefill_mc2: int = 0,
     is_moe: bool = True,
 ):
     monkeypatch.setattr(afc, "is_moe_model", lambda _: is_moe)
     monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: capacity)
     monkeypatch.setattr(afc, "get_ascend_device_type", lambda: device_type)
     monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=ep_world_size))
-    monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=enable_fused_mc2))
+    monkeypatch.setattr(
+        afc,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_fused_mc2=enable_fused_mc2, enable_prefill_mc2=enable_prefill_mc2),
+    )
 
 
 def test_set_mc2_tokens_capacity_without_cudagraph_aligns_per_tp_rank():
@@ -163,9 +170,9 @@ def test_select_moe_comm_method_a2_uses_mc2_within_capacity(monkeypatch, num_tok
     ("num_tokens", "ep_world_size", "expected"),
     [
         (128, 8, MoECommType.FUSED_MC2),
-        (128, 64, MoECommType.MC2),
-        (129, 8, MoECommType.FUSED_MC2),
-        (129, 64, MoECommType.ALLTOALL),
+        (128, 128, MoECommType.MC2),
+        (4097, 8, MoECommType.FUSED_MC2),
+        (4097, 128, MoECommType.ALLTOALL),
     ],
 )
 def test_select_moe_comm_method_a3_enable_fused_mc2_mode_1(
@@ -182,7 +189,9 @@ def test_select_moe_comm_method_a3_enable_fused_mc2_mode_1(
         enable_fused_mc2=1,
     )
 
-    assert afc.select_moe_comm_method(num_tokens, _make_vllm_config()) == expected
+    vllm_config = _make_vllm_config(quant_type="w4a8")
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
 
 
 @pytest.mark.parametrize(
@@ -201,8 +210,130 @@ def test_select_moe_comm_method_a3_without_fused_mc2(
         monkeypatch,
         device_type=afc.AscendDeviceType.A3,
         capacity=128,
+        enable_prefill_mc2=1,
     )
     vllm_config = _make_vllm_config()
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "ep_world_size", "expected"),
+    [
+        (128, 8, MoECommType.FUSED_MC2),
+    ],
+)
+def test_select_moe_comm_method_a3_quant_w4a16(
+    monkeypatch,
+    num_tokens,
+    ep_world_size,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=ep_world_size,
+        enable_fused_mc2=1,
+        enable_prefill_mc2=1,
+    )
+
+    vllm_config = _make_vllm_config(quant_type="w4a16")
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "ep_world_size", "expected"),
+    [
+        (128, 8, MoECommType.FUSED_MC2),
+    ],
+)
+def test_select_moe_comm_method_a3_quant_w4a8(
+    monkeypatch,
+    num_tokens,
+    ep_world_size,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=ep_world_size,
+        enable_fused_mc2=1,
+        enable_prefill_mc2=1,
+    )
+
+    vllm_config = _make_vllm_config(quant_type="w4a8")
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "ep_world_size", "expected"),
+    [
+        (128, 8, MoECommType.FUSED_MC2),
+    ],
+)
+def test_select_moe_comm_method_a3_quant_w8a8(
+    monkeypatch,
+    num_tokens,
+    ep_world_size,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=ep_world_size,
+        enable_fused_mc2=1,
+        enable_prefill_mc2=1,
+    )
+
+    vllm_config = _make_vllm_config(quant_type="w8a8")
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("quant_type", "expected"),
+    [
+        ("w4a8", True),
+        ("w8a8", True),
+        ("w8a16", False),
+    ],
+)
+def test_cann_megamoe_supported_by_config_quant_type(
+    quant_type,
+    expected,
+):
+    vllm_config = _make_vllm_config(quant_type=quant_type)
+
+    assert afc._cann_megamoe_supported_by_config(vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "ep_world_size", "expected"),
+    [
+        (128, 8, MoECommType.FUSED_MC2),
+    ],
+)
+def test_select_moe_comm_method_a3_mc2_invalid_hidden_size(
+    monkeypatch,
+    num_tokens,
+    ep_world_size,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=ep_world_size,
+        enable_fused_mc2=1,
+        enable_prefill_mc2=0,
+    )
+
+    vllm_config = _make_vllm_config(quant_type="w4a8", hidden_size=512)
 
     assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -1,3 +1,4 @@
+import importlib.util
 import math
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -31,6 +32,19 @@ class MoECommType(Enum):
 
 
 _MRV2_IN_PROFILE_RUN: ContextVar[bool] = ContextVar("_MRV2_IN_PROFILE_RUN", default=False)
+_CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
+    "w8a8",
+    "w4a8",
+    "w8a8_dynamic",
+    "w4a8_dynamic",
+    "quanttype.w8a8",
+    "quanttype.w4a8",
+}
+
+_MEGA_MOE_SUPPORTED = importlib.util.find_spec("cann_ops_transformer") is not None
+_MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
+_DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
+_MC2_TOKENS_PER_RANK_LIMIT = 512
 
 
 @contextmanager
@@ -51,6 +65,33 @@ def override_mrv2_in_profile_run(enabled: bool):
 
 def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
+
+
+def _cann_megamoe_supported_by_config(vllm_config: VllmConfig) -> bool:
+    hf_text_config = vllm_config.model_config.hf_text_config
+    hidden_size = getattr(hf_text_config, "hidden_size", None)
+    if hidden_size is None and hasattr(vllm_config.model_config, "get_hidden_size"):
+        hidden_size = vllm_config.model_config.get_hidden_size()
+    if hidden_size is None:
+        return False
+    hidden_size = int(hidden_size)
+    # Hidden-size bounds come from the CANN MegaMoe kernel constraints:
+    # the dispatch / FFN / combine cube tiles require hidden in the closed
+    # range [1024, 8192] and a multiple of 512 (the cube K-step). Models
+    # outside this range (e.g. small Qwen variants with hidden=896, or any
+    # hidden=9216 LLaMA-style head) are silently routed back to MC2.
+    if hidden_size < 1024 or hidden_size > 8192 or hidden_size % 512 != 0:
+        return False
+
+    quant_type = getattr(
+        vllm_config.model_config.hf_text_config,
+        "moe_quantize",
+        getattr(vllm_config.model_config.hf_text_config, "quantize", None),
+    )
+    if quant_type is None:
+        return True
+    quant_name = str(getattr(quant_type, "name", quant_type)).lower()
+    return quant_name in _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES
 
 
 @contextmanager
@@ -94,7 +135,10 @@ def set_ascend_forward_context(
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 
         max_num_tokens = int(num_tokens_across_dp.max().item()) if num_tokens_across_dp is not None else num_tokens
-        moe_comm_type = select_moe_comm_method(max_num_tokens, vllm_config, is_draft_model)
+        moe_comm_type = select_moe_comm_method(
+            max_num_tokens,
+            vllm_config,
+        )
 
         forward_context.moe_comm_type = moe_comm_type
         forward_context.moe_comm_method = get_moe_comm_method(moe_comm_type)
@@ -209,10 +253,19 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
     else:
         max_num_tokens = max_num_reqs * uniform_decode_query_len
     tp_size = vllm_config.parallel_config.tensor_parallel_size
+
     # Use integer arithmetic for ceiling division.
     num_tokens_per_tp_rank = (max_num_tokens + tp_size - 1) // tp_size
-    # NOTE: To save memory, we cap the max number of tokens to 512.
-    num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, 512)
+    # keep the num_tokens_per_tp_rank less than fused_mc2 (mega_moe) tokens per rank limit
+    if get_ascend_config().enable_fused_mc2:
+        if _MEGA_MOE_SUPPORTED:
+            num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _MEGA_MOE_TOKENS_PER_RANK_LIMIT)
+        else:
+            num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT)
+
+    # keep the num_tokens_per_tp_rank less than mc2 tokens per rank limit
+    else:
+        num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _MC2_TOKENS_PER_RANK_LIMIT)
     _mc2_tokens_capacity = num_tokens_per_tp_rank * tp_size
 
 
@@ -254,16 +307,19 @@ def _select_a2_moe_comm_method(
 def _select_a3_moe_comm_method(
     num_tokens: int,
     mc2_tokens_capacity: int,
-    enable_fused_mc2: int,
+    vllm_config: VllmConfig,
 ) -> MoECommType:
-    # TODO: drop the EP-size guard when dispatch_ffn_combine supports larger EP sizes
-    dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
-    if num_tokens <= mc2_tokens_capacity:
-        fused_decode_enable = enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
-        return MoECommType.FUSED_MC2 if fused_decode_enable else MoECommType.MC2
+    if get_ascend_config().enable_fused_mc2 == 1:
+        # TODO: drop the EP-size guard when mega_moe supports larger EP sizes
+        mega_moe_enable = get_ep_group().world_size <= 64 and _cann_megamoe_supported_by_config(vllm_config)
+        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
+        if (_MEGA_MOE_SUPPORTED and mega_moe_enable) or dispatch_ffn_combine_enable:
+            return MoECommType.FUSED_MC2
 
-    fused_prefill_enable = enable_fused_mc2 == 1 and dispatch_ffn_combine_enable
-    return MoECommType.FUSED_MC2 if fused_prefill_enable else MoECommType.ALLTOALL
+    if num_tokens <= mc2_tokens_capacity:
+        return MoECommType.MC2
+
+    return MoECommType.ALLTOALL
 
 
 def _select_a5_moe_comm_method(
@@ -284,7 +340,7 @@ def _select_a5_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_model=False) -> MoECommType | None:
+def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
 
@@ -324,7 +380,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig, is_draft_mo
         moe_comm_type = _select_a3_moe_comm_method(
             num_tokens,
             mc2_tokens_capacity,
-            get_ascend_config().enable_fused_mc2,
+            vllm_config,
         )
     elif soc_version == AscendDeviceType.A5:
         moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)

--- a/vllm_ascend/ops/fused_moe/comm_utils.py
+++ b/vllm_ascend/ops/fused_moe/comm_utils.py
@@ -15,12 +15,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from importlib import import_module
+
 import torch
 import torch.distributed
 import torch.distributed as dist
 import torch_npu
 
+from vllm_ascend.quantization.quant_type import QuantType
+
 COMM_STREAM = None
+
+_CANN_ACL_INT8 = 258
+_CANN_ACL_INT4 = 285
+_CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
 
 
 def async_all_to_all(input_, output_split_sizes, input_split_sizes, group, event=None):
@@ -102,3 +110,33 @@ def gather_from_sequence_parallel_region(
 ):
     """Wrapper for autograd function: forward: AG, backward: RS <first dim>"""
     return _gather_along_first_dim(input_, group, output_split_sizes)
+
+
+def load_cann_mega_moe_ops():
+    ops_module = import_module("cann_ops_transformer.ops")
+    get_symm_buffer_for_mega_moe = ops_module.get_symm_buffer_for_mega_moe
+    mega_moe = ops_module.mega_moe
+    return get_symm_buffer_for_mega_moe, mega_moe
+
+
+def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int | None, int | None]:
+    # Returns (dispatch_quant_mode, dispatch_quant_out_dtype, weight_type).
+    # The current custom op package still requires explicit INT4 for W4A8
+    # packed weights; otherwise it derives W4A8's packed N as an INT8 N and
+    # rejects weight2.
+    #
+    # dispatch_quant_out_dtype: the doc types this as torch.dtype (torch.int8 /
+    # torch.float8_e4m3fn). We pass the ACL enum ints (258 / 24) because W8A8
+    # was validated end-to-end this way in PD; switching W4A8 to torch.int8 did
+    # NOT fix the W4A8 accuracy issue and slowed graph capture (see bug_a3.md),
+    # so keep the working values until the W4A8 accuracy root cause is found on
+    # the operator side.
+    if quant_type == QuantType.W8A8:
+        return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)
+    if quant_type == QuantType.W4A8:
+        return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)
+    raise RuntimeError(
+        "MegaMoe integration supports W8A8/W4A8 INT on A2/A3 and MXFP on FP8-capable "
+        "MegaMoe platforms. "
+        f"Unsupported quant type: {quant_type}."
+    )

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -19,10 +19,13 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
+from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
+from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.ops.fused_moe import comm_utils
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEFusedExpertsInput,
@@ -273,6 +276,10 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
+        self._mega_moe_symm_buffer = None
+        self._mega_moe_weight_type = None
+        if _MEGA_MOE_SUPPORTED:
+            self.get_symm_buffer_for_mega_moe, self.mega_moe = comm_utils.load_cann_mega_moe_ops()
         if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
@@ -286,6 +293,138 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithMC2(self.moe_config)
+
+    def _init_mega_moe_symm_buffer(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+    ):
+        # FusedMC2CommImpl always builds a TokenDispatcherWithMC2 (see
+        # setup_moe_comm_method), which is where global_bs / ep_world_size live.
+        # Assert it so mypy resolves those attributes off the base dispatcher.
+        assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
+        dispatch_quant_mode, dispatch_quant_out_dtype, self._mega_moe_weight_type = (
+            comm_utils._get_cann_mega_moe_quant_settings(fused_experts_input.quant.quant_type)
+        )
+        group = get_mc2_group().device_group
+        # The sym buffer is allocated by get_symm_buffer_for_mega_moe, a
+        # collective handshake over the EP (mc2) group. Its shape params —
+        # especially num_max_tokens_per_rank — MUST be identical on every EP
+        # rank, otherwise ranks allocate mismatched buffers / at different
+        # times and HCCL aborts (SUSPECT REMOTE ERROR 507057). So this value
+        # must be derived ONLY from rank-invariant, compile-time config,
+        # NEVER from the current forward's per-rank token count.
+        if self.token_dispatcher.global_bs > 0:
+            # global_bs = num_tokens_per_tp_rank * ep_world_size (compile-time).
+            num_max_tokens_per_rank = max(
+                1,
+                int(self.token_dispatcher.global_bs // self.token_dispatcher.ep_world_size),
+            )
+        else:
+            # num_tokens_per_tp_rank, set once in TokenDispatcherWithMC2.__init__
+            # from scheduler/graph config — rank-invariant.
+            rank_invariant_cap = getattr(self.token_dispatcher, "max_num_tokens_per_rank", 0)
+            num_max_tokens_per_rank = max(1, int(rank_invariant_cap))
+        num_topk = self.moe_config.experts_per_token
+        num_experts = self.moe_config.num_experts
+        expert_per_rank = max(1, num_experts // int(self.token_dispatcher.ep_world_size))
+        max_recv_token_num = max(
+            1,
+            num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank),
+        )
+
+        logger.info(
+            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): ep_rank=%s ep_world=%s global_bs=%s",
+            getattr(self.token_dispatcher, "ep_rank_id", "?"),
+            getattr(self.token_dispatcher, "ep_world_size", "?"),
+            self.token_dispatcher.global_bs,
+        )
+        self._mega_moe_symm_buffer = self.get_symm_buffer_for_mega_moe(
+            group,
+            num_experts,
+            num_max_tokens_per_rank,
+            num_topk,
+            hidden=self.moe_config.hidden_dim,
+            intermediate_hidden=2 * self.moe_config.intermediate_size_per_partition,
+            max_recv_token_num=max_recv_token_num,
+            dispatch_quant_mode=dispatch_quant_mode,
+            dispatch_quant_out_dtype=dispatch_quant_out_dtype,
+        )
+
+    def _apply_cann_mega_moe(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+        topk_ids: torch.Tensor,
+    ):
+        assert fused_experts_input.weights.w1_scale is not None
+        assert fused_experts_input.weights.w2_scale is not None
+        # TokenDispatcherWithMC2 carries global_bs (used below for the mc2_mask
+        # branch); assert the subtype so mypy resolves it off the base class.
+        assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
+
+        def to_list(x):
+            return x if isinstance(x, list) else [x]
+
+        weight1 = to_list(fused_experts_input.weights.w1)
+        weight2 = to_list(fused_experts_input.weights.w2)
+        # A8W4-INT MegaMoe reads N from weight1.storageShape.lastDim treated as int8 (N = lastDim*2)
+        # and checks weight2.dim0 == N/2, so the weights MUST be int8-shaped (two int4 per byte), NOT
+        # the eight-int4-per-int32 packing (that makes the op read N four times too small and fail
+        # CheckWeight2Input). The op prototype also REQUIRES FRACTAL_NZ per expert. The W4A8 quant
+        # method therefore builds per-expert int8 + FRACTAL_NZ lists (cann_mega_moe_*_weight_list) and
+        # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
+        weight_scales1 = to_list(fused_experts_input.weights.w1_scale)
+        weight_scales2 = to_list(fused_experts_input.weights.w2_scale)
+        # MegaMoe requires per-expert weight scales to be 1-D. The W4A8 method
+        # squeezes w13 scales but leaves w2 scales as [1, hidden]; drop the
+        # leading singleton dim so CheckWeightScaleInput passes. Guarded to the
+        # [1, N] per-channel case to avoid flattening genuine per-group scales.
+        weight_scales1 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales1]
+        weight_scales2 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales2]
+
+        if self._mega_moe_symm_buffer is None:
+            self._init_mega_moe_symm_buffer(
+                fused_experts_input,
+            )
+
+        activation_clamp = fused_experts_input.swiglu_limit if fused_experts_input.swiglu_limit > 0 else None
+        x_active_mask = None
+        if self.token_dispatcher.global_bs == 0 and fused_experts_input.routing.mc2_mask is not None:
+            # mc2_mask comes from the reserved bool buffer in
+            # ascend_forward_context.set_mc2_mask. MegaMoe wants int8 as
+            # the per-token active mask, so cast only when the dtype does
+            # not already match — saves the kernel launch when an upstream
+            # change ever flips the reserved buffer to int8.
+            raw_mask = fused_experts_input.routing.mc2_mask
+            if raw_mask.dtype == torch.int8:
+                x_active_mask = raw_mask.contiguous()
+            else:
+                x_active_mask = raw_mask.to(torch.int8).contiguous()
+        # A8W4-INT precision-compensation biases B1/B2 (l1_bias/l2_bias).
+        l1_bias = fused_experts_input.weights.w1_scale_bias
+        l2_bias = fused_experts_input.weights.w2_scale_bias
+
+        out, expert_tokens = self.mega_moe(
+            fused_experts_input.hidden_states,
+            topk_ids.to(torch.int32),
+            fused_experts_input.topk_weights.to(torch.float32),
+            weight1,
+            weight2,
+            self._mega_moe_symm_buffer,
+            l1_weights_sf=weight_scales1,
+            l2_weights_sf=weight_scales2,
+            l1_bias=l1_bias,
+            l2_bias=l2_bias,
+            x_active_mask=x_active_mask,
+            activation_clamp=activation_clamp,
+            weight1_type=self._mega_moe_weight_type,
+            weight2_type=self._mega_moe_weight_type,
+        )
+        # NOTE: self.expert_token_nums is only used by the
+        # mega_moe path (enable_fused_mc2 == 1) as a
+        # pre-allocated in/out buffer. The MegaMoe op returns a fresh
+        # expert_tokens tensor that is consumed by the caller via the
+        # return value, so there is nothing to keep on the instance.
+        return out, expert_tokens
 
     def fused_experts(
         self,
@@ -306,29 +445,33 @@ class FusedMC2CommImpl(MoECommMethod):
 
         expert_tokens = None
         if get_ascend_config().enable_fused_mc2 == 1:
-            assert not (
-                fused_experts_input.weights.w1_scale_bias is None or fused_experts_input.weights.w2_scale_bias is None
-            ), "w1_scale_bias and w2_scale_bias cannot be None when enable_fused_mc2=1."
+            if _MEGA_MOE_SUPPORTED:
+                out, expert_tokens = self._apply_cann_mega_moe(fused_experts_input, topk_ids)
+            else:
+                assert not (
+                    fused_experts_input.weights.w1_scale_bias is None
+                    or fused_experts_input.weights.w2_scale_bias is None
+                ), "w1_scale_bias and w2_scale_bias cannot be None when enable_fused_mc2=1."
 
-            out = torch.empty_like(fused_experts_input.hidden_states)
-            torch.ops._C_ascend.dispatch_ffn_combine(  # type: ignore
-                x=fused_experts_input.hidden_states,
-                weight1=fused_experts_input.weights.w1,
-                weight2=fused_experts_input.weights.w2,
-                expert_idx=topk_ids,
-                scale1=fused_experts_input.weights.w1_scale,
-                scale2=fused_experts_input.weights.w2_scale,
-                bias1=fused_experts_input.weights.w1_scale_bias,
-                bias2=fused_experts_input.weights.w2_scale_bias,
-                probs=fused_experts_input.topk_weights.to(torch.float32),
-                group=self.token_dispatcher.moe_all_to_all_group_name,
-                max_output_size=get_ascend_config().mega_moe_max_tokens,
-                swiglu_limit=fused_experts_input.swiglu_limit,
-                x_active_mask=fused_experts_input.routing.mc2_mask,
-                out=out,
-                expert_token_nums=self.expert_token_nums,
-            )
-            expert_tokens = self.expert_token_nums
+                out = torch.empty_like(fused_experts_input.hidden_states)
+                torch.ops._C_ascend.dispatch_ffn_combine(  # type: ignore
+                    x=fused_experts_input.hidden_states,
+                    weight1=fused_experts_input.weights.w1,
+                    weight2=fused_experts_input.weights.w2,
+                    expert_idx=topk_ids,
+                    scale1=fused_experts_input.weights.w1_scale,
+                    scale2=fused_experts_input.weights.w2_scale,
+                    bias1=fused_experts_input.weights.w1_scale_bias,
+                    bias2=fused_experts_input.weights.w2_scale_bias,
+                    probs=fused_experts_input.topk_weights.to(torch.float32),
+                    group=self.token_dispatcher.moe_all_to_all_group_name,
+                    max_output_size=get_ascend_config().mega_moe_max_tokens,
+                    swiglu_limit=fused_experts_input.swiglu_limit,
+                    x_active_mask=fused_experts_input.routing.mc2_mask,
+                    out=out,
+                    expert_token_nums=self.expert_token_nums,
+                )
+                expert_tokens = self.expert_token_nums
         else:
             raise ValueError(f"Wrong value of {get_ascend_config().enable_fused_mc2=}")
         return FusedExpertsResult(

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -124,6 +124,11 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         num_tokens_per_tp_rank = mc2_tokens_capacity // tp_size
+        # Surface the per-rank capacity for CANN MegaMoe's get_symm_buffer
+        # sizing (used by FusedMC2CommImpl._get_cann_symm_buffer). Without
+        # this, MegaMoe falls back to hidden_states.shape[0] which jitters
+        # under eager mode and forces sym-buffer rebuilds every step.
+        self.max_num_tokens_per_rank = num_tokens_per_tp_rank
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -950,7 +950,6 @@ class NPUPlatform(Platform):
         moe_comm_type = select_moe_comm_method(
             num_tokens,
             vllm_config,
-            is_draft_model=is_draft_model,
         )
         moe_comm_method = get_moe_comm_method(moe_comm_type)
 

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -25,7 +25,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -558,6 +558,22 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             w2_scale = layer.w2_weight_scale_list
             w1_scale_bias = layer.w13_scale_bias_list
             w2_scale_bias = layer.w2_scale_bias_list
+        elif (
+            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
+            and get_ascend_config().enable_fused_mc2 == 1
+            and _MEGA_MOE_SUPPORTED
+        ):
+            w1 = layer.cann_mega_moe_w13_weight_list
+            w1_scale = layer.cann_mega_moe_w13_weight_scale_list
+            w2 = layer.cann_mega_moe_w2_weight_list
+            w2_scale = layer.cann_mega_moe_w2_weight_scale_list
+
+            def cast_bias_to_fp32(bias):
+                lst = bias if isinstance(bias, list) else [bias]
+                return [t if t.dtype == torch.float32 else t.to(torch.float32) for t in lst]
+
+            w1_scale_bias = cast_bias_to_fp32(layer.cann_mega_moe_w13_scale_bias_list)
+            w2_scale_bias = cast_bias_to_fp32(layer.cann_mega_moe_w2_scale_bias_list)
         else:
             w1 = [layer.w13_weight]
             w1_scale = [layer.w13_weight_scale]
@@ -719,10 +735,38 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         # Packs 2 int4 into 1 int8 on-the-fly to mirror the modelslim new_quant_version path
         layer.w13_weight.data = self.pack_int4_to_int8(layer.w13_weight.data)
         layer.w2_weight.data = self.pack_int4_to_int8(layer.w2_weight.data)
+        # FIX(mega W4A8 all-route): with MegaMoe on, keep ND int8 (skip trans_nz + pack_to_int32);
+        # _maybe_build_cann_mega_moe_lists casts each expert slice to FRACTAL_NZ individually. See
+        # the modelslim path below for the full rationale. Non-mega keeps the standard NZ-int32 form.
+        if get_ascend_config().enable_fused_mc2 == 1 and not self.dynamic_eplb and _MEGA_MOE_SUPPORTED:
+            self._maybe_build_cann_mega_moe_lists(layer)
+        else:
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
+            layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
+            layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)
+
+    def _maybe_build_cann_mega_moe_lists(self, layer):
         layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
         layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
-        layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
-        layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)
+        layer.cann_mega_moe_w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
+        layer.cann_mega_moe_w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
+
+        layer.cann_mega_moe_w13_weight_scale_list = [t.reshape(-1) for t in layer.w13_weight_scale.data.unbind(dim=0)]
+        layer.cann_mega_moe_w2_weight_scale_list = [t.reshape(-1) for t in layer.w2_weight_scale.data.unbind(dim=0)]
+        if not hasattr(layer, "w13_scale_bias"):
+            raise RuntimeError(
+                "MegaMoe only support W4A8 INT on A2/A3 for weight with w1 scale bias and w2 scale bias."
+                "Try to disable MegaMoe to avoid this error."
+            )
+        layer.cann_mega_moe_w13_scale_bias_list = [t.reshape(-1) for t in layer.w13_scale_bias.data.unbind(dim=0)]
+        layer.cann_mega_moe_w2_scale_bias_list = [t.reshape(-1) for t in layer.w2_scale_bias.data.unbind(dim=0)]
+        del layer.w13_weight
+        del layer.w2_weight
+        del layer.w13_weight_scale
+        del layer.w2_weight_scale
+        del layer.w13_scale_bias
+        del layer.w2_scale_bias
 
     def process_weights_after_loading_modelslim(self, layer):
         layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2).contiguous()
@@ -749,10 +793,10 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
 
         if self.is_per_channel_weight:
             layer.w13_weight_scale.data = self.maybe_squeeze_per_channel_weight_scale(layer.w13_weight_scale.data)
-        layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
-        layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
 
         if self.dynamic_eplb:
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
             layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
             layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
             layer.w13_weight_scale_list = [weight.clone() for weight in layer.w13_weight_scale.data.unbind(dim=0)]
@@ -773,6 +817,12 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             del layer.w2_weight_scale
             del layer.w13_scale_bias
             del layer.w2_scale_bias
+        # keep weights as ND int8 when MegaMoe is on (skip trans_nz).
+        elif get_ascend_config().enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED:
+            self._maybe_build_cann_mega_moe_lists(layer)
+
         else:
+            layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
+            layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
             layer.w13_weight.data = self.pack_to_int32(layer.w13_weight.data)
             layer.w2_weight.data = self.pack_to_int32(layer.w2_weight.data)

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -24,7 +24,7 @@ from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -303,14 +303,24 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
             w2 = layer.w2_weight_list
             w2_scale = layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
+            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+
+        elif fused_scale_flag and _MEGA_MOE_SUPPORTED:
+            w1 = layer.cann_mega_moe_w13_weight_list
+            w1_scale = layer.cann_mega_moe_fused_w1_scale_list
+            w2 = layer.cann_mega_moe_w2_weight_list
+            w2_scale = layer.cann_mega_moe_fused_w2_scale_list
+            w1_scale_bias = None
+            w2_scale_bias = None
+
         else:
             w1 = [layer.w13_weight]
             w1_scale = [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
             w2 = [layer.w2_weight]
             w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
-
-        w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-        w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
 
         final_hidden_states = moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(
@@ -384,3 +394,13 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 del layer.fused_w1_scale
                 del layer.fused_w2_scale
             torch.npu.empty_cache()
+
+        elif get_ascend_config().enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED:
+            layer.cann_mega_moe_w13_weight_list = list(layer.w13_weight.data.unbind(dim=0))
+            layer.cann_mega_moe_w2_weight_list = list(layer.w2_weight.data.unbind(dim=0))
+            layer.cann_mega_moe_fused_w1_scale_list = list(
+                layer.fused_w1_scale.view(layer.w13_weight.shape[0], -1).data.unbind(dim=0)
+            )
+            layer.cann_mega_moe_fused_w2_scale_list = list(
+                layer.fused_w2_scale.view(layer.w2_weight.shape[0], -1).data.unbind(dim=0)
+            )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR **backports CANN MegaMoe support** from upstream PR [#11701](https://github.com/vllm-project/vllm-ascend/pull/11701) to the `releases/v0.23.0` branch for Atlas A3 inference products.

CANN 9.1 introduces `cann_ops_transformer.ops.mega_moe` as the maintained replacement for the legacy DispatchFFNCombine fused MoE path. This backport integrates the official CANN operator while preserving the existing v0.23.0 MC2 behavior required by release users.

The resulting mode mapping:

| `enable_fused_mc2` | Runtime path |
| ---: | --- |
| `0` | Baseline MoE dispatch + ordinary grouped matmul |
| `1` | **CANN `cann_ops_transformer.ops.mega_moe`** when the CANN extension is available; legacy `dispatch_ffn_combine` fallback otherwise |
| `2` | Existing v0.23.0 `_C_ascend.dispatch_gmm_combine_decode` path |
| `3` | Unsupported |

Upstream PR #11701 maps MegaMoe to `enable_fused_mc2 == 1`. MC2=2 is retained only because it already exists on the v0.23.0 release branch.

#### Changes in this PR

| File | Change |
| --- | --- |
| `vllm_ascend/ascend_forward_context.py` | Select CANN MegaMoe for supported Atlas A3 configurations, keep the release MC2=2 route, and preserve profile/warmup routing. |
| `vllm_ascend/ops/fused_moe/comm_utils.py` | Load `mega_moe` and `get_symm_buffer_for_mega_moe`; map W8A8 and W4A8 quantization parameters. |
| `vllm_ascend/ops/fused_moe/moe_comm_method.py` | Allocate a rank-invariant symmetric buffer, prepare operator arguments, and invoke CANN MegaMoe. |
| `vllm_ascend/ops/fused_moe/token_dispatcher.py` | Expose the scheduler token capacity needed for deterministic symmetric-buffer sizing on all EP ranks. |
| `vllm_ascend/quantization/methods/w8a8_dynamic.py` | Build per-expert W8A8 weights and scales consumed by MegaMoe. |
| `vllm_ascend/quantization/methods/w4a8.py` | Build per-expert W4A8 weights, scales, and precision-compensation scale biases. |
| `tests/ut/test_ascend_forward_context.py` | Cover A3 route selection, token capacity, profile/warmup, and fallback behavior. |
| `tests/ut/quantization/methods/a2/test_w4a8.py` | Cover the W4A8 per-expert weight preparation introduced by the integration. |

#### Symmetric-buffer correctness

`get_symm_buffer_for_mega_moe` performs a collective handshake over the EP group. All ranks must pass identical shape parameters and allocate the buffer at the same point in execution.

The backport therefore derives `num_max_tokens_per_rank` only from rank-invariant scheduler and graph configuration. It does not size the buffer from the current rank's dynamic token count. This avoids mismatched allocations and HCCL `SUSPECT REMOTE ERROR 507057` failures.

The buffer is cached in the MoE communication method instance and reused after the first allocation.

#### Quantization handling

The A3 MegaMoe path supports the GLM quantization layouts required by this backport:

| Quantization | Dispatch mode | Dispatch output | Weight type |
| --- | --- | --- | --- |
| W8A8 | INT8 | ACL INT8 | ACL INT8 |
| W4A8 | INT8 | ACL INT8 | ACL INT4 |

W4A8 uses an INT8 carrier with two packed INT4 values per byte and an explicit ACL INT4 weight type. The integration also passes the W4A8 first- and second-layer precision-compensation scale biases required by the CANN operator.

#### Compatibility decisions

- The release branch's `is_draft_model` interface is preserved.
- The v0.23.0 MC2=2 `dispatch_gmm_combine_decode` path is unchanged.
- The MegaMoe EP-size guard follows the documented A3 set: **2, 4, 8, 16, 32**.
- MegaMoe uses the documented maximum of **4,096 input tokens per rank**.
- Shared experts and unsupported quantization types remain on their existing path.
- This backport does **not** add A2 MegaMoe route selection.

#### Diff size

```text
8 files changed, 517 insertions(+), 60 deletions(-)
```

- Production code: 6 files, +374/-53
- Tests: 2 files, +143/-7

### Does this PR introduce _any_ user-facing change?

No OpenAI-compatible API, model configuration, or CLI option is added.

The existing `enable_fused_mc2` setting is reused. On Atlas A3 with a compatible CANN 9.1 extension, `enable_fused_mc2=1` now selects the maintained CANN MegaMoe implementation. If the CANN MegaMoe Python extension is unavailable, the existing DispatchFFNCombine fallback remains available.

The existing v0.23.0 `enable_fused_mc2=2` behavior is preserved.

### How was this patch tested?

#### Software baseline

| Component | Revision / Version |
| --- | --- |
| vLLM | `0.23.0+empty` |
| vLLM-Ascend baseline | `0bcb677b528d894752e6a790a36b1f51afd78889` |
| Upstream PR #11701 head | `3307e023673386fedaafa8cb2a03ca7c60059009` |
| Backport commit | `9ebc4edf38f72438f63f67e558c49e7a0231ae40` |
| torch / torch-npu | `2.10.0` |
| triton-ascend | `3.2.2+dev` |
| CANN | **`9.1.0`** |

Validated runtime environment: CANN 9.1.0 / Atlas A3 / Python 3.11 / openEuler 24.03.

#### Model & execution configuration

| Item | Value |
| --- | --- |
| Model | GLM-5.2 W8A8 |
| Device | Atlas A3 inference product |
| Parallelism | TP16 / EP16 / DP1 |
| Max model length | 10,240 |
| Max batched tokens | 4,096 |
| Max sequences | 16 |
| Prefix cache | Enabled |
| Graph mode | `FULL_DECODE_ONLY` |
| Graph capture size | 16 |
| HCCL buffer | 2,048 MB |
| GPU memory utilization | 0.95 |

#### Build

```bash
source /usr/local/Ascend/cann-9.1.0/set_env.sh
cd <PATH_TO_VLLM_ASCEND>
MAX_JOBS=16 pip install -v -e . --no-build-isolation --no-deps
```

#### Unit tests

```bash
pytest -q \
  tests/ut/test_ascend_forward_context.py \
  tests/ut/quantization/methods/a2/test_w4a8.py
```

Result: **42 passed** in 9.28s.

#### CANN operator availability check

```python
from cann_ops_transformer import ops

assert hasattr(ops, "mega_moe")
assert hasattr(ops, "get_symm_buffer_for_mega_moe")
```

Both required interfaces were available in the validation image.

#### Service startup command (reproduction template)

Use generic local model paths when reproducing. No internal host, credential, or account path is required by the implementation.

```bash
source /usr/local/Ascend/cann-9.1.0/set_env.sh

export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
export VLLM_ASCEND_ENABLE_NZ=1
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
export VLLM_ASCEND_ENABLE_MLAPO=0
export HCCL_BUFFSIZE=2048
export HCCL_BUFFSIZE_EP=2048
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True

vllm serve <PATH_TO_GLM-5.2-w8a8> \
  --served-model-name GLM-5.2-w8a8 \
  --tensor-parallel-size 16 \
  --data-parallel-size 1 \
  --enable-expert-parallel \
  --max-model-len 10240 \
  --max-num-batched-tokens 4096 \
  --max-num-seqs 16 \
  --enable-prefix-caching \
  --trust-remote-code \
  --gpu-memory-utilization 0.95 \
  --quantization ascend \
  --safetensors-load-strategy lazy \
  --compilation-config \
    '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[16],"pass_config":{"fuse_norm_quant":false}}' \
  --additional-config \
    '{"enable_fused_mc2":1,"enable_prefill_mc2":true,"enable_sparse_c8":false,
      "ascend_compilation_config":{"enable_npugraph_ex":true,"fuse_norm_quant":false}}'
```

Change only `enable_fused_mc2` to `0` for the baseline comparison.

#### MegaMoe path verification

The MC2=1 service log contained the following message for **all 16 unique EP ranks**:

```text
CANN MegaMoe sym-buffer alloc (must match across all EP ranks):
ep_rank=<0..15> ep_world=16 global_bs=0
```

This confirms that profile/warmup entered the CANN MegaMoe implementation, that all EP ranks participated in the symmetric-buffer allocation, and that the `FULL_DECODE_ONLY` graph capture/replay completed successfully.

#### Online correctness smoke (W8A8)

A fixed greedy request via `POST /v1/chat/completions` returned HTTP 200 with coherent output on both MC2=0 and MC2=1. No all-zero output, malformed JSON, or service failure was observed. W4A8 preparation is covered by the focused unit test; a full W4A8 hardware accuracy suite is not claimed here.

#### AISBench results (round 2, after warmup)

Shape: `input_len=8192, output_len=1024, data_num=64, concurrency=16, prefix_cache dataset` (effective input ≈ 8,204 tokens after chat template · service-observed prefix-cache hit ≈ 88%).

| Metric | MC2=0 baseline | MC2=1 CANN MegaMoe | Δ |
| --- | ---: | ---: | ---: |
| Successful requests | 64/64 | 64/64 | Same |
| Average TTFT | 2,310.2 ms | 2,232.0 ms | **−3.39%** |
| P90 TTFT | 3,531.7 ms | 3,314.2 ms | **−6.16%** |
| Average TPOT | 65.5 ms | 64.1 ms | **−2.14%** |
| P90 TPOT | 66.3 ms | 64.9 ms | **−2.11%** |
| Output throughput | 236.31 tok/s | **241.42 tok/s** | **+2.16%** |
| Total throughput | 2,129.58 tok/s | **2,175.61 tok/s** | **+2.16%** |
| Prefill throughput | 3,551.20 tok/s | **3,675.65 tok/s** | **+3.50%** |
| Benchmark duration | 277.33 s | 271.46 s | **−2.12%** |

Repeatable end-to-end throughput gain after removing KV-capacity interference from the comparison.

#### KV-capacity diagnosis

An initial comparison used `gpu_memory_utilization=0.92` for both modes. MegaMoe's symmetric buffer reduced remaining KV capacity by ≈ 0.38 GiB (35,712 → 31,488 tokens), causing MC2=1 to hit 100% KV usage and queue requests, producing a misleading regression.

Raising both modes to **`gpu_memory_utilization=0.95`** (56,448 vs 52,224 KV tokens) eliminated request waiting in both runs and revealed the signed 2.16% throughput improvement. This is a test-capacity correction, not a MegaMoe code special case; both paths use identical service and benchmark configuration.

#### Reviewer checklist

- [x] Backport is based on the documented v0.23.0 release commit.
- [x] The upstream implementation and merge PR (#11701) are linked.
- [x] vLLM itself is unmodified.
- [x] MC2=0 baseline behavior is preserved.
- [x] Existing v0.23.0 MC2=2 behavior is preserved.
- [x] MC2=1 selects CANN MegaMoe on supported Atlas A3 configurations.
- [x] Symmetric-buffer sizing is rank-invariant.
- [x] W8A8 online smoke passes; W4A8 UT passes.
- [x] All 16 EP ranks enter the MegaMoe allocation path.
- [x] Graph capture and replay complete successfully.
- [x] Two-round AISBench comparison shows an end-to-end performance gain.
- [x] No sensitive environment information is committed.
- [ ] Run the complete upstream CI matrix in the official build environment.
- [ ] Run the full W4A8 hardware accuracy suite if it is required as a release gate.

Co-authored-by: nanshen3000 <2693653227@qq.com>

- Upstream PR: https://github.com/vllm-project/vllm-ascend/pull/11701

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
