### PR TITLE
[Refactor][Misc] Remove unused shared expert DP flags

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/configuration/additional_config.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/user_guide/configuration/additional_config.po
@@ -238,11 +238,10 @@ msgstr ""
 
 msgid ""
 "| `enable_shared_expert_dp`           | bool | `False` | When the expert is "
-"shared in DP, it delivers better performance but consumes more memory. "
-"Currently only DeepSeek series models are supported. |"
+"shared in DP, it delivers better performance but consumes more memory. |"
 msgstr ""
 "| `enable_shared_expert_dp`           | bool | `False` | 当专家在 DP "
-"中共享时，性能更好但内存消耗更大。目前仅支持 DeepSeek 系列模型。 |"
+"中共享时，性能更好但内存消耗更大。 |"
 
 msgid ""
 "| `multistream_overlap_shared_expert` | bool | `False` | Whether to enable "

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -72,7 +72,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `refresh`                           | bool | `false` | Whether to refresh global Ascend configuration content. This is usually used by rlhf or ut/e2e test case. |
 | `dump_config`                       | dict | `None`  | Inline msprobe dump configuration. vLLM-Ascend will materialize it to a temporary JSON file and pass that file to the debugger. |
 | `dump_config_path`                  | str  | `None`  | Configuration file path for msprobe dump (compatible legacy option).                                      |
-| `enable_shared_expert_dp`           | bool | `False` | When the expert is shared in DP, it delivers better performance but consumes more memory. Currently only DeepSeek series models are supported. |
+| `enable_shared_expert_dp`           | bool | `False` | When the expert is shared in DP, it delivers better performance but consumes more memory. |
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
 | `enable_sleep_mode_extra_cleanup`   | bool | `False` | Enables extra sleep-mode cleanup for RL workloads, including HCCL process-group release and ACL graph workspace cleanup. Disabled by default because wakeup may need to restore HCCL and recapture ACL graphs. |

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -85,7 +85,6 @@ class TestAscendMultiHeadLatentAttention(TestBase):
 
         with patch("vllm_ascend.ops.mla.MLAAttention", return_value=mock_mla_attn):
             mock_tp_size.return_value = 2
-            mock_ascend_config.return_value.enable_shared_expert_dp = True
             mock_vllm_config = MagicMock(spec=VllmConfig)
             mock_vllm_config.model_config.hf_text_config = MagicMock(num_hidden_layers=32, first_k_dense_replace=True)
             mock_get_vllm_config.return_value = mock_vllm_config
@@ -107,7 +106,6 @@ class TestAscendMultiHeadLatentAttention(TestBase):
             )
 
             self.assertEqual(attn.tp_size, 2)
-            self.assertTrue(attn.enable_shared_expert_dp)
             self.assertIsNotNone(attn.mla_attn)
 
     @patch("vllm_ascend.ops.mla.torch.ops.vllm.mla_forward")

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -735,7 +735,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
 
         ascend_config = get_ascend_config()
-        self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
         self.enable_kv_nz = ascend_config.enable_kv_nz
 
         self.ring_mla_mask_size = 512

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -542,7 +542,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
 
         ascend_config = get_ascend_config()
-        self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
         self.vllm_config = get_current_vllm_config()
         kv_transfer_config = self.vllm_config.kv_transfer_config
         self.is_kv_producer = kv_transfer_config is not None and kv_transfer_config.is_kv_producer

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -92,7 +92,6 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         self.prefix = prefix
         self.skip_topk = skip_topk
         hf_config = get_current_vllm_config().model_config.hf_text_config
-        self.enable_shared_expert_dp = get_ascend_config().enable_shared_expert_dp
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layers = hf_config.num_hidden_layers
         if mla_modules.indexer is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

Remove unused `enable_shared_expert_dp` attributes from MLA attention paths and update the `additional_config` documentation to avoid describing shared expert DP as DeepSeek-only.

The shared expert DP behavior is implemented in the MoE and linear parallelism paths, so caching this config in MLA attention classes is unnecessary.

### Does this PR introduce _any_ user-facing change?

No. This removes unused internal attributes and updates documentation wording.

### How was this patch tested?

- `git diff --check`
- `python -m py_compile vllm_ascend/attention/mla_v1.py vllm_ascend/attention/sfa_v1.py vllm_ascend/ops/mla.py tests/ut/ops/test_mla.py`

`pytest -q tests/ut/ops/test_mla.py` was attempted locally but could not start because the installed vLLM package in this environment does not expose `MoERunner` from `vllm.model_executor.layers.fused_moe.layer`, which is an environment/API mismatch unrelated to this patch.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
