### PR TITLE
[CI] Adjust schedule time, frequency and operations

### DIFF
--- a/.github/workflows/schedule_stale_manage.yaml
+++ b/.github/workflows/schedule_stale_manage.yaml
@@ -1,7 +1,7 @@
 name: "Close stale resolved/wait-feedback issues"
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 6,14,22 * * *'
   issue_comment:
     types: [created]
 
@@ -43,7 +43,7 @@ jobs:
           # The action processes issues newest-updated-first; with the default
           # of 30, stale-eligible issues sitting at the tail of the list (e.g.
           # ones that have had no activity for weeks) never get processed.
-          operations-per-run: 200
+          operations-per-run: 1000
 
           # Mark as stale after a period of inactivity
           days-before-stale: 7
@@ -74,7 +74,7 @@ jobs:
 
           # See note above: default operations-per-run (30) is too small and
           # causes the oldest wait-feedback issues to starve at the queue tail.
-          operations-per-run: 200
+          operations-per-run: 1000
 
           # Mark as stale after a period of inactivity
           days-before-stale: 7


### PR DESCRIPTION
### What this PR does / why we need it?
Adjusted the frequency and timing of the action that automatically applies the `stale` and `wait-feedback` labels: the frequency was changed from once daily to three times daily, and the execution times were set to 06:00, 14:00, and 22:00 to avoid peak action periods and prevent congestion.

At the same time, increase the number of operations from 200 to 1,000 to enable the processing of more historical issues in a single batch.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Only the automatic trigger timing and operation count were modified; no functional changes were made.