### PR TITLE
[MRV2][Feature] Support sleep-mode

### DIFF
--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 import numpy as np
 import torch
 from vllm.config import VllmConfig
-from vllm.config.compilation import CUDAGraphMode
+from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu import model_runner as vllm_model_runner
@@ -73,6 +73,12 @@ class NPUModelRunner(GPUModelRunner):
 
         with torch_cuda_wrapper():
             super().__init__(vllm_config, device)
+
+        self.use_aclgraph = (
+            self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
+            and self.compilation_config.mode == CompilationMode.VLLM_COMPILE
+            and not self.model_config.enforce_eager
+        )
 
         # because we will override these attribute, delete these attribute to
         # make sure it's collected by python gc immediately.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -272,6 +272,10 @@ class NPUWorker(WorkerBase):
                 if name in self._sleep_saved_buffers:
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
+
+        if tags is None or "kv_cache" in tags:
+            self.model_runner.post_kv_cache_wake_up()
+
         cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
         if cleanup_enabled:
             self.sleep_wakeup_manager.wakeup(tags)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adapts 2 modifications into sleep mode in MRV2.

#### Problem 1: The missing hook

The upstream `gpu_worker.py` (shared by V1 and V2) always refreshes model-runner state after a KV-cache wake-up:

```python
# vllm/v1/worker/gpu_worker.py L222-242
def wake_up(self, tags=None):
    self._get_sleep_mode_backend().resume(tags)
    # ... buffer restore ...
    if tags is None or "kv_cache" in tags:
        self.model_runner.post_kv_cache_wake_up()
```

The Ascend worker (`vllm_ascend/worker/worker.py`) does **not** issue this call.
Its `wake_up` performs:

1. `CaMemAllocator.wake_up(tags=tags)` — remaps memory; KV-cache chunks get fresh `data_ptr()` values.
2. MoE expert-weight layout restoration (`w13_weight` / `w2_weight` transpose).
3. Level-2 buffer restore.
4. `SleepWakeupManager.wakeup()` — recaptures ACL graphs.

Between steps 3 and 4, `post_kv_cache_wake_up()` is missing.

#### Problem 2: AttributeError on extra-cleanup path

`SleepWakeupManager.sleep()` accesses `model_runner.use_aclgraph` (`sleep_mem_optimized.py` L50). V1 `NPUModelRunner.__init__` sets this attribute explicitly; V2 `NPUModelRunner.__init__` does **not**. When `enable_sleep_mode_extra_cleanup=True` (not used in the one-card test, but a supported config), V2 workers would crash with `AttributeError`.

### Does this PR introduce _any_ user-facing change?

None.

### How was this patch tested?

It is tested by tests 
- vllm\vllm-ascend\tests\e2e\pull_request\one_card\test_camem.py
- vllm\vllm-ascend\tests\ut\device_allocator\test_camem.py

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
