### PR TITLE
[CI] Add vLLM interface contract guard

### DIFF
--- a/tests/e2e/vllm_interface/README.md
+++ b/tests/e2e/vllm_interface/README.md
@@ -1,0 +1,22 @@
+# vLLM interface contract tests
+
+`singlecard/test_interface_contracts.py` watches the callable-level vLLM interfaces used by vllm-ascend. The first
+baseline covers monkey patches, callable overrides, direct imported callable calls, and direct inheritance. The existing
+upstream `vllm-interface` job collects this test because it runs the complete `tests/e2e/vllm_interface` directory.
+
+The test only parses Python source code. It does not import `torch_npu`, initialize an NPU, download a model, or run
+inference. Each manifest entry checks that:
+
+- the upstream file, class, and callable still exist;
+- positional, keyword-only, and variadic parameters keep the same names and kinds;
+- parameters do not change between required and optional.
+- direct calls do not use keyword arguments removed from the upstream callable.
+
+Annotations, default values, return values, fields, and runtime behavior are intentionally outside the first version of
+the contract. Direct calls to monkey-patched callables are excluded from keyword validation because their effective
+signature comes from the patch rather than the original upstream callable. This keeps the signal focused on callable
+interface breaks.
+
+The vLLM baseline commit is recorded in `interface_contracts.json`. When a contract fails, review every downstream
+consumer shown in the assertion message. Update the baseline only after confirming that the vllm-ascend implementation
+remains compatible or has been adapted.

