### PR TITLE
[Bugfix][Cherry-pick][v0.24.0rc] fix main2main eplb

### DIFF
--- a/tests/e2e/pull_request/two_card/test_qwen3_30b_a3b.py
+++ b/tests/e2e/pull_request/two_card/test_qwen3_30b_a3b.py
@@ -24,8 +24,6 @@ from vllm.utils.network_utils import get_open_port
 
 from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 
-pytestmark = pytest.mark.skip(reason="broken on vLLM v0.24.0 and the verified main commit, fix me.")
-
 
 @pytest.mark.e2e_model("Qwen/Qwen3-30B-A3B")
 @pytest.mark.e2e_coverage(

--- a/tests/ut/eplb/adaptor/test_vllm_adaptor.py
+++ b/tests/ut/eplb/adaptor/test_vllm_adaptor.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import torch
 from transformers import DeepseekV2Config
@@ -52,6 +52,21 @@ class TestVllmAdaptor(unittest.TestCase):
         self.assertEqual(adaptor.expert_weight_key_per_layer[0], (QuantType.NONE, True))
         self.assertIs(adaptor.expert_param_per_layer[0][0][0], self.mock_layer.w13_weight_list[0])
         self.assertIs(adaptor.expert_param_per_layer[0][0][1], self.mock_layer.w2_weight_list[0])
+
+    @patch("torch.empty_like", return_value=torch.zeros(16, 32))
+    @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")
+    def test_init_fp16_with_parameter_accessor(self, mock_get_config, mock_func):
+        mock_config = MagicMock()
+        mock_config.enable_fused_mc2 = 1
+        mock_get_config.return_value = mock_config
+        self.model.quant_config = None
+        self.mock_layer.get_eplb_parameter = MagicMock(side_effect=lambda name: getattr(self.mock_layer, name))
+
+        adaptor = VllmEplbAdaptor(self.model)
+
+        self.assertIs(adaptor.expert_param_per_layer[0][0][0], self.mock_layer.w13_weight_list[0])
+        self.assertIs(adaptor.expert_param_per_layer[0][0][1], self.mock_layer.w2_weight_list[0])
+        self.mock_layer.get_eplb_parameter.assert_has_calls([call("w13_weight_list"), call("w2_weight_list")])
 
     @patch("torch.empty_like", return_value=torch.zeros(16, 32))
     @patch("vllm_ascend.eplb.adaptor.vllm_adaptor.get_ascend_config")

--- a/tests/ut/eplb/core/a2/test_eplb_utils.py
+++ b/tests/ut/eplb/core/a2/test_eplb_utils.py
@@ -8,7 +8,7 @@ from vllm.config import VllmConfig
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig, FusedMoEParallelConfig
 
 from vllm_ascend.ascend_config import init_ascend_config
-from vllm_ascend.eplb.core.eplb_utils import generate_log2phy_map, init_eplb_config
+from vllm_ascend.eplb.core.eplb_utils import generate_global_placement, generate_log2phy_map, init_eplb_config
 # isort: on
 
 
@@ -54,11 +54,21 @@ class TestAscendConfig(unittest.TestCase):
     def test_init_eplb_config_with_eplb(self):
         eplb_config = init_ascend_config(self.vllm_config).eplb_config
         _, expert_map, log2phy, redundant_experts = init_eplb_config(eplb_config, 0, self.moe_config)
-        gt_expert_map = torch.tensor([4, -1, -1, -1, 0, 1, 2, 3])
-        gt_log2phy = torch.tensor([9, 1, 2, 3, 5, 6, 7, 8])
+        gt_expert_map = torch.tensor([3, 4, -1, -1, -1, 0, 1, 2])
+        gt_log2phy = torch.tensor([8, 9, 2, 3, 4, 5, 6, 7])
         self.assertTrue(torch.equal(expert_map, gt_expert_map))
         self.assertTrue(torch.equal(log2phy, gt_log2phy))
         self.assertEqual(redundant_experts, 2)
+
+    def test_generate_global_placement_matches_vllm_physical_layout(self):
+        placement = generate_global_placement(8, 2, 2, 0)
+
+        self.assertTrue(
+            torch.equal(
+                placement,
+                torch.tensor([[0, 1, 2, 3, 4], [5, 6, 7, 0, 1]], dtype=torch.int32),
+            )
+        )
 
     def test_init_eplb_config_with_eplb_withmap(self):
         _TEST_DIR = os.path.dirname(__file__)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -11,6 +11,8 @@ from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
 from vllm_ascend.ops.fused_moe.fused_moe import (
     AscendMoERunner,
     AscendUnquantizedFusedMoEMethod,
+    make_eplb_placement_config,
+    use_multistage_eplb_load,
 )
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -42,6 +44,30 @@ def _build_unquantized_method(*, dynamic_eplb: bool = False):
     method.moe = SimpleNamespace(has_bias=False)
     method._maybe_pad_weight = MagicMock(side_effect=lambda weight: weight)
     return method
+
+
+@pytest.mark.parametrize(
+    ("dynamic_eplb", "policy_type", "collection_interval", "expected"),
+    [
+        (True, 2, 600, False),
+        (True, 3, 600, True),
+        (True, 3, 1, False),
+        (False, 3, 600, False),
+    ],
+)
+def test_use_multistage_eplb_load(dynamic_eplb, policy_type, collection_interval, expected):
+    assert use_multistage_eplb_load(dynamic_eplb, policy_type, collection_interval) is expected
+
+
+def test_make_eplb_placement_config_does_not_copy_source():
+    source = SimpleNamespace(expert_map_path=None, dynamic_eplb=True, num_redundant_experts=0)
+
+    placement_config = make_eplb_placement_config(source, num_redundant_experts=8)
+
+    assert placement_config.expert_map_path is None
+    assert placement_config.dynamic_eplb is True
+    assert placement_config.num_redundant_experts == 8
+    assert source.num_redundant_experts == 0
 
 
 def test_ascend_unquantized_skips_upstream_modular_kernel_init():

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -16,6 +16,7 @@
 #
 # Todo: Once https://github.com/vllm-project/vllm/issues/22246 is merged in vllm. Remove this adaptor.
 import json
+from inspect import getattr_static
 from typing import Any
 
 import torch
@@ -138,7 +139,16 @@ class VllmEplbAdaptor:
             self.expert_param_per_layer[local_idx] = list()
             for name in expert_weight_names:
                 param_key = f"{local_idx}.{name}"
-                self.param_dict[param_key] = getattr(layer, name)
+                # Inspect the attribute without invoking __getattr__. Besides
+                # avoiding side effects from dynamic proxies, this prevents an
+                # unspecced MagicMock from fabricating the optional accessor.
+                # The refactored MoERunner declares the accessor because its
+                # RoutedExperts child owns weights; legacy layers expose them
+                # directly.
+                get_parameter = (
+                    layer.get_eplb_parameter if getattr_static(layer, "get_eplb_parameter", None) is not None else None
+                )
+                self.param_dict[param_key] = get_parameter(name) if get_parameter is not None else getattr(layer, name)
             for local_expert_id in range(self.num_local_experts):
                 per_expert_param = list()
                 for name in expert_weight_names:

--- a/vllm_ascend/eplb/core/eplb_utils.py
+++ b/vllm_ascend/eplb/core/eplb_utils.py
@@ -47,6 +47,15 @@ def generate_global_placement(n_expert, ep_size, n_redundant, num_shared_experts
     n_expert -= num_shared_experts
     if (n_expert + n_redundant) % ep_size != 0:
         raise ValueError("(n_expert + n_redundant) % ep_size must be 0")
+    if num_shared_experts == 0:
+        # Match vLLM's checkpoint-loading physical layout exactly:
+        # [all logical experts, redundant copies of logical experts 0..N].
+        # The flattened position is the global physical expert ID and must
+        # agree with RoutedExperts.make_expert_params_mapping.
+        physical_to_logical = np.concatenate((np.arange(n_expert), np.arange(n_redundant) % n_expert))
+        return torch.tensor(physical_to_logical.reshape(ep_size, -1), dtype=torch.int32)
+
+    # Shared-expert mix placement has a separate Ascend-only layout.
     all_experts = np.arange(n_expert)
     groups = np.array_split(all_experts, ep_size)
     for i in range(n_redundant):

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -16,8 +16,10 @@
 #
 # ruff: noqa: E501
 from collections.abc import Callable
+from copy import copy
 from dataclasses import dataclass, field
 from functools import wraps
+from types import SimpleNamespace
 
 import torch
 import torch.nn.functional as F
@@ -90,6 +92,20 @@ def mock_false():
 
 def mock_true():
     return True
+
+
+def use_multistage_eplb_load(dynamic_eplb: bool, policy_type: int, collection_interval: int) -> bool:
+    """Whether EPLB should retain a separate expert-load vector per step."""
+    return dynamic_eplb and policy_type == 3 and collection_interval > 1
+
+
+def make_eplb_placement_config(eplb_config, num_redundant_experts: int) -> SimpleNamespace:
+    """Build the minimal config view consumed by init_eplb_config."""
+    return SimpleNamespace(
+        expert_map_path=eplb_config.expert_map_path,
+        dynamic_eplb=eplb_config.dynamic_eplb,
+        num_redundant_experts=num_redundant_experts,
+    )
 
 
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
@@ -385,8 +401,19 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
 
         eplb_config = ascend_config.eplb_config
 
-        if mix_placement:
-            moe_config.num_experts += n_shared_experts
+        # The upstream FusedMoE factory has already included redundant expert
+        # slots in moe_config and allocated RoutedExperts weights accordingly.
+        # Ascend's placement builder operates on logical expert IDs, so give it
+        # a shallow config view with the logical count.
+        placement_moe_config = copy(moe_config)
+        placement_moe_config.num_experts = moe_config.num_logical_experts + (n_shared_experts if mix_placement else 0)
+        allocated_redundancy = moe_config.num_experts - moe_config.num_logical_experts
+        if eplb_config.num_redundant_experts not in (0, allocated_redundancy):
+            raise ValueError(
+                "Conflicting EPLB redundant expert counts: "
+                f"allocated={allocated_redundancy}, Ascend={eplb_config.num_redundant_experts}."
+            )
+        placement_eplb_config = make_eplb_placement_config(eplb_config, allocated_redundancy)
 
         (
             self.global_expert_map,
@@ -394,24 +421,43 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.log2phy,
             self.global_redundant_expert_num,
         ) = init_eplb_config(
-            eplb_config,
+            placement_eplb_config,
             AscendMoERunner.moe_counter,
-            moe_config,
+            placement_moe_config,
             mix_placement,
             n_shared_experts,
             tp_size=vllm_config.parallel_config.tensor_parallel_size,
         )
 
         moe_config.global_redundant_expert_num = self.global_redundant_expert_num
-        local_num_experts = (moe_config.num_experts + self.global_redundant_expert_num) // moe_config.ep_size
-        moe_config.num_local_experts = local_num_experts
-        routed_experts.expert_map_manager._local_num_experts = local_num_experts
-        routed_experts.expert_map_manager._expert_map = self._expert_map
+        local_num_experts = moe_config.num_local_experts
+        expected_local_num_experts = (
+            placement_moe_config.num_experts + self.global_redundant_expert_num
+        ) // moe_config.ep_size
+        if local_num_experts != expected_local_num_experts:
+            raise ValueError(
+                "EPLB local expert capacity mismatch: "
+                f"allocated={local_num_experts}, placement={expected_local_num_experts}. "
+                "Ensure vLLM and Ascend use the same redundant expert count."
+            )
+        # Keep ExpertMapManager's physical-expert map until checkpoint loading
+        # finishes. The upstream loader uses it to place both original and
+        # redundant physical experts. Ascend execution uses self._expert_map,
+        # which maps logical expert IDs to the local physical slots.
 
         self.dynamic_eplb = eplb_config.dynamic_eplb and (self.log2phy is not None)
         self.multi_stage = False
         self.moe_load = torch.zeros(local_num_experts, dtype=torch.int64).npu()
-        if self.dynamic_eplb and eplb_config.expert_heat_collection_interval > 1:
+        # Only FlashLB consumes a time series of expert loads. Other EPLB
+        # policies (including the default SwiftBalance policy) expect one load
+        # vector per layer and rank. Using the collection interval alone here
+        # adds an unexpected window dimension and produces
+        # [layer, rank, interval, expert] after all-gather.
+        if use_multistage_eplb_load(
+            self.dynamic_eplb,
+            eplb_config.eplb_policy_type,
+            eplb_config.expert_heat_collection_interval,
+        ):
             self.multi_stage = True
             self.load_counter = torch.tensor(0, dtype=torch.int32, device="npu")
             self.num_iter = eplb_config.expert_heat_collection_interval
@@ -518,6 +564,32 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             MoECommType.MC2,
             MoECommType.FUSED_MC2,
         } or (moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
+
+    @property
+    def local_num_experts(self) -> int:
+        """Number of physical experts managed by this EPLB layer."""
+        return self.moe_config.num_local_experts
+
+    @property
+    def ep_rank(self) -> int:
+        return self.moe_config.ep_rank
+
+    def update_expert_map(self, new_expert_map: torch.Tensor) -> None:
+        """Update both the runner and routed-expert map references."""
+        self._expert_map = new_expert_map
+        self.routed_experts.expert_map_manager._expert_map = new_expert_map
+
+    def get_log2phy_map(self) -> torch.Tensor | None:
+        return self.log2phy
+
+    def clear_moe_load(self) -> None:
+        self.moe_load.zero_()
+        if self.multi_stage:
+            self.load_counter.zero_()
+
+    def get_eplb_parameter(self, name: str):
+        """Return an expert parameter from the refactored weight owner."""
+        return getattr(self.routed_experts, name)
 
     def _maybe_reduce_shared_expert_output(
         self,

--- a/vllm_ascend/patch/platform/patch_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_fused_moe.py
@@ -30,6 +30,7 @@
 import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
 import vllm.model_executor.layers.fused_moe.layer as _fused_moe_layer
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.utils import is_310p
 
 # Capture the real original before fused_moe.py's module-level code runs.
@@ -44,6 +45,19 @@ else:
 def _ascend_FusedMoE(*args, runner_cls=None, runner_args=None, **kwargs):
     if runner_cls is None:
         runner_cls = _DefaultAscendMoERunner
+    # RoutedExperts allocates its parameters before AscendMoERunner is
+    # constructed. Propagate Ascend EPLB capacity into the upstream factory so
+    # redundant expert slots are present when weights are created and loaded.
+    eplb_config = get_ascend_config().eplb_config
+    if eplb_config.dynamic_eplb or eplb_config.expert_map_path is not None:
+        configured_redundancy = eplb_config.num_redundant_experts
+        upstream_redundancy = kwargs.get("num_redundant_experts", 0)
+        if configured_redundancy and upstream_redundancy not in (0, configured_redundancy):
+            raise ValueError(
+                f"Conflicting EPLB redundant expert counts: vLLM={upstream_redundancy}, Ascend={configured_redundancy}."
+            )
+        kwargs["enable_eplb"] = True
+        kwargs["num_redundant_experts"] = configured_redundancy or upstream_redundancy
     # 'hash' is a DeepSeek V4 flag already consumed before FusedMoE is called;
     # 'tid2eid' is Ascend-specific and must reach AscendMoERunner via runner_args.
     kwargs.pop("hash", None)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR restores the compatibility of the legacy Ascend EPLB implementation with the latest upstream vLLM FusedMoE refactoring.
It:

- Propagates the configured redundant expert count to the upstream FusedMoE factory, ensuring that physical expert slots are allocated before checkpoint loading.

- Separates logical expert placement from physical expert capacity and validates that vLLM and Ascend use consistent expert counts.

- Aligns Ascend's initial physical-to-logical placement with the upstream checkpoint layout: logical experts first, followed by redundant replicas.

- Updates VllmEplbAdaptor to support the refactored MoERunner, where expert weights may be owned by RoutedExperts and accessed through get_eplb_parameter().

- Uses static attribute inspection to avoid dynamic proxy and unspecced MagicMock side effects.

- Fixes expert-load tensor dimensions: only the FlashLB policy uses a per-step collection window, while SwiftBalance consumes one load vector per layer and rank.

- Exposes the local expert count, expert map update, logical-to-physical map, and load-reset interfaces required by EPLB.

- Re-enables the Qwen3 MoE and dynamic EPLB E2E tests and adds corresponding unit-test coverage.

This is needed because upstream vLLM now allocates RoutedExperts parameters before constructing the Ascend MoE runner. Previously, Ascend added redundant-expert information too late, which caused the allocated weight capacity, checkpoint physical layout, and Ascend placement map to become inconsistent. Depending on the configuration, this resulted in missing attributes, expert-capacity mismatches, EPLB worker crashes, or incorrect inference results when redundant experts were enabled.
The adaptor also assumed that expert parameters were stored directly on the MoE runner. After the upstream refactoring, some parameters moved under RoutedExperts, so the adaptor must support both the legacy direct-attribute layout and the new accessor-based layout.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
