### PR TITLE
[Doc][Misc] Update and refine documentation for models and features

### DIFF
--- a/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
+++ b/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-vLLM-Ascend supports Dynamic Chunked Pipeline Parallel (CPP) for optimizing prefill performance in Pipeline Parallelism scenarios. This guide demonstrates deployment with DeepSeek-V3.1 on 1 Atlas 800T A3 server (64G × 16).
+vLLM-Ascend supports Dynamic Chunked Pipeline Parallel (CPP) for optimizing prefill performance in Pipeline Parallelism scenarios. This feature is supported starting from version `v0.19.1rc1`. This guide demonstrates deployment with DeepSeek-V3.1 on 1 Atlas 800T A3 server (64G × 16).
 
 For configuration details, see the [Feature Guide](../../user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md).
 
@@ -12,7 +12,7 @@ For design details, see the [Design Document](../../developer_guide/Design_Docum
 
 ### Model Weight
 
-- `DeepSeek-V3.1-w8a8` (Quantized version): 1 Atlas 800T A3 (64G × 16) node
+- `DeepSeek-V3.1-W8A8` (Quantized version): 1 Atlas 800T A3 (64G × 16) node
 
 Download to shared directory such as `/mnt/weight/`
 
@@ -103,6 +103,8 @@ vllm serve /mnt/weight/DeepSeek-V3.1-w8a8 \
   }'
 ```
 
+The server has started successfully if the log outputs: `vLLM API server started on 0.0.0.0:8003`.
+
 ### Key Parameters
 
 - `--pipeline-parallel-size 2`: Enables Pipeline Parallelism (required)
@@ -162,7 +164,7 @@ Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) f
 
 Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
 
-To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in long sequence LLM inference scenarios, we use **DeepSeek-V3.1-W8A8** and **Qwen3-235B**, deploy P instance in Ascend Atlas A3 inference products*64G (A3), the configuration and performance data are as follows.
+To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in long sequence LLM inference scenarios, we use **DeepSeek-V3.1-W8A8** and **Qwen3-235B**, deploy prefill instance in Ascend Atlas 800T A3 server (64G × 16), the configuration and performance data are as follows.
 
 **Fixed-length requests, concurrency=1**:
 

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
@@ -25,7 +25,7 @@ Execute the following commands on each node in sequence. The results must all be
 
         ```bash
         # Check the remote switch ports
-        for i in {0..15}; do hccn_tool -i $i -lldp -g | grep Ifname; done 
+        for i in {0..15}; do hccn_tool -i $i -lldp -g | grep Ifname; done
         # Get the link status of the Ethernet ports (UP or DOWN)
         for i in {0..15}; do hccn_tool -i $i -link -g ; done
         # Check the network health status
