### PR TITLE
[BugFix][v0.20.2rc] Count DeepSeek-V3-style reasoning tokens

### DIFF
--- a/tests/ut/patch/platform/test_patch_deepseek_v3_reasoning_usage_accounting.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v3_reasoning_usage_accounting.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from vllm.reasoning import ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import (
+    DeepSeekV3ReasoningParser,
+    DeepSeekV3ReasoningWithThinkingParser,
+)
+from vllm.reasoning.nemotron_v3_reasoning_parser import NemotronV3ReasoningParser
+from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
+
+from vllm_ascend.patch.platform import (
+    patch_deepseek_v3_reasoning_usage_accounting as reasoning_usage_patch,  # noqa: F401
+)
+from vllm_ascend.patch.platform import (
+    patch_minimax_usage_accounting as usage_patch,
+)
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {
+            "<think>": 1,
+            "</think>": 2,
+        }
+
+
+PARSER_CASES = [
+    pytest.param("deepseek_v3", {"thinking": True}, id="deepseek-v3"),
+    pytest.param("deepseek_v4", {"thinking": True}, id="deepseek-v4"),
+    pytest.param("glm45", None, id="glm45"),
+    pytest.param("holo2", None, id="holo2"),
+]
+
+
+def _reasoning_parser(parser_name, chat_template_kwargs=None):
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    kwargs = {}
+    if chat_template_kwargs is not None:
+        kwargs["chat_template_kwargs"] = chat_template_kwargs
+    return parser_cls(FakeTokenizer(), **kwargs)
+
+
+def test_reasoning_parser_registration_is_unchanged():
+    assert ReasoningParserManager.get_reasoning_parser("deepseek_v3") is DeepSeekV3ReasoningParser
+    assert ReasoningParserManager.get_reasoning_parser("deepseek_v4") is DeepSeekV3ReasoningParser
+    assert ReasoningParserManager.get_reasoning_parser("glm45") is DeepSeekV3ReasoningWithThinkingParser
+    assert ReasoningParserManager.get_reasoning_parser("holo2") is DeepSeekV3ReasoningWithThinkingParser
+
+
+@pytest.mark.parametrize(("parser_name", "chat_template_kwargs"), PARSER_CASES)
+@pytest.mark.parametrize(
+    ("token_ids", "expected"),
+    [
+        pytest.param([1, 10, 11, 2, 20], 2, id="explicit-start"),
+        pytest.param([99, 1, 10, 11, 2, 20], 2, id="prefix-before-start"),
+        pytest.param([10, 11, 2, 20], 2, id="implicit-start"),
+        pytest.param([10, 11], 2, id="truncated-reasoning"),
+        pytest.param([2, 20], 0, id="end-token-first"),
+        pytest.param([], 0, id="empty-output"),
+    ],
+)
+def test_reasoning_token_count(
+    parser_name,
+    chat_template_kwargs,
+    token_ids,
+    expected,
+):
+    parser = _reasoning_parser(parser_name, chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens(token_ids) == expected
+
+
+@pytest.mark.parametrize("parser_name", ["deepseek_v3", "deepseek_v4"])
+@pytest.mark.parametrize("chat_template_kwargs", [{"thinking": False}, {"enable_thinking": False}])
+def test_reasoning_tokens_when_thinking_is_disabled(parser_name, chat_template_kwargs):
+    parser = _reasoning_parser(parser_name, chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+@pytest.mark.parametrize("parser_name", ["glm45", "holo2"])
+@pytest.mark.parametrize(
+    "chat_template_kwargs",
+    [
+        {"thinking": False, "enable_thinking": False},
+        {"thinking": False, "enable_thinking": None},
+        {"thinking": None, "enable_thinking": False},
+    ],
+)
+def test_reasoning_tokens_when_default_thinking_is_disabled(parser_name, chat_template_kwargs):
+    parser = _reasoning_parser(parser_name, chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+def test_non_wrapper_reasoning_parsers_are_unchanged():
+    assert DeepSeekR1ReasoningParser(FakeTokenizer()).count_reasoning_tokens([10, 11, 2, 20]) == 0
+    assert NemotronV3ReasoningParser(FakeTokenizer()).count_reasoning_tokens([10, 11, 2, 20]) == 0
+    assert ReasoningParserManager.get_reasoning_parser("qwen3") is Qwen3ReasoningParser
+    assert Qwen3ReasoningParser(FakeTokenizer()).count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+def test_full_response_usage_reports_reasoning_tokens():
+    class FakeServing:
+        enable_prompt_tokens_details = False
+
+        def _make_usage_info(self, **kwargs):
+            return usage_patch._make_usage_info(self, **kwargs)
+
+    state = usage_patch._create_usage_tracking_state(
+        num_choices=1,
+        reasoning_parser=_reasoning_parser("glm45"),
+    )
+    state.num_prompt_tokens = 3
+    state.final_res = SimpleNamespace(num_cached_tokens=None)
+    state.completion_tokens = [4]
+    state.raw_output_token_ids = [[10, 11, 2, 20]]
+
+    usage = usage_patch._make_full_response_usage(FakeServing(), state)
+
+    assert usage.completion_tokens_details.reasoning_tokens == 2
+
+
+def test_stream_usage_reports_reasoning_tokens():
+    state = usage_patch._create_usage_tracking_state(
+        num_choices=1,
+        reasoning_parser=_reasoning_parser("deepseek_v4", {"thinking": True}),
+    )
+    state.raw_output_token_ids = [[10, 11, 2, 20]]
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 7,
+        },
+    }
+
+    data = usage_patch._inject_stream_usage_details(
+        f"data: {json.dumps(chunk)}\n\n",
+        state,
+    )
+    payload = json.loads(data.removeprefix("data: ").removesuffix("\n\n"))
+
+    assert payload["usage"]["completion_tokens_details"] == {
+        "reasoning_tokens": 2,
+    }

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -200,6 +200,23 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       GLM47 inline zero-argument streaming parser fix.
 #
+# ** 7c. File: platform/patch_deepseek_v3_reasoning_usage_accounting.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.reasoning.deepseek_v3_reasoning_parser.DeepSeekV3ReasoningParser`
+#    Why:
+#       DeepSeek-V3/V4, GLM, and Holo2 share a reasoning wrapper that does not
+#       delegate token counting. Their chat templates may also place the opening
+#       `<think>` token in the prompt, leaving only `</think>` in generated ids.
+#    How:
+#       Delegate explicit spans to the wrapped parser and count the implicit
+#       leading reasoning span when the generated opening token is absent.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/41077
+#       https://github.com/vllm-project/vllm/pull/49743
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains the upstream
+#       reasoning-token counting fix.
+#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -30,6 +30,7 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v3_reasoning_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v3_reasoning_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v3_reasoning_usage_accounting.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# DeepSeek-V3-style reasoning usage: backport reasoning-token counting.
+#
+
+from collections.abc import Sequence
+
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
+
+
+def _count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+    parser = self._parser
+    if not isinstance(parser, BaseThinkingReasoningParser):
+        return parser.count_reasoning_tokens(token_ids)
+
+    if parser.start_token_id in token_ids:
+        return parser.count_reasoning_tokens(token_ids)
+
+    # Some models and templates put the opening marker in the prompt. A missing
+    # closing marker therefore means generation was truncated.
+    try:
+        return token_ids.index(parser.end_token_id)
+    except ValueError:
+        return len(token_ids)
+
+
+DeepSeekV3ReasoningParser.count_reasoning_tokens = _count_reasoning_tokens


### PR DESCRIPTION
### What this PR does / why we need it?

GLM-5.1/5.2 chat templates can place the opening `<think>` marker in the prompt, so generated token ids contain the reasoning span followed by `</think>`, but no generated opening marker. `DeepSeekV3ReasoningParser` also did not delegate token counting to its wrapped parser. As a result, chat usage reported `completion_tokens_details.reasoning_tokens: 0` even though the response contained reasoning.

This PR adds a wrapper-level `count_reasoning_tokens()` patch that:

- delegates explicit `<think>...</think>` spans to the existing wrapped parser;
- counts tokens before the first generated `</think>` when the opening marker came from the prompt;
- counts all generated tokens as reasoning when generation is truncated before `</think>`;
- preserves identity-parser behavior when thinking is disabled.

The patch is intentionally limited to the existing `DeepSeekV3ReasoningParser` wrapper, covering the `deepseek_v3`, `deepseek_v4`, `glm45`, and `holo2` aliases. It does not modify `DeepSeekR1ReasoningParser`, `NemotronV3ReasoningParser`, Qwen, MiniMax, serving generators, model execution, or the NPU decode path.

Fixes #13070.

Related #10777: this fixes its DeepSeek-V4/GLM portion. Qwen3.6 uses the independent `Qwen3ReasoningParser` and is intentionally out of scope. The `thinking_token_budget` problem reported in #13060 is also separate because the Ascend sampler does not currently implement that budget path.

Upstream context:

- https://github.com/vllm-project/vllm/pull/41077
- https://github.com/vllm-project/vllm/pull/49743

The global Base/DeepSeek-R1 approach from the second PR was not backported because it would also change Nemotron request modes. No duplicate vLLM Ascend PR was found for #13070.

### Does this PR introduce _any_ user-facing change?

Yes. Thinking-enabled chat completions using the affected parser aliases now report the actual reasoning token count instead of zero. Thinking-disabled requests remain unchanged.

### How was this patch tested?

- `pytest -q tests/ut/patch/platform/test_patch_deepseek_v3_reasoning_usage_accounting.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py` (`56 passed`)
- `ruff check` and `ruff format --check` on the new patch and tests
- `python -m py_compile` on the new patch and tests
- `git diff --check`
- Actual GLM-5.1 tokenizer probe: explicit, implicit-opening, and truncated reasoning counts are correct for `deepseek_v3`, `deepseek_v4`, `glm45`, and `holo2`; disabled requests remain zero; the `qwen3` registry remains unchanged.
- CPU-only final usage scan benchmark: 1,024 tokens 0.018 ms, 32,768 tokens 0.571 ms, and 202,752 tokens 3.53 ms. This scan runs in usage post-processing, not model execution or NPU decode.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
