### PR TITLE
[BugFix][v0.23.0] remove unnecessary lazy_init for memcache backend

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -246,19 +246,13 @@ class KVPoolWorker:
         backend_module = importlib.import_module(backend_path)
         real_backend = getattr(backend_module, backend_name)
 
-        if self.backend.lower() == "memcache":
-            self.m_store = real_backend(  # type: ignore[misc]
-                parallel_config,
-                lazy_init=True,
-            )
-        else:
-            backend_kwargs = {}
-            if self.backend.lower() == "mooncake":
-                backend_kwargs["lazy_init"] = self.use_compress
-            self.m_store = real_backend(  # type: ignore[misc]
-                parallel_config,
-                **backend_kwargs,
-            )
+        backend_kwargs = {}
+        if self.backend.lower() == "mooncake":
+            backend_kwargs["lazy_init"] = self.use_compress
+        self.m_store = real_backend(  # type: ignore[misc]
+            parallel_config,
+            **backend_kwargs,
+        )
 
     def _init_kv_events(self, vllm_config) -> None:
         kv_event_config = vllm_config.kv_events_config

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -247,8 +247,10 @@ class KVPoolWorker:
         real_backend = getattr(backend_module, backend_name)
 
         backend_kwargs = {}
-        if self.backend.lower() == "mooncake":
-            backend_kwargs["lazy_init"] = self.use_compress
+        # lazy_init is enabled only for DSV4 compress models. The backend further
+        # gates this based on hardware: Mooncake requires ASCEND_ENABLE_FABRIC_MEM=1
+        # (A3 fabric memory), and Memcache requires device_sdma protocol.
+        backend_kwargs["lazy_init"] = self.use_compress
         self.m_store = real_backend(  # type: ignore[misc]
             parallel_config,
             **backend_kwargs,


### PR DESCRIPTION
## Summary

`lazy_init` is only needed for mooncake backend with deepseekv4 compress model on A3 hardware. The memcache backend handles lazy initialization internally based on device type, so passing `lazy_init=True` from `pool_worker` is redundant.

## Changes

- Remove the memcache-specific branch in `_init_backend()` that passed `lazy_init=True`
- Simplify the code to use a unified backend initialization path
- `lazy_init` for mooncake is still controlled by `self.use_compress` (the backend further gates it with A3 device check via `ASCEND_ENABLE_USE_FABRIC_MEM`)

## Test Plan

- Verified that memcache backend still initializes correctly (it handles lazy_init internally based on `get_ascend_device_type()`)
- Verified that mooncake + DSV4 + A3 still uses lazy_init as expected

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