@@ -239,10 +239,25 @@ Use `launch_online_dp.py` to launch external dp vllm servers.
 Modify `run_dp_template.sh` on each node.
 [run_dp_template.sh](https://github.com/vllm-project/vllm-ascend/blob/main/examples/external_online_dp/run_dp_template.sh)
 
-> **Note**: If speculative decoding is enabled, `num_speculative_tokens` should be subject to one of the following conditions:
->
-> 1. Hybrid Mamba models (e.g., Qwen-Next and Qwen3.5 series): `num_speculative_tokens` should be equal on P nodes and D nodes.
-> 2. Other models: `num_speculative_tokens` on P nodes should be 1, and `num_speculative_tokens` on D nodes should be greater or equal to 1.
+`launch_online_dp.py` starts `dp-size-local` vLLM instances and passes seven positional arguments to `run_dp_template.sh`. The examples below correspond to [Start the service](#start-the-service).
+
+| Launcher option | Template value | Meaning | Example value | Constraints |
+| --- | --- | --- | --- | --- |
+| `--dp-size` | `$3` / `--data-parallel-size` | Total DP ranks in the group. | P: `2`; D: `32` | Positive integer; identical within the same group. Total ranks must cover `[0, dp-size)` without overlap. |
+| `--tp-size` | `$7` / `--tensor-parallel-size` | NPUs used by each instance. | P: `8`; D: `1` | Positive integer; `dp-size-local * tp-size` must not exceed available NPUs on the node.|
+| `--dp-size-local` | Number of template invocations | DP instances on this node. | P: `2`; D: `16` | If set to `-1`, it defaults to `dp-size`. Otherwise, `1 <= dp-size-local <= dp-size`.|
+| `--dp-rank-start` | `$4` / `--data-parallel-rank` = `dp-rank-start + i` | First DP rank on this node. | P: `0`; D: `0` or `16` | Non-negative integer; the assigned rank range must be within `dp-size` and not overlap. |
+| `--dp-address` | `$5` / `--data-parallel-address` | DP master address. | P: `192.0.0.1` or `192.0.0.2`; D: `192.0.0.3` | The IP address must be reachable and identical within the same DP group. |
+| `--dp-rpc-port` | `$6` / `--data-parallel-rpc-port` | DP master RPC port. | `12321` | Free, reachable port; identical within a DP group. |
+| `--vllm-start-port` | `$2` / `--port` = `vllm-start-port + i` | First local API port. | `7100`, then `7101`, ... | Consecutive free ports; must match the proxy configuration. |
+| Computed by the launcher | `$1` / `ASCEND_RT_VISIBLE_DEVICES` | NPU IDs assigned to each instance. | P: `0,...,7`, `8,...,15`; D: `0` through `15` | IDs must exist and not overlap; non-contiguous IDs require adapting the launcher. |
+
+!!! note
+
+    - The launcher validates only argument types and required options. Check the remaining constraints before deployment.
+    - If speculative decoding is enabled, `num_speculative_tokens` should be subject to one of the following conditions:
+        1. Hybrid Mamba models (e.g., Qwen-Next and Qwen3.5 series): `num_speculative_tokens` should be equal on P nodes and D nodes.
+        2. Other models: `num_speculative_tokens` on P nodes should be 1, and `num_speculative_tokens` on D nodes should be greater or equal to 1.
 
 #### Layerwise
 
@@ -812,14 +827,20 @@ We provide two different proxy implementations with distinct request routing beh
         7100 7101 7102 7103 7104 7105 7106 7107 7108 7109 7110 7111 7112 7113 7114 7115\
     ```
 
-|Parameter  | meaning |
-| --- | --- |
-| --port | Proxy service Port |
-| --host | Proxy service Host IP|
-| --prefiller-hosts | Hosts of prefiller nodes |
-| --prefiller-ports | Ports of prefiller nodes |
-| --decoder-hosts | Hosts of decoder nodes |
-| --decoder-ports | Ports of decoder nodes |
+Both proxies share the following backend options.
+
+| Parameter | Applies to | Default | Example value | Meaning and constraints |
+| --- | --- | --- | --- | --- |
+| `--port` | Both | `8000` | `1999` | Proxy listen port. Must be free, reachable, and between `1` and `65535`. |
+| `--host` | Both | `localhost` | `192.0.0.1` | Proxy listen address. Layerwise mode requires a non-wildcard address reachable by D nodes. |
+| `--prefiller-hosts` | Both | `localhost` | `192.0.0.1 192.0.0.1 192.0.0.2 192.0.0.2` | P-instance hosts. Count must equal the number of `--prefiller-ports`. |
+| `--prefiller-ports` | Both | `8001` | `7100 7101 7100 7101` | P-instance ports. Each host-port pair must be unique and reachable. |
+| `--decoder-hosts` | Both | `localhost` | Sixteen `192.0.0.3`, then sixteen `192.0.0.4` | D-instance hosts. Count must equal the number of `--decoder-ports`. |
+| `--decoder-ports` | Both | `8002` | `7100`-`7115` for each D host | D-instance ports. Each host-port pair must be unique and reachable. |
+
+!!! note
+
+    The proxy scripts validate that each host list has the same length as its corresponding port list.
 
 You can get the proxy program in the repository's examples, [load\_balance\_proxy\_server\_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
 

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_single_node.md
@@ -222,7 +222,7 @@ We can run the following scripts to launch a server on the prefiller/decoder NPU
       }'
     ```
 
-If you want to run "2P1D", please set ASCEND_RT_VISIBLE_DEVICES and port to different values for each P process.
+If you want to run "2P1D" (two Prefiller and one Decoder), please set ASCEND_RT_VISIBLE_DEVICES and port to different values for each P process.
 
 ## Example Proxy for Deployment
 
@@ -240,9 +240,9 @@ python load_balance_proxy_server_example.py \
 
 |Parameter  | Meaning |
 | --- | --- |
-| --port | Port of proxy |
-| --prefiller-port | All ports of prefill |
-| --decoder-ports | All ports of decoder |
+| --port | Proxy port |
+| --prefiller-port | All prefiller ports |
+| --decoder-ports | All decoder ports |
 
 ## Verification
 

--- a/docs/source/tutorials/features/ray.md
+++ b/docs/source/tutorials/features/ray.md
@@ -19,7 +19,7 @@ Execute the following commands on each node in sequence. The results must all be
 
 ```bash
  # Check the remote switch ports
- for i in {0..7}; do hccn_tool -i $i -lldp -g | grep Ifname; done 
+ for i in {0..7}; do hccn_tool -i $i -lldp -g | grep Ifname; done
  # Get the link status of the Ethernet ports (UP or DOWN)
  for i in {0..7}; do hccn_tool -i $i -link -g ; done
  # Check the network health status
@@ -53,7 +53,7 @@ hccn_tool -i 0 -ping -g address 10.20.0.20
 
 To ensure a consistent execution environment across all nodes, including the model path and Python environment, it is advised to use Docker images.
 
-For setting up a multi-node inference cluster with Ray, **containerized deployment** is the preferred approach. Containers should be started on both the primary and secondary nodes, with the `--net=host` option to enable proper network connectivity.
+For setting up a multi-node inference cluster with Ray, **containerized deployment** is the preferred approach. Containers should be started on both the head and worker nodes, with the `--net=host` option to enable proper network connectivity.
 
 Below is the example container setup command, which should be executed on **all nodes**:
 
@@ -92,20 +92,20 @@ docker run --rm \
 
 ### Start Ray Cluster
 
-After setting up the containers and installing vllm-ascend on each node, follow the steps below to start the Ray cluster and execute inference tasks.
-
-Choose one machine as the primary node and the others as secondary nodes. Before proceeding, use `ip addr` to check your `nic_name` (network interface name).
-
-Set the `ASCEND_RT_VISIBLE_DEVICES` environment variable to specify the NPU devices to use. For Ray versions above 2.1, also set the `RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES` variable to avoid device recognition issues.
-
-Below are the commands for the primary and secondary nodes:
-
-**Primary node**:
-
 !!! note
 
     When starting a Ray cluster for multi-node inference, the environment variables on each node must be set **before** starting the Ray cluster for them to take effect.
     Updating the environment variables requires restarting the Ray cluster.
+
+After setting up the containers and installing vllm-ascend on each node, follow the steps below to start the Ray cluster and execute inference tasks.
+
+Choose one machine as the head node and the others as worker nodes. Before proceeding, use `ip addr` to check your `nic_name` (network interface name).
+
+Set the `ASCEND_RT_VISIBLE_DEVICES` environment variable to specify the NPU devices to use. For Ray versions above 2.1, also set the `RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES` variable to avoid device recognition issues.
+
+Below are the commands for the head and worker nodes:
+
+**Head node**:
 
 ```shell
 # Head node
@@ -117,11 +117,7 @@ export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 ray start --head
 ```
 
-**Secondary node**:
-
-!!! note
-
-    When starting a Ray cluster for multi-node inference, the environment variables on each node must be set **before** starting the Ray cluster for them to take effect. Updating the environment variables requires restarting the Ray cluster.
+**Worker node**:
 
 ```shell
 # Worker node

--- a/docs/source/tutorials/features/suffix_speculative_decoding.md
+++ b/docs/source/tutorials/features/suffix_speculative_decoding.md
@@ -19,7 +19,7 @@ The benchmarking tool used in this tutorial is AISBench, which supports performa
 
 ## **Download vllm-ascend Image**
 
-This tutorial uses the official image, version v0.13.0rc1. Use the following command to download:
+This tutorial uses the official image, version `{{ vllm_ascend_version }}`. Use the following command to download:
 
 ```bash
 
@@ -142,7 +142,7 @@ ais_bench --models vllm-api-stream-chat \
 
 ## **Test Results**
 
-Below are the detailed test results of the six open-source datasets in this evaluation. Compared to the baseline performance, the improvement in TPOT and throughput performance at different concurrency levels after enabling Suffix Decoding varies across datasets. The extent of improvement after enabling Suffix Decoding differs among the datasets. Below is a summary of the results:
+Below are the detailed test results of the six open-source datasets in this evaluation. Compared to the baseline, the improvement in TPOT and throughput performance at different concurrency levels after enabling Suffix Decoding varies across datasets. Below is a summary of the results:
 
 | **Dataset Category** | **Typical Representative** | **Throughput Improvement (BS=1-10)** | **SLO TPOT** |
 | -------------------- | -------------------------- | ------------------------------------ | ------------ |

--- a/docs/source/tutorials/models/DeepSeek-R1.md
+++ b/docs/source/tutorials/models/DeepSeek-R1.md
@@ -37,7 +37,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -77,7 +77,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}

--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -82,7 +82,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -122,7 +122,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -491,444 +491,444 @@ Parameter descriptions:
 
 1. `run_dp_template.sh` script(A3)
 
-=== "Node 0(Prefill)"
+    === "Node 0(Prefill)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.1"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.1"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export HCCL_BUFFSIZE=256
-    export TASK_QUEUE_ENABLE=1
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export VLLM_USE_V1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=256
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_USE_V1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --served-model-name deepseek_v3 \
-        --max-model-len 65536 \
-        --max-num-batched-tokens 16384 \
-        --max-num-seqs 8 \
-        --enforce-eager \
-        --trust-remote-code \
-        --gpu-memory-utilization 0.9 \
-        --quantization ascend \
-        --no-enable-prefix-caching \
-        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30000",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name deepseek_v3 \
+            --max-model-len 65536 \
+            --max-num-batched-tokens 16384 \
+            --max-num-seqs 8 \
+            --enforce-eager \
+            --trust-remote-code \
+            --gpu-memory-utilization 0.9 \
+            --quantization ascend \
+            --no-enable-prefix-caching \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 1(Prefill)"
+    === "Node 1(Prefill)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.2"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.2"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export HCCL_BUFFSIZE=256
-    export TASK_QUEUE_ENABLE=1
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export VLLM_USE_V1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=256
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_USE_V1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --served-model-name deepseek_v3 \
-        --max-model-len 65536 \
-        --max-num-batched-tokens 16384 \
-        --max-num-seqs 8 \
-        --enforce-eager \
-        --trust-remote-code \
-        --gpu-memory-utilization 0.9 \
-        --quantization ascend \
-        --no-enable-prefix-caching \
-        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30100",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name deepseek_v3 \
+            --max-model-len 65536 \
+            --max-num-batched-tokens 16384 \
+            --max-num-seqs 8 \
+            --enforce-eager \
+            --trust-remote-code \
+            --gpu-memory-utilization 0.9 \
+            --quantization ascend \
+            --no-enable-prefix-caching \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30100",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 0(Decode)"
+    === "Node 0(Decode)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.3"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.3"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export HCCL_BUFFSIZE=1100
-    export TASK_QUEUE_ENABLE=1
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export VLLM_USE_V1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=1100
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_USE_V1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --served-model-name deepseek_v3 \
-        --max-model-len 65536 \
-        --max-num-batched-tokens 256 \
-        --max-num-seqs 28 \
-        --trust-remote-code \
-        --gpu-memory-utilization 0.92 \
-        --quantization ascend \
-        --no-enable-prefix-caching \
-        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
-        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true,"finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30200",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name deepseek_v3 \
+            --max-model-len 65536 \
+            --max-num-batched-tokens 256 \
+            --max-num-seqs 28 \
+            --trust-remote-code \
+            --gpu-memory-utilization 0.92 \
+            --quantization ascend \
+            --no-enable-prefix-caching \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
+            --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true,"finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 1(Decode)"
+    === "Node 1(Decode)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.4"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.4"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        # export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export HCCL_BUFFSIZE=1100
-    export TASK_QUEUE_ENABLE=1
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export VLLM_USE_V1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=1100
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_USE_V1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --served-model-name deepseek_v3 \
-        --max-model-len 65536 \
-        --max-num-batched-tokens 256 \
-        --max-num-seqs 28 \
-        --trust-remote-code \
-        --gpu-memory-utilization 0.92 \
-        --quantization ascend \
-        --no-enable-prefix-caching \
-        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
-        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true,"finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30200",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name deepseek_v3 \
+            --max-model-len 65536 \
+            --max-num-batched-tokens 256 \
+            --max-num-seqs 28 \
+            --trust-remote-code \
+            --gpu-memory-utilization 0.92 \
+            --quantization ascend \
+            --no-enable-prefix-caching \
+            --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
+            --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true,"finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
 2. `run_dp_template.sh` script(Ascend 950DT)
 
-=== "Prefill Node"
+    === "Prefill Node"
 
-    ```shell
-    nic_name="xxx"
-    local_ip="141.xx.xx.1"
+        ```shell
+        nic_name="xxx"
+        local_ip="141.xx.xx.1"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
-    export HCCL_BUFFSIZE=1024
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
+        export HCCL_BUFFSIZE=1024
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export TASK_QUEUE_ENABLE=1
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export TASK_QUEUE_ENABLE=1
 
-    export VLLM_ASCEND_ENABLE_MLAPO=1
-    export DYNAMIC_EPLB="true"
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export DYNAMIC_EPLB="true"
 
-    export ASCEND_RT_VISIBLE_DEVICES=$1
-    vllm serve /weight/dsk_v3.1-T-w8a8c8_attn-0506-full/  \
-    --host 0.0.0.0 \
-    --port $2 \
-    --data-parallel-size $3 \
-    --data-parallel-rank $4 \
-    --data-parallel-address $5 \
-    --data-parallel-rpc-port $6 \
-    --tensor-parallel-size $7 \
-    --max_model_len 135168 \
-    --max-num-batched-tokens 16384 \
-    --served-model-name dsv3 \
-    --gpu-memory-utilization 0.9 \
-    --enable-expert-parallel \
-    --async-scheduling \
-    --max-num-seqs 128 \
-    --no-enable-prefix-caching \
-    --trust-remote-code \
-    --enforce-eager \
-    --speculative-config '{"num_speculative_tokens": 1,"method": "deepseek_mtp"}' \
-    --quantization ascend \
-    --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30100",
-        "engine_id": "1",
-        "kv_connector_extra_config": {
-                    "prefill": {
-                            "dp_size": 4,
-                            "tp_size": 4
-                    },
-                    "decode": {
-                            "dp_size": 32,
-                            "tp_size": 1
-                    },
-                    "ascend_local_comm_res_path": "/etc/hixlep"
-            }
-        }' \
-    --additional-config '{"enable_cpu_binding":"True","multistream_overlap_shared_expert":false,"enable_shared_expert_dp":true, "eplb_config":{"dynamic_eplb": true, "expert_heat_collection_interval": 50, "algorithm_execution_interval": 5, "eplb_policy_type": 2, "num_redundant_experts":16}}'
-    ```
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        vllm serve /weight/dsk_v3.1-T-w8a8c8_attn-0506-full/  \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --max_model_len 135168 \
+        --max-num-batched-tokens 16384 \
+        --served-model-name dsv3 \
+        --gpu-memory-utilization 0.9 \
+        --enable-expert-parallel \
+        --async-scheduling \
+        --max-num-seqs 128 \
+        --no-enable-prefix-caching \
+        --trust-remote-code \
+        --enforce-eager \
+        --speculative-config '{"num_speculative_tokens": 1,"method": "deepseek_mtp"}' \
+        --quantization ascend \
+        --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30100",
+            "engine_id": "1",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 4,
+                                "tp_size": 4
+                        },
+                        "decode": {
+                                "dp_size": 32,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+        --additional-config '{"enable_cpu_binding":"True","multistream_overlap_shared_expert":false,"enable_shared_expert_dp":true, "eplb_config":{"dynamic_eplb": true, "expert_heat_collection_interval": 50, "algorithm_execution_interval": 5, "eplb_policy_type": 2, "num_redundant_experts":16}}'
+        ```
 
-=== "Decode Node"
+    === "Decode Node"
 
-    ```shell
-    nic_name="xxx"
-    local_ip="141.xx.xx.2"
+        ```shell
+        nic_name="xxx"
+        local_ip="141.xx.xx.2"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
-    export HCCL_BUFFSIZE=1024
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
+        export HCCL_BUFFSIZE=1024
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export TASK_QUEUE_ENABLE=1
-    export VLLM_ASCEND_ENABLE_MLAPO=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export TASK_QUEUE_ENABLE=1
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve /weight/dsk_v3.1-T-w8a8c8_attn-0506-full/ \
-    --host 0.0.0.0 \
-    --port $2 \
-    --data-parallel-size $3 \
-    --data-parallel-rank $4 \
-    --data-parallel-address $5 \
-    --data-parallel-rpc-port $6 \
-    --tensor-parallel-size $7 \
-    --max_model_len 135168 \
-    --max-num-batched-tokens 256 \
-    --served-model-name dsv3 \
-    --gpu-memory-utilization 0.9 \
-    --enable-expert-parallel \
-    --async-scheduling \
-    --max-num-seqs 96 \
-    --no-enable-prefix-caching \
-    --trust-remote-code \
-    --safetensors-load-strategy 'prefetch' \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp"}' \
-    --quantization ascend \
-    --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30300",
-        "engine_id": "3",
-        "kv_connector_extra_config": {
-                    "prefill": {
-                            "dp_size": 4,
-                            "tp_size": 4
-                    },
-                    "decode": {
-                            "dp_size": 32,
-                            "tp_size": 1
-                    },
-                    "ascend_local_comm_res_path": "/etc/hixlep"
-            }
-        }' \
-    --additional_config '{"enable_cpu_binding": "True", "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":8}}'
-    ```
+        vllm serve /weight/dsk_v3.1-T-w8a8c8_attn-0506-full/ \
+        --host 0.0.0.0 \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --max_model_len 135168 \
+        --max-num-batched-tokens 256 \
+        --served-model-name dsv3 \
+        --gpu-memory-utilization 0.9 \
+        --enable-expert-parallel \
+        --async-scheduling \
+        --max-num-seqs 96 \
+        --no-enable-prefix-caching \
+        --trust-remote-code \
+        --safetensors-load-strategy 'prefetch' \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp"}' \
+        --quantization ascend \
+        --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30300",
+            "engine_id": "3",
+            "kv_connector_extra_config": {
+                        "prefill": {
+                                "dp_size": 4,
+                                "tp_size": 4
+                        },
+                        "decode": {
+                                "dp_size": 32,
+                                "tp_size": 1
+                        },
+                        "ascend_local_comm_res_path": "/etc/hixlep"
+                }
+            }' \
+        --additional_config '{"enable_cpu_binding": "True", "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true, "finegrained_tp_config":  {"lmhead_tensor_parallel_size":8}}'
+        ```
 
-Key Parameter Descriptions:
+    Key Parameter Descriptions:
 
-- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the communication optimization function on the prefill nodes.
-- `VLLM_ASCEND_ENABLE_MLAPO=1`: enables the fusion operator, which can significantly improve performance but consumes more NPU memory. In the Prefill-Decode (PD) separation scenario, enable MLAPO only on decode nodes.
-- `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the Key-Value Cache (KV Cache) of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, it is recommended to enable this configuration on both prefill and decode nodes simultaneously.
-- `multistream_overlap_shared_expert: true`: When the Tensor Parallelism (TP) size is 1 or `enable_shared_expert_dp: true`, an additional stream is enabled to overlap the computation process of shared experts for improved efficiency.
-- `lmhead_tensor_parallel_size: 16`: When the Tensor Parallelism (TP) size of the decode node is 1, this parameter allows the TP size of the LMHead embedding layer to be greater than 1, which is used to reduce the computational load of each card on the LMHead embedding layer.
+    - `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the communication optimization function on the prefill nodes.
+    - `VLLM_ASCEND_ENABLE_MLAPO=1`: enables the fusion operator, which can significantly improve performance but consumes more NPU memory. In the Prefill-Decode (PD) separation scenario, enable MLAPO only on decode nodes.
+    - `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the Key-Value Cache (KV Cache) of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, it is recommended to enable this configuration on both prefill and decode nodes simultaneously.
+    - `multistream_overlap_shared_expert: true`: When the Tensor Parallelism (TP) size is 1 or `enable_shared_expert_dp: true`, an additional stream is enabled to overlap the computation process of shared experts for improved efficiency.
+    - `lmhead_tensor_parallel_size: 16`: When the Tensor Parallelism (TP) size of the decode node is 1, this parameter allows the TP size of the LMHead embedding layer to be greater than 1, which is used to reduce the computational load of each card on the LMHead embedding layer.
 
 3. run server for each node
 
@@ -1116,7 +1116,7 @@ Not test yet.
 
 Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
 
-The performance result is:  
+The performance result is:
 
 **Hardware**: A3-752T, 4 node
 

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -16,8 +16,8 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `DeepSeek-V3.2-Exp-W8A8` (Quantized version): requires **1 Atlas 800 A3 (64G × 16) node** or **2 Atlas 800 A2 (64G × 8) nodes**. [Download model weight](https://www.modelscope.cn/models/vllm-ascend/DeepSeek-V3.2-Exp-W8A8)
-- `DeepSeek-V3.2-w8a8` (Quantized version): requires **1 Atlas 800 A3 (64G × 16) node** or **2 Atlas 800 A2 (64G × 8) nodes**. [Download model weight](https://www.modelscope.cn/models/vllm-ascend/DeepSeek-V3.2-W8A8/)
+- `DeepSeek-V3.2-Exp-W8A8` (Quantized version): requires **1 Atlas 800 A3 (64GB × 16) node** or **2 Atlas 800 A2 (64GB × 8) nodes**. [Download model weight](https://www.modelscope.cn/models/vllm-ascend/DeepSeek-V3.2-Exp-W8A8)
+- `DeepSeek-V3.2-w8a8` (Quantized version): requires **1 Atlas 800 A3 (64GB × 16) node** or **2 Atlas 800 A2 (64GB × 8) nodes**. [Download model weight](https://www.modelscope.cn/models/vllm-ascend/DeepSeek-V3.2-W8A8/)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 
@@ -33,7 +33,7 @@ You can use our official docker image to run `DeepSeek-V3.2` directly.
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```bash
 
@@ -74,7 +74,7 @@ You can use our official docker image to run `DeepSeek-V3.2` directly.
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```bash
 
@@ -121,7 +121,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 ### 5.1 Single-node Deployment
 
-- Quantized model `DeepSeek-V3.2-w8a8` can be deployed on 1 Atlas 800 A3 (64G × 16).
+- Quantized model `DeepSeek-V3.2-w8a8` can be deployed on 1 Atlas 800 A3 (64GB × 16).
 
 Run the following script to execute online inference.
 
@@ -157,7 +157,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V3.2-W8A8 \
 
 ### 5.2 Multi-node Deployment
 
-- `DeepSeek-V3.2-w8a8`: require at least 2 Atlas 800 A2 (64G × 8).
+- `DeepSeek-V3.2-w8a8`: require at least 2 Atlas 800 A2 (64GB × 8).
 
 Run the following scripts on two nodes respectively.
 
@@ -396,301 +396,301 @@ Parameter descriptions:
 
 1. `run_dp_template.sh` script
 
-=== "Node 0(Prefill)"
+    === "Node 0(Prefill)"
 
-    ```shell
-    nic_name="enp48s3u1u1" # change to your own nic name
-    local_ip=141.61.39.105 # change to your own ip
+        ```shell
+        nic_name="enp48s3u1u1" # change to your own nic name
+        local_ip=141.61.39.105 # change to your own ip
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_OP_EXPANSION_MODE="AIV"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_USE_V1=1
-    export HCCL_BUFFSIZE=256
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export VLLM_USE_V1=1
+        export HCCL_BUFFSIZE=256
 
-    export ASCEND_AGGREGATE_ENABLE=1
-    export ASCEND_TRANSPORT_PRINT=1
-    export ACL_OP_INIT_MODE=1
-    export ASCEND_A3_ENABLE=1
-    # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-    export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+        export ASCEND_AGGREGATE_ENABLE=1
+        export ASCEND_TRANSPORT_PRINT=1
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        # Timeout (in seconds) for automatically releasing the prefiller's KV cache for a particular request.
+        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-    vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' \
-        --profiler-config \
-        '{"profiler": "torch",
-        "torch_profiler_dir": "./vllm_profile",
-        "torch_profiler_with_stack": false}' \
-        --seed 1024 \
-        --served-model-name deepseek_v3.2 \
-        --max-model-len 68000 \
-        --max-num-batched-tokens 32560 \
-        --trust-remote-code \
-        --max-num-seqs 64 \
-        --gpu-memory-utilization 0.82 \
-        --quantization ascend \
-        --enforce-eager \
-        --no-enable-prefix-caching \
-        --additional-config '{"enable_dsa_cp": true}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeLayerwiseConnector",
-        "kv_role": "kv_producer",
-        "kv_port": "30000",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 16
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' \
+            --profiler-config \
+            '{"profiler": "torch",
+            "torch_profiler_dir": "./vllm_profile",
+            "torch_profiler_with_stack": false}' \
+            --seed 1024 \
+            --served-model-name deepseek_v3.2 \
+            --max-model-len 68000 \
+            --max-num-batched-tokens 32560 \
+            --trust-remote-code \
+            --max-num-seqs 64 \
+            --gpu-memory-utilization 0.82 \
+            --quantization ascend \
+            --enforce-eager \
+            --no-enable-prefix-caching \
+            --additional-config '{"enable_dsa_cp": true}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeLayerwiseConnector",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 16
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }'
+            }'
 
-    ```
+        ```
 
-=== "Node 1(Prefill)"
+    === "Node 1(Prefill)"
 
-    ```shell
-    nic_name="enp48s3u1u1" # change to your own nic name
-    local_ip=141.61.39.113 # change to your own ip
+        ```shell
+        nic_name="enp48s3u1u1" # change to your own nic name
+        local_ip=141.61.39.113 # change to your own ip
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_OP_EXPANSION_MODE="AIV"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_USE_V1=1
-    export HCCL_BUFFSIZE=256
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export VLLM_USE_V1=1
+        export HCCL_BUFFSIZE=256
 
-    export ASCEND_AGGREGATE_ENABLE=1
-    export ASCEND_TRANSPORT_PRINT=1
-    export ACL_OP_INIT_MODE=1
-    export ASCEND_A3_ENABLE=1
-    # Timeout (in seconds) for automatically releasing the prefiller's KV cache for a particular request.
-    export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+        export ASCEND_AGGREGATE_ENABLE=1
+        export ASCEND_TRANSPORT_PRINT=1
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
+        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-    vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' \
-        --profiler-config \
-        '{"profiler": "torch",
-        "torch_profiler_dir": "./vllm_profile",
-        "torch_profiler_with_stack": false}' \
-        --seed 1024 \
-        --served-model-name deepseek_v3.2 \
-        --max-model-len 68000 \
-        --max-num-batched-tokens 32560 \
-        --trust-remote-code \
-        --max-num-seqs 64 \
-        --gpu-memory-utilization 0.82 \
-        --quantization ascend \
-        --enforce-eager \
-        --no-enable-prefix-caching \
-        --additional-config '{"enable_dsa_cp": true}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeLayerwiseConnector",
-        "kv_role": "kv_producer",
-        "kv_port": "30000",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 16
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp"}' \
+            --profiler-config \
+            '{"profiler": "torch",
+            "torch_profiler_dir": "./vllm_profile",
+            "torch_profiler_with_stack": false}' \
+            --seed 1024 \
+            --served-model-name deepseek_v3.2 \
+            --max-model-len 68000 \
+            --max-num-batched-tokens 32560 \
+            --trust-remote-code \
+            --max-num-seqs 64 \
+            --gpu-memory-utilization 0.82 \
+            --quantization ascend \
+            --enforce-eager \
+            --no-enable-prefix-caching \
+            --additional-config '{"enable_dsa_cp": true}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeLayerwiseConnector",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 16
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 0(Decode)"
+    === "Node 0(Decode)"
 
-    ```shell
-    nic_name="enp48s3u1u1" # change to your own nic name
-    local_ip=141.61.39.117 # change to your own ip
+        ```shell
+        nic_name="enp48s3u1u1" # change to your own nic name
+        local_ip=141.61.39.117 # change to your own ip
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_OP_EXPANSION_MODE="AIV"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    #Mooncake
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
+        #Mooncake
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
 
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_USE_V1=1
-    export HCCL_BUFFSIZE=256
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export VLLM_USE_V1=1
+        export HCCL_BUFFSIZE=256
 
-    export ASCEND_AGGREGATE_ENABLE=1
-    export ASCEND_TRANSPORT_PRINT=1
-    export ACL_OP_INIT_MODE=1
-    export ASCEND_A3_ENABLE=1
-    # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-    export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+        export ASCEND_AGGREGATE_ENABLE=1
+        export ASCEND_TRANSPORT_PRINT=1
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
+        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 
-    export TASK_QUEUE_ENABLE=1
+        export TASK_QUEUE_ENABLE=1
 
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' \
-        --profiler-config \
-        '{"profiler": "torch",
-        "torch_profiler_dir": "./vllm_profile",
-        "torch_profiler_with_stack": false}' \
-        --seed 1024 \
-        --served-model-name deepseek_v3.2 \
-        --max-model-len 68000 \
-        --max-num-batched-tokens 12 \
-        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
-        --trust-remote-code \
-        --max-num-seqs 4 \
-        --gpu-memory-utilization 0.95 \
-        --no-enable-prefix-caching \
-        --quantization ascend \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeLayerwiseConnector",
-        "kv_role": "kv_consumer",
-        "kv_port": "30100",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 16
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' \
+            --profiler-config \
+            '{"profiler": "torch",
+            "torch_profiler_dir": "./vllm_profile",
+            "torch_profiler_with_stack": false}' \
+            --seed 1024 \
+            --served-model-name deepseek_v3.2 \
+            --max-model-len 68000 \
+            --max-num-batched-tokens 12 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
+            --trust-remote-code \
+            --max-num-seqs 4 \
+            --gpu-memory-utilization 0.95 \
+            --no-enable-prefix-caching \
+            --quantization ascend \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeLayerwiseConnector",
+            "kv_role": "kv_consumer",
+            "kv_port": "30100",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 16
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }' \
-        --additional-config '{"recompute_scheduler_enable" : true}'
-    ```
+            }' \
+            --additional-config '{"recompute_scheduler_enable" : true}'
+        ```
 
-=== "Node 1(Decode)"
+    === "Node 1(Decode)"
 
-    ```shell
-    nic_name="enp48s3u1u1" # change to your own nic name
-    local_ip=141.61.39.181 # change to your own ip
+        ```shell
+        nic_name="enp48s3u1u1" # change to your own nic name
+        local_ip=141.61.39.181 # change to your own ip
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_OP_EXPANSION_MODE="AIV"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    #Mooncake
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=10
+        #Mooncake
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
 
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_USE_V1=1
-    export HCCL_BUFFSIZE=256
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export VLLM_USE_V1=1
+        export HCCL_BUFFSIZE=256
 
-    export ASCEND_AGGREGATE_ENABLE=1
-    export ASCEND_TRANSPORT_PRINT=1
-    export ACL_OP_INIT_MODE=1
-    export ASCEND_A3_ENABLE=1
-    # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
-    export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
+        export ASCEND_AGGREGATE_ENABLE=1
+        export ASCEND_TRANSPORT_PRINT=1
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
+        export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
 
-    export TASK_QUEUE_ENABLE=1
+        export TASK_QUEUE_ENABLE=1
 
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' \
-        --profiler-config \
-        '{"profiler": "torch",
-        "torch_profiler_dir": "./vllm_profile",
-        "torch_profiler_with_stack": false}' \
-        --seed 1024 \
-        --served-model-name deepseek_v3.2 \
-        --max-model-len 68000 \
-        --max-num-batched-tokens 12 \
-        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY",  "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
-        --trust-remote-code \
-        --max-num-seqs 4 \
-        --gpu-memory-utilization 0.95 \
-        --no-enable-prefix-caching \
-        --quantization ascend \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeLayerwiseConnector",
-        "kv_role": "kv_consumer",
-        "kv_port": "30100",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 16
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve /root/.cache/Eco-Tech/DeepSeek-V3.2-w8a8-mtp-QuaRot \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 2, "method":"deepseek_mtp"}' \
+            --profiler-config \
+            '{"profiler": "torch",
+            "torch_profiler_dir": "./vllm_profile",
+            "torch_profiler_with_stack": false}' \
+            --seed 1024 \
+            --served-model-name deepseek_v3.2 \
+            --max-model-len 68000 \
+            --max-num-batched-tokens 12 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY",  "cudagraph_capture_sizes":[3, 6, 9, 12]}' \
+            --trust-remote-code \
+            --max-num-seqs 4 \
+            --gpu-memory-utilization 0.95 \
+            --no-enable-prefix-caching \
+            --quantization ascend \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeLayerwiseConnector",
+            "kv_role": "kv_consumer",
+            "kv_port": "30100",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 16
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }' \
-        --additional-config '{"recompute_scheduler_enable" : true}'
-    ```
+            }' \
+            --additional-config '{"recompute_scheduler_enable" : true}'
+        ```
 
