### PR TITLE
[Doc][BugFix] Fix port mismatch in Kimi-K2.6 tutorial

### DIFF
--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -160,7 +160,7 @@ vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
     --data-parallel-size 4 \
     --no-enable-prefix-caching \
     --enable-expert-parallel \
-    --port 8089 \
+    --port 8000 \
     --max-num-seqs 4 \
     --max-model-len 34816 \
     --max-num-batched-tokens 16384 \
@@ -188,7 +188,7 @@ Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](htt
 Service Verification:
 
 ```shell
-curl http://<node_ip>:8088/v1/chat/completions \
+curl http://<node_ip>:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
         "model": "kimi_k26",


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a port mismatch in the Kimi-K2.6 tutorial. Previously, the startup command used port `8089` while the service verification command used `8088`. This PR aligns both to use the default port `8000`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation update only.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
