### PR TITLE
adapt DSV4 mtp quantization at A3

### DIFF
--- a/vllm_ascend/models/deepseek_v4_mtp.py
+++ b/vllm_ascend/models/deepseek_v4_mtp.py
@@ -65,10 +65,20 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         quant_config = vllm_config.quant_config
 
         self.e_proj = ReplicatedLinear(
-            config.hidden_size, config.hidden_size, bias=False, quant_config=quant_config, return_bias=False
+            config.hidden_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.e_proj",
+            return_bias=False,
         )
         self.h_proj = ReplicatedLinear(
-            config.hidden_size, config.hidden_size, bias=False, quant_config=quant_config, return_bias=False
+            config.hidden_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.h_proj",
+            return_bias=False,
         )
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -79,6 +79,15 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = 0,
     ) -> torch.Tensor:
+        # npu_quant_matmul operates on 2D activations. Flatten any leading dims
+        # (e.g. MTP h_proj passes a [num_tokens, hc_mult, hidden] tensor when
+        # hc_mult > 1) and restore the original shape on the output.
+        reshaped = False
+        leading_dims = x.shape[:-1]
+        if x.dim() > 2:
+            x = x.reshape(-1, x.shape[-1])
+            reshaped = True
+
         quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x, dst_type=self.act_quant_type)
         need_unsqz = False
         if pertoken_scale.dim() == 2:
@@ -122,6 +131,8 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
             )
         if need_unsqz:
             output = output.unsqueeze(dim=1)
+        if reshaped:
+            output = output.reshape(*leading_dims, output.shape[-1])
         return output
 
     def process_weights_after_loading(self, layer):


### PR DESCRIPTION
### What this PR does / why we need it?

对齐Recipes-Infer仓DSV4-Flash量化策略，修复MTP在量化时e_proj与h_proj的报错。

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
