### PR TITLE
[Feature][MRV2] Support FullGraph for MTP in MRV2

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -250,21 +250,27 @@ def test_dspark_spec_decoding(
 
 @pytest.mark.parametrize("model", MTP_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
-@pytest.mark.parametrize("enforce_eager", [True])
+@pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize(
+    "compilation_config",
+    [
+        pytest.param(
+            {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]},
+            id="full_decode_only",
+        ),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
+)
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 def test_mtp_spec_decoding(
     model: str,
     max_tokens: int,
     enforce_eager: bool,
+    compilation_config: dict,
 ) -> None:
     # The MTP draft head has random weights, so acceptance is ~0 and there is
     # no trained golden to compare against -- this is a smoke test (assert only
-    # that the MTP MLA propose->verify loop produces output). Eager only for
-    # now: graph-mode MTP draft is not yet stabilized, so the cudagraph
-    # compilation_config matrix from the eagle/dflash/dspark tests is omitted.
-    # Remaining differences vs those tests are model-inherent: no separate
-    # draft `model` (MTP is unified), no golden, and `enable_expert_parallel`
-    # for the DeepSeek MoE target.
+    # that the MTP MLA propose->verify loop produces output).
     prompts = [
         "Hello, my name is",
         "The president of the United States is",
@@ -283,6 +289,7 @@ def test_mtp_spec_decoding(
             "method": "mtp",
             "num_speculative_tokens": num_speculative_tokens,
         },
+        compilation_config=compilation_config,
     ) as runner:
         outputs = runner.model.generate(prompts, sampling_params)
 

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -22,6 +22,7 @@ from copy import copy
 from typing import Any, cast
 
 import torch
+import vllm.v1.worker.gpu.spec_decode.speculator as vllm_speculator
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -42,15 +43,35 @@ from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
 logger = logging.getLogger(__name__)
 
 
+@contextmanager
+def build_draft_attn_metadata_factory(positions, pad):
+    """Wrap build_attn_metadata to forward MLA rotary positions for the block.
+
+    MLA reads positions inside build_decode_metadata for cos/sin; the flat
+    super() path doesn't forward them. Must run inside build_attn_metadata_wrapper().
+    TODO:This field is removed when the external cos/sin solution is removed from the MLA.
+    """
+    raw = vllm_speculator.build_attn_metadata  # cache
+
+    def build_attn_metadata(*args, **kwargs):
+        kwargs["positions"] = positions[:pad]
+        return raw(*args, **kwargs)
+
+    try:
+        vllm_speculator.build_attn_metadata = build_attn_metadata
+        yield
+    finally:
+        vllm_speculator.build_attn_metadata = raw  # restore
+
+
 class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
     """Shared Ascend spec-decode loop for AscendEagle/AscendMTPSpeculator.
 
-    Subclasses AutoRegressiveSpeculator (the common base of EagleSpeculator and
-    MTPSpeculator) so the Ascend overrides are type-checked against a concrete
-    base. Each override keeps its ``super()`` call; on a combined subclass
-    (e.g. AscendEagleSpeculator) the cooperative MRO routes ``super()`` to the
-    concrete upstream speculator (Eagle/MTP) before reaching
-    AutoRegressiveSpeculator.
+    GQA and MLA draft decode state share one path, branched on
+    ``self.attn_architecture == "MLA"``:
+    MLA's per-step state lives in ``.decode`` (cloned per step, written via an
+    alias), GQA's is top-level. MLA also rebuilds the base (live ``.decode`` is
+    None/wrong-batch) and forwards rotary ``positions`` into build_attn_metadata.
     """
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
@@ -61,6 +82,11 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         AscendInputBuffers after super().__init__.
         """
         super().__init__(vllm_config, device)
+
+        # Attention architecture of the (draft) model; gates the MLA branches
+        # below. "MLA" for MLA models, None otherwise. Extensible to other
+        # architectures.
+        self.attn_architecture = "MLA" if vllm_config.model_config.is_deepseek_mla else None
 
         del self.input_buffers
         # AscendInputBuffers has extra `seq_lens_cpu` attribute.
@@ -304,13 +330,15 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             num_query_per_req: int = 1,
             causal: bool = True,
         ) -> dict[str, Any] | None:
-            attn_metadata = super()._build_draft_attn_metadata(
-                num_reqs,
-                num_reqs_padded,
-                num_tokens_padded,
-                num_query_per_req=num_query_per_req,
-                causal=causal,
-            )
+            with build_draft_attn_metadata_factory(self.input_buffers.positions, num_tokens_padded):
+                attn_metadata = super()._build_draft_attn_metadata(
+                    num_reqs,
+                    num_reqs_padded,
+                    num_tokens_padded,
+                    num_query_per_req=num_query_per_req,
+                    causal=causal,
+                )
+
             if attn_metadata is not None:
                 # Ascend-specific: force DecodeOnly attention state for the draft model.
                 for metadata in attn_metadata.values():
@@ -350,15 +378,16 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             num_query_per_req: int = 1,
             causal: bool = True,
         ) -> dict[str, Any] | None:
-            attn_metadata = super()._build_draft_attn_metadata(
-                num_reqs,
-                num_reqs_padded,
-                num_tokens_padded,
-                seq_lens_cpu_upper_bound,
-                step,
-                num_query_per_req,
-                causal,
-            )
+            with build_draft_attn_metadata_factory(self.input_buffers.positions, num_tokens_padded):
+                attn_metadata = super()._build_draft_attn_metadata(
+                    num_reqs,
+                    num_reqs_padded,
+                    num_tokens_padded,
+                    seq_lens_cpu_upper_bound,
+                    step,
+                    num_query_per_req,
+                    causal,
+                )
             if attn_metadata is not None:
                 # Ascend-specific: force DecodeOnly attention state for the draft model.
                 for metadata in attn_metadata.values():
@@ -391,9 +420,31 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 attn_meta.seq_len_list = attn_meta.seq_lens.tolist()
 
     def _init_decode_draft_attn_metadatas(self, attn_metadata: dict[str, Any] | None, num_reqs_padded: int):
-        """Initialize attention metadata for decode phase in graph mode on Ascend NPUs."""
+        """Initialize per-step decode attention metadata for graph mode."""
         if attn_metadata is None:
             return
+
+        # TODO: _build_draft_attn_metadata pulls data (seq_lens, block_table,
+        # ...) from input_buffers internally; future may pass these as CPU
+        # params directly to build_attn_metadata, decoupling from input_buffers.
+        if self.attn_architecture == "MLA":
+            assert self.input_batch is not None
+            if vllm_version_is("0.26.0"):
+                attn_metadata = self._build_draft_attn_metadata(
+                    num_reqs=self.input_batch.num_reqs,
+                    num_reqs_padded=num_reqs_padded,
+                    num_tokens_padded=num_reqs_padded,  # decode: 1 token/req
+                )
+            else:
+                attn_metadata = self._build_draft_attn_metadata(  # type: ignore[call-arg]
+                    num_reqs=self.input_batch.num_reqs,
+                    num_reqs_padded=num_reqs_padded,
+                    num_tokens_padded=num_reqs_padded,  # decode: 1 token/req
+                    seq_lens_cpu_upper_bound=self.input_batch.seq_lens_cpu_upper_bound,
+                    step=1,
+                )
+            if attn_metadata is None:
+                return
 
         attn_state = AscendAttentionState.DecodeOnly
 
@@ -407,6 +458,9 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             for metadata in per_step_attn_metadata.values():
                 metadata.attn_state = attn_state
                 metadata.seq_lens_cpu = seq_lens_cpu
+                if self.attn_architecture == "MLA":
+                    # clone .decode so per-step seq_lens_list writes don't alias.
+                    metadata.decode = copy(metadata.decode)
             draft_attn_metadatas.append(per_step_attn_metadata)
 
         return draft_attn_metadatas
@@ -414,7 +468,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
     def _update_decode_attn_metadata(
         self, attn_metadata: dict[str, Any] | None, step: int, num_reqs: int | None = None
     ):
-        """Update attention metadata for decode phase on Ascend NPUs."""
+        """Update per-step decode attention metadata on Ascend."""
         if attn_metadata is None:
             return
 
@@ -426,12 +480,13 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
 
         query_lens_list = [i for i in range(1, num_reqs_padded + 1)]
         seq_lens_list = next_seq_lens_cpu.tolist()
-        # attn_metadata is build in vllm's super class.
-        # We need to update attn_state for each layer's metadata.
         for metadata in attn_metadata.values():
-            metadata.actual_seq_lengths_q = query_lens_list
+            decode_metadata = (
+                metadata.decode if self.attn_architecture == "MLA" else metadata
+            )  # .decode (MLA) / top-level (GQA)
+            decode_metadata.seq_lens_list = seq_lens_list
+            decode_metadata.actual_seq_lengths_q = query_lens_list
             metadata.seq_lens_cpu.copy_(next_seq_lens_cpu)
-            metadata.seq_lens_list = seq_lens_list
 
     def _calc_next_seq_lens_cpu(self, seq_lens_cpu, num_reqs, num_reqs_padded, step):
         # NOTE(drslark) to achieve fully alignment with vllm, `num_rejected` should be subtracted from `seq_lens`

--- a/vllm_ascend/worker/v2/spec_decode/mtp/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/mtp/speculator.py
@@ -14,115 +14,16 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-# AscendMTPSpeculator is a sibling of AscendEagleSpeculator: both inherit the
-# shared flat NPU draft loop from AscendAutoRegressiveSpeculator and layer it on
-# their own upstream base (MTPSpeculator vs EagleSpeculator). MTP's draft uses
-# MLA attention, so it overrides only the MLA-specific piece -- forwarding
-# rotary positions into build_attn_metadata -- and leaves the flat loop
-# inherited unchanged. Eager only: no graph-mode adaptations.
-from contextlib import contextmanager
-from typing import Any
-
-import torch
-import vllm.v1.worker.gpu.spec_decode.speculator as _upstream_speculator
+# AscendMTPSpeculator layers the shared Ascend draft loop
+# (AscendAutoRegressiveSpeculator) on upstream MTPSpeculator. All MLA-specific
+# handling lives in the base, gated by is_mla.
 from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 
-from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import AscendAutoRegressiveSpeculator
 
 
-@contextmanager
-def build_position_wrapper(positions, pad):
-    """Temporarily wrap build_attn_metadata to forward MLA rotary positions.
-
-    The flat draft-metadata path (upstream ``_build_draft_attn_metadata``) calls
-    ``build_attn_metadata`` without ``positions``, but MLA reads positions
-    *inside* ``build_decode_metadata`` for rotary cos/sin. This caches the
-    current ``build_attn_metadata``, replaces it for the duration of the block
-    with one that forwards ``positions[:pad]``, and restores it on exit -- so
-    MTP can reuse the flat ``super()._build_draft_attn_metadata()`` path instead
-    of duplicating the ``build_attn_metadata`` call and all its arguments.
-
-    Must run inside ``build_attn_metadata_wrapper()``, which has already
-    replaced the module-level ``build_attn_metadata`` with the Ascend builder.
-    """
-    raw = _upstream_speculator.build_attn_metadata  # cache
-
-    def build_attn_metadata(*args, **kwargs):
-        kwargs["positions"] = positions[:pad]
-        return raw(*args, **kwargs)
-
-    try:
-        _upstream_speculator.build_attn_metadata = build_attn_metadata
-        yield
-    finally:
-        _upstream_speculator.build_attn_metadata = raw  # restore
-
-
 class AscendMTPSpeculator(AscendAutoRegressiveSpeculator, MTPSpeculator):
-    """Ascend MTP speculator (MLA draft, eager only).
+    """Ascend MTP speculator (MLA draft). All MLA handling is in the base
+    (AscendAutoRegressiveSpeculator)"""
 
-    Inherits the shared flat NPU draft loop from AscendAutoRegressiveSpeculator
-    (layered on upstream MTPSpeculator, which supplies ``load_draft_model``) and
-    overrides only the MLA-specific piece: rotary ``positions`` must reach
-    ``build_attn_metadata``, which the flat draft-metadata path does not
-    forward. ``draft_uses_mla`` (read from ``model_config.is_deepseek_mla`` in
-    ``__init__``) gates the wrap so flat (non-MLA) MTP models keep the inherited
-    flat path. No graph-mode adaptations: eager rebuilds draft attention
-    metadata every step, so the MLA ``.decode`` sub-object is fresh each step
-    and needs no per-step mirroring.
-    """
-
-    # The signature is split on vllm_version_is: v0.26.0's
-    # _build_draft_attn_metadata does not accept seq_lens_cpu_upper_bound /
-    # step; d02df748bf+ does.
-    if vllm_version_is("0.26.0"):
-
-        def _build_draft_attn_metadata(  # type: ignore[misc, override]
-            self,
-            num_reqs: int,
-            num_reqs_padded: int,
-            num_tokens_padded: int,
-            num_query_per_req: int = 1,
-            causal: bool = True,
-        ) -> dict[str, Any] | None:
-            # Flat MTP reuses the flat super() build (positions are not needed).
-            # MLA: rotary positions must reach build_attn_metadata, but the flat
-            # super() path does not forward them. Wrap build_attn_metadata to
-            # inject positions[:num_tokens_padded] and reuse super() (no arg
-            # duplication).
-            with build_position_wrapper(self.input_buffers.positions, num_tokens_padded):
-                return super()._build_draft_attn_metadata(
-                    num_reqs,
-                    num_reqs_padded,
-                    num_tokens_padded,
-                    num_query_per_req=num_query_per_req,
-                    causal=causal,
-                )
-    else:
-
-        def _build_draft_attn_metadata(  # type: ignore[misc, override]
-            self,
-            num_reqs: int,
-            num_reqs_padded: int,
-            num_tokens_padded: int,
-            seq_lens_cpu_upper_bound: torch.Tensor | None = None,
-            step: int = 1,
-            num_query_per_req: int = 1,
-            causal: bool = True,
-        ) -> dict[str, Any] | None:
-            # Flat MTP reuses the flat super() build (positions are not needed).
-            # MLA: rotary positions must reach build_attn_metadata, but the flat
-            # super() path does not forward them. Wrap build_attn_metadata to
-            # inject positions[:num_tokens_padded] and reuse super() (no arg
-            # duplication).
-            with build_position_wrapper(self.input_buffers.positions, num_tokens_padded):
-                return super()._build_draft_attn_metadata(  # type: ignore[call-arg]
-                    num_reqs,
-                    num_reqs_padded,
-                    num_tokens_padded,
-                    seq_lens_cpu_upper_bound,  # type: ignore[arg-type]
-                    step,  # type: ignore[arg-type]
-                    num_query_per_req,
-                    causal,
-                )
+    pass


### PR DESCRIPTION
### What this PR does / why we need it?

This PR extends the Ascend MTP speculator to the MLA draft model in MRV2 to support the graph mode (FULL_DECODE_ONLY).

Combine MLA-specific rewriting with `attn_architecture ` to decouple the logic of non-MLA models from MLA models:
a. ` _init_decode_draft_attn_metadatas` — rebuilds a padded graph-batch base through the MLA builder so `.decode` is populated for every step. After the draft prefill step, the live `model_state.attn_metadata.decode `is either None or describes the live (unpadded) batch rather than the padded graph batch being replayed, so it cannot be reused. The rebuild constructs a decode-shaped metadata` (1 token/req → num_decodes > 0 → .decode built)` from the current graph-batch buffers, sets the step-invariant `actual_seq_lengths_q` once, and gives each step its own `.decode` (copied per step) so per-step `seq_lens_list` writes do not alias across steps.
b. `_update_decode_attn_metadata` — advances `.decode.seq_lens_list` per step, the only field that changes per decode step (each request's sequence length grows by one per draft token). The per-step `.decode` ownership established in (a) lets each step advance independently without overwriting other steps.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

```
set -x
export HCCL_OP_EXPANSION_MODE="AIV"
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export PYTHONPATH=/home/j00893003/mr2/vllm:/home/j00893003/mr2/vllm-ascend:$PYTHONPATH
export VLLM_ASCEND_BALANCE_SCHEDULING=1
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10

export VLLM_TORCH_PROFILER_WITH_STACK=0
export HCCL_BUFFSIZE=500
export VLLM_ASCEND_ENABLE_MLAPO=1
export TASK_QUEUE_ENABLE=1
export VLLM_ENGINE_READY_TIMEOUT_S=6000
export VLLM_USE_V2_MODEL_RUNNER=1

exec vllm serve /mnt/a800_weight/DeepSeek-V3.1-w4a8-perchannle \
    --host 90.90.97.29 \
    --port 8000 \
    --data-parallel-size 2 \
    --tensor-parallel-size 8 \
    --quantization ascend \
    --seed 1024 \
    --served-model-name deepseek_v3 \
    --enable-expert-parallel \
    --max-num-seqs 96 \
    --max-model-len 32768 \
    --max-num-batched-tokens 6000 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --gpu-memory-utilization 0.9 \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'

~  
```
------------------------------------------------------------
```
------------------------------------------------------------
ModelRunnerV2
------------------------------------------------------------ 
num_drafts=7023.0
num_accepted_tokens_per_pos=[6474.0, 5028.0, 2807.0]
acceptance_per_pos=[0.9218282785134558, 0.7159333618111918, 0.39968674355688455]
acceptance_len=3.0374483838815323

------------------------------------------------------------
ModelRunnerV1
------------------------------------------------------------
num_drafts=7162.0
num_accepted_tokens_per_pos=[6641.0, 5145.0, 2975.0]
acceptance_per_pos=[0.9272549567160011, 0.718374755654845, 0.41538676347389]
acceptance_len=3.061016475844736
```


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
