### PR TITLE
[BugFix][Worker] Map A5 endpoint config through visible devices

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -133,6 +133,34 @@ class TestUtils(TestBase):
         with mock.patch("torch.npu.current_stream") as mock_current_stream:
             self.assertEqual(utils.current_stream(), mock_current_stream())
 
+    def test_setup_ascend_local_comm_res_maps_endpoint_device(self):
+        kv_transfer_config = mock.MagicMock()
+        kv_transfer_config.kv_connector_extra_config = {
+            "ascend_local_comm_res_path": "/etc/hixl",
+        }
+        cases = [
+            ("visible device list", {"ASCEND_RT_VISIBLE_DEVICES": "4,5"}, 1, {}, 5),
+            ("partial container mount", {}, 0, {"4": {"0": "4"}, "5": {"0": "5"}}, 4),
+        ]
+
+        for name, environ, visible_index, npu_map, endpoint_device_id in cases:
+            with (
+                self.subTest(name),
+                mock.patch("vllm.platforms.current_platform") as mock_platform,
+                mock.patch.dict(os.environ, environ, clear=True),
+                mock.patch(
+                    "vllm_ascend.cpu_binding.DeviceInfo.get_npu_map_info",
+                    return_value=npu_map,
+                ),
+                mock.patch("builtins.open", mock.mock_open(read_data='{"version":"1.3"}')) as mock_file,
+            ):
+                mock_platform.logical_device_id_to_visible_device_id.return_value = visible_index
+
+                utils.setup_ascend_local_comm_res(0, kv_transfer_config)
+
+                mock_platform.logical_device_id_to_visible_device_id.assert_called_once_with(0)
+                mock_file.assert_called_once_with(f"/etc/hixl/ub_endpoint_npu_{endpoint_device_id}.json")
+
     def test_enable_dsa_cp_with_o_proj_tp_accepts_missing_kv_transfer(self):
         mock_vllm_config = mock.MagicMock()
         mock_vllm_config.kv_transfer_config = None

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -542,10 +542,26 @@ def adapt_patch(is_global_patch: bool = False):
 
 
 def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None) -> None:
-    """Load the local A5 endpoint config into ASCEND_LOCAL_COMM_RES."""
+    """Load the local A5 endpoint config into ASCEND_LOCAL_COMM_RES.
+
+    This is a temporary workaround for a HiXL transport dependency on 950DT
+    server/pod deployments. Endpoint resource selection should eventually be
+    handled by HiXL or its lower-level components. The visible device index is
+    mapped through the runtime device list so containers mounting only a subset
+    of host NPUs still select the matching endpoint file.
+    """
     if kv_transfer_config is None:
         return
 
+    extra_config = kv_transfer_config.kv_connector_extra_config or {}
+    local_comm_res_path = extra_config.get("ascend_local_comm_res_path")
+    if not local_comm_res_path:
+        return
+
+    # Inline import avoids a circular dependency with vllm_ascend.platform.
+    from vllm.platforms import current_platform
+
+    visible_device_index = current_platform.logical_device_id_to_visible_device_id(local_rank)
     visible_devices = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
     if visible_devices is None:
         from vllm_ascend.cpu_binding import DeviceInfo
@@ -554,17 +570,14 @@ def setup_ascend_local_comm_res(local_rank: int, kv_transfer_config: Any | None)
     else:
         devices = [int(x) for x in visible_devices.split(",") if x.strip()]
 
-    extra_config = kv_transfer_config.kv_connector_extra_config or {}
-    local_comm_res_path = extra_config.get("ascend_local_comm_res_path")
-    if not local_comm_res_path:
-        return
-
     if not devices:
         raise ValueError("No NPU devices found or specified in ASCEND_RT_VISIBLE_DEVICES.")
-    if local_rank < 0 or local_rank >= len(devices):
-        raise ValueError(f"local_rank {local_rank} is out of bounds for the available NPU devices: {devices}")
+    if visible_device_index < 0 or visible_device_index >= len(devices):
+        raise ValueError(
+            f"visible_device_index {visible_device_index} is out of bounds for the available NPU devices: {devices}"
+        )
 
-    local_comm_res_file = os.path.join(local_comm_res_path, f"ub_endpoint_npu_{devices[local_rank]}.json")
+    local_comm_res_file = os.path.join(local_comm_res_path, f"ub_endpoint_npu_{devices[visible_device_index]}.json")
     try:
         with open(local_comm_res_file) as f:
             data = json.load(f)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -453,6 +453,9 @@ class NPUWorker(WorkerBase):
         torch.npu.empty_cache()
 
         if get_ascend_device_type() == AscendDeviceType.A5:
+            # Temporary workaround for a HiXL transport dependency on 950DT
+            # server/pod deployments. HiXL should eventually select its local
+            # endpoint resource without requiring vLLM Ascend to configure it.
             setup_ascend_local_comm_res(self.local_rank, self.vllm_config.kv_transfer_config)
 
         # take current memory snapshot


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes the device ID mapping issue introduced by #9690.

`setup_ascend_local_comm_res` previously used vLLM's logical `local_rank` to index the runtime NPU list. This is incorrect when a logical device ID differs from its visible device index.

This PR resolves `local_rank` to a visible device index inside `setup_ascend_local_comm_res`, then maps that index through:

1. `ASCEND_RT_VISIBLE_DEVICES`, when it is set; or
2. the `npu-smi` device map, when it is not set.

This supports containers that mount only later host NPUs. For example, when the container mounts host NPUs 4 and 5, visible index 0 is mapped to `ub_endpoint_npu_4.json`.

> [!IMPORTANT]
> This approach has a known compromise: when a container mounts only a subset of host NPUs, `ASCEND_RT_VISIBLE_DEVICES` must not be set to container-local IDs such as `0,1`. If host NPUs 4 and 5 are mounted but `ASCEND_RT_VISIBLE_DEVICES=0,1` is set, it takes precedence over `npu-smi` discovery and the worker incorrectly selects `ub_endpoint_npu_0.json` or `ub_endpoint_npu_1.json`. In this deployment mode, use the container mounting configuration only and leave `ASCEND_RT_VISIBLE_DEVICES` unset.

This is a higher-level alternative to #12873. It preserves the existing device-discovery approach and avoids adding a direct AscendCL/`ctypes` dependency, at the cost of the restriction above.

This setup remains a temporary workaround for a HiXL transport dependency on 950DT server/pod deployments. Endpoint resource selection should eventually be handled by HiXL or its lower-level components.

### Does this PR introduce _any_ user-facing change?

Yes. A5/950DT workers now select endpoint configurations using the mapped visible device instead of directly using `local_rank`.

### How was this patch tested?

- Ruff format and lint passed.
- Python compilation passed.
- Added unit coverage for explicit visible-device lists and containers that mount only later host NPUs.
- Local test execution requires the NPU test environment and is left to CI.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
