### PR TITLE
[Doc] Clarify float16 is only for Atlas inference products in Qwen3.5/3.6-27B w8a8 examples

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -291,7 +291,9 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
 
 === "Atlas inference products"
 
-    Currently only the **TP** scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. Replace `MODEL_PATH` with a ModelScope model id or a local directory path.The quantized versions need to start with the `--quantization ascend` parameter.
+    Currently only the **TP** scenario is supported. Choose **TP=2** or **TP=4** according to the available devices. Replace `MODEL_PATH` with a ModelScope model id or a local directory path. The quantized versions need to start with the `--quantization ascend` parameter.
+
+    > **Warning**: The examples in this tab apply **only to Atlas inference products** (e.g., Atlas 300I Duo). Do not reuse them on Atlas 800 A2 / Atlas 800 A3 (Ascend 910B series) devices: with the w8a8 quantized models, `--dtype float16` is not supported by the quantized matmul operator there and the engine fails during initialization with `aclnnQuantMatmulWeightNz` error code 161002 (`Tensor scale not implemented for DT_FLOAT16`). On Atlas 800 A2 / A3, follow the "Atlas 800 A3 / Atlas 800 A2" tab instead, which keeps the default `bfloat16` dtype.
 
     === "Qwen3.5-27B-w8a8"
 
@@ -355,8 +357,8 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
     - `--max-model-len` represents the context length, which is the maximum value of the input plus output for a single request. Configure it based on the actual workload and available memory; The Qwen3.6-27B model supports up to 262144.
     - `--max-num-seqs` indicates the maximum number of concurrent requests. Configure it as needed—setting it too high may cause OOM.
     - `--gpu-memory-utilization` represents the proportion of HBM that vLLM will use for actual inference. Configure this value according to the actual device memory; setting it too high may cause OOM. The default value is `0.9`.
-    - `--mamba-ssm-cache-dtype` sets the data type of the Mamba SSM cache. On Atlas inference products, only `float16` is supported.
-    - `--dtype float16` must be set on Atlas inference products. These devices only support the FP16 data type.
+    - `--mamba-ssm-cache-dtype` sets the data type of the Mamba SSM cache. On Atlas inference products, only `float16` is supported. On Atlas 800 A2 / A3, keep the default `bfloat16` instead.
+    - `--dtype float16` must be set on Atlas inference products, because these devices only support the FP16 data type. **Do not** set it on Atlas 800 A2 / A3 (Ascend 910B series): the w8a8 quantized matmul only accepts `bfloat16` scales there, and starting with `--dtype float16` fails with `aclnnQuantMatmulWeightNz` error code 161002 (`Tensor scale not implemented for DT_FLOAT16`).
     - `--speculative-config` uses `qwen3_5_mtp` for both `Qwen3.5-27B` and `Qwen3.6-27B` because they share the same MTP head design. On Atlas inference products, it is recommended to set `num_speculative_tokens` to `1`.
     - `--compilation-config` contains configurations related to the aclgraph graph mode. The most significant configurations are `"cudagraph_mode"` and `"cudagraph_capture_sizes"`, which have the following meanings:
         - `"cudagraph_mode"`: represents the specific graph mode. Currently, `"PIECEWISE"` and `"FULL_DECODE_ONLY"` are supported. The graph mode is mainly used to reduce the cost of operator dispatch. Currently, `"FULL_DECODE_ONLY"` is recommended.


### PR DESCRIPTION
### What this PR does / why we need it?

The startup examples under the **Atlas inference products** tab of the Qwen3.5-27B/Qwen3.6-27B tutorial hardcode `--dtype float16` / `--mamba-ssm-cache-dtype float16`. Users running the w8a8 quantized weights on Atlas 800 A2 / A3 (Ascend 910B series) copied these commands and hit an engine initialization failure during the profile run:

```
aclnnQuantMatmulWeightNz failed, error code is 161002
AclNN_Parameter_Error(EZ1001): Tensor scale not implemented for DT_FLOAT16,
should be in dtype support list [DT_UINT64, DT_BFLOAT16, DT_INT64, DT_FLOAT].
```

This is because the quantized matmul only accepts `bfloat16` scales on those devices, while `float16` is required only on Atlas inference products (which support FP16 only).

This PR adds an explicit warning to the Atlas inference products tab and extends the `--dtype` / `--mamba-ssm-cache-dtype` parameter descriptions, so that A2/A3 users keep the default `bfloat16` dtype and follow the correct tab.

Fixes #12907

### Does this PR introduce _any_ user-facing change?

No, documentation only.

### How was this patch tested?

Doc-only change; verified the markdown renders correctly. The failure mode described above matches the report in #12907 (8 x Ascend 910B4-1, vllm-ascend v0.23.0rc1, CANN 9.0.1).

cc @wangxiyuan @Yikun
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
