### PR TITLE
[MRV2][Feature] Add FlashComm1 support to Model Runner V2

### DIFF
--- a/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
+++ b/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
@@ -52,6 +52,30 @@ def test_deepseek_v2_lite_fc1_tp2() -> None:
         vllm_model.generate(example_prompts, sampling_params)
 
 
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+def test_deepseek_v2_lite_fc1_model_runner_v2_tp2() -> None:
+    example_prompts = [
+        "test" * 1001,
+    ]
+    sampling_params = SamplingParams(
+        max_tokens=5,
+        temperature=0.0,
+        top_k=50,
+        top_p=0.9,
+    )
+    with VllmRunner(
+        "vllm-ascend/DeepSeek-V2-Lite-W8A8",
+        dtype="auto",
+        tensor_parallel_size=2,
+        distributed_executor_backend="mp",
+        enable_expert_parallel=True,
+        enforce_eager=True,
+        quantization="ascend",
+        additional_config={"enable_flashcomm1": True},
+    ) as vllm_model:
+        vllm_model.generate(example_prompts, sampling_params)
+
+
 @pytest.mark.parametrize("model", QWEN_DENSE_MODELS)
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"})
 def test_qwen3_dense_fc1_tp2(model):

--- a/tests/ut/worker/test_model_runner_v2_flashcomm.py
+++ b/tests/ut/worker/test_model_runner_v2_flashcomm.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+
+from vllm_ascend.worker.v2.model_runner import (
+    NPUModelRunner,
+    flashcomm_dispatch_wrapper,
+)
+
+
+def _config(tp_size=2):
+    return SimpleNamespace(parallel_config=SimpleNamespace(tensor_parallel_size=tp_size))
+
+
+def test_flashcomm_dispatch_pads_before_graph_selection():
+    config = _config(tp_size=4)
+    dispatch = MagicMock(
+        return_value=(
+            BatchExecutionDescriptor(
+                cg_mode=CUDAGraphMode.NONE,
+                num_tokens=8,
+                num_reqs=1,
+            ),
+            None,
+        )
+    )
+
+    with (
+        patch(
+            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.model_runner.vllm_model_runner.dispatch_cg_and_sync_dp",
+            dispatch,
+        ),
+        flashcomm_dispatch_wrapper(config),
+    ):
+        from vllm.v1.worker.gpu import model_runner as vllm_model_runner
+
+        vllm_model_runner.dispatch_cg_and_sync_dp(
+            None,
+            1,
+            5,
+            None,
+            1,
+            0,
+            need_eager=True,
+        )
+
+    assert dispatch.call_args.args[2] == 8
+
+
+def test_all_gather_hidden_states_trims_flashcomm_padding():
+    local_hidden_states = torch.arange(6).reshape(3, 2)
+    gathered_hidden_states = torch.arange(12).reshape(6, 2)
+
+    with patch(
+        "vllm_ascend.worker.v2.model_runner.tensor_model_parallel_all_gather",
+        return_value=gathered_hidden_states,
+    ):
+        result = NPUModelRunner._all_gather_hidden_states(
+            local_hidden_states,
+            num_tokens=5,
+        )
+
+    torch.testing.assert_close(result, gathered_hidden_states[:5])
+
+
+def test_flashcomm_dense_threshold_and_moe_behavior():
+    config = _config()
+    with (
+        patch(
+            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.model_runner.is_moe_model",
+            return_value=False,
+        ),
+    ):
+        assert not NPUModelRunner._flashcomm_enabled(config, 1000)
+        assert NPUModelRunner._flashcomm_enabled(config, 1001)
+
+    with (
+        patch(
+            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.model_runner.is_moe_model",
+            return_value=True,
+        ),
+    ):
+        assert NPUModelRunner._flashcomm_enabled(config, 1)

--- a/tests/ut/worker/test_model_runner_v2_flashcomm.py
+++ b/tests/ut/worker/test_model_runner_v2_flashcomm.py
@@ -6,8 +6,11 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 
 from vllm_ascend.worker.v2.model_runner import (
-    NPUModelRunner,
     flashcomm_dispatch_wrapper,
+)
+from vllm_ascend.worker.v2.sp_utils import (
+    _all_gather_hidden_states,
+    _flashcomm_enabled,
 )
 
 
@@ -59,10 +62,10 @@ def test_all_gather_hidden_states_trims_flashcomm_padding():
     gathered_hidden_states = torch.arange(12).reshape(6, 2)
 
     with patch(
-        "vllm_ascend.worker.v2.model_runner.tensor_model_parallel_all_gather",
+        "vllm_ascend.worker.v2.sp_utils.tensor_model_parallel_all_gather",
         return_value=gathered_hidden_states,
     ):
