### PR TITLE
[BugFix] bug fix for mega_moe

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -40,7 +40,7 @@ _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
     "quanttype.w4a8",
 }
 
-_MEGA_MOE_SUPPORTED = False
+_MEGA_MOE_SUPPORTED = importlib.util.find_spec("cann_ops_transformer") is not None
 _MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
 _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
 _MC2_TOKENS_PER_RANK_LIMIT = 512
@@ -64,9 +64,6 @@ def override_mrv2_in_profile_run(enabled: bool):
 
 def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
-
-
-_MEGA_MOE_SUPPORTED = importlib.util.find_spec("cann_ops_transformer") is not None
 
 
 def _cann_megamoe_supported_by_config(vllm_config: VllmConfig) -> bool:
@@ -246,7 +243,7 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
     global _mc2_tokens_capacity
     if _mc2_tokens_capacity is not None:
         return
-    if get_ascend_config().enable_prefill_mc2 or get_ascend_config().enable_fused_mc2:
+    if get_ascend_config().enable_prefill_mc2:
         max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
     elif vllm_config.compilation_config.cudagraph_capture_sizes:
         max_num_tokens = vllm_config.compilation_config.max_cudagraph_capture_size

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -432,13 +432,6 @@ class FusedMC2CommImpl(MoECommMethod):
         self,
         fused_experts_input: MoEFusedExpertsInput,
     ):
-        # FIX(mega all-route): the shared expert (and any unquantized MoE) is QuantType.NONE and
-        # cannot go through MegaMoe (which handles W8A8/W4A8/MXFP only). All-route now sends every
-        # MoE layer here, so delegate unquantized layers to the generic base path
-        # (dispatch -> unified_apply_mlp -> combine), which uses their intact weights. Quantized
-        # routed experts (whose standard weights are freed for MegaMoe) still take the path below.
-        if fused_experts_input.quant.quant_type == QuantType.NONE:
-            return MoECommMethod.fused_experts(self, fused_experts_input)
         assert not (fused_experts_input.weights.w1_scale is None or fused_experts_input.weights.w2_scale is None), (
             "w1_scale and w2_scale cannot be None for FusedMC2CommImpl."
         )


### PR DESCRIPTION
### What this PR does / why we need it?
The mega_moe pr introduce an error in main nightly test. This is because the judgment logic for the mc2 capacity size was incorrectly modified. This pr:
1. recover the original mc2 capacity judgement logic. 
2. Besides, it also removes redundant variable. 
3. Removed the judgment of whether it is a quantized model.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
- Nightly test is already passed. Fore details, please refer to the comments. 
