### PR TITLE
[Performance][Kernel]optimize compute_slot_mapping_kernel

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping_v1.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_compute_slot_mapping_v1.py
@@ -1,0 +1,241 @@
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.compute_slot_mapping import (
+    _compute_slot_mapping_kernel,
+    _next_power_of_2,
+)
+
+PAD_ID = -1
+TRITON_BLOCK_SIZE = 1024
+
+
+def _compute_slot_mapping_ref(
+    query_start_loc: list[int],
+    positions: list[int],
+    block_table: list[list[int]],
+    block_size: int,
+    max_num_tokens: int,
+    kv_cache_block_size: int,
+    blocks_per_kv_block: int,
+    total_cp_world_size: int,
+    total_cp_rank: int,
+    cp_kv_cache_interleave_size: int,
+) -> list[int]:
+    slot_mapping = [PAD_ID] * max_num_tokens
+
+    for req_idx, (start_idx, end_idx) in enumerate(zip(query_start_loc[:-1], query_start_loc[1:])):
+        for token_idx in range(start_idx, end_idx):
+            position = positions[token_idx]
+            if total_cp_world_size == 1:
+                block_idx = position // block_size
+                slot_offset = position % block_size
+            else:
+                virtual_block_size = kv_cache_block_size * total_cp_world_size
+                virtual_block_idx = position // virtual_block_size
+                virtual_block_offset = position % virtual_block_size
+                is_local = (virtual_block_offset // cp_kv_cache_interleave_size) % total_cp_world_size == total_cp_rank
+                if not is_local:
+                    continue
+
+                local_block_offset = (
+                    virtual_block_offset
+                    // (total_cp_world_size * cp_kv_cache_interleave_size)
+                    * cp_kv_cache_interleave_size
+                    + virtual_block_offset % cp_kv_cache_interleave_size
+                )
+                block_idx = virtual_block_idx * blocks_per_kv_block + local_block_offset // block_size
+                slot_offset = local_block_offset % block_size
+
+            slot_mapping[token_idx] = block_table[req_idx][block_idx] * block_size + slot_offset
+
+    return slot_mapping
+
+
+@pytest.mark.parametrize(
+    (
+        "query_start_loc",
+        "positions",
+        "kv_cache_block_size",
+        "block_size",
+        "total_cp_world_size",
+        "total_cp_rank",
+        "cp_kv_cache_interleave_size",
+    ),
+    [
+        pytest.param(
+            [0, 10, 17],
+            [0, 1, 3, 4, 7, 8, 11, 12, 15, 16, 2, 5, 6, 9, 10, 13, 14],
+            4,
+            4,
+            1,
+            0,
+            1,
+            id="single_cp_rank",
+        ),
+        pytest.param(
+            [0, 12, 22],
+            list(range(12)) + [12, 13, 14, 15, 16, 17, 18, 19, 22, 23],
+            8,
+            4,
+            2,
+            1,
+            2,
+            id="interleaved_cp_rank",
+        ),
+        pytest.param(
+            [0, 16, 32],
+            [
+                0,
+                1,
+                2,
+                3,
+                64,
+                65,
+                66,
+                67,
+                128,
+                129,
+                130,
+                131,
+                192,
+                193,
+                194,
+                195,
+                256,
+                257,
+                258,
+                259,
+                320,
+                321,
+                322,
+                323,
+                384,
+                385,
+                386,
+                387,
+                448,
+                449,
+                450,
+                451,
+            ],
+            128,
+            32,
+            2,
+            0,
+            2,
+            id="interleaved_cp_rank_zero_hybrid_blocks",
+        ),
+    ],
+)
+def test_compute_slot_mapping_kernel(
+    query_start_loc,
+    positions,
+    kv_cache_block_size,
+    block_size,
+    total_cp_world_size,
+    total_cp_rank,
+    cp_kv_cache_interleave_size,
+):
+    device = "npu"
+    max_num_tokens = 32
+    block_table = [
+        [5, 7, 11, 13, 17, 19, 23, 29],
+        [31, 37, 41, 43, 47, 53, 59, 61],
+    ]
+    blocks_per_kv_block = kv_cache_block_size // block_size
+    num_tokens = len(positions)
+
+    query_start_loc_tensor = torch.tensor(query_start_loc, dtype=torch.int32, device=device)
+    positions_tensor = torch.tensor(positions, dtype=torch.int64, device=device)
+    block_table_tensor = torch.tensor(block_table, dtype=torch.int32, device=device)
+    slot_mapping = torch.full((max_num_tokens,), 123456, dtype=torch.int32, device=device)
+
+    _compute_slot_mapping_kernel[(len(query_start_loc),)](
+        num_tokens,
+        max_num_tokens,
+        query_start_loc_tensor,
+        positions_tensor,
+        block_table_tensor,
+        block_table_tensor.stride(0),
+        block_size,
+        slot_mapping,
+        KV_CACHE_BLOCK_SIZE=kv_cache_block_size,
+        BLOCKS_PER_KV_BLOCK=blocks_per_kv_block,
+        TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+        TOTAL_CP_RANK=total_cp_rank,
+        CP_KV_CACHE_INTERLEAVE_SIZE=cp_kv_cache_interleave_size,
+        PAD_ID=PAD_ID,
+        TILE_BLOCK_SIZE=TRITON_BLOCK_SIZE,
+        BLOCK_TABLE_WINDOW_SIZE=_next_power_of_2((TRITON_BLOCK_SIZE + block_size - 1) // block_size + 1),
+    )
+
+    expected = _compute_slot_mapping_ref(
+        query_start_loc,
+        positions,
+        block_table,
+        block_size,
+        max_num_tokens,
+        kv_cache_block_size,
+        blocks_per_kv_block,
+        total_cp_world_size,
+        total_cp_rank,
+        cp_kv_cache_interleave_size,
+    )
+    torch.testing.assert_close(slot_mapping.cpu(), torch.tensor(expected, dtype=torch.int32))
+
+
+def test_compute_slot_mapping_kernel_four_requests_large_sequences():
+    device = "npu"
+    sequence_lengths = (1024, 2048, 4096, 8192)
+    query_start_loc = [0, 1024, 3072, 7168, 15360]
+    positions = [position for seq_len in sequence_lengths for position in range(seq_len)]
+    block_size = 128
+    kv_cache_block_size = 128
+    blocks_per_kv_block = kv_cache_block_size // block_size
+    blocks_per_request = max(sequence_lengths) // block_size
+    max_num_tokens = 16384
+    num_tokens = len(positions)
+
+    block_table = [
+        list(range(req_idx * blocks_per_request, (req_idx + 1) * blocks_per_request))
+        for req_idx in range(len(sequence_lengths))
+    ]
+
+    query_start_loc_tensor = torch.tensor(query_start_loc, dtype=torch.int32, device=device)
+    positions_tensor = torch.tensor(positions, dtype=torch.int64, device=device)
+    block_table_tensor = torch.tensor(block_table, dtype=torch.int32, device=device)
+    slot_mapping = torch.full((max_num_tokens,), 123456, dtype=torch.int32, device=device)
+
+    _compute_slot_mapping_kernel[(len(query_start_loc),)](
+        num_tokens,
+        max_num_tokens,
+        query_start_loc_tensor,
+        positions_tensor,
+        block_table_tensor,
+        block_table_tensor.stride(0),
+        block_size,
+        slot_mapping,
+        KV_CACHE_BLOCK_SIZE=kv_cache_block_size,
+        BLOCKS_PER_KV_BLOCK=blocks_per_kv_block,
+        TOTAL_CP_WORLD_SIZE=1,
+        TOTAL_CP_RANK=0,
+        CP_KV_CACHE_INTERLEAVE_SIZE=1,
+        PAD_ID=PAD_ID,
+        TILE_BLOCK_SIZE=TRITON_BLOCK_SIZE,
+        BLOCK_TABLE_WINDOW_SIZE=_next_power_of_2((TRITON_BLOCK_SIZE + block_size - 1) // block_size + 1),
+    )
+
+    expected = _compute_slot_mapping_ref(
+        query_start_loc,
+        positions,
+        block_table,
+        block_size,
+        max_num_tokens,
+        kv_cache_block_size,
+        blocks_per_kv_block,
+        1,
+        0,
+        1,
+    )
+    torch.testing.assert_close(slot_mapping.cpu(), torch.tensor(expected, dtype=torch.int32))

--- a/vllm_ascend/ops/triton/compute_slot_mapping.md
+++ b/vllm_ascend/ops/triton/compute_slot_mapping.md
@@ -1,0 +1,175 @@
+# `_compute_slot_mapping_kernel` 算子文档
+
+## 1、算子功能介绍
+
+`_compute_slot_mapping_kernel` 是 vllm-ascend 在 Triton 上实现的 KV Cache 槽位映射算子，文件位置：`vllm_ascend/ops/triton/compute_slot_mapping.py`。
+
+在大模型推理过程中，KV Cache 通常采用 **block-based（分块）** 的物理存储方式：逻辑上属于同一序列的 token 会被分散到若干物理块中，块号由 `block_table` 维护。Attention 算子需要拿到每个 token 在物理 KV Cache 中的 **slot id（槽位号）**，才能正确地读写对应的 K/V 向量。本算子即用于完成「逻辑位置 → 物理 slot id」的映射计算。
+
+具体行为：
+
+- 每个 `program_id(0) == req_idx` 处理一条请求（一个 sequence）。
+- 通过 `query_start_loc_ptr` 得到该请求在 batch 中的 token 起止区间 `[start_idx, end_idx)`。
+- 对区间内每个 token：
+    - 读取其逻辑序列位置 `pos`；
+    - 根据 `block_size` 将 `pos` 拆分为 `block_indices`（块内逻辑块号）与 `slot_offsets`（块内偏移）；
+    - 通过 `block_table` 把逻辑块号转换为物理块号 `block_numbers`；
+    - 计算 `slot_id = block_numbers * block_size + slot_offsets`，写回 `slot_mapping_ptr`。
+- 当 `TOTAL_CP_WORLD_SIZE > 1`（启用 Context Parallel，CP）时，会按 `CP_KV_CACHE_INTERLEAVE_SIZE` 交错布局把虚拟块切分到各 rank：仅属于本 rank 的 token 写入真实 slot id，其余写入 `PAD_ID`（详见下文「多 CP 域下的计算说明」）。
+- **最后一个 program**（`req_idx == num_programs(0) - 1`）专门用于把 `slot_mapping_ptr` 中 `[num_tokens, max_num_tokens)` 这段填充为 `PAD_ID`
+
+### 多 CP 域下的计算说明
+
+当启用 Context Parallel（`TOTAL_CP_WORLD_SIZE > 1`）时，KV Cache 会以 **interleave（交错）** 方式分散存储到各 rank 上：序列中第 `i` 个 token 的 K/V 始终存放在 `dcp_rank == (i // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE` 的设备上。为保证各 rank 仅访问本地显存，本算子在 CP 模式下引入「虚拟块」概念并按以下步骤完成映射：
+
+1. **虚拟块划分**：将 `TOTAL_CP_WORLD_SIZE` 个 rank 的物理块在逻辑上合并为一个虚拟块
+   - `virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE`
+   - `virtual_block_indices = pos // virtual_block_size`（虚拟块号）
+   - `virtual_block_offsets = pos % virtual_block_size`（虚拟块内偏移）
+
+2. **归属判定**：通过 interleave 粒度判断当前 token 是否属于本 rank
+   - `is_local = (virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK`
+   - `is_local == False` 的 token 最终写入 `PAD_ID`，不占用本 rank 的 `block_table` 访问。
+
+3. **本地偏移换算**：将虚拟偏移中属于本 rank 的部分抽取为本地物理偏移
+   - `local_block_offsets = (virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)) * CP_KV_CACHE_INTERLEAVE_SIZE + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)`
+   - 该公式把每个虚拟块内本 rank 拥有的若干 interleave 段拼接成连续的本地偏移。
+
+4. **逻辑块号与块内偏移**：基于本地偏移计算 `block_table` 索引
+   - `block_indices = virtual_block_indices * BLOCKS_PER_KV_BLOCK + local_block_offsets // block_size`
+   - `slot_offsets = local_block_offsets % block_size`
+
+5. **物理块号查询与 slot id 组装**：通过 `block_table` 把逻辑块号转换为物理块号
+   - `block_numbers = gather(block_table, block_indices)`
+   - `slot_ids = block_numbers * block_size + slot_offsets`
+   - 最终写入：`slot_ids = where(is_local, slot_ids, PAD_ID)`
+
+---
+
+## 2、参数含义介绍
+
+### 2.1 运行时参数（设备侧张量/标量）
+
+| 参数名 | 形状 / 类型 | 含义 |
+| --- | --- | --- |
+| `num_tokens` | int | 当前 batch 中实际的 token 数量。 |
+| `max_num_tokens` | int | 预分配的最大 token 数。 |
+| `query_start_loc_ptr` | `[num_reqs + 1]`, int32 | 每条请求在 batch 中的累加起始位置，类似 CSR 的 `indptr`，`req_idx` 的 token 区间为 `[query_start_loc[req_idx], query_start_loc[req_idx+1])`。 |
+| `positions_ptr` | `[num_tokens]`, int64 | 每个 token 在其所属请求中的逻辑序列位置。 |
+| `block_table_ptr` | `[max_num_reqs, max_num_blocks_per_req]`, int32（展平） | 块表，将「逻辑块号」映射为「物理块号」；按行展开存储。 |
+| `block_table_stride` | int | `block_table` 一行的元素个数，即 `max_num_blocks_per_req`。 |
+| `block_size` | int | Attention 内核使用的逻辑块大小（一个逻辑块包含多少 token）。 |
+| `slot_mapping_ptr` | `[max_num_tokens]`, int32 | 输出张量，写入每个 token 对应的物理 KV Cache slot id。 |
+
+### 2.2 编译期常量参数（`tl.constexpr`）
+
+| 参数名 | 含义 |
+| --- | --- |
+| `KV_CACHE_BLOCK_SIZE` | KV Cache 物理分配块大小（物理 block 的大小）。 |
+| `BLOCKS_PER_KV_BLOCK` | 一个物理 KV 块包含多少个逻辑 block，满足 `KV_CACHE_BLOCK_SIZE = BLOCKS_PER_KV_BLOCK * block_size`。 |
+| `TOTAL_CP_WORLD_SIZE` | Context Parallel 通信域的总 rank 数；为 `1` 时走非 CP 路径。 |
+| `TOTAL_CP_RANK` | 当前设备在 CP 通信域中的 rank。 |
+| `CP_KV_CACHE_INTERLEAVE_SIZE` | CP 模式下 KV Cache 的交错大小，用于将虚拟块按 interleave 粒度切分到各 rank。 |
+| `PAD_ID` | 无效槽位的填充值（通常为 `PAD_SLOT_ID = -1`），用于 padding 区域与非本 rank 槽位。 |
+| `TILE_BLOCK_SIZE` | Triton 循环中的 tile 大小，控制单次迭代处理的 token 数。 |
+| `BLOCK_TABLE_WINDOW_SIZE` | 一次性加载到寄存器的 block_table 窗口大小（需 ≥ `TILE_BLOCK_SIZE / block_size + 1`，并取 2 的幂以便 Triton 向量化）。 |
+
+### 2.3 启动网格
+
+```python
+grid = (num_reqs + 1,)
+```
+
+前 `num_reqs` 个 program 分别处理一条请求，最后一个 program 负责 padding。
+
+---
+
+## 3、算子使用示例
+
+假设：
+
+- `block_size = 128`，`KV_CACHE_BLOCK_SIZE = 128`，未启用 CP（`TOTAL_CP_WORLD_SIZE = 1`）；
+- 当前 batch 有 2 条请求，token 区间分别为 `[0, 5)` 与 `[5, 10)`；
+- `max_num_batched_tokens = 8192`，需要把多余位置填充为 `PAD_ID`。
+
+```python
+import torch
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from vllm_ascend.ops.triton.compute_slot_mapping import (
+    _compute_slot_mapping_kernel,
+    _next_power_of_2,
+)
+
+device = "npu"
+
+
+# ---- 1. 输入张量 ----
+num_reqs = 2
+num_tokens = 10
+max_num_batched_tokens = 8192
+block_size = 128
+
+# 每条请求的 token 起止位置（CSR 风格 indptr）
+query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
+
+# 每个 token 在其请求中的逻辑位置
+positions = torch.tensor(
+    [0, 1, 2, 3, 4,   # 请求 0
+     0, 1, 2, 3, 4],  # 请求 1
+    dtype=torch.int64, device=device,
+)
+
+# 块表：逻辑块号 -> 物理块号，形状 [max_num_reqs, max_num_blocks_per_req]
+max_num_reqs = 64
+max_num_blocks_per_req = 320
+block_table = torch.randint(
+    0, 320, (max_num_reqs, max_num_blocks_per_req), dtype=torch.int32, device=device
+)
+
+# ---- 2. 输出张量 ----
+slot_mapping = torch.zeros(max_num_batched_tokens, dtype=torch.int32, device=device)
+
+# ---- 3. 编译期常量 ----
+KV_CACHE_BLOCK_SIZE = 128
+BLOCKS_PER_KV_BLOCK = KV_CACHE_BLOCK_SIZE // block_size   # = 1
+TILE_BLOCK_SIZE = 1024
+BLOCK_TABLE_WINDOW_SIZE = _next_power_of_2(
+    cdiv(TILE_BLOCK_SIZE, block_size) + 1
+)
+
+# ---- 4. 启动 kernel ----
+grid = (num_reqs + 1,)
+_compute_slot_mapping_kernel[grid](
+    num_tokens,
+    max_num_batched_tokens,
+    query_start_loc,
+    positions,
+    block_table,
+    block_table.stride(0),
+    max_num_blocks_per_req
+    block_size,
+    slot_mapping,
+    KV_CACHE_BLOCK_SIZE=KV_CACHE_BLOCK_SIZE,
+    BLOCKS_PER_KV_BLOCK=BLOCKS_PER_KV_BLOCK,
+    TOTAL_CP_WORLD_SIZE=1,
+    TOTAL_CP_RANK=0,
+    CP_KV_CACHE_INTERLEAVE_SIZE=1,
+    PAD_ID=PAD_SLOT_ID,                # 通常为 -1
+    TILE_BLOCK_SIZE=TILE_BLOCK_SIZE,
+    BLOCK_TABLE_WINDOW_SIZE=BLOCK_TABLE_WINDOW_SIZE,
+)
+
+# slot_mapping[:num_tokens] 为各 token 的物理 slot id
+# slot_mapping[num_tokens:max_num_batched_tokens] 被填充为 PAD_ID
+print(slot_mapping[:num_tokens])
+```
+
+### 启用 Context Parallel 的注意事项
+
+当 `TOTAL_CP_WORLD_SIZE > 1` 时：
+
+- 物理块大小被虚拟化为 `virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE`；
+- 仅 `is_local == True`（属于本 `TOTAL_CP_RANK`）的 token 才会写入真实 slot id，其余写 `PAD_ID`；
+- `block_indices` 与 `slot_offsets` 通过 `local_block_offsets` 重新换算，需要保证 `BLOCKS_PER_KV_BLOCK` 与 `CP_KV_CACHE_INTERLEAVE_SIZE` 配置正确。

--- a/vllm_ascend/ops/triton/compute_slot_mapping.py
+++ b/vllm_ascend/ops/triton/compute_slot_mapping.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.triton_utils import tl, triton
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+@triton.jit(do_not_specialize=["num_tokens", "max_num_tokens"])
+def _compute_slot_mapping_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,  # [num_reqs + 1], int32
+    positions_ptr,  # [num_tokens], int64
+    block_table_ptr,  # [max_num_reqs, max_num_blocks_per_req], int32 (flat)
+    block_table_stride,  # max_num_blocks_per_req
+    block_size,  # Logical block size used by the attention kernel
+    slot_mapping_ptr,  # [max_num_tokens], int32
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,  # Physical KV cache allocation block size
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,  # KV_CACHE_BLOCK_SIZE = BLOCKS_PER_KV_BLOCK * block_size
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    TILE_BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_WINDOW_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == tl.num_programs(0) - 1:
+        # Pad remaining slots for CUDA graph compatibility.
+        for i in range(num_tokens, max_num_tokens, TILE_BLOCK_SIZE):
+            offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    row_offset = req_idx * block_table_stride
+    block_table_offsets = tl.arange(0, BLOCK_TABLE_WINDOW_SIZE)
+    for i in range(start_idx, end_idx, TILE_BLOCK_SIZE):
+        offsets = i + tl.arange(0, TILE_BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0).to(tl.int32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            block_indices = pos // block_size
+            slot_offsets = pos - block_indices * block_size
+        else:
+            virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+            virtual_block_indices = pos // virtual_block_size
+            virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
+            is_local = (virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+            local_block_offsets = (
+                virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+            ) * CP_KV_CACHE_INTERLEAVE_SIZE + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)
+
+            block_indices = virtual_block_indices * BLOCKS_PER_KV_BLOCK + local_block_offsets // block_size
+            slot_offsets = local_block_offsets % block_size
+
+        INT32_MAX = 2147483647
+        valid_block_indices = tl.where(mask, block_indices, INT32_MAX)
+        block_idx_base = tl.min(valid_block_indices, axis=0)
+        block_table_window_offsets = block_idx_base + block_table_offsets
+        block_table_window = tl.load(
+            block_table_ptr + row_offset + block_table_window_offsets,
+            mask=block_table_window_offsets < block_table_stride,
+            other=0,
+        ).to(tl.float32)
+        if TOTAL_CP_WORLD_SIZE == 1:
+            relative_block_indices = tl.where(mask, block_indices - block_idx_base, 0)
+        else:
+            relative_block_indices = tl.where(mask & is_local, block_indices - block_idx_base, 0)
+        block_numbers = tl.gather(block_table_window, relative_block_indices, 0).to(tl.int32)
+        slot_ids = block_numbers * block_size + slot_offsets
+        if TOTAL_CP_WORLD_SIZE != 1:
+            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -5,9 +5,12 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec, MambaSpec, UniformTypeKVCacheSpecs
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.block_table import _compute_slot_mapping_kernel
 
 from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
+from vllm_ascend.ops.triton.compute_slot_mapping import (
+    _compute_slot_mapping_kernel,
+    _next_power_of_2,
+)
 
 
 class BlockTable:
@@ -155,17 +158,18 @@ class BlockTable:
             )
             self._compute_dcp_slot_mapping(req_indices, positions)
         else:
+            TILE_BLOCK_SIZE = 1024
             kernel_kwargs = {
+                "KV_CACHE_BLOCK_SIZE": self.physical_block_size,
+                "BLOCKS_PER_KV_BLOCK": self.blocks_per_phys_block,
                 "TOTAL_CP_WORLD_SIZE": total_cp_world_size,
                 "TOTAL_CP_RANK": total_cp_rank,
                 "CP_KV_CACHE_INTERLEAVE_SIZE": self.cp_kv_cache_interleave_size,
                 "PAD_ID": PAD_SLOT_ID,
-                "BLOCK_SIZE": 1024,
+                "TILE_BLOCK_SIZE": TILE_BLOCK_SIZE,
+                "BLOCK_TABLE_WINDOW_SIZE": _next_power_of_2(cdiv(TILE_BLOCK_SIZE, self.block_size) + 1),
             }
-            kernel_kwargs.update(
-                KV_CACHE_BLOCK_SIZE=self.physical_block_size,
-                BLOCKS_PER_KV_BLOCK=self.blocks_per_phys_block,
-            )
+
             _compute_slot_mapping_kernel[(num_reqs + 1,)](
                 num_tokens,
                 self.max_num_batched_tokens,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the Ascend slot mapping Triton kernel in the v1 block table path.

The previous path reused the generic upstream vLLM _compute_slot_mapping_kernel: https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/block_table.py, which can generate excessive scalar computation on Ascend NPUs due to int64 arithmetic, modulo operations, and non-contiguous block table loads.

This PR adds a local Ascend-optimized _compute_slot_mapping_kernel with the following improvements:

- cast pos from int64 to int32 to avoid scalar computation
- fix non-contigious load for block table
- special code path for case TOTAL_CP_WORLD_SIZE=1 which eliminates a lot of scalar computation

performance：
| cases |  shape | time before opt | time after opt | gains |
| --- | --- | --- | --- | --- |
| 1 | num_tokens=4,num_reqs=2,CP=1,max_num_batched_tokens=8192 | 173.1 | 3.02 | 5732% |
| 2 | num_tokens=32\*256,num_reqs=256,CP=1,max_num_batched_tokens=32\*256 | 1038.83 | 21.2 | 4900% |

### Does this PR introduce _any_ user-facing change?
No. This is an internal performance optimization for Ascend slot mapping.

### How was this patch tested?
new tests added with CI passed

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
