### PR TITLE
[Debug][KV Transfer] Add Mooncake port-conflict diagnostic probe

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import contextlib
 import copy
+import errno
 import hashlib
 import logging
 import math
 import os
 import queue
 import random
+import socket
 import struct
 import threading
 import time
@@ -271,8 +273,105 @@ class KVCacheSendingThread(threading.Thread):
         self.kv_caches = kv_caches
         self.pcp_rank = pcp_rank
         self.port_send_num: dict[str, int] = {}
+        self.dp_rank = getattr(vllm_config.parallel_config, "data_parallel_rank", None)
+        self.dp_local_rank = getattr(vllm_config.parallel_config, "data_parallel_rank_local", None)
 
         self.task_tracker = KVCacheTaskTracker()
+
+    @staticmethod
+    def _native_thread_snapshot() -> str:
+        """Return Linux native thread IDs/names for post-mortem debugging."""
+        task_dir = f"/proc/{os.getpid()}/task"
+        try:
+            native_threads = []
+            for task_id in sorted(os.listdir(task_dir), key=int):
+                with open(f"{task_dir}/{task_id}/comm") as comm_file:
+                    native_threads.append(f"{task_id}:{comm_file.read().strip()}")
+            return ", ".join(native_threads)
+        except (OSError, ValueError) as exc:
+            return f"unavailable ({exc})"
+
+    def _hang_on_port_conflict(
+        self,
+        *,
+        host: str,
+        port: int,
+        path: str,
+        stage: str,
+        error: BaseException,
+    ) -> None:
+        current_thread = threading.current_thread()
+        python_threads = ", ".join(
+            f"{thread.name}(ident={thread.ident},native_id={thread.native_id},alive={thread.is_alive()})"
+            for thread in threading.enumerate()
+        )
+        logger.error(
+            "Mooncake handshake port conflict detected; entering an intentional diagnostic hang. "
+            "stage=%s, path=%s, host=%s, port=%d, pid=%d, "
+            "current_thread=%s, python_thread_ident=%s, native_thread_id=%s, "
+            "dp_rank=%s, dp_local_rank=%s, tp_rank=%d, pp_rank=%d, pcp_rank=%d, error=%r. "
+            "Python threads=[%s]. Native threads=[%s]. "
+            "Inspect the live process with: ss -ltnp 'sport = :%d'; "
+            "ls -l /proc/%d/fd; gdb -p %d -batch -ex 'info threads' "
+            "-ex 'thread apply all bt'. The worker will remain blocked here.",
+            stage,
+            path,
+            host,
+            port,
+            os.getpid(),
+            current_thread.name,
+            current_thread.ident,
+            current_thread.native_id,
+            self.dp_rank,
+            self.dp_local_rank,
+            self.tp_rank,
+            self.pp_rank,
+            self.pcp_rank,
+            error,
+            python_threads,
+            self._native_thread_snapshot(),
+            port,
+            os.getpid(),
+            os.getpid(),
+        )
+        threading.Event().wait()
+
+    def _probe_handshake_port(self, host: str, port: int, path: str) -> None:
+        """Probe for an existing TCP bind before creating the ZMQ listener."""
+        try:
+            addresses = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        except OSError as exc:
+            logger.warning(
+                "Unable to resolve Mooncake handshake endpoint before ZMQ bind. "
+                "path=%s, error=%r. Deferring validation to ZMQ.",
+                path,
+                exc,
+            )
+            return
+
+        for family, sock_type, protocol, _, sockaddr in addresses:
+            try:
+                with socket.socket(family, sock_type, protocol) as probe_socket:
+                    probe_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    probe_socket.bind(sockaddr)
+                return
+            except OSError as exc:
+                if exc.errno == errno.EADDRINUSE:
+                    self._hang_on_port_conflict(
+                        host=host,
+                        port=port,
+                        path=path,
+                        stage="pre-bind probe",
+                        error=exc,
+                    )
+                    return
+                logger.warning(
+                    "Unable to probe Mooncake handshake endpoint before ZMQ bind. "
+                    "path=%s, sockaddr=%s, error=%r. Deferring validation to ZMQ.",
+                    path,
+                    sockaddr,
+                    exc,
+                )
 
     def get_and_clear_finished_requests(self) -> set[str]:
         """
@@ -290,6 +389,8 @@ class KVCacheSendingThread(threading.Thread):
 
     def run(self):
         """Run the thread to handle KV cache transfer requests."""
+        path = "not-computed"
+        handshake_port = -1
         try:
             # Listen for new requests for metadata. NOTE(rob): we need each rank
             # to have a unique port. This hack to keeps us moving. We will
@@ -298,6 +399,7 @@ class KVCacheSendingThread(threading.Thread):
             device_index = (self.pp_rank * self.pcp_size + self.pcp_rank) * self.tp_size + self.tp_rank
             handshake_port = self.side_channel_port + device_index
             path = make_zmq_path("tcp", self.side_channel_host, handshake_port)
+            self._probe_handshake_port(self.side_channel_host, handshake_port, path)
             logger.info(
                 "KVCacheSendingThread started listening on path: %s. Thread: tp_rank=%d, pp_rank=%d, pcp_rank=%d",
                 path,
@@ -309,6 +411,14 @@ class KVCacheSendingThread(threading.Thread):
                 self.ready_event.set()
                 self.run_busy_loop(sock)
         except Exception as e:
+            if isinstance(e, zmq.ZMQError) and e.errno == zmq.EADDRINUSE:
+                self._hang_on_port_conflict(
+                    host=self.side_channel_host,
+                    port=handshake_port,
+                    path=path,
+                    stage="ZMQ bind",
+                    error=e,
+                )
             logger.exception(
                 "Mooncake KVCacheSendingThread encountered exception. "
                 "Thread: tp_rank=%d, pp_rank=%d, listening_path=%s. "


### PR DESCRIPTION
> [!WARNING]
> 这是一个仅供现场定位端口冲突的诊断 PR，不准备合入。发生端口冲突时，相关 worker 会被故意永久挂起，请勿用于生产服务。

### What this PR does / why we need it?

PD 分离与池化/MemCache 叠加后，Mooncake 的 ZMQ handshake 端口偶发 `Address already in use`。现场观察到冲突总是落在固定 rank，例如 TP rank 12 对应端口 `60512`，但原有异常路径会直接退出监听线程，导致冲突发生后难以检查端口占用者和进程内线程栈。

本 PR 只修改一个文件：

```text
vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
```

诊断逻辑：

1. 创建 ZMQ listener 前，使用临时 TCP socket 探测 handshake 地址是否已被占用。
2. 同时保留 ZMQ 实际 `bind()` 的 `EADDRINUSE` 兜底，覆盖“预探测成功、正式绑定前被抢占”的竞态。
3. 检测到冲突后打印：
   - PID、目标地址和端口；
   - DP rank、local DP rank、TP/PP/PCP rank；
   - 当前 Python thread ident 和 Linux native TID；
   - 当前进程的 Python 线程列表；
   - `/proc/<pid>/task` 中的 native 线程 ID 和线程名。
4. 打印完成后停在 `threading.Event().wait()`，保留故障现场供 `ss`、`gdb` 等工具检查。

关键日志标记：

```text
Mooncake handshake port conflict detected; entering an intentional diagnostic hang
```

### 使用方法

在需要排障的服务器上，只替换这一份文件。建议先备份：

```bash
cd /vllm-workspace/vllm-ascend

TARGET=vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
cp "$TARGET" "${TARGET}.bak"

git fetch https://github.com/Yuli-yx/vllm-ascend.git \
  codex/debug-mooncake-port-conflict-v023
git show FETCH_HEAD:"$TARGET" > /tmp/mooncake_connector.py
python -m py_compile /tmp/mooncake_connector.py
cp /tmp/mooncake_connector.py "$TARGET"
```

然后按原启动脚本启动服务。出现上述关键日志后，记录日志中的 `port` 和 `pid`，在故障节点执行：

```bash
PORT=60512
PID=<日志中的pid>

ss -ltnp "sport = :${PORT}"
ls -l "/proc/${PID}/fd"

gdb -p "$PID" \
  -batch \
  -ex 'info threads' \
  -ex 'thread apply all bt'
```

重点在全线程栈中查找 `memcache`、`smem`、`hybm`、`hcom`、`zmq` 等符号。TCP socket 在 Linux 中归属于进程的共享文件描述符表，`ss` 通常只能直接给出 PID，不能可靠给出“由哪个线程创建”；因此需要结合本 PR 打印的 native TID 快照和 GDB 全线程调用栈判断。

排查完成后终止本次诊断服务，并恢复原文件：

```bash
cd /vllm-workspace/vllm-ascend
TARGET=vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
cp "${TARGET}.bak" "$TARGET"
```

### Does this PR introduce _any_ user-facing change?

是，但仅限诊断分支：发生 handshake 端口冲突时，worker 不再立即退出，而会故意永久挂起。正常无冲突路径不改变业务逻辑。

本 PR 不建议合入，也不应作为正式修复。最终修复应为 Mooncake 与 MemCache/HCOM 分配互不重叠的端口区间。

### How was this patch tested?

- `ruff check`：通过。
- `git diff --check`：通过。
- `python -m py_compile`：通过。
- 未在本 PR 中添加 UT，以保持只修改 `mooncake_connector.py`，方便现场单文件替换。
- 本地完整 pytest 在收集阶段受到现有 vLLM/vLLM-Ascend API 版本不匹配影响，未进入本修改路径。

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