--- a/tests/e2e/vllm_interface/interface_contracts.json
+++ b/tests/e2e/vllm_interface/interface_contracts.json
@@ -1,0 +1,22524 @@
+{
+  "schema_version": 1,
+  "generated_from": {
+    "vllm_commit": "61ac368021033dea54448d36ed98c7426e82cd18",
+    "vllm_ascend_commit": "a0cc4ce1de3f736dd4d4fb9f74802b851ade036e",
+    "scope": [
+      "high-confidence monkey patches",
+      "direct and indirect callable overrides",
+      "patch call closures",
+      "direct imported callable calls",
+      "direct imported base classes"
+    ],
+    "relation_count": 1207,
+    "contract_count": 711,
+    "skipped_non_member_candidates": [
+      "vllm/distributed/__init__.py::None.divide",
+      "vllm/distributed/__init__.py::None.ensure_model_parallel_initialized",
+      "vllm/distributed/__init__.py::None.get_dcp_group",
+      "vllm/distributed/__init__.py::None.get_dp_group",
+      "vllm/distributed/__init__.py::None.get_ep_group",
+      "vllm/distributed/__init__.py::None.get_pcp_group",
+      "vllm/distributed/__init__.py::None.get_pp_group",
+      "vllm/distributed/__init__.py::None.get_tensor_model_parallel_rank",
+      "vllm/distributed/__init__.py::None.get_tensor_model_parallel_world_size",
+      "vllm/distributed/__init__.py::None.get_tp_group",
+      "vllm/distributed/__init__.py::None.get_world_group",
+      "vllm/distributed/__init__.py::None.init_distributed_environment",
+      "vllm/distributed/__init__.py::None.split_tensor_along_last_dim",
+      "vllm/distributed/__init__.py::None.tensor_model_parallel_all_gather",
+      "vllm/distributed/__init__.py::None.tensor_model_parallel_all_reduce",
+      "vllm/distributed/__init__.py::None.tensor_model_parallel_reduce_scatter"
+    ]
+  },
+  "contracts": [
+    {
+      "upstream_file": "vllm/compilation/backends.py",
+      "owner": null,
+      "callable": "set_model_tag",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "tag",
+            "required": true
+          },
+          {
+            "name": "is_encoder",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "set_model_tag(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/compiler_interface.py",
+      "owner": null,
+      "callable": "CompilerInterface",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/compiler_interface.py",
+          "qualified_name": "AscendCompiler(CompilerInterface)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/compiler_interface.py",
+      "owner": "CompilerInterface",
+      "callable": "compile",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "graph",
+            "required": true
+          },
+          {
+            "name": "example_inputs",
+            "required": true
+          },
+          {
+            "name": "compiler_config",
+            "required": true
+          },
+          {
+            "name": "compile_range",
+            "required": true
+          },
+          {
+            "name": "key",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/compiler_interface.py",
+          "qualified_name": "AscendCompiler.compile"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/compiler_interface.py",
+      "owner": "CompilerInterface",
+      "callable": "compute_hash",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/compiler_interface.py",
+          "qualified_name": "AscendCompiler.compute_hash"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/compiler_interface.py",
+      "owner": "CompilerInterface",
+      "callable": "initialize_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "cache_dir",
+            "required": true
+          },
+          {
+            "name": "disable_cache",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/compiler_interface.py",
+          "qualified_name": "AscendCompiler.initialize_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/compiler_interface.py",
+      "owner": "CompilerInterface",
+      "callable": "load",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "handle",
+            "required": true
+          },
+          {
+            "name": "graph",
+            "required": true
+          },
+          {
+            "name": "example_inputs",
+            "required": true
+          },
+          {
+            "name": "graph_index",
+            "required": true
+          },
+          {
+            "name": "compile_range",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/compiler_interface.py",
+          "qualified_name": "AscendCompiler.load"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/cuda_graph.py",
+      "owner": null,
+      "callable": "CUDAGraphOptions",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/compilation/acl_graph.py",
+          "qualified_name": "CUDAGraphOptions(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/cuda_graph.py",
+      "owner": null,
+      "callable": "CUDAGraphStat",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "CUDAGraphStat(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/decorators.py",
+      "owner": null,
+      "callable": "support_torch_compile",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "dynamic_arg_dims",
+            "required": false
+          },
+          {
+            "name": "mark_unbacked_dims",
+            "required": false
+          },
+          {
+            "name": "enable_if",
+            "required": false
+          },
+          {
+            "name": "is_encoder",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "support_torch_compile(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/monitor.py",
+      "owner": null,
+      "callable": "validate_cudagraph_capturing_enabled",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/compilation/acl_graph.py",
+          "qualified_name": "validate_cudagraph_capturing_enabled(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/passes/inductor_pass.py",
+      "owner": null,
+      "callable": "get_pass_context",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/compilation/graph_fusion_pass_manager.py",
+          "qualified_name": "get_pass_context(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/passes/vllm_inductor_pass.py",
+      "owner": null,
+      "callable": "VllmInductorPass",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/allgather_chunk_noop_pass.py",
+          "qualified_name": "AllGatherChunkNoOpCleanupPass(VllmInductorPass)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/muls_add_pass.py",
+          "qualified_name": "MulsAddFusionPass(VllmInductorPass)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/noop_elimination.py",
+          "qualified_name": "NoOpEliminationPass(VllmInductorPass)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/norm_quant_fusion_pass.py",
+          "qualified_name": "AddRMSNormQuantFusionPass(VllmInductorPass)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py",
+          "qualified_name": "QKNormRopeFusionPass(VllmInductorPass)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/sequence_parallelism.py",
+          "qualified_name": "SequenceParallelismPass(VllmInductorPass)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/compilation/passes/sequence_parallelism_moe.py",
+          "qualified_name": "SequenceParallelismMoePass(VllmInductorPass)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/compilation/passes/vllm_inductor_pass.py",
+      "owner": "VllmInductorPass",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/passes/allgather_chunk_noop_pass.py",
+          "qualified_name": "AllGatherChunkNoOpCleanupPass.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/passes/muls_add_pass.py",
+          "qualified_name": "MulsAddFusionPass.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/passes/norm_quant_fusion_pass.py",
+          "qualified_name": "AddRMSNormQuantFusionPass.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py",
+          "qualified_name": "QKNormRopeFusionPass.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/passes/sequence_parallelism.py",
+          "qualified_name": "SequenceParallelismPass.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/compilation/passes/sequence_parallelism_moe.py",
+          "qualified_name": "SequenceParallelismMoePass.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "CUDAGraphMode",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "CUDAGraphMode(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "SchedulerConfig",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeSchedulerConfig(SchedulerConfig)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "get_current_vllm_config",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/quantization/modelslim_config.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/context_parallel/dsa_cp.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/parallel_state.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/layer/attention/layer.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/dsa.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/token_dispatcher.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/linear_op.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/fp8.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/kv_c8.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a16.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a16_mxfp4.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a4_mxfp4.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a4_mxfp4_flatquant.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a8.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a8_mxfp4.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w8a8_dynamic.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w8a8_mxfp8.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w8a8_pdmix.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/utils.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/attn_utils.py",
+          "qualified_name": "get_current_vllm_config(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "get_current_vllm_config_or_none",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/utils.py",
+          "qualified_name": "get_current_vllm_config_or_none(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "get_layers_from_vllm_config",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/compilation/passes/qknorm_rope_fusion_pass.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/dspark_proposer.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/step3p5.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/attn_utils.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/speculator.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/dspark/speculator.py",
+          "qualified_name": "get_layers_from_vllm_config(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "replace",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/step3p5.py",
+          "qualified_name": "replace(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/__init__.py",
+      "owner": null,
+      "callable": "set_current_vllm_config",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/device_allocator/sleep_mem_optimized.py",
+          "qualified_name": "set_current_vllm_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "set_current_vllm_config(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/model.py",
+      "owner": "ModelConfig",
+      "callable": "_verify_cuda_graph",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_minimax_m2_config.py",
+          "qualified_name": "_patched_verify_cuda_graph"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/config/model.py",
+      "owner": "ModelConfig",
+      "callable": "_verify_quantization",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_minimax_m2_config.py",
+          "qualified_name": "_patched_verify_quantization"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/communication_op.py",
+      "owner": null,
+      "callable": "tensor_model_parallel_all_reduce",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "input_",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/linearnorm/split_qkv_tp_rmsnorm_rope.py",
+          "qualified_name": "tensor_model_parallel_all_reduce(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/device_communicators/base_device_communicator.py",
+      "owner": null,
+      "callable": "DeviceCommunicatorBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/device_communicators/npu_communicator.py",
+          "qualified_name": "NPUCommunicator(DeviceCommunicatorBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/device_communicators/base_device_communicator.py",
+      "owner": "DeviceCommunicatorBase",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "cpu_group",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": false
+          },
+          {
+            "name": "device_group",
+            "required": false
+          },
+          {
+            "name": "unique_name",
+            "required": false
+          },
+          {
+            "name": "global_ranks",
+            "required": false
+          },
+          {
+            "name": "global_world_size",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/device_communicators/npu_communicator.py",
+          "qualified_name": "NPUCommunicator.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/device_communicators/shm_broadcast.py",
+      "owner": null,
+      "callable": "MessageQueue",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "MessageQueue(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/ec_transfer/__init__.py",
+      "owner": null,
+      "callable": "ensure_ec_transfer_initialized",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "ensure_ec_transfer_initialized(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/ec_transfer/__init__.py",
+      "owner": null,
+      "callable": "get_ec_transfer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_ec_transfer(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/ec_transfer/__init__.py",
+      "owner": null,
+      "callable": "has_ec_transfer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "has_ec_transfer(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": null,
+      "callable": "BlockStored",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py",
+          "qualified_name": "BlockStored(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py",
+          "qualified_name": "BlockStored(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": null,
+      "callable": "KVConnectorKVEvents",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents(KVConnectorKVEvents)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": null,
+      "callable": "KVEventAggregator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "KVEventAggregator(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": null,
+      "callable": "KVEventBatch",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "KVEventBatch(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": "KVConnectorKVEvents",
+      "callable": "add_events",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "events",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents.add_events"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": "KVConnectorKVEvents",
+      "callable": "aggregate",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents.aggregate"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": "KVConnectorKVEvents",
+      "callable": "clear_events",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents.clear_events"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": "KVConnectorKVEvents",
+      "callable": "get_all_events",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents.get_all_events"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": "KVConnectorKVEvents",
+      "callable": "get_number_of_workers",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents.get_number_of_workers"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_events.py",
+      "owner": "KVConnectorKVEvents",
+      "callable": "increment_workers",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "count",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreKVEvents.increment_workers"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/__init__.py",
+      "owner": null,
+      "callable": "ensure_kv_transfer_initialized",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "ensure_kv_transfer_initialized(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/__init__.py",
+      "owner": null,
+      "callable": "ensure_kv_transfer_shutdown",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "ensure_kv_transfer_shutdown(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/__init__.py",
+      "owner": null,
+      "callable": "get_kv_transfer_group",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "get_kv_transfer_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_kv_transfer_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "get_kv_transfer_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/__init__.py",
+      "owner": null,
+      "callable": "has_kv_transfer_group",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "has_kv_transfer_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "has_kv_transfer_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "has_kv_transfer_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/__init__.py",
+      "owner": null,
+      "callable": "is_v1_kv_transfer_group",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "is_v1_kv_transfer_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": null,
+      "callable": "KVConnectorBase_V1",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector(KVConnectorBase_V1)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector(KVConnectorBase_V1)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector(KVConnectorBase_V1)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector(KVConnectorBase_V1)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1(KVConnectorBase_V1)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1(KVConnectorBase_V1)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": null,
+      "callable": "KVConnectorMetadata",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnectorMetadata(KVConnectorMetadata)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnectorMetadata(KVConnectorMetadata)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnectorMetadata(KVConnectorMetadata)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py",
+          "qualified_name": "AscendConnectorMetadata(KVConnectorMetadata)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/metadata.py",
+          "qualified_name": "RecomputeCPUOffloadMetadata(KVConnectorMetadata)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": null,
+      "callable": "KVConnectorWorkerMetadata",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py",
+          "qualified_name": "AscendStoreKVConnectorWorkerMetadata(KVConnectorWorkerMetadata)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/metadata.py",
+          "qualified_name": "RecomputeCPUOffloadWorkerMetadata(KVConnectorWorkerMetadata)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": null,
+      "callable": "SupportsHMA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector(SupportsHMA)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector(SupportsHMA)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector(SupportsHMA)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector(SupportsHMA)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector(SupportsHMA)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1(SupportsHMA)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1(SupportsHMA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": null,
+      "callable": "supports_hma",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "connector",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "supports_hma(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "role",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.__init__"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "bind_connector_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "connector_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.bind_connector_metadata"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.bind_connector_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "bind_gpu_block_pool",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "gpu_block_pool",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.bind_gpu_block_pool"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.bind_gpu_block_pool"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "build_connector_meta",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.build_connector_meta"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.build_connector_meta"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.build_connector_meta"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.build_connector_meta"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.build_connector_meta"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.build_connector_meta"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "build_connector_worker_meta",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.build_connector_worker_meta"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.build_connector_worker_meta"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.build_connector_worker_meta"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "build_kv_connector_stats",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "data",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.build_kv_connector_stats"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "build_prom_metrics",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "metric_types",
+            "required": true
+          },
+          {
+            "name": "labelnames",
+            "required": true
+          },
+          {
+            "name": "per_engine_labelvalues",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.build_prom_metrics"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "clear_connector_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.clear_connector_metadata"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.clear_connector_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_block_ids_with_load_errors",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.get_block_ids_with_load_errors"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.get_block_ids_with_load_errors"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.get_block_ids_with_load_errors"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_block_ids_with_load_errors"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_finished",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "finished_req_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.get_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.get_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.get_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.get_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_finished"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.get_finished"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_finished_count",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_finished_count"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_handshake_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.get_handshake_metadata"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.get_handshake_metadata"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_handshake_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_kv_connector_kv_cache_events",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.get_kv_connector_kv_cache_events"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_kv_connector_kv_cache_events"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_kv_connector_stats",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_kv_connector_stats"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "get_num_new_matched_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "num_computed_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.get_num_new_matched_tokens"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.get_num_new_matched_tokens"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.get_num_new_matched_tokens"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.get_num_new_matched_tokens"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.get_num_new_matched_tokens"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.get_num_new_matched_tokens"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "handle_preemptions",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_connector_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.handle_preemptions"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.handle_preemptions"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "has_connector_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.has_connector_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "register_kv_caches",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_caches",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.register_kv_caches"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.register_kv_caches"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.register_kv_caches"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.register_kv_caches"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.register_kv_caches"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.register_kv_caches"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "request_finished",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "block_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.request_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.request_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.request_finished"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.request_finished"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.request_finished"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "requires_piecewise_for_cudagraph",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "extra_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.requires_piecewise_for_cudagraph"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "reset_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.reset_cache"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.reset_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "save_kv_layer",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer_name",
+            "required": true
+          },
+          {
+            "name": "kv_layer",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.save_kv_layer"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.save_kv_layer"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.save_kv_layer"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.save_kv_layer"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.save_kv_layer"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.save_kv_layer"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "set_host_xfer_buffer_ops",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "copy_operation",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.set_host_xfer_buffer_ops"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "set_xfer_handshake_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.set_xfer_handshake_metadata"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.set_xfer_handshake_metadata"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.set_xfer_handshake_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "set_xfer_handshake_metadata_pp_aware",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.set_xfer_handshake_metadata_pp_aware"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "shutdown",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.shutdown"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "start_load_kv",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "forward_context",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.start_load_kv"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.start_load_kv"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.start_load_kv"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.start_load_kv"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.start_load_kv"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.start_load_kv"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "take_events",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.take_events"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.take_events"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.take_events"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "update_connector_output",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "connector_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.update_connector_output"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.update_connector_output"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.update_connector_output"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "update_state_after_alloc",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "blocks",
+            "required": true
+          },
+          {
+            "name": "num_external_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.update_state_after_alloc"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.update_state_after_alloc"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.update_state_after_alloc"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.update_state_after_alloc"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.update_state_after_alloc"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.update_state_after_alloc"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "wait_for_layer_load",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer_name",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.wait_for_layer_load"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.wait_for_layer_load"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.wait_for_layer_load"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.wait_for_layer_load"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.wait_for_layer_load"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.wait_for_layer_load"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorBase_V1",
+      "callable": "wait_for_save",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.wait_for_save"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.wait_for_save"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.wait_for_save"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.wait_for_save"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.wait_for_save"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.wait_for_save"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "KVConnectorWorkerMetadata",
+      "callable": "aggregate",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "other",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py",
+          "qualified_name": "AscendStoreKVConnectorWorkerMetadata.aggregate"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/metadata.py",
+          "qualified_name": "RecomputeCPUOffloadWorkerMetadata.aggregate"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/base.py",
+      "owner": "SupportsHMA",
+      "callable": "request_finished_all_groups",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "block_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector.request_finished_all_groups"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "MooncakeConnector.request_finished_all_groups"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "MooncakeConnector.request_finished_all_groups"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "MooncakeLayerwiseConnector.request_finished_all_groups"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "AscendStoreConnector.request_finished_all_groups"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ucm_connector.py",
+          "qualified_name": "UCMConnectorV1.request_finished_all_groups"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/recompute_cpu_offload_connector.py",
+          "qualified_name": "RecomputeCPUOffloadConnectorV1.request_finished_all_groups"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py",
+      "owner": null,
+      "callable": "MultiConnector",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector(MultiConnector)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py",
+      "owner": "MultiConnector",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "role",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py",
+      "owner": "MultiConnector",
+      "callable": "get_num_new_matched_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "num_computed_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector.get_num_new_matched_tokens"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py",
+      "owner": "MultiConnector",
+      "callable": "request_finished_all_groups",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "block_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector.request_finished_all_groups"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py",
+      "owner": "MultiConnector",
+      "callable": "update_state_after_alloc",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "blocks",
+            "required": true
+          },
+          {
+            "name": "num_external_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py",
+          "qualified_name": "AscendMultiConnector.update_state_after_alloc"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py",
+      "owner": null,
+      "callable": "SimpleCPUOffloadConnector",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/simple_cpu_offload/simple_cpu_offload_connector.py",
+          "qualified_name": "AscendSimpleCPUOffloadConnector(SimpleCPUOffloadConnector)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py",
+      "owner": "SimpleCPUOffloadConnector",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "role",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/simple_cpu_offload/simple_cpu_offload_connector.py",
+          "qualified_name": "AscendSimpleCPUOffloadConnector.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "GroupCoordinator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/worker/patch_distributed.py",
+          "qualified_name": "GroupCoordinatorPatch(GroupCoordinator)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_distributed.py",
+          "qualified_name": "GroupCoordinatorPatch"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "_get_unique_name",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "name",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_distributed.py",
+          "qualified_name": "_get_unique_name(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "_register_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "group",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_distributed.py",
+          "qualified_name": "_register_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_dcp_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_dcp_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_dp_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/prepare_finalize.py",
+          "qualified_name": "get_dp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_dp_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_ep_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/fused_moe/token_dispatcher.py",
+          "qualified_name": "get_ep_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "get_ep_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/token_dispatcher.py",
+          "qualified_name": "get_ep_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_pcp_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/prepare_finalize.py",
+          "qualified_name": "get_pcp_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_pp_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/eplb/eplb_updator.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_pp_aux.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_pp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "get_pp_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_tensor_model_parallel_rank",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "get_tensor_model_parallel_rank(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "get_tensor_model_parallel_rank(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "get_tensor_model_parallel_rank(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/prepare_finalize.py",
+          "qualified_name": "get_tensor_model_parallel_rank(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_tensor_model_parallel_world_size",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "get_tensor_model_parallel_world_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "get_tensor_model_parallel_world_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/prepare_finalize.py",
+          "qualified_name": "get_tensor_model_parallel_world_size(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_tp_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/linear_op.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/bincount.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_routed_experts_capture.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_tp_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "get_tp_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "get_world_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "get_world_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py",
+          "qualified_name": "get_world_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py",
+          "qualified_name": "get_world_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py",
+          "qualified_name": "get_world_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/parallel_state.py",
+          "qualified_name": "get_world_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "get_world_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": null,
+      "callable": "init_model_parallel_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "group_ranks",
+            "required": true
+          },
+          {
+            "name": "local_rank",
+            "required": true
+          },
+          {
+            "name": "backend",
+            "required": true
+          },
+          {
+            "name": "use_message_queue_broadcaster",
+            "required": false
+          },
+          {
+            "name": "group_name",
+            "required": false
+          },
+          {
+            "name": "use_device_communicator",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/parallel_state.py",
+          "qualified_name": "init_model_parallel_group(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "init_model_parallel_group(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": "GroupCoordinator",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "group_ranks",
+            "required": true
+          },
+          {
+            "name": "local_rank",
+            "required": true
+          },
+          {
+            "name": "torch_distributed_backend",
+            "required": true
+          },
+          {
+            "name": "use_device_communicator",
+            "required": true
+          },
+          {
+            "name": "use_message_queue_broadcaster",
+            "required": false
+          },
+          {
+            "name": "group_name",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/worker/patch_distributed.py",
+          "qualified_name": "GroupCoordinatorPatch.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/parallel_state.py",
+      "owner": "GroupCoordinator",
+      "callable": "destroy",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/worker/patch_distributed.py",
+          "qualified_name": "GroupCoordinatorPatch.destroy"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/utils.py",
+      "owner": null,
+      "callable": "divide",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "numerator",
+            "required": true
+          },
+          {
+            "name": "denominator",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/utils.py",
+          "qualified_name": "divide(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/utils.py",
+      "owner": null,
+      "callable": "get_pp_indices",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "num_hidden_layers",
+            "required": true
+          },
+          {
+            "name": "pp_rank",
+            "required": true
+          },
+          {
+            "name": "pp_size",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "get_pp_indices(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "get_pp_indices(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/utils.py",
+      "owner": null,
+      "callable": "get_worker_rank_suffix",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "global_rank",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "get_worker_rank_suffix(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": null,
+      "callable": "WeightTransferInitInfo",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferInitInfo(WeightTransferInitInfo)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferInitInfo(WeightTransferInitInfo)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": null,
+      "callable": "WeightTransferUpdateInfo",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferUpdateInfo(WeightTransferUpdateInfo)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "config",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.__init__"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "finish_weight_update",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.finish_weight_update"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.finish_weight_update"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "init_transfer_engine",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "init_info",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.init_transfer_engine"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.init_transfer_engine"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "parse_update_info",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "update_dict",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.parse_update_info"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "receive_weights",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "update_info",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.receive_weights"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.receive_weights"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "shutdown",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.shutdown"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.shutdown"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "start_weight_update",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.start_weight_update"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.start_weight_update"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/base.py",
+      "owner": "WeightTransferEngine",
+      "callable": "trainer_send_weights",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "iterator",
+            "required": true
+          },
+          {
+            "name": "trainer_args",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "HCCLWeightTransferEngine.trainer_send_weights"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferEngine.trainer_send_weights"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/ipc_engine.py",
+      "owner": null,
+      "callable": "IPCTrainerSendWeightsArgs",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCTrainerSendWeightsArgs(IPCTrainerSendWeightsArgs)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/distributed/weight_transfer/ipc_engine.py",
+      "owner": null,
+      "callable": "IPCWeightTransferUpdateInfo",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py",
+          "qualified_name": "NPUIPCWeightTransferUpdateInfo(IPCWeightTransferUpdateInfo)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/exceptions.py",
+      "owner": null,
+      "callable": "VLLMValidationError",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_structured_output.py",
+          "qualified_name": "VLLMValidationError(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/forward_context.py",
+      "owner": null,
+      "callable": "BatchDescriptor",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_cudagraph.py",
+          "qualified_name": "BatchDescriptor(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "BatchDescriptor(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/forward_context.py",
+      "owner": null,
+      "callable": "get_forward_context",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/model_runner_310p.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/ops/fla/gdn_310.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ascend_forward_context.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/compilation/acl_graph.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/bailing_moe_linear_attn.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/dsa.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/experts_selector.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/fused_moe/prepare_finalize.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/gdn.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/register_custom_ops.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/fla/chunk.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_routed_experts_capture.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a8_mxfp4.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/dflash_proposer.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/step3p5.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/utils.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/aclgraph_utils.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py",
+          "qualified_name": "get_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/xlite/xlite.py",
+          "qualified_name": "get_forward_context(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/forward_context.py",
+      "owner": null,
+      "callable": "is_forward_context_available",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "is_forward_context_available(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/forward_context.py",
+      "owner": null,
+      "callable": "set_forward_context",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "attn_metadata",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": false
+          },
+          {
+            "name": "num_tokens_across_dp",
+            "required": false
+          },
+          {
+            "name": "cudagraph_runtime_mode",
+            "required": false
+          },
+          {
+            "name": "batch_descriptor",
+            "required": false
+          },
+          {
+            "name": "ubatch_slices",
+            "required": false
+          },
+          {
+            "name": "slot_mapping",
+            "required": false
+          },
+          {
+            "name": "skip_compiled",
+            "required": false
+          },
+          {
+            "name": "is_padding",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ascend_forward_context.py",
+          "qualified_name": "set_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/extract_hidden_states_proposer.py",
+          "qualified_name": "set_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/aclgraph_utils.py",
+          "qualified_name": "set_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py",
+          "qualified_name": "set_forward_context(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py",
+          "qualified_name": "set_forward_context(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/logging_utils/__init__.py",
+      "owner": null,
+      "callable": "ColoredFormatter",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/logger.py",
+          "qualified_name": "AscendColoredFormatter(ColoredFormatter)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/logging_utils/__init__.py",
+      "owner": null,
+      "callable": "NewLineFormatter",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/logger.py",
+          "qualified_name": "AscendFormatter(NewLineFormatter)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/__init__.py",
+      "owner": null,
+      "callable": "MergedQKVParallelLinearWithLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendMergedQKVParallelLinearWithLoRA(MergedQKVParallelLinearWithLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/__init__.py",
+      "owner": null,
+      "callable": "MergedQKVParallelLinearWithShardedLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendMergedQKVParallelLinearWithShardedLoRA(MergedQKVParallelLinearWithShardedLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/__init__.py",
+      "owner": null,
+      "callable": "QKVParallelLinearWithLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendQKVParallelLinearWithLoRA(QKVParallelLinearWithLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/__init__.py",
+      "owner": null,
+      "callable": "QKVParallelLinearWithShardedLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendQKVParallelLinearWithShardedLoRA(QKVParallelLinearWithShardedLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/column_parallel_linear.py",
+      "owner": "MergedQKVParallelLinearWithLoRA",
+      "callable": "can_replace_layer",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "source_layer",
+            "required": true
+          },
+          {
+            "name": "lora_config",
+            "required": true
+          },
+          {
+            "name": "packed_modules_list",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": false
+          },
+          {
+            "name": "decorate",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendMergedQKVParallelLinearWithLoRA.can_replace_layer"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/column_parallel_linear.py",
+      "owner": "MergedQKVParallelLinearWithShardedLoRA",
+      "callable": "can_replace_layer",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "source_layer",
+            "required": true
+          },
+          {
+            "name": "lora_config",
+            "required": true
+          },
+          {
+            "name": "packed_modules_list",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": false
+          },
+          {
+            "name": "decorate",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendMergedQKVParallelLinearWithShardedLoRA.can_replace_layer"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/column_parallel_linear.py",
+      "owner": "QKVParallelLinearWithLoRA",
+      "callable": "can_replace_layer",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "source_layer",
+            "required": true
+          },
+          {
+            "name": "lora_config",
+            "required": true
+          },
+          {
+            "name": "packed_modules_list",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendQKVParallelLinearWithLoRA.can_replace_layer"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/column_parallel_linear.py",
+      "owner": "QKVParallelLinearWithShardedLoRA",
+      "callable": "can_replace_layer",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "source_layer",
+            "required": true
+          },
+          {
+            "name": "lora_config",
+            "required": true
+          },
+          {
+            "name": "packed_modules_list",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/utils.py",
+          "qualified_name": "AscendQKVParallelLinearWithShardedLoRA.can_replace_layer"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/fused_moe.py",
+      "owner": null,
+      "callable": "FusedMoE3DWithLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/fused_moe.py",
+          "qualified_name": "AscendFusedMoE3DWithLoRA(FusedMoE3DWithLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/fused_moe.py",
+      "owner": null,
+      "callable": "FusedMoEWithLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/fused_moe.py",
+          "qualified_name": "AscendFusedMoEWithLoRA(FusedMoEWithLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/fused_moe.py",
+      "owner": "FusedMoE3DWithLoRA",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "base_layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/lora/fused_moe.py",
+          "qualified_name": "AscendFusedMoE3DWithLoRA.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/fused_moe.py",
+      "owner": "FusedMoEWithLoRA",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "base_layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/lora/fused_moe.py",
+          "qualified_name": "AscendFusedMoEWithLoRA.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/fused_moe.py",
+      "owner": "FusedMoEWithLoRA",
+      "callable": "set_mapping",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "punica_wrapper",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/lora/fused_moe.py",
+          "qualified_name": "AscendFusedMoEWithLoRA.set_mapping"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/layers/utils.py",
+      "owner": null,
+      "callable": "_get_lora_device",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "base_layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/lora/fused_moe.py",
+          "qualified_name": "_get_lora_device(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": null,
+      "callable": "PunicaWrapperBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU(PunicaWrapperBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "max_num_batched_tokens",
+            "required": true
+          },
+          {
+            "name": "max_batches",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "add_expand",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "lora_b_stacked",
+            "required": true
+          },
+          {
+            "name": "output_slices",
+            "required": true
+          },
+          {
+            "name": "offset_start",
+            "required": false
+          },
+          {
+            "name": "add_inputs",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.add_expand"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "add_lora_embedding",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "lora_b_stacked",
+            "required": true
+          },
+          {
+            "name": "add_inputs",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.add_lora_embedding"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "add_lora_fused_moe",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "lora_a_stacked",
+            "required": true
+          },
+          {
+            "name": "lora_b_stacked",
+            "required": true
+          },
+          {
+            "name": "topk_weights",
+            "required": true
+          },
+          {
+            "name": "sorted_token_ids",
+            "required": true
+          },
+          {
+            "name": "expert_ids",
+            "required": true
+          },
+          {
+            "name": "num_tokens_post_padded",
+            "required": true
+          },
+          {
+            "name": "max_lora_rank",
+            "required": true
+          },
+          {
+            "name": "top_k_num",
+            "required": true
+          },
+          {
+            "name": "shrink_config",
+            "required": true
+          },
+          {
+            "name": "expand_config",
+            "required": true
+          },
+          {
+            "name": "adapter_enabled",
+            "required": true
+          },
+          {
+            "name": "mul_routed_weight",
+            "required": false
+          },
+          {
+            "name": "fully_sharded",
+            "required": false
+          },
+          {
+            "name": "offset",
+            "required": false
+          },
+          {
+            "name": "token_lora_mapping",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.add_lora_fused_moe"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "add_lora_linear",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "lora_a_stacked",
+            "required": true
+          },
+          {
+            "name": "lora_b_stacked",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": true
+          },
+          {
+            "name": "output_slices",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "buffer",
+            "required": false
+          }
+        ],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.add_lora_linear"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "add_lora_logits",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "lora_a_stacked",
+            "required": true
+          },
+          {
+            "name": "lora_b_stacked",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "buffer",
+            "required": false
+          }
+        ],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.add_lora_logits"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/lora/punica_wrapper/punica_base.py",
+      "owner": "PunicaWrapperBase",
+      "callable": "add_shrink",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "lora_a_stacked",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/lora/punica_npu.py",
+          "qualified_name": "PunicaWrapperNPU.add_shrink"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/activation.py",
+      "owner": null,
+      "callable": "QuickGELU",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/activation.py",
+          "qualified_name": "AscendQuickGELU(QuickGELU)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/activation.py",
+      "owner": null,
+      "callable": "SiluAndMul",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "SiluAndMul(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/activation.py",
+          "qualified_name": "AscendSiluAndMul(SiluAndMul)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/activation.py",
+      "owner": null,
+      "callable": "SiluAndMulWithClamp",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "SiluAndMulWithClamp(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/activation.py",
+          "qualified_name": "AscendSiluAndMulWithClamp(SiluAndMulWithClamp)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/__init__.py",
+      "owner": null,
+      "callable": "MLAAttention",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "MLAAttention(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/attention.py",
+      "owner": null,
+      "callable": "_init_kv_cache_quant",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "quant_config",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/layer/attention/layer.py",
+          "qualified_name": "_init_kv_cache_quant(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/mla_attention.py",
+      "owner": "MLACommonMetadataBuilder",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "layer_names",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "metadata_cls",
+            "required": false
+          },
+          {
+            "name": "supports_dcp_with_varlen",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAMetadataBuilder.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAMetadataBuilder.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/mla_attention.py",
+      "owner": "MLACommonMetadataBuilder",
+      "callable": "build",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "common_prefix_len",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "fast_build",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAMetadataBuilder.build"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAMetadataBuilder.build"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/mla_attention.py",
+      "owner": "MLACommonMetadataBuilder",
+      "callable": "determine_chunked_prefill_workspace_size",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAMetadataBuilder.determine_chunked_prefill_workspace_size"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAMetadataBuilder.determine_chunked_prefill_workspace_size"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/mm_encoder_attention.py",
+      "owner": null,
+      "callable": "MMEncoderAttention",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/ops/mm_encoder_attention.py",
+          "qualified_name": "AscendMMEncoderAttention310(MMEncoderAttention)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/mm_encoder_attention.py",
+          "qualified_name": "AscendMMEncoderAttention(MMEncoderAttention)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention/mm_encoder_attention.py",
+      "owner": "MMEncoderAttention",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_heads",
+            "required": true
+          },
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": false
+          },
+          {
+            "name": "num_kv_heads",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/_310p/ops/mm_encoder_attention.py",
+          "qualified_name": "AscendMMEncoderAttention310.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/mm_encoder_attention.py",
+          "qualified_name": "AscendMMEncoderAttention.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention_layer_base.py",
+      "owner": null,
+      "callable": "AttentionLayerBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/layer/attention/layer.py",
+          "qualified_name": "DSAAttention(AttentionLayerBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention_layer_base.py",
+      "owner": "AttentionLayerBase",
+      "callable": "get_attn_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/layer/attention/layer.py",
+          "qualified_name": "DSAAttention.get_attn_backend"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/attention_layer_base.py",
+      "owner": "AttentionLayerBase",
+      "callable": "get_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/layer/attention/layer.py",
+          "qualified_name": "DSAAttention.get_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/conv.py",
+      "owner": null,
+      "callable": "Conv3dLayer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/conv.py",
+          "qualified_name": "AscendConv3dLayer(Conv3dLayer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/__init__.py",
+      "owner": null,
+      "callable": "FusedMoE",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "FusedMoE(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/__init__.py",
+      "owner": null,
+      "callable": "FusedMoEMethodBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendFusedMoEMethod(FusedMoEMethodBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/__init__.py",
+      "owner": null,
+      "callable": "fused_moe_make_expert_params_mapping",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "fused_moe_make_expert_params_mapping(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "fused_moe_make_expert_params_mapping(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "fused_moe_make_expert_params_mapping(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/expert_map_manager.py",
+      "owner": null,
+      "callable": "determine_expert_map",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "ep_size",
+            "required": true
+          },
+          {
+            "name": "ep_rank",
+            "required": true
+          },
+          {
+            "name": "global_num_experts",
+            "required": true
+          },
+          {
+            "name": "expert_placement_strategy",
+            "required": false
+          },
+          {
+            "name": "num_fused_shared_experts",
+            "required": false
+          },
+          {
+            "name": "return_expert_mask",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/eplb/core/eplb_utils.py",
+          "qualified_name": "determine_expert_map(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/layer.py",
+      "owner": null,
+      "callable": "MoERunner",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendMoERunner(MoERunner)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/router/gate_linear.py",
+      "owner": null,
+      "callable": "GateLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/fused_moe/gate_linear.py",
+          "qualified_name": "AscendGateLinear(GateLinear)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/router/gate_linear.py",
+      "owner": "GateLinear",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_size",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "out_dtype",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "force_fp32_compute",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/fused_moe/gate_linear.py",
+          "qualified_name": "AscendGateLinear.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/router/gate_linear.py",
+      "owner": "GateLinear",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/fused_moe/gate_linear.py",
+          "qualified_name": "AscendGateLinear.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py",
+      "owner": null,
+      "callable": "UnquantizedFusedMoEMethod",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py",
+      "owner": "UnquantizedFusedMoEMethod",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "moe",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/_310p/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod310.__init__"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py",
+      "owner": "UnquantizedFusedMoEMethod",
+      "callable": "apply",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "topk_weights",
+            "required": true
+          },
+          {
+            "name": "topk_ids",
+            "required": true
+          },
+          {
+            "name": "shared_experts",
+            "required": true
+          },
+          {
+            "name": "shared_experts_input",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/_310p/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod310.apply"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod.apply"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py",
+      "owner": "UnquantizedFusedMoEMethod",
+      "callable": "is_monolithic",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/_310p/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod310.is_monolithic"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod.is_monolithic"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py",
+      "owner": "UnquantizedFusedMoEMethod",
+      "callable": "maybe_make_prepare_finalize",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "routing_tables",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/_310p/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod310.maybe_make_prepare_finalize"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod.maybe_make_prepare_finalize"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py",
+      "owner": "UnquantizedFusedMoEMethod",
+      "callable": "process_weights_after_loading",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/_310p/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod310.process_weights_after_loading"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/fused_moe/fused_moe.py",
+          "qualified_name": "AscendUnquantizedFusedMoEMethod.process_weights_after_loading"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/layernorm.py",
+      "owner": null,
+      "callable": "GemmaRMSNorm",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "AscendGemmaRMSNorm(GemmaRMSNorm)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/layernorm.py",
+      "owner": null,
+      "callable": "RMSNorm",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "RMSNorm(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "RMSNorm(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "RMSNorm(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "RMSNorm(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "RMSNorm(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "AscendRMSNorm(RMSNorm)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/layernorm.py",
+      "owner": null,
+      "callable": "RMSNormGated",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/ops/layernorm.py",
+          "qualified_name": "AscendRMSNormGated310(RMSNormGated)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "AscendRMSNormGated(RMSNormGated)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/layernorm.py",
+      "owner": "RMSNorm",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_size",
+            "required": true
+          },
+          {
+            "name": "eps",
+            "required": false
+          },
+          {
+            "name": "var_hidden_size",
+            "required": false
+          },
+          {
+            "name": "has_weight",
+            "required": false
+          },
+          {
+            "name": "dtype",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "AscendRMSNorm.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/layernorm.py",
+      "owner": "RMSNormGated",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_size",
+            "required": true
+          },
+          {
+            "name": "eps",
+            "required": false
+          },
+          {
+            "name": "group_size",
+            "required": false
+          },
+          {
+            "name": "norm_before_gate",
+            "required": false
+          },
+          {
+            "name": "device",
+            "required": false
+          },
+          {
+            "name": "dtype",
+            "required": false
+          },
+          {
+            "name": "activation",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "AscendRMSNormGated.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/layernorm.py",
+      "owner": "RMSNormGated",
+      "callable": "reset_parameters",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/layernorm.py",
+          "qualified_name": "AscendRMSNormGated.reset_parameters"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "ColumnParallelLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "ColumnParallelLinear(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "ColumnParallelLinear(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendColumnParallelLinear(ColumnParallelLinear)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "LinearBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendLinearBase(LinearBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "LinearMethodBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendLinearMethod(LinearMethodBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "MergedColumnParallelLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "MergedColumnParallelLinear(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendMergedColumnParallelLinear(MergedColumnParallelLinear)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "QKVParallelLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "QKVParallelLinear(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendQKVParallelLinear(QKVParallelLinear)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "ReplicatedLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "ReplicatedLinear(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "ReplicatedLinear(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "ReplicatedLinear(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "ReplicatedLinear(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "ReplicatedLinear(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendReplicatedLinear(ReplicatedLinear)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "RowParallelLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "RowParallelLinear(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "RowParallelLinear(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendRowParallelLinear(RowParallelLinear)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": null,
+      "callable": "UnquantizedLinearMethod",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "UnquantizedLinearMethod(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendUnquantizedLinearMethod(UnquantizedLinearMethod)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "ColumnParallelLinear",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_size",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "gather_output",
+            "required": false
+          },
+          {
+            "name": "skip_bias_add",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "return_bias",
+            "required": false
+          },
+          {
+            "name": "disable_tp",
+            "required": false
+          },
+          {
+            "name": "tp_rank",
+            "required": false
+          },
+          {
+            "name": "tp_size",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendColumnParallelLinear.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "ColumnParallelLinear",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendColumnParallelLinear.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "ColumnParallelLinear",
+      "callable": "weight_loader",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "param",
+            "required": true
+          },
+          {
+            "name": "loaded_weight",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendColumnParallelLinear.weight_loader"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "LinearBase",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_size",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "skip_bias_add",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "return_bias",
+            "required": false
+          },
+          {
+            "name": "disable_tp",
+            "required": false
+          },
+          {
+            "name": "tp_rank",
+            "required": false
+          },
+          {
+            "name": "tp_size",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendLinearBase.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "LinearMethodBase",
+      "callable": "apply",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendLinearMethod.apply"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "LinearMethodBase",
+      "callable": "create_weights",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "input_size_per_partition",
+            "required": true
+          },
+          {
+            "name": "output_partition_sizes",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_size",
+            "required": true
+          },
+          {
+            "name": "params_dtype",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "extra_weight_attrs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendLinearMethod.create_weights"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "MergedColumnParallelLinear",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_sizes",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "gather_output",
+            "required": false
+          },
+          {
+            "name": "skip_bias_add",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "return_bias",
+            "required": false
+          },
+          {
+            "name": "disable_tp",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendMergedColumnParallelLinear.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "QKVParallelLinear",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_size",
+            "required": true
+          },
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "total_num_heads",
+            "required": true
+          },
+          {
+            "name": "total_num_kv_heads",
+            "required": false
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "skip_bias_add",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "return_bias",
+            "required": false
+          },
+          {
+            "name": "disable_tp",
+            "required": false
+          },
+          {
+            "name": "v_head_size",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendQKVParallelLinear.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "ReplicatedLinear",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_size",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "skip_bias_add",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "return_bias",
+            "required": false
+          },
+          {
+            "name": "disable_tp",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendReplicatedLinear.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "ReplicatedLinear",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendReplicatedLinear.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "RowParallelLinear",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_size",
+            "required": true
+          },
+          {
+            "name": "output_size",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "input_is_parallel",
+            "required": false
+          },
+          {
+            "name": "skip_bias_add",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "reduce_results",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "return_bias",
+            "required": false
+          },
+          {
+            "name": "disable_tp",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendRowParallelLinear.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "RowParallelLinear",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendRowParallelLinear.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "UnquantizedLinearMethod",
+      "callable": "apply",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendUnquantizedLinearMethod.apply"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/linear.py",
+      "owner": "UnquantizedLinearMethod",
+      "callable": "process_weights_after_loading",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "AscendUnquantizedLinearMethod.process_weights_after_loading"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/logits_processor.py",
+      "owner": null,
+      "callable": "LogitsProcessor",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "LogitsProcessor(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "LogitsProcessor(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "LogitsProcessor(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "LogitsProcessor(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_init.py",
+          "qualified_name": "LogitsProcessor(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendLogitsProcessor(LogitsProcessor)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/logits_processor.py",
+      "owner": "LogitsProcessor",
+      "callable": "_get_logits",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "lm_head",
+            "required": true
+          },
+          {
+            "name": "embedding_bias",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendLogitsProcessor._get_logits"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mamba/gdn/base.py",
+      "owner": null,
+      "callable": "GatedDeltaNetAttention",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/ops/fla/gdn_310.py",
+          "qualified_name": "AscendGatedDeltaNetAttention310(GatedDeltaNetAttention)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/gdn.py",
+          "qualified_name": "AscendGatedDeltaNetAttention(GatedDeltaNetAttention)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mamba/linear/minimax_linear_attn.py",
+      "owner": null,
+      "callable": "clear_linear_attention_cache_for_new_sequences",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_cache",
+            "required": true
+          },
+          {
+            "name": "state_indices_tensor",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/bailing_moe_linear_attn.py",
+          "qualified_name": "clear_linear_attention_cache_for_new_sequences(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mamba/linear/minimax_linear_attn.py",
+      "owner": null,
+      "callable": "linear_attention_decode",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "k",
+            "required": true
+          },
+          {
+            "name": "v",
+            "required": true
+          },
+          {
+            "name": "kv_cache",
+            "required": true
+          },
+          {
+            "name": "slope_rate",
+            "required": true
+          },
+          {
+            "name": "state_indices_tensor",
+            "required": true
+          },
+          {
+            "name": "q_start",
+            "required": false
+          },
+          {
+            "name": "q_end",
+            "required": false
+          },
+          {
+            "name": "slot_start",
+            "required": false
+          },
+          {
+            "name": "slot_end",
+            "required": false
+          },
+          {
+            "name": "block_size",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/bailing_moe_linear_attn.py",
+          "qualified_name": "linear_attention_decode(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mamba/linear/minimax_linear_attn.py",
+      "owner": null,
+      "callable": "linear_attention_prefill_and_mix",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "k",
+            "required": true
+          },
+          {
+            "name": "v",
+            "required": true
+          },
+          {
+            "name": "kv_cache",
+            "required": true
+          },
+          {
+            "name": "state_indices_tensor",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          },
+          {
+            "name": "slope_rate",
+            "required": true
+          },
+          {
+            "name": "block_size",
+            "required": true
+          },
+          {
+            "name": "decode_fn",
+            "required": true
+          },
+          {
+            "name": "prefix_fn",
+            "required": true
+          },
+          {
+            "name": "layer_idx",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/bailing_moe_linear_attn.py",
+          "qualified_name": "linear_attention_prefill_and_mix(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mamba/ops/causal_conv1d.py",
+      "owner": null,
+      "callable": "causal_conv1d_update",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "conv_state",
+            "required": true
+          },
+          {
+            "name": "weight",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "activation",
+            "required": false
+          },
+          {
+            "name": "conv_state_indices",
+            "required": false
+          },
+          {
+            "name": "num_accepted_tokens",
+            "required": false
+          },
+          {
+            "name": "query_start_loc",
+            "required": false
+          },
+          {
+            "name": "max_query_len",
+            "required": false
+          },
+          {
+            "name": "null_block_id",
+            "required": false
+          },
+          {
+            "name": "block_idx_last_scheduled_token",
+            "required": false
+          },
+          {
+            "name": "initial_state_idx",
+            "required": false
+          },
+          {
+            "name": "validate_data",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_triton.py",
+          "qualified_name": "causal_conv1d_update_npu"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mla.py",
+      "owner": null,
+      "callable": "MLAModules",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "MLAModules(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mla.py",
+      "owner": null,
+      "callable": "MultiHeadLatentAttentionWrapper",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "MultiHeadLatentAttentionWrapper(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/dsa.py",
+          "qualified_name": "AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mla.py",
+      "owner": "MultiHeadLatentAttentionWrapper",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_size",
+            "required": true
+          },
+          {
+            "name": "num_heads",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": true
+          },
+          {
+            "name": "qk_nope_head_dim",
+            "required": true
+          },
+          {
+            "name": "qk_rope_head_dim",
+            "required": true
+          },
+          {
+            "name": "v_head_dim",
+            "required": true
+          },
+          {
+            "name": "q_lora_rank",
+            "required": true
+          },
+          {
+            "name": "kv_lora_rank",
+            "required": true
+          },
+          {
+            "name": "mla_modules",
+            "required": true
+          },
+          {
+            "name": "cache_config",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          },
+          {
+            "name": "skip_topk",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/dsa.py",
+          "qualified_name": "AscendDeepseekSparseAttention.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "AscendMultiHeadLatentAttention.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/mla.py",
+      "owner": "MultiHeadLatentAttentionWrapper",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "llama_4_scaling",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/dsa.py",
+          "qualified_name": "AscendDeepseekSparseAttention.forward"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "AscendMultiHeadLatentAttention.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/__init__.py",
+      "owner": null,
+      "callable": "register_quantization_config",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "quantization",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/quantization/modelslim_config.py",
+          "qualified_name": "register_quantization_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "register_quantization_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "register_quantization_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "register_quantization_config(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": null,
+      "callable": "QuantizationConfig",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig(QuantizationConfig)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config(QuantizationConfig)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig(QuantizationConfig)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": null,
+      "callable": "method_has_implemented_embedding",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "method_class",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "method_has_implemented_embedding(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "apply_vllm_mapper",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hf_to_vllm_mapper",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.apply_vllm_mapper"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.apply_vllm_mapper"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "from_config",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.from_config"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.from_config"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.from_config"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "get_config_filenames",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.get_config_filenames"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.get_config_filenames"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.get_config_filenames"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "get_min_capability",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.get_min_capability"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.get_min_capability"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.get_min_capability"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "get_name",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.get_name"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.get_name"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.get_name"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "get_quant_method",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.get_quant_method"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.get_quant_method"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.get_quant_method"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "get_supported_act_dtypes",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "AscendCompressedTensorsConfig.get_supported_act_dtypes"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/fp8_config.py",
+          "qualified_name": "AscendFp8Config.get_supported_act_dtypes"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.get_supported_act_dtypes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "maybe_update_config",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "model_name",
+            "required": true
+          },
+          {
+            "name": "hf_config",
+            "required": false
+          },
+          {
+            "name": "revision",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.maybe_update_config"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/base_config.py",
+      "owner": "QuantizationConfig",
+      "callable": "override_quantization_method",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "hf_quant_cfg",
+            "required": true
+          },
+          {
+            "name": "user_quant",
+            "required": true
+          },
+          {
+            "name": "hf_config",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "AscendModelSlimConfig.override_quantization_method"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/compressed_tensors/utils.py",
+      "owner": null,
+      "callable": "find_matched_target",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "layer_name",
+            "required": true
+          },
+          {
+            "name": "module",
+            "required": true
+          },
+          {
+            "name": "targets",
+            "required": true
+          },
+          {
+            "name": "fused_mapping",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "find_matched_target(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/compressed_tensors/utils.py",
+      "owner": null,
+      "callable": "is_activation_quantization_format",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "format",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "is_activation_quantization_format(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/compressed_tensors/utils.py",
+      "owner": null,
+      "callable": "should_ignore_layer",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "layer_name",
+            "required": true
+          },
+          {
+            "name": "ignore",
+            "required": false
+          },
+          {
+            "name": "fused_mapping",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/compressed_tensors_config.py",
+          "qualified_name": "should_ignore_layer(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/kv_cache.py",
+      "owner": null,
+      "callable": "BaseKVCacheMethod",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendKVCacheMethod(BaseKVCacheMethod)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/kv_cache.py",
+      "owner": "BaseKVCacheMethod",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "quant_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendKVCacheMethod.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/kv_cache.py",
+      "owner": "BaseKVCacheMethod",
+      "callable": "apply",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendKVCacheMethod.apply"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/kv_cache.py",
+      "owner": "BaseKVCacheMethod",
+      "callable": "create_weights",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendKVCacheMethod.create_weights"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/quantization/kv_cache.py",
+      "owner": "BaseKVCacheMethod",
+      "callable": "process_weights_after_loading",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "AscendKVCacheMethod.process_weights_after_loading"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/__init__.py",
+      "owner": null,
+      "callable": "DeepseekScalingRotaryEmbedding",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "AscendDeepseekScalingRotaryEmbedding(DeepseekScalingRotaryEmbedding)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/__init__.py",
+      "owner": null,
+      "callable": "MRotaryEmbedding",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/ops/rotary_embedding.py",
+          "qualified_name": "AscendMRotaryEmbedding310(MRotaryEmbedding)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "AscendMRotaryEmbedding(MRotaryEmbedding)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/__init__.py",
+      "owner": null,
+      "callable": "RotaryEmbedding",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "AscendRotaryEmbedding(RotaryEmbedding)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/__init__.py",
+      "owner": null,
+      "callable": "YaRNScalingRotaryEmbedding",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "AscendYaRNRotaryEmbedding(YaRNScalingRotaryEmbedding)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/__init__.py",
+      "owner": null,
+      "callable": "get_rope",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "max_position",
+            "required": true
+          },
+          {
+            "name": "is_neox_style",
+            "required": false
+          },
+          {
+            "name": "rope_parameters",
+            "required": false
+          },
+          {
+            "name": "dtype",
+            "required": false
+          },
+          {
+            "name": "dual_chunk_attention_config",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "get_rope(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/common.py",
+      "owner": null,
+      "callable": "ApplyRotaryEmb",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "AscendApplyRotaryEmb(ApplyRotaryEmb)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/common.py",
+      "owner": "ApplyRotaryEmb",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "enforce_enable",
+            "required": false
+          },
+          {
+            "name": "is_neox_style",
+            "required": false
+          },
+          {
+            "name": "enable_fp32_compute",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "AscendApplyRotaryEmb.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/mrope.py",
+      "owner": null,
+      "callable": "apply_interleaved_rope",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "mrope_section",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/ops/rotary_embedding.py",
+          "qualified_name": "apply_interleaved_rope(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/rotary_embedding/mrope.py",
+      "owner": null,
+      "callable": "triton_mrope",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "k",
+            "required": true
+          },
+          {
+            "name": "cos",
+            "required": true
+          },
+          {
+            "name": "sin",
+            "required": true
+          },
+          {
+            "name": "mrope_section",
+            "required": true
+          },
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "rotary_dim",
+            "required": true
+          },
+          {
+            "name": "mrope_interleaved",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/rotary_embedding.py",
+          "qualified_name": "triton_mrope(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": null,
+      "callable": "ParallelLMHead",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "ParallelLMHead(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "ParallelLMHead(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "ParallelLMHead(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "ParallelLMHead(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_init.py",
+          "qualified_name": "ParallelLMHead(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendParallelLMHead(ParallelLMHead)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": null,
+      "callable": "UnquantizedEmbeddingMethod",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "UnquantizedEmbeddingMethod(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "UnquantizedEmbeddingMethod(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendUnquantizedEmbeddingMethod310(UnquantizedEmbeddingMethod)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": null,
+      "callable": "VocabParallelEmbedding",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "VocabParallelEmbedding(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "VocabParallelEmbedding(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "VocabParallelEmbedding(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VocabParallelEmbedding(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendVocabParallelEmbedding(VocabParallelEmbedding)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": null,
+      "callable": "pad_vocab_size",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vocab_size",
+            "required": true
+          },
+          {
+            "name": "pad_to",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "pad_vocab_size(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": "ParallelLMHead",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_embeddings",
+            "required": true
+          },
+          {
+            "name": "embedding_dim",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "org_num_embeddings",
+            "required": false
+          },
+          {
+            "name": "padding_size",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendParallelLMHead.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": "UnquantizedEmbeddingMethod",
+      "callable": "apply",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/_310p/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendUnquantizedEmbeddingMethod310.apply"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": "UnquantizedEmbeddingMethod",
+      "callable": "process_weights_after_loading",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/_310p/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendUnquantizedEmbeddingMethod310.process_weights_after_loading"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": "VocabParallelEmbedding",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_embeddings",
+            "required": true
+          },
+          {
+            "name": "embedding_dim",
+            "required": true
+          },
+          {
+            "name": "params_dtype",
+            "required": false
+          },
+          {
+            "name": "org_num_embeddings",
+            "required": false
+          },
+          {
+            "name": "padding_size",
+            "required": false
+          },
+          {
+            "name": "quant_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendVocabParallelEmbedding.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/layers/vocab_parallel_embedding.py",
+      "owner": "VocabParallelEmbedding",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "AscendVocabParallelEmbedding.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/__init__.py",
+      "owner": null,
+      "callable": "ShardedStateLoader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/sharded_state_loader_310p.py",
+          "qualified_name": "ShardedStateLoader310(ShardedStateLoader)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/__init__.py",
+      "owner": null,
+      "callable": "get_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          },
+          {
+            "name": "load_config",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "get_model(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "get_model(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_model(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/__init__.py",
+      "owner": null,
+      "callable": "register_model_loader",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "load_format",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "register_model_loader(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "register_model_loader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/base_loader.py",
+      "owner": null,
+      "callable": "BaseModelLoader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "ModelNetLoaderElastic(BaseModelLoader)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "RForkModelLoader(BaseModelLoader)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/base_loader.py",
+      "owner": "BaseModelLoader",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "load_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "ModelNetLoaderElastic.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "RForkModelLoader.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/base_loader.py",
+      "owner": "BaseModelLoader",
+      "callable": "download_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "ModelNetLoaderElastic.download_model"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "RForkModelLoader.download_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/base_loader.py",
+      "owner": "BaseModelLoader",
+      "callable": "load_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "ModelNetLoaderElastic.load_model"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "RForkModelLoader.load_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/base_loader.py",
+      "owner": "BaseModelLoader",
+      "callable": "load_weights",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "model",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "ModelNetLoaderElastic.load_weights"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "RForkModelLoader.load_weights"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/default_loader.py",
+      "owner": null,
+      "callable": "DefaultModelLoader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "DefaultModelLoader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/reload/__init__.py",
+      "owner": null,
+      "callable": "finalize_layerwise_reload",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "finalize_layerwise_reload(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "finalize_layerwise_reload(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/reload/__init__.py",
+      "owner": null,
+      "callable": "initialize_layerwise_reload",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/weight_transfer/hccl_engine.py",
+          "qualified_name": "initialize_layerwise_reload(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "initialize_layerwise_reload(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/reload/__init__.py",
+      "owner": null,
+      "callable": "set_torchao_reload_attrs",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_process_weights_after_loading.py",
+          "qualified_name": "set_torchao_reload_attrs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/utils.py",
+      "owner": null,
+      "callable": "device_loading_context",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "module",
+            "required": true
+          },
+          {
+            "name": "target_device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_process_weights_after_loading.py",
+          "qualified_name": "device_loading_context(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/utils.py",
+      "owner": null,
+      "callable": "initialize_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "prefix",
+            "required": false
+          },
+          {
+            "name": "model_class",
+            "required": false
+          },
+          {
+            "name": "model_config",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "initialize_model(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "initialize_model(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/utils.py",
+      "owner": null,
+      "callable": "process_weights_after_loading",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "model",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": true
+          },
+          {
+            "name": "target_device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "process_weights_after_loading(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "process_weights_after_loading(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/model_loader/weight_utils.py",
+      "owner": null,
+      "callable": "maybe_remap_kv_scale_name",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "name",
+            "required": true
+          },
+          {
+            "name": "params_dict",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "maybe_remap_kv_scale_name(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "maybe_remap_kv_scale_name(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/__init__.py",
+      "owner": null,
+      "callable": "supports_multimodal",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "supports_multimodal(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/bailing_moe_linear.py",
+      "owner": null,
+      "callable": "BailingMoELinearAttention",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/bailing_moe_linear_attn.py",
+          "qualified_name": "AscendBailingMoELinearAttention(BailingMoELinearAttention)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/config.py",
+      "owner": "HybridAttentionMambaModelConfig",
+      "callable": "verify_and_update_config",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config.py",
+          "qualified_name": "verify_and_update_config"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config_310.py",
+          "qualified_name": "verify_and_update_config"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder.py",
+      "owner": null,
+      "callable": "RelPosAttention",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/rel_pos_attention.py",
+          "qualified_name": "AscendRelPosAttention(RelPosAttention)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder.py",
+      "owner": null,
+      "callable": "add_decomposed_rel_pos",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "rel_pos_h",
+            "required": true
+          },
+          {
+            "name": "rel_pos_w",
+            "required": true
+          },
+          {
+            "name": "q_size",
+            "required": true
+          },
+          {
+            "name": "k_size",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/rel_pos_attention.py",
+          "qualified_name": "add_decomposed_rel_pos(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder.py",
+      "owner": "RelPosAttention",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "dim",
+            "required": true
+          },
+          {
+            "name": "num_heads",
+            "required": false
+          },
+          {
+            "name": "qkv_bias",
+            "required": false
+          },
+          {
+            "name": "use_rel_pos",
+            "required": false
+          },
+          {
+            "name": "rel_pos_zero_init",
+            "required": false
+          },
+          {
+            "name": "input_size",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/rel_pos_attention.py",
+          "qualified_name": "AscendRelPosAttention.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder.py",
+      "owner": "RelPosAttention",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/rel_pos_attention.py",
+          "qualified_name": "AscendRelPosAttention.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder2.py",
+      "owner": null,
+      "callable": "CustomQwen2Decoder",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/qwen2_decoder.py",
+          "qualified_name": "AscendCustomQwen2Decoder(CustomQwen2Decoder)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder2.py",
+      "owner": "CustomQwen2Decoder",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "decoder_layer",
+            "required": false
+          },
+          {
+            "name": "max_position_embeddings",
+            "required": false
+          },
+          {
+            "name": "hidden_dimension",
+            "required": false
+          },
+          {
+            "name": "num_attention_heads",
+            "required": false
+          },
+          {
+            "name": "num_key_value_heads",
+            "required": false
+          },
+          {
+            "name": "intermediate_size",
+            "required": false
+          },
+          {
+            "name": "vocab_size",
+            "required": false
+          },
+          {
+            "name": "attn_implementation",
+            "required": false
+          },
+          {
+            "name": "rms_norm_eps",
+            "required": false
+          },
+          {
+            "name": "rope_theta",
+            "required": false
+          },
+          {
+            "name": "attention_dropout",
+            "required": false
+          },
+          {
+            "name": "hidden_act",
+            "required": false
+          },
+          {
+            "name": "initializer_range",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/qwen2_decoder.py",
+          "qualified_name": "AscendCustomQwen2Decoder.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepencoder2.py",
+      "owner": "CustomQwen2Decoder",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "inputs_embeds",
+            "required": true
+          },
+          {
+            "name": "token_type_ids",
+            "required": true
+          },
+          {
+            "name": "attention_mask",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/ops/qwen2_decoder.py",
+          "qualified_name": "AscendCustomQwen2Decoder.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_eagle3.py",
+      "owner": null,
+      "callable": "DeepseekV2Eagle3Model",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_init.py",
+          "qualified_name": "DeepseekV2Eagle3Model(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_mtp.py",
+      "owner": null,
+      "callable": "DeepSeekMTP",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMTP(DeepSeekMTP)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMTP"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_mtp.py",
+      "owner": null,
+      "callable": "DeepSeekMultiTokenPredictorLayer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMultiTokenPredictorLayer(DeepSeekMultiTokenPredictorLayer)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMultiTokenPredictorLayer"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_mtp.py",
+      "owner": null,
+      "callable": "get_spec_layer_idx_from_weight_name",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "get_spec_layer_idx_from_weight_name"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_mtp.py",
+      "owner": "DeepSeekMTP",
+      "callable": "_rewrite_spec_layer_name",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "spec_layer",
+            "required": true
+          },
+          {
+            "name": "name",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMTP._rewrite_spec_layer_name"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_mtp.py",
+      "owner": "DeepSeekMultiTokenPredictorLayer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMultiTokenPredictorLayer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_mtp.py",
+      "owner": "DeepSeekMultiTokenPredictorLayer",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_ids",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "previous_hidden_states",
+            "required": true
+          },
+          {
+            "name": "inputs_embeds",
+            "required": false
+          },
+          {
+            "name": "spec_step_index",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendDeepSeekMultiTokenPredictorLayer.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_v2.py",
+      "owner": null,
+      "callable": "DeepSeekV2FusedQkvAProjLinear",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "DeepSeekV2FusedQkvAProjLinear(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_v2.py",
+      "owner": null,
+      "callable": "GlmMoeDsaForCausalLM",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AscendGlmMoeDsaForCausalLM(GlmMoeDsaForCausalLM)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_v2.py",
+      "owner": null,
+      "callable": "Indexer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "Indexer(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_v2.py",
+      "owner": null,
+      "callable": "_get_llama_4_scaling",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "original_max_position_embeddings",
+            "required": true
+          },
+          {
+            "name": "scaling_beta",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "_get_llama_4_scaling(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_pp_aux.py",
+          "qualified_name": "_get_llama_4_scaling(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_v2.py",
+      "owner": null,
+      "callable": "get_spec_layer_idx_from_weight_name",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "get_spec_layer_idx_from_weight_name"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/deepseek_v2.py",
+      "owner": null,
+      "callable": "yarn_get_mscale",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "scale",
+            "required": false
+          },
+          {
+            "name": "mscale",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "yarn_get_mscale(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "EagleModelMixin",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "DeepseekV4Model(EagleModelMixin)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "MixtureOfExperts",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "DeepseekV2MixtureOfExperts(MixtureOfExperts)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "SupportsEagle3",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4ForCausalLM(SupportsEagle3)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "SupportsLoRA",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4ForCausalLM(SupportsLoRA)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "SupportsPP",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4ForCausalLM(SupportsPP)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "DeepSeekV4MTP(SupportsPP)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "supports_eagle3",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "supports_eagle3(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": null,
+      "callable": "supports_multimodal_pruning",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "supports_multimodal_pruning(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": "MixtureOfExperts",
+      "callable": "update_physical_experts_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_physical_experts",
+            "required": true
+          },
+          {
+            "name": "num_local_physical_experts",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "DeepseekV2MixtureOfExperts.update_physical_experts_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/interfaces.py",
+      "owner": "SupportsPP",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_ids",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "intermediate_tensors",
+            "required": true
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4ForCausalLM.forward"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "DeepSeekV4MTP.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/kimi_k25_vit.py",
+      "owner": "Learnable2DInterpPosEmbDivided_fixed",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "grid_thws",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_kimi_k25.py",
+          "qualified_name": "AscendLearnable2DInterpPosEmbDivided_fixed.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": null,
+      "callable": "Eagle3LlamaForCausalLM",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "Eagle3VwnLlamaForCausalLM(Eagle3LlamaForCausalLM)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": null,
+      "callable": "LlamaDecoderLayer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VwnLlamaDecoderLayer(Eagle3LlamaDecoderLayer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": null,
+      "callable": "LlamaModel",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_init.py",
+          "qualified_name": "LlamaModel(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VwnLlamaModel(Eagle3LlamaModel)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": null,
+      "callable": "get_draft_quant_config",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_init.py",
+          "qualified_name": "get_draft_quant_config(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "Eagle3LlamaForCausalLM",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "Eagle3VwnLlamaForCausalLM.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "Eagle3LlamaForCausalLM",
+      "callable": "combine_hidden_states",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "Eagle3VwnLlamaForCausalLM.combine_hidden_states"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "Eagle3LlamaForCausalLM",
+      "callable": "compute_logits",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "Eagle3VwnLlamaForCausalLM.compute_logits"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "LlamaDecoderLayer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": false
+          },
+          {
+            "name": "config",
+            "required": false
+          },
+          {
+            "name": "layer_idx",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VwnLlamaDecoderLayer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "LlamaDecoderLayer",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "embeds",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "residual",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VwnLlamaDecoderLayer.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "LlamaModel",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "start_layer_id",
+            "required": false
+          },
+          {
+            "name": "prefix",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VwnLlamaModel.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/llama_eagle3.py",
+      "owner": "LlamaModel",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_ids",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "input_embeds",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "VwnLlamaModel.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/minimax_m2.py",
+      "owner": "MiniMaxM2Attention",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_minimax_m2.py",
+          "qualified_name": "_patch_forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/minimax_m2.py",
+      "owner": "MiniMaxM2MoE",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_minimax_m2.py",
+          "qualified_name": "_patched_moe_forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/minimax_m2.py",
+      "owner": "MiniMaxM2Model",
+      "callable": "load_weights",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "weights",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_minimax_m2.py",
+          "qualified_name": "_patched_load_weights"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3.py",
+      "owner": "Qwen3Attention",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_qwen3vl.py",
+          "qualified_name": "forward_with_split_qkv_rmsnorm_mrope"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_5.py",
+      "owner": null,
+      "callable": "Qwen3_5DecoderLayer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "AscendQwen3_5DecoderLayer(Qwen3_5DecoderLayer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_dflash.py",
+      "owner": "DFlashQwen3Model",
+      "callable": "precompute_and_store_context_kv",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "context_states",
+            "required": true
+          },
+          {
+            "name": "context_positions",
+            "required": true
+          },
+          {
+            "name": "context_slot_mapping",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_dflash.py",
+          "qualified_name": "precompute_and_store_context_kv"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_dspark.py",
+      "owner": null,
+      "callable": "Qwen3DSparkForCausalLM",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/qwen3_dspark.py",
+          "qualified_name": "AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_moe.py",
+      "owner": "Qwen3MoeAttention",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_qwen3vl.py",
+          "qualified_name": "forward_with_split_qkv_rmsnorm_mrope"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_next.py",
+      "owner": null,
+      "callable": "Qwen3NextAttention",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "AscendQwen3NextAttention(Qwen3NextAttention)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_next.py",
+      "owner": null,
+      "callable": "_all_gather_hidden_and_residual",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "residual",
+            "required": true
+          },
+          {
+            "name": "full_num_tokens",
+            "required": true
+          },
+          {
+            "name": "hidden_size",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "_all_gather_hidden_and_residual(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_next.py",
+      "owner": "Qwen3NextAttention",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "AscendQwen3NextAttention.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_next.py",
+      "owner": "Qwen3NextDecoderLayer",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "residual",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "AscendQwen3_5DecoderLayer.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_vl.py",
+      "owner": null,
+      "callable": "pos_embed_interpolate_native",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "embed_weight",
+            "required": true
+          },
+          {
+            "name": "t",
+            "required": true
+          },
+          {
+            "name": "h",
+            "required": true
+          },
+          {
+            "name": "w",
+            "required": true
+          },
+          {
+            "name": "num_grid_per_side",
+            "required": true
+          },
+          {
+            "name": "m_size",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_qwen3vl.py",
+          "qualified_name": "pos_embed_interpolate_native(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/qwen3_vl.py",
+      "owner": "Qwen3_VisionTransformer",
+      "callable": "fast_pos_embed_interpolate",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "grid_thw",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_qwen3vl.py",
+          "qualified_name": "_fast_pos_embed_interpolate"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "AutoWeightsLoader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_mtp.py",
+          "qualified_name": "AutoWeightsLoader(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_draft_quarot.py",
+          "qualified_name": "AutoWeightsLoader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "PPMissingLayer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "PPMissingLayer(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "WeightsMapper",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/modelslim_config.py",
+          "qualified_name": "WeightsMapper(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "extract_layer_index",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "layer_name",
+            "required": true
+          },
+          {
+            "name": "num_attn_module",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ascend_config.py",
+          "qualified_name": "extract_layer_index(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py",
+          "qualified_name": "extract_layer_index(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/linear_op.py",
+          "qualified_name": "extract_layer_index(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "extract_layer_index(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/utils.py",
+          "qualified_name": "extract_layer_index(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "get_draft_quant_config",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "get_draft_quant_config(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/step3p5.py",
+          "qualified_name": "get_draft_quant_config(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "is_pp_missing_parameter",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "name",
+            "required": true
+          },
+          {
+            "name": "model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "is_pp_missing_parameter(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "make_layers",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "num_hidden_layers",
+            "required": true
+          },
+          {
+            "name": "layer_fn",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "make_layers(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "maybe_prefix",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "prefix",
+            "required": true
+          },
+          {
+            "name": "name",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "maybe_prefix(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_dspark.py",
+          "qualified_name": "maybe_prefix(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4_mtp.py",
+          "qualified_name": "maybe_prefix(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/llama_eagle3_vwn.py",
+          "qualified_name": "maybe_prefix(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_init.py",
+          "qualified_name": "maybe_prefix(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "process_eagle_weight",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "model",
+            "required": true
+          },
+          {
+            "name": "name",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_draft_quarot.py",
+          "qualified_name": "process_eagle_weight(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/models/utils.py",
+      "owner": null,
+      "callable": "sequence_parallel_chunk",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "sequence_parallel_chunk(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/base.py",
+      "owner": null,
+      "callable": "NoopOffloader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_executor/offloader/base.py",
+          "qualified_name": "NoopOffloader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/base.py",
+      "owner": null,
+      "callable": "get_offloader",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/compilation/acl_graph.py",
+          "qualified_name": "get_offloader(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_offloader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/base.py",
+      "owner": null,
+      "callable": "set_offloader",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "instance",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "set_offloader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": null,
+      "callable": "ParamInfo",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "ParamInfo(VllmParamInfo)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": null,
+      "callable": "PrefetchOffloader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "AscendPrefetchOffloader(PrefetchOffloader)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": null,
+      "callable": "_ModuleOffloader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "_ModuleOffloader(VllmModuleOffloader)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": "PrefetchOffloader",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "group_size",
+            "required": true
+          },
+          {
+            "name": "num_in_group",
+            "required": true
+          },
+          {
+            "name": "prefetch_step",
+            "required": true
+          },
+          {
+            "name": "offload_params",
+            "required": false
+          },
+          {
+            "name": "mode",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "AscendPrefetchOffloader.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": "PrefetchOffloader",
+      "callable": "post_init",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "AscendPrefetchOffloader.post_init"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": "PrefetchOffloader",
+      "callable": "wrap_modules",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "modules_generator",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "AscendPrefetchOffloader.wrap_modules"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": "_ModuleOffloader",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "mode",
+            "required": true
+          },
+          {
+            "name": "module",
+            "required": true
+          },
+          {
+            "name": "copy_stream",
+            "required": true
+          },
+          {
+            "name": "whitelist_param_names",
+            "required": true
+          },
+          {
+            "name": "layer_idx",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "_ModuleOffloader.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/offloader/prefetch.py",
+      "owner": "_ModuleOffloader",
+      "callable": "get_param_infos",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/model_executor/offloader/prefetch.py",
+          "qualified_name": "_ModuleOffloader.get_param_infos"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/parameter.py",
+      "owner": null,
+      "callable": "PerTensorScaleParameter",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "PerTensorScaleParameter(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/model_executor/utils.py",
+      "owner": null,
+      "callable": "set_weight_attrs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "weight",
+            "required": true
+          },
+          {
+            "name": "weight_attrs",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "set_weight_attrs(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/vocab_parallel_embedding.py",
+          "qualified_name": "set_weight_attrs(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/method_adapters.py",
+          "qualified_name": "set_weight_attrs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/attention.py",
+      "owner": null,
+      "callable": "DeepseekV4IndexerCache",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/attention.py",
+      "owner": "DeepseekV4IndexerCache",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "head_dim",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          },
+          {
+            "name": "cache_config",
+            "required": true
+          },
+          {
+            "name": "compress_ratio",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4IndexerCache.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/attention.py",
+      "owner": "DeepseekV4IndexerCache",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4IndexerCache.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/attention.py",
+      "owner": "DeepseekV4IndexerCache",
+      "callable": "get_attn_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4IndexerCache.get_attn_backend"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/attention.py",
+      "owner": "DeepseekV4IndexerCache",
+      "callable": "get_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4IndexerCache.get_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/compressor.py",
+      "owner": null,
+      "callable": "CompressorStateCache",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendCompressorStateCache(CompressorStateCache)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/compressor.py",
+      "owner": "CompressorStateCache",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "state_dim",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          },
+          {
+            "name": "compress_ratio",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendCompressorStateCache.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/compressor.py",
+      "owner": "CompressorStateCache",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendCompressorStateCache.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/compressor.py",
+      "owner": "CompressorStateCache",
+      "callable": "get_attn_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendCompressorStateCache.get_attn_backend"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/models/deepseek_v4/compressor.py",
+      "owner": "CompressorStateCache",
+      "callable": "get_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendCompressorStateCache.get_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/platforms/__init__.py",
+      "owner": null,
+      "callable": "Platform",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/platform.py",
+          "qualified_name": "NPUPlatform(Platform)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/platforms/interface.py",
+      "owner": null,
+      "callable": "set_assigned_physical_gpu_ids",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "set_assigned_physical_gpu_ids(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/platforms/rocm.py",
+      "owner": null,
+      "callable": "on_gfx942",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/minimax_m3/ops/msa_m3_triton.py",
+          "qualified_name": "on_gfx942(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/profiler/wrapper.py",
+      "owner": null,
+      "callable": "WorkerProfiler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/profiler/torch_npu_profiler.py",
+          "qualified_name": "TorchNPUProfilerWrapper(WorkerProfiler)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/profiler/wrapper.py",
+      "owner": "WorkerProfiler",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "profiler_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/profiler/torch_npu_profiler.py",
+          "qualified_name": "TorchNPUProfilerWrapper.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/sequence.py",
+      "owner": null,
+      "callable": "IntermediateTensors",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "IntermediateTensors(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_deepseek_v2.py",
+          "qualified_name": "IntermediateTensors(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_eagle3_pp_aux.py",
+          "qualified_name": "IntermediateTensors(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_5.py",
+          "qualified_name": "IntermediateTensors(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/utils.py",
+          "qualified_name": "IntermediateTensors(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "IntermediateTensors(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/third_party/flash_linear_attention/ops/index.py",
+      "owner": null,
+      "callable": "prepare_lens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cu_seqlens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/ops/fla/idex.py",
+          "qualified_name": "prepare_lens(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/third_party/flash_linear_attention/ops/l2norm.py",
+      "owner": null,
+      "callable": "l2norm_fwd",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "eps",
+            "required": false
+          },
+          {
+            "name": "output_dtype",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/gdn.py",
+          "qualified_name": "l2norm_fwd(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/third_party/flash_linear_attention/ops/layernorm_guard.py",
+      "owner": null,
+      "callable": "layernorm_fn",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "weight",
+            "required": true
+          },
+          {
+            "name": "bias",
+            "required": true
+          },
+          {
+            "name": "z",
+            "required": false
+          },
+          {
+            "name": "eps",
+            "required": false
+          },
+          {
+            "name": "group_size",
+            "required": false
+          },
+          {
+            "name": "norm_before_gate",
+            "required": false
+          },
+          {
+            "name": "is_rms_norm",
+            "required": false
+          },
+          {
+            "name": "activation",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/bailing_moe_linear_attn.py",
+          "qualified_name": "layernorm_fn(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/import_utils.py",
+      "owner": null,
+      "callable": "LazyLoader",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_speculative_config.py",
+          "qualified_name": "LazyLoader(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "LazyLoader(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/math_utils.py",
+      "owner": null,
+      "callable": "cdiv",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "a",
+            "required": true
+          },
+          {
+            "name": "b",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/block_table.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/model_runner_310p.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ascend_config.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/context_parallel/mla_cp.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/context_parallel/sfa_cp.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/single_type_kv_cache_manager.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/manager.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/kda/kda.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config_310.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_mamba_utils.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w4a4_mxfp4.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/quantization/methods/w8a8_mxfp8.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/block_table.py",
+          "qualified_name": "cdiv(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "cdiv(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/math_utils.py",
+      "owner": null,
+      "callable": "largest_power_of_2_divisor",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "n",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/utils.py",
+          "qualified_name": "largest_power_of_2_divisor(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/math_utils.py",
+      "owner": null,
+      "callable": "next_power_of_2",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "n",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/kda/kda.py",
+          "qualified_name": "next_power_of_2(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/math_utils.py",
+      "owner": null,
+      "callable": "round_down",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "round_down(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "round_down(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/math_utils.py",
+      "owner": null,
+      "callable": "round_up",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "y",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/minimax_m3/ops/msa_m3_triton.py",
+          "qualified_name": "round_up(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "round_up(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "round_up(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/mem_utils.py",
+      "owner": null,
+      "callable": "DeviceMemoryProfiler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "DeviceMemoryProfiler(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/mem_utils.py",
+      "owner": null,
+      "callable": "MemorySnapshot",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/worker_310p.py",
+          "qualified_name": "MemorySnapshot(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "MemorySnapshot(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/mem_utils.py",
+      "owner": null,
+      "callable": "format_gib",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "b",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "format_gib(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/mem_utils.py",
+      "owner": null,
+      "callable": "memory_profiling",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "baseline_snapshot",
+            "required": true
+          },
+          {
+            "name": "weights_memory",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/worker_310p.py",
+          "qualified_name": "memory_profiling(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "memory_profiling(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "get_distributed_init_method",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "ip",
+            "required": true
+          },
+          {
+            "name": "port",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "get_distributed_init_method(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "get_ip",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "get_ip(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "get_ip(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "get_ip(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py",
+          "qualified_name": "get_ip(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "get_ip(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/seed_protocol.py",
+          "qualified_name": "get_ip(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/transfer_backend.py",
+          "qualified_name": "get_ip(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "get_loopback_ip",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "get_loopback_ip(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "get_open_port",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/transfer_backend.py",
+          "qualified_name": "get_open_port(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "get_open_port(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "join_host_port",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "host",
+            "required": true
+          },
+          {
+            "name": "port",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/transfer_backend.py",
+          "qualified_name": "join_host_port(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "make_zmq_path",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "scheme",
+            "required": true
+          },
+          {
+            "name": "host",
+            "required": true
+          },
+          {
+            "name": "port",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "make_zmq_path(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "make_zmq_path(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "make_zmq_path(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "make_zmq_socket",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "ctx",
+            "required": true
+          },
+          {
+            "name": "path",
+            "required": true
+          },
+          {
+            "name": "socket_type",
+            "required": true
+          },
+          {
+            "name": "bind",
+            "required": false
+          },
+          {
+            "name": "identity",
+            "required": false
+          },
+          {
+            "name": "linger",
+            "required": false
+          },
+          {
+            "name": "router_handover",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "make_zmq_socket(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py",
+          "qualified_name": "make_zmq_socket(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "make_zmq_socket(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "make_zmq_socket(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py",
+          "qualified_name": "make_zmq_socket(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/network_utils.py",
+      "owner": null,
+      "callable": "split_host_port",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "host_port",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py",
+          "qualified_name": "split_host_port(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/platform_utils.py",
+      "owner": null,
+      "callable": "is_pin_memory_available",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/kv_offload/cpu_npu.py",
+          "qualified_name": "is_pin_memory_available(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/penalties.py",
+          "qualified_name": "is_pin_memory_available(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/simple_kv_offload/worker.py",
+          "qualified_name": "is_pin_memory_available(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "is_pin_memory_available(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/system_utils.py",
+      "owner": null,
+      "callable": "get_mp_context",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "get_mp_context(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/torch_utils.py",
+      "owner": null,
+      "callable": "direct_register_custom_op",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "op_name",
+            "required": true
+          },
+          {
+            "name": "op_func",
+            "required": true
+          },
+          {
+            "name": "mutates_args",
+            "required": false
+          },
+          {
+            "name": "fake_impl",
+            "required": false
+          },
+          {
+            "name": "target_lib",
+            "required": false
+          },
+          {
+            "name": "dispatch_key",
+            "required": false
+          },
+          {
+            "name": "tags",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/dsa.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/linear.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/mla.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/register_custom_ops.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_rope_simt.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/triton/linearnorm/split_qkv_tp_rmsnorm_rope.py",
+          "qualified_name": "direct_register_custom_op(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/torch_utils.py",
+      "owner": null,
+      "callable": "get_dtype_size",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "dtype",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/model_runner_310p.py",
+          "qualified_name": "get_dtype_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "get_dtype_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "get_dtype_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "get_dtype_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config.py",
+          "qualified_name": "get_dtype_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_dtype_size(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/torch_utils.py",
+      "owner": null,
+      "callable": "kv_cache_dtype_str_to_dtype",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_cache_dtype",
+            "required": true
+          },
+          {
+            "name": "model_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/models/layer/attention/layer.py",
+          "qualified_name": "kv_cache_dtype_str_to_dtype(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/torch_utils.py",
+      "owner": null,
+      "callable": "make_tensor_with_pad",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "pad",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "max_len",
+            "required": false
+          },
+          {
+            "name": "device",
+            "required": false
+          },
+          {
+            "name": "pin_memory",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/penalties.py",
+          "qualified_name": "make_tensor_with_pad(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/torch_utils.py",
+      "owner": null,
+      "callable": "set_default_torch_dtype",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "dtype",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/netloader/netloader.py",
+          "qualified_name": "set_default_torch_dtype(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/model_loader/rfork/rfork_loader.py",
+          "qualified_name": "set_default_torch_dtype(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/utils/torch_utils.py",
+      "owner": null,
+      "callable": "set_random_seed",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "seed",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/worker_310p.py",
+          "qualified_name": "set_random_seed(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "set_random_seed(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": null,
+      "callable": "AttentionBackend",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackend(AttentionBackend)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSABackend(AttentionBackend)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/fa3_v1.py",
+          "qualified_name": "AscendFABackend(AttentionBackend)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerBackend(AttentionBackend)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLABackend(AttentionBackend)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFABackend(AttentionBackend)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": null,
+      "callable": "AttentionImpl",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackendImpl(AttentionImpl)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": null,
+      "callable": "MLAAttentionImpl",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAImpl(MLAAttentionImpl)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAImpl(MLAAttentionImpl)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionBackend",
+      "callable": "get_builder_cls",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackend.get_builder_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSABackend.get_builder_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/fa3_v1.py",
+          "qualified_name": "AscendFABackend.get_builder_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLABackend.get_builder_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFABackend.get_builder_cls"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerBackend.get_builder_cls"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionBackend",
+      "callable": "get_impl_cls",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackend.get_impl_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSABackend.get_impl_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/fa3_v1.py",
+          "qualified_name": "AscendFABackend.get_impl_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLABackend.get_impl_cls"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFABackend.get_impl_cls"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionBackend",
+      "callable": "get_kv_cache_shape",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "num_blocks",
+            "required": true
+          },
+          {
+            "name": "block_size",
+            "required": true
+          },
+          {
+            "name": "num_kv_heads",
+            "required": true
+          },
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "cache_dtype_str",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackend.get_kv_cache_shape"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSABackend.get_kv_cache_shape"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/fa3_v1.py",
+          "qualified_name": "AscendFABackend.get_kv_cache_shape"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLABackend.get_kv_cache_shape"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFABackend.get_kv_cache_shape"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerBackend.get_kv_cache_shape"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionBackend",
+      "callable": "get_name",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackend.get_name"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSABackend.get_name"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/fa3_v1.py",
+          "qualified_name": "AscendFABackend.get_name"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLABackend.get_name"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFABackend.get_name"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerBackend.get_name"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionBackend",
+      "callable": "get_supported_kernel_block_sizes",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackend.get_supported_kernel_block_sizes"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSABackend.get_supported_kernel_block_sizes"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/fa3_v1.py",
+          "qualified_name": "AscendFABackend.get_supported_kernel_block_sizes"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLABackend.get_supported_kernel_block_sizes"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFABackend.get_supported_kernel_block_sizes"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerBackend.get_supported_kernel_block_sizes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionImpl",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_heads",
+            "required": true
+          },
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": true
+          },
+          {
+            "name": "num_kv_heads",
+            "required": false
+          },
+          {
+            "name": "alibi_slopes",
+            "required": false
+          },
+          {
+            "name": "sliding_window",
+            "required": false
+          },
+          {
+            "name": "kv_cache_dtype",
+            "required": false
+          },
+          {
+            "name": "logits_soft_cap",
+            "required": false
+          },
+          {
+            "name": "attn_type",
+            "required": false
+          },
+          {
+            "name": "kv_sharing_target_layer_name",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/abstract.py",
+          "qualified_name": "DSAAttentionImpl.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackendImpl.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionImpl",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          },
+          {
+            "name": "query",
+            "required": true
+          },
+          {
+            "name": "key",
+            "required": true
+          },
+          {
+            "name": "value",
+            "required": true
+          },
+          {
+            "name": "kv_cache",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          },
+          {
+            "name": "output",
+            "required": true
+          },
+          {
+            "name": "output_scale",
+            "required": false
+          },
+          {
+            "name": "output_block_scale",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/abstract.py",
+          "qualified_name": "DSAAttentionImpl.forward"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionBackendImpl.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionMetadataBuilder",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "layer_names",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionMetadataBuilder.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/context_parallel/dsa_cp.py",
+          "qualified_name": "AscendDSACPMetadataBuilder.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSAMetadataBuilder.__init__"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerMetadataBuilder.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionMetadataBuilder",
+      "callable": "build",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "common_prefix_len",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "fast_build",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionMetadataBuilder.build"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/context_parallel/dsa_cp.py",
+          "qualified_name": "AscendDSACPMetadataBuilder.build"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSAMetadataBuilder.build"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerMetadataBuilder.build"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionMetadataBuilder",
+      "callable": "build_for_drafting",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "draft_index",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/context_parallel/dsa_cp.py",
+          "qualified_name": "AscendDSACPMetadataBuilder.build_for_drafting"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSAMetadataBuilder.build_for_drafting"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "AttentionMetadataBuilder",
+      "callable": "get_cudagraph_support",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "AscendAttentionMetadataBuilder.get_cudagraph_support"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/context_parallel/dsa_cp.py",
+          "qualified_name": "AscendDSACPMetadataBuilder.get_cudagraph_support"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/dsa_v1.py",
+          "qualified_name": "AscendDSAMetadataBuilder.get_cudagraph_support"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/attention/indexer.py",
+          "qualified_name": "AscendSFAIndexerMetadataBuilder.get_cudagraph_support"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "MLAAttentionImpl",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_heads",
+            "required": true
+          },
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "scale",
+            "required": true
+          },
+          {
+            "name": "num_kv_heads",
+            "required": true
+          },
+          {
+            "name": "alibi_slopes",
+            "required": true
+          },
+          {
+            "name": "sliding_window",
+            "required": true
+          },
+          {
+            "name": "kv_cache_dtype",
+            "required": true
+          },
+          {
+            "name": "logits_soft_cap",
+            "required": true
+          },
+          {
+            "name": "attn_type",
+            "required": true
+          },
+          {
+            "name": "kv_sharing_target_layer_name",
+            "required": true
+          },
+          {
+            "name": "q_lora_rank",
+            "required": true
+          },
+          {
+            "name": "kv_lora_rank",
+            "required": true
+          },
+          {
+            "name": "qk_nope_head_dim",
+            "required": true
+          },
+          {
+            "name": "qk_rope_head_dim",
+            "required": true
+          },
+          {
+            "name": "qk_head_dim",
+            "required": true
+          },
+          {
+            "name": "v_head_dim",
+            "required": true
+          },
+          {
+            "name": "kv_b_proj",
+            "required": true
+          },
+          {
+            "name": "indexer",
+            "required": false
+          },
+          {
+            "name": "q_pad_num_heads",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAImpl.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAImpl.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "MLAAttentionImpl",
+      "callable": "forward_mha",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "kv_c_normed",
+            "required": true
+          },
+          {
+            "name": "k_pe",
+            "required": true
+          },
+          {
+            "name": "kv_c_and_k_pe_cache",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          },
+          {
+            "name": "k_scale",
+            "required": true
+          },
+          {
+            "name": "output",
+            "required": true
+          },
+          {
+            "name": "output_scale",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAImpl.forward_mha"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAImpl.forward_mha"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backend.py",
+      "owner": "MLAAttentionImpl",
+      "callable": "forward_mqa",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "kv_c_and_k_pe_cache",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          },
+          {
+            "name": "layer",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/mla_v1.py",
+          "qualified_name": "AscendMLAImpl.forward_mqa"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "AscendSFAImpl.forward_mqa"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/gdn_attn.py",
+      "owner": null,
+      "callable": "GDNAttentionBackend",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "AscendGDNAttentionBackend(GDNAttentionBackend)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/gdn_attn.py",
+      "owner": null,
+      "callable": "GDNAttentionMetadata",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "GDNAttentionMetadata(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/gdn_attn.py",
+      "owner": null,
+      "callable": "GDNAttentionMetadataBuilder",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/gdn_attn.py",
+      "owner": "GDNAttentionBackend",
+      "callable": "get_builder_cls",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "AscendGDNAttentionBackend.get_builder_cls"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/gdn_attn.py",
+      "owner": "GDNAttentionMetadataBuilder",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "layer_names",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "AscendGDNAttentionMetadataBuilder.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/gdn_attn.py",
+      "owner": "GDNAttentionMetadataBuilder",
+      "callable": "build",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "common_prefix_len",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "num_accepted_tokens",
+            "required": false
+          },
+          {
+            "name": "num_decode_draft_tokens_cpu",
+            "required": false
+          },
+          {
+            "name": "fast_build",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "AscendGDNAttentionMetadataBuilder.build"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/prefill/base.py",
+      "owner": null,
+      "callable": "MLAPrefillBackend",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_mla_prefill_backend.py",
+          "qualified_name": "AscendMLAPrefillBackend(MLAPrefillBackend)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/prefill/base.py",
+      "owner": "MLAPrefillBackend",
+      "callable": "get_name",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_mla_prefill_backend.py",
+          "qualified_name": "AscendMLAPrefillBackend.get_name"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/prefill/base.py",
+      "owner": "MLAPrefillBackend",
+      "callable": "is_available",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_mla_prefill_backend.py",
+          "qualified_name": "AscendMLAPrefillBackend.is_available"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/prefill/base.py",
+      "owner": "MLAPrefillBackend",
+      "callable": "run_prefill_context_chunk",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "chunk_idx",
+            "required": true
+          },
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "k",
+            "required": true
+          },
+          {
+            "name": "v",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_mla_prefill_backend.py",
+          "qualified_name": "AscendMLAPrefillBackend.run_prefill_context_chunk"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/prefill/base.py",
+      "owner": "MLAPrefillBackend",
+      "callable": "run_prefill_new_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "q",
+            "required": true
+          },
+          {
+            "name": "k",
+            "required": true
+          },
+          {
+            "name": "v",
+            "required": true
+          },
+          {
+            "name": "return_softmax_lse",
+            "required": true
+          },
+          {
+            "name": "out",
+            "required": false
+          },
+          {
+            "name": "output_scale",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_mla_prefill_backend.py",
+          "qualified_name": "AscendMLAPrefillBackend.run_prefill_new_tokens"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/sparse_swa.py",
+      "owner": null,
+      "callable": "DeepseekV4SWACache",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4SWACache(VllmDeepseekV4SWACache)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/sparse_swa.py",
+      "owner": "DeepseekV4SWACache",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "head_dim",
+            "required": true
+          },
+          {
+            "name": "window_size",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          },
+          {
+            "name": "prefix",
+            "required": true
+          },
+          {
+            "name": "cache_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4SWACache.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/sparse_swa.py",
+      "owner": "DeepseekV4SWACache",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4SWACache.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/sparse_swa.py",
+      "owner": "DeepseekV4SWACache",
+      "callable": "get_attn_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4SWACache.get_attn_backend"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/mla/sparse_swa.py",
+      "owner": "DeepseekV4SWACache",
+      "callable": "get_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/models/deepseek_v4.py",
+          "qualified_name": "AscendDeepseekV4SWACache.get_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/registry.py",
+      "owner": null,
+      "callable": "register_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "backend",
+            "required": true
+          },
+          {
+            "name": "class_path",
+            "required": false
+          },
+          {
+            "name": "is_mamba",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/attention/attention_v1.py",
+          "qualified_name": "register_backend(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/attention_v1.py",
+          "qualified_name": "register_backend(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/utils.py",
+      "owner": null,
+      "callable": "CommonAttentionMetadata",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/attention/utils.py",
+          "qualified_name": "AscendCommonAttentionMetadata(CommonAttentionMetadata)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/utils.py",
+      "owner": null,
+      "callable": "compute_causal_conv1d_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "query_start_loc_p_cpu",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "compute_causal_conv1d_metadata(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/utils.py",
+      "owner": null,
+      "callable": "mamba_get_block_table_tensor",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "block_table",
+            "required": true
+          },
+          {
+            "name": "seq_lens",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "mamba_cache_mode",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "mamba_get_block_table_tensor(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/backends/utils.py",
+      "owner": null,
+      "callable": "split_decodes_and_prefills",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "decode_threshold",
+            "required": false
+          },
+          {
+            "name": "require_uniform",
+            "required": false
+          },
+          {
+            "name": "treat_short_extends_as_decodes",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/ops/gdn_attn_builder.py",
+          "qualified_name": "split_decodes_and_prefills(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/attention/selector.py",
+      "owner": null,
+      "callable": "get_attn_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "head_size",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          },
+          {
+            "name": "kv_cache_dtype",
+            "required": true
+          },
+          {
+            "name": "use_mla",
+            "required": false
+          },
+          {
+            "name": "has_sink",
+            "required": false
+          },
+          {
+            "name": "use_sparse",
+            "required": false
+          },
+          {
+            "name": "use_mm_prefix",
+            "required": false
+          },
+          {
+            "name": "use_per_head_quant_scales",
+            "required": false
+          },
+          {
+            "name": "attn_type",
+            "required": false
+          },
+          {
+            "name": "num_heads",
+            "required": false
+          },
+          {
+            "name": "has_sliding_window",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "get_attn_backend(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/block_pool.py",
+      "owner": null,
+      "callable": "BlockPool",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "BlockPool(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_coordinator.py",
+      "owner": null,
+      "callable": "HybridKVCacheCoordinator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_coordinator.py",
+      "owner": null,
+      "callable": "get_kv_cache_coordinator",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          },
+          {
+            "name": "max_in_flight_tokens",
+            "required": true
+          },
+          {
+            "name": "use_eagle",
+            "required": true
+          },
+          {
+            "name": "enable_caching",
+            "required": true
+          },
+          {
+            "name": "enable_kv_cache_events",
+            "required": true
+          },
+          {
+            "name": "dcp_world_size",
+            "required": true
+          },
+          {
+            "name": "pcp_world_size",
+            "required": true
+          },
+          {
+            "name": "scheduler_block_size",
+            "required": true
+          },
+          {
+            "name": "hash_block_size",
+            "required": true
+          },
+          {
+            "name": "metrics_collector",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/manager.py",
+          "qualified_name": "get_kv_cache_coordinator(...)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "get_kv_cache_coordinator"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_coordinator.py",
+      "owner": "HybridKVCacheCoordinator",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          },
+          {
+            "name": "max_in_flight_tokens",
+            "required": true
+          },
+          {
+            "name": "use_eagle",
+            "required": true
+          },
+          {
+            "name": "enable_caching",
+            "required": true
+          },
+          {
+            "name": "enable_kv_cache_events",
+            "required": true
+          },
+          {
+            "name": "dcp_world_size",
+            "required": true
+          },
+          {
+            "name": "pcp_world_size",
+            "required": true
+          },
+          {
+            "name": "scheduler_block_size",
+            "required": true
+          },
+          {
+            "name": "hash_block_size",
+            "required": true
+          },
+          {
+            "name": "metrics_collector",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "AscendHybridKVCacheCoordinator.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_coordinator.py",
+      "owner": "HybridKVCacheCoordinator",
+      "callable": "find_longest_cache_hit",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "block_hashes",
+            "required": true
+          },
+          {
+            "name": "max_cache_hit_length",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "AscendHybridKVCacheCoordinator.find_longest_cache_hit"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_coordinator.py",
+      "owner": "HybridKVCacheCoordinator",
+      "callable": "find_longest_cache_hit_per_group",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "block_hashes",
+            "required": true
+          },
+          {
+            "name": "max_cache_hit_length",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "AscendHybridKVCacheCoordinator.find_longest_cache_hit_per_group"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_coordinator.py",
+      "owner": "HybridKVCacheCoordinator",
+      "callable": "verify_and_split_kv_cache_groups",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "AscendHybridKVCacheCoordinator.verify_and_split_kv_cache_groups"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_utils.py",
+      "owner": null,
+      "callable": "BlockHashListWithBlockSize",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/single_type_kv_cache_manager.py",
+          "qualified_name": "BlockHashListWithBlockSize(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_coordinator.py",
+          "qualified_name": "BlockHashListWithBlockSize(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_utils.py",
+      "owner": null,
+      "callable": "KVCacheBlock",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py",
+          "qualified_name": "KVCacheBlock(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_utils.py",
+      "owner": null,
+      "callable": "_approximate_gcd",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "values",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "lower_bound",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "_approximate_gcd(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_utils.py",
+      "owner": null,
+      "callable": "may_override_num_blocks",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "num_blocks",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "may_override_num_blocks(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_utils.py",
+      "owner": null,
+      "callable": "maybe_convert_block_hash",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "hash_bytes",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py",
+          "qualified_name": "maybe_convert_block_hash(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py",
+          "qualified_name": "maybe_convert_block_hash(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/kv_cache_utils.py",
+      "owner": null,
+      "callable": "resolve_kv_cache_block_sizes",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/manager.py",
+          "qualified_name": "resolve_kv_cache_block_sizes(...)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "_ascend_resolve_kv_cache_block_sizes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/async_scheduler.py",
+      "owner": null,
+      "callable": "AsyncScheduler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareAsyncScheduler(AsyncScheduler)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "AsyncRecomputeScheduler(AsyncScheduler)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstAsyncScheduler(AsyncScheduler)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/async_scheduler.py",
+      "owner": "AsyncScheduler",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": "args",
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "AsyncRecomputeScheduler.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/output.py",
+      "owner": null,
+      "callable": "SchedulerOutput",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/scheduler_profiling_chunk.py",
+          "qualified_name": "SchedulerOutput(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "SchedulerOutput(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeSchedulerOutput(SchedulerOutput)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": null,
+      "callable": "RequestQueue",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue(RequestQueue)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue(RequestQueue)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": null,
+      "callable": "create_request_queue",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "policy",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "create_request_queue(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/scheduler_profiling_chunk.py",
+          "qualified_name": "create_request_queue(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "create_request_queue(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "create_request_queue(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "add_request",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.add_request"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.add_request"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "peek_request",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.peek_request"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.peek_request"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "pop_request",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.pop_request"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.pop_request"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "prepend_request",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.prepend_request"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.prepend_request"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "prepend_requests",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "requests",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.prepend_requests"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.prepend_requests"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "remove_request",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.remove_request"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.remove_request"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/request_queue.py",
+      "owner": "RequestQueue",
+      "callable": "remove_requests",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "requests",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareRequestQueue.remove_requests"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/short_request_first_scheduler.py",
+          "qualified_name": "ShortRequestFirstRequestQueue.remove_requests"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/scheduler.py",
+      "owner": null,
+      "callable": "Scheduler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareScheduler(Scheduler)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeScheduler(Scheduler)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/scheduler_profiling_chunk.py",
+          "qualified_name": "ProfilingChunkScheduler(Scheduler)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "BalanceScheduler(Scheduler)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "BalanceScheduler"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/scheduler.py",
+      "owner": "Scheduler",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "structured_output_manager",
+            "required": true
+          },
+          {
+            "name": "block_size",
+            "required": true
+          },
+          {
+            "name": "hash_block_size",
+            "required": false
+          },
+          {
+            "name": "mm_registry",
+            "required": false
+          },
+          {
+            "name": "include_finished_set",
+            "required": false
+          },
+          {
+            "name": "log_stats",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeScheduler.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/scheduler_profiling_chunk.py",
+          "qualified_name": "ProfilingChunkScheduler.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "BalanceScheduler.__init__"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareScheduler.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/scheduler.py",
+      "owner": "Scheduler",
+      "callable": "_update_waiting_for_remote_kv",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeScheduler._update_waiting_for_remote_kv"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/scheduler.py",
+      "owner": "Scheduler",
+      "callable": "schedule",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "throttle_prefills",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeScheduler.schedule"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/scheduler_profiling_chunk.py",
+          "qualified_name": "ProfilingChunkScheduler.schedule"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "BalanceScheduler.schedule"
+        },
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/batch_job_aware_scheduler.py",
+          "qualified_name": "BatchJobAwareScheduler.schedule"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/scheduler.py",
+      "owner": "Scheduler",
+      "callable": "update_from_output",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "model_runner_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "RecomputeScheduler.update_from_output"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/sched/utils.py",
+      "owner": null,
+      "callable": "remove_all",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "lst",
+            "required": true
+          },
+          {
+            "name": "items_to_remove",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "remove_all(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": null,
+      "callable": "FullAttentionManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/single_type_kv_cache_manager.py",
+          "qualified_name": "CompressAttentionManager(FullAttentionManager)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": null,
+      "callable": "MambaManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_mamba_manager.py",
+          "qualified_name": "AscendMambaManager(MambaManager)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": null,
+      "callable": "get_manager_for_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "max_in_flight_tokens",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "patch_call_closure",
+          "file": "vllm_ascend/core/single_type_kv_cache_manager.py",
+          "qualified_name": "get_manager_for_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": "FullAttentionManager",
+      "callable": "cache_blocks",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "retention_interval",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/single_type_kv_cache_manager.py",
+          "qualified_name": "CompressAttentionManager.cache_blocks"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": "FullAttentionManager",
+      "callable": "find_longest_cache_hit",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "block_hashes",
+            "required": true
+          },
+          {
+            "name": "max_length",
+            "required": true
+          },
+          {
+            "name": "kv_cache_group_ids",
+            "required": true
+          },
+          {
+            "name": "block_pool",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "drop_eagle_block",
+            "required": true
+          },
+          {
+            "name": "alignment_tokens",
+            "required": true
+          },
+          {
+            "name": "dcp_world_size",
+            "required": false
+          },
+          {
+            "name": "pcp_world_size",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/core/single_type_kv_cache_manager.py",
+          "qualified_name": "CompressAttentionManager.find_longest_cache_hit"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": "MambaManager",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "block_pool",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_mamba_manager.py",
+          "qualified_name": "AscendMambaManager.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": "MambaManager",
+      "callable": "find_longest_cache_hit",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "block_hashes",
+            "required": true
+          },
+          {
+            "name": "max_length",
+            "required": true
+          },
+          {
+            "name": "kv_cache_group_ids",
+            "required": true
+          },
+          {
+            "name": "block_pool",
+            "required": true
+          },
+          {
+            "name": "kv_cache_spec",
+            "required": true
+          },
+          {
+            "name": "drop_eagle_block",
+            "required": true
+          },
+          {
+            "name": "alignment_tokens",
+            "required": true
+          },
+          {
+            "name": "dcp_world_size",
+            "required": false
+          },
+          {
+            "name": "pcp_world_size",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_mamba_manager.py",
+          "qualified_name": "AscendMambaManager.find_longest_cache_hit"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/core/single_type_kv_cache_manager.py",
+      "owner": "MambaManager",
+      "callable": "get_num_blocks_to_allocate",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "request_id",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "new_computed_blocks",
+            "required": true
+          },
+          {
+            "name": "total_computed_tokens",
+            "required": true
+          },
+          {
+            "name": "num_local_computed_tokens",
+            "required": true
+          },
+          {
+            "name": "num_tokens_main_model",
+            "required": true
+          },
+          {
+            "name": "apply_admission_cap",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/patch/platform/patch_mamba_manager.py",
+          "qualified_name": "AscendMambaManager.get_num_blocks_to_allocate"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/cudagraph_dispatcher.py",
+      "owner": "CudagraphDispatcher",
+      "callable": "_create_padded_batch_descriptor",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "uniform_decode",
+            "required": true
+          },
+          {
+            "name": "has_lora",
+            "required": true
+          },
+          {
+            "name": "num_active_loras",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_cudagraph.py",
+          "qualified_name": "_create_padded_batch_descriptor"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/engine/__init__.py",
+      "owner": null,
+      "callable": "EngineCoreOutput",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "EngineCoreOutput(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/engine/__init__.py",
+      "owner": null,
+      "callable": "EngineCoreOutputs",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "EngineCoreOutputs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/engine/core.py",
+      "owner": null,
+      "callable": "DPEngineCoreProc",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "BalanceDPEngineCoreProc(DPEngineCoreProc)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/engine/core.py",
+      "owner": null,
+      "callable": "resolve_kv_cache_block_sizes",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "_ascend_resolve_kv_cache_block_sizes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/engine/core.py",
+      "owner": "EngineCore",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "executor_class",
+            "required": true
+          },
+          {
+            "name": "log_stats",
+            "required": true
+          },
+          {
+            "name": "executor_fail_callback",
+            "required": false
+          },
+          {
+            "name": "include_finished_set",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_profiling_chunk.py",
+          "qualified_name": "_patched_engine_core_init"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/engine/core.py",
+      "owner": "EngineCoreProc",
+      "callable": "run_engine_core",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": "args",
+        "keyword_only": [
+          {
+            "name": "dp_rank",
+            "required": false
+          },
+          {
+            "name": "local_dp_rank",
+            "required": false
+          }
+        ],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "run_engine_core"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_profiling_chunk.py",
+          "qualified_name": "_patched_run_engine_core"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": null,
+      "callable": "MultiprocExecutor",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendMultiprocExecutor(MultiprocExecutor)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendMultiprocExecutor"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": null,
+      "callable": "UnreadyWorkerProcHandle",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "UnreadyWorkerProcHandle(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": null,
+      "callable": "WorkerProc",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendWorkerProc(WorkerProc)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": null,
+      "callable": "set_multiprocessing_worker_envs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "set_multiprocessing_worker_envs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": "MultiprocExecutor",
+      "callable": "_get_parallel_sizes",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendMultiprocExecutor._get_parallel_sizes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": "MultiprocExecutor",
+      "callable": "_init_executor",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendMultiprocExecutor._init_executor"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": "MultiprocExecutor",
+      "callable": "_is_driver_worker",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "rank",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendMultiprocExecutor._is_driver_worker"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": "MultiprocExecutor",
+      "callable": "_post_init_executor",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendMultiprocExecutor._post_init_executor"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/executor/multiproc_executor.py",
+      "owner": "WorkerProc",
+      "callable": "make_worker_process",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "local_rank",
+            "required": true
+          },
+          {
+            "name": "rank",
+            "required": true
+          },
+          {
+            "name": "distributed_init_method",
+            "required": true
+          },
+          {
+            "name": "input_shm_handle",
+            "required": true
+          },
+          {
+            "name": "shared_worker_lock",
+            "required": true
+          },
+          {
+            "name": "is_driver_worker",
+            "required": true
+          },
+          {
+            "name": "inherited_fds",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/patch/platform/patch_multiproc_executor.py",
+          "qualified_name": "AscendWorkerProc.make_worker_process"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "FullAttentionSpec",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config_310.py",
+          "qualified_name": "FullAttentionSpec(...)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSFAIndexerCacheSpec(FullAttentionSpec)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "HiddenStateCacheSpec",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "HiddenStateCacheSpec(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "KVCacheConfig",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/manager.py",
+          "qualified_name": "KVCacheConfigCls(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "KVCacheGroupSpec",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "KVCacheGroupSpec(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "KVCacheTensor",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/recompute_cpu_offload/manager.py",
+          "qualified_name": "KVCacheTensor(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_kv_cache_utils.py",
+          "qualified_name": "KVCacheTensor(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "MLAAttentionSpec",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendMLAAttentionSpec(MLAAttentionSpec)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "MambaSpec",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_mamba_config_310.py",
+          "qualified_name": "MambaSpec(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": null,
+      "callable": "SlidingWindowMLASpec",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSlidingWindowMLASpec(SlidingWindowMLASpec)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": "FullAttentionSpec",
+      "callable": "merge",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "specs",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSFAIndexerCacheSpec.merge"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": "FullAttentionSpec",
+      "callable": "real_page_size_bytes",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSFAIndexerCacheSpec.real_page_size_bytes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": "MLAAttentionSpec",
+      "callable": "merge",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "specs",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendMLAAttentionSpec.merge"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": "SlidingWindowMLASpec",
+      "callable": "merge",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "specs",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSlidingWindowMLASpec.merge"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": "SlidingWindowMLASpec",
+      "callable": "real_page_size_bytes",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSlidingWindowMLASpec.real_page_size_bytes"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_cache_interface.py",
+      "owner": "SlidingWindowMLASpec",
+      "callable": "storage_block_size",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/core/kv_cache_interface.py",
+          "qualified_name": "AscendSlidingWindowMLASpec.storage_block_size"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_offload/base.py",
+      "owner": "OffloadingSpec",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/kv_offload/npu.py",
+          "qualified_name": "NPUOffloadingSpec.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_offload/base.py",
+      "owner": "OffloadingSpec",
+      "callable": "get_manager",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/kv_offload/npu.py",
+          "qualified_name": "NPUOffloadingSpec.get_manager"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/kv_offload/cpu/manager.py",
+      "owner": null,
+      "callable": "CPUOffloadingManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/kv_offload/npu.py",
+          "qualified_name": "CPUOffloadingManager(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/outputs.py",
+      "owner": null,
+      "callable": "LogprobsTensors",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/sample/logprob.py",
+          "qualified_name": "LogprobsTensors(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/outputs.py",
+      "owner": null,
+      "callable": "ModelRunnerOutput",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "ModelRunnerOutput(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/outputs.py",
+      "owner": null,
+      "callable": "RoutedExpertsLists",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "RoutedExpertsLists(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/outputs.py",
+      "owner": null,
+      "callable": "RoutedExpertsTensors",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "RoutedExpertsTensors(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/outputs.py",
+      "owner": null,
+      "callable": "SamplerOutput",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "SamplerOutput(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/outputs.py",
+      "owner": null,
+      "callable": "make_empty_encoder_model_runner_output",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "scheduler_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "make_empty_encoder_model_runner_output(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/logits_processor/__init__.py",
+      "owner": null,
+      "callable": "BatchUpdateBuilder",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/npu_input_batch.py",
+          "qualified_name": "BatchUpdateBuilder(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/logits_processor/__init__.py",
+      "owner": null,
+      "callable": "LogitsProcessors",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/npu_input_batch.py",
+          "qualified_name": "LogitsProcessors(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/logits_processor/__init__.py",
+      "owner": null,
+      "callable": "build_logitsprocs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "is_pin_memory",
+            "required": true
+          },
+          {
+            "name": "is_pooling_model",
+            "required": true
+          },
+          {
+            "name": "custom_logitsprocs",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "build_logitsprocs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/ops/bad_words.py",
+      "owner": null,
+      "callable": "apply_bad_words_with_drafts",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "bad_words_token_ids",
+            "required": true
+          },
+          {
+            "name": "past_tokens_ids",
+            "required": true
+          },
+          {
+            "name": "num_draft_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "apply_bad_words_with_drafts(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/ops/topk_topp_sampler.py",
+      "owner": null,
+      "callable": "TopKTopPSampler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendTopKTopPSampler(TopKTopPSampler)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/ops/topk_topp_sampler.py",
+      "owner": "TopKTopPSampler",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "logprobs_mode",
+            "required": false
+          },
+          {
+            "name": "use_fp64_gumbel",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendTopKTopPSampler.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/ops/topk_topp_sampler.py",
+      "owner": "TopKTopPSampler",
+      "callable": "forward_native",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "generators",
+            "required": true
+          },
+          {
+            "name": "k",
+            "required": true
+          },
+          {
+            "name": "p",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendTopKTopPSampler.forward_native"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": null,
+      "callable": "RejectionSampler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "AscendRejectionSampler(RejectionSampler)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": null,
+      "callable": "apply_sampling_constraints",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "cu_num_draft_tokens",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_rejection_sampler.py",
+          "qualified_name": "apply_sampling_constraints"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": null,
+      "callable": "expand_batch_to_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "cu_num_tokens",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "replace_from",
+            "required": false
+          },
+          {
+            "name": "replace_to",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_rejection_sampler.py",
+          "qualified_name": "expand_batch_to_tokens"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": null,
+      "callable": "generate_uniform_probs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "num_draft_tokens",
+            "required": true
+          },
+          {
+            "name": "generators",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "generate_uniform_probs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": null,
+      "callable": "rejection_sample",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "draft_token_ids",
+            "required": true
+          },
+          {
+            "name": "num_draft_tokens",
+            "required": true
+          },
+          {
+            "name": "max_spec_len",
+            "required": true
+          },
+          {
+            "name": "cu_num_draft_tokens",
+            "required": true
+          },
+          {
+            "name": "draft_probs",
+            "required": true
+          },
+          {
+            "name": "target_logits",
+            "required": true
+          },
+          {
+            "name": "bonus_token_ids",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "synthetic_mode",
+            "required": false
+          },
+          {
+            "name": "synthetic_conditional_rates",
+            "required": false
+          },
+          {
+            "name": "use_fp64_gumbel",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_rejection_sampler.py",
+          "qualified_name": "rejection_sample"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": "RejectionSampler",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "sampler",
+            "required": true
+          },
+          {
+            "name": "spec_config",
+            "required": false
+          },
+          {
+            "name": "device",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "AscendRejectionSampler.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": "RejectionSampler",
+      "callable": "apply_logits_processors",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "AscendRejectionSampler.apply_logits_processors"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": "RejectionSampler",
+      "callable": "apply_penalties",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "metadata",
+            "required": true
+          },
+          {
+            "name": "repeat_indices",
+            "required": true
+          },
+          {
+            "name": "output_token_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "AscendRejectionSampler.apply_penalties"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/rejection_sampler.py",
+      "owner": "RejectionSampler",
+      "callable": "forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "metadata",
+            "required": true
+          },
+          {
+            "name": "draft_probs",
+            "required": true
+          },
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/rejection_sampler.py",
+          "qualified_name": "AscendRejectionSampler.forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/sampler.py",
+      "owner": null,
+      "callable": "Sampler",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendSampler(Sampler)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/sampler.py",
+      "owner": "Sampler",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "logprobs_mode",
+            "required": false
+          },
+          {
+            "name": "use_fp64_gumbel",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendSampler.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/sampler.py",
+      "owner": "Sampler",
+      "callable": "apply_penalties",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "output_token_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendSampler.apply_penalties"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/sample/sampler.py",
+      "owner": "Sampler",
+      "callable": "greedy_sample",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/sample/sampler.py",
+          "qualified_name": "AscendSampler.greedy_sample"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/serial_utils.py",
+      "owner": null,
+      "callable": "MsgpackDecoder",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py",
+          "qualified_name": "MsgpackDecoder(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/serial_utils.py",
+      "owner": null,
+      "callable": "MsgpackEncoder",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py",
+          "qualified_name": "MsgpackEncoder(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/simple_kv_offload/worker.py",
+      "owner": null,
+      "callable": "SimpleCPUOffloadWorker",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/simple_kv_offload/worker.py",
+          "qualified_name": "SimpleCPUOffloadNPUWorker(SimpleCPUOffloadWorker)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/simple_kv_offload/worker.py",
+      "owner": "SimpleCPUOffloadWorker",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "cpu_capacity_bytes",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/simple_kv_offload/worker.py",
+          "qualified_name": "SimpleCPUOffloadNPUWorker.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/simple_kv_offload/worker.py",
+      "owner": "SimpleCPUOffloadWorker",
+      "callable": "register_kv_caches",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_caches",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/simple_kv_offload/worker.py",
+          "qualified_name": "SimpleCPUOffloadNPUWorker.register_kv_caches"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/dflash.py",
+      "owner": "DFlashProposer",
+      "callable": "set_inputs_first_pass",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "target_token_ids",
+            "required": true
+          },
+          {
+            "name": "next_token_ids",
+            "required": true
+          },
+          {
+            "name": "target_positions",
+            "required": true
+          },
+          {
+            "name": "target_hidden_states",
+            "required": true
+          },
+          {
+            "name": "token_indices_to_sample",
+            "required": true
+          },
+          {
+            "name": "cad",
+            "required": true
+          },
+          {
+            "name": "num_rejected_tokens_gpu",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/dflash_proposer.py",
+          "qualified_name": "AscendDflashProposer.set_inputs_first_pass"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/draft_model.py",
+      "owner": null,
+      "callable": "DraftModelProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/draft_proposer.py",
+          "qualified_name": "AscendDraftModelProposer(DraftModelProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/draft_model.py",
+      "owner": "DraftModelProposer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "runner",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/draft_proposer.py",
+          "qualified_name": "AscendDraftModelProposer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/eagle.py",
+      "owner": null,
+      "callable": "EagleProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/eagle_proposer.py",
+          "qualified_name": "AscendEagleProposer(EagleProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/eagle.py",
+      "owner": "EagleProposer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "runner",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/eagle_proposer.py",
+          "qualified_name": "AscendEagleProposer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/extract_hidden_states.py",
+      "owner": null,
+      "callable": "ExtractHiddenStatesProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/extract_hidden_states_proposer.py",
+          "qualified_name": "AscendExtractHiddenStatesProposer(ExtractHiddenStatesProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/extract_hidden_states.py",
+      "owner": "ExtractHiddenStatesProposer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/extract_hidden_states_proposer.py",
+          "qualified_name": "AscendExtractHiddenStatesProposer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/extract_hidden_states.py",
+      "owner": "ExtractHiddenStatesProposer",
+      "callable": "dummy_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "use_cudagraphs",
+            "required": false
+          },
+          {
+            "name": "is_graph_capturing",
+            "required": false
+          },
+          {
+            "name": "slot_mappings",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/extract_hidden_states_proposer.py",
+          "qualified_name": "AscendExtractHiddenStatesProposer.dummy_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/extract_hidden_states.py",
+      "owner": "ExtractHiddenStatesProposer",
+      "callable": "prepare_next_token_ids_padded",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "sampled_token_ids",
+            "required": true
+          },
+          {
+            "name": "requests",
+            "required": true
+          },
+          {
+            "name": "gpu_input_batch",
+            "required": true
+          },
+          {
+            "name": "discard_request_mask",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/extract_hidden_states_proposer.py",
+          "qualified_name": "AscendExtractHiddenStatesProposer.prepare_next_token_ids_padded"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": null,
+      "callable": "SpecDecodeBaseProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": null,
+      "callable": "compute_probs_and_sample_next_token",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "use_fp64_gumbel",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/step3p5.py",
+          "qualified_name": "compute_probs_and_sample_next_token(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "pass_hidden_states_to_model",
+            "required": true
+          },
+          {
+            "name": "runner",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "_get_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer._get_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "_maybe_share_embeddings",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "target_language_model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer._maybe_share_embeddings"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "_maybe_share_lm_head",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "target_language_model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer._maybe_share_lm_head"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "dummy_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "use_cudagraphs",
+            "required": false
+          },
+          {
+            "name": "is_graph_capturing",
+            "required": false
+          },
+          {
+            "name": "slot_mappings",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.dummy_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "load_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "target_model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.load_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "model_returns_tuple",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.model_returns_tuple"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "prepare_inputs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "sampled_token_ids",
+            "required": true
+          },
+          {
+            "name": "num_draft_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.prepare_inputs"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "prepare_inputs_padded",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "spec_decode_metadata",
+            "required": true
+          },
+          {
+            "name": "valid_sampled_tokens_count",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.prepare_inputs_padded"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "prepare_next_token_ids_padded",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "sampled_token_ids",
+            "required": true
+          },
+          {
+            "name": "requests",
+            "required": true
+          },
+          {
+            "name": "gpu_input_batch",
+            "required": true
+          },
+          {
+            "name": "discard_request_mask",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.prepare_next_token_ids_padded"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/llm_base_proposer.py",
+      "owner": "SpecDecodeBaseProposer",
+      "callable": "set_inputs_first_pass",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "target_token_ids",
+            "required": true
+          },
+          {
+            "name": "next_token_ids",
+            "required": true
+          },
+          {
+            "name": "target_positions",
+            "required": true
+          },
+          {
+            "name": "target_hidden_states",
+            "required": true
+          },
+          {
+            "name": "token_indices_to_sample",
+            "required": true
+          },
+          {
+            "name": "cad",
+            "required": true
+          },
+          {
+            "name": "num_rejected_tokens_gpu",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "AscendSpecDecodeBaseProposer.set_inputs_first_pass"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/medusa.py",
+      "owner": null,
+      "callable": "MedusaProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/medusa_proposer.py",
+          "qualified_name": "AscendMedusaProposer(MedusaProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/medusa.py",
+      "owner": "MedusaProposer",
+      "callable": "dummy_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/medusa_proposer.py",
+          "qualified_name": "AscendMedusaProposer.dummy_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/medusa.py",
+      "owner": "MedusaProposer",
+      "callable": "propose",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_speculative_tokens",
+            "required": true
+          },
+          {
+            "name": "target_hidden_states",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "slot_mappings",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/medusa_proposer.py",
+          "qualified_name": "AscendMedusaProposer.propose"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/metadata.py",
+      "owner": null,
+      "callable": "SpecDecodeMetadata",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "SpecDecodeMetadata(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer.py",
+      "owner": null,
+      "callable": "NgramProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/ngram_proposer.py",
+          "qualified_name": "AscendNgramProposer(NgramProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer.py",
+      "owner": "NgramProposer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/ngram_proposer.py",
+          "qualified_name": "AscendNgramProposer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer.py",
+      "owner": "NgramProposer",
+      "callable": "load_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": "args",
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/ngram_proposer.py",
+          "qualified_name": "AscendNgramProposer.load_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer.py",
+      "owner": "NgramProposer",
+      "callable": "propose",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_speculative_tokens",
+            "required": true
+          },
+          {
+            "name": "sampled_token_ids",
+            "required": true
+          },
+          {
+            "name": "num_tokens_no_spec",
+            "required": true
+          },
+          {
+            "name": "token_ids_cpu",
+            "required": true
+          },
+          {
+            "name": "slot_mappings",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/ngram_proposer.py",
+          "qualified_name": "AscendNgramProposer.propose"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer_gpu.py",
+      "owner": null,
+      "callable": "NgramProposerGPU",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/ngram_proposer_npu.py",
+          "qualified_name": "AscendNgramProposerNPU(NgramProposerGPU)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer_gpu.py",
+      "owner": null,
+      "callable": "copy_num_valid_draft_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "num_valid_draft_tokens_cpu",
+            "required": true
+          },
+          {
+            "name": "num_valid_draft_tokens_copy_stream",
+            "required": true
+          },
+          {
+            "name": "num_valid_draft_tokens_event",
+            "required": true
+          },
+          {
+            "name": "num_valid_draft_tokens",
+            "required": true
+          },
+          {
+            "name": "batch_size",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "copy_num_valid_draft_tokens(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer_gpu.py",
+      "owner": "NgramProposerGPU",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "runner",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/ngram_proposer_npu.py",
+          "qualified_name": "AscendNgramProposerNPU.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer_gpu.py",
+      "owner": "NgramProposerGPU",
+      "callable": "load_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": "args",
+        "keyword_only": [],
+        "variadic_keyword": "kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/ngram_proposer_npu.py",
+          "qualified_name": "AscendNgramProposerNPU.load_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/ngram_proposer_gpu.py",
+      "owner": "NgramProposerGPU",
+      "callable": "propose",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_speculative_tokens",
+            "required": true
+          },
+          {
+            "name": "num_tokens_no_spec",
+            "required": true
+          },
+          {
+            "name": "token_ids_gpu",
+            "required": true
+          },
+          {
+            "name": "valid_sampled_token_ids_gpu",
+            "required": true
+          },
+          {
+            "name": "valid_sampled_tokens_count",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/ngram_proposer_npu.py",
+          "qualified_name": "AscendNgramProposerNPU.propose"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/suffix_decoding.py",
+      "owner": null,
+      "callable": "SuffixDecodingProposer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/spec_decode/suffix_proposer.py",
+          "qualified_name": "AscendSuffixDecodingProposer(SuffixDecodingProposer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/suffix_decoding.py",
+      "owner": "SuffixDecodingProposer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/suffix_proposer.py",
+          "qualified_name": "AscendSuffixDecodingProposer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/suffix_decoding.py",
+      "owner": "SuffixDecodingProposer",
+      "callable": "propose",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_speculative_tokens",
+            "required": true
+          },
+          {
+            "name": "input_batch",
+            "required": true
+          },
+          {
+            "name": "sampled_token_ids",
+            "required": true
+          },
+          {
+            "name": "slot_mappings",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/spec_decode/suffix_proposer.py",
+          "qualified_name": "AscendSuffixDecodingProposer.propose"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/utils.py",
+      "owner": null,
+      "callable": "compute_new_slot_mapping",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cad",
+            "required": true
+          },
+          {
+            "name": "new_positions",
+            "required": true
+          },
+          {
+            "name": "is_rejected_token_mask",
+            "required": true
+          },
+          {
+            "name": "block_size",
+            "required": true
+          },
+          {
+            "name": "num_new_tokens",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "compute_new_slot_mapping(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/spec_decode/utils.py",
+      "owner": null,
+      "callable": "extend_all_queries_by_N",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "N",
+            "required": true
+          },
+          {
+            "name": "arange",
+            "required": true
+          },
+          {
+            "name": "new_slot_mapping",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/llm_base_proposer.py",
+          "qualified_name": "extend_all_queries_by_N(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/structured_output/utils.py",
+      "owner": null,
+      "callable": "apply_grammar_bitmask",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "grammar_output",
+            "required": true
+          },
+          {
+            "name": "input_batch",
+            "required": true
+          },
+          {
+            "name": "logits",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "apply_grammar_bitmask(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/utils.py",
+      "owner": null,
+      "callable": "CpuGpuBuffer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/block_table.py",
+          "qualified_name": "CpuGpuBuffer(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/dcp_utils.py",
+          "qualified_name": "CpuGpuBuffer(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/utils.py",
+      "owner": null,
+      "callable": "record_function_or_nullcontext",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "name",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/recompute_scheduler.py",
+          "qualified_name": "record_function_or_nullcontext(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/core/scheduler_profiling_chunk.py",
+          "qualified_name": "record_function_or_nullcontext(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/eplb/core/eplb_device_transfer_loader.py",
+          "qualified_name": "record_function_or_nullcontext(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/eplb/eplb_updator.py",
+          "qualified_name": "record_function_or_nullcontext(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/platform/patch_balance_schedule.py",
+          "qualified_name": "record_function_or_nullcontext(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "record_function_or_nullcontext(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/utils.py",
+      "owner": null,
+      "callable": "report_usage_stats",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "usage_context",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "report_usage_stats(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/encoder_cudagraph.py",
+      "owner": null,
+      "callable": "BudgetGraphMetadata",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/encoder_acl_graph.py",
+          "qualified_name": "BudgetGraphMetadata(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/encoder_cudagraph.py",
+      "owner": null,
+      "callable": "EncoderCudaGraphManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/encoder_acl_graph.py",
+          "qualified_name": "EncoderAclGraphManager(EncoderCudaGraphManager)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/encoder_cudagraph.py",
+      "owner": "EncoderCudaGraphManager",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "dtype",
+            "required": true
+          },
+          {
+            "name": "model",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/encoder_acl_graph.py",
+          "qualified_name": "EncoderAclGraphManager.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/encoder_cudagraph.py",
+      "owner": "EncoderCudaGraphManager",
+      "callable": "capture",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "graph_pool",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/encoder_acl_graph.py",
+          "qualified_name": "EncoderAclGraphManager.capture"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/attn_utils.py",
+      "owner": null,
+      "callable": "_allocate_kv_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "shared_layers",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_attn_utils.py",
+          "qualified_name": "_allocate_kv_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/attn_utils.py",
+      "owner": null,
+      "callable": "_reshape_kv_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "attn_groups",
+            "required": true
+          },
+          {
+            "name": "kv_cache_raw_tensors",
+            "required": true
+          },
+          {
+            "name": "cache_dtype",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          },
+          {
+            "name": "shared_kv_cache_layers",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_attn_utils.py",
+          "qualified_name": "_reshape_kv_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/block_table.py",
+      "owner": null,
+      "callable": "BlockTables",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/block_table.py",
+          "qualified_name": "AscendBlockTables(BlockTables)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/block_table.py",
+      "owner": null,
+      "callable": "_load_ptr",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/block_table.py",
+          "qualified_name": "_load_ptr(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/block_table.py",
+      "owner": "BlockTables",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "block_sizes",
+            "required": true
+          },
+          {
+            "name": "max_num_reqs",
+            "required": true
+          },
+          {
+            "name": "max_num_batched_tokens",
+            "required": true
+          },
+          {
+            "name": "max_num_blocks_per_group",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          },
+          {
+            "name": "cp_size",
+            "required": false
+          },
+          {
+            "name": "cp_rank",
+            "required": false
+          },
+          {
+            "name": "cp_interleave",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/block_table.py",
+          "qualified_name": "AscendBlockTables.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/block_table.py",
+      "owner": "BlockTables",
+      "callable": "compute_slot_mappings",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "query_start_loc",
+            "required": true
+          },
+          {
+            "name": "positions",
+            "required": true
+          },
+          {
+            "name": "num_tokens_padded",
+            "required": true
+          },
+          {
+            "name": "out",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/block_table.py",
+          "qualified_name": "AscendBlockTables.compute_slot_mappings"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/buffer_utils.py",
+      "owner": null,
+      "callable": "UvaBuffer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_uva.py",
+          "qualified_name": "UvaBufferWrapper"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/buffer_utils.py",
+      "owner": null,
+      "callable": "async_copy_to_gpu",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "x",
+            "required": true
+          },
+          {
+            "name": "out",
+            "required": false
+          },
+          {
+            "name": "device",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "async_copy_to_gpu(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": null,
+      "callable": "BatchExecutionDescriptor",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py",
+          "qualified_name": "BatchExecutionDescriptor(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": null,
+      "callable": "InputBatch",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_input_batch.py",
+          "qualified_name": "AscendInputBatch"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": null,
+      "callable": "ModelCudaGraphManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/aclgraph_utils.py",
+          "qualified_name": "ModelAclGraphManager(ModelCudaGraphManager)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": null,
+      "callable": "prepare_inputs_to_capture",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "num_reqs",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "model_state",
+            "required": true
+          },
+          {
+            "name": "input_buffers",
+            "required": true
+          },
+          {
+            "name": "block_tables",
+            "required": true
+          },
+          {
+            "name": "attn_groups",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "full_cudagraph",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py",
+          "qualified_name": "prepare_inputs_to_capture(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": "ModelCudaGraphManager",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "cudagraph_mode",
+            "required": true
+          },
+          {
+            "name": "decode_query_len",
+            "required": true
+          },
+          {
+            "name": "lora_capture_cases",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/aclgraph_utils.py",
+          "qualified_name": "ModelAclGraphManager.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": "ModelCudaGraphManager",
+      "callable": "capture",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "model",
+            "required": true
+          },
+          {
+            "name": "model_state",
+            "required": true
+          },
+          {
+            "name": "input_buffers",
+            "required": true
+          },
+          {
+            "name": "intermediate_tensors",
+            "required": true
+          },
+          {
+            "name": "block_tables",
+            "required": true
+          },
+          {
+            "name": "attn_groups",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "has_lora",
+            "required": false
+          },
+          {
+            "name": "use_aux_hidden_state_outputs",
+            "required": false
+          },
+          {
+            "name": "lora_capture_hook",
+            "required": false
+          },
+          {
+            "name": "progress_bar_desc",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/aclgraph_utils.py",
+          "qualified_name": "ModelAclGraphManager.capture"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/cudagraph_utils.py",
+      "owner": "ModelCudaGraphManager",
+      "callable": "run_fullgraph",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "desc",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/aclgraph_utils.py",
+          "qualified_name": "ModelAclGraphManager.run_fullgraph"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "InputBatch",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/input_batch.py",
+          "qualified_name": "AscendInputBatch(InputBatch)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "InputBuffers",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/input_batch.py",
+          "qualified_name": "AscendInputBuffers(InputBuffers)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "combine_sampled_and_draft_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "input_ids",
+            "required": true
+          },
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "last_sampled_tokens",
+            "required": true
+          },
+          {
+            "name": "query_start_loc",
+            "required": true
+          },
+          {
+            "name": "seq_lens",
+            "required": true
+          },
+          {
+            "name": "prefill_len",
+            "required": true
+          },
+          {
+            "name": "draft_tokens",
+            "required": true
+          },
+          {
+            "name": "cu_num_logits",
+            "required": true
+          },
+          {
+            "name": "num_logits",
+            "required": true
+          },
+          {
+            "name": "num_new_sampled_tokens",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "combine_sampled_and_draft_tokens(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "expand_idx_mapping",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "total_num_logits",
+            "required": true
+          },
+          {
+            "name": "cu_num_logits",
+            "required": true
+          },
+          {
+            "name": "max_expand_len",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "expand_idx_mapping(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "post_update",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "num_computed_tokens",
+            "required": true
+          },
+          {
+            "name": "last_sampled_tokens",
+            "required": true
+          },
+          {
+            "name": "output_bin_counts",
+            "required": true
+          },
+          {
+            "name": "sampled_tokens",
+            "required": true
+          },
+          {
+            "name": "num_sampled",
+            "required": true
+          },
+          {
+            "name": "num_rejected",
+            "required": true
+          },
+          {
+            "name": "query_start_loc",
+            "required": true
+          },
+          {
+            "name": "all_token_ids",
+            "required": true
+          },
+          {
+            "name": "total_len",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "post_update"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "prepare_pos_seq_lens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "query_start_loc",
+            "required": true
+          },
+          {
+            "name": "num_computed_tokens",
+            "required": true
+          },
+          {
+            "name": "pos",
+            "required": true
+          },
+          {
+            "name": "seq_lens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "prepare_pos_seq_lens(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": null,
+      "callable": "prepare_prefill_inputs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "input_ids",
+            "required": true
+          },
+          {
+            "name": "next_prefill_tokens",
+            "required": true
+          },
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "query_start_loc",
+            "required": true
+          },
+          {
+            "name": "all_token_ids",
+            "required": true
+          },
+          {
+            "name": "prefill_len",
+            "required": true
+          },
+          {
+            "name": "num_computed_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "prepare_prefill_inputs(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": "InputBatch",
+      "callable": "make_dummy",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "cls",
+            "required": true
+          },
+          {
+            "name": "num_reqs",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "input_buffers",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/input_batch.py",
+          "qualified_name": "AscendInputBatch.make_dummy"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/input_batch.py",
+      "owner": "InputBuffers",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "max_num_reqs",
+            "required": true
+          },
+          {
+            "name": "max_num_tokens",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/input_batch.py",
+          "qualified_name": "AscendInputBuffers.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": null,
+      "callable": "BlockTables",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_block_table.py",
+          "qualified_name": "AscendBlockTables"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": null,
+      "callable": "GPUModelRunner",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "NPUModelRunner(GPUModelRunner)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": null,
+      "callable": "InputBatch",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_input_batch.py",
+          "qualified_name": "AscendInputBatch"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": null,
+      "callable": "init_model_state",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_model_state.py",
+          "qualified_name": "init_asecnd_model_state"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": null,
+      "callable": "post_update",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "post_update"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "NPUModelRunner.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "initialize_kv_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "NPUModelRunner.initialize_kv_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "postprocess_sampled",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "idx_mapping",
+            "required": true
+          },
+          {
+            "name": "sampled_tokens",
+            "required": true
+          },
+          {
+            "name": "num_sampled",
+            "required": true
+          },
+          {
+            "name": "num_rejected",
+            "required": true
+          },
+          {
+            "name": "query_start_loc",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "NPUModelRunner.postprocess_sampled"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "prepare_inputs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "batch_desc",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "NPUModelRunner.prepare_inputs"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "profile_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/model_runner.py",
+          "qualified_name": "NPUModelRunner.profile_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_states/default.py",
+      "owner": null,
+      "callable": "DefaultModelState",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/model_states/default.py",
+          "qualified_name": "AscendModelState(DefaultModelState)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/model_states/default.py",
+      "owner": "DefaultModelState",
+      "callable": "prepare_attn",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_batch",
+            "required": true
+          },
+          {
+            "name": "cudagraph_mode",
+            "required": true
+          },
+          {
+            "name": "block_tables",
+            "required": true
+          },
+          {
+            "name": "slot_mappings",
+            "required": true
+          },
+          {
+            "name": "attn_groups",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "for_capture",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/model_states/default.py",
+          "qualified_name": "AscendModelState.prepare_attn"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/bad_words.py",
+      "owner": null,
+      "callable": "apply_bad_words",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "expanded_idx_mapping",
+            "required": true
+          },
+          {
+            "name": "bad_word_token_ids",
+            "required": true
+          },
+          {
+            "name": "bad_word_offsets",
+            "required": true
+          },
+          {
+            "name": "num_bad_words",
+            "required": true
+          },
+          {
+            "name": "all_token_ids",
+            "required": true
+          },
+          {
+            "name": "prompt_len",
+            "required": true
+          },
+          {
+            "name": "total_len",
+            "required": true
+          },
+          {
+            "name": "input_ids",
+            "required": true
+          },
+          {
+            "name": "expanded_local_pos",
+            "required": true
+          },
+          {
+            "name": "max_num_bad_words",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "apply_bad_words"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/gumbel.py",
+      "owner": null,
+      "callable": "apply_temperature",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "expanded_idx_mapping",
+            "required": true
+          },
+          {
+            "name": "temperature",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "apply_temperature"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/logprob.py",
+      "owner": null,
+      "callable": "compute_token_logprobs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "token_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "compute_token_logprobs"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/penalties.py",
+      "owner": null,
+      "callable": "apply_penalties",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "expanded_idx_mapping",
+            "required": true
+          },
+          {
+            "name": "token_ids",
+            "required": true
+          },
+          {
+            "name": "expanded_local_pos",
+            "required": true
+          },
+          {
+            "name": "repetition_penalty",
+            "required": true
+          },
+          {
+            "name": "frequency_penalty",
+            "required": true
+          },
+          {
+            "name": "presence_penalty",
+            "required": true
+          },
+          {
+            "name": "prompt_bin_mask",
+            "required": true
+          },
+          {
+            "name": "output_bin_counts",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "apply_penalties"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/penalties.py",
+      "owner": null,
+      "callable": "bincount",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "expanded_idx_mapping",
+            "required": true
+          },
+          {
+            "name": "all_token_ids",
+            "required": true
+          },
+          {
+            "name": "prompt_len",
+            "required": true
+          },
+          {
+            "name": "prefill_len",
+            "required": true
+          },
+          {
+            "name": "prompt_bin_mask",
+            "required": true
+          },
+          {
+            "name": "output_bin_counts",
+            "required": true
+          },
+          {
+            "name": "max_prefill_len",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "bincount"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/sampler.py",
+      "owner": null,
+      "callable": "gumbel_sample",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "gumbel_sample"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/states.py",
+      "owner": null,
+      "callable": "apply_min_p",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "apply_min_p"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/sample/states.py",
+      "owner": null,
+      "callable": "apply_temperature",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_v2/patch_triton.py",
+          "qualified_name": "apply_temperature"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py",
+      "owner": null,
+      "callable": "SpeculatorCudaGraphManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py",
+          "qualified_name": "EagleAclGraphManager(SpeculatorCudaGraphManager)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py",
+      "owner": null,
+      "callable": "AutoRegressiveSpeculator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py",
+          "qualified_name": "AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py",
+      "owner": null,
+      "callable": "DFlashCudaGraphManager",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py",
+          "qualified_name": "DFlashAclGraphManager(DFlashCudaGraphManager)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py",
+      "owner": "DFlashCudaGraphManager",
+      "callable": "capture",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "forward_fn",
+            "required": true
+          },
+          {
+            "name": "input_buffers",
+            "required": true
+          },
+          {
+            "name": "block_tables",
+            "required": true
+          },
+          {
+            "name": "attn_groups",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          },
+          {
+            "name": "causal",
+            "required": true
+          },
+          {
+            "name": "progress_bar_desc",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py",
+          "qualified_name": "DFlashAclGraphManager.capture"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/speculator.py",
+      "owner": null,
+      "callable": "DFlashSpeculator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/speculator.py",
+          "qualified_name": "AscendDFlashSpeculator(DFlashSpeculator)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/speculator.py",
+      "owner": "DFlashSpeculator",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/speculator.py",
+          "qualified_name": "AscendDFlashSpeculator.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/speculator.py",
+      "owner": "DFlashSpeculator",
+      "callable": "init_cudagraph_manager",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "cudagraph_mode",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/speculator.py",
+          "qualified_name": "AscendDFlashSpeculator.init_cudagraph_manager"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/speculator.py",
+      "owner": "DFlashSpeculator",
+      "callable": "propose",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_batch",
+            "required": true
+          },
+          {
+            "name": "attn_metadata",
+            "required": true
+          },
+          {
+            "name": "slot_mappings",
+            "required": true
+          },
+          {
+            "name": "last_hidden_states",
+            "required": true
+          },
+          {
+            "name": "aux_hidden_states",
+            "required": true
+          },
+          {
+            "name": "num_sampled",
+            "required": true
+          },
+          {
+            "name": "num_rejected",
+            "required": true
+          },
+          {
+            "name": "last_sampled",
+            "required": true
+          },
+          {
+            "name": "next_prefill_tokens",
+            "required": true
+          },
+          {
+            "name": "temperature",
+            "required": true
+          },
+          {
+            "name": "seeds",
+            "required": true
+          },
+          {
+            "name": "num_tokens_across_dp",
+            "required": false
+          },
+          {
+            "name": "dummy_run",
+            "required": false
+          },
+          {
+            "name": "skip_attn_for_dummy_run",
+            "required": false
+          },
+          {
+            "name": "mm_inputs",
+            "required": false
+          },
+          {
+            "name": "is_profile",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/speculator.py",
+          "qualified_name": "AscendDFlashSpeculator.propose"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dflash/speculator.py",
+      "owner": "DFlashSpeculator",
+      "callable": "set_attn",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "model_state",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "block_tables",
+            "required": true
+          },
+          {
+            "name": "target_input_buffers",
+            "required": true
+          },
+          {
+            "name": "target_attn_groups",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/spec_decode/dflash/speculator.py",
+          "qualified_name": "AscendDFlashSpeculator.set_attn"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dspark/speculator.py",
+      "owner": null,
+      "callable": "DSparkSpeculator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/dspark/speculator.py",
+          "qualified_name": "AscendDSparkSpeculator(DSparkSpeculator)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/dspark/speculator.py",
+      "owner": "DSparkSpeculator",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/v2/spec_decode/dspark/speculator.py",
+          "qualified_name": "AscendDSparkSpeculator.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/eagle/speculator.py",
+      "owner": null,
+      "callable": "EagleSpeculator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/eagle/speculator.py",
+          "qualified_name": "AscendEagleSpeculator(EagleSpeculator)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/mtp/speculator.py",
+      "owner": null,
+      "callable": "MTPSpeculator",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/spec_decode/mtp/speculator.py",
+          "qualified_name": "AscendMTPSpeculator(MTPSpeculator)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py",
+      "owner": null,
+      "callable": "_compute_global_logsumexp",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "local_max_ptr",
+            "required": true
+          },
+          {
+            "name": "local_max_stride",
+            "required": true
+          },
+          {
+            "name": "local_sumexp_ptr",
+            "required": true
+          },
+          {
+            "name": "local_sumexp_stride",
+            "required": true
+          },
+          {
+            "name": "logit_idx",
+            "required": true
+          },
+          {
+            "name": "vocab_num_blocks",
+            "required": true
+          },
+          {
+            "name": "PADDED_VOCAB_NUM_BLOCKS",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py",
+          "qualified_name": "_compute_global_lse(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/states.py",
+      "owner": null,
+      "callable": "RequestState",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/v2/states.py",
+          "qualified_name": "AscendRequestState(RequestState)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/states.py",
+      "owner": "RequestState",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "max_num_reqs",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          },
+          {
+            "name": "max_num_batched_tokens",
+            "required": true
+          },
+          {
+            "name": "num_speculative_steps",
+            "required": true
+          },
+          {
+            "name": "vocab_size",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/states.py",
+          "qualified_name": "AscendRequestState.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu/states.py",
+      "owner": "RequestState",
+      "callable": "add_request",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "req_id",
+            "required": true
+          },
+          {
+            "name": "prompt_len",
+            "required": true
+          },
+          {
+            "name": "all_token_ids",
+            "required": true
+          },
+          {
+            "name": "num_computed_tokens",
+            "required": true
+          },
+          {
+            "name": "max_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/v2/states.py",
+          "qualified_name": "AscendRequestState.add_request"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_input_batch.py",
+      "owner": null,
+      "callable": "InputBatch",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/npu_input_batch.py",
+          "qualified_name": "NPUInputBatch(InputBatch)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_input_batch.py",
+      "owner": "InputBatch",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "max_num_reqs",
+            "required": true
+          },
+          {
+            "name": "max_model_len",
+            "required": true
+          },
+          {
+            "name": "max_num_batched_tokens",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "vocab_size",
+            "required": true
+          },
+          {
+            "name": "block_sizes",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          },
+          {
+            "name": "max_num_blocks_per_req",
+            "required": true
+          },
+          {
+            "name": "logitsprocs",
+            "required": false
+          },
+          {
+            "name": "logitsprocs_need_output_token_ids",
+            "required": false
+          },
+          {
+            "name": "num_spec_tokens",
+            "required": false
+          },
+          {
+            "name": "is_pooling_model",
+            "required": false
+          },
+          {
+            "name": "cp_kv_cache_interleave_size",
+            "required": false
+          },
+          {
+            "name": "reasoning_config",
+            "required": false
+          },
+          {
+            "name": "use_replayssm",
+            "required": false
+          },
+          {
+            "name": "slot_mapping_modes",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/npu_input_batch.py",
+          "qualified_name": "NPUInputBatch.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": null,
+      "callable": "AsyncGPUModelRunnerOutput",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "AsyncGPUModelRunnerOutput(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": null,
+      "callable": "GPUModelRunner",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner(GPUModelRunner)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_allocate_kv_cache_tensors",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._allocate_kv_cache_tensors"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_bookkeeping_sync",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "sampler_output",
+            "required": true
+          },
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "num_scheduled_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._bookkeeping_sync"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_build_attention_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "num_reqs",
+            "required": true
+          },
+          {
+            "name": "max_query_len",
+            "required": true
+          },
+          {
+            "name": "num_tokens_padded",
+            "required": false
+          },
+          {
+            "name": "num_reqs_padded",
+            "required": false
+          },
+          {
+            "name": "ubatch_slices",
+            "required": false
+          },
+          {
+            "name": "logits_indices",
+            "required": false
+          },
+          {
+            "name": "use_spec_decode",
+            "required": false
+          },
+          {
+            "name": "for_cudagraph_capture",
+            "required": false
+          },
+          {
+            "name": "num_scheduled_tokens",
+            "required": false
+          },
+          {
+            "name": "cascade_attn_prefix_lens",
+            "required": false
+          },
+          {
+            "name": "slot_mappings",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._build_attention_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_calc_spec_decode_metadata",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_draft_tokens",
+            "required": true
+          },
+          {
+            "name": "cu_num_scheduled_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._calc_spec_decode_metadata"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_check_and_update_cudagraph_mode",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "attention_backends",
+            "required": true
+          },
+          {
+            "name": "kv_cache_groups",
+            "required": true
+          },
+          {
+            "name": "is_profiling",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._check_and_update_cudagraph_mode"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_copy_valid_sampled_token_count",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "next_token_ids",
+            "required": true
+          },
+          {
+            "name": "valid_sampled_tokens_count",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._copy_valid_sampled_token_count"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_determine_batch_execution_and_padding",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "num_reqs",
+            "required": true
+          },
+          {
+            "name": "num_scheduled_tokens_np",
+            "required": true
+          },
+          {
+            "name": "max_num_scheduled_tokens",
+            "required": true
+          },
+          {
+            "name": "use_cascade_attn",
+            "required": true
+          },
+          {
+            "name": "allow_microbatching",
+            "required": false
+          },
+          {
+            "name": "force_eager",
+            "required": false
+          },
+          {
+            "name": "force_uniform_decode",
+            "required": false
+          },
+          {
+            "name": "force_has_lora",
+            "required": false
+          },
+          {
+            "name": "force_num_active_loras",
+            "required": false
+          },
+          {
+            "name": "num_encoder_reqs",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._determine_batch_execution_and_padding"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_dummy_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "cudagraph_runtime_mode",
+            "required": false
+          },
+          {
+            "name": "force_attention",
+            "required": false
+          },
+          {
+            "name": "uniform_decode",
+            "required": false
+          },
+          {
+            "name": "allow_microbatching",
+            "required": false
+          },
+          {
+            "name": "skip_eplb",
+            "required": false
+          },
+          {
+            "name": "is_profile",
+            "required": false
+          },
+          {
+            "name": "create_mixed_batch",
+            "required": false
+          },
+          {
+            "name": "remove_lora",
+            "required": false
+          },
+          {
+            "name": "is_graph_capturing",
+            "required": false
+          },
+          {
+            "name": "num_active_loras",
+            "required": false
+          },
+          {
+            "name": "profile_seq_lens",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._dummy_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_dummy_sampler_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._dummy_sampler_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_init_device_properties",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._init_device_properties"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_model_forward",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "input_ids",
+            "required": false
+          },
+          {
+            "name": "positions",
+            "required": false
+          },
+          {
+            "name": "intermediate_tensors",
+            "required": false
+          },
+          {
+            "name": "inputs_embeds",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": "model_kwargs"
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._model_forward"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_pad_for_sequence_parallelism",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_scheduled_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._pad_for_sequence_parallelism"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_prepare_inputs",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "num_scheduled_tokens",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._prepare_inputs"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_reshape_kv_cache_tensors",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_raw_tensors",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._reshape_kv_cache_tensors"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_sample",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "logits",
+            "required": true
+          },
+          {
+            "name": "spec_decode_metadata",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._sample"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "_sync_device",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner._sync_device"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "capture_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.capture_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "execute_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "intermediate_tensors",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.execute_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "get_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.get_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "get_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.get_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "initialize_attn_backend",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "is_profiling",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.initialize_attn_backend"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "initialize_kv_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "is_profiling",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.initialize_kv_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "initialize_kv_cache_tensors",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.initialize_kv_cache_tensors"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "load_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "load_dummy_weights",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.load_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "may_reinitialize_input_batch",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "kv_cache_config",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.may_reinitialize_input_batch"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "profile_run",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.profile_run"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "propose_draft_token_ids",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          },
+          {
+            "name": "sampled_token_ids",
+            "required": true
+          },
+          {
+            "name": "sampling_metadata",
+            "required": true
+          },
+          {
+            "name": "hidden_states",
+            "required": true
+          },
+          {
+            "name": "sample_hidden_states",
+            "required": true
+          },
+          {
+            "name": "aux_hidden_states",
+            "required": true
+          },
+          {
+            "name": "spec_decode_metadata",
+            "required": true
+          },
+          {
+            "name": "common_attn_metadata",
+            "required": true
+          },
+          {
+            "name": "slot_mappings",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.propose_draft_token_ids"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "sample_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "grammar_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.sample_tokens"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_model_runner.py",
+      "owner": "GPUModelRunner",
+      "callable": "sync_and_gather_intermediate_tensors",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "num_tokens",
+            "required": true
+          },
+          {
+            "name": "intermediate_tensors",
+            "required": true
+          },
+          {
+            "name": "sync_self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "NPUModelRunner.sync_and_gather_intermediate_tensors"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/gpu_worker.py",
+      "owner": null,
+      "callable": "AsyncIntermediateTensors",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "AsyncIntermediateTensors(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/mamba_utils.py",
+      "owner": null,
+      "callable": "batch_memcpy",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "src_ptrs",
+            "required": true
+          },
+          {
+            "name": "dst_ptrs",
+            "required": true
+          },
+          {
+            "name": "sizes",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_mamba_utils.py",
+          "qualified_name": "_batch_memcpy_triton"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/mamba_utils.py",
+      "owner": null,
+      "callable": "batch_memcpy_kernel",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "src_ptrs",
+            "required": true
+          },
+          {
+            "name": "dst_ptrs",
+            "required": true
+          },
+          {
+            "name": "sizes",
+            "required": true
+          },
+          {
+            "name": "BLOCK_SIZE",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_mamba_utils.py",
+          "qualified_name": "batch_memcpy_kernel"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/ubatch_utils.py",
+      "owner": null,
+      "callable": "maybe_create_ubatch_slices",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "should_ubatch",
+            "required": true
+          },
+          {
+            "name": "num_scheduled_tokens",
+            "required": true
+          },
+          {
+            "name": "num_tokens_padded",
+            "required": true
+          },
+          {
+            "name": "num_reqs_padded",
+            "required": true
+          },
+          {
+            "name": "num_ubatches",
+            "required": true
+          },
+          {
+            "name": "split_point",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "maybe_create_ubatch_slices(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": null,
+      "callable": "AttentionGroup",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/dspark_proposer.py",
+          "qualified_name": "AttentionGroup(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/spec_decode/step3p5.py",
+          "qualified_name": "AttentionGroup(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "AttentionGroup(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": null,
+      "callable": "KVBlockZeroer",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/_310p/kv_block_zeroer.py",
+          "qualified_name": "AscendKVBlockZeroer310(KVBlockZeroer)"
+        },
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/utils.py",
+          "qualified_name": "AscendKVBlockZeroer(KVBlockZeroer)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": null,
+      "callable": "bind_kv_cache",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_caches",
+            "required": true
+          },
+          {
+            "name": "forward_context",
+            "required": true
+          },
+          {
+            "name": "runner_kv_caches",
+            "required": true
+          },
+          {
+            "name": "num_attn_module",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/_310p/model_runner_310p.py",
+          "qualified_name": "bind_kv_cache(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "bind_kv_cache(...)"
+        },
+        {
+          "relation": "monkey_patch",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_next_mtp.py",
+          "qualified_name": "bind_kv_cache"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": null,
+      "callable": "defaultdict",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_next_mtp.py",
+          "qualified_name": "defaultdict(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": null,
+      "callable": "extract_layer_index",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py",
+          "qualified_name": "extract_layer_index(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py",
+          "qualified_name": "extract_layer_index(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/patch/worker/patch_qwen3_next_mtp.py",
+          "qualified_name": "extract_layer_index(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": null,
+      "callable": "select_common_block_size",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "kv_manager_block_size",
+            "required": true
+          },
+          {
+            "name": "backends",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/attention/sfa_v1.py",
+          "qualified_name": "select_common_block_size(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/model_runner_v1.py",
+          "qualified_name": "select_common_block_size(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": "KVBlockZeroer",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "attn_groups_iter",
+            "required": true
+          },
+          {
+            "name": "kernel_block_sizes",
+            "required": true
+          },
+          {
+            "name": "cache_dtype",
+            "required": true
+          },
+          {
+            "name": "static_forward_context",
+            "required": true
+          },
+          {
+            "name": "runner_only_attn_layers",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/_310p/kv_block_zeroer.py",
+          "qualified_name": "AscendKVBlockZeroer310.__init__"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/utils.py",
+          "qualified_name": "AscendKVBlockZeroer.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/utils.py",
+      "owner": "KVBlockZeroer",
+      "callable": "zero_block_ids",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "block_ids",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/_310p/kv_block_zeroer.py",
+          "qualified_name": "AscendKVBlockZeroer310.zero_block_ids"
+        },
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/utils.py",
+          "qualified_name": "AscendKVBlockZeroer.zero_block_ids"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": null,
+      "callable": "CompilationTimes",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "CompilationTimes(...)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": null,
+      "callable": "WorkerBase",
+      "signature": null,
+      "consumers": [
+        {
+          "relation": "inheritance",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker(WorkerBase)"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "__init__",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "vllm_config",
+            "required": true
+          },
+          {
+            "name": "local_rank",
+            "required": true
+          },
+          {
+            "name": "rank",
+            "required": true
+          },
+          {
+            "name": "distributed_init_method",
+            "required": true
+          },
+          {
+            "name": "is_driver_worker",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.__init__"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "add_lora",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "lora_request",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.add_lora"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "check_health",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.check_health"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "compile_or_warm_up_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.compile_or_warm_up_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "execute_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "scheduler_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.execute_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "get_kv_cache_spec",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.get_kv_cache_spec"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "get_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.get_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "init_device",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.init_device"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "list_loras",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.list_loras"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "load_model",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [
+          {
+            "name": "load_dummy_weights",
+            "required": false
+          }
+        ],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.load_model"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "pin_lora",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "lora_id",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.pin_lora"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "remove_lora",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "lora_id",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.remove_lora"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "sample_tokens",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          },
+          {
+            "name": "grammar_output",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.sample_tokens"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/worker_base.py",
+      "owner": "WorkerBase",
+      "callable": "shutdown",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "self",
+            "required": true
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "override_candidate",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "NPUWorker.shutdown"
+        }
+      ]
+    },
+    {
+      "upstream_file": "vllm/v1/worker/workspace.py",
+      "owner": null,
+      "callable": "init_workspace_manager",
+      "signature": {
+        "kind": "function",
+        "positional_only": [],
+        "positional_or_keyword": [
+          {
+            "name": "device",
+            "required": true
+          },
+          {
+            "name": "num_ubatches",
+            "required": false
+          }
+        ],
+        "variadic_positional": null,
+        "keyword_only": [],
+        "variadic_keyword": null
+      },
+      "consumers": [
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/worker/worker.py",
+          "qualified_name": "init_workspace_manager(...)"
+        },
+        {
+          "relation": "direct_callable",
+          "file": "vllm_ascend/xlite/xlite_worker.py",
+          "qualified_name": "init_workspace_manager(...)"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/vllm_interface/singlecard/test_interface_contracts.py
+++ b/tests/e2e/vllm_interface/singlecard/test_interface_contracts.py
@@ -1,0 +1,217 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import os
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MANIFEST_PATH = Path(__file__).parents[1] / "interface_contracts.json"
+_VLLM_ASCEND_SOURCE_ROOT = Path(__file__).parents[4]
+
+
+def _load_contracts() -> list[dict[str, Any]]:
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    return manifest["contracts"]
+
+
+def _vllm_source_root() -> Path:
+    configured_root = os.getenv("VLLM_SOURCE_ROOT")
+    if configured_root:
+        candidate = Path(configured_root).resolve()
+        if (candidate / "vllm" / "__init__.py").is_file():
+            return candidate
+        if candidate.name == "vllm" and (candidate / "__init__.py").is_file():
+            return candidate.parent
+        raise AssertionError(f"VLLM_SOURCE_ROOT does not contain the vllm package: {candidate}")
+
+    spec = importlib.util.find_spec("vllm")
+    assert spec is not None and spec.submodule_search_locations, (
+        "Cannot locate the vllm source package. Install vLLM or set VLLM_SOURCE_ROOT."
+    )
+    package_root = Path(next(iter(spec.submodule_search_locations))).resolve()
+    return package_root.parent
+
+
+@cache
+def _parse_source(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _find_named_node(nodes: list[ast.stmt], name: str) -> ast.AST | None:
+    # Python binds the last definition, which matters for overloaded functions.
+    for node in reversed(nodes):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef)) and node.name == name:
+            return node
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if any(isinstance(target, ast.Name) and target.id == name for target in targets):
+                return node
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            if any((alias.asname or alias.name.rsplit(".", 1)[-1]) == name for alias in node.names):
+                return node
+    return None
+
+
+def _find_contract_node(tree: ast.Module, owner: str | None, callable_name: str) -> ast.AST | None:
+    if owner is None:
+        return _find_named_node(tree.body, callable_name)
+
+    owner_node = next(
+        (node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == owner),
+        None,
+    )
+    if owner_node is None:
+        return None
+    return _find_named_node(owner_node.body, callable_name)
+
+
+def _parameter(name: str, required: bool) -> dict[str, object]:
+    return {"name": name, "required": required}
+
+
+def _callable_signature(node: ast.AST) -> dict[str, object] | None:
+    if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+        return None
+
+    arguments = node.args
+    positional = [*arguments.posonlyargs, *arguments.args]
+    required_count = len(positional) - len(arguments.defaults)
+
+    return {
+        "kind": "async_function" if isinstance(node, ast.AsyncFunctionDef) else "function",
+        "positional_only": [
+            _parameter(argument.arg, index < required_count) for index, argument in enumerate(arguments.posonlyargs)
+        ],
+        "positional_or_keyword": [
+            _parameter(argument.arg, index + len(arguments.posonlyargs) < required_count)
+            for index, argument in enumerate(arguments.args)
+        ],
+        "variadic_positional": arguments.vararg.arg if arguments.vararg else None,
+        "keyword_only": [
+            _parameter(argument.arg, default is None)
+            for argument, default in zip(arguments.kwonlyargs, arguments.kw_defaults)
+        ],
+        "variadic_keyword": arguments.kwarg.arg if arguments.kwarg else None,
+    }
+
+
+def _contract_id(contract: dict[str, Any]) -> str:
+    owner = f"{contract['owner']}." if contract["owner"] else ""
+    return f"{contract['upstream_file']}::{owner}{contract['callable']}"
+
+
+def _direct_callable_contracts() -> list[dict[str, Any]]:
+    return [
+        contract
+        for contract in _load_contracts()
+        if contract["signature"] is not None
+        and any(consumer["relation"] == "direct_callable" for consumer in contract["consumers"])
+        and not any(consumer["relation"] == "monkey_patch" for consumer in contract["consumers"])
+    ]
+
+
+@pytest.mark.parametrize("contract", _load_contracts(), ids=_contract_id)
+def test_watched_vllm_callable_contract(contract: dict[str, Any]) -> None:
+    """Detect changes to vLLM callables coupled to vllm-ascend without importing NPU code."""
+    source_path = _vllm_source_root() / contract["upstream_file"]
+    consumers = "\n".join(
+        f"  - {consumer['relation']}: {consumer['file']}::{consumer['qualified_name']}"
+        for consumer in contract["consumers"]
+    )
+    interface_name = _contract_id(contract)
+
+    assert source_path.is_file(), (
+        f"Watched vLLM source file was removed or moved: {contract['upstream_file']}\n"
+        f"vllm-ascend consumers that need review:\n{consumers}"
+    )
+
+    tree = _parse_source(source_path)
+    node = _find_contract_node(tree, contract["owner"], contract["callable"])
+    assert node is not None, (
+        f"Watched vLLM interface was removed or moved: {interface_name}\n"
+        f"vllm-ascend consumers that need review:\n{consumers}"
+    )
+
+    expected_signature = contract["signature"]
+    if expected_signature is None:
+        return
+
+    actual_signature = _callable_signature(node)
+    assert actual_signature == expected_signature, (
+        f"Watched vLLM interface changed: {interface_name}\n"
+        f"Expected: {json.dumps(expected_signature, sort_keys=True)}\n"
+        f"Actual:   {json.dumps(actual_signature, sort_keys=True)}\n"
+        f"vllm-ascend consumers that need review:\n{consumers}\n"
+        "Review the downstream implementation before accepting a new baseline."
+    )
+
+
+@pytest.mark.parametrize("contract", _direct_callable_contracts(), ids=_contract_id)
+def test_direct_callable_keywords_are_supported(contract: dict[str, Any]) -> None:
+    """Ensure direct vLLM calls do not use keywords removed by an upstream change."""
+    upstream_path = _vllm_source_root() / contract["upstream_file"]
+    upstream_node = _find_contract_node(
+        _parse_source(upstream_path),
+        contract["owner"],
+        contract["callable"],
+    )
+    assert upstream_node is not None
+    upstream_signature = _callable_signature(upstream_node)
+    assert upstream_signature is not None
+
+    supported_keywords = {
+        parameter["name"]
+        for parameter in [
+            *upstream_signature["positional_or_keyword"],
+            *upstream_signature["keyword_only"],
+        ]
+    }
+    if upstream_signature["variadic_keyword"] is not None:
+        return
+
+    for consumer in contract["consumers"]:
+        if consumer["relation"] != "direct_callable":
+            continue
+
+        local_name = consumer["qualified_name"].removesuffix("(...)")
+        consumer_path = _VLLM_ASCEND_SOURCE_ROOT / consumer["file"]
+        consumer_tree = _parse_source(consumer_path)
+        calls = [
+            node
+            for node in ast.walk(consumer_tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == local_name
+        ]
+        assert calls, f"Direct callable consumer was removed or renamed: {consumer['file']}::{local_name}"
+
+        for call in calls:
+            unsupported_keywords = {
+                keyword.arg
+                for keyword in call.keywords
+                if keyword.arg is not None and keyword.arg not in supported_keywords
+            }
+            assert not unsupported_keywords, (
+                f"{consumer['file']}::{local_name} uses keyword arguments no longer accepted by "
+                f"{_contract_id(contract)}: {sorted(unsupported_keywords)}"
+            )

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -52,6 +52,9 @@ class NPUInputBatch(InputBatch):
     ):
         self.is_pooling_model = is_pooling_model
         self.is_spec_decode = is_spec_decode
+        # ReplaySSM is not supported on NPU. InputBatch methods check this
+        # attribute before accessing ReplaySSM-only buffers.
+        self.use_replayssm = False
         # Added for compatibility with InputBatch methods that reference these
         # attributes after PR vllm-project/vllm#34668. NPU does not use
         # thinking budget, so the holder is always None.

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -109,7 +109,7 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
                     block_tables,
                     attn_groups,
                     kv_cache_config,
-                    skip_attn=(desc.cg_mode == CUDAGraphMode.PIECEWISE),
+                    full_cudagraph=(desc.cg_mode == CUDAGraphMode.FULL),
                 )
                 return lambda cg_mode: forward_fn(
                     num_reqs,


### PR DESCRIPTION
### What this PR does / why we need it?

This draft adds a CPU-only callable interface guard to the existing `vllm-interface` suite so upstream vLLM changes can identify affected vllm-ascend code early.

- Records 711 watched vLLM callables and 1,207 vllm-ascend dependency relations covering monkey patches, overrides, direct callable use, and inheritance.
- Parses source with `ast`; it does not import `torch_npu`, initialize an NPU, download a model, or run inference.
- Detects removed/moved callables and changes to parameter names, kinds, and required/optional status.
- Validates that direct calls do not use keyword arguments removed by upstream.
- Reports the related vllm-ascend consumer files in each failure.
- Updates the baseline to current main snapshots and fixes two compatibility issues found by the new checks: `prepare_inputs_to_capture(full_cudagraph=...)` and the inherited `InputBatch.use_replayssm` attribute.

The existing upstream job already runs `pytest -v -s tests/e2e/vllm_interface/`, so this test is collected without changing the upstream command. The job still uses NPU resources because the existing sampler test requires them; the new contract checks themselves are CPU-only.

Current first-version exclusions: fields, annotation/default-value/return changes, and runtime behavior. Direct calls to monkey-patched callables are excluded from original-upstream keyword validation because their effective signature is supplied by the patch.

### Does this PR introduce _any_ user-facing change?

No. This adds CI coverage and adapts internal calls to the current upstream interface.

### How was this patch tested?

Baseline revisions:

- vllm-ascend main: `a0cc4ce1de3f736dd4d4fb9f74802b851ade036e`

Before adapting, the old baseline detected 3 upstream interface changes (`707 passed, 3 failed`), including one real removed-keyword break. After review, adaptation, and baseline refresh:

```powershell
$env:VLLM_SOURCE_ROOT="C:\path\to\vllm"
python -m pytest tests/e2e/vllm_interface/singlecard/test_interface_contracts.py -q --confcutdir=tests/e2e/vllm_interface/singlecard
```

Result: `833 passed in 5.49s`.

Additional checks:

```text
ruff check: passed
ruff format --check: passed
python -m json.tool: passed
git diff --check: passed
```

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
