### PR TITLE
[BugFix][RFork] Consolidate transfer layout and fallback fixes

### DIFF
--- a/tests/ut/model_loader/rfork/test_rfork_loader.py
+++ b/tests/ut/model_loader/rfork/test_rfork_loader.py
@@ -30,6 +30,7 @@ from vllm_ascend.model_loader.rfork.rfork_loader import (
     _make_fallback_load_config,
     _reset_process_global_model_state,
     _rfork_pre_transfer_weight_processing,
+    _rfork_skip_unquantized_moe_post_load_processing,
 )
 from vllm_ascend.model_loader.rfork.seed_protocol import get_local_seed_key
 
@@ -497,10 +498,14 @@ def test_rfork_fallback_clears_only_failed_model_state_before_reinit(monkeypatch
     loader = RForkModelLoader(load_config)
     model_config = SimpleNamespace(dtype=torch.float32, model="/models/test", quantization="ascend")
     vllm_config = _vllm_config(model_config=model_config)
-    stale_attention = SimpleNamespace()
-    stale_moe = SimpleNamespace()
-    unrelated_layer = SimpleNamespace()
-    fallback_down_proj = SimpleNamespace()
+
+    class _FakeModule:
+        pass
+
+    stale_attention = _FakeModule()
+    stale_moe = _FakeModule()
+    unrelated_layer = _FakeModule()
+    fallback_down_proj = _FakeModule()
     vllm_config.compilation_config = SimpleNamespace(
         static_forward_context={
             "model.layers.0.self_attn.indexer.k_cache": stale_attention,
@@ -534,11 +539,11 @@ def test_rfork_fallback_clears_only_failed_model_state_before_reinit(monkeypatch
 
     rfork_worker = SimpleNamespace(
         is_seed_available=lambda: True,
-        pre_transfer=lambda model: True,
-        transfer=lambda model: False,
+        pre_transfer=lambda model, processed_layout: True,
+        transfer=lambda model, processed_layout: False,
         post_transfer=lambda: True,
         reset_transfer_state=lambda: None,
-        start_seed_service=lambda model: None,
+        start_seed_service=lambda model, processed_layout: None,
     )
 
     monkeypatch.setattr(loader, "_ensure_rfork_worker", lambda vc, mc: rfork_worker)
@@ -595,7 +600,7 @@ def test_rfork_seed_miss_fallback_preserves_existing_process_global_state(monkey
         is_seed_available=lambda: False,
         post_transfer=lambda: True,
         reset_transfer_state=lambda: None,
-        start_seed_service=lambda model: None,
+        start_seed_service=lambda model, processed_layout: None,
     )
 
     monkeypatch.setattr(loader, "_ensure_rfork_worker", lambda vc, mc: rfork_worker)
@@ -625,7 +630,7 @@ def test_rfork_pre_transfer_weight_processing_unwraps_and_restores_quant_methods
 
     class _FakeAscendMoERunner:
         def __init__(self, quant_method):
-            self.quant_method = quant_method
+            self._quant_method = quant_method
 
     calls = []
 
@@ -659,3 +664,59 @@ def test_rfork_pre_transfer_weight_processing_unwraps_and_restores_quant_methods
         assert quant_method.process_weights_after_loading is original_process_weights
         raise RuntimeError("boom")
     assert quant_method.process_weights_after_loading is wrapped_process_weights
+
+
+def test_rfork_skips_only_unquantized_moe_post_load_processing(monkeypatch):
+    import vllm_ascend.ops.fused_moe.fused_moe as fused_moe_module
+    import vllm_ascend.ops.fused_moe.routed_experts as routed_experts_module
+
+    class _FakeAscendUnquantizedFusedMoEMethod:
+        def __init__(self, process_weights_after_loading):
+            self.process_weights_after_loading = process_weights_after_loading
+
+    class _FakeAscendMoERunner:
+        def __init__(self, quant_method):
+            self._quant_method = quant_method
+
+    calls = []
+
+    def unquantized_process(*args, **kwargs):
+        calls.append("unquantized")
+
+    def quantized_process(*args, **kwargs):
+        calls.append("quantized")
+
+    unquantized_method = _FakeAscendUnquantizedFusedMoEMethod(unquantized_process)
+    quantized_method = SimpleNamespace(process_weights_after_loading=quantized_process)
+    unquantized_layer = _FakeAscendMoERunner(unquantized_method)
+    quantized_layer = _FakeAscendMoERunner(quantized_method)
+    duplicate_unquantized_layer = _FakeAscendMoERunner(unquantized_method)
+
+    class _FakeModule:
+        def modules(self):
+            return iter(
+                [
+                    self,
+                    unquantized_layer,
+                    quantized_layer,
+                    duplicate_unquantized_layer,
+                ]
+            )
+
+    monkeypatch.setattr(
+        routed_experts_module,
+        "AscendUnquantizedFusedMoEMethod",
+        _FakeAscendUnquantizedFusedMoEMethod,
+    )
+    monkeypatch.setattr(fused_moe_module, "AscendMoERunner", _FakeAscendMoERunner)
+
+    with _rfork_skip_unquantized_moe_post_load_processing(_FakeModule()):
+        assert unquantized_method.process_weights_after_loading() is None
+        quantized_method.process_weights_after_loading()
+        assert calls == ["quantized"]
+    assert unquantized_method.process_weights_after_loading is unquantized_process
+    assert quantized_method.process_weights_after_loading is quantized_process
+
+    with pytest.raises(RuntimeError, match="boom"), _rfork_skip_unquantized_moe_post_load_processing(_FakeModule()):
+        raise RuntimeError("boom")
+    assert unquantized_method.process_weights_after_loading is unquantized_process

--- a/tests/ut/model_loader/rfork/test_rfork_loader.py
+++ b/tests/ut/model_loader/rfork/test_rfork_loader.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from functools import wraps
 from types import SimpleNamespace
 
 import pytest
@@ -27,6 +28,8 @@ from vllm_ascend.model_loader.rfork.rfork_loader import (
     _is_draft_model,
     _is_dynamic_eplb_enabled,
     _make_fallback_load_config,
+    _reset_process_global_model_state,
+    _rfork_pre_transfer_weight_processing,
 )
 from vllm_ascend.model_loader.rfork.seed_protocol import get_local_seed_key
 
@@ -483,3 +486,176 @@ def test_rfork_native_eplb_uses_default_loader(monkeypatch):
     assert captured["load_config"] is not load_config
     assert captured["load_config"].load_format == "auto"
     assert captured["load_config"].model_loader_extra_config == {}
+
+
+def test_rfork_fallback_clears_only_failed_model_state_before_reinit(monkeypatch):
+    """Fallback re-init in the same process must first clear stale layer registries."""
+    import vllm.model_executor.model_loader as model_loader
+    from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+    load_config = DummyLoadConfig({"model_url": "model", "model_deploy_strategy_name": "tp8"})
+    loader = RForkModelLoader(load_config)
+    model_config = SimpleNamespace(dtype=torch.float32, model="/models/test", quantization="ascend")
+    vllm_config = _vllm_config(model_config=model_config)
+    stale_attention = SimpleNamespace()
+    stale_moe = SimpleNamespace()
+    unrelated_layer = SimpleNamespace()
+    fallback_down_proj = SimpleNamespace()
+    vllm_config.compilation_config = SimpleNamespace(
+        static_forward_context={
+            "model.layers.0.self_attn.indexer.k_cache": stale_attention,
+            "unrelated.layer": unrelated_layer,
+        },
+        static_all_moe_layers=[
+            stale_moe,
+            "model.layers.0.self_attn.indexer.k_cache",
+            "unrelated.layer",
+        ],
+    )
+    _ROPE_DICT[("identity", 1.0, 32768)] = object()
+
+    class _DiscardedModel:
+        def modules(self):
+            return iter([self, stale_attention, stale_moe])
+
+    rfork_model = _DiscardedModel()
+    expected_model = SimpleNamespace()
+    get_model_calls = []
+
+    def fake_get_model(**kwargs):
+        get_model_calls.append(kwargs)
+        assert vllm_config.compilation_config.static_forward_context == {
+            "unrelated.layer": unrelated_layer,
+        }
+        assert vllm_config.compilation_config.static_all_moe_layers == ["unrelated.layer"]
+        assert _ROPE_DICT == {}
+        vllm_config.compilation_config.static_forward_context["model.layers.0.mlp.down_proj"] = fallback_down_proj
+        return expected_model
+
+    rfork_worker = SimpleNamespace(
+        is_seed_available=lambda: True,
+        pre_transfer=lambda model: True,
+        transfer=lambda model: False,
+        post_transfer=lambda: True,
+        reset_transfer_state=lambda: None,
+        start_seed_service=lambda model: None,
+    )
+
+    monkeypatch.setattr(loader, "_ensure_rfork_worker", lambda vc, mc: rfork_worker)
+    monkeypatch.setattr(model_loader, "get_model", fake_get_model)
+    monkeypatch.setattr(
+        "vllm_ascend.model_loader.rfork.rfork_loader.initialize_model",
+        lambda **kwargs: rfork_model,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.model_loader.rfork.rfork_loader.process_weights_after_loading",
+        lambda *args, **kwargs: None,
+    )
+
+    model = loader.load_model(vllm_config=vllm_config, model_config=model_config)
+
+    assert model is expected_model
+    assert len(get_model_calls) == 1
+    assert vllm_config.compilation_config.static_forward_context == {
+        "unrelated.layer": unrelated_layer,
+        "model.layers.0.mlp.down_proj": fallback_down_proj,
+    }
+    assert vllm_config.compilation_config.static_all_moe_layers == ["unrelated.layer"]
+    assert _ROPE_DICT == {}
+
+
+def test_rfork_seed_miss_fallback_preserves_existing_process_global_state(monkeypatch):
+    import vllm.model_executor.model_loader as model_loader
+    from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+    load_config = DummyLoadConfig({"model_url": "model", "model_deploy_strategy_name": "tp8"})
+    loader = RForkModelLoader(load_config)
+    model_config = SimpleNamespace(dtype=torch.float32, model="/models/test", quantization="ascend")
+    vllm_config = _vllm_config(model_config=model_config)
+    existing_layer = SimpleNamespace()
+    vllm_config.compilation_config = SimpleNamespace(
+        static_forward_context={"existing.layer": existing_layer},
+        static_all_moe_layers=["existing.layer"],
+    )
+    rope_key = ("identity", 1.0, 32768)
+    rope_value = object()
+    _ROPE_DICT[rope_key] = rope_value
+
+    expected_model = SimpleNamespace()
+
+    def fake_get_model(**kwargs):
+        assert vllm_config.compilation_config.static_forward_context == {
+            "existing.layer": existing_layer,
+        }
+        assert vllm_config.compilation_config.static_all_moe_layers == ["existing.layer"]
+        assert _ROPE_DICT[rope_key] is rope_value
+        return expected_model
+
+    rfork_worker = SimpleNamespace(
+        is_seed_available=lambda: False,
+        post_transfer=lambda: True,
+        reset_transfer_state=lambda: None,
+        start_seed_service=lambda model: None,
+    )
+
+    monkeypatch.setattr(loader, "_ensure_rfork_worker", lambda vc, mc: rfork_worker)
+    monkeypatch.setattr(model_loader, "get_model", fake_get_model)
+    monkeypatch.setattr(
+        "vllm_ascend.model_loader.rfork.rfork_loader.initialize_model",
+        lambda **kwargs: pytest.fail("seed-miss fallback must not initialize an RFork model"),
+    )
+
+    model = loader.load_model(vllm_config=vllm_config, model_config=model_config)
+
+    assert model is expected_model
+    assert vllm_config.compilation_config.static_forward_context == {
+        "existing.layer": existing_layer,
+    }
+    assert vllm_config.compilation_config.static_all_moe_layers == ["existing.layer"]
+    assert _ROPE_DICT[rope_key] is rope_value
+
+
+def test_reset_process_global_model_state_is_safe_when_attrs_missing():
+    vllm_config = SimpleNamespace(compilation_config=SimpleNamespace())
+    _reset_process_global_model_state(vllm_config)
+
+
+def test_rfork_pre_transfer_weight_processing_unwraps_and_restores_quant_methods(monkeypatch):
+    import vllm_ascend.ops.fused_moe.fused_moe as fused_moe_module
+
+    class _FakeAscendMoERunner:
+        def __init__(self, quant_method):
+            self.quant_method = quant_method
+
+    calls = []
+
+    def original_process_weights(*args, **kwargs):
+        calls.append("original")
+
+    @wraps(original_process_weights)
+    def wrapped_process_weights(*args, **kwargs):
+        calls.append("wrapped")
+        original_process_weights(*args, **kwargs)
+
+    quant_method = SimpleNamespace(process_weights_after_loading=wrapped_process_weights)
+    fused_moe_layer = _FakeAscendMoERunner(quant_method)
+    other_layer = SimpleNamespace()
+
+    class _FakeModule:
+        def modules(self):
+            return iter([self, fused_moe_layer, other_layer])
+
+    fake_module = _FakeModule()
+    monkeypatch.setattr(fused_moe_module, "AscendMoERunner", _FakeAscendMoERunner)
+
+    with _rfork_pre_transfer_weight_processing(fake_module):
+        assert quant_method.process_weights_after_loading is original_process_weights
+        quant_method.process_weights_after_loading()
+    assert quant_method.process_weights_after_loading is wrapped_process_weights
+    assert calls == ["original"]
+
+    # Restoration must happen even when the wrapped block raises.
+    with pytest.raises(RuntimeError, match="boom"), _rfork_pre_transfer_weight_processing(fake_module):
+        assert quant_method.process_weights_after_loading is original_process_weights
+        raise RuntimeError("boom")
+    assert quant_method.process_weights_after_loading is wrapped_process_weights

--- a/tests/ut/model_loader/rfork/test_transfer_backend.py
+++ b/tests/ut/model_loader/rfork/test_transfer_backend.py
@@ -21,6 +21,8 @@ import torch
 import vllm_ascend.model_loader.rfork.transfer_backend as transfer_backend
 from vllm_ascend.model_loader.rfork.transfer_backend import (
     RForkTransferBackend,
+    _collect_checkpoint_layout_tensors,
+    _collect_processed_layout_tensors,
     _parse_weight_info,
     _reshape_tensor_to_seed_shape,
     get_remote_instance_transfer_engine_info,
@@ -65,7 +67,11 @@ def test_recv_from_source_refreshes_registered_shape_after_reshape(monkeypatch):
     )
     backend.rfork_transfer_engine_weights_shape_dict = {"weight": (2, 3)}
 
-    monkeypatch.setattr(transfer_backend, "_iter_transferable_tensors", lambda model: iter([("weight", tensor)]))
+    monkeypatch.setattr(
+        transfer_backend,
+        "_iter_transferable_tensors",
+        lambda model, processed_layout: iter([("weight", tensor)]),
+    )
     monkeypatch.setattr(
         transfer_backend,
         "get_remote_instance_transfer_engine_info",
@@ -76,7 +82,7 @@ def test_recv_from_source_refreshes_registered_shape_after_reshape(monkeypatch):
         ),
     )
 
-    assert backend.recv_from_source(object(), "127.0.0.1", 8000, "seed-key")
+    assert backend.recv_from_source(object(), "127.0.0.1", 8000, "seed-key", True)
     assert tuple(tensor.shape) == (1, 2, 3)
     assert backend.rfork_transfer_engine_weights_shape_dict["weight"] == (1, 2, 3)
 
@@ -90,7 +96,7 @@ def test_recv_from_source_reuses_registered_transferable_tensors(monkeypatch):
     backend.rfork_transfer_engine_weights_shape_dict = {"weight": (2, 3)}
     backend._registered_transferable_tensors = [("weight", tensor)]
 
-    def fail_if_rescanned(model):
+    def fail_if_rescanned(model, processed_layout):
         raise AssertionError("recv_from_source should reuse the registered tensor cache")
 
     monkeypatch.setattr(transfer_backend, "_iter_transferable_tensors", fail_if_rescanned)
@@ -104,8 +110,31 @@ def test_recv_from_source_reuses_registered_transferable_tensors(monkeypatch):
         ),
     )
 
-    assert backend.recv_from_source(object(), "127.0.0.1", 8000, "seed-key")
+    assert backend.recv_from_source(object(), "127.0.0.1", 8000, "seed-key", True)
     assert backend._registered_transferable_tensors is None
+
+
+def test_transferable_tensor_scan_depends_on_runtime_layout(monkeypatch):
+    class _RuntimeImpl:
+        def __init__(self):
+            self.runtime_weight = torch.ones(2)
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(2))
+            self.register_buffer("buffer", torch.ones(2))
+            self.runtime_constant = torch.ones(2)
+            self.impl = _RuntimeImpl()
+
+    monkeypatch.setattr(transfer_backend, "_is_transferable_tensor", lambda tensor: True)
+    model = _Model()
+
+    processed_names = {name for name, _ in _collect_processed_layout_tensors(model)}
+    checkpoint_names = {name for name, _ in _collect_checkpoint_layout_tensors(model)}
+
+    assert processed_names == {"weight", "buffer", "runtime_constant", "impl.runtime_weight"}
+    assert checkpoint_names == {"weight", "buffer", "impl.runtime_weight"}
 
 
 def test_get_remote_instance_transfer_engine_info_non_200_returns_three_values(monkeypatch):