-Once the preparation is done, you can start the server with the following command on each node:
-Refer to [Distributed DP Server With Large-Scale Expert Parallelism](https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/large_scale_ep.html) to get the detailed boot method.
+    Once the preparation is done, you can start the server with the following command on each node:
+    Refer to [Distributed DP Server With Large-Scale Expert Parallelism](https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/large_scale_ep.html) to get the detailed boot method.
 
 2. run server for each node:
 
@@ -747,10 +747,10 @@ Common Issues Tip: If you encounter issues with PD separation deployment, please
 
 Once your server is started, you can query the model with input prompts:
 
-**Note**:
+!!! note
 
-- `<node0_ip>`: The IP address of the node where the server is running (e.g., localhost). For PD-separated deployment, use the host IP of the node where the proxy script resides.
-- `<port>`: The port number specified in the server startup command (e.g., 8000). For PD-separated deployment, use the port configured in the proxy script.
+    - `<node0_ip>`: The IP address of the node where the server is running (e.g., localhost). For PD-separated deployment, use the host IP of the node where the proxy script resides.
+    - `<port>`: The port number specified in the server startup command (e.g., 8000). For PD-separated deployment, use the port configured in the proxy script.
 
 ```shell
 curl http://<node0_ip>:<port>/v1/completions \
@@ -803,7 +803,7 @@ As an example, take the `gsm8k` dataset as a test dataset, and run accuracy eval
 
 Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
 
-The performance result is:  
+The performance result is:
 
 **Hardware**: A3-752T, 4 node
 

--- a/docs/source/tutorials/models/GLM4.x.md
+++ b/docs/source/tutorials/models/GLM4.x.md
@@ -23,7 +23,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-4.7`(BF16 version): [Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-4.7).
 - `GLM-4.5-w8a8-with-float-mtp`(Quantized version with mtp): [Download model weight](https://modelers.cn/models/Modelers_Park/GLM-4.5-w8a8).
 - `GLM-4.6-w8a8`(Quantized version without mtp): [Download model weight](https://modelers.cn/models/Modelers_Park/GLM-4.6-w8a8). Because vllm does not support GLM4.6 mtp in October, we do not provide an mtp version. Since it is now supported, you can use the following quantization scheme to add mtp weights to the quantized weights.
-- `GLM-4.7-w8a8-with-float-mtp`(Quantized version without mtp): [Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-4.7-W8A8-floatmtp).
+- `GLM-4.7-w8a8-with-float-mtp`(Quantized version with mtp): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-4.7-W8A8-floatmtp).
 - `Method of Quantization`: [quantization scheme](https://ai.gitcode.com/Ascend-SACT/GLM-4.5-w8a8). You can use these methods to quantize the model.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
@@ -663,7 +663,7 @@ Once the preparation is done, you can start the server with the following comman
 === "Decode node 1"
 
     ```shell
-    
+
     # change ip to your own
     python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 12778 --vllm-start-port 9300
     ```
@@ -708,15 +708,15 @@ curl -H "Accept: application/json" \
     -H "Content-type: application/json" \
     -X POST \
     -d '{
-        "model": "glm", 
-        "messages": [{ 
-            "role": "user", 
-            "content": "The future of AI is" 
-        }], 
-        "stream": false, 
-        "ignore_eos": false, 
-        "temperature": 0, 
-        "max_tokens": 200 
+        "model": "glm",
+        "messages": [{
+            "role": "user",
+            "content": "The future of AI is"
+        }],
+        "stream": false,
+        "ignore_eos": false,
+        "temperature": 0,
+        "max_tokens": 200
     }' http://<node0_ip>:<port>/v1/chat/completions
 ```
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -28,7 +28,7 @@ You can use our official docker image to run GLM-5.2 directly.
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
 
@@ -704,7 +704,7 @@ Before you start, please
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        
+
         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8 \
             --host 0.0.0.0 \
             --port $2 \
@@ -823,7 +823,7 @@ Before you start, please
         ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
-            
+
         export HCCL_OP_EXPANSION_MODE="AIV"
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -21,7 +21,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 ### 3.1 Model Weight
 
 - `GLM-5`(BF16 version): [Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5).
-- `GLM-5-w4a8`(Quantized version): [Download model weight](https://modelscope.cn/models/Eco-Tech/GLM-5-w4a8).
+- `GLM-5-w4a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w4a8).
 - `GLM-5-w8a8`(Quantized version): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5-w8a8).
 - `GLM-5.1`(BF16 version): [Download model weight](https://huggingface.co/zai-org/GLM-5.1).
 - `GLM-5.1-w4a8`(Quantized version): [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.1-w4a8).
@@ -41,7 +41,7 @@ You can use our official docker image to run GLM-5/5.1 directly.
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
 
@@ -85,7 +85,7 @@ You can use our official docker image to run GLM-5/5.1 directly.
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
 
@@ -169,7 +169,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-prefix-caching \
     --additional-config '{"multistream_overlap_shared_expert": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' 
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
     - Quantized model `glm-5-w8a8` and `glm-5.1-w8a8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
@@ -204,7 +204,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-prefix-caching \
     --additional-config '{"multistream_overlap_shared_expert": true}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' 
+    --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
 === "A2 series"
@@ -750,7 +750,7 @@ Before you start, please
 
         export ASCEND_RT_VISIBLE_DEVICES=$1
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-          
+
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
@@ -830,7 +830,7 @@ Before you start, please
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-       
+
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
@@ -885,37 +885,37 @@ Before you start, please
         ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
-    
+
         export HCCL_OP_EXPANSION_MODE="AIV"
-    
+
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name
         export TP_SOCKET_IFNAME=$nic_name
         export HCCL_SOCKET_IFNAME=$nic_name
-    
+
         #Mooncake
         export OMP_PROC_BIND=false
         export OMP_NUM_THREADS=1
-    
+
         export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
         export HCCL_BUFFSIZE=256
-    
-    
+
+
         export ASCEND_AGGREGATE_ENABLE=1
         export ASCEND_TRANSPORT_PRINT=1
         export ACL_OP_INIT_MODE=1
         export ASCEND_A3_ENABLE=1
         # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
         export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-    
+
         export TASK_QUEUE_ENABLE=1
-    
+
         export ASCEND_RT_VISIBLE_DEVICES=$1
-          
+
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
         export VLLM_ASCEND_ENABLE_MLAPO=1
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-    
+
         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
             --host 0.0.0.0 \
             --port $2 \
@@ -966,36 +966,36 @@ Before you start, please
          ```shell
          nic_name="xxxx" # change to your own nic name
          local_ip="xxxx" # change to your own ip
-            
+
          export HCCL_OP_EXPANSION_MODE="AIV"
-            
+
          export HCCL_IF_IP=$local_ip
          export GLOO_SOCKET_IFNAME=$nic_name
          export TP_SOCKET_IFNAME=$nic_name
          export HCCL_SOCKET_IFNAME=$nic_name
-            
+
          #Mooncake
          export OMP_PROC_BIND=false
          export OMP_NUM_THREADS=1
-            
+
          export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
          export HCCL_BUFFSIZE=256
-            
+
          export ASCEND_AGGREGATE_ENABLE=1
          export ASCEND_TRANSPORT_PRINT=1
          export ACL_OP_INIT_MODE=1
          export ASCEND_A3_ENABLE=1
          # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
          export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-            
+
          export TASK_QUEUE_ENABLE=1
-            
+
          export ASCEND_RT_VISIBLE_DEVICES=$1
-                     
+
          export VLLM_ASCEND_ENABLE_FUSED_MC2=1
          export VLLM_ASCEND_ENABLE_MLAPO=1
          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-            
+
          vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
              --host 0.0.0.0 \
              --port $2 \
@@ -1046,36 +1046,36 @@ Before you start, please
          ```shell
          nic_name="xxxx" # change to your own nic name
          local_ip="xxxx" # change to your own ip
-            
+
          export HCCL_OP_EXPANSION_MODE="AIV"
-            
+
          export HCCL_IF_IP=$local_ip
          export GLOO_SOCKET_IFNAME=$nic_name
          export TP_SOCKET_IFNAME=$nic_name
          export HCCL_SOCKET_IFNAME=$nic_name
-            
+
          #Mooncake
          export OMP_PROC_BIND=false
          export OMP_NUM_THREADS=1
-            
+
          export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
          export HCCL_BUFFSIZE=256
-            
+
          export ASCEND_AGGREGATE_ENABLE=1
          export ASCEND_TRANSPORT_PRINT=1
          export ACL_OP_INIT_MODE=1
          export ASCEND_A3_ENABLE=1
          # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
          export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-            
+
          export TASK_QUEUE_ENABLE=1
-            
+
          export ASCEND_RT_VISIBLE_DEVICES=$1
-                     
+
          export VLLM_ASCEND_ENABLE_FUSED_MC2=1
          export VLLM_ASCEND_ENABLE_MLAPO=1
          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-            
+
          vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
              --host 0.0.0.0 \
              --port $2 \
@@ -1126,36 +1126,36 @@ Before you start, please
          ```shell
          nic_name="xxxx" # change to your own nic name
          local_ip="xxxx" # change to your own ip
-            
+
          export HCCL_OP_EXPANSION_MODE="AIV"
-            
+
          export HCCL_IF_IP=$local_ip
          export GLOO_SOCKET_IFNAME=$nic_name
          export TP_SOCKET_IFNAME=$nic_name
          export HCCL_SOCKET_IFNAME=$nic_name
-            
+
          #Mooncake
          export OMP_PROC_BIND=false
          export OMP_NUM_THREADS=1
-            
+
          export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
          export HCCL_BUFFSIZE=256
-            
+
          export ASCEND_AGGREGATE_ENABLE=1
          export ASCEND_TRANSPORT_PRINT=1
          export ACL_OP_INIT_MODE=1
          export ASCEND_A3_ENABLE=1
          # Timeout (in seconds) for automatically releasing the prefiller’s KV cache for a particular request.
          export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
-            
+
          export TASK_QUEUE_ENABLE=1
-            
+
          export ASCEND_RT_VISIBLE_DEVICES=$1
-                     
+
          export VLLM_ASCEND_ENABLE_FUSED_MC2=1
          export VLLM_ASCEND_ENABLE_MLAPO=1
          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-            
+
          vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
              --host 0.0.0.0 \
              --port $2 \
@@ -1283,7 +1283,7 @@ python load_balance_proxy_server_example.py \
       6721 6722 6723 6724 \
       6721 6722 6723 6724 \
       6721 6722 6723 6724 \
-      6721 6722 6723 6724      
+      6721 6722 6723 6724
 ```
 
 **Notice:**

--- a/docs/source/tutorials/models/Hy3-preview.md
+++ b/docs/source/tutorials/models/Hy3-preview.md
@@ -17,7 +17,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 ### Model Weight
 
 - Hugging Face: [tencent/Hy3-preview](https://huggingface.co/tencent/Hy3-preview)
-- ModelScope: [Tencent-Hunyuan/Hy3-preview](https://modelscope.cn/models/Tencent-Hunyuan/Hy3-preview)
+- ModelScope: [Tencent-Hunyuan/Hy3-preview](https://www.modelscope.cn/models/Tencent-Hunyuan/Hy3-preview)
 - GitCode: [tencent_hunyuan/Hy3-preview](https://ai.gitcode.com/tencent_hunyuan/Hy3-preview)
 
 Download or mount the checkpoint to a path shared by the runtime container, for example `/models/Hy3-preview`.
@@ -97,7 +97,7 @@ vllm serve ${MODEL_PATH} \
   --port 8000
 ```
 
-- `--enable-ep-weight-filter` is optional. It skips expert weights that do not belong to the local EP rank during loading, reducing disk and host-memory pressure for very large MoE checkpoints. We recommend keeping it enabled.
+- `--enable-ep-weight-filter` recommended. It skips expert weights that do not belong to the local EP rank during loading, reducing disk and host-memory pressure for very large MoE checkpoints. We recommend keeping it enabled.
 - Tool calling and reasoning are service interfaces declared in the Hy3 README, so it is recommended to pass the corresponding `hy_v3` parsers by default.
 
 ## Functional Verification

--- a/docs/source/tutorials/models/InternVL3.5.md
+++ b/docs/source/tutorials/models/InternVL3.5.md
@@ -76,15 +76,13 @@ In addition, if you don't want to use the docker image as above, you can also bu
 
 - Install `vllm-ascend` from source, refer to [installation](../../installation.md).
 
-If you want to deploy multi-node environment, you need to set up environment on each node.
-
 ## 5 Online Service Deployment
 
 ### 5.1 Single-Node Online Deployment
 
 === "InternVL3_5-38B"
 
-    - Quantized model `InternVL3_5-38B-w8a8` can be deployed on 1 Atlas 800 A3 (64G × 16) .
+    - Quantized model `InternVL3_5-38B-w8a8` can be deployed on 1 Atlas 800 A3 (64G × 16) node.
 
     Run the following script to execute online inference.
 
@@ -129,7 +127,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 === "InternVL3_5-241B-A28B"
 
-    - Quantized model `InternVL3_5-241B-A28B-w8a8` can be deployed on 1 Atlas 800 A3 (64G × 16) .
+    - Quantized model `InternVL3_5-241B-A28B-w8a8` can be deployed on 1 Atlas 800 A3 (64G × 16) node.
 
     Run the following script to execute online inference.
 
@@ -227,4 +225,4 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more
 
 ## 9 FAQ
 
-- Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
+- Common Issues Tip: If you encounter issues, refer to [FAQs](../../faqs.md).

--- a/docs/source/tutorials/models/Kimi-K2-Thinking.md
+++ b/docs/source/tutorials/models/Kimi-K2-Thinking.md
@@ -4,9 +4,9 @@
 
 Kimi-K2-Thinking is a large-scale Mixture-of-Experts (MoE) model developed by Moonshot AI. It features a hybrid thinking architecture that excels in complex reasoning and problem-solving tasks.
 
-This document will demonstrate the main verification steps of the model, including supported features, environment preparation, installation, online service deployment, functional verification, accuracy evaluation, performance evaluation, performance tuning, and FAQ.
+This document will demonstrate the main verification steps and references of the model, including supported features, environment preparation, installation, online service deployment, functional verification, accuracy evaluation, performance evaluation, performance tuning, and FAQ.
 
-This document is recommended to use the latest release candidate or official version.
+This document is validated and written based on **vLLM-Ascend v0.9.0rc1**. The current model (Kimi-K2-Thinking) is first supported in this version, and **v0.9.0rc1 and later versions** can run stably. It is recommended to use the latest release candidate or stable version alongside this document.
 
 ## 2 Supported Features
 
@@ -18,11 +18,11 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `Kimi-K2-Thinking` (bfloat16): requires 1 Atlas 800 A3 (64G x 16) node. [Download model weight](https://huggingface.co/moonshotai/Kimi-K2-Thinking).
+- `Kimi-K2-Thinking` (bfloat16): requires 1 Atlas 800 A3 (64G × 16) node. [Download model weight](https://huggingface.co/moonshotai/Kimi-K2-Thinking).
 
 It is recommended to download the model weight to the shared directory, such as `/mnt/sfs_turbo/.cache/`.
 
-After downloading the model weights, please edit the value of `"quantization_config.config_groups.group_0.targets"` from `["Linear"]` to `["MoE"]` in `config.json` of the original model to verify the quantized model.
+After downloading the model weights, please edit the value of `"quantization_config.config_groups.group_0.targets"` from `["Linear"]` to `["MoE"]` in `config.json` of the original model to use the quantized model.
 
 ```json
 {
@@ -170,15 +170,13 @@ Expected Status:
 - The command exits successfully.
 - `vllm and vllm_ascend import ok` is printed.
 
-If you want to deploy a multi-node environment, set up the same software environment on each node.
-
 ## 5 Online Service Deployment
 
 ### 5.1 Single-Node Online Deployment
 
 Single-node deployment completes both Prefill and Decode within the same node, suitable for online inference scenarios with moderate concurrency requirements.
 
-For an Atlas 800 A3 (64G x 16) node, `tensor-parallel-size` should be at least 16.
+For an Atlas 800 A3 (64G × 16) node, `tensor-parallel-size` should be at least 16.
 
 Run the following script to start the vLLM server:
 

--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -18,7 +18,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `Kimi-K2.5-w4a8` (Quantized version for w4a8): requires 1 Atlas 800 A3 (64G × 16) node or 2 Atlas 800 A2 (64G × 8) nodes. [Download model weight](https://modelscope.cn/models/Eco-Tech/Kimi-K2.5-W4A8).
+- `Kimi-K2.5-w4a8` (Quantized version for w4a8): requires 1 Atlas 800 A3 (64G × 16) node or 2 Atlas 800 A2 (64G × 8) nodes. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Kimi-K2.5-W4A8).
 - `kimi-k2.5-eagle3` (Eagle3 MTP draft model for accelerating inference of Kimi-K2.5): [Download model weight](https://huggingface.co/lightseekorg/kimi-k2.5-eagle3)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
@@ -35,7 +35,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -75,7 +75,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -443,344 +443,344 @@ Parameter descriptions:
 
 1. `run_dp_template.sh` script
 
-=== "Node 0(Prefill)"
+    === "Node 0(Prefill)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.1"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.1"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=256
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=256
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k25 \
-        --trust-remote-code \
-        --max-num-seqs 8 \
-        --max-model-len 32768 \
-        --max-num-batched-tokens 16384 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.8 \
-        --enforce-eager \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
-        --additional-config '{"recompute_scheduler_enable":true}' \
-        --mm-encoder-tp-mode data \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30000",
-        "engine_id": "0",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k25 \
+            --trust-remote-code \
+            --max-num-seqs 8 \
+            --max-model-len 32768 \
+            --max-num-batched-tokens 16384 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.8 \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
+            --additional-config '{"recompute_scheduler_enable":true}' \
+            --mm-encoder-tp-mode data \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 1(Prefill)"
+    === "Node 1(Prefill)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.2"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.2"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=256
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=256
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k25 \
-        --trust-remote-code \
-        --max-num-seqs 8 \
-        --max-model-len 32768 \
-        --max-num-batched-tokens 16384 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.8 \
-        --enforce-eager \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
-        --additional-config '{"recompute_scheduler_enable":true}' \
-        --mm-encoder-tp-mode data \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30100",
-        "engine_id": "1",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k25 \
+            --trust-remote-code \
+            --max-num-seqs 8 \
+            --max-model-len 32768 \
+            --max-num-batched-tokens 16384 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.8 \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
+            --additional-config '{"recompute_scheduler_enable":true}' \
+            --mm-encoder-tp-mode data \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30100",
+            "engine_id": "1",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 0(Decode)"
+    === "Node 0(Decode)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.3"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.3"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=1100
-    export VLLM_ASCEND_ENABLE_MLAPO=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=1100
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k25 \
-        --trust-remote-code \
-        --max-num-seqs 48 \
-        --max-model-len 32768 \
-        --max-num-batched-tokens 256 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.95 \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": false}' \
-        --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30200",
-        "engine_id": "2",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k25 \
+            --trust-remote-code \
+            --max-num-seqs 48 \
+            --max-model-len 32768 \
+            --max-num-batched-tokens 256 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.95 \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": false}' \
+            --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 1(Decode)"
+    === "Node 1(Decode)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.4"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.4"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=1100
-    export VLLM_ASCEND_ENABLE_MLAPO=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=1100
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k25 \
-        --trust-remote-code \
-        --max-num-seqs 48 \
-        --max-model-len 32768 \
-        --max-num-batched-tokens 256 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.95 \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": false}' \
-        --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30200",
-        "engine_id": "2",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 2,
-                        "tp_size": 8
-                },
-                "decode": {
-                        "dp_size": 32,
-                        "tp_size": 1
+        vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k25 \
+            --trust-remote-code \
+            --max-num-seqs 48 \
+            --max-model-len 32768 \
+            --max-num-batched-tokens 256 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.95 \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": false}' \
+            --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens": 3}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 2,
+                            "tp_size": 8
+                    },
+                    "decode": {
+                            "dp_size": 32,
+                            "tp_size": 1
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-Key Parameter Descriptions:
+    Key Parameter Descriptions:
 
-- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the communication optimization function on the prefill nodes.
-- `VLLM_ASCEND_ENABLE_MLAPO=1`: enables the fusion operator, which can significantly improve performance but consumes more NPU memory. In the Prefill-Decode (PD) separation scenario, enable MLAPO only on decode nodes.
-- `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the Key-Value Cache (KV Cache) of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, it is recommended to enable this configuration on both prefill and decode nodes simultaneously.
-- `multistream_overlap_shared_expert: true`: When the Tensor Parallelism (TP) size is 1 or `enable_shared_expert_dp: true`, an additional stream is enabled to overlap the computation process of shared experts for improved efficiency.
+    - `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the communication optimization function on the prefill nodes.
+    - `VLLM_ASCEND_ENABLE_MLAPO=1`: enables the fusion operator, which can significantly improve performance but consumes more NPU memory. In the Prefill-Decode (PD) separation scenario, enable MLAPO only on decode nodes.
+    - `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the Key-Value Cache (KV Cache) of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, it is recommended to enable this configuration on both prefill and decode nodes simultaneously.
+    - `multistream_overlap_shared_expert: true`: When the Tensor Parallelism (TP) size is 1 or `enable_shared_expert_dp: true`, an additional stream is enabled to overlap the computation process of shared experts for improved efficiency.
 
-The `run_dp_template.sh` scripts use positional parameters (`$1`-`$7`) to receive configuration values from `launch_online_dp.py`:
+    The `run_dp_template.sh` scripts use positional parameters (`$1`-`$7`) to receive configuration values from `launch_online_dp.py`:
 
-- `$1` (`ASCEND_RT_VISIBLE_DEVICES`): the NPU devices assigned to this DP instance, e.g., `0,1,2,3` or `4,5,6,7`.
-- `$2` (`--port`): the vLLM server port for this DP instance, auto-assigned starting from `--vllm-start-port` (e.g., `7100`, `7101`).
-- `$3` (`--data-parallel-size`): total number of DP ranks.
-- `$4` (`--data-parallel-rank`): the rank index of this DP instance.
-- `$5` (`--data-parallel-address`): IP address of the DP master node.
-- `$6` (`--data-parallel-rpc-port`): RPC port for DP master communication.
-- `$7` (`--tensor-parallel-size`): TP size within each DP rank.
+    - `$1` (`ASCEND_RT_VISIBLE_DEVICES`): the NPU devices assigned to this DP instance, e.g., `0,1,2,3` or `4,5,6,7`.
+    - `$2` (`--port`): the vLLM server port for this DP instance, auto-assigned starting from `--vllm-start-port` (e.g., `7100`, `7101`).
+    - `$3` (`--data-parallel-size`): total number of DP ranks.
+    - `$4` (`--data-parallel-rank`): the rank index of this DP instance.
+    - `$5` (`--data-parallel-address`): IP address of the DP master node.
+    - `$6` (`--data-parallel-rpc-port`): RPC port for DP master communication.
+    - `$7` (`--tensor-parallel-size`): TP size within each DP rank.
 
 2. Run server for each node:
 
@@ -1012,7 +1012,7 @@ After about several minutes, you can get the performance evaluation result.
 |--------|---------------|-----------|--------------|------------------|
 |High Throughput / Low Latency<br>(16K context)|Single-Node Mixed|16 (A3)|kimi-k2.5-w4a8|Use dp4 tp4 for optimal throughput and low latency|
 |High Throughput / Low Latency<br>(16K context)|2-Node Data Parallel|16 (A2)|kimi-k2.5-w4a8|dp4 tp4 across 2 nodes; balanced latency and throughput|
-|High Throughput / Low Latency<br>(16K context)|2P2D deployment|64 (A3)|kimi-k2.5-w4a8|Prefill: dp2 tp8; Decode: dp32 tp1 for high concurrency|
+|High Throughput / Low Latency<br>(16K context)|2P1D deployment|64 (A3)|kimi-k2.5-w4a8|Prefill: dp2 tp8; Decode: dp32 tp1 for high concurrency|
 |Long Context<br>(128K, low concurrency ≤4)|Single-Node Mixed|16 (A3)|kimi-k2.5-w4a8|dp1 tp16 to maximize TP, accommodate extreme context lengths|
 |Long Context<br>(128K, high concurrency >4)|Single-Node Mixed|16 (A3)|kimi-k2.5-w4a8|dp2 tp8 to optimize memory bandwidth and support higher concurrency|
 

--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -18,7 +18,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `Kimi-K2.6-w4a8` (Quantized version for w4a8): requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 8) nodes. [Download model weight](https://modelscope.cn/models/Eco-Tech/Kimi-K2.6-W4A8).
+- `Kimi-K2.6-w4a8` (Quantized version for w4a8): requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 8) nodes. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Kimi-K2.6-W4A8).
 - `kimi-k2.6-eagle3` (Eagle3 MTP draft model for accelerating inference of Kimi-K2.6): [Download model weight](https://huggingface.co/lightseekorg/kimi-k2.6-eagle3)
 - `Kimi-K2.5-DFlash` (a speculative decoding framework that leverages a lightweight block diffusion model for parallel drafting): [Download model weight](https://huggingface.co/z-lab/Kimi-K2.5-DFlash)
 
@@ -36,7 +36,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -76,7 +76,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -181,7 +181,7 @@ Key Parameter Descriptions:
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For performance testing with an input length of 3.5K and output length of 1.5K, a value of `16384` is sufficient, however, for precision testing, please set it at least `35000`.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
 - `--mm-encoder-tp-mode` indicates how to optimize multi-modal encoder inference using tensor parallelism (TP). If you want to test the multimodal inputs, we recommend using `data`.
-- If you use the w4a8 weight, more memory will be allocated to kvcache, and you can try to increase system throughput to achieve greater throughput.
+- If you use the w4a8 weight, more memory will be allocated to kvcache, and you can try increasing `--max-num-seqs` to improve system throughput.
 
 Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 
@@ -287,340 +287,340 @@ Parameter descriptions:
 
 1. `run_dp_template.sh` script
 
-=== "Node 0(Prefill)"
+    === "Node 0(Prefill)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.1"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.1"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=1536
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=1536
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k26 \
-        --trust-remote-code \
-        --max-num-seqs 1 \
-        --max-model-len 133120 \
-        --max-num-batched-tokens 16384 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.92 \
-        --enforce-eager \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --additional-config '{"recompute_scheduler_enable":true,"enable_shared_expert_dp": true}' \
-        --mm-encoder-tp-mode data \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30000",
-        "engine_id": "0",
-        "kv_connector_extra_config": {
-                "use_ascend_direct": true,
-                "prefill": {
-                        "dp_size": 4,
-                        "tp_size": 4
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k26 \
+            --trust-remote-code \
+            --max-num-seqs 1 \
+            --max-model-len 133120 \
+            --max-num-batched-tokens 16384 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.92 \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --additional-config '{"recompute_scheduler_enable":true,"enable_shared_expert_dp": true}' \
+            --mm-encoder-tp-mode data \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                    "use_ascend_direct": true,
+                    "prefill": {
+                            "dp_size": 4,
+                            "tp_size": 4
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 1(Prefill)"
+    === "Node 1(Prefill)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.2"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.2"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=1536
-    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=1536
+        export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k26 \
-        --trust-remote-code \
-        --max-num-seqs 1 \
-        --max-model-len 133120 \
-        --max-num-batched-tokens 16384 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.92 \
-        --enforce-eager \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --additional-config '{"recompute_scheduler_enable":true,"enable_shared_expert_dp": true}' \
-        --mm-encoder-tp-mode data \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30100",
-        "engine_id": "1",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 4,
-                        "tp_size": 4
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k26 \
+            --trust-remote-code \
+            --max-num-seqs 1 \
+            --max-model-len 133120 \
+            --max-num-batched-tokens 16384 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.92 \
+            --enforce-eager \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --additional-config '{"recompute_scheduler_enable":true,"enable_shared_expert_dp": true}' \
+            --mm-encoder-tp-mode data \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30100",
+            "engine_id": "1",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 4,
+                            "tp_size": 4
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 0(Decode)"
+    === "Node 0(Decode)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.3"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.3"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=800
-    export VLLM_ASCEND_ENABLE_MLAPO=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=800
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k26 \
-        --trust-remote-code \
-        --max-num-seqs 8 \
-        --max-model-len 133720 \
-        --max-num-batched-tokens 32 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.91 \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true}' \
-        --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 3}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30200",
-        "engine_id": "2",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 4,
-                        "tp_size": 4
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k26 \
+            --trust-remote-code \
+            --max-num-seqs 8 \
+            --max-model-len 133720 \
+            --max-num-batched-tokens 32 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.91 \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true}' \
+            --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 3}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 4,
+                            "tp_size": 4
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
-=== "Node 1(Decode)"
+    === "Node 1(Decode)"
 
-    ```shell
-    # this obtained through ifconfig
-    # nic_name is the network interface name corresponding to local_ip of the current node
-    nic_name="xxx"
-    local_ip="141.xx.xx.4"
+        ```shell
+        # this obtained through ifconfig
+        # nic_name is the network interface name corresponding to local_ip of the current node
+        nic_name="xxx"
+        local_ip="141.xx.xx.4"
 
-    # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
-    node0_ip="xxxx"
+        # The value of node0_ip must be consistent with the value of local_ip set in node0 (master node)
+        node0_ip="xxxx"
 
-    export HCCL_IF_IP=$local_ip
-    export GLOO_SOCKET_IFNAME=$nic_name
-    export TP_SOCKET_IFNAME=$nic_name
-    export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
 
-    # [Optional] jemalloc
-    # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
-    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-    echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-    sysctl -w vm.swappiness=0
-    sysctl -w kernel.numa_balancing=0
-    sysctl kernel.sched_migration_cost_ns=50000
-    export VLLM_RPC_TIMEOUT=3600000
-    export HCCL_EXEC_TIMEOUT=204
-    export HCCL_CONNECT_TIMEOUT=120
-    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+        # [Optional] jemalloc
+        # jemalloc is for better performance, if `libjemalloc.so` is installed on your machine, you can turn it on.
+        export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+        echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+        sysctl -w vm.swappiness=0
+        sysctl -w kernel.numa_balancing=0
+        sysctl kernel.sched_migration_cost_ns=50000
+        export VLLM_RPC_TIMEOUT=3600000
+        export HCCL_EXEC_TIMEOUT=204
+        export HCCL_CONNECT_TIMEOUT=120
+        export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
 
-    export HCCL_OP_EXPANSION_MODE="AIV"
-    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
-    export TASK_QUEUE_ENABLE=1
-    export ASCEND_BUFFER_POOL=4:8
-    export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_BUFFER_POOL=4:8
+        export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-    export HCCL_BUFFSIZE=800
-    export VLLM_ASCEND_ENABLE_MLAPO=1
-    export ASCEND_RT_VISIBLE_DEVICES=$1
+        export HCCL_BUFFSIZE=800
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
 
-    vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
-        --host 0.0.0.0 \
-        --port $2 \
-        --data-parallel-size $3 \
-        --data-parallel-rank $4 \
-        --data-parallel-address $5 \
-        --data-parallel-rpc-port $6 \
-        --tensor-parallel-size $7 \
-        --enable-expert-parallel \
-        --seed 1024 \
-        --quantization ascend \
-        --served-model-name kimi_k26 \
-        --trust-remote-code \
-        --max-num-seqs 8 \
-        --max-model-len 133720 \
-        --max-num-batched-tokens 32 \
-        --no-enable-prefix-caching \
-        --gpu-memory-utilization 0.91 \
-        --enable-auto-tool-choice \
-        --tool-call-parser kimi_k2 \
-        --reasoning-parser kimi_k2 \
-        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-        --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true}' \
-        --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 3}' \
-        --kv-transfer-config \
-        '{"kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30300",
-        "engine_id": "3",
-        "kv_connector_extra_config": {
-                "prefill": {
-                        "dp_size": 4,
-                        "tp_size": 4
-                },
-                "decode": {
-                        "dp_size": 8,
-                        "tp_size": 4
+        vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --quantization ascend \
+            --served-model-name kimi_k26 \
+            --trust-remote-code \
+            --max-num-seqs 8 \
+            --max-model-len 133720 \
+            --max-num-batched-tokens 32 \
+            --no-enable-prefix-caching \
+            --gpu-memory-utilization 0.91 \
+            --enable-auto-tool-choice \
+            --tool-call-parser kimi_k2 \
+            --reasoning-parser kimi_k2 \
+            --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+            --additional-config '{"recompute_scheduler_enable":true,"multistream_overlap_shared_expert": true}' \
+            --speculative-config '{"method": "eagle3", "model":"lightseekorg/kimi-k2.6-eagle3", "num_speculative_tokens": 3}' \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30300",
+            "engine_id": "3",
+            "kv_connector_extra_config": {
+                    "prefill": {
+                            "dp_size": 4,
+                            "tp_size": 4
+                    },
+                    "decode": {
+                            "dp_size": 8,
+                            "tp_size": 4
+                    }
                 }
-            }
-        }'
-    ```
+            }'
+        ```
 
     Key Parameter Descriptions:
 
     - `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the communication optimization function on the prefill nodes.
     - `VLLM_ASCEND_ENABLE_MLAPO=1`: enables the fusion operator, which can significantly improve performance but consumes more NPU memory. In the Prefill-Decode (PD) separation scenario, enable MLAPO only on decode nodes.
-    - `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the Key-Value Cache (KV Cache) of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, it is recommended to enable this configuration on both prefill and decode nodes simultaneously.
+    - `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the Key-Value Cache (KV Cache) of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, it is recommended to enable this configuration on both prefill and decode nodes  simultaneously.
     - `multistream_overlap_shared_expert: true`: When the Tensor Parallelism (TP) size is 1 or `enable_shared_expert_dp: true`, an additional stream is enabled to overlap the computation process of shared experts for improved efficiency.
 
 2. Run server for each node:

--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -22,11 +22,11 @@ The following model weights and EAGLE3 weights are available on ModelScope. Sear
 
 | Model | Description | Recommended Hardware | Source |
 |-------|-------------|---------------------|--------|
-| `MiniMax-M2.7-w8a8-QuaRot` | M2.7 W8A8 quantized version | 1× Atlas 800 A3 (64GB × 16) or 1× Atlas 800I A2 (64GB × 8) | [MiniMax-M2.7-w8a8-QuaRot](https://modelscope.ai/models/vllm-ascend/MiniMax-M2.7-w8a8-QuaRot) |
-| `MiniMax-M2.5-w8a8-QuaRot` | M2.5 W8A8 quantized version | 1× Atlas 800 A3 (64GB × 16) or 1× Atlas 800I A2 (64GB × 8) | [MiniMax-M2.5-w8a8-QuaRot](https://modelscope.cn/models/Eco-Tech/MiniMax-M2.5-w8a8-QuaRot) |
+| `MiniMax-M2.7-w8a8-QuaRot` | M2.7 W8A8 quantized version | 1× Atlas 800 A3 (64GB × 16) or 1× Atlas 800I A2 (64GB × 8) | [MiniMax-M2.7-w8a8-QuaRot](https://www.modelscope.ai/models/vllm-ascend/MiniMax-M2.7-w8a8-QuaRot) |
+| `MiniMax-M2.5-w8a8-QuaRot` | M2.5 W8A8 quantized version | 1× Atlas 800 A3 (64GB × 16) or 1× Atlas 800I A2 (64GB × 8) | [MiniMax-M2.5-w8a8-QuaRot](https://www.modelscope.cn/models/Eco-Tech/MiniMax-M2.5-w8a8-QuaRot) |
 | `MiniMax-M2.7-w8a8c8-QuaRot` | M2.7 W8A8C8 quantized version | 1× Atlas 800 A3 (64GB × 16) or 1× Atlas 800I A2 (64GB × 8) | [MiniMax-M2.7-w8a8c8-QuaRot](https://www.modelscope.ai/models/vllm-ascend/MiniMax-M2.7-w8a8c8-QuaRot) |
-| `Eagle3` (M2.7) | M2.7 speculative decoding head model | Matches the base model node count | [MiniMax-M2.7-eagle-model](https://modelscope.cn/models/Eco-Tech/MiniMax-M2.7-eagle-model-short) |
-| `Eagle3` (M2.5) | M2.5 speculative decoding head model | Matches the base model node count | [MiniMax-M2.5-eagle-model](https://modelscope.cn/models/vllm-ascend/MiniMax-M2.5-eagle-model-0318) |
+| `EAGLE3` (M2.7) | M2.7 speculative decoding head model | Matches the base model node count | [MiniMax-M2.7-eagle-model](https://www.modelscope.cn/models/Eco-Tech/MiniMax-M2.7-eagle-model-short) |
+| `EAGLE3` (M2.5) | M2.5 speculative decoding head model | Matches the base model node count | [MiniMax-M2.5-eagle-model](https://www.modelscope.cn/models/vllm-ascend/MiniMax-M2.5-eagle-model-0318) |
 
 It is recommended to download the model weights to a shared directory, such as `/root/.cache/`.
 
@@ -681,9 +681,9 @@ For common environment, installation, and general parameter issues, please refer
 
   A: For tool calling tasks, it is recommended to use `--reasoning-parser minimax_m2_append_think`.
 
-- **Q: Why is the `reasoning` field often empty after using `minimax_m2_append_think`?**
+- **Q: Why is the `reasoning` field often empty when using `minimax_m2_append_think`, and how should I choose the right `--reasoning-parser`?**
 
-  A: This is expected. The parser keeps `<think>...</think>` inside `content`. If you mainly rely on the reasoning semantics of `/v1/responses`, use `--reasoning-parser minimax_m2` instead.
+  A: This is expected behavior. The `minimax_m2_append_think` parser retains `<think>...</think>` blocks directly inside the `content` field instead of separating them. If your downstream application relies on the standard reasoning semantics of `/v1/responses` (where the thinking process and final answer are separated), you should use `--reasoning-parser minimax_m2` to ensure the dedicated `reasoning` field is properly populated.
 
 - **Q: Startup fails with HCCL port conflicts (address already bound). What should I do?**
 
@@ -692,10 +692,6 @@ For common environment, installation, and general parameter issues, please refer
 - **Q: How to handle OOM or unstable startup?**
 
   A: Refer to the upstream vLLM guide on [out-of-memory troubleshooting](https://docs.vllm.ai/en/latest/usage/troubleshooting/#out-of-memory). In short: reduce `--max-num-seqs` and `--max-num-batched-tokens` first, lower `--gpu-memory-utilization` (e.g., from 0.9 to 0.85), or decrease the number of concurrent requests.
-
-- **Q: How should I choose `--reasoning-parser`?**
-
-  A: This guide uses `minimax_m2_append_think` so that `<think>...</think>` is kept in `content`. If you mainly rely on the reasoning semantics of `/v1/responses`, consider using `--reasoning-parser minimax_m2`.
 
 - **Q: Which ports must be accessible?**
 

--- a/docs/source/tutorials/models/Mixtral-8x7B-Instruct-v0.1.md
+++ b/docs/source/tutorials/models/Mixtral-8x7B-Instruct-v0.1.md
@@ -151,13 +151,15 @@ curl http://localhost:8000/v1/chat/completions \
     }'
 ```
 
+## Accuracy Evaluation
+
 ### Using AISBench
 
 1. Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for details.
 
 2. After execution, you can get the result. For reference, Mixtral-8x7B-Instruct-v0.1 typically performs well on various benchmarks including reasoning, comprehension, and instruction following tasks.
 
-## Performance
+## Performance Evaluation
 
 ### Using AISBench
 

--- a/docs/source/tutorials/models/PaddleOCR-VL.md
+++ b/docs/source/tutorials/models/PaddleOCR-VL.md
@@ -10,9 +10,9 @@ This document is validated and written based on **vLLM-Ascend v0.21.0rc1**. The 
 
 ## 2 Supported Features
 
-Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
+Refer to [Supported Features List](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
 
-Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
+Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
 ## 3 Prerequisites
 
@@ -204,7 +204,7 @@ In the above example, we demonstrated how to use vLLM to infer the PaddleOCR-VL-
         ```bash
         python -m pip install paddlepaddle==3.2.0
         wget https://paddle-whl.bj.bcebos.com/stable/npu/paddle-custom-npu/paddle_custom_npu-3.2.0-cp310-cp310-linux_aarch64.whl
-        pip  install  paddle_custom_npu-3.2.0-cp310-cp310-linux_aarch64.whl
+        pip install paddle_custom_npu-3.2.0-cp310-cp310-linux_aarch64.whl
         python -m pip install -U "paddleocr[doc-parser]"
         pip install safetensors
         ```
@@ -236,9 +236,9 @@ from paddleocr import PaddleOCRVL
 
 doclayout_model_path = "/path/to/your/PP-DocLayoutV2/"
 
-pipeline = PaddleOCRVL(vl_rec_backend="vllm-server", 
-                       vl_rec_server_url="http://localhost:8000/v1", 
-                       layout_detection_model_name="PP-DocLayoutV2",  
+pipeline = PaddleOCRVL(vl_rec_backend="vllm-server",
+                       vl_rec_server_url="http://localhost:8000/v1",
+                       layout_detection_model_name="PP-DocLayoutV2",
                        layout_detection_model_dir=doclayout_model_path,
                        device="npu")
 

--- a/docs/source/tutorials/models/Qwen-VL-Dense.md
+++ b/docs/source/tutorials/models/Qwen-VL-Dense.md
@@ -24,13 +24,13 @@ Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the fea
 
 Requires 1 card on Atlas 800I A2 (64G × 8), Atlas 800 A3 (64G × 16), or Atlas inference products:
 
-- `Qwen3-VL-2B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-2B-Instruct)
-- `Qwen3-VL-4B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-4B-Instruct)
-- `Qwen3-VL-8B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-8B-Instruct)
+- `Qwen3-VL-2B-Instruct`: [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-2B-Instruct)
+- `Qwen3-VL-4B-Instruct`: [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-4B-Instruct)
+- `Qwen3-VL-8B-Instruct`: [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-8B-Instruct)
 
 Requires 2 cards on Atlas 800I A2 (64G × 8), Atlas 800 A3 (64G × 16), or Atlas inference products:
 
-- `Qwen3-VL-32B-Instruct`: [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct)
+- `Qwen3-VL-32B-Instruct`: [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-32B-Instruct)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 

--- a/docs/source/tutorials/models/Qwen2.5-Math-RM-72B.md
+++ b/docs/source/tutorials/models/Qwen2.5-Math-RM-72B.md
@@ -21,7 +21,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `Qwen2.5-Math-RM-72B` (BF16 version):
     - With CPU offloading: requires at least 1 Atlas 910B4 (32GB × 1) card or higher
     - Without CPU offloading: requires at least 4 Atlas 910B4 (32GB × 4) cards or higher
-  [Download model weight](https://modelscope.cn/models/Qwen/Qwen2.5-Math-RM-72B)
+  [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen2.5-Math-RM-72B)
 
 It is recommended to download the model weights to a local directory (e.g., `./Qwen2.5-Math-RM-72B/`) for quick access during deployment.
 

--- a/docs/source/tutorials/models/Qwen3-235B-A22B.md
+++ b/docs/source/tutorials/models/Qwen3-235B-A22B.md
@@ -24,13 +24,13 @@ The following model variants are available. It is recommended to download the mo
 
 | Model | Hardware Requirement | Download |
 |-------|---------------------|----------|
-| Qwen3-235B-A22B (BF16) | 1 Atlas 800I A3 (64GB × 16), 1 Atlas 800I A2 (64GB × 8)| [Download](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B) |
+| Qwen3-235B-A22B (BF16) | 1 Atlas 800I A3 (64GB × 16), 1 Atlas 800I A2 (64GB × 8), 2 Atlas 800I A2 (32GB × 8)| [Download](https://www.modelscope.cn/models/Qwen/Qwen3-235B-A22B) |
 
 **Quantized Version (Pre-converted):**
 
 | Model | Quantization | Hardware Requirement | Download |
 |-------|-------------|---------------------|----------|
-| Qwen3-235B-A22B-W8A8 | W8A8 | 1 Atlas 800I A3 (64GB × 16), 1 Atlas 800I A2 (64GB × 8)| [Download](https://modelers.cn/models/Modelers_Park/Qwen3-235B-A22B-w8a8) |
+| Qwen3-235B-A22B-W8A8 | W8A8 | 1 Atlas 800I A3 (64GB × 16), 1 Atlas 800I A2 (64GB × 8), 2 Atlas 800I A2 (32GB × 8)| [Download](https://modelers.cn/models/Modelers_Park/Qwen3-235B-A22B-w8a8) |
 
 These are the recommended numbers of cards, which can be adjusted according to the actual situation.
 
@@ -82,7 +82,7 @@ docker pull quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
 
 **Docker Run:**
 
-Start the docker image on your each node.
+Start the docker image on each node.
 
 === "A3 series"
 

--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -24,13 +24,13 @@ The following model variants are available. It is recommended to download the mo
 | -------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | Qwen3-30B-A3B (BF16) | Atlas 800I A3 (64GB, 1\~2 cards)<br>Atlas 800I A2 (64GB, 2\~4 cards) | [Download](https://www.modelscope.cn/models/Qwen/Qwen3-30B-A3B)          |
 | Qwen3-30B-A3B-W8A8   | Atlas 800I A3 (64GB, 1\~2 cards)<br>Atlas 800I A2 (64GB, 2\~4 cards)                               | [Download](https://www.modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8) |
-| Eagle3 Draft Model   | NA                                                                                               | [Download](https://modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8-QuaRot-310)            |
+| Eagle3 Draft Model   | NA                                                                                               | [Download](https://www.modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8-QuaRot-310)            |
 
 **Quantized Versions for Atlas inference products:**
 
 | Model | Quantization | Hardware Requirement | Download |
 |-------|-------------|---------------------|----------|
-| Qwen3-30B-A3B-w8a8-QuaRot-310  |W8A8 | Atlas inference products (48G 2 cards)                                                                                               | [Download](https://modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8-QuaRot-310)            |
+| Qwen3-30B-A3B-w8a8-QuaRot-310  |W8A8 | Atlas inference products (48G 2 cards)                                                                                               | [Download](https://www.modelscope.cn/models/Eco-Tech/Qwen3-30B-A3B-w8a8-QuaRot-310)            |
 
 These are the recommended numbers of cards, which can be adjusted according to the actual situation.
 
@@ -200,7 +200,7 @@ If you prefer not to use the Docker image, you can build from source. Install vL
 
     ```bash
     pip uninstall -y triton-ascend triton
-    ```   
+    ```
 
 **Installation Verification:**
 
@@ -250,7 +250,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
         --gpu-memory-utilization 0.95 \
         --port 8000 \
-        --speculative-config '{"method": "eagle3", "model": "your_eagle3_model_path", "draft_tensor_parallel_size": 1, "num_speculative_tokens": 3}'
+        --speculative-config '{"method": "eagle3", "model": "your_eagle3_model_path", "num_speculative_tokens": 3}'
     ```
 
 === "Atlas inference products"

--- a/docs/source/tutorials/models/Qwen3-ASR-1.7B.md
+++ b/docs/source/tutorials/models/Qwen3-ASR-1.7B.md
@@ -18,7 +18,7 @@ Please refer to the [Feature Guide](../../user_guide/feature_guide/index.md) for
 
 ### 3.1 Model Weight
 
-The BF16 model can be deployed with one Ascend 910B 64 GB NPU or one Ascend Atlas inference products 48 GB NPU. Download the model weights from [ModelScope](https://modelscope.cn/models/Qwen/Qwen3-ASR-1.7B).
+The BF16 model can be deployed with one Ascend 910B 64 GB NPU or one Ascend Atlas inference products 48 GB NPU. Download the model weights from [ModelScope](https://www.modelscope.cn/models/Qwen/Qwen3-ASR-1.7B).
 
 Download the weights to a directory that is accessible from the deployment environment. For multi-node deployments, use a shared directory; for example, `/root/.cache/`.
 

--- a/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
@@ -210,7 +210,7 @@ vllm serve your_model_path \
     --additional-config '{"enable_flashcomm1": true, "weight_nz_mode": 2}' \
     --gpu-memory-utilization 0.95 \
     --port 8000 \
-    --speculative-config '{"method": "eagle3", "model": "your_eagle3_model_path", "draft_tensor_parallel_size": 1, "num_speculative_tokens": 3}'
+    --speculative-config '{"method": "eagle3", "model": "your_eagle3_model_path", "num_speculative_tokens": 3}'
 ```
 
 !!! note

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -68,7 +68,7 @@ docker pull quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
 
 **Docker Run:**
 
-Start the docker image on your each node.
+Start the docker image on each node.
 
 === "Atlas A3 inference products"
 
@@ -263,7 +263,7 @@ Single-node deployment completes both Prefill and Decode within the same node, s
         --data-parallel-size 1 \
         --tensor-parallel-size 2 \
         --served-model-name qwen3 \
-        --distributed_executor_backend "mp" \
+        --distributed-executor-backend "mp" \
         --max-model-len 40960 \
         --max-num-batched-tokens 16384 \
         --max-num-seqs 64 \
@@ -415,17 +415,17 @@ models = [
         abbr='vllm-api-general-chat',
         path="your_model_path",
         model="qwen3",
-        request_rate = 0,
-        retry = 2,
-        host_ip = "127.0.0.1",
-        host_port = 2001,
-        max_out_len = 32768,
-        batch_size = 32,
+        request_rate=0,
+        retry=2,
+        host_ip="127.0.0.1",
+        host_port=2001,
+        max_out_len=32768,
+        batch_size=32,
         trust_remote_code=False,
-        generation_kwargs = dict(
-            temperature = 0.6,
-            top_k = 20,
-            top_p = 0.95,
+        generation_kwargs=dict(
+            temperature=0.6,
+            top_k=20,
+            top_p=0.95,
         ),
         pred_postprocessor=dict(type=extract_non_reasoning_content)
     )
@@ -471,7 +471,7 @@ models = [
         trust_remote_code=False,
         generation_kwargs=dict(
             temperature=0,
-            ignore_eos = True
+            ignore_eos=True
         ),
     )
 ]

--- a/docs/source/tutorials/models/Qwen3-Embedding.md
+++ b/docs/source/tutorials/models/Qwen3-Embedding.md
@@ -28,7 +28,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -53,7 +53,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
       export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -78,7 +78,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
@@ -210,24 +210,24 @@ Here are two accuracy evaluation methods.
 2. Run follow code to execute the accuracy evaluation.
 
     ```python
-  
+
     import os
     import mteb
-    
+
     from mteb.models.vllm_wrapper import VllmEncoderWrapper
-    
+
     if __name__ == "__main__":
-    
+
         data_path = "/home/data/mteb_data"
         os.environ["HF_DATASETS_CACHE"] = data_path
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
-    
+
         model = VllmEncoderWrapper(f"/root/.cache/Qwen3-Embedding-0.6B",
                                     revision="norm",
                                     dtype="float16",
                                     max_model_len=10240,
                                    )
-    
+
         cache = mteb.ResultCache("/home/data/mteb_data")
         tasks = mteb.get_tasks(tasks=["LeCaRDv2"])
         results = mteb.evaluate(model, tasks=tasks, cache=cache, encode_kwargs={"batch_size": 2}, overwrite_strategy="always")

--- a/docs/source/tutorials/models/Qwen3-Next.md
+++ b/docs/source/tutorials/models/Qwen3-Next.md
@@ -18,7 +18,7 @@ Refer to [Feature Guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-`Qwen3-Next-80B-A3B-Instruct`: requires **8 cards in 1 Atlas 800 A3 (64GB × 16) node** or **8 cards in 1 Atlas 800 A2 (64GB × 8) node**. [Model Weight](https://modelscope.cn/models/Qwen/Qwen3-Next-80B-A3B-Instruct)
+`Qwen3-Next-80B-A3B-Instruct`: requires **8 cards in 1 Atlas 800 A3 (64GB × 16) node** or **8 cards in 1 Atlas 800 A2 (64GB × 8) node**. [Model Weight](https://www.modelscope.cn/models/Qwen/Qwen3-Next-80B-A3B-Instruct)
 
 ## 4 Installation
 
@@ -28,7 +28,7 @@ Select an image based on your machine type and start the docker image on your no
 
 **A3 series:**
 
-Start the docker image on your each node.
+Start the docker image on each node.
 
 ```bash
 #!/bin/sh
@@ -228,7 +228,7 @@ vllm bench serve --model Qwen/Qwen3-Next-80B-A3B-Instruct  --dataset-name random
 
 After about several minutes, you can get the performance evaluation result.
 
-The performance result is:  
+The performance result is:
 
 ```bash
 Hardware: A3-752T, 2 node

--- a/docs/source/tutorials/models/Qwen3-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-Reranker.md
@@ -28,7 +28,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -53,7 +53,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
       export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -78,7 +78,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
@@ -239,25 +239,25 @@ Here are two accuracy evaluation methods.
 2. Run follow code to execute the accuracy evaluation.
 
     ```python
-  
+
     import os
-    
+
     from mteb.models.vllm_wrapper import VllmCrossEncoderWrapper
-    
+
     if __name__ == "__main__":
         import mteb
-    
+
         data_path = "/home/data/mteb_data"
         os.environ["HF_DATASETS_CACHE"] = data_path
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
-    
+
         model = VllmCrossEncoderWrapper(f"/home/data/Qwen3-Reranker-0.6B",
                                     revision="norm",
                                     dtype="float16",
                                     enforce_eager=True,
                                     max_model_len=10240,
                                     hf_overrides={"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": True})
-    
+
         cache = mteb.ResultCache("/home/data/mteb_data")
         tasks = mteb.get_tasks(
             task_types=["Reranking"],

--- a/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
@@ -18,7 +18,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### Model Weight
 
-- `Qwen3-VL-235B-A22B-Instruct`(BF16 version): require 1 Atlas 800 A3 (64G × 16) node，2 Atlas 800 A2（64G × 8）nodes. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct/)
+- `Qwen3-VL-235B-A22B-Instruct`(BF16 version): require 1 Atlas 800 A3 (64G × 16) node，2 Atlas 800 A2（64G × 8）nodes. [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3-VL-235B-A22B-Instruct/)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
 
@@ -211,7 +211,7 @@ INFO:     Application startup complete.
 
 Once your server is started, you can query the model with input prompts:
 
-```shell  
+```shell
 curl http://<node0_ip>:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{

--- a/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-30B-A3B-Instruct.md
@@ -17,7 +17,7 @@ This document will show the main verification steps of the `Qwen3-VL-30B-A3B-Ins
 
 Running this model requires 1 Atlas 800I A2 (64G × 8) node or 1 Atlas 800 A3 (64G × 16) node.
 
-Download model weight at [ModelScope Website](https://modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Instruct) or download by below command:
+Download model weight at [ModelScope Website](https://www.modelscope.cn/models/Qwen/Qwen3-VL-30B-A3B-Instruct) or download by below command:
 
 ```bash
 pip install modelscope

--- a/docs/source/tutorials/models/Qwen3-VL-Embedding.md
+++ b/docs/source/tutorials/models/Qwen3-VL-Embedding.md
@@ -27,7 +27,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -52,7 +52,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
       export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -112,7 +112,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 === "A3/A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     #!/bin/sh
@@ -125,7 +125,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     #!/bin/sh
@@ -214,24 +214,24 @@ Here are two accuracy evaluation methods.
 2. Run follow code to execute the accuracy evaluation.
 
     ```python
-  
+
     import os
     import mteb
-    
+
     from mteb.models.vllm_wrapper import VllmEncoderWrapper
-    
+
     if __name__ == "__main__":
-    
+
         data_path = "/home/data/mteb_data"
         os.environ["HF_DATASETS_CACHE"] = data_path
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
-    
+
         model = VllmEncoderWrapper(f"/root/.cache/Qwen3-VL-Embedding-2B",
                                     revision="norm",
                                     dtype="float16",
                                     max_model_len=10240,
                                    )
-    
+
         cache = mteb.ResultCache("/home/data/mteb_data")
         tasks = mteb.get_tasks(tasks=["LeCaRDv2"])
         results = mteb.evaluate(model, tasks=tasks, cache=cache, encode_kwargs={"batch_size": 2}, overwrite_strategy="always")

--- a/docs/source/tutorials/models/Qwen3-VL-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-VL-Reranker.md
@@ -27,7 +27,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -52,7 +52,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
       export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -77,7 +77,7 @@ Select an image based on your machine type and start the docker image on your no
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
@@ -159,7 +159,7 @@ Save this file to a location of your choice (e.g., `./qwen3_vl_reranker.jinja`).
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```shell
     #!/bin/sh
@@ -243,25 +243,25 @@ Here are two accuracy evaluation methods.
 2. Run follow code to execute the accuracy evaluation.
 
     ```python
-  
+
     import os
-    
+
     from mteb.models.vllm_wrapper import VllmCrossEncoderWrapper
-    
+
     if __name__ == "__main__":
         import mteb
-    
+
         data_path = "/home/data/mteb_data"
         os.environ["HF_DATASETS_CACHE"] = data_path
         os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
-    
+
         model = VllmCrossEncoderWrapper(f"/home/data/Qwen3-VL-Reranker-2B",
                                     revision="norm",
                                     dtype="float16",
                                     enforce_eager=True,
                                     max_model_len=10240,
                                     hf_overrides={"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": True})
-    
+
         cache = mteb.ResultCache("/home/data/mteb_data")
         tasks = mteb.get_tasks(
             task_types=["Reranking"],

--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -20,12 +20,12 @@ Please refer to the [Feature Guide](../../user_guide/feature_guide/index.md) for
 
 **Qwen3.5-27B**
 
-- `Qwen3.5-27B` (BF16 version): requires 1 Atlas 800 A3 (64GB × 16) node or 1 Atlas 800 A2 (64GB × 8) node or Atlas inference products. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.5-27B)
+- `Qwen3.5-27B` (BF16 version): requires 1 Atlas 800 A3 (64GB × 16) node or 1 Atlas 800 A2 (64GB × 8) node or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3.5-27B)
 - `Qwen3.5-27B-w8a8` (Quantized version): requires 1 Atlas 800 A3 (64GB × 16) node or 1 Atlas 800 A2 (64GB × 8) node or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.5-27B-w8a8-mtp)
 
 **Qwen3.6-27B**
 
-- `Qwen3.6-27B` (BF16 version): requires 1 Atlas 800 A3 (64GB × 16) node or 1 Atlas 800 A2 (64GB × 8) node or Atlas inference products. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-27B)
+- `Qwen3.6-27B` (BF16 version): requires 1 Atlas 800 A3 (64GB × 16) node or 1 Atlas 800 A2 (64GB × 8) node or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B)
 - `Qwen3.6-27B-w8a8` (Quantized version): requires 1 Atlas 800 A3 (64GB × 16) node or 1 Atlas 800 A2 (64GB × 8) node or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8)
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
@@ -44,7 +44,7 @@ It is **recommended to use the latest release candidate (rc) version or the late
 
 === "A3 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```bash
     export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
@@ -83,7 +83,7 @@ It is **recommended to use the latest release candidate (rc) version or the late
 
 === "A2 series"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```bash
     export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -114,7 +114,7 @@ It is **recommended to use the latest release candidate (rc) version or the late
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```bash
     export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
@@ -220,7 +220,7 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         --served-model-name qwen3.5 \
         --max-num-seqs 32 \
         --max-model-len 133000 \
-        --max-num-batched-tokens 8096 \
+        --max-num-batched-tokens 16384 \
         --trust-remote-code \
         --gpu-memory-utilization 0.90 \
         --no-enable-prefix-caching \
@@ -262,7 +262,7 @@ Both `Qwen3.5-27B` and `Qwen3.6-27B` share the same MTP head design, so the `qwe
         --served-model-name qwen3.6 \
         --max-num-seqs 32 \
         --max-model-len 262144 \
-        --max-num-batched-tokens 8096 \
+        --max-num-batched-tokens 16384 \
         --trust-remote-code \
         --gpu-memory-utilization 0.90 \
         --no-enable-prefix-caching \
@@ -551,12 +551,12 @@ To run the vllm-ascend Prefill-Decode Disaggregation service, you need to:
       }'
     ```
 
-Key Parameter Descriptions:
+   Key Parameter Descriptions:
 
-- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the Allreduce communication optimization on prefill nodes, which reduces the communication overhead of long-context prefill.
-- `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the KV Cache of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, enable this configuration only on decode nodes.
-- `--async-scheduling` (on decode nodes): enables asynchronous scheduling, which can reduce TPOT for high-concurrency decode workloads.
-- `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` (on decode nodes): enables the full-decode aclgraph mode, which significantly reduces scheduling latency on the decode side.
+   - `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`: enables the Allreduce communication optimization on prefill nodes, which reduces the communication overhead of long-context prefill.
+   - `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the KV Cache of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, enable this configuration only on decode nodes.
+   - `--async-scheduling` (on decode nodes): enables asynchronous scheduling, which can reduce TPOT for high-concurrency decode workloads.
+   - `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` (on decode nodes): enables the full-decode aclgraph mode, which significantly reduces scheduling latency on the decode side.
 
 4. Run server for each node:
 
@@ -820,10 +820,10 @@ After about several minutes, you can get the performance evaluation result.
 
 | Scenario | Configuration | NPUs | TP | DP | Max Num Seqs | Max Num Batched Tokens | Max Model Len | MTP Speculation Num | Async Scheduling |
 |----------|---------------|-------|----|----|----|-------------|--------------------|---------------------|------------------|
-| High Throughput (128k) | Single-Node (A2) | 8 | 2 | 4 | 32 | 16384 | 133000 | 3 | On |
-| High Throughput (128k) | Single-Node (A3) | 16 | 2 | 8 | 32 | 16384 | 133000 | 3 | On |
-| Low Latency (128k) | Single-Node (A3) | 16 | 2 | 8 | 4 | 4096 | 133000 | 3 | On |
-| Long Context (256k+) | Single-Node (A3) | 16 | 8 | 2 | 8 | 8192 | 266000 | 3 | On |
+| High Throughput (128K) | Single-Node (A2) | 8 | 2 | 4 | 32 | 16384 | 133000 | 3 | On |
+| High Throughput (128K) | Single-Node (A3) | 16 | 2 | 8 | 32 | 16384 | 133000 | 3 | On |
+| Low Latency (128K) | Single-Node (A3) | 16 | 2 | 8 | 4 | 4096 | 133000 | 3 | On |
+| Long Context (256K+) | Single-Node (A3) | 16 | 8 | 2 | 8 | 8192 | 262144 | 3 | On |
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
 

--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -312,8 +312,8 @@ unset http_proxy
 
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
-nic_name="xxx"
-local_ip="xxx"
+nic_name="xxxx"
+local_ip="xxxx"
 
 export VLLM_ENGINE_READY_TIMEOUT_S=30000
 export VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT=480
@@ -388,8 +388,8 @@ unset http_proxy
 
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
-nic_name="xxx"
-local_ip="xxx"
+nic_name="xxxx"
+local_ip="xxxx"
 
 # The value of node0_ip must be consistent with local_ip on the first decode node.
 node0_ip="xxxx"
@@ -470,8 +470,8 @@ unset http_proxy
 
 # Get these values through ifconfig.
 # nic_name is the network interface name corresponding to local_ip.
-nic_name="xxx"
-local_ip="xxx"
+nic_name="xxxx"
+local_ip="xxxx"
 
 # The value of node0_ip must be consistent with local_ip on the first decode node.
 node0_ip="xxxx"

--- a/docs/source/tutorials/models/Qwen3.5-Dense.md
+++ b/docs/source/tutorials/models/Qwen3.5-Dense.md
@@ -20,9 +20,9 @@ Please refer to the [Feature Guide](../../user_guide/feature_guide/index.md) for
 
 | Model | Version | Hardware Requirement | Download |
 |-------|---------|----------------------|----------|
-| Qwen3.5-2B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://modelscope.cn/models/Qwen/Qwen3.5-2B) |
-| Qwen3.5-4B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://modelscope.cn/models/Qwen/Qwen3.5-4B) |
-| Qwen3.5-9B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://modelscope.cn/models/Qwen/Qwen3.5-9B) |
+| Qwen3.5-2B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://www.modelscope.cn/models/Qwen/Qwen3.5-2B) |
+| Qwen3.5-4B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://www.modelscope.cn/models/Qwen/Qwen3.5-4B) |
+| Qwen3.5-9B | FP16 | Atlas inference products or Atlas 200I Pro | [Download](https://www.modelscope.cn/models/Qwen/Qwen3.5-9B) |
 
 It is recommended to download the model weight to a local directory such as `/root/.cache/` or `/home/data/`.
 
@@ -36,7 +36,7 @@ It is **recommended to use the latest release candidate (rc) version or the late
 
 === "Atlas inference products"
 
-    Start the docker image on your each node.
+    Start the docker image on each node.
 
     ```bash
     export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-310p
@@ -66,7 +66,7 @@ It is **recommended to use the latest release candidate (rc) version or the late
 
 === "Atlas 200I Pro"
 
-    Start the docker image on your each node. Adjust `--device=/dev/davinci0` according to the NPU ID you want to use.
+    Start the docker image on each node. Adjust `--device=/dev/davinci0` according to the NPU ID you want to use.
 
     === "Ubuntu 24.04"
 

--- a/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3.6-35B-A3B.md
@@ -18,7 +18,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get feature
 
 ### 3.1 Model Weight
 
-- `Qwen3.6-35B-A3B` (BF16 version): requires 1 Atlas A3 inference products (64G x 16) node, 1 Atlas A2 inference products (64G x 8) node, or Atlas inference products. [Download model weight](https://modelscope.cn/models/Qwen/Qwen3.6-35B-A3B).
+- `Qwen3.6-35B-A3B` (BF16 version): requires 1 Atlas A3 inference products (64G x 16) node, 1 Atlas A2 inference products (64G x 8) node, or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B).
 - `Qwen3.6-35B-A3B-w8a8` (quantized version): requires 1 Atlas A3 inference products (64G x 16) node, 1 Atlas A2 inference products (64G x 8) node, or Atlas inference products. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-35B-A3B-w8a8).
 
 It is recommended to download the model weight to `/root/.cache/`.

--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -60,6 +60,7 @@ export PYTHONHASHSEED=0
         ```bash
         cat /etc/hccn.conf
         ```
+
         For A5 series, additionally mount:
         * devices: `/dev/ummu`, `/dev/uburma`
         * commands: `/usr/bin/urma_admin`
@@ -112,12 +113,12 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
 }
 ```
 
-**metadata_server**: Configured as **P2PHANDSHAKE**.  
+**metadata_server**: Configured as **P2PHANDSHAKE**.
 **protocol:** Must be set to 'Ascend' on the NPU.
 **device_name**: ""
-**master_server_address**: Configured with the IP and port of the master service. It can also be set via the **MOONCAKE_MASTER** environment variable, which takes precedence over this configuration item (useful for injecting the master address through Kubernetes).  
-**global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.** It can also be set via the **MOONCAKE_GLOBAL_SEGMENT_SIZE** environment variable, which takes precedence over this configuration item.  
-**preferred_segment**: Whether to prefer storing KV on the local segment when putting objects to the KV Pool. Defaults to **false**.  
+**master_server_address**: Configured with the IP and port of the master service. It can also be set via the **MOONCAKE_MASTER** environment variable, which takes precedence over this configuration item (useful for injecting the master address through Kubernetes).
+**global_segment_size**: Registered memory size per card to the KV Pool. **Needs to be aligned to 1GB.** It can also be set via the **MOONCAKE_GLOBAL_SEGMENT_SIZE** environment variable, which takes precedence over this configuration item.
+**preferred_segment**: Whether to prefer storing KV on the local segment when putting objects to the KV Pool. Defaults to **false**.
 **prefer_alloc_in_same_node**: Whether to prefer allocating KV on the same node. Defaults to **true**.
 
 #### 2. Start mooncake_master
@@ -214,7 +215,7 @@ python3 -m vllm.entrypoints.openai.api_server \
                     "lookup_rpc_port":"0",
                     "backend": "mooncake"
                 }
-            }  
+            }
         ]
     }
     }'


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates and refines various documentation files for models and features to improve clarity, fix typos, correct links, and ensure consistent formatting.

Key changes include:
- Correcting typos (e.g., "zhe" -> "the", "your each node" -> "each node", "Eagle3" -> "EAGLE3").
- Updating ModelScope links to use `www.modelscope.cn` consistently.
- Clarifying terminology (e.g., explaining "2P1D" as "two Prefiller and one Decoder", correcting "2P2D" to "2P1D" in Kimi-K2.5 deployment table).
- Removing redundant environment setup notes in multi-node deployment sections.
- Fixing code block indentation and formatting across several model tutorials.
- Updating version placeholders (e.g., using `{{ vllm_ascend_version }}` in suffix speculative decoding guide).

Synchronize the main PR:https://github.com/vllm-project/vllm-ascend/pull/12858

### Does this PR introduce _any_ user-facing change?

No, this PR only contains documentation updates.

### How was this patch tested?

Documentation-only changes, no code execution or testing required.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
