### PR TITLE
[Cherry-pick][releases/v0.23.0][BugFix] Fix commmode setting of mm_reduce_scatter for bf16 in A5 (#12689)

### DIFF
--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+import os
 from typing import Any
 
 import torch
@@ -157,6 +158,35 @@ class BaseDeviceAdaptor:
             bias_opt=bias_opt,
         )
         return topk_weights, topk_ids.to(torch.int32), out
+
+    @staticmethod
+    def npu_mm_reduce_scatter_base(
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        hcom: str,
+        world_size: int,
+        *,
+        reduce_op: str = "sum",
+        bias: torch.Tensor | None = None,
+        x1_scale: torch.Tensor | None = None,
+        x2_scale: torch.Tensor | None = None,
+        comm_turn: int = 0,
+        output_dtype: torch.dtype | None = None,
+        comm_mode: str = "aiv",
+    ):
+        return torch_npu.npu_mm_reduce_scatter_base(
+            x1,
+            x2,
+            hcom,
+            world_size,
+            reduce_op=reduce_op,
+            bias=bias,
+            comm_turn=comm_turn,
+            x1_scale=x1_scale,
+            x2_scale=x2_scale,
+            output_dtype=output_dtype,
+            comm_mode=comm_mode,
+        )
 
     @staticmethod
     def npu_dynamic_quant(
@@ -1234,6 +1264,39 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
 
         return topk_weights, topk_ids.to(torch.int32), out
+
+    @staticmethod
+    def npu_mm_reduce_scatter_base(
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        hcom: str,
+        world_size: int,
+        *,
+        reduce_op: str = "sum",
+        bias: torch.Tensor | None = None,
+        x1_scale: torch.Tensor | None = None,
+        x2_scale: torch.Tensor | None = None,
+        comm_turn: int = 0,
+        output_dtype: torch.dtype | None = None,
+        comm_mode: str = "ai_cpu",
+    ):
+        expansion_mode = os.environ.get("HCCL_OP_EXPANSION_MODE")
+        if expansion_mode == "CCU_SCHED":
+            comm_mode = "ccu"
+
+        return torch_npu.npu_mm_reduce_scatter_base(
+            x1,
+            x2,
+            hcom,
+            world_size,
+            reduce_op=reduce_op,
+            bias=bias,
+            comm_turn=comm_turn,
+            x1_scale=x1_scale,
+            x2_scale=x2_scale,
+            output_dtype=output_dtype,
+            comm_mode=comm_mode,
+        )
 
     @staticmethod
     def npu_dynamic_quant(

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -62,6 +62,7 @@ from vllm.model_executor.models.utils import extract_layer_index
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import (
     get_flashcomm2_odp_group,
     get_flashcomm2_otp_group,
@@ -556,7 +557,6 @@ class SequenceRowParallelOp(CustomRowParallelOp):
             x = F.pad(x, (0, 0, 0, pad_size))
 
         world_size = self.layer.tp_size
-        comm_mode = "aiv"
         hcom_name = get_tp_group().device_group._get_backend(torch.device("npu")).get_hccl_comm_name(self.layer.tp_rank)
 
         from vllm.model_executor.layers.linear import UnquantizedLinearMethod
@@ -566,7 +566,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
 
         # For unquant
         if mmrs_fusion and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
-            output = torch_npu.npu_mm_reduce_scatter_base(
+            output = DeviceOperator.npu_mm_reduce_scatter_base(
                 x,
                 self.layer.weight.t(),
                 hcom_name,
@@ -574,7 +574,6 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 reduce_op="sum",
                 bias=None,
                 comm_turn=0,
-                comm_mode=comm_mode,
             )
             if bias_ is not None:
                 output.add_(bias_)
@@ -595,7 +594,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
             quant_bias = self.layer.quant_bias
             deq_scale = self.layer.deq_scale
             output_dtype = torch.bfloat16
-            output = torch_npu.npu_mm_reduce_scatter_base(
+            output = DeviceOperator.npu_mm_reduce_scatter_base(
                 x_quant,
                 self.layer.weight,
                 hcom_name,
@@ -605,7 +604,6 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 comm_turn=0,
                 x2_scale=deq_scale,
                 output_dtype=output_dtype,
-                comm_mode=comm_mode,
             )
             output = torch.add(output, torch.mul(quant_bias, deq_scale).to(self.layer.params_dtype))
         else:


### PR DESCRIPTION
### What this PR does / why we need it?
Cherry-pick of https://github.com/vllm-project/vllm-ascend/pull/12689 to releases/v0.23.0.

In old version CANN for A5, mm_reduce_scatter op treated all values for comm_mode as "ccu". Even "aiv" is passed.
In new version CANN for A5, mm_reduce_scatter can read the real value for comm_mode. When it gets "aiv", it thows Invalid_Argument ERROR and remaids that it should be "ccu" or "ai_cpu". So it should be set according to the hccl expansion mode in A5.
In A2/A3, it still be set as "aiv".

### Does this PR introduce _any_ user-facing change?
NO.

### How was this patch tested?
CI passed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
