### PR TITLE
[Ops][BugFix] Fix RoPE cache offsets for non-power-of-two rotary dims

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rope.py
@@ -13,6 +13,7 @@ MAX_POSITION_EMBEDDINGS = [262144]
 # (head_size, rotary_dim)
 HEAD_ROTARY_DIMS = [
     (64, 32),
+    (128, 96),
     (128, 128),
 ]
 # (num_q_heads, num_k_heads)

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -84,7 +84,7 @@ def _triton_rope(
         # m of this program instance
         # ####################################################################
         cos_offsets = tl.arange(0, pad_rope_dim // 2)
-        sin_offsets = tl.arange(pad_rope_dim // 2, pad_rope_dim)
+        sin_offsets = cos_offsets + (rope_dim // 2)
         cos_mask = cos_offsets < (rope_dim // 2)
         if USE_COS_SIN:
             pos_idx = tl.load(pos_ptr + row_idx).to(tl.int64)
@@ -209,7 +209,7 @@ def _triton_rope_siso(
         # m of this program instance
         # ####################################################################
         cos_offsets = tl.arange(0, pad_rope_dim // 2)
-        sin_offsets = tl.arange(pad_rope_dim // 2, pad_rope_dim)
+        sin_offsets = cos_offsets + (rope_dim // 2)
         cos_mask = cos_offsets < (rope_dim // 2)
         if USE_COS_SIN:
             pos_idx = tl.load(pos_ptr + row_idx).to(tl.int64)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes incorrect `sin` offsets in the Triton RoPE kernels when `rope_dim` is not a power of two.

The Triton block dimension is padded with `triton.next_power_of_2(rope_dim)`, but the concatenated `cos_sin_cache` layout is based on the actual `rope_dim`. The previous implementation used the padded dimension to calculate the start of the `sin` cache, causing incorrect cache reads.

For example, when `rope_dim=96`:
* `pad_rope_dim=128`
* Correct `sin` offset: `96 // 2 = 48`
* Previous `sin` offset: `128 // 2 = 64`

The padded dimension should only be used for the Triton tile shape, not for the physical cache layout.

Fixes #12723

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `(head_size=128, rotary_dim=96)` to the existing RoPE tests to cover a non-power-of-two rotary dimension.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
