### PR TITLE
[BugFix] Report prefiller cached tokens in PD proxy，added first curl and non-streaming scenarios

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -171,7 +171,7 @@ def extract_cached_tokens(response_json: dict) -> int | None:
     usage = response_json.get("usage") or {}
     prompt_tokens_details = usage.get("prompt_tokens_details") or {}
     cached_tokens = prompt_tokens_details.get("cached_tokens")
-    return cached_tokens if isinstance(cached_tokens, int) else None
+    return cached_tokens if isinstance(cached_tokens, int) else 0
 
 
 def update_cached_tokens_in_chunk(chunk_json: dict, cached_tokens: int | None) -> bool:
@@ -1060,11 +1060,12 @@ async def handle_completions_impl(api: str, request: Request):
                             yield chunk
                             continue
                         choices = chunk_json.get("choices", [])
-                        if not choices:
+                        if not choices or not stream_flag:
                             if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
                                 chunk = encode_response_chunk(chunk_json, is_sse)
-                            yield chunk
-                            continue
+                                if not choices:
+                                    yield chunk
+                                    continue
 
                         choice = choices[0]
                         delta = choice.get("delta") or {}


### PR DESCRIPTION
### What this PR does / why we need it?
Improvements built on top of #11630. Summary of improvements:
  1. First curl request now returns cached_tokens = 0 (cold cache case)
  2. Covers non-streaming scenarios

  The existing proxy fix approach (extracting the real prefix-cache hit count from the Prefiller's response and overriding the Decoder's incorrect value at the proxy layer) is correct in
  direction, but fails in two scenarios:

  1. Cold cache (P has no prefix-cache hit): P-side num_cached_tokens=0 gets filtered into prompt_tokens_details: None by vLLM's truthiness check if ... and final_res.num_cached_tokens:. The
  proxy extracts None and skips the override entirely.
  2. Non-streaming requests: The proxy's override logic is only attached to the if not choices branch (the last streaming chunk). Non-streaming responses have non-empty choices, so the override
   never triggers.

  **Root Causes**

  Root Cause 1: extract_cached_tokens treats None as failure

`  return cached_tokens if isinstance(cached_tokens, int) else None`

  When P has a cold cache, the response carries no cached_tokens field → returns None → downstream update_cached_tokens_in_chunk sees None and return False → no override. 0 and "field missing"
  are conflated.

  Root Cause 2: Override logic only targets the last streaming chunk

```
  if not choices:                    # non-streaming has non-empty choices → never enters
      if update_cached_tokens_in_chunk(...):
          ...
      yield chunk
      continue
```

  A non-streaming response is a single complete JSON with both choices and usage in the same chunk. Since choices is non-empty, the override is skipped.

  **Changes**

  Change 1: else None → else 0 (extract_cached_tokens, line 174)

```
   def extract_cached_tokens(response_json: dict) -> int | None:
       usage = response_json.get("usage") or {}
       prompt_tokens_details = usage.get("prompt_tokens_details") or {}
       cached_tokens = prompt_tokens_details.get("cached_tokens")
  -    return cached_tokens if isinstance(cached_tokens, int) else None
  +    return cached_tokens if isinstance(cached_tokens, int) else 0
```

  Falls back to 0 (a valid int) for cold cache, so the downstream update_cached_tokens_in_chunk can write normally.

  Change 2: Add or not stream_flag to the override condition (line 1063)

 ```
  choices = chunk_json.get("choices", [])
  -if not choices:
  +if not choices or not stream_flag:
       if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
           chunk = encode_response_chunk(chunk_json, is_sse)
  +    if not choices:
  +        yield chunk
  +        continue
  -    yield chunk
  -    continue

```
  - Outer condition adds or not stream_flag: lets non-streaming responses enter the override branch.
  - Inner condition adds if not choices: only the last streaming chunk does yield + continue; non-streaming responses fall through to the normal token-concatenation path after the override is
  applied.

  Streaming behavior is fully preserved — only the non-streaming path gains the override.
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
                                         
