### PR TITLE
[BugFix][Cherry-pick][v0.24.0rc] Pack SFA DSA-CP KV tensors into one all-gather

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -74,6 +74,42 @@ class TestAscendSFABackend(TestBase):
         self.assertIsNotNone(impl_cls)
 
 
+class TestAscendSFABytePackedGather(TestBase):
+    @patch("vllm_ascend.attention.sfa_v1.get_tp_group")
+    def test_byte_packed_gather_preserves_mixed_dtype_tensors(self, mock_get_tp_group):
+        mock_get_tp_group.return_value = SimpleNamespace(world_size=1)
+        sfa_kv = torch.arange(12, dtype=torch.float16).view(2, 6)
+        k_li = torch.arange(16, dtype=torch.int8).view(2, 1, 8)
+        k_li_scale = torch.arange(2, dtype=torch.float32).view(2, 1)
+
+        gathered, handle, metadata = AscendSFAImpl._all_gather_byte_packed_async(
+            [
+                ("sfa_kv", sfa_kv),
+                ("k_li", k_li),
+                ("k_li_scale", k_li_scale),
+            ],
+            async_op=True,
+        )
+
+        self.assertIsNone(handle)
+        self.assertEqual(gathered.dtype, torch.int8)
+        restored = AscendSFAImpl._restore_byte_gathered_tensors(gathered, metadata)
+        for name, expected in (("sfa_kv", sfa_kv), ("k_li", k_li), ("k_li_scale", k_li_scale)):
+            self.assertEqual(restored[name].shape, expected.shape)
+            self.assertEqual(restored[name].dtype, expected.dtype)
+            self.assertTrue(torch.equal(restored[name], expected))
+
+    def test_byte_packed_gather_rejects_mismatched_token_counts(self):
+        with self.assertRaisesRegex(RuntimeError, "different token counts"):
+            AscendSFAImpl._all_gather_byte_packed_async(
+                [
+                    ("sfa_kv", torch.zeros(2, 6, dtype=torch.float16)),
+                    ("k_li", torch.zeros(3, 8, dtype=torch.int8)),
+                ],
+                async_op=True,
+            )
+
+
 class TestAscendSFAKVQuantSparseAttention(TestBase):
     @patch("vllm_ascend.attention.sfa_v1.torch_npu.npu_dynamic_block_quant")
     @patch("vllm_ascend.attention.sfa_v1.torch_npu.npu_interleave_rope")

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -71,6 +71,14 @@ if TYPE_CHECKING:
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
 
+
+class _ByteGatherPart(NamedTuple):
+    name: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    num_bytes_per_row: int
+
+
 O_PROJ_ACLNN_INPUT_PARAMS = (
     "aclnn_input_scale",
     "aclnn_input_scale_reciprocal",
@@ -1456,6 +1464,70 @@ class AscendSFAImpl(MLAAttentionImpl):
     ) -> None:
         return
 
