### PR TITLE
[Performance] Optimize Qwen3-VL/Qwen3.5 ViT preprocess with device-side rescale/normalize

### DIFF
--- a/tests/ut/patch/worker/test_patch_qwen3vl_preprocess.py
+++ b/tests/ut/patch/worker/test_patch_qwen3vl_preprocess.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Equivalence guards for the device-side Qwen3-VL rescale/normalize patch.
+
+The device path only replaces work the HF processor used to do on the host, so
+these tests pin it against a reference implementation of that host math. The
+packed-patch layout is the fragile part: the HF image/video processors flatten
+each patch as ``[channel][temporal][ph][pw]``, and reading it back with the
+channel axis in the wrong place silently normalizes the wrong channels. That
+mistake is invisible for checkpoints whose ``image_mean``/``image_std`` are
+equal across channels, so the tests below deliberately use per-channel values.
+"""
+
+import importlib
+import inspect
+
+import pytest
+import torch
+from vllm.model_executor.models.qwen3_vl import Qwen3VLForConditionalGeneration
+
+from vllm_ascend.patch.worker.patch_qwen3vl import _PREPROCESS_ATTR, _apply_rescale_normalize, _VLPreprocessConfig
+
+CHANNEL = 3
+TEMPORAL_PATCH_SIZE = 2
+PATCH_SIZE = 4
+GRID_H = GRID_W = 2
+
+# Per-channel values (the transformers class defaults) rather than the equal
+# values some checkpoints ship, so a channel mixup shows up as a mismatch.
+IMAGE_MEAN = (0.48145466, 0.4578275, 0.40821073)
+IMAGE_STD = (0.26862954, 0.26130258, 0.27577711)
+RESCALE_FACTOR = 1 / 255.0
+
+
+class _FakeVisual:
+    dtype = torch.float32
+
+
+class _FakeModel:
+    """Stands in for the model the patch binds ``_apply_rescale_normalize`` to."""
+
+    def __init__(self, cfg):
+        self.visual = _FakeVisual()
+        setattr(self, _PREPROCESS_ATTR, cfg)  # noqa: B010
+
+
+def _make_config(do_rescale=True, do_normalize=True):
+    return _VLPreprocessConfig(
+        channel=CHANNEL,
+        patch_size=PATCH_SIZE,
+        temporal_patch_size=TEMPORAL_PATCH_SIZE,
+        do_rescale=do_rescale,
+        rescale_factor=RESCALE_FACTOR,
+        do_normalize=do_normalize,
+        image_mean=IMAGE_MEAN,
+        image_std=IMAGE_STD,
+    )
+
+
+def _flatten_patches(image: torch.Tensor) -> torch.Tensor:
+    """Pack ``(C, T, H, W)`` the way the HF processors emit ``pixel_values``."""
+    packed = image.reshape(CHANNEL, TEMPORAL_PATCH_SIZE, GRID_H, PATCH_SIZE, GRID_W, PATCH_SIZE)
+    packed = packed.permute(2, 4, 0, 1, 3, 5)
+    return packed.reshape(GRID_H * GRID_W, CHANNEL * TEMPORAL_PATCH_SIZE * PATCH_SIZE * PATCH_SIZE)
+
+
+def _host_reference(image: torch.Tensor, do_rescale: bool, do_normalize: bool) -> torch.Tensor:
+    """What the HF processor would have produced before this patch."""
+    out = image
+    if do_rescale:
+        out = out * RESCALE_FACTOR
+    if do_normalize:
+        mean = torch.tensor(IMAGE_MEAN).view(CHANNEL, 1, 1, 1)
+        std = torch.tensor(IMAGE_STD).view(CHANNEL, 1, 1, 1)
+        out = (out - mean) / std
+    return _flatten_patches(out)
+
+
+def _random_image() -> torch.Tensor:
+    generator = torch.Generator().manual_seed(0)
+    shape = (CHANNEL, TEMPORAL_PATCH_SIZE, GRID_H * PATCH_SIZE, GRID_W * PATCH_SIZE)
+    return torch.randint(0, 256, shape, generator=generator).float()
+
+
+def test_device_preprocess_matches_host_fused_rescale_normalize():
+    image = _random_image()
+    model = _FakeModel(_make_config())
+
+    actual = _apply_rescale_normalize(model, _flatten_patches(image))
+
+    torch.testing.assert_close(actual, _host_reference(image, True, True), rtol=1e-5, atol=1e-5)
+
+
+def test_device_preprocess_matches_host_normalize_only():
+    image = _random_image()
+    model = _FakeModel(_make_config(do_rescale=False))
+
+    actual = _apply_rescale_normalize(model, _flatten_patches(image))
+
+    torch.testing.assert_close(actual, _host_reference(image, False, True), rtol=1e-5, atol=1e-5)
+
+
+def test_device_preprocess_matches_host_rescale_only():
+    image = _random_image()
+    model = _FakeModel(_make_config(do_normalize=False))
+
+    actual = _apply_rescale_normalize(model, _flatten_patches(image))
+
+    torch.testing.assert_close(actual, _host_reference(image, True, False), rtol=1e-5, atol=1e-5)
+
+
+def test_device_preprocess_is_a_noop_when_host_still_preprocesses():
+    """Both flags off means the platform patch did not run and HF already did the work."""
+    image = _random_image()
+    flat = _flatten_patches(image)
+    model = _FakeModel(_make_config(do_rescale=False, do_normalize=False))
+
+    actual = _apply_rescale_normalize(model, flat)
+
+    torch.testing.assert_close(actual, flat)
+
+
+def test_device_preprocess_preserves_packed_patch_shape():
+    image = _random_image()
+    flat = _flatten_patches(image)
+    model = _FakeModel(_make_config())
+
+    assert _apply_rescale_normalize(model, flat).shape == flat.shape
+
+
+def _hooked_model_classes():
+    classes = [Qwen3VLForConditionalGeneration]
+    for module_name, class_names in (
+        ("vllm.model_executor.models.qwen3_vl_moe", ("Qwen3VLMoeForConditionalGeneration",)),
+        (
+            "vllm.model_executor.models.qwen3_5",
+            ("Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration"),
+        ),
+    ):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        classes.extend(cls for cls in (getattr(module, name, None) for name in class_names) if cls is not None)
+    return classes
+
+
+@pytest.mark.parametrize("model_cls", _hooked_model_classes(), ids=lambda cls: cls.__name__)
+def test_init_hook_keeps_vllm_config_visible_in_signature(model_cls):
+    """vLLM picks the construction path by looking for these two parameter names.
+
+    A wrapper that only takes ``*args, **kwargs`` hides them, and vLLM then
+    falls back to its old-style path and constructs the model without
+    ``vllm_config``.
+    """
+    params = inspect.signature(model_cls.__init__).parameters
+
+    assert "vllm_config" in params
+    assert "prefix" in params

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -585,8 +585,10 @@
 #       be a platform patch; otherwise CPU still normalizes and the worker
 #       normalizes again (token drift).
 #    How：
-#       Force image/video processor do_rescale=False and do_normalize=False.
-#       Device-side fused normalize is applied in worker/patch_qwen3vl.py.
+#       Record what the image/video processor was configured to do, then force
+#       do_rescale=False and do_normalize=False. worker/patch_qwen3vl.py reads
+#       the recorded flags so the device applies exactly the same math, and can
+#       stay idle when this patch did not run.
 #    Future Plan:
 #       Remove when upstream vLLM applies equivalent device-side preprocess for
 #       Qwen3-VL / Qwen3.5.
@@ -1030,15 +1032,18 @@
 #   4. `Qwen3VLForConditionalGeneration.__init__`,
 #      `Qwen3VLForConditionalGeneration._process_image_input`,
 #      `Qwen3VLForConditionalGeneration._process_video_input`,
-#      and Qwen3.5 / Qwen3.5-MoE `__init__`
+#      and Qwen3-VL-MoE / Qwen3.5 / Qwen3.5-MoE `__init__`
 #    Why:
 #       Apply fused rescale+normalize on device before ViT, after HF processor
 #       rescale/normalize is disabled by platform/patch_qwen3vl_processor.py.
-#       Qwen3.5 reimplements __init__ without calling Qwen3VL.__init__, so it
-#       must be patched separately.
+#       Qwen3-VL-MoE, Qwen3.5 and Qwen3.5-MoE reimplement __init__ without
+#       calling Qwen3VL.__init__, so each must be patched separately.
 #    How：
-#       Cache preprocess params in init; reshape pixel_values and run
-#       rescale_and_normalize on NPU before the vision tower.
+#       Cache preprocess params in init; view pixel_values as NCHW with the
+#       temporal patches folded into the height axis (the packed layout is
+#       [channel][temporal][ph][pw], so reshaping straight to a per-patch NCHW
+#       would normalize the wrong channels) and run rescale_and_normalize on
+#       NPU before the vision tower.
 #    Future Plan:
 #       Remove when upstream vLLM applies equivalent device-side preprocess for
 #       Qwen3-VL / Qwen3.5.

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -576,6 +576,21 @@
 #       the code path that actually needs ray), so importing the IPC engine no
 #       longer requires the optional ray dependency.
 #
+# ** 22. File: platform/patch_qwen3vl_processor.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.model_executor.models.qwen3_vl.Qwen3VLProcessingInfo.get_hf_processor`
+#    Why:
+#       Move image/video rescale+normalize off the HF processor (CPU) onto the
+#       device (NPU). The APIServer owns multimodal preprocessing, so this must
+#       be a platform patch; otherwise CPU still normalizes and the worker
+#       normalizes again (token drift).
+#    How：
+#       Force image/video processor do_rescale=False and do_normalize=False.
+#       Device-side fused normalize is applied in worker/patch_qwen3vl.py.
+#    Future Plan:
+#       Remove when upstream vLLM applies equivalent device-side preprocess for
+#       Qwen3-VL / Qwen3.5.
+#
 # * Worker Patch:
 # ===============
 # Entries are listed in alphabetical order by file name.
@@ -1012,6 +1027,21 @@
 #       when using mrope.
 #    Future Plan:
 #       Remove this patch when vllm-ascend supports pattern matching for this fused kernel.
+#   4. `Qwen3VLForConditionalGeneration.__init__`,
+#      `Qwen3VLForConditionalGeneration._process_image_input`,
+#      `Qwen3VLForConditionalGeneration._process_video_input`,
+#      and Qwen3.5 / Qwen3.5-MoE `__init__`
+#    Why:
+#       Apply fused rescale+normalize on device before ViT, after HF processor
+#       rescale/normalize is disabled by platform/patch_qwen3vl_processor.py.
+#       Qwen3.5 reimplements __init__ without calling Qwen3VL.__init__, so it
+#       must be patched separately.
+#    How：
+#       Cache preprocess params in init; reshape pixel_values and run
+#       rescale_and_normalize on NPU before the vision tower.
+#    Future Plan:
+#       Remove when upstream vLLM applies equivalent device-side preprocess for
+#       Qwen3-VL / Qwen3.5.
 #
 # ** 21. File: worker/patch_rejection_sampler.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -45,3 +45,4 @@ import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 
 import vllm_ascend.patch.platform.patch_fused_moe  # noqa
 import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
+import vllm_ascend.patch.platform.patch_qwen3vl_processor  # noqa

--- a/vllm_ascend/patch/platform/patch_qwen3vl_processor.py
+++ b/vllm_ascend/patch/platform/patch_qwen3vl_processor.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Disable HF image/video rescale+normalize on the API/frontend.
+
+Device-side normalize is applied in worker/patch_qwen3vl.py. Without this
+platform patch, the APIServer still normalizes on CPU and the Engine applies
+it again, which changes tokens.
+"""
+
+from vllm.model_executor.models.qwen3_vl import Qwen3VLProcessingInfo
+
+
+def _disable_processor_rescale_normalize(processor):
+    image_processor = getattr(processor, "image_processor", None)
+    if image_processor is not None:
+        if hasattr(image_processor, "do_rescale"):
+            image_processor.do_rescale = False
+        if hasattr(image_processor, "do_normalize"):
+            image_processor.do_normalize = False
+    video_processor = getattr(processor, "video_processor", None)
+    if video_processor is not None:
+        if hasattr(video_processor, "do_rescale"):
+            video_processor.do_rescale = False
+        if hasattr(video_processor, "do_normalize"):
+            video_processor.do_normalize = False
+    return processor
+
+
+_orig_get_hf_processor = Qwen3VLProcessingInfo.get_hf_processor
+
+
+def _patched_get_hf_processor(self, **kwargs: object):
+    processor = _orig_get_hf_processor(self, **kwargs)
+    return _disable_processor_rescale_normalize(processor)
+
+
+Qwen3VLProcessingInfo.get_hf_processor = _patched_get_hf_processor

