### PR TITLE
[310P] Decouple 310P inference pipeline from Triton via supports_trit…

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -175,7 +175,7 @@ def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
     spec_decode_metadata.cu_num_draft_tokens = torch.tensor([2, 3], dtype=torch.int32)
     valid_sampled_tokens_count = torch.tensor([3, 1], dtype=torch.int32)
 
-    with patch.object(llm_base_proposer, "HAS_TRITON", False):
+    with patch.object(llm_base_proposer, "supports_triton", return_value=False):
         spec_common_attn_metadata, *_ = proposer.prepare_inputs_padded(
             common_attn_metadata,
             spec_decode_metadata,
@@ -3389,13 +3389,13 @@ class TestEagleProposerPrepareInputsPadded:
             return proposer, vllm_config
 
     @pytest.mark.parametrize(
-        "has_triton,num_aicore,num_vectorcore",
+        "triton_supported,num_aicore,num_vectorcore",
         [
             (True, 24, 48),
             (False, -1, -1),
         ],
     )
-    def test_prepare_inputs_padded_basic(self, has_triton, num_aicore, num_vectorcore):
+    def test_prepare_inputs_padded_basic(self, triton_supported, num_aicore, num_vectorcore):
         """Test prepare_inputs_padded with basic scenario.
 
         Setup:
@@ -3437,8 +3437,8 @@ class TestEagleProposerPrepareInputsPadded:
 
         with (
             patch(
-                "vllm_ascend.spec_decode.llm_base_proposer.HAS_TRITON",
-                has_triton,
+                "vllm_ascend.spec_decode.llm_base_proposer.supports_triton",
+                return_value=triton_supported,
             ),
             patch.multiple(
                 "vllm_ascend.ops.triton.triton_utils",
@@ -3515,13 +3515,13 @@ class TestEagleProposerPrepareInputsPadded:
             assert_attr_equal(attr, self.runner, spec_common_attn_metadata)
 
     @pytest.mark.parametrize(
-        "has_triton,num_aicore,num_vectorcore",
+        "triton_supported,num_aicore,num_vectorcore",
         [
             (True, 24, 48),
             (False, -1, -1),
         ],
     )
-    def test_prepare_inputs_padded_all_rejected(self, has_triton, num_aicore, num_vectorcore):
+    def test_prepare_inputs_padded_all_rejected(self, triton_supported, num_aicore, num_vectorcore):
         """Test prepare_inputs_padded when all draft tokens are rejected.
 
         Setup:
@@ -3563,8 +3563,8 @@ class TestEagleProposerPrepareInputsPadded:
 
         with (
             patch(
-                "vllm_ascend.spec_decode.llm_base_proposer.HAS_TRITON",
-                has_triton,
+                "vllm_ascend.spec_decode.llm_base_proposer.supports_triton",
+                return_value=triton_supported,
             ),
             patch.multiple(
                 "vllm_ascend.ops.triton.triton_utils",

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -7,7 +7,7 @@ import torch_npu
 from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.forward_context import get_forward_context
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -435,7 +435,7 @@ class AscendSFACPImpl(AscendSFAImpl):
         weights = kw[:, self.head_dim :]
         q_li, _ = self.wq_b(q_c)  # [b,s,1536] @ [1536,64*128] = [b,s,64*128]
         q_li = q_li.view(-1, self.n_head, self.head_dim)  # [n_toks,64,128]
-        if HAS_TRITON:
+        if supports_triton():
             q_li = rope_forward_triton_siso(
                 q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
             )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -10,7 +10,7 @@ import vllm.envs as envs_vllm
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms
 
-if HAS_TRITON:
+if supports_triton():
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
     triton_q_rms = None  # type: ignore

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -12,7 +12,7 @@ from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 from vllm.v1.attention.backend import (
     AttentionBackend,  # type: ignore
     AttentionCGSupport,
@@ -1408,7 +1408,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         k_li = self.k_norm(k_li).unsqueeze(1)
         k_li = k_li.view(-1, 1, self.head_dim)
 
-        if HAS_TRITON:
+        if supports_triton():
             cos = cos.view(-1, self.qk_rope_head_dim)
             sin = sin.view(-1, self.qk_rope_head_dim)
             k_li = rope_forward_triton_siso(
@@ -1486,7 +1486,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         else:
             q_li, _ = self.wq_b(q_c)
         q_li = q_li.view(-1, self.n_head, self.head_dim)
-        if HAS_TRITON:
+        if supports_triton():
             q_li = rope_forward_triton_siso(
                 q_li, cos, sin, rope_dim=self.qk_rope_head_dim, is_neox_style=self.is_rope_neox_style
             )

--- a/vllm_ascend/batch_invariant.py
+++ b/vllm_ascend/batch_invariant.py
@@ -22,13 +22,13 @@ import torch
 import torch_npu
 import vllm.envs as envs
 from vllm.logger import logger
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 
 # in case recursive call in reduce_sum.
 torch_sum = torch.sum
 
 
-if HAS_TRITON:
+if supports_triton():
     from vllm_ascend.ops.triton.batch_invariant.matmul import (
         addmm_batch_invariant,
         bmm_batch_invariant,
@@ -100,12 +100,12 @@ def enable_batch_invariant_mode():
     _batch_invariant_LIB = torch.library.Library("aten", "IMPL")
     logger.debug(
         "Batch-invariant op registration: Triton=%s, AscendC=%s",
-        HAS_TRITON,
+        supports_triton(),
         HAS_ASCENDC_BATCH_INVARIANT,
     )
 
     # Register operators only implemented in triton.
-    if HAS_TRITON:
+    if supports_triton():
         _batch_invariant_LIB.impl("aten::addmm", addmm_batch_invariant, "NPU")
         _batch_invariant_LIB.impl("aten::bmm", bmm_batch_invariant, "NPU")
         _batch_invariant_LIB.impl("aten::softmax", softmax_batch_invariant, "NPU")
@@ -127,7 +127,7 @@ def enable_batch_invariant_mode():
         torch.sum = reduce_sum
 
     # register triton implementations if ascendc is not available.
-    elif HAS_TRITON:
+    elif supports_triton():
         _batch_invariant_LIB.impl("aten::mm", mm_batch_invariant, "NPU")
         _batch_invariant_LIB.impl("aten::matmul", matmul_batch_invariant, "NPU")
 
@@ -149,7 +149,7 @@ def init_batch_invariance():
     environment variable to enable automatically.
     """
     if envs.VLLM_BATCH_INVARIANT:
-        if HAS_TRITON or HAS_ASCENDC_BATCH_INVARIANT:
+        if supports_triton() or HAS_ASCENDC_BATCH_INVARIANT:
             logger.info(
                 "Enabling batch-invariant mode for vLLM on Ascend NPU.",
             )

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 import torch_npu
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, supports_triton
 
 from vllm_ascend.device import utils as device_utils
 from vllm_ascend.device.mxfp_compat import (
@@ -32,12 +32,11 @@ from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
 
-if HAS_TRITON:
+if supports_triton():
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
     triton_q_rms = None  # type: ignore

--- a/vllm_ascend/ops/__init__.py
+++ b/vllm_ascend/ops/__init__.py
@@ -16,13 +16,13 @@
 #
 
 import torch
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 
 import vllm_ascend.ops.fused_moe.fused_moe  # noqa
 import vllm_ascend.ops.layernorm  # noqa
 import vllm_ascend.ops.register_custom_ops  # noqa
 
-if HAS_TRITON:
+if supports_triton():
     import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_rope  # noqa
     import vllm_ascend.ops.triton.linearnorm.split_qkv_rmsnorm_mrope
     import vllm_ascend.ops.triton.linearnorm.split_qkv_tp_rmsnorm_rope

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -68,9 +68,9 @@ class AscendSwigluStepAndMul:
         # silu + clamp + mul into a single launch (see
         # vllm_ascend/ops/triton/activation/swiglustep.py). Numerically
         # equivalent to forward_native below.
-        from vllm.triton_utils import HAS_TRITON
+        from vllm_ascend.utils import supports_triton
 
-        if HAS_TRITON:
+        if supports_triton():
             from vllm_ascend.ops.triton.activation.swiglustep import (
                 swiglustep_forward_triton,
             )

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -19,7 +19,7 @@ import torch
 import torch_npu
 from torch.nn.functional import pad
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
@@ -378,7 +378,7 @@ def quant_apply_mlp(
                 approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
                 hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
-            elif HAS_TRITON:
+            elif supports_triton():
                 from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
 
                 hidden_states, swiglu_out_scale = swiglu_quant(

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -29,13 +29,12 @@ from vllm.model_executor.layers.rotary_embedding import (
     YaRNScalingRotaryEmbedding,
 )
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import has_rope, is_vl_model, supports_triton
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.platform import NPUPlatform
-from vllm_ascend.utils import has_rope, is_vl_model
 
-if HAS_TRITON:
+if supports_triton():
     from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
 
     from vllm_ascend.ops.triton.rope import rope_forward_triton
@@ -164,7 +163,7 @@ def rope_forward_oot(
     query_shape, key_shape = query.shape, key.shape
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
-    if HAS_TRITON:
+    if supports_triton():
         num_tokens = query.shape[0]
         query, key = rope_forward_triton(
             query.view(num_tokens, -1, head_size),
@@ -521,7 +520,7 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor,
     ):
-        if HAS_TRITON and positions.ndim == 2 and self.mrope_interleaved:
+        if supports_triton() and positions.ndim == 2 and self.mrope_interleaved:
             # todo: need cann update in 8.5.0
             return self.forward_triton(positions, query, key)
 

--- a/vllm_ascend/ops/triton/mamba/causal_conv1d.py
+++ b/vllm_ascend/ops/triton/mamba/causal_conv1d.py
@@ -8,12 +8,13 @@
 # mypy: ignore-errors
 
 import torch
-from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID  # type: ignore
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+from vllm_ascend.utils import supports_triton
 
-if not HAS_TRITON:
+if not supports_triton():
     from vllm_ascend._310p.ops.causal_conv1d import (
         causal_conv1d_update as _pytorch_update,
     )
@@ -450,7 +451,7 @@ def causal_conv1d_update_npu(
             indices 0 and 3
     out: (batch, dim) or (batch, dim, seqlen) or (num_tokens, dim), same shape as `x`
     """
-    if not HAS_TRITON:
+    if not supports_triton():
         return _pytorch_update(
             x,
             conv_state,

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -15,11 +15,9 @@
 # limitations under the License.
 #
 
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import is_310p, supports_triton
 
-from vllm_ascend.utils import is_310p
-
-if HAS_TRITON:
+if supports_triton():
     import vllm_ascend.patch.worker.patch_triton
     import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -16,11 +16,11 @@ from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
-from vllm_ascend.utils import is_310p
+from vllm_ascend.utils import supports_triton
 
 
 def _can_launch_triton_batch_memcpy() -> bool:
-    return not is_310p()
+    return supports_triton()
 
 
 def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):

--- a/vllm_ascend/patch/worker/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_triton.py
@@ -8,6 +8,7 @@ from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 from vllm_ascend.ops.triton.fla.layernorm_guard import LayerNormFn
 from vllm_ascend.ops.triton.fla.sigmoid_gating import fused_recurrent_gated_delta_rule_fwd_kernel
 from vllm_ascend.ops.triton.mamba.causal_conv1d import causal_conv1d_update_npu
+from vllm_ascend.utils import supports_triton
 
 triton.next_power_of_2 = next_power_of_2
 
@@ -21,8 +22,9 @@ vllm.model_executor.layers.fla.ops.chunk_gated_delta_rule = chunk_gated_delta_ru
 # On NPU platforms without an active Triton backend (e.g. 310P), replace the
 # Triton-based fused_post_conv_prep with a pure-PyTorch fallback so that
 # qwen_gdn_linear_attn's from-import picks up the replacement before model
-# load.
-if not HAS_TRITON:
+# load.  Use supports_triton() instead of HAS_TRITON so that 310P never
+# enters Triton paths even when Triton-Ascend is installed.
+if not supports_triton():
     import torch
     import torch.nn.functional as _F
 

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -56,7 +56,7 @@ class AscendRejectionSampler(RejectionSampler):
             return logits
 
         """Use Triton-Ascend penalties on NPU when Triton is available; else vLLM default."""
-        if not HAS_TRITON:
+        if not supports_triton():
             logger.warning_once(
                 "[sample/rejection_sampler] Triton not available, falling back to vLLM default "
                 "penalty implementation in rejection sampler. Rejection sampling performance "
@@ -94,7 +94,7 @@ class AscendRejectionSampler(RejectionSampler):
             "ascend_optimizations_enabled=%s, triton_available=%s, "
             "reduce_sample=%s",
             self._ascend_optimizations_enabled,
-            HAS_TRITON,
+            supports_triton(),
             get_ascend_config().enable_reduce_sample,
         )
 
@@ -491,7 +491,7 @@ def rejection_sample(
         sampling_metadata.all_greedy,
         sampling_metadata.all_random,
         get_ascend_config().enable_reduce_sample,
-        HAS_TRITON,
+        supports_triton(),
     )
 
     if using_entropy_verify and ori_target_logits is not None:
@@ -511,7 +511,7 @@ def rejection_sample(
         is_greedy = None
     else:
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
-    if HAS_TRITON:
+    if supports_triton():
         grid, block_size = cal_grid_and_block_size(batch_size)
 
     if using_block_verify or using_entropy_verify:
@@ -524,7 +524,7 @@ def rejection_sample(
             posterior_threshold,
             posterior_alpha,
             target_indices is not None,
-            HAS_TRITON,
+            supports_triton(),
             sampling_metadata.all_greedy,
             sampling_metadata.all_random,
         )
@@ -536,7 +536,7 @@ def rejection_sample(
         else:
             target_argmax = target_logits.argmax(dim=-1).view(-1)
 
-        if HAS_TRITON:
+        if supports_triton():
             rejection_greedy_sample_with_triton(
                 output_token_ids,
                 num_draft_tokens,
@@ -612,7 +612,7 @@ def rejection_sample(
 
         if not using_block_verify:
             # Rejection sampling for random sampling requests with selected logits
-            if HAS_TRITON:
+            if supports_triton():
                 rejection_random_sample_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -664,7 +664,7 @@ def rejection_sample(
         else:
             # MagicMTP: Improving acceptance rate with Block Verify.
             # Entropy_verify: Improving acceptance rate with entropy Verify.
-            if HAS_TRITON:
+            if supports_triton():
                 rejection_random_sample_block_verify_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -754,7 +754,7 @@ def rejection_sample(
         )
 
         if not using_block_verify:
-            if HAS_TRITON:
+            if supports_triton():
                 rejection_random_sample_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -804,7 +804,7 @@ def rejection_sample(
                     ori_target_probs=ori_target_probs,
                 )
         else:
-            if HAS_TRITON:
+            if supports_triton():
                 rejection_random_sample_block_verify_kernel[(grid,)](
                     output_token_ids,
                     cu_num_draft_tokens,
@@ -886,7 +886,7 @@ def expand_batch_to_tokens(
     batch_size = x.shape[0]
     assert cu_num_tokens.shape[0] == batch_size
     expanded_x = x.new_empty(num_tokens)
-    if HAS_TRITON:
+    if supports_triton():
         expand_triton(batch_size, expanded_x, x, cu_num_tokens, replace_from, replace_to, max_num_tokens=MAX_SPEC_LEN)
     else:
         expand_pytorch(
@@ -933,7 +933,7 @@ def sample_recovered_tokens(
         q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
-    if HAS_TRITON:
+    if supports_triton():
         sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
             recovered_token_ids,
             cu_num_draft_tokens,

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -2,7 +2,7 @@ import torch
 import vllm.envs as envs
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
-from vllm.triton_utils import HAS_TRITON
+from vllm_ascend.utils import supports_triton
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 from vllm.v1.sample.sampler import Sampler
@@ -50,7 +50,7 @@ class AscendSampler(Sampler):
         output_token_ids: list[list[int]],
     ) -> torch.Tensor:
         """Use Triton-Ascend penalties on NPU when Triton is available; else vLLM default."""
-        if not HAS_TRITON:
+        if not supports_triton():
             logger.warning_once(
                 "[sample/sampler] Triton not available, falling back to vLLM default "
                 "penalty implementation. Penalty performance may be degraded on NPU. "
@@ -76,7 +76,7 @@ class AscendSampler(Sampler):
         logger.debug(
             "[sample/sampler] AscendSampler initialized. logprobs_mode=%s, triton_available=%s",
             logprobs_mode,
-            HAS_TRITON,
+            supports_triton(),
         )
 
     def prepare_sampling(self, top_k):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -27,7 +27,8 @@ from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
-from vllm.triton_utils import HAS_TRITON, triton
+from vllm.triton_utils import triton
+from vllm_ascend.utils import supports_triton
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -1935,7 +1936,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         used as padding and filtered out later by `token_indices_to_sample`.
         No blocking CPU operations should be introduced in this function.
         """
-        if HAS_TRITON:
+        if supports_triton():
             num_reqs = common_attn_metadata.num_reqs
             device = valid_sampled_tokens_count.device
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -145,6 +145,20 @@ def is_310p():
     return get_ascend_device_type() == AscendDeviceType._310P
 
 
+def supports_triton() -> bool:
+    """Return True if Triton kernels can be executed on the current device.
+
+    On 310P hardware, Triton is fundamentally unsupported regardless of
+    whether Triton-Ascend is installed in the environment. On other Ascend
+    devices (A2/A3/A5), Triton availability depends on the software
+    environment (HAS_TRITON from upstream vllm).
+    """
+    if is_310p():
+        return False
+    from vllm.triton_utils import HAS_TRITON
+    return HAS_TRITON
+
+
 _IS_RC_DEVICE: bool | None = None
 
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -444,9 +444,9 @@ class NPUWorker(WorkerBase):
         # This lazy import avoids torch_npu re-initialization in patch
         # Note that this should be imported after torch.npu.set_device
         # to avoid repeated set_device in extra processes
-        from vllm.triton_utils import HAS_TRITON
+        from vllm_ascend.utils import supports_triton
 
-        if HAS_TRITON:
+        if supports_triton():
             import torch_npu._inductor  # noqa: F401
 
         gc.collect()


### PR DESCRIPTION
…on() gate

On 310P hardware, Triton is fundamentally unsupported regardless of whether Triton-Ascend is installed. The current codebase uses two independent gates -- HAS_TRITON (upstream vllm, software environment) and is_310p() (hardware capability) -- which creates a dangerous mismatch where HAS_TRITON=True on a 310P device still leads the code into Triton compilation/execution paths that crash.

This patch introduces supports_triton() in vllm_ascend.utils, which returns False on 310P unconditionally and delegates to HAS_TRITON on other Ascend devices. All HAS_TRITON references in vllm-ascend source files (except ops/triton/triton_utils.py which is Triton-internal) are replaced with supports_triton(), ensuring the 310P inference pipeline is fully decoupled from Triton -- even when Triton-Ascend is present in the environment.

Key changes:
- Add supports_triton() to vllm_ascend/utils.py
- Replace HAS_TRITON with supports_triton() in 17 source files
- Update test mocking targets accordingly

Addresses: https://github.com/vllm-project/vllm-ascend/issues/10665

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