+    @staticmethod
+    def _flatten_for_byte_gather(tensor: torch.Tensor) -> tuple[torch.Tensor, int]:
+        if tensor.dim() == 0:
+            raise RuntimeError("Byte-packed all-gather requires tensors with a token dimension.")
+        tensor = tensor.contiguous()
+        num_rows = tensor.shape[0]
+        num_bytes_per_row = tensor.element_size()
+        for dim in tensor.shape[1:]:
+            num_bytes_per_row *= dim
+        return tensor.view(torch.int8).view(num_rows, num_bytes_per_row), num_bytes_per_row
+
+    @classmethod
+    def _all_gather_byte_packed_async(
+        cls,
+        parts: list[tuple[str, torch.Tensor]],
+        async_op: bool,
+    ) -> tuple[torch.Tensor, torch.distributed.Work | None, tuple[_ByteGatherPart, ...]]:
+        if not parts:
+            raise RuntimeError("Byte-packed all-gather requires at least one tensor.")
+
+        packed_parts = []
+        metadata = []
+        expected_num_rows: int | None = None
+        for name, tensor in parts:
+            num_rows = tensor.shape[0]
+            if expected_num_rows is None:
+                expected_num_rows = num_rows
+            elif num_rows != expected_num_rows:
+                raise RuntimeError(
+                    "Cannot byte-pack KV tensors with different token counts: "
+                    f"expected {expected_num_rows}, got {num_rows} for {name}."
+                )
+
+            packed_tensor, num_bytes_per_row = cls._flatten_for_byte_gather(tensor)
+            packed_parts.append(packed_tensor)
+            metadata.append(
+                _ByteGatherPart(
+                    name=name,
+                    shape=tuple(tensor.shape),
+                    dtype=tensor.dtype,
+                    num_bytes_per_row=num_bytes_per_row,
+                )
+            )
+
+        packed_input = torch.cat(packed_parts, dim=1) if len(packed_parts) > 1 else packed_parts[0]
+        gathered, handle = all_gather_async(
+            packed_input,
+            get_tp_group(),
+            async_op=async_op,
+        )
+        return gathered, handle, tuple(metadata)
+
+    @staticmethod
+    def _restore_byte_gathered_tensors(
+        gathered: torch.Tensor,
+        metadata: tuple[_ByteGatherPart, ...],
+    ) -> dict[str, torch.Tensor]:
+        chunks = torch.split(gathered, [part.num_bytes_per_row for part in metadata], dim=1)
+        num_rows = gathered.shape[0]
+        restored = {}
+        for part, chunk in zip(metadata, chunks):
+            restored[part.name] = chunk.contiguous().view(part.dtype).view(num_rows, *part.shape[1:])
+        return restored
+
     def _compose_sfa_kv_cache(self, kv_cache) -> tuple[torch.Tensor, ...] | None:
         """Compose split cache handles into the tuple expected by SFA kernels.
 
@@ -1671,7 +1743,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                 assert k_pe is not None
                 assert k_nope is not None
                 async_op = full_gather_o_proj_enabled
-                # support all_gather kv async for communication calculation overlap
+                # Pack all KV-related tensors into one byte stream so DSA-CP only
+                # submits one KV all-gather while still preserving original dtypes.
                 if self.use_sparse_c8_sfa:
                     assert knope_scale is not None
                     fused_kv_parts = [
@@ -1684,31 +1757,23 @@ class AscendSFAImpl(MLAAttentionImpl):
                         k_pe.view(-1, k_pe.shape[-1]),
                         k_nope.view(-1, k_nope.shape[-1]),
                     ]
-                    if self.has_indexer and not self.use_sparse_c8_indexer:
-                        assert k_li is not None
-                        fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
 
                 fused_kv_input = torch.cat(fused_kv_parts, dim=1)
-                fused_kv_no_split, kv_ag_handle = all_gather_async(
-                    fused_kv_input,
-                    get_tp_group(),
-                    async_op=async_op,
-                )
-
-                if self.has_indexer and self.use_sparse_c8_indexer:
+                kv_gather_parts = [("sfa_kv", fused_kv_input)]
+                if self.has_indexer:
                     assert k_li is not None
-                    k_li, kv_ag_handle = all_gather_async(
-                        k_li,
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
+                    k_li_gather_input = k_li
+                    if not self.use_sparse_c8_sfa and not self.use_sparse_c8_indexer:
+                        k_li_gather_input = k_li.view(-1, k_li.shape[-1])
+                    kv_gather_parts.append(("k_li", k_li_gather_input))
                 if self.has_indexer and self.use_sparse_c8_indexer:
                     assert k_li_scale is not None
-                    k_li_scale, kv_ag_handle = all_gather_async(
-                        k_li_scale,
-                        get_tp_group(),
-                        async_op=async_op,
-                    )
+                    kv_gather_parts.append(("k_li_scale", k_li_scale))
+
+                kv_gathered_bytes, kv_ag_handle, kv_gather_metadata = self._all_gather_byte_packed_async(
+                    kv_gather_parts,
+                    async_op=async_op,
+                )
 
             ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
             q_pe = self.rope_single(q_pe, cos, sin)
@@ -1717,6 +1782,12 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.enable_dsa_cp:
                 if kv_ag_handle is not None:
                     kv_ag_handle.wait()
+                kv_gather_outputs = self._restore_byte_gathered_tensors(kv_gathered_bytes, kv_gather_metadata)
+                fused_kv_no_split = kv_gather_outputs["sfa_kv"]
+                if self.has_indexer:
+                    k_li = kv_gather_outputs["k_li"]
+                    if self.use_sparse_c8_indexer:
+                        k_li_scale = kv_gather_outputs["k_li_scale"]
 
                 if full_gather_o_proj_enabled:
                     _, o_proj_full_handle = all_gather_async(
@@ -1743,16 +1814,6 @@ class AscendSFAImpl(MLAAttentionImpl):
                         )
                         k_pe = None
                         k_nope = None
-                    elif not self.has_indexer:
-                        k_pe, k_nope = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank],
-                            dim=-1,
-                        )
-                    elif not self.use_sparse_c8_indexer:
-                        k_pe, k_nope, k_li = fused_kv_no_split.split(
-                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
-                            dim=-1,
-                        )
                     else:
                         k_pe, k_nope = fused_kv_no_split.split(
                             [self.qk_rope_head_dim, self.kv_lora_rank],


### PR DESCRIPTION
Cherry-pick/backport of the KV all-gather byte-packing logic from #12867 for `releases/v0.24.0rc`.

This release PR references the main PR #12868, but intentionally does not cherry-pick the full main-branch refactor. It only ports the pack-allgather logic used by the v0.23.0 backport:

- add byte metadata for packed gather parts
- pack `sfa_kv`, `k_li`, and sparse C8 `k_li_scale` into one `int8` byte stream before DSA-CP all-gather
- restore each tensor to its original shape and dtype after the gather
- keep o_proj weight all-gather behavior unchanged

Validation:

- `python -c "compile(...)"` for `vllm_ascend/attention/sfa_v1.py` and `tests/ut/attention/a2/test_sfa_v1.py`
- `git diff --check upstream/releases/v0.24.0rc...HEAD`

`ruff` is not installed in the local workspace, so full lint validation is left to CI.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
