### PR TITLE
[Feature][Model] Add MiniMax M3 model core support

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -156,6 +156,14 @@ class AscendConfig:
             ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
         )
         assert self.enable_fused_mc2 in (0, 1), f"enable_fused_mc2 must be 0 or 1, got {self.enable_fused_mc2}"
+        model_architectures = getattr(vllm_config.model_config, "architectures", None) or []
+        assert not (
+            self.enable_fused_mc2 == 1
+            and any(architecture.startswith("MiniMaxM3") for architecture in model_architectures)
+        ), (
+            "MiniMax M3 does not support enable_fused_mc2=1. Please set "
+            "additional_config.enable_fused_mc2 to 0 or unset VLLM_ASCEND_ENABLE_FUSED_MC2."
+        )
         if self.enable_fused_mc2 == 1 and self.multistream_overlap_shared_expert:
             self.multistream_overlap_shared_expert = False
             logger.warning_once(

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -3,6 +3,10 @@ from vllm import ModelRegistry
 
 def register_model():
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
+    ModelRegistry.register_model(
+        "MiniMaxM3SparseForCausalLM",
+        "vllm_ascend.models.minimax_m3:MiniMaxM3SparseForCausalLM",
+    )
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
     ModelRegistry.register_model(
         "DSparkDraftModel",

--- a/vllm_ascend/models/minimax_m3/__init__.py
+++ b/vllm_ascend/models/minimax_m3/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm_ascend.models.minimax_m3.minimax_m3 import (
+    MiniMaxM3Attention,
+    MiniMaxM3MoE,
+    MiniMaxM3SparseAttention,
+    MiniMaxM3SparseForCausalLM,
+    _get_rope_parameters,
+    _sparse_attention_layer_ids,
+)
+
+__all__ = [
+    "MiniMaxM3Attention",
+    "MiniMaxM3MoE",
+    "MiniMaxM3SparseAttention",
+    "MiniMaxM3SparseForCausalLM",
+    "_get_rope_parameters",
+    "_sparse_attention_layer_ids",
+]

--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -1,0 +1,1177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright 2025 The MiniMax AI team.
+# Copyright 2023 The vLLM team.
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only MiniMaxM3 model."""
+
+from collections.abc import Iterable
+from itertools import islice
+from typing import Any
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.forward_context import get_forward_context
+from vllm.logger import logger
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    GateLinear,
+    fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsPP,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    WeightsMapper,
+    is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.utils.torch_utils import kv_cache_dtype_str_to_dtype
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    get_kv_quant_mode,
+)
+
+from vllm_ascend.models.minimax_m3.msa_m3 import (
+    AscendMiniMaxM3Indexer,
+    AscendMiniMaxM3IndexerLinear,
+    AscendMiniMaxM3IndexerMetadata,
+    AscendMiniMaxM3QKVParallelLinearWithIndexer,
+    AscendMiniMaxM3SparseBackend,
+    AscendMiniMaxM3SparseImpl,
+    AscendMiniMaxM3SparseMetadata,
+    _register_m3_sparse_packed_modules,
+    _use_fused_qkv_indexer,
+)
+
+
+class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
+    """Block-sparse attention with lightning indexer on Ascend."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rotary_dim: int,
+        rope_parameters: dict[str, Any] | None = None,
+        attn_window_size: int | None = None,
+        max_position_embeddings: int = 8192,
+        head_dim: int | None = None,
+        rms_norm_eps: float = 1e-06,
+        qkv_bias: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        sparse_cfg: dict[str, Any] | None = None,
+        disable_index_value: bool = False,
+        reduce_results: bool = True,
+    ) -> None:
+        super().__init__()
+        assert sparse_cfg is not None
+        self.hidden_size = hidden_size
+        self.disable_index_value = disable_index_value
+
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim or (hidden_size // self.total_num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.max_position_embeddings = max_position_embeddings
+
+        self.total_idx_heads = sparse_cfg["sparse_num_index_heads"]
+        self.idx_head_dim = sparse_cfg["sparse_index_dim"]
+        assert self.total_idx_heads == self.total_num_kv_heads, (
+            "MiniMax M3 sparse attention requires sparse_num_index_heads == num_key_value_heads"
+        )
+        self.num_idx_heads = self.num_kv_heads
+        self.index_q_size = self.num_idx_heads * self.idx_head_dim
+        self._use_fused_qkv_indexer = _use_fused_qkv_indexer(quant_config, prefix)
+        _register_m3_sparse_packed_modules(quant_config, self._use_fused_qkv_indexer)
+
+        if self._use_fused_qkv_indexer:
+            self.qkv_proj = AscendMiniMaxM3QKVParallelLinearWithIndexer(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                self.total_idx_heads,
+                self.idx_head_dim,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+            self.indexer_proj = None
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+            self.indexer_proj = AscendMiniMaxM3IndexerLinear(
+                hidden_size,
+                self.total_idx_heads,
+                self.idx_head_dim,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.indexer_proj",
+            )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        if rope_parameters is not None and "partial_rotary_factor" not in rope_parameters:
+            rope_parameters["partial_rotary_factor"] = rotary_dim / self.head_dim
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            max_position=max_position_embeddings,
+            rope_parameters=rope_parameters,
+        )
+
+        self.index_q_norm = GemmaRMSNorm(self.idx_head_dim, eps=rms_norm_eps)
+        self.index_k_norm = GemmaRMSNorm(self.idx_head_dim, eps=rms_norm_eps)
+
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=rms_norm_eps)
+
+        vllm_config = get_current_vllm_config()
+        self.layer_name = f"{prefix}.attn"
+        self.kv_cache_dtype = cache_config.cache_dtype if cache_config is not None else "auto"
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
+        self.attn_backend = AscendMiniMaxM3SparseBackend
+        self.impl = AscendMiniMaxM3SparseImpl(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+            kv_cache_dtype=self.kv_cache_dtype,
+            topk_blocks=sparse_cfg["sparse_topk_blocks"],
+            sparse_block_size=sparse_cfg["sparse_block_size"],
+        )
+        self.topk_blocks = sparse_cfg["sparse_topk_blocks"]
+        self.sparse_block_size = sparse_cfg["sparse_block_size"]
+        self.indexer = AscendMiniMaxM3Indexer(
+            num_kv_heads=self.num_kv_heads,
+            scale=self.scaling,
+            topk_blocks=self.topk_blocks,
+            sparse_block_size=self.sparse_block_size,
+            num_index_heads=self.num_idx_heads,
+            index_head_dim=self.idx_head_dim,
+            prefix=self.layer_name,
+            init_blocks=sparse_cfg.get("sparse_init_block", 0),
+            local_blocks=sparse_cfg.get("sparse_local_block", 0),
+            cache_config=cache_config,
+        )
+
+        compilation_config = vllm_config.compilation_config
+        if self.layer_name in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {self.layer_name}")
+        compilation_config.static_forward_context[self.layer_name] = self
+        self.kv_cache = torch.tensor([])
+
+    def get_attn_backend(self) -> type[AscendMiniMaxM3SparseBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        return FullAttentionSpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.head_dim,
+            dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
+    def _insert_kv(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        index_key: torch.Tensor,
+    ) -> None:
+        attn_metadata = get_forward_context().attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return
+        main_meta = attn_metadata[self.layer_name]
+        index_meta = attn_metadata[self.indexer.index_cache.prefix]
+        assert isinstance(main_meta, AscendMiniMaxM3SparseMetadata)
+        assert isinstance(index_meta, AscendMiniMaxM3IndexerMetadata)
+
+        from vllm_ascend.device.device_op import DeviceOperator
+
+        key_cache, value_cache = self.kv_cache
+        num_tokens = main_meta.num_actual_tokens
+        k_insert = key[:num_tokens].view(-1, self.num_kv_heads, self.head_dim)
+        v_insert = value[:num_tokens].view(-1, self.num_kv_heads, self.head_dim)
+        DeviceOperator.reshape_and_cache(
+            k_insert,
+            v_insert,
+            key_cache,
+            value_cache,
+            main_meta.slot_mapping[:num_tokens],
+        )
+
+        idx_cache = self.indexer.index_cache.kv_cache
+        if isinstance(idx_cache, (tuple, list)):
+            idx_cache = idx_cache[0]
+        flat = idx_cache.view(-1, self.idx_head_dim)
+        # Scatter ND update ignores indices outside the cache bounds, so graph
+        # padding slots set to -1 do not write into the last cache row.
+        torch.ops._C_ascend.npu_scatter_nd_update_v2(
+            flat,
+            index_meta.slot_mapping[:num_tokens].view(-1, 1),
+            index_key[:num_tokens].to(flat.dtype),
+        )
+
+    def _sparse_prepare(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        qkv, _ = self.qkv_proj(hidden_states)
+        main_qkv_size = self.q_size + 2 * self.kv_size
+        if self.indexer_proj is None:
+            main_qkv = qkv.narrow(-1, 0, main_qkv_size)
+            index_q = qkv.narrow(-1, main_qkv_size, self.index_q_size)
+            index_k = qkv.narrow(
+                -1,
+                main_qkv_size + self.index_q_size,
+                self.idx_head_dim,
+            )
+        else:
+            main_qkv = qkv
+            index_qk, _ = self.indexer_proj(hidden_states)
+            index_q, index_k = index_qk.split(
+                [self.index_q_size, self.idx_head_dim],
+                dim=-1,
+            )
+
+        if (
+            main_qkv.device.type != "npu"
+            or main_qkv.dtype != torch.bfloat16
+            or positions.ndim != 1
+            or not getattr(self.rotary_emb, "is_neox_style", True)
+        ):
+            q, k, v = main_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            v = v.contiguous()
+            q, k = self._qk_norm(q, k)
+            q, k = self.rotary_emb(positions, q, k)
+        else:
+            q, k, v = torch.ops.vllm.qkv_rmsnorm_rope(
+                input=main_qkv.contiguous(),
+                q_weight=1.0 + self.q_norm.weight,
+                k_weight=1.0 + self.k_norm.weight,
+                q_hidden_size=self.q_size,
+                kv_hidden_size=self.kv_size,
+                head_dim=self.head_dim,
+                eps=self.q_norm.variance_epsilon,
+                q_bias=None,
+                k_bias=None,
+                cos_sin_cache=self.rotary_emb.cos_sin_cache,
+                positions=positions,
+            )
+
+        index_q, index_k = self._index_qk_norm(index_q, index_k)
+        index_q, index_k = self.rotary_emb(positions, index_q, index_k)
+
+        return q, k, v, index_q, index_k
+
+    def _run_sparse_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        index_query: torch.Tensor,
+        index_key: torch.Tensor,
+        attn_output: torch.Tensor,
+    ) -> None:
+        """Insert KV, build sparse top-k indices, then run sparse attention."""
+        self._insert_kv(key, value, index_key)
+        topk_idx = self.indexer(index_query)
+        self.impl.forward(self, query, self.kv_cache, topk_idx, attn_output)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        q, k, v, index_q, index_k = self._sparse_prepare(positions, hidden_states)
+        attn_out = torch.empty_like(q)
+        torch.ops.vllm.minimax_m3_sparse_forward(
+            q,
+            k,
+            v,
+            index_q,
+            index_k,
+            attn_out,
+            self.layer_name,
+        )
+        projected, _ = self.o_proj(attn_out)
+        return projected
+
+    def _qk_norm(self, q: torch.Tensor, k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        q_shape = q.shape
+        k_shape = k.shape
+        q = q.reshape(-1, self.head_dim).contiguous()
+        k = k.reshape(-1, self.head_dim).contiguous()
+        q = self.q_norm(q).reshape(q_shape)
+        k = self.k_norm(k).reshape(k_shape)
+        return q, k
+
+    def _index_qk_norm(self, idx_q: torch.Tensor, idx_k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        idx_q_shape = idx_q.shape
+        idx_k_shape = idx_k.shape
+        idx_q = idx_q.reshape(-1, self.index_q_size)
+        idx_k = idx_k.reshape(-1, self.idx_head_dim)
+        idx_q = self.index_q_norm(idx_q).reshape(idx_q_shape)
+        idx_k = self.index_k_norm(idx_k).reshape(idx_k_shape)
+        return idx_q, idx_k
+
+
+def _sparse_attention_layer_ids(config: PretrainedConfig) -> set[int]:
+    cfg = getattr(config, "sparse_attention_config", None)
+    if not cfg:
+        return set()
+    freq = cfg.get("sparse_attention_freq")
+    if freq is None:
+        return set()
+    return {i for i, f in enumerate(freq) if f != 0}
+
+
+def _get_text_config(vllm_config: VllmConfig) -> PretrainedConfig:
+    return vllm_config.model_config.hf_text_config
+
+
+def _get_max_position_embeddings(config: PretrainedConfig) -> int:
+    max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+    max_model_len = getattr(config, "max_model_len", None)
+    if isinstance(max_model_len, int):
+        max_position_embeddings = max(max_position_embeddings, max_model_len)
+    return max_position_embeddings
+
+
+def _get_rope_parameters(config: PretrainedConfig) -> dict[str, Any] | None:
+    rope_parameters = getattr(config, "rope_parameters", None)
+    if rope_parameters is not None:
+        rope_parameters = dict(rope_parameters)
+    else:
+        rope_parameters = {
+            "rope_theta": getattr(config, "rope_theta", 10000),
+            "partial_rotary_factor": getattr(config, "partial_rotary_factor", 1.0),
+        }
+    return rope_parameters
+
+
+class MiniMaxM3SwiGLUOAI(nn.Module):
+    """MiniMax-M3 SwiGLU-OAI activation for packed gate/up outputs."""
+
+    def __init__(self, alpha: float, beta: float, limit: float):
+        super().__init__()
+        self.alpha = float(alpha)
+        self.beta = float(beta)
+        self.limit = float(limit)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.npu.npu_clipped_swiglu(
+            x,
+            dim=-1,
+            alpha=self.alpha,
+            limit=self.limit,
+            bias=self.beta,
+            interleaved=False,
+        )
+
+
+class MiniMaxM3MLP(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        intermediate_size: int | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        hidden_act = config.hidden_act
+        if intermediate_size is None:
+            intermediate_size = config.intermediate_size
+
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act == "swigluoai":
+            self.act_fn = MiniMaxM3SwiGLUOAI(
+                alpha=config.swiglu_alpha,
+                beta=getattr(config, "swiglu_beta", 1.0),
+                limit=config.swiglu_limit,
+            )
+        else:
+            raise ValueError(f"Unsupported activation: {hidden_act}. Only swigluoai is supported.")
+
+    def forward(
+        self,
+        x,
+    ):
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class MiniMaxM3MoE(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.n_shared_experts = getattr(config, "n_shared_experts", None)
+
+        if self.tp_size > config.num_local_experts:
+            raise ValueError(
+                f"Tensor parallel size {self.tp_size} is greater than the number of experts {config.num_local_experts}."
+            )
+        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+        self.use_routing_bias = getattr(config, "use_routing_bias", False)
+        if self.use_routing_bias:
+            self.e_score_correction_bias = nn.Parameter(torch.empty(config.num_local_experts, dtype=torch.float32))
+            self.e_score_correction_bias.weight_loader = MiniMaxM3MoE.ebias_weight_loader
+        else:
+            self.e_score_correction_bias = None
+
+        self.shared_experts: MiniMaxM3MLP | None
+        if self.n_shared_experts:
+            intermediate_size = config.intermediate_size * self.n_shared_experts
+            self.shared_experts = MiniMaxM3MLP(
+                config=config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.shared_experts",
+                reduce_results=False,
+                intermediate_size=intermediate_size,
+            )
+        else:
+            self.shared_experts = None
+
+        self.gate = GateLinear(
+            config.hidden_size,
+            config.num_local_experts,
+            bias=False,
+            params_dtype=torch.float32,
+            out_dtype=torch.float32,
+            prefix=f"{prefix}.gate",
+        )
+
+        self.experts = FusedMoE(
+            shared_experts=self.shared_experts,
+            num_experts=config.num_local_experts,
+            top_k=config.num_experts_per_tok,
+            scoring_func=config.scoring_func,
+            e_score_correction_bias=self.e_score_correction_bias,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            renormalize=True,
+            activation="swigluoai_uninterleave",
+            swiglu_limit=config.swiglu_limit,
+            swiglu_alpha=config.swiglu_alpha,
+            swiglu_beta=getattr(config, "swiglu_beta", 1.0),
+            quant_config=quant_config,
+            prefix=f"{prefix}.experts",
+            router_logits_dtype=self.gate.out_dtype,
+            routed_scaling_factor=self.routed_scaling_factor,
+            apply_routed_scale_to_output=True,
+        )
+
+    @staticmethod
+    def ebias_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        assert param.size() == loaded_weight.size()
+        param.data.copy_(loaded_weight.to(torch.float32))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        num_tokens, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+
+        # router_logits: (num_tokens, n_experts)
+        router_logits, _ = self.gate(hidden_states)
+        final_hidden_states = self.experts(hidden_states=hidden_states, router_logits=router_logits)
+
+        return final_hidden_states.view(num_tokens, hidden_dim)
+
+
+class MiniMaxM3Attention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rotary_dim: int,
+        rope_parameters: dict[str, Any] | None = None,
+        attn_window_size: int | None = None,
+        max_position_embeddings: int = 8192,
+        head_dim: int | None = None,
+        rms_norm_eps: float = 1e-06,
+        qkv_bias: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            # Number of KV heads is greater than TP size, so we partition
+            # the KV heads across multiple tensor parallel GPUs.
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            # Number of KV heads is less than TP size, so we replicate
+            # the KV heads across multiple tensor parallel GPUs.
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim or (hidden_size // self.total_num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.max_position_embeddings = max_position_embeddings
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=qkv_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        if rope_parameters is not None and "partial_rotary_factor" not in rope_parameters:
+            rope_parameters["partial_rotary_factor"] = rotary_dim / self.head_dim
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            max_position=max_position_embeddings,
+            rope_parameters=rope_parameters,
+        )
+
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=rms_norm_eps)
+
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            per_layer_sliding_window=attn_window_size,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+        )
+
+    def _qk_norm(self, q: torch.Tensor, k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        q_shape = q.shape
+        k_shape = k.shape
+        q = q.reshape(-1, self.head_dim).contiguous()
+        k = k.reshape(-1, self.head_dim).contiguous()
+        q = self.q_norm(q).reshape(q_shape)
+        k = self.k_norm(k).reshape(k_shape)
+        return q, k
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        v = v.contiguous()
+
+        q, k = self._qk_norm(q, k)
+        q, k = self.rotary_emb(positions, q, k)
+
+        attn_output = self.attn(q, k, v)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class MiniMaxM3DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        prefix: str,
+        model_config: ModelConfig,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        max_position_embeddings = _get_max_position_embeddings(config)
+        # DecoderLayers are created with `make_layers` which passes the prefix
+        # with the layer's index.
+        layer_idx = int(prefix.split(sep=".")[-1])
+
+        self.layer_idx = layer_idx
+
+        sparse_attention_config = getattr(config, "sparse_attention_config", None)
+
+        if sparse_attention_config is not None:
+            is_sparse_attention_layer = layer_idx in _sparse_attention_layer_ids(config)
+            disable_index_value = sparse_attention_config["sparse_disable_index_value"][layer_idx] == 1
+        else:
+            is_sparse_attention_layer = False
+            disable_index_value = False
+
+        attn_kwargs = dict(
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            rotary_dim=config.rotary_dim,
+            rope_parameters=_get_rope_parameters(config),
+            max_position_embeddings=max_position_embeddings,
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, "attention_bias", False),
+            head_dim=getattr(config, "head_dim", None),
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+        )
+        if is_sparse_attention_layer:
+            self.self_attn = MiniMaxM3SparseAttention(
+                **attn_kwargs,
+                sparse_cfg=sparse_attention_config,
+                disable_index_value=disable_index_value,
+            )
+        else:
+            self.self_attn = MiniMaxM3Attention(**attn_kwargs)
+
+        moe_layer_freq = getattr(config, "moe_layer_freq", None)
+        # ``is_layer_sparse`` here means "this layer's MLP is a sparse MoE",
+        # not anything about attention sparsity. The name is kept (instead of
+        # the clearer ``is_layer_moe``) to match the convention used by the
+        # rest of sglang -- ``OperationsStrategy``, ``LayerScatterModes``,
+        # ``LayerCommunicator``, ``gpt_oss``, ``falcon_h1`` etc all access
+        # ``layer.is_layer_sparse``.
+        self.is_layer_sparse = moe_layer_freq[layer_idx] != 0 if moe_layer_freq is not None else True
+
+        if self.is_layer_sparse:
+            self.block_sparse_moe = MiniMaxM3MoE(
+                config=config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.block_sparse_moe",
+            )
+        else:
+            self.mlp = MiniMaxM3MLP(
+                config=config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+                intermediate_size=config.dense_intermediate_size,
+            )
+        self.input_layernorm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> torch.Tensor:
+        # Self Attention
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+
+        # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+
+        if self.is_layer_sparse:
+            hidden_states = self.block_sparse_moe(hidden_states)
+        else:
+            hidden_states = self.mlp(hidden_states)
+
+        return hidden_states, residual
+
+
+@support_torch_compile
+class MiniMaxM3Model(nn.Module, EagleModelMixin):
+    fall_back_to_pt_during_load = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+
+        # config = vllm_config.model_config.hf_config
+        config = _get_text_config(vllm_config)
+        text_config = config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+        self._enable_eagle3_aux_hidden_states = (
+            vllm_config.speculative_config is not None and vllm_config.speculative_config.method == "eagle3"
+        )
+
+        self.vocab_size = text_config.vocab_size
+        self.num_hidden_layers = text_config.num_hidden_layers
+        if get_pp_group().is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                text_config.vocab_size,
+                text_config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            text_config.num_hidden_layers,
+            lambda prefix: MiniMaxM3DecoderLayer(
+                config,
+                prefix,
+                model_config=model_config,
+                cache_config=cache_config,
+                quant_config=quant_config,
+            ),
+            prefix=f"{prefix}.layers",
+        )
+
+        if get_pp_group().is_last_rank:
+            self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        for idx, layer in enumerate(islice(self.layers, self.start_layer, self.end_layer)):
+            hidden_states, residual = layer(positions, hidden_states, residual)
+            self._maybe_add_hidden_state(aux_hidden_states, idx + 1, hidden_states, residual)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+        hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+
+        return hidden_states
+
+    def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        if self._enable_eagle3_aux_hidden_states:
+            EagleModelMixin._set_aux_hidden_state_layers(self, layers)
+        else:
+            EagleModelMixin._set_aux_hidden_state_layers(self, ())
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self._set_aux_hidden_state_layers(layers)
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+            num_experts=self.config.num_local_experts,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping: list[tuple[str, str, int | str]] = [
+            # (param_name, shard_name, shard_id)
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".indexer_proj", ".index_q_proj", "index_q"),
+            (".indexer_proj", ".index_k_proj", "index_k"),
+            (".qkv_proj", ".index_q_proj", "index_q"),
+            (".qkv_proj", ".index_k_proj", "index_k"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+
+        # Params for weights, fp8 weight scales, fp8 activation scales
+        # (param_name, weight_name, expert_id, shard_id)
+        expert_params_mapping = self.get_expert_mapping()
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        loaded_tensors = 0
+        skipped_tensors = 0
+        skipped_reasons: dict[str, int] = {}
+
+        def mark_loaded(param_name: str) -> None:
+            nonlocal loaded_tensors
+            loaded_params.add(param_name)
+            loaded_tensors += 1
+
+        def mark_skipped(reason: str) -> None:
+            nonlocal skipped_tensors
+            skipped_tensors += 1
+            skipped_reasons[reason] = skipped_reasons.get(reason, 0) + 1
+
+        for name, loaded_weight in weights:
+            if name.startswith("model."):
+                name = name[len("model.") :]
+            if "mtp." in name:
+                mark_skipped("mtp")
+                continue
+            if "weight_scale_inv" in name:
+                name = name.replace("weight_scale_inv", "weight_scale")
+            elif "scale_inv" in name:
+                name = name.replace("scale_inv", "scale")
+            if "rotary_emb.inv_freq" in name:
+                mark_skipped("rotary_emb")
+                continue
+
+            spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+            if spec_layer is not None:
+                mark_skipped("spec_decode")
+                continue  # skip spec decode layers for main model
+
+            # Sparse layers fold index_q/index_k into fused qkv_proj (handled below).
+            # Other index_* weights (e.g. index_v/index_o) load explicitly here.
+            if ".index_" in name and ".index_q_proj" not in name and ".index_k_proj" not in name:
+                if name.endswith(".bias") and name not in params_dict:
+                    mark_skipped("missing_bias")
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    mark_skipped("pp_missing")
+                    continue
+                if name not in params_dict:
+                    mark_skipped("missing_index_param")
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                mark_loaded(name)
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                # Routed experts (w1/w2/w3) are handled below; don't let
+                # stacked dense/shared-expert mappings rewrite them.
+                if ("block_sparse_moe.experts." in name) and name not in params_dict:
+                    continue
+                param_name_full = name.replace(weight_name, param_name)
+                if param_name_full.endswith(".bias") and param_name_full not in params_dict:
+                    mark_skipped("missing_bias")
+                    continue
+                if is_pp_missing_parameter(param_name_full, self):
+                    mark_skipped("pp_missing")
+                    continue
+                if param_name_full.endswith((".k_scale", ".v_scale")):
+                    remapped_name = maybe_remap_kv_scale_name(param_name_full, params_dict)
+                    if remapped_name is not None and remapped_name in params_dict:
+                        param = params_dict[remapped_name]
+                        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                        weight_loader(param, loaded_weight)
+                        mark_loaded(remapped_name)
+                        break
+                if param_name_full not in params_dict:
+                    continue
+
+                param = params_dict[param_name_full]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                mark_loaded(param_name_full)
+                break
+            else:
+                is_expert_weight = False
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    if is_pp_missing_parameter(name_mapped, self):
+                        mark_skipped("pp_missing")
+                        break
+                    if name_mapped not in params_dict:
+                        continue
+
+                    param = params_dict[name_mapped]
+                    weight_loader = param.weight_loader
+                    success = weight_loader(
+                        param,
+                        loaded_weight,
+                        name_mapped,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        return_success=True,
+                    )
+                    if success:
+                        mark_loaded(name_mapped)
+                        break
+                else:
+                    if is_expert_weight:
+                        mark_skipped("nonlocal_or_unmapped_expert")
+                        continue
+
+                    if name.endswith(".bias") and name not in params_dict:
+                        mark_skipped("missing_bias")
+                        continue
+
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        mark_skipped("kv_scale_remap_missing")
+                        continue
+
+                    if is_pp_missing_parameter(name, self):
+                        mark_skipped("pp_missing")
+                        continue
+                    if name not in params_dict:
+                        mark_skipped("missing_param")
+                        continue
+
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    if getattr(weight_loader, "supports_moe_loading", False):
+                        if loaded_weight.shape == param.shape:
+                            default_weight_loader(param, loaded_weight)
+                            mark_loaded(name)
+                            continue
+                        raise ValueError(
+                            f"FusedMoE parameter {name!r} reached the "
+                            "fallback loader with an incompatible shape: "
+                            f"checkpoint={tuple(loaded_weight.shape)}, "
+                            f"parameter={tuple(param.shape)}. Add an expert "
+                            "mapping for this checkpoint weight instead."
+                        )
+                    weight_loader(param, loaded_weight)
+                    mark_loaded(name)
+        logger.warning(
+            "MiniMax M3 text load_weights loaded %d checkpoint tensors into "
+            "%d parameter names; skipped %d tensors by reason: %s",
+            loaded_tensors,
+            len(loaded_params),
+            skipped_tensors,
+            skipped_reasons,
+        )
+        return loaded_params
+
+
+class MiniMaxM3SparseForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "indexer_proj": ["index_q_proj", "index_k_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "experts": ["experts.0.w1", "experts.0.w2", "experts.0.w3"],
+    }
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "language_model.model.": "model.",
+            "language_model.lm_head.": "lm_head.",
+        }
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = _get_text_config(vllm_config)
+        quant_config = vllm_config.quant_config
+        self.config = config
+        self.quant_config = quant_config
+        if hasattr(vllm_config.model_config, "max_model_len"):
+            self.config.max_model_len = vllm_config.model_config.max_model_len
+        self.model = MiniMaxM3Model(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+            self.logits_processor = LogitsProcessor(config.vocab_size)
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.model.set_aux_hidden_state_layers(layers)
+
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        num_layers = len(self.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | IntermediateTensors:
+        hidden_states = self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        raw_tensors = 0
+        text_tensors = 0
+        skipped_multimodal_tensors = 0
+
+        def text_weights() -> Iterable[tuple[str, torch.Tensor]]:
+            nonlocal raw_tensors, text_tensors, skipped_multimodal_tensors
+            for name, weight in weights:
+                raw_tensors += 1
+                if "vision_tower" in name or "multi_modal_projector" in name or "patch_merge_mlp" in name:
+                    skipped_multimodal_tensors += 1
+                    continue
+                text_tensors += 1
+                yield name, weight
+
+        loaded_params = loader.load_weights(text_weights(), mapper=self.hf_to_vllm_mapper)
+        logger.warning(
+            "MiniMax M3 top-level load_weights saw %d checkpoint tensors, "
+            "passed %d text tensors, skipped %d multimodal tensors, "
+            "returned %d loaded parameter names",
+            raw_tensors,
+            text_tensors,
+            skipped_multimodal_tensors,
+            len(loaded_params),
+        )
+        return loaded_params
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.model.get_expert_mapping()
+
+
+def get_spec_layer_idx_from_weight_name(config: PretrainedConfig, weight_name: str) -> int | None:
+    if hasattr(config, "num_mtp_modules") and (config.num_mtp_modules > 0):
+        layer_idx = config.num_hidden_layers
+        for i in range(config.num_mtp_modules):
+            if weight_name.startswith(f"model.layers.{layer_idx + i}."):
+                return layer_idx + i
+    return None

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -1,0 +1,1067 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax-M3 sparse attention and indexer backends for Ascend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import torch
+from torch import nn
+from torch.nn.parameter import Parameter
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.config.cache import CacheDType
+from vllm.distributed import divide, get_tensor_model_parallel_world_size
+from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.linear import (
+    QKVParallelLinear,
+    adjust_block_scale_shard,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.parameter import BasevLLMParameter, BlockQuantScaleParameter
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionImplBase,
+    AttentionLayer,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheSpec,
+)
+
+from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import minimax_m3_sparse_attn
+from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
+    minimax_m3_index_decode,
+    minimax_m3_index_score,
+    minimax_m3_index_topk,
+    minimax_m3_sparse_attn_decode,
+)
+from vllm_ascend.ops.linear import AscendColumnParallelLinear
+from vllm_ascend.ops.linear_op import get_parallel_op
+
+
+def _active_decode_num_reqs(
+    num_decodes: int,
+    num_decode_tokens: int,
+    decode_query_len: int,
+) -> int:
+    """Return the number of real decode requests, ignoring FIA/graph padding."""
+    if decode_query_len <= 0:
+        return 0
+    return min(num_decodes, num_decode_tokens // decode_query_len)
+
+
+def _active_prefill_num_reqs(
+    num_prefills: int,
+    num_prefill_tokens: int,
+    query_start_loc_cpu: torch.Tensor,
+    num_decodes: int,
+) -> int:
+    """Return real prefill requests, ignoring FIA/SP tail padding segments."""
+    if num_prefills <= 0 or num_prefill_tokens <= 0:
+        return 0
+    qsl_cpu = query_start_loc_cpu.detach().cpu()
+    num_reqs_fia = int(qsl_cpu.shape[0] - 1)
+    active = 0
+    tokens_accounted = 0
+    for i in range(num_decodes, min(num_reqs_fia, num_decodes + num_prefills)):
+        query_len = int(qsl_cpu[i + 1] - qsl_cpu[i])
+        if query_len <= 0:
+            continue
+        if tokens_accounted + query_len > num_prefill_tokens:
+            break
+        tokens_accounted += query_len
+        active += 1
+    if active > 0:
+        return active
+    return min(1, num_prefills)
+
+
+class AscendMiniMaxM3IndexerBackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16, torch.float16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+        "fp8_e5m2",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "ASCEND_MINIMAX_M3_SPARSE_INDEXER"
+
+    @staticmethod
+    def get_impl_cls() -> type[AscendMiniMaxM3IndexerImpl]:
+        return AscendMiniMaxM3IndexerImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[AscendMiniMaxM3IndexerMetadataBuilder]:
+        return AscendMiniMaxM3IndexerMetadataBuilder
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [128]
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [128]
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        del num_kv_heads, cache_dtype_str
+        return (num_blocks, block_size, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        if include_num_layers_dimension:
+            raise NotImplementedError
+        return (0, 1, 2)
+
+
+class AscendMiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
+    def __init__(
+        self,
+        head_dim: int,
+        prefix: str,
+        cache_config: CacheConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.kv_cache = torch.tensor([])
+        self.head_dim = head_dim
+        self.dtype = torch.bfloat16
+        self.prefix = prefix
+        self.cache_config = cache_config
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return AscendSFAIndexerCacheSpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=1,
+            head_size=self.head_dim,
+            dtype=self.dtype,
+        )
+
+    def forward(self) -> None: ...
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return AscendMiniMaxM3IndexerBackend
+
+
+@dataclass
+class AscendMiniMaxM3IndexerPrefillMetadata:
+    cu_seqlens_q: torch.Tensor
+    seq_lens: torch.Tensor
+    context_lens: torch.Tensor
+    block_table: torch.Tensor
+    max_query_len: int
+    max_seq_len: int
+
+
+@dataclass
+class AscendMiniMaxM3IndexerDecodeMetadata:
+    seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    max_seq_len: int
+    decode_query_len: int
+
+
+@dataclass
+class AscendMiniMaxM3IndexerMetadata(AttentionMetadata):
+    seq_lens: torch.Tensor
+    max_seq_len: int
+    slot_mapping: torch.Tensor
+    num_actual_tokens: int
+    num_decodes: int
+    num_decode_tokens: int
+    num_prefills: int
+    num_prefill_tokens: int
+    prefill: AscendMiniMaxM3IndexerPrefillMetadata | None = None
+    decode: AscendMiniMaxM3IndexerDecodeMetadata | None = None
+
+
+class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniMaxM3IndexerMetadata]):
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    reorder_batch_threshold: int = 1
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        self.context_len_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> AscendMiniMaxM3IndexerMetadata:
+        num_tokens = common_attn_metadata.num_actual_tokens
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        block_table = common_attn_metadata.block_table_tensor
+        qsl_cpu = common_attn_metadata.query_start_loc_cpu
+
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.reorder_batch_threshold,
+            require_uniform=True,
+        )
+
+        prefill_metadata: AscendMiniMaxM3IndexerPrefillMetadata | None = None
+        active_prefills = 0
+        if num_prefills > 0:
+            active_prefills = _active_prefill_num_reqs(num_prefills, num_prefill_tokens, qsl_cpu, num_decodes)
+            prefill_end = num_decodes + active_prefills
+            prefill_query_lens_cpu = qsl_cpu[num_decodes + 1 : prefill_end + 1] - qsl_cpu[num_decodes:prefill_end]
+            prefill_context_lens = self.context_len_buffer[num_decodes:prefill_end]
+            prefill_context_lens.copy_(
+                (seq_lens[num_decodes:prefill_end].detach().cpu() - prefill_query_lens_cpu).to(
+                    device=self.context_len_buffer.device,
+                    dtype=torch.int32,
+                    non_blocking=True,
+                ),
+                non_blocking=True,
+            )
+            cu_seqlens_q = (query_start_loc[num_decodes : prefill_end + 1] - num_decode_tokens).to(torch.int32)
+            prefill_metadata = AscendMiniMaxM3IndexerPrefillMetadata(
+                cu_seqlens_q=cu_seqlens_q,
+                seq_lens=seq_lens[num_decodes:prefill_end],
+                context_lens=prefill_context_lens,
+                block_table=block_table[num_decodes:prefill_end],
+                max_query_len=common_attn_metadata.max_query_len,
+                max_seq_len=common_attn_metadata.max_seq_len,
+            )
+
+        decode_metadata: AscendMiniMaxM3IndexerDecodeMetadata | None = None
+        active_decodes = 0
+        if num_decodes > 0:
+            qsl_cpu = common_attn_metadata.query_start_loc_cpu
+            query_lens_cpu = qsl_cpu[1 : num_decodes + 1] - qsl_cpu[:num_decodes]
+            decode_query_len = int(query_lens_cpu[0].item())
+            active_decodes = _active_decode_num_reqs(num_decodes, num_decode_tokens, decode_query_len)
+            decode_metadata = AscendMiniMaxM3IndexerDecodeMetadata(
+                seq_lens=seq_lens[:active_decodes],
+                block_table=block_table[:active_decodes],
+                max_seq_len=common_attn_metadata.max_seq_len,
+                decode_query_len=decode_query_len,
+            )
+
+        return AscendMiniMaxM3IndexerMetadata(
+            seq_lens=seq_lens,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            slot_mapping=common_attn_metadata.slot_mapping,
+            num_actual_tokens=num_tokens,
+            num_decodes=active_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_prefills=active_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            prefill=prefill_metadata,
+            decode=decode_metadata,
+        )
+
+
+class AscendMiniMaxM3IndexerImpl(nn.Module):
+    def __init__(
+        self,
+        *,
+        num_kv_heads: int,
+        scale: float,
+        topk_blocks: int,
+        sparse_block_size: int,
+        num_index_heads: int,
+        index_head_dim: int,
+        prefix: str,
+        init_blocks: int = 0,
+        local_blocks: int = 0,
+        cache_config: CacheConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.num_kv_heads = num_kv_heads
+        self.scale = scale
+        self.topk_blocks = topk_blocks
+        self.block_size = sparse_block_size
+        self.init_blocks = init_blocks
+        self.local_blocks = local_blocks
+        self.num_index_heads = num_index_heads
+        self.index_head_dim = index_head_dim
+        self.index_cache = AscendMiniMaxM3IndexerCache(
+            head_dim=index_head_dim,
+            prefix=f"{prefix}.index_cache",
+            cache_config=cache_config,
+        )
+
+    def forward(
+        self,
+        index_query: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        attn_metadata = get_forward_context().attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return None, None
+        index_md = attn_metadata[self.index_cache.prefix]
+        assert isinstance(index_md, AscendMiniMaxM3IndexerMetadata)
+        num_tokens = index_md.num_actual_tokens
+        num_decode_tokens = index_md.num_decode_tokens
+        iq = index_query[:num_tokens].view(-1, self.num_index_heads, self.index_head_dim)
+        kv = self.index_cache.kv_cache
+
+        decode_topk: torch.Tensor | None = None
+        prefill_topk: torch.Tensor | None = None
+        if index_md.num_decodes > 0:
+            d = index_md.decode
+            assert d is not None
+            decode_topk = minimax_m3_index_decode(
+                iq[:num_decode_tokens],
+                kv,
+                d.block_table,
+                d.seq_lens,
+                d.max_seq_len,
+                self.topk_blocks,
+                self.init_blocks,
+                self.local_blocks,
+                self.num_kv_heads,
+                d.decode_query_len,
+                sm_scale=self.scale,
+            )
+        if index_md.num_prefills > 0:
+            p = index_md.prefill
+            assert p is not None
+            score = minimax_m3_index_score(
+                iq[num_decode_tokens:],
+                kv,
+                p.block_table,
+                p.cu_seqlens_q,
+                p.seq_lens,
+                p.context_lens,
+                p.max_query_len,
+                p.max_seq_len,
+                self.num_kv_heads,
+                self.scale,
+            )
+            prefill_topk = minimax_m3_index_topk(
+                score,
+                p.cu_seqlens_q,
+                p.context_lens,
+                p.max_query_len,
+                self.topk_blocks,
+                self.init_blocks,
+                self.local_blocks,
+            )
+        return decode_topk, prefill_topk
+
+
+class AscendMiniMaxM3Indexer(nn.Module):
+    def __init__(
+        self,
+        *,
+        num_kv_heads: int,
+        scale: float,
+        topk_blocks: int,
+        sparse_block_size: int,
+        num_index_heads: int,
+        index_head_dim: int,
+        prefix: str,
+        init_blocks: int = 0,
+        local_blocks: int = 0,
+        cache_config: CacheConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.impl = AscendMiniMaxM3IndexerImpl(
+            num_kv_heads=num_kv_heads,
+            scale=scale,
+            topk_blocks=topk_blocks,
+            sparse_block_size=sparse_block_size,
+            num_index_heads=num_index_heads,
+            index_head_dim=index_head_dim,
+            prefix=prefix,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            cache_config=cache_config,
+        )
+
+    @property
+    def index_cache(self) -> AscendMiniMaxM3IndexerCache:
+        return self.impl.index_cache
+
+    def forward(
+        self,
+        index_query: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        return self.impl(index_query)
+
+
+class AscendMiniMaxM3SparseBackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16, torch.float16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+        "fp8_e5m2",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "ASCEND_MINIMAX_M3_SPARSE"
+
+    @staticmethod
+    def get_impl_cls() -> type[AscendMiniMaxM3SparseImpl]:
+        return AscendMiniMaxM3SparseImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[AscendMiniMaxM3SparseMetadataBuilder]:
+        return AscendMiniMaxM3SparseMetadataBuilder
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [128]
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [128]
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        if include_num_layers_dimension:
+            raise NotImplementedError
+        return (0, 1, 2, 3, 4)
+
+
+@dataclass
+class AscendMiniMaxM3SparsePrefillMetadata:
+    cu_seqlens_q: torch.Tensor
+    cu_seqlens_k: torch.Tensor
+    seq_lens: torch.Tensor
+    context_lens: torch.Tensor
+    block_table: torch.Tensor
+    max_query_len: int
+    max_seq_len: int
+
+
+@dataclass
+class AscendMiniMaxM3SparseDecodeMetadata:
+    seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    max_seq_len: int
+    decode_query_len: int
+
+
+@dataclass
+class AscendMiniMaxM3SparseMetadata(AttentionMetadata):
+    seq_lens: torch.Tensor
+    max_seq_len: int
+    slot_mapping: torch.Tensor
+    num_actual_tokens: int
+    num_decodes: int
+    num_decode_tokens: int
+    num_prefills: int
+    num_prefill_tokens: int
+    prefill: AscendMiniMaxM3SparsePrefillMetadata | None = None
+    decode: AscendMiniMaxM3SparseDecodeMetadata | None = None
+
+
+class AscendMiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[AscendMiniMaxM3SparseMetadata]):
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    reorder_batch_threshold: int = 1
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        self.context_len_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> AscendMiniMaxM3SparseMetadata:
+        num_tokens = common_attn_metadata.num_actual_tokens
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        block_table = common_attn_metadata.block_table_tensor
+        qsl_cpu = common_attn_metadata.query_start_loc_cpu
+
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.reorder_batch_threshold,
+            require_uniform=True,
+        )
+
+        prefill_metadata: AscendMiniMaxM3SparsePrefillMetadata | None = None
+        active_prefills = 0
+        if num_prefills > 0:
+            active_prefills = _active_prefill_num_reqs(num_prefills, num_prefill_tokens, qsl_cpu, num_decodes)
+            prefill_end = num_decodes + active_prefills
+            prefill_kv_lens = seq_lens[num_decodes:prefill_end]
+            prefill_cu_seqlens_k = torch.empty(active_prefills + 1, dtype=torch.int32, device=seq_lens.device)
+            prefill_cu_seqlens_k[0] = 0
+            torch.cumsum(prefill_kv_lens, dim=0, out=prefill_cu_seqlens_k[1:])
+            prefill_query_lens_cpu = qsl_cpu[num_decodes + 1 : prefill_end + 1] - qsl_cpu[num_decodes:prefill_end]
+            prefill_context_lens = self.context_len_buffer[num_decodes:prefill_end]
+            prefill_context_lens.copy_(
+                (prefill_kv_lens.detach().cpu() - prefill_query_lens_cpu).to(
+                    device=self.context_len_buffer.device,
+                    dtype=torch.int32,
+                    non_blocking=True,
+                ),
+                non_blocking=True,
+            )
+            cu_seqlens_q = (query_start_loc[num_decodes : prefill_end + 1] - num_decode_tokens).to(torch.int32)
+            prefill_metadata = AscendMiniMaxM3SparsePrefillMetadata(
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=prefill_cu_seqlens_k,
+                seq_lens=prefill_kv_lens,
+                context_lens=prefill_context_lens,
+                block_table=block_table[num_decodes:prefill_end],
+                max_query_len=common_attn_metadata.max_query_len,
+                max_seq_len=common_attn_metadata.max_seq_len,
+            )
+
+        decode_metadata: AscendMiniMaxM3SparseDecodeMetadata | None = None
+        active_decodes = 0
+        if num_decodes > 0:
+            qsl_cpu = common_attn_metadata.query_start_loc_cpu
+            query_lens_cpu = qsl_cpu[1 : num_decodes + 1] - qsl_cpu[:num_decodes]
+            decode_query_len = int(query_lens_cpu[0].item())
+            active_decodes = _active_decode_num_reqs(num_decodes, num_decode_tokens, decode_query_len)
+            decode_metadata = AscendMiniMaxM3SparseDecodeMetadata(
+                seq_lens=seq_lens[:active_decodes],
+                block_table=block_table[:active_decodes],
+                max_seq_len=common_attn_metadata.max_seq_len,
+                decode_query_len=decode_query_len,
+            )
+
+        return AscendMiniMaxM3SparseMetadata(
+            seq_lens=seq_lens,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            slot_mapping=common_attn_metadata.slot_mapping,
+            num_actual_tokens=num_tokens,
+            num_decodes=active_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_prefills=active_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            prefill=prefill_metadata,
+            decode=decode_metadata,
+        )
+
+
+class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int | None = None,
+        kv_cache_dtype: str = "auto",
+        *,
+        topk_blocks: int,
+        sparse_block_size: int,
+    ) -> None:
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = scale
+        self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        self.topk_blocks = topk_blocks
+        self.block_size = sparse_block_size
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        kv_cache: torch.Tensor,
+        topk_idx: tuple[torch.Tensor | None, torch.Tensor | None],
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        attn_metadata = get_forward_context().attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return output
+        main_md = attn_metadata[layer.layer_name]
+        assert isinstance(main_md, AscendMiniMaxM3SparseMetadata)
+        decode_topk, prefill_topk = topk_idx
+
+        num_decode_tokens = main_md.num_decode_tokens
+        num_tokens = main_md.num_actual_tokens
+        hd = self.head_size
+        q = query[:num_tokens].view(-1, self.num_heads, hd)
+        out = output[:num_tokens].view(-1, self.num_heads, hd)
+
+        if main_md.num_decodes > 0:
+            d = main_md.decode
+            assert d is not None and decode_topk is not None
+            minimax_m3_sparse_attn_decode(
+                q[:num_decode_tokens],
+                kv_cache,
+                decode_topk,
+                d.block_table,
+                d.seq_lens,
+                self.num_kv_heads,
+                self.scale,
+                out[:num_decode_tokens],
+                d.decode_query_len,
+            )
+
+        if main_md.num_prefills > 0:
+            p = main_md.prefill
+            assert p is not None and prefill_topk is not None
+            minimax_m3_sparse_attn(
+                q[num_decode_tokens:],
+                kv_cache,
+                prefill_topk,
+                p.block_table,
+                p.cu_seqlens_q,
+                p.seq_lens,
+                p.context_lens,
+                p.max_query_len,
+                self.num_kv_heads,
+                self.scale,
+                out[num_decode_tokens:],
+                block_size=self.block_size,
+            )
+        return output
+
+
+class AscendMiniMaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
+    """Fused [q | k | v | index_q | index_k] column-parallel GEMM for M3 sparse layers."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: int,
+        total_num_index_heads: int,
+        index_head_size: int,
+        bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        assert total_num_index_heads == total_num_kv_heads, (
+            "AscendMiniMaxM3QKVParallelLinearWithIndexer requires total_num_index_heads == total_num_kv_heads"
+        )
+        self.hidden_size = hidden_size
+        self.head_size = head_size
+        self.v_head_size = head_size
+        self.total_num_heads = total_num_heads
+        self.total_num_kv_heads = total_num_kv_heads
+        self.total_num_index_heads = total_num_index_heads
+        self.index_head_size = index_head_size
+
+        tp_size = get_tensor_model_parallel_world_size()
+        self.num_heads = divide(self.total_num_heads, tp_size)
+        if tp_size >= self.total_num_kv_heads:
+            self.num_kv_heads = 1
+            self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
+        else:
+            self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
+            self.num_kv_head_replicas = 1
+        self.num_index_heads = self.num_kv_heads
+
+        q = self.num_heads * self.head_size
+        kv = self.num_kv_heads * self.head_size
+        iq = self.num_index_heads * self.index_head_size
+        ik = self.index_head_size
+        self.output_sizes = [
+            q * tp_size,
+            kv * tp_size,
+            kv * tp_size,
+            iq * tp_size,
+            ik * tp_size,
+        ]
+
+        self.custom_op, _, _ = get_parallel_op(False, prefix, self, "column")
+        AscendColumnParallelLinear.__init__(
+            self,
+            input_size=self.hidden_size,
+            output_size=sum(self.output_sizes),
+            bias=bias,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    def forward(self, input_):
+        if self.custom_op is not None:
+            return self.custom_op.apply(input_)
+        return super().forward(input_)
+
+    def validate_shard_id(self, loaded_shard_id: str | None) -> None:
+        if loaded_shard_id is None:
+            return
+        if loaded_shard_id not in ("q", "k", "v", "index_q", "index_k"):
+            raise ValueError(
+                "Shard id for AscendMiniMaxM3QKVParallelLinearWithIndexer must be "
+                "one of 'q', 'k', 'v', 'index_q', 'index_k'; got "
+                f"{loaded_shard_id}."
+            )
+
+    def _get_shard_offset_mapping(self, loaded_shard_id: str) -> int | None:
+        h = self.head_size
+        nq, nkv, nidx = self.num_heads, self.num_kv_heads, self.num_index_heads
+        return {
+            "q": 0,
+            "k": nq * h,
+            "v": (nq + nkv) * h,
+            "index_q": (nq + 2 * nkv) * h,
+            "index_k": (nq + 2 * nkv + nidx) * h,
+        }.get(loaded_shard_id)
+
+    def _get_shard_size_mapping(self, loaded_shard_id: str) -> int | None:
+        h = self.head_size
+        return {
+            "q": self.num_heads * h,
+            "k": self.num_kv_heads * h,
+            "v": self.num_kv_heads * h,
+            "index_q": self.num_index_heads * h,
+            "index_k": self.index_head_size,
+        }.get(loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        self.validate_shard_id(loaded_shard_id)
+        assert loaded_shard_id in ("q", "k", "v", "index_q", "index_k")
+
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        shard_size = self._get_shard_size_mapping(loaded_shard_id)
+        assert shard_offset is not None and shard_size is not None
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = getattr(self, "weight_block_size", None)
+            shard_size, shard_offset = adjust_block_scale_shard(weight_block_size, shard_size, shard_offset)
+
+        num_heads = self.tp_size if loaded_shard_id == "index_k" else self.num_kv_head_replicas
+        param.load_qkv_weight(
+            loaded_weight=loaded_weight,
+            num_heads=num_heads,
+            shard_id=loaded_shard_id,
+            shard_offset=shard_offset,
+            shard_size=shard_size,
+            tp_rank=self.tp_rank,
+        )
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        self.validate_shard_id(loaded_shard_id)
+        assert loaded_shard_id in ("q", "k", "v", "index_q", "index_k")
+        output_dim = getattr(param, "output_dim", None)
+        assert output_dim is not None
+
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        shard_size = self._get_shard_size_mapping(loaded_shard_id)
+        assert shard_offset is not None and shard_size is not None
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = getattr(self, "weight_block_size", None)
+            shard_size, shard_offset = adjust_block_scale_shard(weight_block_size, shard_size, shard_offset)
+
+        param_data = param.data.narrow(output_dim, shard_offset, shard_size)
+        if loaded_shard_id == "q":
+            shard_rank = self.tp_rank
+        elif loaded_shard_id == "index_k":
+            shard_rank = 0
+        else:
+            shard_rank = self.tp_rank // self.num_kv_head_replicas
+        loaded_weight = loaded_weight.narrow(output_dim, shard_rank * shard_size, shard_size)
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+
+class AscendMiniMaxM3IndexerLinear(AscendColumnParallelLinear):
+    """Merged [index_q | index_k] projection for M3 sparse layers.
+
+    index_q follows KV-head tensor parallel sharding. index_k is always
+    replicated, so every TP rank loads the first index_k shard.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        total_num_index_heads: int,
+        index_head_size: int,
+        bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        self.hidden_size = hidden_size
+        self.total_num_index_heads = total_num_index_heads
+        self.index_head_size = index_head_size
+
+        tp_size = get_tensor_model_parallel_world_size()
+        if tp_size >= self.total_num_index_heads:
+            self.num_index_heads = 1
+            self.num_index_head_replicas = divide(tp_size, self.total_num_index_heads)
+        else:
+            self.num_index_heads = divide(self.total_num_index_heads, tp_size)
+            self.num_index_head_replicas = 1
+
+        self.index_q_size = self.num_index_heads * self.index_head_size
+        self.index_k_size = self.index_head_size
+        self.output_sizes = [
+            self.index_q_size * tp_size,
+            self.index_k_size * tp_size,
+        ]
+
+        self.custom_op, _, _ = get_parallel_op(False, prefix, self, "column")
+        AscendColumnParallelLinear.__init__(
+            self,
+            input_size=self.hidden_size,
+            output_size=sum(self.output_sizes),
+            bias=bias,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    def forward(self, input_):
+        if self.custom_op is not None:
+            return self.custom_op.apply(input_)
+        return super().forward(input_)
+
+    def validate_shard_id(self, loaded_shard_id: str | None) -> None:
+        if loaded_shard_id is None:
+            return
+        if loaded_shard_id not in ("index_q", "index_k"):
+            raise ValueError(
+                f"Shard id for AscendMinimaxM3Indexer must be one of 'index_q', 'index_k'; got {loaded_shard_id}."
+            )
+
+    def _get_shard_offset_mapping(self, loaded_shard_id: str) -> int | None:
+        return {
+            "index_q": 0,
+            "index_k": self.index_q_size,
+        }.get(loaded_shard_id)
+
+    def _get_shard_size_mapping(self, loaded_shard_id: str) -> int | None:
+        return {
+            "index_q": self.index_q_size,
+            "index_k": self.index_k_size,
+        }.get(loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        self.validate_shard_id(loaded_shard_id)
+        assert loaded_shard_id in ("index_q", "index_k")
+
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        shard_size = self._get_shard_size_mapping(loaded_shard_id)
+        assert shard_offset is not None and shard_size is not None
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = getattr(self, "weight_block_size", None)
+            shard_size, shard_offset = adjust_block_scale_shard(weight_block_size, shard_size, shard_offset)
+
+        num_heads = self.tp_size if loaded_shard_id == "index_k" else self.num_index_head_replicas
+        param.load_qkv_weight(
+            loaded_weight=loaded_weight,
+            num_heads=num_heads,
+            shard_id=loaded_shard_id,
+            shard_offset=shard_offset,
+            shard_size=shard_size,
+            tp_rank=self.tp_rank,
+        )
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight,
+        loaded_shard_id: str | None = None,
+    ) -> None:
+        self.validate_shard_id(loaded_shard_id)
+        assert loaded_shard_id in ("index_q", "index_k")
+        output_dim = getattr(param, "output_dim", None)
+        assert output_dim is not None
+
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        shard_size = self._get_shard_size_mapping(loaded_shard_id)
+        assert shard_offset is not None and shard_size is not None
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = getattr(self, "weight_block_size", None)
+            shard_size, shard_offset = adjust_block_scale_shard(weight_block_size, shard_size, shard_offset)
+        assert shard_size is not None
+
+        param_data = param.data.narrow(output_dim, shard_offset, shard_size)
+        if loaded_shard_id == "index_k":
+            shard_rank = 0
+        else:
+            shard_rank = self.tp_rank // self.num_index_head_replicas
+        loaded_weight = loaded_weight.narrow(output_dim, shard_rank * shard_size, shard_size)
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+
+def _quant_description_value(
+    quant_config: QuantizationConfig | None,
+    key: str,
+) -> Any | None:
+    quant_description = getattr(quant_config, "quant_description", None)
+    if not isinstance(quant_description, dict):
+        return None
+    return quant_description.get(key)
+
+
+def _sparse_proj_quant_type(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+    proj_name: str,
+) -> Any | None:
+    candidates = [prefix]
+    if not prefix.startswith("language_model."):
+        candidates.append(f"language_model.{prefix}")
+    if prefix.startswith("model."):
+        candidates.append(f"language_model.{prefix}")
+
+    for candidate in dict.fromkeys(candidates):
+        value = _quant_description_value(
+            quant_config,
+            f"{candidate}.{proj_name}.weight",
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def _use_fused_qkv_indexer(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> bool:
+    if quant_config is None:
+        return True
+
+    qkv_types = [
+        _sparse_proj_quant_type(quant_config, prefix, proj_name) for proj_name in ("q_proj", "k_proj", "v_proj")
+    ]
+    index_q_type = _sparse_proj_quant_type(quant_config, prefix, "index_q_proj")
+    index_k_type = _sparse_proj_quant_type(quant_config, prefix, "index_k_proj")
+
+    if any(value is None for value in (*qkv_types, index_q_type, index_k_type)):
+        return True
+    if len(set(qkv_types)) != 1:
+        raise ValueError(f"MiniMax M3 q/k/v quantization types differ for {prefix}: {qkv_types}")
+    if index_q_type != index_k_type:
+        raise ValueError(
+            f"MiniMax M3 index_q/index_k quantization types differ for {prefix}: {index_q_type} vs {index_k_type}"
+        )
+    return qkv_types[0] == index_q_type
+
+
+def _register_m3_sparse_packed_modules(
+    quant_config: QuantizationConfig | None,
+    fused_qkv_indexer: bool,
+) -> None:
+    if quant_config is None:
+        return
+    packed_modules_mapping = getattr(quant_config, "packed_modules_mapping", None)
+    if not isinstance(packed_modules_mapping, dict):
+        return
+    packed_modules_mapping["qkv_proj"] = ["q_proj", "k_proj", "v_proj"]
+    if not fused_qkv_indexer:
+        packed_modules_mapping["indexer_proj"] = ["index_q_proj", "index_k_proj"]
+
+
+def minimax_m3_sparse_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    index_query: torch.Tensor,
+    index_key: torch.Tensor,
+    attn_output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    forward_context: ForwardContext = get_forward_context()
+
+    attn_metadata = forward_context.attn_metadata
+    if not isinstance(attn_metadata, dict):
+        attn_output.zero_()
+        return
+
+    layer = forward_context.no_compile_layers[layer_name]
+    layer._run_sparse_attention(query, key, value, index_query, index_key, attn_output)
+
+
+def minimax_m3_sparse_forward_fake(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    index_query: torch.Tensor,
+    index_key: torch.Tensor,
+    attn_output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="minimax_m3_sparse_forward",
+    op_func=minimax_m3_sparse_forward,
+    mutates_args=["attn_output"],
+    fake_impl=minimax_m3_sparse_forward_fake,
+    dispatch_key="PrivateUse1",
+)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -57,6 +57,7 @@ from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
     AttentionMetadata,
+    MultipleOf,
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
@@ -4425,6 +4426,22 @@ class NPUModelRunner(GPUModelRunner):
             layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase, kv_cache_group_spec.layer_names)
             attn_backends = {}
             attn_backend_layers = defaultdict(list)
+
+            def backend_supports_kernel_block_size(
+                attn_backend: type[AttentionBackend],
+                block_size: int,
+            ) -> bool:
+                for supported_size in attn_backend.get_supported_kernel_block_sizes():
+                    if isinstance(supported_size, int):
+                        if block_size == supported_size:
+                            return True
+                    elif isinstance(supported_size, MultipleOf):
+                        if block_size % supported_size.base == 0:
+                            return True
+                    else:
+                        raise ValueError(f"Unknown supported size: {supported_size}")
+                return False
+
             # Dedupe based on full class name; this is a bit safer than
             # using the class itself as the key because when we create dynamic
             # attention backend subclasses (e.g. ChunkedLocalAttention) unless
@@ -4434,12 +4451,19 @@ class NPUModelRunner(GPUModelRunner):
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                     layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
-                if isinstance(layer_kv_cache_spec, AscendSFAIndexerCacheSpec):
+                # Prefer the backend declared by the layer itself. Some
+                # indexer-cache layers require their own metadata builder.
+                attn_backend = layers[layer_name].get_attn_backend()
+                if (
+                    isinstance(layer_kv_cache_spec, AscendSFAIndexerCacheSpec)
+                    and not backend_supports_kernel_block_size(
+                        attn_backend,
+                        layer_kv_cache_spec.block_size,
+                    )
+                ):
                     from vllm_ascend.attention.indexer import AscendSFAIndexerBackend
 
                     attn_backend = AscendSFAIndexerBackend
-                else:
-                    attn_backend = layers[layer_name].get_attn_backend()
                 full_cls_name = attn_backend.full_cls_name()
                 key = (full_cls_name, layer_kv_cache_spec)
                 attn_backends[key] = AttentionGroupKey(attn_backend, layer_kv_cache_spec)
@@ -4607,6 +4631,11 @@ class NPUModelRunner(GPUModelRunner):
                         dtype=spec.dtype,
                         cache_dtype_str=spec.cache_dtype_str,
                     )
+                    attn_layer_names.add(layer_name)
+
+            elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
+                kv_cache_spec[layer_name] = spec
+                if isinstance(spec, AttentionSpec):
                     attn_layer_names.add(layer_name)
 
         if len(mamba_layers) > 0:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the MiniMax M3 model core support on Ascend (split from https://github.com/vllm-project/vllm-ascend/pull/12734, based on the implementation from https://github.com/vllm-project/vllm-ascend/pull/12448):

- Registers `MiniMaxM3SparseForCausalLM` in the Ascend model registry.
- Adds the MiniMax M3 sparse text model implementation.
- Adds MiniMax M3 MSA/indexer cache support.
- Adds a guard to reject `enable_fused_mc2=1` for MiniMax M3, which is currently unsupported.
- Updates `model_runner_v1.py` to discover custom `AttentionLayerBase` KV cache specs and attention backends through the existing `get_kv_cache_spec()` and `get_attn_backend()` interfaces.

The runner change does not introduce MiniMax-specific imports into `model_runner_v1.py`. It keeps model-specific behavior inside the model/backend implementation and lets the runner depend on the common `AttentionLayerBase` abstraction.

These changes provide the model-side components required to run MiniMax M3 sparse attention on Ascend, together with the sparse-attention operators added in https://github.com/vllm-project/vllm-ascend/pull/12833.

### Does this PR introduce _any_ user-facing change?

Yes. This PR introduces MiniMax M3 sparse text model support on Ascend. It does not change an existing public CLI or API.

### How was this patch tested?

Verified MiniMax M3 service startup on 8 Ascend cards with W8A8 quantization.

Verified single curl requests:

- Text request passed.
- Image request passed.
- Video request passed.

The following checks were run:

- `bash format.sh`
- `bash format.sh ci`
- `pytest tests/ut/worker/a2/test_model_runner_v1.py`
- `pytest tests/ut/attention/a2/test_sfa_v1.py`
- `pytest tests/ut/attention/a2/test_sfa_cp_precision.py`
- `pytest tests/ut/patch/worker/test_patch_deepseek_v2.py`
- `pytest tests/ut/kv_offload/test_mooncake_connector.py -k "sfa or indexer"`

Test results:

- `tests/ut/worker/a2/test_model_runner_v1.py`: 18 passed
- `tests/ut/attention/a2/test_sfa_v1.py`: 31 passed
- `tests/ut/attention/a2/test_sfa_cp_precision.py`: 2 passed
- `tests/ut/patch/worker/test_patch_deepseek_v2.py`: 3 passed
- `tests/ut/kv_offload/test_mooncake_connector.py -k "sfa or indexer"`: 5 passed, 99 deselected


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