--- a/vllm_ascend/patch/platform/patch_qwen3vl_processor.py
+++ b/vllm_ascend/patch/platform/patch_qwen3vl_processor.py
@@ -22,20 +22,34 @@ it again, which changes tokens.
 
 from vllm.model_executor.models.qwen3_vl import Qwen3VLProcessingInfo
 
+# Attribute holding the flags the HF processor was configured with before they
+# were turned off here. The worker patch reads them so the device path applies
+# exactly what HF would have applied, and so it can tell "HF was disabled by us"
+# apart from "this patch never ran".
+ORIG_PREPROCESS_FLAGS_ATTR = "_ascend_orig_preprocess_flags"
+
+
+def _disable_sub_processor(sub_processor) -> None:
+    if sub_processor is None:
+        return
+    if not hasattr(sub_processor, ORIG_PREPROCESS_FLAGS_ATTR):
+        setattr(
+            sub_processor,
+            ORIG_PREPROCESS_FLAGS_ATTR,
+            {
+                "do_rescale": bool(getattr(sub_processor, "do_rescale", False)),
+                "do_normalize": bool(getattr(sub_processor, "do_normalize", False)),
+            },
+        )
+    if hasattr(sub_processor, "do_rescale"):
+        sub_processor.do_rescale = False
+    if hasattr(sub_processor, "do_normalize"):
+        sub_processor.do_normalize = False
+
 
 def _disable_processor_rescale_normalize(processor):