--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -17,6 +17,7 @@
 import gc
 import os
 import time
+from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import copy
 from typing import Any, cast
@@ -146,34 +147,34 @@ def _reset_process_global_model_state(vllm_config: VllmConfig, model: Module | N
         logger.debug("RFork fallback: skip clearing _ROPE_DICT: %s", e)
 
 
-@contextmanager
-def _rfork_pre_transfer_weight_processing(model: Module):
-    """Bypass FusedMoE post-load validation during RFork pre-transfer layout work.
-
-    AscendMoERunner wraps quant_method.process_weights_after_loading with a
-    shared-expert consistency check. RFork's processed-layout transfer calls
-    process_weights_after_loading before receiver weights arrive, so only this
-    RFork phase should use the wrapped function's original implementation.
-    """
+def _iter_ascend_moe_quant_methods(model: Module) -> Iterator[Any]:
+    """Yield each quant method owned by an Ascend MoE runner once."""
     from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 
-    restored: list[tuple[Any, object]] = []
     seen_quant_methods: set[int] = set()
     for module in model.modules():
         if not isinstance(module, AscendMoERunner):
             continue
 
-        quant_method = getattr(module, "quant_method", None) or getattr(module, "_quant_method", None)
+        # AscendMoERunner exposes the routed experts' method via private _quant_method.
+        quant_method = getattr(module, "_quant_method", None)
         if quant_method is None or id(quant_method) in seen_quant_methods:
             continue
 
+        seen_quant_methods.add(id(quant_method))
+        yield cast(Any, quant_method)
+
+
+@contextmanager
+def _rfork_pre_transfer_weight_processing(model: Module):
+    """Use the unwrapped MoE post-load step so RFork pre-transfer skips shared-expert validation."""
+    restored: list[tuple[Any, object]] = []
+    for quant_method in _iter_ascend_moe_quant_methods(model):
         process_weights = getattr(quant_method, "process_weights_after_loading", None)
         original_process_weights = getattr(process_weights, "__wrapped__", None)
         if original_process_weights is None:
             continue
 
-        quant_method = cast(Any, quant_method)
-        seen_quant_methods.add(id(quant_method))
         restored.append((quant_method, process_weights))
         quant_method.process_weights_after_loading = original_process_weights
 
@@ -182,6 +183,8 @@ def _rfork_pre_transfer_weight_processing(model: Module):
     finally:
         for quant_method, process_weights in restored:
             quant_method.process_weights_after_loading = process_weights
+
+
 def _is_dynamic_eplb_enabled(vllm_config: VllmConfig) -> bool:
     parallel_config = getattr(vllm_config, "parallel_config", None)
     if bool(getattr(parallel_config, "enable_eplb", False)):
@@ -192,6 +195,35 @@ def _is_dynamic_eplb_enabled(vllm_config: VllmConfig) -> bool:
     if not isinstance(eplb_config, dict):
         return False
     return bool(eplb_config.get("dynamic_eplb") or eplb_config.get("expert_map_record_path"))
+
+
+@contextmanager
+def _rfork_skip_unquantized_moe_post_load_processing(model: Module):
+    """Suppress unquantized MoE post-load processing; dense layers still run theirs."""
+
+    from vllm_ascend.ops.fused_moe.routed_experts import AscendUnquantizedFusedMoEMethod
+
+    restored_methods: list[tuple[Any, object]] = []
+    for quant_method in _iter_ascend_moe_quant_methods(model):
+        if not isinstance(quant_method, AscendUnquantizedFusedMoEMethod):
+            continue
+
+        process_weights = getattr(quant_method, "process_weights_after_loading", None)
+        if process_weights is None:
+            continue
+
+        restored_methods.append((quant_method, process_weights))
+        quant_method.process_weights_after_loading = _noop_process_weights_after_loading  # type: ignore[method-assign]
+
+    try:
+        yield
+    finally:
+        for quant_method, process_weights in restored_methods:
+            quant_method.process_weights_after_loading = process_weights
+
+
+def _noop_process_weights_after_loading(*args: Any, **kwargs: Any) -> None:
+    pass
 
 
 @register_model_loader("rfork")
@@ -348,9 +380,9 @@ class RForkModelLoader(BaseModelLoader):
                     torch.npu.synchronize()
 
                 weight_load_start_time = time.perf_counter()
-                if not rfork_worker.pre_transfer(model):
+                if not rfork_worker.pre_transfer(model, processed_layout_transfer):
                     raise RuntimeError("pre_transfer failed.")
-                if not rfork_worker.transfer(model):
+                if not rfork_worker.transfer(model, processed_layout_transfer):
                     raise RuntimeError("transfer failed.")
                 if not rfork_worker.post_transfer():
                     raise RuntimeError("post_transfer failed.")
@@ -359,10 +391,10 @@ class RForkModelLoader(BaseModelLoader):
                     time.perf_counter() - weight_load_start_time,
                 )
 
