### PR TITLE
[Doc][Model] Fix Kimi-K3 openEuler image tag

### DIFF
--- a/docs/source/tutorials/models/Kimi-K3.md
+++ b/docs/source/tutorials/models/Kimi-K3.md
@@ -39,7 +39,7 @@ Kimi K3 is validated on Atlas 800 A3 (64G × 16). Select the image that matches 
 | Host operating system | Image |
 | --- | --- |
 | Ubuntu | `quay.io/ascend/vllm-ascend:kimi-k3-a3` |
-| openEuler | `quay.io/ascend/vllm-ascend:kimi-k3-openeuler` |
+| openEuler | `quay.io/ascend/vllm-ascend:kimi-k3-a3-openeuler` |
 
 Run the following command on each node:
 
@@ -47,7 +47,7 @@ Run the following command on each node:
 # Ubuntu:
 export IMAGE=quay.io/ascend/vllm-ascend:kimi-k3-a3
 # openEuler:
-# export IMAGE=quay.io/ascend/vllm-ascend:kimi-k3-openeuler
+# export IMAGE=quay.io/ascend/vllm-ascend:kimi-k3-a3-openeuler
 docker run --rm \
     --name vllm-ascend \
     --shm-size=1g \


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up to #12952.

Updates the Kimi-K3 openEuler image reference from `quay.io/ascend/vllm-ascend:kimi-k3-openeuler` to the Atlas 800 A3 variant `quay.io/ascend/vllm-ascend:kimi-k3-a3-openeuler` in both the image table and Docker startup example.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only correction.

### How was this patch tested?

- Markdown lint with markdownlint-cli 0.45.0.
- Strict Sphinx HTML build with warnings treated as errors.
- `git diff --check`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
