### PR TITLE
[CI][BugFix]Change failure analysis secret keys names in _analyze_failure.yaml

### DIFF
--- a/.github/workflows/_analyze_failure.yaml
+++ b/.github/workflows/_analyze_failure.yaml
@@ -132,8 +132,8 @@ jobs:
       group: failure-analysis-obs-daily-archive
       cancel-in-progress: false
     env:
-      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY_FAILURE_ANALYSIS }}
-      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY_FAILURE_ANALYSIS }}
+      OBS_ACCESS_KEY: ${{ secrets.OBS_ACCESS_KEY_PRECISION }}
+      OBS_SECRET_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY_PRECISION }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -487,7 +487,9 @@ jobs:
 
           echo "=== CI Gate: PASSED ==="
 
-  #this job collects failure from uploaded logs
+  # this job collects failure from uploaded logs
+  # failure analyze & upload reports
+  
   analyze-failure-report:
     name: Analyze failure report
     needs: [run-selected-tests, recommend-tests-from-coverage]

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -498,5 +498,5 @@ jobs:
       recommendations_file: .github/workflows/scripts/recommended_pytest_paths.txt
       recommendations_content: ${{ needs.recommend-tests-from-coverage.outputs.coverage_paths || '' }}
     secrets:
-      OBS_ACCESS_KEY_FAILURE_ANALYSIS: ${{ secrets.OBS_ACCESS_KEY_FAILURE_ANALYSIS }}
-      OBS_SECRET_ACCESS_KEY_FAILURE_ANALYSIS: ${{ secrets.OBS_SECRET_ACCESS_KEY_FAILURE_ANALYSIS }}
+      OBS_ACCESS_KEY_FAILURE_ANALYSIS: ${{ secrets.OBS_ACCESS_KEY_PRECISION }}
+      OBS_SECRET_ACCESS_KEY_FAILURE_ANALYSIS: ${{ secrets.OBS_SECRET_ACCESS_KEY_PRECISION }}


### PR DESCRIPTION
### What this PR does / why we need it?
Update the name of obs secrets in _analyze.failure.yaml to fix the problem : unable to upload
### Does this PR introduce _any_ user-facing change?
N/A
### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