**Stream:**

 bash-5.2$ curl http://100.111.123.123:8088/v1/chat/completions -H "Content-Type: application/json" -d @edge_test_261.json
data: {"id":"chatcmpl-bcb8240e-90db-4688-8352-66e81cdf3198","object":"chat.completion.chunk","created":1785378357,"model":"glm-52","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"prompt_token_ids":null,"prompt_text":null}

......

data: {"id": "chatcmpl-bcb8240e-90db-4688-8352-66e81cdf3198", "object": "chat.completion.chunk", "created": 1785378357, "model": "glm-52", "choices": [], "usage": {"prompt_tokens": 723, "total_tokens": 733, "completion_tokens": 10, "prompt_tokens_details": {"cached_tokens": 0}}, "system_fingerprint": "vllm-0.23.0-dp32-ep-18f00f9a"}

data: [DONE]

bash-5.2$ curl http://100.111.123.123:8088/v1/chat/completions -H "Content-Type: application/json" -d @edge_test_261.json
data: {"id":"chatcmpl-2ec914ee-a3bd-4ec6-82e6-3f57ad0bce23","object":"chat.completion.chunk","created":1785378364,"model":"glm-52","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"prompt_token_ids":null,"prompt_text":null}

......

data: {"id": "chatcmpl-2ec914ee-a3bd-4ec6-82e6-3f57ad0bce23", "object": "chat.completion.chunk", "created": 1785378364, "model": "glm-52", "choices": [], "usage": {"prompt_tokens": 723, "total_tokens": 733, "completion_tokens": 10, "prompt_tokens_details": {"cached_tokens": 640}}, "system_fingerprint": "vllm-0.23.0-dp32-ep-18f00f9a"}                                                                      

**Non-Stream:**

bash-5.2$ curl http://100.111.123.123:8088/v1/chat/completions -H "Content-Type: application/json" -d @edge_test_260.json
{"id": "chatcmpl-9d4ea50e-2e98-4d66-a7d4-fb8beb05c86d", "object": "chat.completion", "created": 1785377804, "model": "glm-52", "choices": [{"index": 0, "message": {"role": "assistant", "content": null, "refusal": null, "annotations": null, "audio": null, "function_call": null, "reasoning": "1. 分析用户输入：\n*   内容："}, "logprobs": null, "finish_reason": "length", "stop_reason": null, "token_ids": null, "routed_experts": null}], "service_tier": null, "system_fingerprint": "vllm-0.23.0-dp32-ep-18f00f9a", "usage": {"prompt_tokens": 633, "total_tokens": 643, "completion_tokens": 10, "prompt_tokens_details": {"cached_tokens": 0}, "completion_tokens_details": null}, "prompt_logprobs": null, "prompt_token_ids": null, "prompt_text": null, "kv_transfer_params": null}

bash-5.2$ curl http://100.111.123.123:8088/v1/chat/completions -H "Content-Type: application/json" -d @edge_test_260.json
{"id": "chatcmpl-4b71f02c-eb39-4474-bc5e-ef8442a41aed", "object": "chat.completion", "created": 1785377812, "model": "glm-52", "choices": [{"index": 0, "message": {"role": "assistant", "content": null, "refusal": null, "annotations": null, "audio": null, "function_call": null, "reasoning": "1. **分析输入：**\n    * **"}, "logprobs": null, "finish_reason": "length", "stop_reason": null, "token_ids": null, "routed_experts": null}], "service_tier": null, "system_fingerprint": "vllm-0.23.0-dp32-ep-18f00f9a", "usage": {"prompt_tokens": 633, "total_tokens": 643, "completion_tokens": 10, "prompt_tokens_details": {"cached_tokens": 512}, "completion_tokens_details": null}, "prompt_logprobs": null, "prompt_token_ids": null, "prompt_text": null, "kv_transfer_params": null}

As u can see above, first curl cached_tokens=0, second=prefill cached tokens


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
