### PR TITLE
[BugFix][v0.25.1] remove unnecessary lazy_init for memcache backend

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -300,19 +300,15 @@ class KVPoolWorker:
         backend_module = importlib.import_module(backend_path)
         real_backend = getattr(backend_module, backend_name)
 
-        if self.backend.lower() == "memcache":
-            self.m_store = real_backend(  # type: ignore[misc]
-                parallel_config,
-                lazy_init=True,
-            )
-        else:
-            backend_kwargs = {}
-            if self.backend.lower() == "mooncake":
-                backend_kwargs["lazy_init"] = self.use_compress
-            self.m_store = real_backend(  # type: ignore[misc]
-                parallel_config,
-                **backend_kwargs,
-            )
+        backend_kwargs = {}
+        # lazy_init is enabled only for DSV4 compress models. The backend further
+        # gates this based on hardware: Mooncake requires ASCEND_ENABLE_USE_FABRIC_MEM=1
+        # (A3 fabric memory), and Memcache requires non-A2 devices (A3/A5).
+        backend_kwargs["lazy_init"] = self.use_compress
+        self.m_store = real_backend(  # type: ignore[misc]
+            parallel_config,
+            **backend_kwargs,
+        )
 
     def _init_kv_events(self, vllm_config) -> None:
         kv_event_config = vllm_config.kv_events_config

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -302,8 +302,8 @@ class KVPoolWorker:
 
         backend_kwargs = {}
         # lazy_init is enabled only for DSV4 compress models. The backend further
-        # gates this based on hardware: Mooncake requires ASCEND_ENABLE_USE_FABRIC_MEM=1
-        # (A3 fabric memory), and Memcache requires non-A2 devices (A3/A5).
+        # gates this based on hardware: Mooncake requires ASCEND_ENABLE_FABRIC_MEM=1
+        # (A3 fabric memory), and Memcache requires device_sdma protocol.
         backend_kwargs["lazy_init"] = self.use_compress
         self.m_store = real_backend(  # type: ignore[misc]
             parallel_config,


### PR DESCRIPTION
Cherry-pick of PR #13028 to releases/v0.25.1rc branch.

`lazy_init` is only needed for mooncake backend with deepseekv4 compress model on A3 hardware. The memcache backend handles lazy initialization internally based on device type, so passing `lazy_init=True` from `pool_worker` is redundant.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
