### PR TITLE
[CI] drop e2e test for vllm main commit

### DIFF
--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -185,7 +185,6 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.e2e-test.outputs.main_commit }}
           - ${{ needs.e2e-test.outputs.release_tag }}
     needs: [e2e-test]
     if: ${{ needs.e2e-test.outputs.has_tests == 'true' }}

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -238,7 +238,6 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
           - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
@@ -253,7 +252,6 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
           - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:


### PR DESCRIPTION
### What this PR does / why we need it?

drop e2e test for vllm main commit

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
