### PR TITLE
[Feat] Support SWA-DFlash using FIA in MRV1

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -785,7 +785,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         actual_seq_lengths_q = metadata.actual_seq_lengths_q
                         block_tables = metadata.block_tables
                         attn_count = attn_count + 1
-                        if not metadata.causal:
+                        # Preserve SWA (band) draft layers: their sparse_mode=4
+                        # and 2048 band-mask were baked at capture. Forcing
+                        # sparse_mode=0 here (as for non-causal full layers)
+                        # replays the baked mask with sparse_mode=0, which NPU
+                        # FIA rejects ("When attnMask is provided, sparseMode
+                        # must be 3 or 4"). Only fall back to unmasked full
+                        # (sparse_mode=0) for non-SWA draft layers.
+                        if not metadata.causal and sparse_mode != 4:
                             sparse_mode = 0
                     else:
                         metadata_key = layer_name if layer_name is not None and layer_name in attn_metadata else key
@@ -866,6 +873,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
         input_layout = "TND"
         attn_mask = attn_metadata.attn_mask
+        # NPU FIA sparse_mode=4 (band) requires a fixed 2048x2048 lower-
+        # triangular causal template mask (sparse_mode 2/3/4 must carry one;
+        # passing None is rejected with "sparseMode must be 0"). The DFlash
+        # structural-SWA draft carries no attn_mask, so supply the template
+        # for sliding layers here (the band itself still comes from
+        # pre_tokens/next_tokens below). Target SWA layers already receive a
+        # mask from the metadata builder, so this only fires when the mask is
+        # None. See swa-dflash-optionA-impl.md.
+        if attn_mask is None and self.sliding_window is not None:
+            attn_mask = AttentionMaskBuilder(query.device).get_splitfuse_attn_mask()
         sparse_mode = 4 if self.sliding_window else 3 if attn_metadata.causal else 0
         pre_tokens = self.sliding_window or SWA_INT_MAX
         next_tokens = 0 if self.sliding_window else SWA_INT_MAX

--- a/vllm_ascend/patch/worker/patch_qwen3_dflash.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_dflash.py
@@ -68,6 +68,59 @@ def precompute_and_store_context_kv(
 
 DFlashQwen3Model.precompute_and_store_context_kv = precompute_and_store_context_kv
 
+
+def _apply_dflash_structural_swa(self) -> None:
+    """Enable per-layer structural SWA on the Ascend FIA impl for DFlash
+    drafts whose config marks some layers as ``sliding_attention``.
+
+    The DFlash draft builds every layer as a full-attention layer
+    (``Attention.sliding_window`` is None -> ``FullAttentionSpec``, i.e. a
+    single KV-cache group). Mixed sliding/full DFlash checkpoints such as
+    ``Qwen3.6-35B-A3B-DFlash-SW`` (``layer_types = [sliding_attention x5,
+    full_attention]``, ``sliding_window = 4096``) need the sliding layers to
+    run causal-band sliding-window attention.
+
+    Ascend V1 draft attention only plumbs a single KV-cache group, so we
+    cannot split the layers into ``SlidingWindowSpec`` + ``FullAttentionSpec``
+    groups (that is the V2-only path in upstream vLLM PR #47914). Instead we
+    keep one ``FullAttentionSpec`` group and set ``sliding_window`` directly
+    on each sliding layer's FIA impl. Ascend FIA then runs ``sparse_mode=4``
+    (``pre_tokens=window``, ``next_tokens=0`` == causal band) for those
+    layers -- exactly what upstream assigns them (SWA layers default causal
+    in PR #47914 ``_resolve_layer_attention``). Full layers keep
+    ``sliding_window=None`` -> ``sparse_mode=0`` (non-causal). Applying the
+    causal-band mask over the fully-retained cache is numerically equivalent
+    to the upstream windowed-cache path. See ``swa-dflash-design.md``.
+    """
+    cfg = getattr(self, "config", None)
+    if cfg is None:
+        return
+    layer_types = getattr(cfg, "layer_types", None)
+    sliding_window = getattr(cfg, "sliding_window", None)
+    # Only mixed/structural SWA configs need this; an absent layer_types or
+    # sliding_window (the "standard" all-full DFlash) is left untouched.
+    if not layer_types or not sliding_window:
+        return
+    for i, layer in enumerate(self.layers):
+        if i >= len(layer_types):
+            break
+        if layer_types[i] == "sliding_attention":
+            # Attention.impl is created eagerly in Attention.__init__; setting
+            # sliding_window here (model construction, before ACL-graph
+            # capture) makes FIA bake sparse_mode=4 into the captured graph.
+            layer.self_attn.attn.impl.sliding_window = sliding_window
+
+
+_orig_dflash_model_init = DFlashQwen3Model.__init__
+
+
+def _patched_dflash_model_init(self, *args, **kwargs) -> None:
+    _orig_dflash_model_init(self, *args, **kwargs)
+    _apply_dflash_structural_swa(self)
+
+
+DFlashQwen3Model.__init__ = _patched_dflash_model_init
+
 _orig_read_mask_embedding = DFlashQwen3ForCausalLM._read_mask_embedding
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
Z-Lab changes the structure of DFlash using Slliding Window Attention in https://github.com/vllm-project/vllm/pull/47914; thus the new SWA-DFlash can only be used in MRV2 currently; I used FIA to replace SWA in vllm-ascend, to swiftly checkout the performace of the new SWA-DFlash. 
### Does this PR introduce _any_ user-facing change?
Nope
### How was this patch tested?
VLLM-Asecnd: Main @ a0cc4ce1de3f736dd4d4fb9f74802b851ade036e
VLLM：0.25.1

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