-                rfork_worker.start_seed_service(model)
+                rfork_worker.start_seed_service(model, processed_layout_transfer)
                 if not processed_layout_transfer:
-                    process_weights_after_loading(model, model_config, target_device)
-
+                    with _rfork_skip_unquantized_moe_post_load_processing(model):
+                        process_weights_after_loading(model, model_config, target_device)
                 return model.eval()
             except Exception as e:
                 logger.warning("RFork transfer failed: %s, clean up and fall back to default loader", e)
@@ -397,7 +429,7 @@ class RForkModelLoader(BaseModelLoader):
 
                 try:
                     rfork_worker.reset_transfer_state()
-                    rfork_worker.start_seed_service(model)
+                    rfork_worker.start_seed_service(model, processed_layout_transfer)
                 except Exception as e:
                     logger.warning(
                         "Fallback model loaded, but start_seed_service failed: %s",

--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -344,6 +344,8 @@ class RForkModelLoader(BaseModelLoader):
                     logger.info("RFork uses post-load tensor layout transfer for quantized model.")
                     with _rfork_pre_transfer_weight_processing(model):
                         process_weights_after_loading(model, model_config, target_device)
+                    # Complete async NPU layout conversion before exposing buffers.
+                    torch.npu.synchronize()
 
                 weight_load_start_time = time.perf_counter()
                 if not rfork_worker.pre_transfer(model):

--- a/vllm_ascend/model_loader/rfork/rfork_loader.py
+++ b/vllm_ascend/model_loader/rfork/rfork_loader.py
@@ -17,7 +17,9 @@
 import gc
 import os
 import time
+from contextlib import contextmanager
 from copy import copy
+from typing import Any, cast
 
 import torch
 import torch.nn as nn
@@ -107,6 +109,79 @@ def _make_fallback_load_config(load_config: LoadConfig) -> LoadConfig:
     return fallback_load_config
 
 
+def _reset_process_global_model_state(vllm_config: VllmConfig, model: Module | None = None) -> None:
+    """Remove process-global layer registries a discarded RFork model left behind."""
+    stale_modules = set(model.modules()) if model is not None else None
+    removed_names: set[str] = set()
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    if compilation_config is not None:
+        static_forward_context = getattr(compilation_config, "static_forward_context", None)
+        if isinstance(static_forward_context, dict):
+            if stale_modules is None:
+                removed_names.update(static_forward_context)
+                static_forward_context.clear()
+            else:
+                for name, module in list(static_forward_context.items()):
+                    if module in stale_modules:
+                        removed_names.add(name)
+                        del static_forward_context[name]
+        static_all_moe_layers = getattr(compilation_config, "static_all_moe_layers", None)
+        if isinstance(static_all_moe_layers, list):
+            if stale_modules is None:
+                static_all_moe_layers.clear()
+            else:
+                static_all_moe_layers[:] = [
+                    layer
+                    for layer in static_all_moe_layers
+                    if layer not in stale_modules and layer not in removed_names
+                ]
+
+    # ROPE instances are cached globally and keyed by config; rebuild fresh rope.
+    try:
+        from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
+
+        if isinstance(_ROPE_DICT, dict):
+            _ROPE_DICT.clear()
+    except Exception as e:  # pragma: no cover - best-effort across vLLM versions
+        logger.debug("RFork fallback: skip clearing _ROPE_DICT: %s", e)
+
+
+@contextmanager
+def _rfork_pre_transfer_weight_processing(model: Module):
+    """Bypass FusedMoE post-load validation during RFork pre-transfer layout work.
+
+    AscendMoERunner wraps quant_method.process_weights_after_loading with a
+    shared-expert consistency check. RFork's processed-layout transfer calls
+    process_weights_after_loading before receiver weights arrive, so only this
+    RFork phase should use the wrapped function's original implementation.
+    """
+    from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
+
+    restored: list[tuple[Any, object]] = []
+    seen_quant_methods: set[int] = set()
+    for module in model.modules():
+        if not isinstance(module, AscendMoERunner):
+            continue
+
+        quant_method = getattr(module, "quant_method", None) or getattr(module, "_quant_method", None)
+        if quant_method is None or id(quant_method) in seen_quant_methods:
+            continue
+
+        process_weights = getattr(quant_method, "process_weights_after_loading", None)
+        original_process_weights = getattr(process_weights, "__wrapped__", None)
+        if original_process_weights is None:
+            continue
+
+        quant_method = cast(Any, quant_method)
+        seen_quant_methods.add(id(quant_method))
+        restored.append((quant_method, process_weights))
+        quant_method.process_weights_after_loading = original_process_weights
+
+    try:
+        yield
+    finally:
+        for quant_method, process_weights in restored:
+            quant_method.process_weights_after_loading = process_weights
 def _is_dynamic_eplb_enabled(vllm_config: VllmConfig) -> bool:
     parallel_config = getattr(vllm_config, "parallel_config", None)
     if bool(getattr(parallel_config, "enable_eplb", False)):
@@ -267,7 +342,8 @@ class RForkModelLoader(BaseModelLoader):
 
                 if processed_layout_transfer:
                     logger.info("RFork uses post-load tensor layout transfer for quantized model.")
-                    process_weights_after_loading(model, model_config, target_device)
+                    with _rfork_pre_transfer_weight_processing(model):
+                        process_weights_after_loading(model, model_config, target_device)
 
                 weight_load_start_time = time.perf_counter()
                 if not rfork_worker.pre_transfer(model):
@@ -293,6 +369,8 @@ class RForkModelLoader(BaseModelLoader):
                 rfork_worker.reset_transfer_state()
 
                 if need_del:
+                    _reset_process_global_model_state(vllm_config, model)
+
                     del model
                     gc.collect()
                     torch.npu.empty_cache()

--- a/vllm_ascend/model_loader/rfork/rfork_worker.py
+++ b/vllm_ascend/model_loader/rfork/rfork_worker.py
@@ -64,10 +64,10 @@ class RForkWorker:
         self.rfork_seed = self.seed_protocol.get_seed()
         return self.rfork_seed is not None
 
-    def pre_transfer(self, model) -> bool:
+    def pre_transfer(self, model, processed_layout: bool) -> bool:
         try:
             assert self.transfer_backend.is_initialized(), "transfer_backend is not initialized, cannot pre_transfer."
-            result = self.transfer_backend.register_memory_region(model)
+            result = self.transfer_backend.register_memory_region(model, processed_layout)
             self.ready_to_start_seed_service = result
             return result
         except AssertionError as e:
@@ -81,7 +81,7 @@ class RForkWorker:
             logger.warning("Failed to unregister rfork memory region: %s", e)
         self.ready_to_start_seed_service = False
 
-    def transfer(self, model) -> bool:
+    def transfer(self, model, processed_layout: bool) -> bool:
         try:
             assert self.transfer_backend.is_initialized(), "transfer_backend is not initialized, cannot transfer."
             assert self.rfork_seed is not None, "rfork seed is None, cannot transfer."
@@ -90,6 +90,7 @@ class RForkWorker:
                 seed_instance_ip=self.rfork_seed["seed_ip"],
                 seed_instance_service_port=self.rfork_seed["seed_port"],
                 local_seed_key=self.seed_protocol.get_local_seed_key(),
+                processed_layout=processed_layout,
             )
         except AssertionError as e:
             logger.exception(
@@ -107,13 +108,13 @@ class RForkWorker:
         self.rfork_seed = None
         return True
 
-    def start_seed_service(self, model):
+    def start_seed_service(self, model, processed_layout: bool):
         if self.seed_service_started:
             logger.info("Seed service already started, skipping.")
             return
 
         if not self.ready_to_start_seed_service:
-            if not self.pre_transfer(model):
+            if not self.pre_transfer(model, processed_layout):
                 logger.warning(
                     "start_seed_service aborted for device_id=%s: pre_transfer failed",
                     self.device_id,

--- a/vllm_ascend/model_loader/rfork/transfer_backend.py
+++ b/vllm_ascend/model_loader/rfork/transfer_backend.py
@@ -164,7 +164,7 @@ def _try_collect_transferable_tensor(
     return True, False
 
 
-def _collect_transferable_tensors(model: nn.Module) -> list[tuple[str, torch.Tensor]]:
+def _collect_processed_layout_tensors(model: nn.Module) -> list[tuple[str, torch.Tensor]]:
     seen_data_ptrs: set[int] = set()
     collected_tensors: list[tuple[str, torch.Tensor]] = []
 
@@ -184,8 +184,7 @@ def _collect_transferable_tensors(model: nn.Module) -> list[tuple[str, torch.Ten
             collected_tensors,
         )
 
-    # Some Ascend post-load paths replace checkpoint parameters with runtime
-    # tensors stored as plain module attributes, e.g. MLA/SFA W_UV and W_UK_T.
+    # Post-load processing can replace checkpoint params with runtime tensors stored as direct attrs or inside `impl`.
     for module_prefix, module in model.named_modules():
         for attr_name, attr_value in vars(module).items():
             if attr_name.startswith("_") or isinstance(attr_value, nn.Module):
@@ -203,8 +202,48 @@ def _collect_transferable_tensors(model: nn.Module) -> list[tuple[str, torch.Ten
     return collected_tensors
 
 
-def _iter_transferable_tensors(model: nn.Module):
-    yield from _collect_transferable_tensors(model)
+def _collect_checkpoint_layout_tensors(model: nn.Module) -> list[tuple[str, torch.Tensor]]:
+    seen_data_ptrs: set[int] = set()
+    collected_tensors: list[tuple[str, torch.Tensor]] = []
+
+    for name, tensor in model.named_parameters():
+        _try_collect_transferable_tensor(
+            name,
+            tensor,
+            seen_data_ptrs,
+            collected_tensors,
+        )
+
+    for name, tensor in model.named_buffers():
+        _try_collect_transferable_tensor(
+            name,
+            tensor,
+            seen_data_ptrs,
+            collected_tensors,
+        )
+
+    # Before post-load processing, only impl-stored runtime tensors supplement params/buffers.
+    for module_prefix, module in model.named_modules():
+        impl = getattr(module, "impl", None)
+        if impl is None or isinstance(impl, nn.Module):
+            continue
+
+        for tensor_name, tensor in _iter_tensors_in_value("impl", impl, set(), scan_objects=True):
+            full_name = f"{module_prefix}.{tensor_name}" if module_prefix else tensor_name
+            _try_collect_transferable_tensor(
+                full_name,
+                tensor,
+                seen_data_ptrs,
+                collected_tensors,
+            )
+    return collected_tensors
+
+
+def _iter_transferable_tensors(model: nn.Module, processed_layout: bool):
+    if processed_layout:
+        yield from _collect_processed_layout_tensors(model)
+    else:
+        yield from _collect_checkpoint_layout_tensors(model)
 
 
 def _block_contains_weight_ptr(address: int, size: int, sorted_weight_ptrs: list[int]) -> bool:
@@ -295,7 +334,7 @@ class RForkTransferBackend:
             raise RuntimeError("TransferEngine is not initialized.")
         return self.rfork_transfer_engine
 
-    def register_memory_region(self, model):
+    def register_memory_region(self, model, processed_layout: bool):
         transfer_engine = self._get_transfer_engine()
         start_reg_mr_time = time.perf_counter()
         self._registered_transferable_tensors = None
@@ -303,7 +342,7 @@ class RForkTransferBackend:
         weight_mr_dict = {}
         weight_shape_dict = {}
         weight_addr_set = set()
-        transferable_tensors = list(_iter_transferable_tensors(model))
+        transferable_tensors = list(_iter_transferable_tensors(model, processed_layout))
         for name, weight in transferable_tensors:
             weight_mr_dict[name] = (
                 weight.data_ptr(),
@@ -396,6 +435,7 @@ class RForkTransferBackend:
         seed_instance_ip,
         seed_instance_service_port,
         local_seed_key,
+        processed_layout: bool,
     ):
         transfer_engine = self._get_transfer_engine()
         seed_url = f"http://{seed_instance_ip}:{seed_instance_service_port}"
@@ -410,7 +450,7 @@ class RForkTransferBackend:
 
         transferable_tensors = getattr(self, "_registered_transferable_tensors", None)
         if transferable_tensors is None:
-            transferable_tensors = list(_iter_transferable_tensors(model))
+            transferable_tensors = list(_iter_transferable_tensors(model, processed_layout))
 
         seed_ptr_list = []
         client_ptr_list = []


### PR DESCRIPTION
### What this PR does / why we need it?

This PR consolidates the RFork fixes from #12173 and #11497 into one reviewable series.

- Synchronize asynchronous NPU post-load layout conversion before RFork registers and transfers processed-layout buffers.
- Temporarily bypass the `AscendMoERunner` shared-expert validation during pre-transfer layout processing, then restore it even on exceptions.
- Remove only process-global registrations owned by a failed RFork model before the fallback loader reconstructs it.
- Propagate the processed-layout mode through RFork and use separate post-load/checkpoint-layout tensor inventories.
- Keep unquantized MoE weights in their checkpoint layout while still running normal post-load processing for dense layers.
- Add regression coverage for fallback cleanup, method restoration, and runtime-layout tensor selection.

This supersedes #12173 and #11497.

### Does this PR introduce _any_ user-facing change?

Yes. RFork loading avoids corrupted output from incomplete layout conversion and avoids startup/fallback failures for affected quantized and unquantized MoE models. There is no public API or configuration change.

### How was this patch tested?

Passed locally.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