-    image_processor = getattr(processor, "image_processor", None)
-    if image_processor is not None:
-        if hasattr(image_processor, "do_rescale"):
-            image_processor.do_rescale = False
-        if hasattr(image_processor, "do_normalize"):
-            image_processor.do_normalize = False
-    video_processor = getattr(processor, "video_processor", None)
-    if video_processor is not None:
-        if hasattr(video_processor, "do_rescale"):
-            video_processor.do_rescale = False
-        if hasattr(video_processor, "do_normalize"):
-            video_processor.do_normalize = False
+    _disable_sub_processor(getattr(processor, "image_processor", None))
+    _disable_sub_processor(getattr(processor, "video_processor", None))
     return processor
 
 

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -1,4 +1,7 @@
+from functools import lru_cache
+
 import torch
+from torchvision.transforms import v2  # type: ignore[import-untyped]
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.model_executor.models.qwen3 import Qwen3Attention
 from vllm.model_executor.models.qwen3_moe import Qwen3MoeAttention
@@ -6,7 +9,9 @@ from vllm.model_executor.models.qwen3_vl import (
     Qwen3_VisionTransformer,
     Qwen3VLForConditionalGeneration,
     pos_embed_interpolate_native,
+    run_dp_sharded_mrope_vision_model,
 )
