### PR TITLE
[Doc][Misc] Add deployment reference notice for GLM-5

### DIFF
--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -159,7 +159,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-expert-parallel \
     --seed 1024 \
     --served-model-name glm-5 \
-    --max-num-seqs 8 \
+    --max-num-seqs 16 \
     --max-model-len 200000 \
     --max-num-batched-tokens 4096 \
     --trust-remote-code \
@@ -194,7 +194,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-expert-parallel \
     --seed 1024 \
     --served-model-name glm-5 \
-    --max-num-seqs 8 \
+    --max-num-seqs 16 \
     --max-model-len 40960 \
     --max-num-batched-tokens 4096 \
     --trust-remote-code \
@@ -232,7 +232,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-expert-parallel \
     --seed 1024 \
     --served-model-name glm-5 \
-    --max-num-seqs 2 \
+    --max-num-seqs 8 \
     --max-model-len 32768 \
     --max-num-batched-tokens 4096 \
     --trust-remote-code \

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -1357,6 +1357,11 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/) for more
 |High Throughput (A3)|1P1D deployment|32|P:8 D:4|P:4 D:8|P:64 D:128|P:4096 D:32|P:133120 D:150000|3|
 |Low Latency (A3)|1P1D deployment|32|4|8|P:64 D:128|P:4096 D:32|P:133120 D:150000|3|
 
+> For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
+
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
+
 ## 10 FAQ
 
 - Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds a notice and a reference link to Chapter 5 (Online Service Deployment) in the GLM-5 tutorial. This helps users find complete startup commands and parameter descriptions, and reminds them to configure `max-model-len` and `max-num-seqs` according to their actual usage scenarios.
### Does this PR introduce _any_ user-facing change?
No, this is a documentation-only update.
### How was this patch tested?
Documentation changes only, verified markdown rendering.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