-        result = NPUModelRunner._all_gather_hidden_states(
+        result = _all_gather_hidden_states(
             local_hidden_states,
             num_tokens=5,
         )
@@ -74,25 +77,25 @@ def test_flashcomm_dense_threshold_and_moe_behavior():
     config = _config()
     with (
         patch(
-            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            "vllm_ascend.worker.v2.sp_utils.enable_sp",
             return_value=True,
         ),
         patch(
-            "vllm_ascend.worker.v2.model_runner.is_moe_model",
+            "vllm_ascend.worker.v2.sp_utils.is_moe_model",
             return_value=False,
         ),
     ):
-        assert not NPUModelRunner._flashcomm_enabled(config, 1000)
-        assert NPUModelRunner._flashcomm_enabled(config, 1001)
+        assert not _flashcomm_enabled(config, 1000)
+        assert _flashcomm_enabled(config, 1001)
 
     with (
         patch(
-            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            "vllm_ascend.worker.v2.sp_utils.enable_sp",
             return_value=True,
         ),
         patch(
-            "vllm_ascend.worker.v2.model_runner.is_moe_model",
+            "vllm_ascend.worker.v2.sp_utils.is_moe_model",
             return_value=True,
         ),
     ):
-        assert NPUModelRunner._flashcomm_enabled(config, 1)
+        assert _flashcomm_enabled(config, 1)

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -75,11 +75,9 @@ def _maybe_pad_and_reduce_impl(x: torch.Tensor, is_ep_comm: bool = False) -> tor
     except AssertionError:
         return tensor_model_parallel_all_reduce(x)
 
-    flash_comm_v1_enabled = getattr(forward_context, "flash_comm_v1_enabled", False) or (
-        enable_sp_by_pass() and is_ep_comm
-    )
+    flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (enable_sp_by_pass() and is_ep_comm)
 
-    if not flash_comm_v1_enabled or (forward_context.is_draft_model and is_vl_model() and not is_ep_comm):
+    if not flash_comm_v1_enabled or (_EXTRA_CTX.is_draft_model and is_vl_model() and not is_ep_comm):
         return tensor_model_parallel_all_reduce(x)
 
     dp_metadata = forward_context.dp_metadata

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -65,6 +65,7 @@ from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
 FLASHCOMM_DENSE_TOKEN_THRESHOLD = 1000
 
 
+# TODO: remove this wrapper when vllm-ascend supports sequence parallel on model runner v2.
 @contextmanager
 def flashcomm_dispatch_wrapper(vllm_config: VllmConfig):
     """Pad batches before v2 selects an eager or graph execution shape.

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -23,7 +23,6 @@ import numpy as np
 import torch
 from vllm.config import VllmConfig
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
-from vllm.distributed import tensor_model_parallel_all_gather
 from vllm.sequence import IntermediateTensors
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -52,17 +51,19 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_tokens_capacity,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
-from vllm_ascend.utils import enable_sp, is_moe_model
+from vllm_ascend.utils import enable_sp
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import maybe_build_ascend_pcp_manager
+from vllm_ascend.worker.v2.sp_utils import (
+    _all_gather_hidden_states_and_aux,
+    _flashcomm_enabled,
+)
 from vllm_ascend.worker.v2.spec_decode import init_speculator
 from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
 from vllm_ascend.worker.v2.states import AscendRequestState
 from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
-
-FLASHCOMM_DENSE_TOKEN_THRESHOLD = 1000
 
 
 # TODO: remove this wrapper when vllm-ascend supports sequence parallel on model runner v2.
@@ -199,24 +200,6 @@ class NPUModelRunner(GPUModelRunner):
                 self.block_tables,
             )
 
-    @staticmethod
-    def _flashcomm_enabled(vllm_config: VllmConfig, num_tokens: int) -> bool:
-        return enable_sp(vllm_config) and (is_moe_model(vllm_config) or num_tokens > FLASHCOMM_DENSE_TOKEN_THRESHOLD)
-
-    @staticmethod
-    def _all_gather_hidden_states(hidden_states: torch.Tensor, num_tokens: int):
-        hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
-        return hidden_states[:num_tokens]
-
-    @classmethod
-    def _all_gather_hidden_states_and_aux(cls, hidden_states, num_tokens: int):
-        if isinstance(hidden_states, tuple):
-            return (
-                cls._all_gather_hidden_states(hidden_states[0], num_tokens),
-                [cls._all_gather_hidden_states(aux_hidden_state, num_tokens) for aux_hidden_state in hidden_states[1]],
-            )
-        return cls._all_gather_hidden_states(hidden_states, num_tokens)
-
     @torch.inference_mode()
     def execute_model(
         self,
@@ -239,11 +222,11 @@ class NPUModelRunner(GPUModelRunner):
         if (
             self.is_last_pp_rank
             and state is not None
-            and self._flashcomm_enabled(self.vllm_config, state.input_batch.num_tokens_after_padding)
+            and _flashcomm_enabled(self.vllm_config, state.input_batch.num_tokens_after_padding)
         ):
             num_tokens = state.input_batch.num_tokens
             assert state.hidden_states is not None
-            gathered_output = self._all_gather_hidden_states_and_aux(
+            gathered_output = _all_gather_hidden_states_and_aux(
                 (state.hidden_states, state.aux_hidden_states)
                 if state.aux_hidden_states is not None
                 else state.hidden_states,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -23,6 +23,8 @@ import numpy as np
 import torch
 from vllm.config import VllmConfig
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
+from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.sequence import IntermediateTensors
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu import model_runner as vllm_model_runner
@@ -34,7 +36,11 @@ from vllm.v1.worker.gpu.input_batch import (
     prepare_pos_seq_lens,
     prepare_prefill_inputs,
 )
-from vllm.v1.worker.gpu.model_runner import GPUModelRunner, sort_batch_req_ids
+from vllm.v1.worker.gpu.model_runner import (
+    ExecuteModelState,
+    GPUModelRunner,
+    sort_batch_req_ids,
+)
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import (
@@ -46,6 +52,7 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_tokens_capacity,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
+from vllm_ascend.utils import enable_sp, is_moe_model
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
@@ -55,9 +62,57 @@ from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpecul
 from vllm_ascend.worker.v2.states import AscendRequestState
 from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
 
+FLASHCOMM_DENSE_TOKEN_THRESHOLD = 1000
+
+
+@contextmanager
+def flashcomm_dispatch_wrapper(vllm_config: VllmConfig):
+    """Pad batches before v2 selects an eager or graph execution shape.
+
+    FlashComm1 reduce-scatter requires the token dimension to be divisible by
+    tensor parallel size. Padding in ``prepare_inputs`` is too late for full
+    graphs because their replay shape has already been selected by then.
+    """
+    if not enable_sp(vllm_config):
+        yield
+        return
+
+    original_dispatch = vllm_model_runner.dispatch_cg_and_sync_dp
+    tp_size = vllm_config.parallel_config.tensor_parallel_size
+
+    def dispatch_with_flashcomm_padding(
+        cudagraph_manager,
+        num_reqs,
+        num_tokens,
+        uniform_token_count,
+        dp_size,
+        dp_rank,
+        need_eager=False,
+        num_active_loras=0,
+    ):
+        num_tokens = (num_tokens + tp_size - 1) // tp_size * tp_size
+        return original_dispatch(
+            cudagraph_manager,
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            dp_size,
+            dp_rank,
+            need_eager=need_eager,
+            num_active_loras=num_active_loras,
+        )
+
+    vllm_model_runner.dispatch_cg_and_sync_dp = dispatch_with_flashcomm_padding
+    try:
+        yield
+    finally:
+        vllm_model_runner.dispatch_cg_and_sync_dp = original_dispatch
+
 
 class NPUModelRunner(GPUModelRunner):
     """Model runner for Ascend NPUs."""
+
+    execute_model_state: ExecuteModelState | None
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         # Ascend-specific configurations
@@ -142,6 +197,68 @@ class NPUModelRunner(GPUModelRunner):
                 self.req_states,
                 self.block_tables,
             )
+
+    @staticmethod
+    def _flashcomm_enabled(vllm_config: VllmConfig, num_tokens: int) -> bool:
+        return enable_sp(vllm_config) and (is_moe_model(vllm_config) or num_tokens > FLASHCOMM_DENSE_TOKEN_THRESHOLD)
+
+    @staticmethod
+    def _all_gather_hidden_states(hidden_states: torch.Tensor, num_tokens: int):
+        hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
+        return hidden_states[:num_tokens]
+
+    @classmethod
+    def _all_gather_hidden_states_and_aux(cls, hidden_states, num_tokens: int):
+        if isinstance(hidden_states, tuple):
+            return (
+                cls._all_gather_hidden_states(hidden_states[0], num_tokens),
+                [cls._all_gather_hidden_states(aux_hidden_state, num_tokens) for aux_hidden_state in hidden_states[1]],
+            )
+        return cls._all_gather_hidden_states(hidden_states, num_tokens)
+
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: SchedulerOutput,
+        intermediate_tensors: IntermediateTensors | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        is_profile: bool = False,
+    ):
+        with flashcomm_dispatch_wrapper(self.vllm_config):
+            output = super().execute_model(
+                scheduler_output,
+                intermediate_tensors=intermediate_tensors,
+                dummy_run=dummy_run,
+                skip_attn_for_dummy_run=skip_attn_for_dummy_run,
+                is_profile=is_profile,
+            )
+
+        state = self.execute_model_state
+        if (
+            self.is_last_pp_rank
+            and state is not None
+            and self._flashcomm_enabled(self.vllm_config, state.input_batch.num_tokens_after_padding)
+        ):
+            num_tokens = state.input_batch.num_tokens
+            assert state.hidden_states is not None
+            gathered_output = self._all_gather_hidden_states_and_aux(
+                (state.hidden_states, state.aux_hidden_states)
+                if state.aux_hidden_states is not None
+                else state.hidden_states,
+                num_tokens,
+            )
+            if isinstance(gathered_output, tuple):
+                hidden_states, aux_hidden_states = gathered_output
+            else:
+                hidden_states = gathered_output
+                aux_hidden_states = state.aux_hidden_states
+            self.execute_model_state = state._replace(
+                hidden_states=hidden_states,
+                aux_hidden_states=aux_hidden_states,
+            )
+
+        return output
 
     @torch.inference_mode()
     def profile_run(self) -> None:

--- a/vllm_ascend/worker/v2/sp_utils.py
+++ b/vllm_ascend/worker/v2/sp_utils.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import torch
+from vllm.config import VllmConfig
+from vllm.distributed import tensor_model_parallel_all_gather
+
+from vllm_ascend.utils import enable_sp, is_moe_model
+
+FLASHCOMM_DENSE_TOKEN_THRESHOLD = 1000
+
+
+def _flashcomm_enabled(vllm_config: VllmConfig, num_tokens: int) -> bool:
+    return enable_sp(vllm_config) and (is_moe_model(vllm_config) or num_tokens > FLASHCOMM_DENSE_TOKEN_THRESHOLD)
+
+
+def _all_gather_hidden_states(hidden_states: torch.Tensor, num_tokens: int):
+    hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
+    return hidden_states[:num_tokens]
+
+
+def _all_gather_hidden_states_and_aux(hidden_states, num_tokens: int):
+    if isinstance(hidden_states, tuple):
+        return (
+            _all_gather_hidden_states(hidden_states[0], num_tokens),
+            [_all_gather_hidden_states(aux_hidden_state, num_tokens) for aux_hidden_state in hidden_states[1]],
+        )
+    return _all_gather_hidden_states(hidden_states, num_tokens)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds FlashComm1 support to Model Runner V2 on Ascend.

Model Runner V2 uses the new vLLM forward context, where Ascend-specific fields are stored in `additional_kwargs`. This PR uses `_EXTRA_CTX` to correctly access `flash_comm_v1_enabled` and other Ascend-specific fields across both Model Runner V1 and V2, ensuring that FlashComm1 uses reduce-scatter instead of falling back to all-reduce.

It also:

- Pads the token count to a multiple of the tensor-parallel size before eager/graph execution shape selection, as required by FlashComm1 reduce-scatter.
- Enables FlashComm1 for MoE models and for dense models above the existing token threshold.
- All-gathers sequence-parallel hidden states and auxiliary hidden states on the last pipeline-parallel rank.
- Removes FlashComm1 padding from gathered outputs before downstream post-processing.

### Does this PR introduce *any* user-facing change?

Yes.

Users can now enable FlashComm1 when using Model Runner V2 on Ascend with `VLLM_USE_V2_MODEL_RUNNER=1` and `additional_config={"enable_flashcomm1": true}`.

### How was this patch tested?

- Added unit tests covering:
  - Token padding before execution shape selection.
  - Hidden-state all-gather and removal of FlashComm1 padding.
  - FlashComm1 enablement for MoE models and the dense-model token threshold.
- Added a two-card E2E test for `vllm-ascend/DeepSeek-V2-Lite-W8A8` with Model Runner V2, TP=2, expert parallelism, and FlashComm1 enabled.
- Manually verified Model Runner V2 with FlashComm1 for successful generation and output accuracy.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
