### PR TITLE
[CI]Coverage rate upload lacks regex installation and repair.

### DIFF
--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -408,6 +408,7 @@ jobs:
             find "${TASK_DIR}" -type f | wc -l
 
             echo "=== building test_case_map.json ==="
+            pip install regex
             python3 .github/workflows/scripts/test_selector.py \
               --build-map \
               --coverage-dir "${TASK_DIR}" \


### PR DESCRIPTION
### What this PR does / why we need it?

When converting coverage data into a map, regex is needed, but the installation is missing.Add regex installation here.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
After modification, it can correctly generate the map required for coverage analysis.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
