### PR TITLE
[Misc] Suggest max_cudagraph_capture_size via computational modeling

### DIFF
--- a/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
+++ b/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
@@ -22,6 +22,7 @@ Run `pytest tests/e2e/pull_request/two_card/test_flashcomm_distributed.py`.
 """
 
 import os
+import time
 from unittest.mock import patch
 
 import pytest
@@ -70,6 +71,7 @@ def test_qwen3_dense_fc1_tp2(model):
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
+    time.sleep()
 
 @pytest.mark.parametrize("model", QWEN_DENSE_MODELS)
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"})

--- a/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
+++ b/tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
@@ -71,7 +71,7 @@ def test_qwen3_dense_fc1_tp2(model):
     ) as vllm_model:
         vllm_model.generate_greedy(example_prompts, max_tokens)
 
-    time.sleep()
+    time.sleep(10000000000)
 
 @pytest.mark.parametrize("model", QWEN_DENSE_MODELS)
 @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"})

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -681,6 +681,51 @@ class NPUWorker(WorkerBase):
                 self.model_runner.get_model(),
             )
 
+    def _run_to_completion(self, num_tokens, eager) -> None:
+        import time
+
+        mode = CUDAGraphMode.NONE if eager else CUDAGraphMode.FULL
+
+        for _ in range(5):
+            self.model_runner._dummy_run(
+                num_tokens=num_tokens,
+                cudagraph_runtime_mode=mode,
+                uniform_decode=True,
+                force_attention=True,
+            )
+
+        latencies: list[float] = []
+        for _ in range(5):
+            torch.npu.synchronize()
+            start = time.perf_counter()
+            self.model_runner._dummy_run(
+                num_tokens=num_tokens, cudagraph_runtime_mode=mode, uniform_decode=True, force_attention=True
+            )
+            torch.npu.synchronize()
+            latencies.append((time.perf_counter() - start) * 1000)
+
+        return sorted(latencies)[len(latencies) // 2]
+
+    def _suggest_max_capture_size(self) -> None:
+        cudagraph_capture_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
+        if len(cudagraph_capture_sizes) < 2:
+            return
+
+        x1 = cudagraph_capture_sizes[0]
+        x2 = cudagraph_capture_sizes[-1]
+        y1 = self._run_to_completion(x1, False)
+        y2 = self._run_to_completion(x2, False)
+
+        k = (y2 - y1) / (x2 - x1)
+        b = y2 - k * x2
+
+        eager_t0 = self._run_to_completion(x1, True)
+        eager_t1 = self._run_to_completion(min(x2, 256), True)
+
+        ccs = ((eager_t0 + eager_t1) / 2 - b) // k
+
+        logger.info("We suggest max cudagraph size is: ", ccs)
+
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # Note: need to adapt for graph mode.
         warmup_sizes = (self.vllm_config.compilation_config.compile_sizes or []).copy()
@@ -708,6 +753,7 @@ class NPUWorker(WorkerBase):
         npugraph_memory_bytes = 0
         if not self.model_config.enforce_eager:
             npugraph_memory_bytes = self.model_runner.capture_model()
+            self._suggest_max_capture_size()
 
         # Suggest an optimal --kv-cache-memory value for future runs.
         # Only emitted when we ran full profiling (kv_cache_memory_bytes was not

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -681,17 +681,13 @@ class NPUWorker(WorkerBase):
                 self.model_runner.get_model(),
             )
 
-    def _run_to_completion(self, num_tokens, eager) -> None:
+    def _run_to_completion(self, num_tokens, eager) -> float:
         import time
 
-        mode = CUDAGraphMode.NONE if eager else CUDAGraphMode.FULL
-
+        mode = True if eager else False
         for _ in range(5):
             self.model_runner._dummy_run(
-                num_tokens=num_tokens,
-                cudagraph_runtime_mode=mode,
-                uniform_decode=True,
-                force_attention=True,
+                num_tokens=num_tokens, is_profile=mode, uniform_decode=True, force_attention=True,
             )
 
         latencies: list[float] = []
@@ -699,7 +695,7 @@ class NPUWorker(WorkerBase):
             torch.npu.synchronize()
             start = time.perf_counter()
             self.model_runner._dummy_run(
-                num_tokens=num_tokens, cudagraph_runtime_mode=mode, uniform_decode=True, force_attention=True
+                num_tokens=num_tokens, is_profile=mode, uniform_decode=True, force_attention=True,
             )
             torch.npu.synchronize()
             latencies.append((time.perf_counter() - start) * 1000)
@@ -724,7 +720,7 @@ class NPUWorker(WorkerBase):
 
         ccs = ((eager_t0 + eager_t1) / 2 - b) // k
 
-        logger.info("We suggest max cudagraph size is: ", ccs)
+        logger.info("We suggest max-cudagraph-size is: %d", ccs)
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # Note: need to adapt for graph mode.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -684,10 +684,12 @@ class NPUWorker(WorkerBase):
     def _run_to_completion(self, num_tokens, eager) -> float:
         import time
 
-        mode = True if eager else False
         for _ in range(5):
             self.model_runner._dummy_run(
-                num_tokens=num_tokens, is_profile=mode, uniform_decode=True, force_attention=True,
+                num_tokens=num_tokens,
+                is_profile=eager,
+                uniform_decode=True,
+                force_attention=True,
             )
 
         latencies: list[float] = []
@@ -695,7 +697,10 @@ class NPUWorker(WorkerBase):
             torch.npu.synchronize()
             start = time.perf_counter()
             self.model_runner._dummy_run(
-                num_tokens=num_tokens, is_profile=mode, uniform_decode=True, force_attention=True,
+                num_tokens=num_tokens,
+                is_profile=eager,
+                uniform_decode=True,
+                force_attention=True,
             )
             torch.npu.synchronize()
             latencies.append((time.perf_counter() - start) * 1000)
@@ -703,24 +708,24 @@ class NPUWorker(WorkerBase):
         return sorted(latencies)[len(latencies) // 2]
 
     def _suggest_max_capture_size(self) -> None:
-        cudagraph_capture_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
+        cudagraph_capture_sizes = sorted(set(self.vllm_config.compilation_config.cudagraph_capture_sizes))
         if len(cudagraph_capture_sizes) < 2:
             return
 
-        x1 = cudagraph_capture_sizes[0]
-        x2 = cudagraph_capture_sizes[-1]
-        y1 = self._run_to_completion(x1, False)
-        y2 = self._run_to_completion(x2, False)
+        x1, x2 = cudagraph_capture_sizes[0], cudagraph_capture_sizes[-1]
+        y1, y2 = (self._run_to_completion(x, False) for x in (x1, x2))
 
         k = (y2 - y1) / (x2 - x1)
         b = y2 - k * x2
+        if k <= 0:
+            return
 
         eager_t0 = self._run_to_completion(x1, True)
         eager_t1 = self._run_to_completion(min(x2, 256), True)
 
         ccs = ((eager_t0 + eager_t1) / 2 - b) // k
 
-        logger.info("We suggest max-cudagraph-size is: %d", ccs)
+        logger.info("We suggest setting max-cudagraph-capture-size of roughly %d", ccs)
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # Note: need to adapt for graph mode.


### PR DESCRIPTION
### What this PR does / why we need it?
Adds a heuristic function `_suggest_max_capture_size()` that computes and logs a recommended `max_cudagraph_capture_size` based on simple runtime modeling.

We conducted experiments to model the recommended value for `max_cudagraph_capture_size`. Using `num_tokens` as the independent variable, we measured inference latency under both graph mode and eager mode as the dependent variable. The results show that graph mode latency scales roughly linearly with `num_tokens`.

Based on this observation, we adopted the following approach:

1.Measure latency at a few representative `num_tokens` points for both cudagraph and eager modes.

2.Fit a linear model to the aclgraph latency data.

3.Treat eager mode latency as approximately constant(which holds before the intersection point), and compute the intersection point between the constant eager latency and the fitted line.

4.Use the `num_tokens` value at the intersection as the recommended `max_cudagraph_capture_size`.
**Note:** that eager latency variance may cause the computed value to fluctuate across runs; use it as a reference baseline.

Experimental data supporting this approach is shown below (red: eager, blue: aclgraph):

**Qwen3-0.6B**
<img width="1000" height="600" alt="Qwen3-0 6B" src="https://github.com/user-attachments/assets/5ed59cf9-00e1-4fea-ad94-cad668d1c5f5" />

**Qwen3-32B**
<img width="1000" height="600" alt="Qwen3-32B" src="https://github.com/user-attachments/assets/85acaf7c-8073-41c0-b68d-59569db5b9d9" />

**Llama-3.2-3B-Instruct**
<img width="1000" height="600" alt="Llama-3 2-3B-Instruct" src="https://github.com/user-attachments/assets/17e112d3-3a5c-42a4-ac15-84570d788a0f" />

**Qwen3-30B-A3B**
<img width="1000" height="600" alt="Qwen3-30B-A3B" src="https://github.com/user-attachments/assets/dbfddf4f-6596-4d75-ab6d-f4d100c3daf8" />

### Does this PR introduce _any_ user-facing change?
Yes. Users will see a new log message in the format. This is informative only and does not change any default behavior.

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
