### PR TITLE
[BugFix][MRV2] Avoid global synchronization for ACL graph replay

### DIFF
--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -76,6 +76,9 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # when call `run_fullgraph` method in CudaGraphManager,
         # then we don't need to # copy `execute_model` method in `NPUModelRunner` class.
         self.model_runner = model_runner
+        self.update_stream: torch.npu.Stream | None = None
+        if cudagraph_mode.has_full_cudagraphs():
+            self.update_stream = torch.npu.Stream()
         # The attention backend keys its per-size graph params by the actual
         # captured token counts (rounded up to decode_query_len when using
         # speculative decoding), so derive them from the capture descriptors
@@ -90,6 +93,8 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         """Override run_fullgraph to update full graph params in run_fullgraph."""
         num_tokens = desc.num_tokens
         logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
+        assert self.update_stream is not None
+        self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
@@ -108,7 +113,7 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             update_full_graph_params(
                 # FIXME(Ronald1995): support hybrid attn backend
                 self.model_runner.attn_groups[0][0].backend,
-                self.model_runner.update_stream,
+                self.update_stream,
                 forward_context,
                 num_tokens,
                 self.vllm_config,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -125,11 +125,6 @@ class NPUModelRunner(GPUModelRunner):
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
 
-        # we need to update full graph params in run_fullgraph,
-        # so create a stream to update full graph params.
-        if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
-            self.update_stream: torch.npu.Stream = torch.npu.Stream()
-
         # we need to use return value of `get_cudagraph_and_dp_padding`
         # to set forward_context in `run_fullgraph`.
         # so we can inherit `execute_model` method.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR refines the synchronization introduced for the async-scheduling ACL graph hang described in #4233.

The hang occurs when the parameter-update stream records the current iteration event before the previous graph replay has completed. A device-wide synchronization prevents the race, but also introduces an unnecessary global barrier.

This change:

- moves ownership of the full-graph parameter update stream from `NPUModelRunner` to `ModelAclGraphManager`;
- makes the update stream wait for work already submitted to the current graph replay stream;
- preserves the required replay/update ordering without synchronizing the entire NPU device.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

None.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