+from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
@@ -108,3 +113,173 @@ def patch_qwen3_vl_moe_pp_layer_range():
 
 
 patch_qwen3_vl_moe_pp_layer_range()
+
+
+# ---------------------------------------------------------------------------
+# Move image/video rescale+normalize from HF processor (CPU) onto device (NPU).
+# HF processor disable lives in platform/patch_qwen3vl_processor.py so the
+# APIServer also skips CPU normalize; otherwise values are normalized twice.
+# ---------------------------------------------------------------------------
+
+
+def _rescale(image: torch.Tensor, scale: float) -> torch.Tensor:
+    return image * scale
+
+
+def _normalize(image: torch.Tensor, mean, std) -> torch.Tensor:
+    return v2.functional.normalize(image, mean, std)
+
+
+@lru_cache(maxsize=10)
+def _fuse_mean_std_and_rescale_factor(
+    do_normalize: bool | None = None,
+    image_mean: float | tuple[float, ...] | None = None,
+    image_std: float | tuple[float, ...] | None = None,
+    do_rescale: bool | None = None,
+    rescale_factor: float | None = None,
+    device: torch.device | None = None,
+) -> tuple:
+    if do_rescale and do_normalize:
+        assert rescale_factor is not None
+        image_mean = torch.tensor(image_mean, device=device) * (1.0 / rescale_factor)
+        image_std = torch.tensor(image_std, device=device) * (1.0 / rescale_factor)
+        do_rescale = False
+    return image_mean, image_std, do_rescale
+
+
+def rescale_and_normalize(
+    images: torch.Tensor,
+    do_rescale: bool,
+    rescale_factor: float,
+    do_normalize: bool,
+    image_mean: float | tuple[float, ...],
+    image_std: float | tuple[float, ...],
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Rescale and normalize images on device (fused when both are enabled)."""
+    image_mean, image_std, do_rescale = _fuse_mean_std_and_rescale_factor(
+        do_normalize=do_normalize,
+        image_mean=image_mean,
+        image_std=image_std,
+        do_rescale=do_rescale,
+        rescale_factor=rescale_factor,
+        device=images.device,
+    )
+    if do_normalize:
+        images = _normalize(images.to(dtype=torch.float32), image_mean, image_std)
+    elif do_rescale:
+        images = _rescale(images.to(dtype=torch.float32), rescale_factor)
+    return images.to(dtype)
+
+
+def _image_post_process_config(self, vision_config, model_config) -> None:
+    image_processor = MULTIMODAL_REGISTRY.create_processor(model_config).info.get_hf_processor().image_processor
+    self.channel = vision_config.in_channels
+    self.patch_size = vision_config.patch_size
+    self.temporal_patch_size = vision_config.temporal_patch_size
+    # HF processor side is disabled (platform patch); always apply on device.
+    self.do_rescale = True
+    self.do_normalize = True
+    self.rescale_factor = image_processor.rescale_factor
+    self.image_mean = tuple(image_processor.image_mean)
+    self.image_std = tuple(image_processor.image_std)
+
+
+def _apply_rescale_normalize(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    if not hasattr(self, "channel"):
+        _image_post_process_config(self, self.config.vision_config, self.model_config)
+    # Keep raw integer/float range until after fp32 normalize; do not cast
+    # uint8 -> bf16 before normalize (avoids precision / scale surprises).
+    pixel_values = pixel_values.to(dtype=torch.float32).reshape(-1, self.channel, self.patch_size, self.patch_size)
+    pixel_values = rescale_and_normalize(
+        pixel_values,
+        self.do_rescale,
+        self.rescale_factor,
+        self.do_normalize,
+        self.image_mean,
+        self.image_std,
+        dtype=self.visual.dtype,
+    )
+    return pixel_values.reshape(
+        -1,
+        self.channel * self.temporal_patch_size * self.patch_size * self.patch_size,
+    )
+
+
+_orig_qwen3vl_init = Qwen3VLForConditionalGeneration.__init__
+
+
+def _patched_qwen3vl_init(self, *, vllm_config, prefix: str = "model"):
+    _orig_qwen3vl_init(self, vllm_config=vllm_config, prefix=prefix)
+    _image_post_process_config(self, self.config.vision_config, self.model_config)
+
+
+Qwen3VLForConditionalGeneration.__init__ = _patched_qwen3vl_init
+
+# Qwen3.5 / Qwen3.5-MoE reimplement __init__ without calling Qwen3VL.__init__,
+# so they must be patched separately.
+try:
+    from vllm.model_executor.models.qwen3_5 import (
+        Qwen3_5ForConditionalGeneration,
+        Qwen3_5MoeForConditionalGeneration,
+    )
+
+    _orig_qwen35_init = Qwen3_5ForConditionalGeneration.__init__
+    _orig_qwen35_moe_init = Qwen3_5MoeForConditionalGeneration.__init__
+
+    def _patched_qwen35_init(self, *, vllm_config, prefix: str = "model"):
+        _orig_qwen35_init(self, vllm_config=vllm_config, prefix=prefix)
+        _image_post_process_config(self, self.config.vision_config, self.model_config)
+
+    def _patched_qwen35_moe_init(self, *, vllm_config, prefix: str = "model"):
+        _orig_qwen35_moe_init(self, vllm_config=vllm_config, prefix=prefix)
+        _image_post_process_config(self, self.config.vision_config, self.model_config)
+
+    Qwen3_5ForConditionalGeneration.__init__ = _patched_qwen35_init
+    Qwen3_5MoeForConditionalGeneration.__init__ = _patched_qwen35_moe_init
+except Exception:
+    pass
+
+
+def _patched_process_image_input(self, image_input):
+    grid_thw = image_input["image_grid_thw"]
+    assert grid_thw.ndim == 2
+
+    if image_input["type"] == "image_embeds":
+        image_embeds = image_input["image_embeds"].type(self.visual.dtype)
+    else:
+        # Do not cast to visual.dtype before normalize (raw uint8/[0,255]).
+        pixel_values = _apply_rescale_normalize(self, image_input["pixel_values"])
+        if self.use_data_parallel:
+            return run_dp_sharded_mrope_vision_model(self.visual, pixel_values, grid_thw.tolist(), rope_type="rope_3d")
+        image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
+
+    merge_size = self.visual.spatial_merge_size
+    sizes = (grid_thw.prod(-1) // merge_size // merge_size).tolist()
+    return image_embeds.split(sizes)
+
+
+def _patched_process_video_input(self, video_input):
+    grid_thw = video_input["video_grid_thw"]
+    assert grid_thw.ndim == 2
+
+    if video_input["type"] == "video_embeds":
+        video_embeds = video_input["video_embeds"].type(self.visual.dtype)
+    else:
+        pixel_values_videos = _apply_rescale_normalize(self, video_input["pixel_values_videos"])
+        if self.use_data_parallel:
+            return run_dp_sharded_mrope_vision_model(
+                self.visual,
+                pixel_values_videos,
+                grid_thw.tolist(),
+                rope_type="rope_3d",
+            )
+        video_embeds = self.visual(pixel_values_videos, grid_thw=grid_thw)
+
+    merge_size = self.visual.spatial_merge_size
+    sizes = (grid_thw.prod(-1) // merge_size // merge_size).tolist()
+    return video_embeds.split(sizes)
+
+
+Qwen3VLForConditionalGeneration._process_image_input = _patched_process_image_input
+Qwen3VLForConditionalGeneration._process_video_input = _patched_process_video_input

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -1,8 +1,10 @@
-from functools import lru_cache
+import importlib
+from functools import lru_cache, wraps
+from typing import NamedTuple
 
 import torch
-from torchvision.transforms import v2  # type: ignore[import-untyped]
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+from vllm.logger import logger
 from vllm.model_executor.models.qwen3 import Qwen3Attention
 from vllm.model_executor.models.qwen3_moe import Qwen3MoeAttention
 from vllm.model_executor.models.qwen3_vl import (
@@ -15,6 +17,7 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
+from vllm_ascend.patch.platform.patch_qwen3vl_processor import ORIG_PREPROCESS_FLAGS_ATTR
 
 
 def tensor_parallel_wrap(func):
@@ -122,29 +125,32 @@ patch_qwen3_vl_moe_pp_layer_range()
 # ---------------------------------------------------------------------------
 
 
-def _rescale(image: torch.Tensor, scale: float) -> torch.Tensor:
-    return image * scale
-
-
-def _normalize(image: torch.Tensor, mean, std) -> torch.Tensor:
-    return v2.functional.normalize(image, mean, std)
-
-
 @lru_cache(maxsize=10)
 def _fuse_mean_std_and_rescale_factor(
-    do_normalize: bool | None = None,
-    image_mean: float | tuple[float, ...] | None = None,
-    image_std: float | tuple[float, ...] | None = None,
-    do_rescale: bool | None = None,
-    rescale_factor: float | None = None,
+    do_normalize: bool,
+    image_mean: tuple[float, ...] | None,
+    image_std: tuple[float, ...] | None,
+    do_rescale: bool,
+    rescale_factor: float | None,
     device: torch.device | None = None,
 ) -> tuple:
-    if do_rescale and do_normalize:
+    """Build device-side mean/std, folding the rescale factor into them.
+
+    ``(x * s - mean) / std`` equals ``(x - mean / s) / (std / s)``, so when both
+    steps are enabled the rescale collapses into the normalize and only one pass
+    over the tensor is needed. Cached so the mean/std tensors are built once
+    instead of being copied from host on every forward.
+    """
+    if not do_normalize:
+        return None, None, do_rescale
+    mean = torch.tensor(image_mean, device=device, dtype=torch.float32)
+    std = torch.tensor(image_std, device=device, dtype=torch.float32)
+    if do_rescale:
         assert rescale_factor is not None
-        image_mean = torch.tensor(image_mean, device=device) * (1.0 / rescale_factor)
-        image_std = torch.tensor(image_std, device=device) * (1.0 / rescale_factor)
+        mean = mean / rescale_factor
+        std = std / rescale_factor
         do_rescale = False
-    return image_mean, image_std, do_rescale
+    return mean.view(1, -1, 1, 1), std.view(1, -1, 1, 1), do_rescale
 
 
 def rescale_and_normalize(
@@ -152,12 +158,12 @@ def rescale_and_normalize(
     do_rescale: bool,
     rescale_factor: float,
     do_normalize: bool,
-    image_mean: float | tuple[float, ...],
-    image_std: float | tuple[float, ...],
+    image_mean: tuple[float, ...],
+    image_std: tuple[float, ...],
     dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
-    """Rescale and normalize images on device (fused when both are enabled)."""
-    image_mean, image_std, do_rescale = _fuse_mean_std_and_rescale_factor(
+    """Rescale and normalize NCHW images on device (fused when both are on)."""
+    mean, std, do_rescale = _fuse_mean_std_and_rescale_factor(
         do_normalize=do_normalize,
         image_mean=image_mean,
         image_std=image_std,
@@ -166,79 +172,120 @@ def rescale_and_normalize(
         device=images.device,
     )
     if do_normalize:
-        images = _normalize(images.to(dtype=torch.float32), image_mean, image_std)
+        images = (images.to(dtype=torch.float32) - mean) / std
     elif do_rescale:
-        images = _rescale(images.to(dtype=torch.float32), rescale_factor)
+        images = images.to(dtype=torch.float32) * rescale_factor
     return images.to(dtype)
+
+
+class _VLPreprocessConfig(NamedTuple):
+    channel: int
+    patch_size: int
+    temporal_patch_size: int
+    do_rescale: bool
+    rescale_factor: float | None
+    do_normalize: bool
+    image_mean: tuple[float, ...]
+    image_std: tuple[float, ...]
+
+
+_PREPROCESS_ATTR = "_ascend_vl_preprocess"
 
 
 def _image_post_process_config(self, vision_config, model_config) -> None:
     image_processor = MULTIMODAL_REGISTRY.create_processor(model_config).info.get_hf_processor().image_processor
-    self.channel = vision_config.in_channels
-    self.patch_size = vision_config.patch_size
-    self.temporal_patch_size = vision_config.temporal_patch_size
-    # HF processor side is disabled (platform patch); always apply on device.
-    self.do_rescale = True
-    self.do_normalize = True
-    self.rescale_factor = image_processor.rescale_factor
-    self.image_mean = tuple(image_processor.image_mean)
-    self.image_std = tuple(image_processor.image_std)
+    flags = getattr(image_processor, ORIG_PREPROCESS_FLAGS_ATTR, None)
+    if flags is None:
+        # The platform patch never ran, so HF is still rescaling/normalizing on
+        # the host. Doing nothing here is what keeps values from being
+        # normalized twice; the request stays correct, just without the speedup.
+        logger.warning(
+            "Qwen3-VL HF processor still applies rescale/normalize on host, "
+            "skipping device-side preprocess to avoid normalizing twice."
+        )
+        flags = {"do_rescale": False, "do_normalize": False}
+    setattr(
+        self,
+        _PREPROCESS_ATTR,
+        _VLPreprocessConfig(
+            channel=vision_config.in_channels,
+            patch_size=vision_config.patch_size,
+            temporal_patch_size=vision_config.temporal_patch_size,
+            do_rescale=flags["do_rescale"],
+            rescale_factor=getattr(image_processor, "rescale_factor", None),
+            do_normalize=flags["do_normalize"],
+            image_mean=tuple(image_processor.image_mean),
+            image_std=tuple(image_processor.image_std),
+        ),
+    )
 
 
 def _apply_rescale_normalize(self, pixel_values: torch.Tensor) -> torch.Tensor:
-    if not hasattr(self, "channel"):
+    cfg = getattr(self, _PREPROCESS_ATTR, None)
+    if cfg is None:
         _image_post_process_config(self, self.config.vision_config, self.model_config)
-    # Keep raw integer/float range until after fp32 normalize; do not cast
-    # uint8 -> bf16 before normalize (avoids precision / scale surprises).
-    pixel_values = pixel_values.to(dtype=torch.float32).reshape(-1, self.channel, self.patch_size, self.patch_size)
+        cfg = getattr(self, _PREPROCESS_ATTR)
+    if not (cfg.do_rescale or cfg.do_normalize):
+        return pixel_values.to(self.visual.dtype)
+
+    # Each row packs one patch as [channel][temporal][ph][pw] (see the flatten
+    # step in the HF image/video processors), so folding temporal into the
+    # height axis exposes the channel axis to mean/std without moving any data.
+    # Reshaping straight to (-1, channel, ph, pw) would instead line temporal
+    # slices up under the channel axis and normalize the wrong channels.
+    pixel_values = pixel_values.reshape(
+        -1,
+        cfg.channel,
+        cfg.temporal_patch_size * cfg.patch_size,
+        cfg.patch_size,
+    )
+    # Keep the raw integer/float range until after the fp32 normalize; casting
+    # uint8 -> bf16 first would lose precision before the scale is applied.
     pixel_values = rescale_and_normalize(
         pixel_values,
-        self.do_rescale,
-        self.rescale_factor,
-        self.do_normalize,
-        self.image_mean,
-        self.image_std,
+        cfg.do_rescale,
+        cfg.rescale_factor,
+        cfg.do_normalize,
+        cfg.image_mean,
+        cfg.image_std,
         dtype=self.visual.dtype,
     )
     return pixel_values.reshape(
         -1,
-        self.channel * self.temporal_patch_size * self.patch_size * self.patch_size,
+        cfg.channel * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size,
     )
 
 
-_orig_qwen3vl_init = Qwen3VLForConditionalGeneration.__init__
+def _hook_preprocess_config(cls) -> None:
+    orig_init = cls.__init__
 
-
-def _patched_qwen3vl_init(self, *, vllm_config, prefix: str = "model"):
-    _orig_qwen3vl_init(self, vllm_config=vllm_config, prefix=prefix)
-    _image_post_process_config(self, self.config.vision_config, self.model_config)
-
-
-Qwen3VLForConditionalGeneration.__init__ = _patched_qwen3vl_init
-
-# Qwen3.5 / Qwen3.5-MoE reimplement __init__ without calling Qwen3VL.__init__,
-# so they must be patched separately.
-try:
-    from vllm.model_executor.models.qwen3_5 import (
-        Qwen3_5ForConditionalGeneration,
-        Qwen3_5MoeForConditionalGeneration,
-    )
-
-    _orig_qwen35_init = Qwen3_5ForConditionalGeneration.__init__
-    _orig_qwen35_moe_init = Qwen3_5MoeForConditionalGeneration.__init__
-
-    def _patched_qwen35_init(self, *, vllm_config, prefix: str = "model"):
-        _orig_qwen35_init(self, vllm_config=vllm_config, prefix=prefix)
+    # vLLM decides how to construct a model by looking for `vllm_config` and
+    # `prefix` in the __init__ signature, so the wrapper has to keep reporting
+    # the wrapped signature -- `functools.wraps` is what makes that work.
+    @wraps(orig_init)
+    def patched_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
         _image_post_process_config(self, self.config.vision_config, self.model_config)
 
-    def _patched_qwen35_moe_init(self, *, vllm_config, prefix: str = "model"):
-        _orig_qwen35_moe_init(self, vllm_config=vllm_config, prefix=prefix)
-        _image_post_process_config(self, self.config.vision_config, self.model_config)
+    cls.__init__ = patched_init
 
-    Qwen3_5ForConditionalGeneration.__init__ = _patched_qwen35_init
-    Qwen3_5MoeForConditionalGeneration.__init__ = _patched_qwen35_moe_init
-except Exception:
-    pass
+
+# Qwen3-VL-MoE, Qwen3.5 and Qwen3.5-MoE each define their own __init__ that
+# bypasses Qwen3VLForConditionalGeneration.__init__, so hooking the base class
+# alone would leave them falling back to the lazy path on the first request.
+_hook_preprocess_config(Qwen3VLForConditionalGeneration)
+for _module_name, _class_names in (
+    ("vllm.model_executor.models.qwen3_vl_moe", ("Qwen3VLMoeForConditionalGeneration",)),
+    ("vllm.model_executor.models.qwen3_5", ("Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration")),
+):
+    try:
+        _module = importlib.import_module(_module_name)
+    except ImportError:
+        continue
+    for _class_name in _class_names:
+        _cls = getattr(_module, _class_name, None)
+        if _cls is not None and "__init__" in _cls.__dict__:
+            _hook_preprocess_config(_cls)
 
 
 def _patched_process_image_input(self, image_input):


### PR DESCRIPTION
### What this PR does / why we need it?

For Qwen3-VL / Qwen3.5 multimodal requests, HuggingFace image/video processors currently run `rescale` + `normalize` on CPU before `pixel_values` are sent to the vision tower. This adds host-side preprocess latency on every image/video request.

This PR ports the idea from omniinfer PR [#1515](https://gitee.com/omniai/omniinfer/pulls/1515/files) and moves fused rescale/normalize onto the device (NPU), right before ViT:

1. **Platform patch** (`patch_qwen3vl_processor.py`): force HF image/video processor `do_rescale=False` / `do_normalize=False` on the APIServer side (required to avoid double-normalization in vLLM V1 dual-process).
2. **Worker patch** (`patch_qwen3vl.py`): cache preprocess params in model init; in `_process_image_input` / `_process_video_input`, reshape packed patches, run fused `rescale_and_normalize` on device, then feed ViT.
3. Also patch `Qwen3_5ForConditionalGeneration` / `Qwen3_5MoeForConditionalGeneration` `__init__`, because Qwen3.5 reimplements init without calling `Qwen3VLForConditionalGeneration.__init__`.

This reduces CPU preprocess overhead for vision inputs and improves TTFT for image requests.

### Does this PR introduce _any_ user-facing change?

No intentional API change. Request/response interfaces stay the same.

Behavior note: image/video `rescale`/`normalize` now runs on device instead of in the HF processor. Numerically it should match the previous fused `(x * rescale_factor - mean) / std` path; if only the worker patch were applied without the platform patch, values would be normalized twice (incorrect). This PR applies both.

### How was this patch tested?

Manual e2e / perf on Ascend 910B with Qwen3.5-0.8B (`vllm serve`, OpenAI-compatible chat completions).

Single-image VL request: one 1080P (1920×1080) image plus a short text prompt, concurrency 1.

**TTFT**
| Setting | TTFT |
|---|---|
| Before (HF CPU rescale/normalize) | **317.1ms** |
| After (device-side fused rescale/normalize) | **273.1 ms** |
| Delta | **-44ms (~13.9%)** |

Also verified service startup and image chat correctness (no double-normalize regression).

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
