### PR TITLE
[310P][Performance] Add custom fused infer attention for Ascend 310P

### DIFF
--- a/csrc/attention/custom_fused_infer_attention_v310/CMakeLists.txt
+++ b/csrc/attention/custom_fused_infer_attention_v310/CMakeLists.txt
@@ -1,0 +1,16 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/custom_fused_infer_attention_v310/custom_fused_infer_attention_v310_torch_adpt.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/custom_fused_infer_attention_v310_torch_adpt.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CUSTOM_FUSED_INFER_ATTENTION_V310_TORCH_ADPT_H
+#define CUSTOM_FUSED_INFER_ATTENTION_V310_TORCH_ADPT_H
+namespace vllm_ascend {
+
+at::Tensor npu_custom_fused_infer_attention_v310(
+    const at::Tensor &query, at::TensorList key, at::TensorList value,
+    const c10::optional<at::Tensor> &attn_mask,
+    c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_q,
+    c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_kv,
+    const c10::optional<at::Tensor> &block_table,
+    int64_t num_heads, double scale_value, c10::string_view input_layout,
+    int64_t num_key_value_heads, int64_t block_size, int64_t inner_precise)
+{
+    at::Tensor output = at::empty_symint(query.sym_sizes(), query.options());
+
+    auto actSeqLenQueryMiddle = actual_seq_lengths_q.value_or(at::ArrayRef<c10::SymInt>{});
+    auto actSeqLenQuery = c10::asIntArrayRefUnchecked(actSeqLenQueryMiddle);
+
+    auto actSeqLenKeyMiddle = actual_seq_lengths_kv.value_or(at::ArrayRef<c10::SymInt>{});
+    auto actSeqLenKey = c10::asIntArrayRefUnchecked(actSeqLenKeyMiddle);
+
+    std::string input_layout_str = std::string(input_layout);
+    const char *input_layout_char = input_layout_str.c_str();
+    // dispatch hostAPI
+    EXEC_NPU_CMD(aclnnCustomFusedInferAttentionV310, query, key, value, attn_mask,
+                 actSeqLenQuery, actSeqLenKey, block_table, num_heads, scale_value, input_layout_char,
+                 num_key_value_heads, block_size, inner_precise, output);
+    return output;
+}
+
+}
+#endif

--- a/csrc/attention/custom_fused_infer_attention_v310/custom_fused_infer_attention_v310_torch_adpt.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/custom_fused_infer_attention_v310_torch_adpt.h
@@ -18,7 +18,7 @@
 namespace vllm_ascend {
 
 at::Tensor npu_custom_fused_infer_attention_v310(
-    const at::Tensor &query, at::TensorList key, at::TensorList value,
+    const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
     const c10::optional<at::Tensor> &attn_mask,
     c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_q,
     c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_kv,
@@ -36,8 +36,14 @@ at::Tensor npu_custom_fused_infer_attention_v310(
 
     std::string input_layout_str = std::string(input_layout);
     const char *input_layout_char = input_layout_str.c_str();
+
+    // The OpDef declares key/value as TensorList; wrap single tensors here
+    // so the Python API accepts plain Tensor instead of Tensor[].
+    at::TensorList keyList({key});
+    at::TensorList valueList({value});
+
     // dispatch hostAPI
-    EXEC_NPU_CMD(aclnnCustomFusedInferAttentionV310, query, key, value, attn_mask,
+    EXEC_NPU_CMD(aclnnCustomFusedInferAttentionV310, query, keyList, valueList, attn_mask,
                  actSeqLenQuery, actSeqLenKey, block_table, num_heads, scale_value, input_layout_char,
                  num_key_value_heads, block_size, inner_precise, output);
     return output;

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/CMakeLists.txt
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This file is a part of the CANN Open Software.
+# Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ======================================================================================================================
+
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        custom_fused_infer_attention_v310_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME CustomFusedInferAttentionV310
+    OPTIONS --cce-auto-sync=on
+            -Wno-deprecated-declarations
+            -Werror
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE custom_fused_infer_attention_v310 ACLNNTYPE aclnn)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_def.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_def.cpp
@@ -27,46 +27,46 @@ public:
     {
         this->Input("query")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("key")
             .ParamType(DYNAMIC)
-            .DataType({ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_FRACTAL_NZ})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_FRACTAL_NZ});
         this->Input("value")
             .ParamType(DYNAMIC)
-            .DataType({ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_FRACTAL_NZ})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_FRACTAL_NZ});
         this->Input("attn_mask")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("actual_seq_lengths_q")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("actual_seq_lengths_kv")
             .ParamType(OPTIONAL)
             .ValueDepend(OPTIONAL)
-            .DataType({ge::DT_INT64})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Input("block_table")
             .ParamType(OPTIONAL)
-            .DataType({ge::DT_INT32})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Output("attention_out")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_FLOAT16})
-            .Format({ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND});
+            .DataType({ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
         this->Attr("num_heads").AttrType(REQUIRED).Int(1);
         this->Attr("scale_value").AttrType(OPTIONAL).Float(1.0);
         this->Attr("input_layout").AttrType(OPTIONAL).String("BSH");

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_def.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_def.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310.cpp
+ * \brief
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class CustomFusedInferAttentionV310 : public OpDef {
+public:
+    CustomFusedInferAttentionV310(const char *name) : OpDef(name)
+    {
+        this->Input("query")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("key")
+            .ParamType(DYNAMIC)
+            .DataType({ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("value")
+            .ParamType(DYNAMIC)
+            .DataType({ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("attn_mask")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("actual_seq_lengths_q")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("actual_seq_lengths_kv")
+            .ParamType(OPTIONAL)
+            .ValueDepend(OPTIONAL)
+            .DataType({ge::DT_INT64})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("block_table")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Output("attention_out")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Attr("num_heads").AttrType(REQUIRED).Int(1);
+        this->Attr("scale_value").AttrType(OPTIONAL).Float(1.0);
+        this->Attr("input_layout").AttrType(OPTIONAL).String("BSH");
+        this->Attr("num_key_value_heads").AttrType(OPTIONAL).Int(0);
+        this->Attr("block_size").AttrType(OPTIONAL).Int(0);
+        this->Attr("inner_precise").AttrType(OPTIONAL).Int(1);
+
+        OpAICoreConfig config_310p;
+        config_310p.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+        this->AICore().AddConfig("ascend310p", config_310p);
+    }
+};
+OP_ADD(CustomFusedInferAttentionV310);
+} // namespace ops

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_infershape.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_infershape.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_proto.cpp
+ * \brief
+ */
+
+#include <graph/utils/type_utils.h>
+#include <register/op_impl_registry.h>
+#include "log/ops_log.h"
+
+using namespace ge;
+
+namespace ops {
+static constexpr uint32_t IFA_LAYOUT_DIM0 = 0;
+static constexpr uint32_t IFA_QUERY_INDEX = 0;
+static constexpr int32_t IFA_UNKNOWN_DIMS = -2;
+static constexpr uint32_t IFA_DIM_NUMS_1 = 1;
+static constexpr uint32_t IFA_LAYOUT_BSND_DIMS = 4;
+static constexpr uint32_t IFA_LAYOUT_TND_DIMS = 3;
+static constexpr uint32_t IFA_ATTENTION_OUT_INDEX = 0;
+static constexpr uint32_t IFA_ATTR_INPUT_LAYOUT_INDEX = 2;
+static constexpr uint32_t IFA_INPUT_ACTUAL_SEQ_LENGTHS_Q_INDEX = 4;
+static constexpr uint32_t IFA_INPUT_ACTUAL_SEQ_LENGTHS_KV_INDEX = 5;
+
+static ge::graphStatus InferShapeIncreFlashAttention(gert::InferShapeContext *context)
+{
+    OPS_LOG_D(context->GetNodeName(), "Enter CustomFusedInferAttentionV310 inferShape impl.");
+    // query shape
+    const gert::Shape *queryShape = context->GetInputShape(IFA_QUERY_INDEX);
+    OPS_LOG_E_IF_NULL(context, queryShape, return ge::GRAPH_FAILED)
+
+    // attentionOut
+    gert::Shape *attentionOutShape = context->GetOutputShape(IFA_ATTENTION_OUT_INDEX);
+    OPS_LOG_E_IF_NULL(context, attentionOutShape, return ge::GRAPH_FAILED)
+
+    // Set output shape
+    *attentionOutShape = *queryShape;
+
+    // UNKNOWN DIM
+    if ((queryShape->GetDimNum() == IFA_DIM_NUMS_1) && (queryShape->GetDim(IFA_LAYOUT_DIM0) == IFA_UNKNOWN_DIMS)) {
+        attentionOutShape->SetDimNum(IFA_DIM_NUMS_1);
+        (*attentionOutShape)[IFA_LAYOUT_DIM0] = IFA_UNKNOWN_DIMS;
+        return ge::GRAPH_SUCCESS;
+    }
+
+    // Get attr
+    auto attrs = context->GetAttrs();
+    OPS_LOG_E_IF_NULL(context, attrs, return ge::GRAPH_FAILED)
+
+    const char *inputLayoutPtr = attrs->GetAttrPointer<char>(IFA_ATTR_INPUT_LAYOUT_INDEX);
+    OPS_LOG_E_IF_NULL(context, inputLayoutPtr, return ge::GRAPH_FAILED)
+
+    if (strcmp(inputLayoutPtr, "BSND") == 0) {
+        if (queryShape->GetDimNum() != IFA_LAYOUT_BSND_DIMS) {
+            OPS_LOG_E(context->GetNodeName(), "Layout BSND, queryDims(%zu) must be 4!", queryShape->GetDimNum());
+            return ge::GRAPH_FAILED;
+        }
+    } else if (strcmp(inputLayoutPtr, "TND") == 0) {
+        if (queryShape->GetDimNum() != IFA_LAYOUT_TND_DIMS) {
+            OPS_LOG_E(context->GetNodeName(), "Layout TND, queryDims(%zu) must be 3!", queryShape->GetDimNum());
+            return ge::GRAPH_FAILED;
+        }
+    } else {
+        OPS_LOG_E(context->GetNodeName(), "Invalid input layout: %s, only BSND and TND are supported", inputLayoutPtr);
+        return ge::GRAPH_FAILED;
+    }
+
+    OPS_LOG_D(context->GetNodeName(), "CustomFusedInferAttentionV310 inferShape end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus InferDataTypeIncreFlashAttention(gert::InferDataTypeContext *context)
+{
+    OPS_LOG_D(context->GetNodeName(), "Enter CustomFusedInferAttentionV310 inferDataType impl.");
+    context->SetOutputDataType(IFA_ATTENTION_OUT_INDEX, ge::DT_FLOAT16);
+    OPS_LOG_D(context->GetNodeName(), "CustomFusedInferAttentionV310 inferDataType end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(CustomFusedInferAttentionV310)
+    .InferShape(InferShapeIncreFlashAttention)
+    .InferDataType(InferDataTypeIncreFlashAttention)
+    .InputsDataDependency({IFA_INPUT_ACTUAL_SEQ_LENGTHS_Q_INDEX})
+    .InputsDataDependency({IFA_INPUT_ACTUAL_SEQ_LENGTHS_KV_INDEX});
+} // namespace ops

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.cpp
@@ -1,0 +1,523 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_tiling.cc
+ * \brief
+ */
+
+#include "custom_fused_infer_attention_v310_tiling.h"
+#include "custom_fused_infer_attention_v310_tiling_base.h"
+#include <vector>
+#include <graph/utils/type_utils.h>
+#include "tiling/platform/platform_ascendc.h"
+#include "error/ops_error.h"
+
+using namespace ge;
+namespace optiling {
+
+constexpr uint32_t ATB_INNER_PRECISE = 2;
+constexpr uint32_t DIM_NUM_ONE = 1;
+constexpr uint32_t DIM_NUM_TWO = 2;
+
+// FP16 BSND paged-attention key: mode=3, layout=BSND(0), q=FP16(0), kv=FP16(0), out=FP16(0), origin=0, pa=2
+constexpr uint64_t IFA_TILINGKEY_BSND_FP16 = 30000000000200000UL;
+// FP16 TND paged-attention key: mode=3, layout=TND(1), q=FP16(0), kv=FP16(0), out=FP16(0), origin=0, pa=2
+constexpr uint64_t IFA_TILINGKEY_TND_FP16  = 30000000000200001UL;
+
+ge::graphStatus CustomFIATiling::GenTilingKey()
+{
+    switch (inputLayout_) {
+        case IfaLayout::BSND:
+            context_->tilingKey = IFA_TILINGKEY_BSND_FP16;
+            break;
+        case IfaLayout::TND:
+            context_->tilingKey = IFA_TILINGKEY_TND_FP16;
+            break;
+        default:
+            OPS_LOG_E(context_->opName, "not support inputLayout %u", inputLayout_);
+            return ge::GRAPH_FAILED;
+    }
+
+    OPS_LOG_I(context_->opName, "IFA tilingKey: %lu.", context_->tilingKey);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::ConvertContext(gert::TilingContext &context, IncreFlashAttentionContext &ifaContext)
+{
+    if (context.GetNodeName() == nullptr) {
+        OPS_LOG_E("CustomFusedInferAttentionV310", "opName got from TilingContext is nullptr");
+        return ge::GRAPH_FAILED;
+    }
+    ifaContext.opName = context.GetNodeName();
+    ifaContext.platformInfo = context.GetPlatformInfo();
+    ifaContext.query.desc = context.GetInputDesc(QUERY_INPUT_INDEX);
+    ifaContext.query.shape = context.GetInputShape(QUERY_INPUT_INDEX);
+    ifaContext.key.desc = context.GetInputDesc(KEY_INPUT_INDEX);
+    ifaContext.key.shape = context.GetInputShape(KEY_INPUT_INDEX);
+    OPS_ERR_IF((ifaContext.query.shape == nullptr) || (ifaContext.key.shape == nullptr),
+               OPS_LOG_E(context.GetNodeName(), "shape of query or shape of key is null."), return ge::GRAPH_FAILED);
+    auto batchOfQuery = ifaContext.query.shape->GetStorageShape().GetDim(0);
+    auto batchOfKey = ifaContext.key.shape->GetStorageShape().GetDim(0);
+    if (batchOfQuery != batchOfKey) {
+        ifaContext.kCache.resize(batchOfQuery);
+        ifaContext.vCache.resize(batchOfQuery);
+        for (int64_t size = 0; size < batchOfQuery; ++size) {
+            ifaContext.kCache[size] =
+                const_cast<gert::StorageShape *>(context.GetDynamicInputShape(KEY_INPUT_INDEX, size));
+            ifaContext.vCache[size] =
+                const_cast<gert::StorageShape *>(context.GetDynamicInputShape(VALUE_INPUT_INDEX, size));
+        }
+    } else {
+        ifaContext.kCache.resize(1);
+        ifaContext.vCache.resize(1);
+        ifaContext.kCache[0] = const_cast<gert::StorageShape *>(context.GetDynamicInputShape(KEY_INPUT_INDEX, 0));
+        ifaContext.vCache[0] = const_cast<gert::StorageShape *>(context.GetDynamicInputShape(VALUE_INPUT_INDEX, 0));
+    }
+
+    ifaContext.value.desc = context.GetInputDesc(VALUE_INPUT_INDEX);
+    ifaContext.value.shape = context.GetInputShape(VALUE_INPUT_INDEX);
+    ifaContext.attnMask.desc = context.GetOptionalInputDesc(ATTN_MASK_INPUT_INDEX);
+    ifaContext.attnMask.tensor = context.GetOptionalInputTensor(ATTN_MASK_INPUT_INDEX);
+    ifaContext.attenOut.desc = context.GetOutputDesc(OUTPUT_INDEX);
+    ifaContext.attenOut.shape = context.GetOutputShape(OUTPUT_INDEX);
+    ifaContext.actualSeqLengthsQ.tensor = context.GetOptionalInputTensor(ACT_SEQ_LEN_Q_INPUT_INDEX);
+    ifaContext.actualSeqLengths.tensor = context.GetOptionalInputTensor(ACT_SEQ_LEN_INPUT_INDEX);
+    ifaContext.blockTable.tensor = context.GetOptionalInputTensor(BLOCK_TABLE_INPUT_INDEX);
+    ifaContext.blockTable.desc = context.GetOptionalInputDesc(BLOCK_TABLE_INPUT_INDEX);
+
+    auto attrs = context.GetAttrs();
+    OPS_ERR_IF(attrs == nullptr, OPS_LOG_E(context.GetNodeName(), "attrs got from GE is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    ifaContext.numHeads = attrs->GetAttrPointer<uint32_t>(NUM_HEADS_ATTR_INDEX);
+    ifaContext.scaleValue = attrs->GetAttrPointer<float>(SCALE_VALUE_ATTR_INDEX);
+    ifaContext.layOut = attrs->GetStr(LAYOUT_ATTR_INDEX);
+    ifaContext.kvHeadNums = attrs->GetAttrPointer<uint32_t>(KV_NUM_HEADS_ATTR_INDEX);
+    ifaContext.blockSize = attrs->GetAttrPointer<uint32_t>(BLOCK_SIZE_ATTR_INDEX);
+    ifaContext.innerPrecise = attrs->GetAttrPointer<uint32_t>(INNER_PRECISE_ATTR_INDEX);
+
+    OPS_ERR_IF(context.GetWorkspaceSizes(1) == nullptr,
+               OPS_REPORT_VECTOR_INNER_ERR(context.GetNodeName(), "workSpaceSize got from GE is nullptr"),
+               return ge::GRAPH_FAILED);
+    ifaContext.workSpaces = context.GetWorkspaceSizes(1);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::RunCustomFIATiling(IncreFlashAttentionContext &context)
+{
+    this->context_ = &context;
+
+    // Step 1: Initialize hardware-platform information.
+    if (InitPlatformInfo() != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+
+    // Step 2: Check whether the custom operator can handle this input.
+    if (CheckIfShouldRunCustomFIA()) {
+        return CustomFIATilingProcess();
+    }
+
+    return ge::GRAPH_FAILED;
+}
+
+ge::graphStatus CustomFIATiling::InitPlatformInfo()
+{
+    OPS_ERR_IF(context_->platformInfo == nullptr,
+               OPS_REPORT_VECTOR_INNER_ERR(context_->opName, "GetPlatformInfo is nullptr."),
+               return ge::GRAPH_FAILED);
+
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(context_->platformInfo);
+
+#ifdef ASCENDC_OP_TEST
+    constexpr uint32_t testCoreNum = 8;
+    libapiSize_ = 2 * 1024 * 1024;
+    context_->blockDim = testCoreNum;
+#else
+    if (ascendcPlatform.GetSocVersion() != platform_ascendc::SocVersion::ASCEND310P) {
+        OPS_LOG_E(context_->opName, "Only ASCEND310P is supported.");
+        return ge::GRAPH_FAILED;
+    }
+    aicNum_ = ascendcPlatform.GetCoreNumAic();
+    aivNum_ = ascendcPlatform.GetCoreNumAiv();
+    libapiSize_ = ascendcPlatform.GetLibApiWorkSpaceSize();
+    context_->blockDim = ascendcPlatform.CalcTschBlockDim(aivNum_, aicNum_, aivNum_);
+#endif
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::ParseTilingAttributes()
+{
+    // 1. Parse basic attributes.
+    numHeads_ = *context_->numHeads;
+    numKvHeads_ = (*context_->kvHeadNums == 0) ? numHeads_ : *context_->kvHeadNums;
+    blockSize_ = *context_->blockSize;
+    
+    // 2. Parse data types.
+    inputQType_ = context_->query.desc->GetDataType();
+    inputKvType_ = context_->key.desc->GetDataType();
+    
+    // 3. Parse the batch size.
+    batchSize_ = static_cast<uint32_t>(context_->blockTable.tensor->GetStorageShape().GetDim(0));
+
+    // 4. Parse the head dimension.
+    const auto& qShape = context_->query.shape->GetStorageShape();
+    const auto dimNum = qShape.GetDimNum();
+    if (dimNum > 0) {
+        headDim_ = static_cast<uint32_t>(qShape.GetDim(dimNum - 1));
+    } else {
+        OPS_LOG_E(context_->opName, "query shape is empty or scalar!");
+        return ge::GRAPH_FAILED;
+    }
+
+    // 5. Parse the query layout.
+    const std::string layout(context_->layOut);
+    if (layout == "BSND") {
+        inputLayout_ = IfaLayout::BSND;
+    } else if (layout == "TND") {
+        inputLayout_ = IfaLayout::TND;
+    } else {
+        OPS_LOG_E(context_->opName, "unsupported layout: %s", layout.c_str());
+        return ge::GRAPH_FAILED;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+bool CustomFIATiling::CheckIfShouldRunCustomFIA()
+{
+#ifdef ASCENDC_OP_TEST
+    return true;
+#endif
+
+    bool isPrecise = (*context_->innerPrecise == ATB_INNER_PRECISE);
+
+    if (!isPrecise) {
+        OPS_LOG_E(context_->opName, "Only innerPrecise=2 is supported.");
+        return false;
+    }
+    if (context_->blockTable.tensor == nullptr) {
+        OPS_LOG_E(context_->opName, "Only paged attention is supported.");
+        return false;
+    }
+
+    // Check required inputs for null pointers.
+    if (CheckBaseInputsNull() != ge::GRAPH_SUCCESS) {
+        OPS_LOG_E(context_->opName, "Base inputs check failed.");
+        return false;
+    }
+
+    // Parse operator attributes and initialize the base state required by tiling.
+    if (ParseTilingAttributes() != ge::GRAPH_SUCCESS) {
+        OPS_LOG_E(context_->opName, "Failed to parse tiling attributes.");
+        return false;
+    }
+
+    // Check 4: Enforce supported features, inputs, and data types.
+    if (CheckInputFormatAndLimits() != ge::GRAPH_SUCCESS) {
+        OPS_LOG_E(context_->opName, "Input format and limits check failed.");
+        return false;
+    }
+
+    return true;
+}
+
+ge::graphStatus CustomFIATiling::IncreFlashAttentionSetTilingData(gert::TilingContext &context)
+{
+    OPS_ERR_IF(context.GetRawTilingData() == nullptr,
+               OPS_REPORT_VECTOR_INNER_ERR(context.GetNodeName(), "RawTilingData got from GE context is nullptr."),
+               return GRAPH_FAILED);
+
+    ifaTilingAtbData.SaveToBuffer(context.GetRawTilingData()->GetData(), context.GetRawTilingData()->GetCapacity());
+    context.GetRawTilingData()->SetDataSize(ifaTilingAtbData.GetDataSize());
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingCustomFIAAdapter(gert::TilingContext *context, IncreFlashAttentionContext &ifaContext)
+{
+    CustomFIATiling ifaTilingNew;
+    if (ifaTilingNew.RunCustomFIATiling(ifaContext) == ge::SUCCESS) {
+        context->SetTilingKey(ifaContext.tilingKey);
+        context->SetBlockDim(ifaContext.blockDim);
+        ifaTilingNew.IncreFlashAttentionSetTilingData(*context);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    return ge::GRAPH_FAILED;
+}
+
+void CustomFIATiling::ParseMask()
+{
+    // Enable the compressed mask by default; use MASK_NORM for debugging.
+    attenMaskFlag_ = (context_->attnMask.tensor != nullptr) ? IfaMaskType::MASK_COMPRESS : IfaMaskType::NO_MASK;
+    if (attenMaskFlag_) {
+        OPS_LOG_D(context_->opName, "attenMaskFlag_:%d", attenMaskFlag_);
+        auto maskShape = context_->attnMask.tensor;
+        auto maxPromptLen = maskShape->GetStorageShape().GetDim(1);
+        auto maskDimZero = maskShape->GetStorageShape().GetDim(0);
+        maskKvLen_ = maskShape->GetStorageShape().GetDim(DIM_NUM_TWO);
+        maskBatchStride_ =
+            (maskDimZero == static_cast<int64_t>(batchSize_))
+                ? static_cast<uint32_t>(maskKvLen_ * maxPromptLen)
+                : 0;
+    }
+}
+
+ge::graphStatus CustomFIATiling::ParseTndVarlenParams(const gert::Shape& qShape)
+{
+    if (qShape.GetDimNum() < 1) {
+        OPS_LOG_E(context_->opName, "invalid query dim num for TND");
+        return ge::GRAPH_FAILED;
+    }
+
+    tSeqSize_ = static_cast<uint32_t>(qShape.GetDim(0));
+
+    OPS_ERR_IF(batchSize_ == 0,
+        OPS_REPORT_VECTOR_INNER_ERR(context_->opName, "batchSize is zero in TND mode"),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF(context_->actualSeqLengthsQ.tensor == nullptr,
+        OPS_REPORT_VECTOR_INNER_ERR(context_->opName, "actualSeqLengthsQ is required in TND varlen concat mode"),
+        return ge::GRAPH_FAILED);
+
+    const int64_t *actualLenDataQ = context_->actualSeqLengthsQ.tensor->GetData<int64_t>();
+    OPS_ERR_IF(actualLenDataQ == nullptr,
+        OPS_REPORT_VECTOR_INNER_ERR(context_->opName, "actualSeqLengthsQ data is nullptr in TND mode"),
+        return ge::GRAPH_FAILED);
+
+    uint32_t actualLenQDims = static_cast<uint32_t>(context_->actualSeqLengthsQ.tensor->GetShapeSize());
+    OPS_ERR_IF(actualLenQDims != batchSize_,
+        OPS_REPORT_VECTOR_INNER_ERR(context_->opName, "actualSeqLengthsQ size must equal batchSize in TND mode"),
+        return ge::GRAPH_FAILED);
+
+    tndQSeqLens_.resize(batchSize_);
+
+    uint32_t totalQTokens = 0;
+    for (uint32_t b = 0; b < batchSize_; ++b) {
+        uint32_t seqLen = static_cast<uint32_t>(actualLenDataQ[b]);
+        tndQSeqLens_[b] = seqLen;
+        totalQTokens += seqLen;
+    }
+
+    OPS_ERR_IF(totalQTokens != tSeqSize_,
+        OPS_REPORT_VECTOR_INNER_ERR(context_->opName, "TND query first dim must equal sum(actualSeqLengthsQ)"),
+        return ge::GRAPH_FAILED);
+
+    qTokens_ = 0;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::ParsePagedAttentionParams()
+{
+    if (context_->kCache.empty()) {
+        OPS_LOG_E(context_->opName, "The Key cache is empty in pa situation.");
+        return ge::GRAPH_FAILED;
+    }
+
+    maxBlockNumPerBatch_ = static_cast<uint32_t>(context_->blockTable.tensor->GetStorageShape().GetDim(1));
+    totalBlockNum_ = static_cast<uint32_t>(context_->kCache[0]->GetStorageShape().GetDim(0));
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CustomFIAParamGet()
+{
+    // 1. Read basic attributes.
+    scaleValue_ = *context_->scaleValue;
+    if (headDim_ == 256) {
+        seqStepQ_ = DEFAULT_QUERY_SEQ_STEP_HEAD_DIM_256;
+    } else {
+        seqStepQ_ = DEFAULT_QUERY_SEQ_STEP_HEAD_DIM_128_LESS;
+    }
+
+    const auto &qShape = context_->query.shape->GetStorageShape();
+
+    // 2. Parse and strictly validate layout-specific attributes.
+    if (inputLayout_ == IfaLayout::TND) {
+        if (ParseTndVarlenParams(qShape) != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+    } else if (inputLayout_ == IfaLayout::BSND) {
+        // In BSND layout, the S dimension is at index 1.
+        qTokens_ = static_cast<uint32_t>(qShape.GetDim(DIM_NUM_ONE));
+    }
+
+    // 3. Parse paged-attention KV-cache attributes.
+    if (ParsePagedAttentionParams() != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+
+    // 4. Parse mask attributes.
+    ParseMask();
+    
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CustomFIAParamSet()
+{
+    tilingDataBase_->set_batchSize(batchSize_);
+    tilingDataBase_->set_headSize(headDim_);
+    tilingDataBase_->set_qHeadNum(numHeads_);
+    tilingDataBase_->set_kvHeadNum(numKvHeads_);
+    tilingDataBase_->set_totalBlockNum(totalBlockNum_);
+    tilingDataBase_->set_scaleValue(scaleValue_);
+    tilingDataBase_->set_querySeqStep(seqStepQ_);
+    tilingDataCore_->set_qTokens(qTokens_);
+    tilingDataBase_->set_attenMaskFlag(attenMaskFlag_);
+    tilingDataCore_->set_maskHeadStride(0);
+    tilingDataCore_->set_maskBatchStride(maskBatchStride_);
+    tilingDataCore_->set_maskKvLen(maskKvLen_);
+    tilingDataBase_->set_blockSize(blockSize_);
+    tilingDataBase_->set_maxBlockNumPerBatch(maxBlockNumPerBatch_);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CustomFIASplitBlock()
+{
+    const uint32_t taskNum = GetTotalQTaskNum();
+    context_->blockDim = taskNum < context_->blockDim ? taskNum : context_->blockDim;
+    OPS_ERR_IF(context_->blockDim == 0, OPS_LOG_E(context_->opName, "block dim is zero."), return ge::GRAPH_FAILED);
+
+    const uint32_t taskNumPerCore = taskNum / context_->blockDim;
+    const uint32_t tailTaskNum = taskNum % context_->blockDim;
+    uint32_t taskStart = 0;
+    uint32_t taskEnd = 0;
+    std::vector<uint32_t> startTaskId(MAX_CORE_NUM, 0U);
+    std::vector<uint32_t> endTaskId(MAX_CORE_NUM, 0U);
+    std::vector<uint32_t> startBatch(MAX_CORE_NUM, 0U);
+    std::vector<uint32_t> endBatch(MAX_CORE_NUM, 0U);
+
+    auto FindBatchByTaskId = [this](uint32_t taskId) -> uint32_t {
+        uint32_t acc = 0;
+        for (uint32_t b = 0; b < batchSize_; ++b) {
+            uint32_t qBlkNum = (tndQSeqLens_[b] + seqStepQ_ - 1) / seqStepQ_;
+            uint32_t batchTaskNum = qBlkNum * numHeads_;
+            if (taskId < acc + batchTaskNum) {
+                return b;
+            }
+            acc += batchTaskNum;
+        }
+        return batchSize_ == 0 ? 0 : (batchSize_ - 1);
+    };
+
+    for (uint32_t blockIdx = 0; blockIdx < context_->blockDim; blockIdx++) {
+        taskStart = taskEnd;
+        taskEnd = blockIdx < tailTaskNum ? taskEnd + taskNumPerCore + 1 : taskEnd + taskNumPerCore;
+        startTaskId[blockIdx] = taskStart;
+        endTaskId[blockIdx] = taskEnd;
+
+        if (inputLayout_ == IfaLayout::TND) {
+            startBatch[blockIdx] = FindBatchByTaskId(taskStart);
+            endBatch[blockIdx] = (taskEnd == 0) ? 0 : FindBatchByTaskId(taskEnd - 1);
+        } else {
+            startBatch[blockIdx] = static_cast<uint32_t>(taskStart / numHeads_);
+            endBatch[blockIdx] = static_cast<uint32_t>((taskEnd - 1) / numHeads_);
+        }
+    }
+
+    tilingDataCore_->set_startTaskId(startTaskId.data());
+    tilingDataCore_->set_endTaskId(endTaskId.data());
+    tilingDataCore_->set_startBatch(startBatch.data());
+    tilingDataCore_->set_endBatch(endBatch.data());
+    return ge::GRAPH_SUCCESS;
+}
+
+uint32_t CustomFIATiling::GetTotalQTaskNum()
+{
+    OPS_ERR_IF(context_->actualSeqLengthsQ.tensor == nullptr,
+        OPS_REPORT_VECTOR_INNER_ERR(context_->opName,
+            "actualSeqLengthsQ is required"),
+        return 0);
+
+    uint32_t actualLenQDims = static_cast<uint32_t>(context_->actualSeqLengthsQ.tensor->GetShapeSize());
+    const int64_t *actualLenDataQ = context_->actualSeqLengthsQ.tensor->GetData<int64_t>();
+    if (actualLenDataQ == nullptr) {
+        return 0;
+    }
+
+    uint32_t totalQblockSum = 0;
+    for (uint32_t bIdx = 0; bIdx < actualLenQDims; ++bIdx) {
+        uint32_t curSeqLenQ = static_cast<uint32_t>(actualLenDataQ[bIdx]);
+        uint32_t tmpBlkNum = (curSeqLenQ + seqStepQ_ - 1) / seqStepQ_;
+        totalQblockSum += tmpBlkNum;
+    }
+
+    return totalQblockSum * numHeads_;
+}
+
+ge::graphStatus CustomFIATiling::CustomFIATilingProcess()
+{
+    this->tilingDataBase_ = &ifaTilingAtbData.tilingBase;
+    this->tilingDataCore_ = &ifaTilingAtbData.tilingPerCore;
+
+    if (CustomFIAParamGet() != ge::SUCCESS ||
+        CustomFIAParamSet() != ge::SUCCESS ||
+        CustomFIASplitBlock() != ge::SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+
+    size_t workspaceSize = libapiSize_;
+    if (context_->workSpaces) {
+        context_->workSpaces[0] = workspaceSize;
+    }
+    OPS_LOG_D(context_->opName, "IFA block dim:%u aivNum:%u aicNum:%u", context_->blockDim, aivNum_, aicNum_);
+    OPS_LOG_D(context_->opName, "batchSize_:%d", batchSize_);
+
+    OPS_LOG_D(context_->opName, "headDim_:%d", headDim_);
+    OPS_LOG_D(context_->opName, "numHeads_:%d", numHeads_);
+    OPS_LOG_D(context_->opName, "numKvHeads_:%d", numKvHeads_);
+    OPS_LOG_D(context_->opName, "maxBlockNumPerBatch_:%d", maxBlockNumPerBatch_);
+    OPS_LOG_D(context_->opName, "totalBlockNum_:%d", totalBlockNum_);
+    OPS_LOG_D(context_->opName, "scaleValue_:%lf", scaleValue_);
+
+    return GenTilingKey();
+}
+
+IFA_EXTERN_C ge::graphStatus TilingIncreFlashAttention(gert::TilingContext *context)
+{
+    OPS_ERR_IF(context == nullptr, OPS_REPORT_VECTOR_INNER_ERR("CustomFusedInferAttentionV310", "Context is nullptr."),
+               return ge::GRAPH_FAILED);
+    IncreFlashAttentionContext ifaContext{.opName = nullptr,
+                                          .platformInfo = nullptr,
+                                          .query = {nullptr, nullptr},
+                                          .key = {nullptr, nullptr},
+                                          .value = {nullptr, nullptr},
+                                          .attnMask = {nullptr, nullptr},
+                                          .actualSeqLengthsQ = {nullptr, nullptr},
+                                          .actualSeqLengths = {nullptr, nullptr},
+                                          .blockTable = {nullptr, nullptr},
+                                          .attenOut = {nullptr, nullptr},
+                                          .numHeads = nullptr,
+                                          .scaleValue = nullptr,
+                                          .kvHeadNums = nullptr,
+                                          .layOut = nullptr,
+                                          .blockSize = nullptr,
+                                          .innerPrecise = nullptr,
+                                          .workSpaces = nullptr,
+                                          .kCache = {nullptr},
+                                          .vCache = {nullptr},
+                                          .tilingKey = 0,
+                                          .blockDim = 0};
+    if (CustomFIATiling::ConvertContext(*context, ifaContext) != ge::GRAPH_SUCCESS) {
+        OPS_LOG_E(context->GetNodeName(), "Error occurred while converting tilingContext to ifa context");
+        return ge::GRAPH_FAILED;
+    }
+    return TilingCustomFIAAdapter(context, ifaContext);
+}
+} // namespace optiling

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.cpp
@@ -71,23 +71,12 @@ ge::graphStatus CustomFIATiling::ConvertContext(gert::TilingContext &context, In
     ifaContext.key.shape = context.GetInputShape(KEY_INPUT_INDEX);
     OPS_ERR_IF((ifaContext.query.shape == nullptr) || (ifaContext.key.shape == nullptr),
                OPS_LOG_E(context.GetNodeName(), "shape of query or shape of key is null."), return ge::GRAPH_FAILED);
-    auto batchOfQuery = ifaContext.query.shape->GetStorageShape().GetDim(0);
-    auto batchOfKey = ifaContext.key.shape->GetStorageShape().GetDim(0);
-    if (batchOfQuery != batchOfKey) {
-        ifaContext.kCache.resize(batchOfQuery);
-        ifaContext.vCache.resize(batchOfQuery);
-        for (int64_t size = 0; size < batchOfQuery; ++size) {
-            ifaContext.kCache[size] =
-                const_cast<gert::StorageShape *>(context.GetDynamicInputShape(KEY_INPUT_INDEX, size));
-            ifaContext.vCache[size] =
-                const_cast<gert::StorageShape *>(context.GetDynamicInputShape(VALUE_INPUT_INDEX, size));
-        }
-    } else {
-        ifaContext.kCache.resize(1);
-        ifaContext.vCache.resize(1);
-        ifaContext.kCache[0] = const_cast<gert::StorageShape *>(context.GetDynamicInputShape(KEY_INPUT_INDEX, 0));
-        ifaContext.vCache[0] = const_cast<gert::StorageShape *>(context.GetDynamicInputShape(VALUE_INPUT_INDEX, 0));
-    }
+    // Paged attention uses a single shared KV-cache tensor per key/value;
+    // batch addressing is handled by block_table, not by per-batch tensors.
+    ifaContext.kCache.resize(1);
+    ifaContext.vCache.resize(1);
+    ifaContext.kCache[0] = const_cast<gert::StorageShape *>(context.GetDynamicInputShape(KEY_INPUT_INDEX, 0));
+    ifaContext.vCache[0] = const_cast<gert::StorageShape *>(context.GetDynamicInputShape(VALUE_INPUT_INDEX, 0));
 
     ifaContext.value.desc = context.GetInputDesc(VALUE_INPUT_INDEX);
     ifaContext.value.shape = context.GetInputShape(VALUE_INPUT_INDEX);
@@ -392,6 +381,7 @@ ge::graphStatus CustomFIATiling::CustomFIASplitBlock()
 {
     const uint32_t taskNum = GetTotalQTaskNum();
     context_->blockDim = taskNum < context_->blockDim ? taskNum : context_->blockDim;
+    context_->blockDim = context_->blockDim > MAX_CORE_NUM ? MAX_CORE_NUM : context_->blockDim;
     OPS_ERR_IF(context_->blockDim == 0, OPS_LOG_E(context_->opName, "block dim is zero."), return ge::GRAPH_FAILED);
 
     const uint32_t taskNumPerCore = taskNum / context_->blockDim;

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.h
@@ -122,7 +122,6 @@ private:
                                             const gert::StorageShape *keyShape,
                                             const gert::StorageShape *valueShape);
 
-    bool IsSupportFormat(const ge::Format format);
 
     ge::graphStatus GenTilingKey();
 

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling.h
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_tiling.h
+ * \brief
+ */
+#ifndef AIR_CXX_RUNTIME_V2_OP_IMPL_INCREFLASHATTENTIONSCORE_NEW_H_
+#define AIR_CXX_RUNTIME_V2_OP_IMPL_INCREFLASHATTENTIONSCORE_NEW_H_
+
+#include <cstdint>
+#include <vector>
+#include "exe_graph/runtime/tiling_context.h"
+#include "exe_graph/runtime/tiling_parse_context.h"
+#include "custom_fused_infer_attention_v310_tiling_base.h"
+#include "custom_fused_infer_attention_v310_tiling_data.h"
+
+#ifdef ASCENDC_OP_TEST
+#define IFA_EXTERN_C extern "C"
+#else
+#define IFA_EXTERN_C
+#endif
+namespace optiling {
+
+struct IncreFlashAttentionCompileInfo {};
+
+struct RequiredParaInfo {
+    const gert::CompileTimeTensorDesc *desc;
+    const gert::StorageShape *shape;
+};
+
+struct OptionalParaInfo {
+    const gert::CompileTimeTensorDesc *desc;
+    const gert::Tensor *tensor;
+};
+
+struct IncreFlashAttentionContext {
+    const char *opName;
+    fe::PlatFormInfos *platformInfo;
+    RequiredParaInfo query;
+    RequiredParaInfo key;
+    RequiredParaInfo value;
+    OptionalParaInfo attnMask;
+    OptionalParaInfo actualSeqLengthsQ;
+    OptionalParaInfo actualSeqLengths;
+    OptionalParaInfo blockTable;
+
+    RequiredParaInfo attenOut;
+    const uint32_t *numHeads;
+    const float *scaleValue;
+    const uint32_t *kvHeadNums;
+    const char *layOut;
+    const uint32_t *blockSize;
+    const uint32_t *innerPrecise;
+
+    size_t *workSpaces;
+    std::vector<gert::StorageShape *> kCache;
+    std::vector<gert::StorageShape *> vCache;
+    uint64_t tilingKey;
+    uint32_t blockDim;
+};
+
+enum IfaLayout : uint32_t {
+    BSH_BSND = 0,
+    BSND = 1,
+    TND = 3,
+};
+
+enum IfaMaskType : uint32_t {
+    NO_MASK = 0,
+    MASK_NORM = 1,
+    MASK_COMPRESS = 2
+};
+
+
+class CustomFIATiling {
+public:
+    CustomFIATiling() = default;
+    ~CustomFIATiling() = default;
+
+    ge::graphStatus RunCustomFIATiling(IncreFlashAttentionContext &context);
+    ge::graphStatus IncreFlashAttentionSetTilingData(gert::TilingContext &context);
+    static ge::graphStatus ConvertContext(gert::TilingContext &context, IncreFlashAttentionContext &ifaContext);
+private:
+    ge::graphStatus CustomFIATilingProcess();
+    ge::graphStatus CustomFIAParamSet();
+    ge::graphStatus CustomFIAParamGet();
+    ge::graphStatus CustomFIASplitBlock();
+    void ParseMask();
+    uint32_t GetTotalQTaskNum();
+
+    ge::graphStatus InitPlatformInfo();
+    ge::graphStatus ParseTilingAttributes();
+    bool CheckIfShouldRunCustomFIA();
+
+    ge::graphStatus ParseTndVarlenParams(const gert::Shape& qShape);
+    ge::graphStatus ParsePagedAttentionParams();
+
+    ge::graphStatus CheckBaseInputsNull();
+
+    ge::graphStatus CheckInputFormatAndLimits();
+    ge::graphStatus CheckInputParameterFormat();
+    ge::graphStatus ProcessCheckCustomFIAInput();
+    ge::graphStatus CheckCustomFIABaseParams();
+    ge::graphStatus CheckCustomFIAInputDtype();
+    ge::graphStatus CheckCustomFIAPageAttention();
+    ge::graphStatus CheckCustomFIAQueryShape(const gert::StorageShape *queryShape);
+    ge::graphStatus CheckCustomFIAKvShapeAndToken(const gert::StorageShape *queryShape,
+                                            const gert::StorageShape *keyShape,
+                                            const gert::StorageShape *valueShape);
+
+    bool IsSupportFormat(const ge::Format format);
+
+    ge::graphStatus GenTilingKey();
+
+private:
+    uint32_t numHeads_ = 0;
+    float scaleValue_ = 0;
+    uint32_t numKvHeads_ = 0;
+    uint32_t qTokens_ = 0;
+    uint32_t maskKvLen_ = 0;
+    uint32_t blockSize_ = 0;
+    uint32_t maskBatchStride_ = 0;
+
+    uint32_t headDim_ = 0;
+    uint32_t batchSize_ = 0;
+    IfaLayout inputLayout_ = IfaLayout::BSH_BSND;
+    uint32_t tSeqSize_ = 1; // Length of the T axis in TND layout.
+
+    ge::DataType inputQType_ = ge::DT_FLOAT16;
+    ge::DataType inputKvType_ = ge::DT_FLOAT16;
+
+    uint32_t aicNum_ = 0;
+    uint32_t aivNum_ = 0;
+    size_t libapiSize_ = 0;
+
+    uint32_t attenMaskFlag_ = IfaMaskType::NO_MASK;
+
+    uint32_t maxBlockNumPerBatch_ = 0;
+    uint32_t totalBlockNum_ = 0;
+
+    uint32_t seqStepQ_ = 0;
+
+    IncreFlashAttentionContext *context_ = nullptr;
+    IncreFlashAttentionBaseParams *tilingDataBase_ = nullptr;
+    IncreFlashAttentionSplitCoreParams *tilingDataCore_ = nullptr;
+
+    IncreFlashAttentionTilingAtbDataV2 ifaTilingAtbData;
+
+    std::vector<uint32_t> tndQSeqLens_;
+};
+
+ge::graphStatus TilingPrepareForIncreFlashAttention(gert::TilingParseContext *context);
+ge::graphStatus TilingCustomFIAAdapter(gert::TilingContext *context, IncreFlashAttentionContext &ifaContext);
+
+IFA_EXTERN_C ge::graphStatus TilingIncreFlashAttention(gert::TilingContext *context);
+
+} // namespace optiling
+#endif // AIR_CXX_RUNTIME_V2_OP_IMPL_INCREFLASHATTENTIONSCORE_H_

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_base.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_base.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_tiling_base.h
+ * \brief
+ */
+#ifndef IFA_TILING_BASE_DEFINE_H
+#define IFA_TILING_BASE_DEFINE_H
+
+#include <cstdint>
+using namespace ge;
+namespace optiling {
+
+constexpr uint32_t QUERY_INPUT_INDEX = 0;
+constexpr uint32_t KEY_INPUT_INDEX = 1;
+constexpr uint32_t VALUE_INPUT_INDEX = 2;
+constexpr uint32_t ATTN_MASK_INPUT_INDEX = 3;
+constexpr uint32_t ACT_SEQ_LEN_Q_INPUT_INDEX = 4;
+constexpr uint32_t ACT_SEQ_LEN_INPUT_INDEX = 5;
+constexpr uint32_t BLOCK_TABLE_INPUT_INDEX = 6;
+constexpr uint32_t OUTPUT_INDEX = 0;
+constexpr uint32_t NUM_HEADS_ATTR_INDEX = 0;
+constexpr uint32_t SCALE_VALUE_ATTR_INDEX = 1;
+constexpr uint32_t LAYOUT_ATTR_INDEX = 2;
+constexpr uint32_t KV_NUM_HEADS_ATTR_INDEX = 3;
+constexpr uint32_t BLOCK_SIZE_ATTR_INDEX = 4;
+constexpr uint32_t INNER_PRECISE_ATTR_INDEX = 5;
+constexpr uint32_t DEFAULT_QUERY_SEQ_STEP_HEAD_DIM_128_LESS = 32;
+constexpr uint32_t DEFAULT_QUERY_SEQ_STEP_HEAD_DIM_256 = 16;
+
+const uint32_t MAX_CORE_NUM = 50;
+
+}// namespace optiling
+
+
+#endif // IFA_TILING_BASE_DEFINE_H

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_check.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_check.cpp
@@ -69,32 +69,11 @@ ge::graphStatus CustomFIATiling::CheckBaseInputsNull()
     return ge::GRAPH_SUCCESS;
 }
 
-bool CustomFIATiling::IsSupportFormat(const ge::Format format)
-{
-    return format == ge::FORMAT_ND || format == ge::FORMAT_NCHW;
-}
-
 ge::graphStatus CustomFIATiling::CheckInputParameterFormat()
 {
-    auto qFormat = context_->query.desc->GetOriginFormat();
-    auto kFormat = context_->key.desc->GetOriginFormat();
-    auto vFormat = context_->value.desc->GetOriginFormat();
-
-    OPS_ERR_IF(
-        (!IsSupportFormat(qFormat)), OPS_LOG_E(
-            context_->opName, "Query format %d should be ND", qFormat), return ge::GRAPH_FAILED);
-    OPS_ERR_IF(
-        (!IsSupportFormat(kFormat)), OPS_LOG_E(
-            context_->opName, "Key format %d should be ND", kFormat), return ge::GRAPH_FAILED);
-    OPS_ERR_IF(
-        (!IsSupportFormat(vFormat)), OPS_LOG_E(
-            context_->opName, "Value format %d should be ND", vFormat), return ge::GRAPH_FAILED);
-    if (context_->attnMask.desc != nullptr) {
-        auto mFormat = context_->attnMask.desc->GetOriginFormat();
-        OPS_ERR_IF((!IsSupportFormat(mFormat)),
-                OPS_LOG_E(context_->opName, "attn_mask format should be ND"),
-                return ge::GRAPH_FAILED);
-    }
+    // No format whitelist: the kernel only cares about storage shape dimensions,
+    // not the origin format tag.  Accepting all formats allows callers to pass
+    // NZ-layout tensors (with either ND or NZ metadata) without being rejected.
     return ge::GRAPH_SUCCESS;
 }
 

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_check.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_check.cpp
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_tiling_check.cc
+ * \brief
+ */
+
+#include "custom_fused_infer_attention_v310_tiling.h"
+#include "custom_fused_infer_attention_v310_tiling_base.h"
+#include <graph/utils/type_utils.h>
+#include "error/ops_error.h"
+
+
+using namespace ge;
+namespace optiling {
+
+ge::graphStatus CustomFIATiling::CheckBaseInputsNull()
+{
+    // Check base input tensors
+    OPS_ERR_IF(context_->query.shape == nullptr, OPS_LOG_E(context_->opName, "Shape of tensor query is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->query.shape->GetStorageShape().GetShapeSize() == 0,
+               OPS_LOG_E(context_->opName, "Tensor q is empty cause shapesize is 0."), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->query.desc == nullptr, OPS_LOG_E(context_->opName, "Desc of tensor query is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->key.shape == nullptr, OPS_LOG_E(context_->opName, "Shape of tensor k is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->key.desc == nullptr, OPS_LOG_E(context_->opName, "Desc of tensor k is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->value.shape == nullptr, OPS_LOG_E(context_->opName, "Shape of tensor value is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->value.desc == nullptr, OPS_LOG_E(context_->opName, "Desc of tensor value is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->attenOut.desc == nullptr, OPS_LOG_E(context_->opName, "Desc of tensor output is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->attenOut.shape == nullptr, OPS_LOG_E(context_->opName, "Shape of tensor output is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->actualSeqLengths.tensor == nullptr,
+               OPS_LOG_E(context_->opName, "actualSeqLengths tensor is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    // Check base input attrs
+    OPS_ERR_IF(context_->innerPrecise == nullptr, OPS_LOG_E(context_->opName, "attr innerPrecise is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->numHeads == nullptr, OPS_LOG_E(context_->opName, "attr numHeads is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->scaleValue == nullptr, OPS_LOG_E(context_->opName, "attr scaleValue is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->kvHeadNums == nullptr, OPS_LOG_E(context_->opName, "attr kvHeadNums is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->layOut == nullptr, OPS_LOG_E(context_->opName, "attr layOut is nullptr"),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(context_->blockSize == nullptr, OPS_LOG_E(context_->opName, "attr blockSize is nullptr"),
+               return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+bool CustomFIATiling::IsSupportFormat(const ge::Format format)
+{
+    return format == ge::FORMAT_ND || format == ge::FORMAT_NCHW;
+}
+
+ge::graphStatus CustomFIATiling::CheckInputParameterFormat()
+{
+    auto qFormat = context_->query.desc->GetOriginFormat();
+    auto kFormat = context_->key.desc->GetOriginFormat();
+    auto vFormat = context_->value.desc->GetOriginFormat();
+
+    OPS_ERR_IF(
+        (!IsSupportFormat(qFormat)), OPS_LOG_E(
+            context_->opName, "Query format %d should be ND", qFormat), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(
+        (!IsSupportFormat(kFormat)), OPS_LOG_E(
+            context_->opName, "Key format %d should be ND", kFormat), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(
+        (!IsSupportFormat(vFormat)), OPS_LOG_E(
+            context_->opName, "Value format %d should be ND", vFormat), return ge::GRAPH_FAILED);
+    if (context_->attnMask.desc != nullptr) {
+        auto mFormat = context_->attnMask.desc->GetOriginFormat();
+        OPS_ERR_IF((!IsSupportFormat(mFormat)),
+                OPS_LOG_E(context_->opName, "attn_mask format should be ND"),
+                return ge::GRAPH_FAILED);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CheckCustomFIABaseParams()
+{
+    OPS_ERR_IF((numHeads_ == 0),
+        OPS_LOG_E(context_->opName, "headSize is invalid."),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((numKvHeads_ == 0 || numHeads_ % numKvHeads_ != 0),
+        OPS_LOG_E(context_->opName, "kvHead is invalid."),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((context_->kCache.empty()),
+        OPS_LOG_E(context_->opName, "kCache is null."),
+        return ge::GRAPH_FAILED);
+    OPS_ERR_IF((context_->kCache[0] == nullptr),
+        OPS_LOG_E(context_->opName, "kCache[0] shape is null."),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((context_->vCache.empty()),
+        OPS_LOG_E(context_->opName, "vCache is null."),
+        return ge::GRAPH_FAILED);
+    OPS_ERR_IF((context_->vCache[0] == nullptr),
+        OPS_LOG_E(context_->opName, "vCache[0] shape is null."),
+        return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CheckCustomFIAInputDtype()
+{
+    OPS_ERR_IF((inputQType_ != ge::DT_FLOAT16),
+        OPS_LOG_E(context_->opName, "query dtype %u invalid, should be float16", inputQType_),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((inputKvType_ != ge::DT_FLOAT16),
+        OPS_LOG_E(context_->opName, "key and vaule dtype %u invalid, should be float16", inputKvType_),
+        return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CheckCustomFIAPageAttention()
+{
+    static const size_t BLOCK_TABLE_DIM_NUM = 2;
+
+    OPS_ERR_IF(context_->blockTable.desc == nullptr,
+        OPS_LOG_E(context_->opName, "blockTable desc is nullptr"),
+        return ge::GRAPH_FAILED);
+
+    auto blockTablesShape = context_->blockTable.tensor->GetStorageShape();
+    ge::DataType inputBlockTableType_ = context_->blockTable.desc->GetDataType();
+    int64_t taskNumI64 = static_cast<int64_t>(numHeads_) * batchSize_;
+
+    OPS_ERR_IF((inputBlockTableType_ != ge::DT_INT32),
+        OPS_LOG_E(context_->opName, "block_table dtype %u invalid, should be int32", inputBlockTableType_),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((blockTablesShape.GetDimNum() != BLOCK_TABLE_DIM_NUM),
+        OPS_LOG_E(context_->opName, "blockTables dim num %lu, invalid, should be %lu",
+            blockTablesShape.GetDimNum(), BLOCK_TABLE_DIM_NUM),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((taskNumI64 > UINT32_MAX),
+        OPS_LOG_E(context_->opName, "numHeads * batchSize overflow"),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((blockSize_ == 0 || blockSize_ % 16 != 0),
+        OPS_LOG_E(context_->opName, "blockSize is invalid"),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((headDim_ * blockSize_ > 128 * 128),
+        OPS_LOG_E(context_->opName, "headDim * blockSize should no greater than 128 * 128"),
+        return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CheckCustomFIAQueryShape(const gert::StorageShape *queryShape)
+{
+    static const size_t Q_CACHE_DIM_NUM_BSND = 4;
+    static const size_t Q_CACHE_DIM_NUM_TND = 3;
+
+    const size_t queryDimNum = queryShape->GetStorageShape().GetDimNum();
+
+    if (inputLayout_ == IfaLayout::TND) {
+        OPS_ERR_IF((queryDimNum != Q_CACHE_DIM_NUM_TND),
+            OPS_LOG_E(context_->opName,
+                "query dim num %lu, invalid, should be %lu for TND",
+                queryDimNum, Q_CACHE_DIM_NUM_TND),
+            return ge::GRAPH_FAILED);
+    } else if (inputLayout_ == IfaLayout::BSND){
+        OPS_ERR_IF((queryDimNum != Q_CACHE_DIM_NUM_BSND),
+            OPS_LOG_E(context_->opName,
+                "query dim num %lu, invalid, should be %lu",
+                queryDimNum, Q_CACHE_DIM_NUM_BSND),
+            return ge::GRAPH_FAILED);
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CheckCustomFIAKvShapeAndToken(const gert::StorageShape *queryShape,
+                                                   const gert::StorageShape *keyShape,
+                                                   const gert::StorageShape *valueShape)
+{
+    static const size_t KV_CACHE_DIM_NUM = 4;
+
+    OPS_ERR_IF((keyShape->GetStorageShape().GetDimNum() != KV_CACHE_DIM_NUM),
+        OPS_LOG_E(context_->opName,
+            "key dim num %lu, invalid, should be %lu",
+            keyShape->GetStorageShape().GetDimNum(), KV_CACHE_DIM_NUM),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((valueShape->GetStorageShape().GetDimNum() != KV_CACHE_DIM_NUM),
+        OPS_LOG_E(context_->opName,
+            "value dim num %lu, invalid, should be %lu",
+            valueShape->GetStorageShape().GetDimNum(), KV_CACHE_DIM_NUM),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((keyShape->GetStorageShape().GetDim(3) != 16),
+        OPS_LOG_E(context_->opName, "K_cache Shape should be in nz format"),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((valueShape->GetStorageShape().GetDim(3) != 16),
+        OPS_LOG_E(context_->opName, "V_cache Shape should be in nz format"),
+        return ge::GRAPH_FAILED);
+
+    OPS_ERR_IF((headDim_ == 0 || headDim_ > 256),
+        OPS_LOG_E(context_->opName, "headdim is invalid"),
+        return ge::GRAPH_FAILED);
+
+    int64_t numTokensI64 = (inputLayout_ == IfaLayout::TND) ?
+        queryShape->GetStorageShape().GetDim(0) :
+        queryShape->GetStorageShape().GetDim(2);
+
+    OPS_ERR_IF((numTokensI64 <= 0 || numTokensI64 > INT32_MAX),
+        OPS_LOG_E(context_->opName, "numTokens must be in (0, INT32_MAX]"),
+        return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::ProcessCheckCustomFIAInput()
+{
+    const gert::StorageShape *queryShape = context_->query.shape;
+    const gert::StorageShape *keyShape = context_->kCache[0];
+    const gert::StorageShape *valueShape = context_->vCache[0];
+
+    if (CheckCustomFIABaseParams() != ge::GRAPH_SUCCESS ||
+        CheckCustomFIAInputDtype() != ge::GRAPH_SUCCESS ||
+        CheckCustomFIAPageAttention() != ge::GRAPH_SUCCESS ||
+        CheckCustomFIAQueryShape(queryShape) != ge::GRAPH_SUCCESS ||
+        CheckCustomFIAKvShapeAndToken(queryShape, keyShape, valueShape) != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus CustomFIATiling::CheckInputFormatAndLimits()
+{
+    if (CheckInputParameterFormat() != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+    return ProcessCheckCustomFIAInput();
+}
+
+} // namespace optiling

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_check.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_check.cpp
@@ -111,7 +111,7 @@ ge::graphStatus CustomFIATiling::CheckCustomFIAInputDtype()
         return ge::GRAPH_FAILED);
 
     OPS_ERR_IF((inputKvType_ != ge::DT_FLOAT16),
-        OPS_LOG_E(context_->opName, "key and vaule dtype %u invalid, should be float16", inputKvType_),
+        OPS_LOG_E(context_->opName, "key and value dtype %u invalid, should be float16", inputKvType_),
         return ge::GRAPH_FAILED);
 
     return ge::GRAPH_SUCCESS;

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_data.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_data.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_tiling_data.h
+ * \brief
+ */
+#ifndef ADN_FUSED_INFER_ATTENTION_TILING_DATA_H_
+#define ADN_FUSED_INFER_ATTENTION_TILING_DATA_H_
+
+#include <cstdint>
+#include "register/tilingdata_base.h"
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(IncreFlashAttentionBaseParams)
+TILING_DATA_FIELD_DEF(uint32_t, batchSize)
+TILING_DATA_FIELD_DEF(uint32_t, headSize)
+TILING_DATA_FIELD_DEF(uint32_t, blockSize)
+TILING_DATA_FIELD_DEF(uint32_t, maxBlockNumPerBatch)
+TILING_DATA_FIELD_DEF(float, scaleValue)
+TILING_DATA_FIELD_DEF(uint32_t, kvHeadNum)
+TILING_DATA_FIELD_DEF(uint32_t, qHeadNum)
+TILING_DATA_FIELD_DEF(uint32_t, attenMaskFlag)
+TILING_DATA_FIELD_DEF(uint32_t, totalBlockNum)
+TILING_DATA_FIELD_DEF(uint32_t, querySeqStep)
+END_TILING_DATA_DEF
+REGISTER_TILING_DATA_CLASS(IncreFlashAttentionBaseParamsOp, IncreFlashAttentionBaseParams)
+
+BEGIN_TILING_DATA_DEF(IncreFlashAttentionSplitCoreParams)
+TILING_DATA_FIELD_DEF(uint32_t, maskHeadStride)
+TILING_DATA_FIELD_DEF(uint32_t, maskBatchStride)
+TILING_DATA_FIELD_DEF(uint32_t, maskKvLen)
+TILING_DATA_FIELD_DEF(uint32_t, qTokens)
+TILING_DATA_FIELD_DEF_ARR(uint32_t, 50, startTaskId);
+TILING_DATA_FIELD_DEF_ARR(uint32_t, 50, endTaskId);
+TILING_DATA_FIELD_DEF_ARR(uint32_t, 50, startBatch);
+TILING_DATA_FIELD_DEF_ARR(uint32_t, 50, endBatch);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(IncreFlashAttentionSplitCoreParamsOp, IncreFlashAttentionSplitCoreParams)
+
+BEGIN_TILING_DATA_DEF(IncreFlashAttentionTilingDataV2)
+TILING_DATA_FIELD_DEF_STRUCT(IncreFlashAttentionBaseParams, tilingBase);
+TILING_DATA_FIELD_DEF_STRUCT(IncreFlashAttentionSplitCoreParams, tilingPerCore);
+END_TILING_DATA_DEF
+REGISTER_TILING_DATA_CLASS(CustomFusedInferAttentionV310, IncreFlashAttentionTilingDataV2)
+
+BEGIN_TILING_DATA_DEF(IncreFlashAttentionTilingAtbDataV2)
+TILING_DATA_FIELD_DEF_STRUCT(IncreFlashAttentionBaseParams, tilingBase);
+TILING_DATA_FIELD_DEF_STRUCT(IncreFlashAttentionSplitCoreParams, tilingPerCore);
+END_TILING_DATA_DEF
+REGISTER_TILING_DATA_CLASS(CustomFusedInferAttentionV310_30000000000200000, IncreFlashAttentionTilingAtbDataV2)
+REGISTER_TILING_DATA_CLASS(CustomFusedInferAttentionV310_30000000000200001, IncreFlashAttentionTilingAtbDataV2)
+
+} // namespace optiling
+#endif // ADN_FUSED_INFER_ATTENTION_TILING_DATA_H_

--- a/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_register.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_host/custom_fused_infer_attention_v310_tiling_register.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310_tiling.cc
+ * \brief
+ */
+
+#include "custom_fused_infer_attention_v310_tiling.h"
+#include "register/op_def_registry.h"
+
+using namespace ge;
+namespace optiling {
+ge::graphStatus TilingPrepareForIncreFlashAttention(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+IMPL_OP_OPTILING(CustomFusedInferAttentionV310)
+    .Tiling(TilingIncreFlashAttention)
+    .TilingParse<IncreFlashAttentionCompileInfo>(TilingPrepareForIncreFlashAttention)
+    .TilingInputsDataDependency({5}, {gert::TilingPlacement::TILING_ON_HOST, gert::TilingPlacement::TILING_ON_AICPU});
+} // namespace optiling

--- a/csrc/attention/custom_fused_infer_attention_v310/op_kernel/custom_fia_mem.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_kernel/custom_fia_mem.h
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file custom_fia_mem.h
+ * \brief 310P-specific local buffer initialization.
+ *
+ * Why this file exists:
+ *   The common mem.h (csrc/common/include/kernel/mem.h) guards the V200 buffer
+ *   initialization with #ifndef __clang__. Bisheng CCE defines __clang__, so on
+ *   310P the UB/CB/L0A/L0B/L0C local storage is never initialized, causing NaN
+ *   outputs and AICore exceptions.
+ *
+ *   FiaV200Buffer uses InitBuffer() + address_.logicPos (same as the
+ *   Ascend_Ops reference), which works under both GCC and Bisheng CCE,
+ *   independent of __clang__.
+ *
+ *   The dedicated type keeps the fix local to CustomFusedInferAttentionV310.
+ *   The common AsdopsBuffer and all other operators remain unchanged.
+ */
+
+#ifndef CUSTOM_FIA_MEM_H
+#define CUSTOM_FIA_MEM_H
+
+#include "mem.h"
+
+class FiaV200Buffer {
+public:
+    __aicore__ FiaV200Buffer()
+    {
+        constexpr uint32_t bufferSize[(uint32_t)BufferType::ASCEND_MAX] = {
+            HardwareInfo<ArchType::ASCEND_V200>::ubSize,
+            HardwareInfo<ArchType::ASCEND_V200>::l1Size,
+            HardwareInfo<ArchType::ASCEND_V200>::l0ASize,
+            HardwareInfo<ArchType::ASCEND_V200>::l0BSize,
+            HardwareInfo<ArchType::ASCEND_V200>::l0CSize};
+        tensor[(uint32_t)BufferType::ASCEND_UB].InitBuffer(0, bufferSize[(uint32_t)BufferType::ASCEND_UB]);
+        tensor[(uint32_t)BufferType::ASCEND_UB].address_.logicPos = static_cast<uint8_t>(AscendC::TPosition::VECIN);
+        tensor[(uint32_t)BufferType::ASCEND_CB].InitBuffer(0, bufferSize[(uint32_t)BufferType::ASCEND_CB]);
+        tensor[(uint32_t)BufferType::ASCEND_CB].address_.logicPos = static_cast<uint8_t>(AscendC::TPosition::A1);
+        tensor[(uint32_t)BufferType::ASCEND_L0A].InitBuffer(0, bufferSize[(uint32_t)BufferType::ASCEND_L0A]);
+        tensor[(uint32_t)BufferType::ASCEND_L0A].address_.logicPos = static_cast<uint8_t>(AscendC::TPosition::A2);
+        tensor[(uint32_t)BufferType::ASCEND_L0B].InitBuffer(0, bufferSize[(uint32_t)BufferType::ASCEND_L0B]);
+        tensor[(uint32_t)BufferType::ASCEND_L0B].address_.logicPos = static_cast<uint8_t>(AscendC::TPosition::B2);
+        tensor[(uint32_t)BufferType::ASCEND_L0C].InitBuffer(0, bufferSize[(uint32_t)BufferType::ASCEND_L0C]);
+        tensor[(uint32_t)BufferType::ASCEND_L0C].address_.logicPos = static_cast<uint8_t>(AscendC::TPosition::CO1);
+    }
+
+    template <BufferType BufferType_, typename DstDataType = half>
+    __aicore__ AscendC::LocalTensor<DstDataType> GetBuffer(const uint32_t offset) const
+    {
+        return tensor[(uint32_t)BufferType_][offset].template ReinterpretCast<DstDataType>();
+    }
+
+private:
+    AscendC::LocalTensor<uint8_t> tensor[(uint32_t)BufferType::ASCEND_MAX];
+};
+#endif

--- a/csrc/attention/custom_fused_infer_attention_v310/op_kernel/custom_fused_infer_attention_v310.cpp
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_kernel/custom_fused_infer_attention_v310.cpp
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file custom_fused_infer_attention_v310.cpp
+ * \brief
+ */
+
+#include "kernel_operator.h"
+
+#if (__CCE_AICORE__ == 200)
+#include "unpad_paged_attention_decoder.h"
+#endif
+using namespace AscendC;
+
+#define INVOKE_IFA_NEW_GQA_OP_IMPL(templateClass, ...)                                                                 \
+    do {                                                                                                               \
+        templateClass<IFAType<__VA_ARGS__>> op;                                                                        \
+        GET_TILING_DATA_WITH_STRUCT(IncreFlashAttentionTilingAtbDataV2, tiling_data_in, tiling);                       \
+        const IncreFlashAttentionTilingAtbDataV2 *__restrict tiling_data = &tiling_data_in;                            \
+        op.Init(query, key, value, attnMask, actualSeqLengthsQ, actualSeqLengths, blocktable, attentionOut, user,      \
+                tiling_data);                                                                                          \
+        op.Process();                                                                                                  \
+    } while (0)
+
+
+extern "C" __global__ __aicore__ void custom_fused_infer_attention_v310_FIAS(
+    __gm__ uint8_t *query, __gm__ uint8_t *key, __gm__ uint8_t *value, __gm__ uint8_t *attnMask,
+    __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengths,
+    __gm__ uint8_t *blocktable, __gm__ uint8_t *attentionOut,
+    __gm__ uint8_t *workspace, __gm__ uint8_t *tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    TPipe tPipe;
+
+    __gm__ uint8_t *user = GetUserWorkspace(workspace);
+#if (__CCE_AICORE__ > 200)
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+#endif
+
+#if (ORIG_DTYPE_QUERY == DT_FLOAT16) && (ORIG_DTYPE_ATTENTION_OUT == DT_FLOAT16) && (ORIG_DTYPE_KEY == DT_FLOAT16)
+    TILING_KEY_IS(30000000000200000);
+    TILING_KEY_IS(30000000000200001);
+    #if (__CCE_AICORE__ <= 200)
+        #if TILING_KEY_VAR == 30000000000200000
+            INVOKE_IFA_NEW_GQA_OP_IMPL(
+                PagedAttentionDecoderMask, half, half, half, half, true, false, LAYOUT::BSND,
+                false, false, LAYOUT::BSND, AMLAMODE::NORMAL, false, IncreFlashAttentionTilingAtbDataV2);
+        #elif TILING_KEY_VAR == 30000000000200001
+            INVOKE_IFA_NEW_GQA_OP_IMPL(
+                PagedAttentionDecoderMask, half, half, half, half, true, false, LAYOUT::TND,
+                false, false, LAYOUT::TND, AMLAMODE::NORMAL, false, IncreFlashAttentionTilingAtbDataV2);
+        #endif
+    #endif
+#endif
+}
+
+extern "C" __global__ __aicore__ void
+custom_fused_infer_attention_v310(
+    __gm__ uint8_t *query, __gm__ uint8_t *key, __gm__ uint8_t *value, __gm__ uint8_t *attnMask,
+    __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengthsKv,
+    __gm__ uint8_t *blocktable, __gm__ uint8_t *attentionOut,
+    __gm__ uint8_t *workspace, __gm__ uint8_t *tiling)
+{
+    custom_fused_infer_attention_v310_FIAS(
+        query, key, value, attnMask, actualSeqLengthsQ, actualSeqLengthsKv, blocktable,
+        attentionOut, workspace, tiling);
+}

--- a/csrc/attention/custom_fused_infer_attention_v310/op_kernel/ifa_public_define.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_kernel/ifa_public_define.h
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * \file ifa_public_define.h
+ * \brief
+ */
+#ifndef IFA_PUBLIC_DEFINE_H
+#define IFA_PUBLIC_DEFINE_H
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+using AscendC::GlobalTensor;
+using AscendC::LocalTensor;
+
+constexpr int32_t FLOAT_VECTOR_SIZE_I = 64;
+constexpr int32_t VECTOR_SIZE_I = 128;
+constexpr int32_t BLOCK_SIZE_I = 16;
+constexpr int32_t BLOCK_SIZE_FLOAT = 8;
+constexpr uint32_t L0AB_HALF_BUF_SIZE_I = 16384;
+constexpr uint32_t CUBE_MATRIX_SIZE_I = 256;
+
+constexpr uint32_t L1_UINT8_BLOCK_SIZE = 131072;
+constexpr int32_t UB_UINT8_BLOCK_SIZE_I = 32768;
+constexpr int32_t UB_UINT8_LINE_SIZE_I = 1024;
+constexpr int32_t UB_FLOAT_LINE_SIZE_I = 256;
+constexpr int32_t UB_HALF_LINE_SIZE_I = 512;
+constexpr uint32_t MAX_LEN_64_BYTES = 64;
+constexpr uint32_t DEC_UB_UINT8_BLOCK_SIZE = 8192;
+
+enum class CalcMode : uint8_t {
+    CALC_MODE_DEFAULT = 0,
+    CALC_MODE_PREFILL = 1,
+};
+
+enum class LAYOUT {
+    BSH = 0,
+    BSND = 0,
+    BNSD = 1,
+    NZ = 2,
+    TND = 3,
+    NBSD = 4,
+    NTD = 5
+};
+
+enum class AMLAMODE {
+    NORMAL = 0,
+    AMLA = 1,
+    AMLA_3BUF = 2
+};
+
+template <typename Q_T, typename KV_T, typename OUT_T, typename ORIGIN_T, const bool PAGE_ATTENTION = false,
+          const bool FLASH_DECODE = false, LAYOUT LAYOUT_T = LAYOUT::BSH, const uint8_t ANTIQUANT_MODE = 0,
+          const bool SHARED_PREFIX = false, LAYOUT KV_LAYOUT_T = LAYOUT::BSH, const AMLAMODE AMLA = AMLAMODE::NORMAL,
+          const bool BALANCE = false, typename TILING_T = IncreFlashAttentionTilingDataV2, typename... Args>
+struct IFAType {
+    using queryType = Q_T;
+    using kvType = KV_T;
+    using outputType = OUT_T;
+    using orginalType = ORIGIN_T;
+    using TilingType = TILING_T;
+    static constexpr bool pageAttention = PAGE_ATTENTION;
+    static constexpr bool flashDecode = FLASH_DECODE;
+    static constexpr LAYOUT layout = LAYOUT_T;
+    static constexpr uint8_t antiquantMode = ANTIQUANT_MODE;
+    static constexpr bool sharedPrefix = SHARED_PREFIX;
+    static constexpr LAYOUT kvLayout = KV_LAYOUT_T;
+    static constexpr AMLAMODE isAMla = AMLA;
+    static constexpr bool isBalance = BALANCE;
+};
+
+#endif // IFA_PUBLIC_DEFINE_H

--- a/csrc/attention/custom_fused_infer_attention_v310/op_kernel/unpad_paged_attention_decoder.h
+++ b/csrc/attention/custom_fused_infer_attention_v310/op_kernel/unpad_paged_attention_decoder.h
@@ -1,0 +1,1981 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 1.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file unpad_paged_attention_decoder.h
+ * \brief
+ */
+
+#ifndef UNPAD_PAGED_ATTENTION_DECODER_H
+#define UNPAD_PAGED_ATTENTION_DECODER_H
+
+#include "custom_fia_mem.h"
+#include "common.h"
+#include "common_func.h"
+#include "simd.h"
+#include "iterator.h"
+#include "mma.h"
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "ifa_public_define.h"
+#include "gm_to_l1_iterator.h"
+#include "gm_to_ub_iterator.h"
+#include "l0c_to_ub_iterator.h"
+#include "l1_to_l0_iterator.h"
+#include "l1_to_ub_iterator.h"
+
+constexpr int32_t LOCAL_STORAGE_BUFFER_SIZE = 4096;
+
+constexpr int32_t MASK_TYPE_NORMAL = 1;
+constexpr int32_t MASK_TYPE_COMPRESSED = 2;
+
+// PingFlag (0) and PongFlag (1) select the two event IDs in each ping-pong event pair.
+// Event IDs are scoped by the source/destination pipeline pair, so different directions may reuse the same base ID.
+// MTE1 -> MTE2: MTE1 has consumed K from L1, allowing MTE2 to refill the corresponding K buffer.
+constexpr uint32_t L1_K_REUSE_EVENT_BASE = 4;
+// MTE2 -> MTE1: MTE2 has loaded V into L1, allowing MTE1 to consume the corresponding V buffer.
+constexpr uint32_t L1_V_READY_EVENT_BASE = 4;
+// MTE1 -> MTE2: MTE1 has consumed V from L1, allowing MTE2 to refill the corresponding V buffer.
+constexpr uint32_t L1_V_REUSE_EVENT_BASE = 6;
+
+template <CalcMode DECODE_MODE = CalcMode::CALC_MODE_DEFAULT>
+class PagedAttentionDecoder {
+public:
+    __aicore__ inline PagedAttentionDecoder(__gm__ uint8_t *__restrict__ gmSrcQ, __gm__ uint8_t *__restrict__ gmSrcK,
+                                            __gm__ uint8_t *__restrict__ gmSrcV, __gm__ uint8_t *__restrict__ gmSrcM,
+                                            __gm__ uint8_t *__restrict__ gmDstO, half tor,
+                                            uint32_t blockSize)
+        : tor(tor), blockSize(blockSize)
+    {
+        gmSrcQTensor.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(gmSrcQ));
+        gmSrcKTensor.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(gmSrcK));
+        gmSrcVTensor.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(gmSrcV));
+        gmSrcMTensor.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(gmSrcM));
+        gmDstOTensor.SetGlobalBuffer(reinterpret_cast<__gm__ half *>(gmDstO));
+
+        switch (DECODE_MODE) {
+            case (CalcMode::CALC_MODE_PREFILL):{
+                InitOffsetPrefill();
+                break;
+            }
+            case (CalcMode::CALC_MODE_DEFAULT):{
+            }
+            default: {
+                InitOffsetDefault();
+            }
+        }
+
+        lsUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(lsUbufOffset);
+        lpUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(lpUbufOffset);
+        ls32UbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, float>(ls32UbufOffset);
+        loUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, float>(loUbufOffset);
+        lmUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(lmUbufOffset);
+        hmUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(hmUbufOffset);
+        gmUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(gmUbufOffset);
+        dmUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(dmUbufOffset);
+        llUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, float>(llUbufOffset);
+        glUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, float>(glUbufOffset);
+        tvUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(tvUbufOffset);
+        goUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, float>(goUbufOffset);
+        maskUbufTensor = buf.GetBuffer<BufferType::ASCEND_UB, half>(maskUbufOffset);
+    }
+
+    __aicore__ inline void SetMask(int32_t len)
+    {
+        if (len >= VECTOR_SIZE_I) {
+            SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            return;
+        }
+        int32_t highMask = len - static_cast<int32_t>(MAX_LEN_64_BYTES) > 0 ? len - MAX_LEN_64_BYTES : 0;
+        int32_t lowMask = len -static_cast<int32_t>(MAX_LEN_64_BYTES) >= 0 ? MAX_LEN_64_BYTES : len;
+        if (len < MAX_LEN_64_BYTES) {
+            SetVectorMask<int8_t>(0x0, ((uint64_t)1 << lowMask) - 1);
+            return;
+        }
+        SetVectorMask<int8_t>(((uint64_t)1 << highMask) - 1, 0xffffffffffffffff);
+    }
+
+    __aicore__ inline void SetVcgMask(int32_t len)
+    {
+        if (len > BLOCK_SIZE_I) {
+            SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            return;
+        }
+        uint64_t subMask = ((uint64_t)1 << len) - 1;
+        uint64_t maskValue = (subMask << 48) + (subMask << 32) + (subMask << 16) + subMask;
+        SetVectorMask<int8_t>(maskValue, maskValue);
+    }
+
+    __aicore__ inline void ExpandToBlockHalf(AscendC::LocalTensor<half> dstTensor,
+                                            AscendC::LocalTensor<half> srcTensor, int32_t len)
+    {
+        // Expand srcTensor by copying each block 16 times.
+        const uint32_t BLOCK_TWO = 2;
+        const uint32_t BLOCK_NUM = 8;
+        // (len,) -> len / 16 blocks of shape (16, 16)
+        for (int32_t vaddsIdx = 0; vaddsIdx < BLOCK_TWO; ++vaddsIdx) {
+            adds_v<ArchType::ASCEND_V200, half>(
+                dstTensor[vaddsIdx * BLOCK_NUM * BLOCK_SIZE_I],
+                srcTensor,
+                0.0, len / BLOCK_SIZE_I, 1, 0, BLOCK_TWO * BLOCK_NUM, 1);
+        }
+        PIPE_BARRIER(V);
+        // (16, len) -> (len, 16)
+        for (int32_t vtransIdx = 0; vtransIdx < (len / BLOCK_SIZE_I); ++vtransIdx) {
+            tranpose_v<ArchType::ASCEND_V200, half>(
+                dstTensor[vtransIdx * CUBE_MATRIX_SIZE_I],
+                dstTensor[vtransIdx * CUBE_MATRIX_SIZE_I]);
+        }
+        PIPE_BARRIER(V);
+    }
+
+    __aicore__ inline void InitOffsetPrefill()
+    {
+        uint32_t ls32_pre_block_index = 2;
+        uint32_t lm_pre_block_index = 4;
+        uint32_t tv_pre_block_index = 5;
+        uint32_t go_pre_block_index = 6;
+
+        uint32_t hm_pre_line_index = 1;
+        uint32_t gm_pre_line_index = 2;
+        uint32_t dm_pre_line_index = 3;
+        uint32_t ll_pre_line_index = 5;
+        uint32_t gl_pre_line_index = 7;
+
+        lsUbufOffset = 0; // Initialize at an offset of two UB_UINT8_BLOCK_SIZE units.
+        lpUbufOffset = 0; // Initialize at an offset of two UB_UINT8_BLOCK_SIZE units.
+        ls32UbufOffset = ls32_pre_block_index * UB_UINT8_BLOCK_SIZE_I; // Offset by two UB_UINT8_BLOCK_SIZE units.
+        loUbufOffset = ls32_pre_block_index * UB_UINT8_BLOCK_SIZE_I; // Offset by two UB_UINT8_BLOCK_SIZE units.
+        lmUbufOffset = lm_pre_block_index * UB_UINT8_BLOCK_SIZE_I; // Offset by one UB_UINT8_LINE_SIZE unit.
+        // Offset by one UB_UINT8_LINE_SIZE unit.
+        hmUbufOffset = lm_pre_block_index * UB_UINT8_BLOCK_SIZE_I + hm_pre_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by one UB_UINT8_LINE_SIZE unit.
+        gmUbufOffset = lm_pre_block_index * UB_UINT8_BLOCK_SIZE_I + gm_pre_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by two UB_UINT8_LINE_SIZE units.
+        dmUbufOffset = lm_pre_block_index * UB_UINT8_BLOCK_SIZE_I + dm_pre_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by two UB_UINT8_LINE_SIZE units.
+        llUbufOffset = lm_pre_block_index * UB_UINT8_BLOCK_SIZE_I + ll_pre_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by 25 UB_UINT8_LINE_SIZE units.
+        glUbufOffset = lm_pre_block_index * UB_UINT8_BLOCK_SIZE_I + gl_pre_line_index * UB_UINT8_LINE_SIZE_I;
+        tvUbufOffset = tv_pre_block_index * UB_UINT8_BLOCK_SIZE_I; // Offset by one UB_UINT8_LINE_SIZE unit.
+        goUbufOffset = go_pre_block_index * UB_UINT8_BLOCK_SIZE_I;
+    }
+
+    __aicore__ inline void InitOffsetDefault()
+    {
+        uint32_t lp_dec_block_index = 2;
+        uint32_t ls_dec_block_index = 4;
+        uint32_t mask_dec_block_index = 8;
+        uint32_t lo_dec_block_index = 10;
+
+        uint32_t lm_block_index = 4;
+        uint32_t tv_block_index = 5;
+        uint32_t go_block_index = 6;
+
+        uint32_t hm_line_index = 1;
+        uint32_t dm_line_index = 2;
+        uint32_t ll_line_index = 4;
+        uint32_t gm_line_index = 6;
+        uint32_t gl_line_index = 16;
+
+        lsUbufOffset = 0; // Initialize at an offset of two DEC_UB_UINT8_BLOCK_SIZE units.
+        lpUbufOffset = lp_dec_block_index * DEC_UB_UINT8_BLOCK_SIZE; // Offset by two DEC_UB_UINT8_BLOCK_SIZE units.
+        ls32UbufOffset = ls_dec_block_index * DEC_UB_UINT8_BLOCK_SIZE; // Offset by four DEC_UB_UINT8_BLOCK_SIZE units.
+        maskUbufOffset = mask_dec_block_index * DEC_UB_UINT8_BLOCK_SIZE; // Offset by two DEC_UB_UINT8_BLOCK_SIZE units.
+        loUbufOffset = lo_dec_block_index * DEC_UB_UINT8_BLOCK_SIZE;
+        lmUbufOffset = lm_block_index * UB_UINT8_BLOCK_SIZE_I; // Offset by one UB_UINT8_LINE_SIZE unit.
+        // Offset by one UB_UINT8_LINE_SIZE unit.
+        hmUbufOffset = lm_block_index * UB_UINT8_BLOCK_SIZE_I + hm_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by two UB_UINT8_LINE_SIZE units.
+        dmUbufOffset = lm_block_index * UB_UINT8_BLOCK_SIZE_I + dm_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by two UB_UINT8_LINE_SIZE units.
+        llUbufOffset = lm_block_index * UB_UINT8_BLOCK_SIZE_I + ll_line_index * UB_UINT8_LINE_SIZE_I;
+        // Offset by 26 UB_UINT8_LINE_SIZE units.
+        gmUbufOffset = lm_block_index * UB_UINT8_BLOCK_SIZE_I + gm_line_index * UB_UINT8_LINE_SIZE_I;
+        tvUbufOffset = tv_block_index * UB_UINT8_BLOCK_SIZE_I; // Offset by 16 UB_UINT8_LINE_SIZE units.
+        // Offset by 16 UB_UINT8_LINE_SIZE units.
+        glUbufOffset = tv_block_index * UB_UINT8_BLOCK_SIZE_I + gl_line_index * UB_UINT8_LINE_SIZE_I;
+        goUbufOffset = go_block_index * UB_UINT8_BLOCK_SIZE_I;
+    }
+
+    __aicore__ inline void Init(uint64_t srcqOffsetReal, uint64_t srckOffsetReal, uint64_t srcvOffsetReal,
+                                uint64_t srckOffsetReal1, uint64_t srcvOffsetReal1, uint64_t srcmOffsetReal,
+                                uint64_t dstoOffsetReal, uint32_t initGReal, uint32_t wrapOReal,
+                                uint32_t constextLenAlign16, uint32_t queryHeadNum, int32_t cmRowPing, int32_t cmRowPong)
+    {
+        srcqOffset = srcqOffsetReal;
+        srckOffset = srckOffsetReal;
+        srcvOffset = srcvOffsetReal;
+        srckOffset1 = srckOffsetReal1;
+        srcvOffset1 = srcvOffsetReal1;
+        srcmOffset = srcmOffsetReal;
+        dstoOffset = dstoOffsetReal;
+        initG = initGReal;
+        wrapO = wrapOReal;
+        kvSeqAlign16 = constextLenAlign16;
+        qHeadNum = queryHeadNum;
+        compressMaskRowPing = cmRowPing;
+        compressMaskRowPong = cmRowPong;
+    }
+
+public:
+    __aicore__ inline void ProcessKvBlockPair(const uint32_t fm, const uint32_t fn, const uint32_t fk, const uint32_t bn,
+                                const uint32_t mActual, const uint32_t n0Actual, const uint32_t n1Actual,
+                                const uint32_t maskType, const uint32_t initKVE, const uint32_t headOffset = 0,
+                                const uint32_t initKV = 1, half localTor = 1, const uint32_t scaleType = 0);
+
+private:
+    const uint32_t PingFlag = 0;
+    const uint32_t PongFlag = 1;
+    uint32_t vmPingPongFlag = 1;
+
+    __aicore__ inline void LoadQueryAndAttentionMask(
+        const uint32_t fm, const uint32_t fn, const uint32_t fk, const uint32_t bn,
+        const uint32_t mActual, const uint32_t n1Actual,
+        const uint32_t maskType, const uint32_t initGgO, const uint32_t initKVG,
+        const uint32_t qOffset);
+
+    __aicore__ inline void MoveQKPingToL0(
+        const uint32_t fm, const uint32_t fn, const uint32_t fk,
+        const uint32_t mActual, const uint32_t initGgO, const uint32_t initKV,
+        const uint32_t qOffset,
+        AscendC::LocalTensor<half> &l1kPingBufTensor);
+
+    __aicore__ inline void MoveQKPongToL0(
+        const uint32_t fm, const uint32_t bn, const uint32_t fk,
+        const uint32_t mActual, const uint32_t n1Actual,
+        const uint32_t initGgO, const uint32_t initKV,
+        const uint32_t qOffset,
+        AscendC::LocalTensor<half> &l1kPongBufTensor);
+
+    __aicore__ inline void CalculateQKPingAndPrepareV(
+        const uint32_t fm, const uint32_t fn, const uint32_t fk,
+        const uint32_t mActual, const uint32_t n0Actual,
+        const uint32_t initKV,
+        AscendC::LocalTensor<half> &l1vPingBufTensor);
+
+    __aicore__ inline void CalculateQKPongAndPrepareV(
+        const uint32_t fm, const uint32_t bn, const uint32_t fk,
+        const uint32_t mActual, const uint32_t n1Actual,
+        const uint32_t initKV,
+        AscendC::LocalTensor<half> &l1vPongBufTensor);
+
+    __aicore__ inline void CalculateSoftmaxPing(
+        const uint32_t fm, const uint32_t fn,
+        const uint32_t mActual, const uint32_t n0Actual,
+        const uint32_t maskType, half localTor,
+        const uint32_t n0AlignVector, const uint32_t n0AlignBlock,
+        const uint32_t pSize, const uint32_t pSizeAlignFloat,
+        const uint32_t gmUOffset, uint32_t &initGgDm,
+        AscendC::LocalTensor<half> &l1pPingBufTensor);
+
+    __aicore__ inline void CalculateSoftmaxPong(
+        const uint32_t fm, const uint32_t bn,
+        const uint32_t mActual, const uint32_t n1Actual,
+        const uint32_t maskType, half localTor,
+        const uint32_t n1AlignVector, const uint32_t n1AlignBlock,
+        const uint32_t pSizeB, const uint32_t pSizeBAlignFloat,
+        const uint32_t gmUOffset,
+        AscendC::LocalTensor<half> &l1pPingBufTensor,
+        AscendC::LocalTensor<half> &l1pPongBufTensor);
+
+    __aicore__ inline void CalculatePVPing(
+        const uint32_t fm, const uint32_t fn, const uint32_t fk,
+        const uint32_t mActual, const uint32_t n0Actual,
+        const uint32_t initKVE, const uint32_t n1Actual,
+        AscendC::LocalTensor<half> &l1pPingBufTensor);
+
+    __aicore__ inline void CalculatePVPong(
+        const uint32_t fm, const uint32_t bn, const uint32_t fk,
+        const uint32_t mActual, const uint32_t n1Actual,
+        const uint32_t initKVE,
+        AscendC::LocalTensor<half> &l1pPingBufTensor,
+        AscendC::LocalTensor<half> &l1pPongBufTensor);
+
+    __aicore__ inline void MovePVResultsToUb(
+        const uint32_t fm, const uint32_t fk,
+        const uint32_t mActual, const uint32_t oSize,
+        const uint32_t n1Actual);
+
+    __aicore__ inline void UpdateOnlineSoftmaxPing(
+        const uint32_t fm, const uint32_t fk,
+        const uint32_t mActual, const uint32_t kAlignVector,
+        const uint32_t oSizeAlignFloat,
+        const uint32_t glUOffset, const uint32_t goUOffset,
+        uint32_t &initGgO);
+
+    __aicore__ inline void UpdateOnlineSoftmaxPong(
+        const uint32_t fm, const uint32_t fk,
+        const uint32_t mActual, const uint32_t kAlignVector,
+        const uint32_t oSizeAlignFloat,
+        const uint32_t n1Actual,
+        const uint32_t glUOffset, const uint32_t goUOffset);
+
+    __aicore__ inline void NormalizeAndStoreOutput(
+        const uint32_t fm, const uint32_t fk,
+        const uint32_t mActual, const uint32_t oSizeAlignFloat,
+        const uint32_t glUOffset, const uint32_t goUOffset,
+        const uint32_t wrapO);
+
+    AscendC::GlobalTensor<half> gmSrcQTensor;
+    AscendC::GlobalTensor<half> gmSrcKTensor;
+    AscendC::GlobalTensor<half> gmSrcVTensor;
+    AscendC::GlobalTensor<half> gmSrcMTensor;
+    AscendC::GlobalTensor<half> gmDstOTensor;
+
+    FiaV200Buffer buf;
+
+    uint32_t l1qBufAddrOffset = 0;
+    uint32_t l1kBufAddrOffset = 2 * UB_UINT8_BLOCK_SIZE_I;
+    uint32_t l1pBufAddrOffset = 2 * L1_UINT8_BLOCK_SIZE;
+    uint32_t l1vBufAddrOffset = 2 * L1_UINT8_BLOCK_SIZE + 2 * UB_UINT8_BLOCK_SIZE_I;
+    uint32_t l1maskBufAddrOffset = 4 * L1_UINT8_BLOCK_SIZE;
+
+    uint32_t l0aBufOffset = 0;
+    uint32_t l0bBufOffset = 0;
+    uint32_t l0cBufOffset = 0;
+
+    uint32_t lsUbufOffset = 0;
+    uint32_t lpUbufOffset = 0;
+    uint32_t ls32UbufOffset = 0;
+    uint32_t maskUbufOffset = 0;
+    uint32_t loUbufOffset = 0;
+    uint32_t lmUbufOffset = 0;
+    uint32_t hmUbufOffset = 0;
+    uint32_t gmUbufOffset = 0;
+    uint32_t dmUbufOffset = 0;
+    uint32_t llUbufOffset = 0;
+    uint32_t glUbufOffset = 0;
+    uint32_t tvUbufOffset = 0;
+    uint32_t goUbufOffset = 0;
+
+    AscendC::LocalTensor<half> l1qBufAddrTensor = buf.GetBuffer<BufferType::ASCEND_CB, half>(l1qBufAddrOffset);
+    AscendC::LocalTensor<half> l1kBufAddrTensor = buf.GetBuffer<BufferType::ASCEND_CB, half>(l1kBufAddrOffset);
+    AscendC::LocalTensor<half> l1pBufAddrTensor = buf.GetBuffer<BufferType::ASCEND_CB, half>(l1pBufAddrOffset);
+    AscendC::LocalTensor<half> l1vBufAddrTensor = buf.GetBuffer<BufferType::ASCEND_CB, half>(l1vBufAddrOffset);
+    AscendC::LocalTensor<half> l1maskBufAddr_tensor =
+        buf.GetBuffer<BufferType::ASCEND_CB, half>(l1maskBufAddrOffset);
+
+    AscendC::LocalTensor<half> l0aBufTensor = buf.GetBuffer<BufferType::ASCEND_L0A, half>(l0aBufOffset);
+    AscendC::LocalTensor<half> l0bBufTensor = buf.GetBuffer<BufferType::ASCEND_L0B, half>(l0bBufOffset);
+    AscendC::LocalTensor<float> l0cBufTensor = buf.GetBuffer<BufferType::ASCEND_L0C, float>(l0cBufOffset);
+
+    AscendC::LocalTensor<half> lsUbufTensor;
+    AscendC::LocalTensor<half> lpUbufTensor;
+    AscendC::LocalTensor<half> lmUbufTensor;
+    AscendC::LocalTensor<half> hmUbufTensor;
+    AscendC::LocalTensor<half> gmUbufTensor;
+    AscendC::LocalTensor<half> dmUbufTensor;
+    AscendC::LocalTensor<half> tvUbufTensor;
+    AscendC::LocalTensor<half> maskUbufTensor;
+    AscendC::LocalTensor<float> ls32UbufTensor;
+    AscendC::LocalTensor<float> loUbufTensor;
+    AscendC::LocalTensor<float> llUbufTensor;
+    AscendC::LocalTensor<float> glUbufTensor;
+    AscendC::LocalTensor<float> goUbufTensor;
+
+    half tor = 1.0;
+    uint32_t blockSize = VECTOR_SIZE_I;
+
+    uint64_t srcqOffset = 0;
+    uint64_t srckOffset = 0;
+    uint64_t srcvOffset = 0;
+    uint64_t srckOffset1 = 0;
+    uint64_t srcvOffset1 = 0;
+    uint64_t dstoOffset = 0;
+    uint64_t srcmOffset = 0;
+
+    // For a compressed mask, record the causal offset of the first query in the current query block.
+    int32_t compressMaskRowPing = 0;
+    int32_t compressMaskRowPong = 0;
+
+    uint32_t initG = 0;
+    uint32_t wrapO = 0;
+    uint32_t kvSeqAlign16 = 0;
+    uint32_t qHeadNum = 0;
+};
+
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::LoadQueryAndAttentionMask(
+    const uint32_t fm, const uint32_t fn, const uint32_t fk, const uint32_t bn,
+    const uint32_t mActual, const uint32_t n1Actual,
+    const uint32_t maskType, const uint32_t initGgO, const uint32_t initKVG,
+    const uint32_t qOffset)
+{
+    if (initGgO != 0) {
+        if (initKVG) {
+            WAIT_FLAG(MTE1, MTE2, PingFlag);
+            WAIT_FLAG(MTE1, MTE2, PongFlag);
+        }
+        if (mActual == 1) {
+            AscendC::DataCopy(l1qBufAddrTensor[qOffset], gmSrcQTensor[srcqOffset], fk);
+        } else {
+            Nd2NzParams nd2NzParams;
+            nd2NzParams.ndNum = 1;
+            nd2NzParams.nValue = mActual;
+            nd2NzParams.dValue = fk;
+            nd2NzParams.srcNdMatrixStride = 0;
+            nd2NzParams.srcDValue = fk * qHeadNum;
+            nd2NzParams.dstNzC0Stride = fm;
+            nd2NzParams.dstNzNStride = 1;
+            nd2NzParams.dstNzMatrixStride = 0;
+
+            AscendC::DataCopy(l1qBufAddrTensor[qOffset], gmSrcQTensor[srcqOffset], nd2NzParams);
+        }
+
+        SET_FLAG(MTE2, MTE1, PingFlag);
+        if (n1Actual != 0) {
+            SET_FLAG(MTE2, MTE1, PongFlag);
+        }
+    }
+
+    if (maskType != 0) {
+        WAIT_FLAG(MTE1, MTE2, PingFlag + 2);
+        if (maskType == MASK_TYPE_NORMAL) {
+            AscendC::DataCopy(l1maskBufAddr_tensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+                                gmSrcMTensor[srcmOffset],
+                                AscendC::DataCopyParams(mActual,
+                                                        fn / 16,
+                                                        (kvSeqAlign16 - fn) / 16,
+                                                        0));
+        } else if (maskType == MASK_TYPE_COMPRESSED) {
+            uint32_t l1BaseOffset = PingFlag * L0AB_HALF_BUF_SIZE_I;
+            uint64_t srcStartOffset = compressMaskRowPing * blockSize;
+
+            AscendC::DataCopy(
+                l1maskBufAddr_tensor[l1BaseOffset],
+                gmSrcMTensor[srcStartOffset],
+                AscendC::DataCopyParams(
+                    mActual,
+                    fn / 16,
+                    (blockSize - fn) / 16,
+                    0
+                )
+            );
+        }
+
+        SET_FLAG(MTE2, MTE1, PingFlag + 2);
+        WAIT_FLAG(MTE2, MTE1, PingFlag + 2);
+        WAIT_FLAG(V, MTE1, PingFlag);
+        l1_to_ub<ArchType::ASCEND_V200, half>(
+            maskUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            l1maskBufAddr_tensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            1, mActual * fn / BLOCK_SIZE_I, 0, 0);
+        SET_FLAG(MTE1, V, PingFlag);
+        SET_FLAG(MTE1, MTE2, PingFlag + 2);
+        if (n1Actual != 0) {
+            WAIT_FLAG(MTE1, MTE2, PongFlag + 2);
+            if (maskType == MASK_TYPE_NORMAL) {
+                AscendC::DataCopy(l1maskBufAddr_tensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+                                    gmSrcMTensor[srcmOffset + blockSize],
+                                    AscendC::DataCopyParams(mActual,
+                                                            bn / 16,
+                                                            (kvSeqAlign16 - bn) / 16,
+                                                            0));
+            } else if (maskType == MASK_TYPE_COMPRESSED) {
+                uint32_t l1BaseOffset = PongFlag * L0AB_HALF_BUF_SIZE_I;
+                uint64_t srcStartOffset = compressMaskRowPong * blockSize;
+
+                AscendC::DataCopy(
+                    l1maskBufAddr_tensor[l1BaseOffset],
+                    gmSrcMTensor[srcStartOffset],
+                    AscendC::DataCopyParams(
+                        mActual,
+                        bn / 16,
+                        (blockSize - bn) / 16,
+                        0
+                    )
+                );
+            }
+
+            SET_FLAG(MTE2, MTE1, PongFlag + 2);
+            WAIT_FLAG(MTE2, MTE1, PongFlag + 2);
+            WAIT_FLAG(V, MTE1, PongFlag);
+            l1_to_ub<ArchType::ASCEND_V200, half>(
+                maskUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                l1maskBufAddr_tensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+                1, mActual * bn / BLOCK_SIZE_I, 0, 0);
+            SET_FLAG(MTE1, V, PongFlag);
+            SET_FLAG(MTE1, MTE2, PongFlag + 2);
+        }
+    }
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::MoveQKPingToL0(
+    const uint32_t fm, const uint32_t fn, const uint32_t fk,
+    const uint32_t mActual, const uint32_t initGgO, const uint32_t initKV,
+    const uint32_t qOffset,
+    AscendC::LocalTensor<half> &l1kPingBufTensor)
+{
+    if (initGgO == 1) {
+        WAIT_FLAG(MTE2, MTE1, PingFlag);
+    }
+    if (mActual == 1) {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+            l0aBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            l1qBufAddrTensor[qOffset].ReinterpretCast<half>(),
+            0, 1, 0, 1, 0, 0);
+    } else {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::NZ, DataFormatT::ZZ>(
+            l0aBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            l1qBufAddrTensor[qOffset].ReinterpretCast<half>(),
+            fm, fk, 0, 0, 0, 0);
+    }
+
+    SET_FLAG(MTE1, M, PingFlag);
+    WAIT_FLAG(MTE1, MTE2, L1_K_REUSE_EVENT_BASE + PingFlag);
+    if (initKV) {
+        gm_to_l1<ArchType::ASCEND_V200, half, DataFormatT::NZ, DataFormatT::NZ>(
+            l1kPingBufTensor,
+            gmSrcKTensor[srckOffset],
+            fn, blockSize, fn, fk, fk, fk);
+    }
+    SET_FLAG(MTE2, MTE1, PingFlag);
+    WAIT_FLAG(MTE2, MTE1, PingFlag);
+    WAIT_FLAG(M, MTE1, PingFlag + 2);
+    l1_to_l0_b<ArchType::ASCEND_V200, half, false, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+        l0bBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        l1kPingBufTensor,
+        0, fk * fn / CUBE_MATRIX_SIZE_I, 0, 1, 0, 0);
+    SET_FLAG(MTE1, MTE2, L1_K_REUSE_EVENT_BASE + PingFlag);
+    SET_FLAG(MTE1, M, PingFlag + 2);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::MoveQKPongToL0(
+    const uint32_t fm, const uint32_t bn, const uint32_t fk,
+    const uint32_t mActual, const uint32_t n1Actual,
+    const uint32_t initGgO, const uint32_t initKV,
+    const uint32_t qOffset,
+    AscendC::LocalTensor<half> &l1kPongBufTensor)
+{
+    WAIT_FLAG(M, MTE1, PongFlag);
+    if (initGgO == 1) {
+        WAIT_FLAG(MTE2, MTE1, PongFlag);
+    }
+    if (mActual == 1) {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+            l0aBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            l1qBufAddrTensor[qOffset],
+            0, 1, 0, 1, 0, 0);
+    } else {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::NZ, DataFormatT::ZZ>(
+            l0aBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            l1qBufAddrTensor[qOffset].ReinterpretCast<half>(),
+            fm, fk, 0, 0, 0, 0);
+    }
+
+    SET_FLAG(MTE1, M, PongFlag);
+    WAIT_FLAG(MTE1, MTE2, L1_K_REUSE_EVENT_BASE + PongFlag);
+    if (initKV) {
+        gm_to_l1<ArchType::ASCEND_V200, half, DataFormatT::NZ, DataFormatT::NZ>(
+            l1kPongBufTensor,
+            gmSrcKTensor[srckOffset1],
+            bn, blockSize, bn, fk, fk, fk);
+    }
+    SET_FLAG(MTE2, MTE1, PongFlag);
+    WAIT_FLAG(MTE2, MTE1, PongFlag);
+    WAIT_FLAG(M, MTE1, PongFlag + 2);
+    l1_to_l0_b<ArchType::ASCEND_V200, half, false, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+        l0bBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        l1kPongBufTensor,
+        0, fk * bn / CUBE_MATRIX_SIZE_I, 0, 1, 0, 0);
+    SET_FLAG(MTE1, M, PongFlag + 2);
+    SET_FLAG(MTE1, MTE2, L1_K_REUSE_EVENT_BASE + PongFlag);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::CalculateQKPingAndPrepareV(
+    const uint32_t fm, const uint32_t fn, const uint32_t fk,
+    const uint32_t mActual, const uint32_t n0Actual,
+    const uint32_t initKV,
+    AscendC::LocalTensor<half> &l1vPingBufTensor)
+{
+    WAIT_FLAG(MTE1, MTE2, L1_V_REUSE_EVENT_BASE + PingFlag);
+    if (initKV) {
+        gm_to_l1<ArchType::ASCEND_V200, half, DataFormatT::NZ, DataFormatT::NZ>(
+            l1vPingBufTensor,
+            gmSrcVTensor[srcvOffset],
+            fn, blockSize, fn, fk, fk, fk);
+    }
+    SET_FLAG(MTE2, MTE1, L1_V_READY_EVENT_BASE + PingFlag);
+    WAIT_FLAG(MTE1, M, PingFlag + 2);
+    WAIT_FLAG(MTE1, M, PingFlag);
+    WAIT_FLAG(V, M, PingFlag);
+
+    mmad<ArchType::ASCEND_V200, half, half, float, false>(
+        l0cBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        l0aBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        l0bBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        mActual, n0Actual, fk, 1);
+
+    SET_FLAG(M, V, PingFlag);
+    SET_FLAG(M, MTE1, PingFlag);
+    SET_FLAG(M, MTE1, PingFlag + 2);
+    WAIT_FLAG(MTE2, MTE1, L1_V_READY_EVENT_BASE + PingFlag);
+    WAIT_FLAG(M, MTE1, PingFlag + 2);
+    if (fk == 16) {
+        l1_to_l0_b<ArchType::ASCEND_V200, half, 1, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+            l0bBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            l1vPingBufTensor,
+            0, fn / BLOCK_SIZE_I, 0, 1, 0, 0);
+    } else {
+        for (int32_t l0bLoadIdx = 0; l0bLoadIdx < (fn / BLOCK_SIZE_I); ++l0bLoadIdx) {
+            l1_to_l0_b<ArchType::ASCEND_V200, half, 1, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+                l0bBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I + l0bLoadIdx * fk * BLOCK_SIZE_I],
+                l1vPingBufTensor[l0bLoadIdx * CUBE_MATRIX_SIZE_I],
+                0, fk / BLOCK_SIZE_I, 0, fn / BLOCK_SIZE_I, 0, 0);
+        }
+    }
+    SET_FLAG(MTE1, MTE2, L1_V_REUSE_EVENT_BASE + PingFlag);
+    SET_FLAG(MTE1, M, PingFlag + 2);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::CalculateQKPongAndPrepareV(
+    const uint32_t fm, const uint32_t bn, const uint32_t fk,
+    const uint32_t mActual, const uint32_t n1Actual,
+    const uint32_t initKV,
+    AscendC::LocalTensor<half> &l1vPongBufTensor)
+{
+    WAIT_FLAG(MTE1, MTE2, L1_V_REUSE_EVENT_BASE + PongFlag);
+    if (initKV) {
+        gm_to_l1<ArchType::ASCEND_V200, half, DataFormatT::NZ, DataFormatT::NZ>(
+            l1vPongBufTensor,
+            gmSrcVTensor[srcvOffset1],
+            bn, blockSize, bn, fk, fk, fk);
+    }
+    SET_FLAG(MTE2, MTE1, L1_V_READY_EVENT_BASE + PongFlag);
+    WAIT_FLAG(MTE1, M, PongFlag + 2);
+    WAIT_FLAG(MTE1, M, PongFlag);
+    WAIT_FLAG(V, M, PongFlag);
+
+    mmad<ArchType::ASCEND_V200, half, half, float, false>(
+        l0cBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        l0aBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        l0bBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        mActual, n1Actual, fk, 1);
+
+    SET_FLAG(M, V, PongFlag);
+    SET_FLAG(M, MTE1, PongFlag);
+    SET_FLAG(M, MTE1, PongFlag + 2);
+    WAIT_FLAG(MTE2, MTE1, L1_V_READY_EVENT_BASE + PongFlag);
+    WAIT_FLAG(M, MTE1, PongFlag + 2);
+    if (fk == 16) {
+        l1_to_l0_b<ArchType::ASCEND_V200, half, true, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+            l0bBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            l1vPongBufTensor,
+            0, bn / BLOCK_SIZE_I, 0, 1, 0, 0);
+    } else {
+        for (int32_t l0bLoadIdx = 0; l0bLoadIdx < (bn / BLOCK_SIZE_I); ++l0bLoadIdx) {
+            l1_to_l0_b<ArchType::ASCEND_V200, half, true, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+                l0bBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I + l0bLoadIdx * fk * BLOCK_SIZE_I],
+                l1vPongBufTensor[l0bLoadIdx * CUBE_MATRIX_SIZE_I],
+                0, fk / BLOCK_SIZE_I, 0, bn / BLOCK_SIZE_I, 0, 0);
+        }
+    }
+    SET_FLAG(MTE1, MTE2, L1_V_REUSE_EVENT_BASE + PongFlag);
+    SET_FLAG(MTE1, M, PongFlag + 2);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::CalculateSoftmaxPing(
+    const uint32_t fm, const uint32_t fn,
+    const uint32_t mActual, const uint32_t n0Actual,
+    const uint32_t maskType, half localTor,
+    const uint32_t n0AlignVector, const uint32_t n0AlignBlock,
+    const uint32_t pSize, const uint32_t pSizeAlignFloat,
+    const uint32_t gmUOffset, uint32_t &initGgDm,
+    AscendC::LocalTensor<half> &l1pPingBufTensor)
+{
+    WAIT_FLAG(M, V, PingFlag);
+    l0c_to_ub<ArchType::ASCEND_V200, float, half>(
+        ls32UbufTensor.ReinterpretCast<half>()[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        l0cBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        1, pSize / CUBE_MATRIX_SIZE_I, 0, 0);
+
+    PIPE_BARRIER(V);
+    SET_FLAG(V, M, PingFlag);
+
+    // NZ->ND
+    for (uint32_t fractalBlkIdx = 0; fractalBlkIdx < n0AlignBlock; fractalBlkIdx++) {
+        ub_to_ub<ArchType::ASCEND_V200, half>(
+            lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * BLOCK_SIZE_I],
+            ls32UbufTensor.ReinterpretCast<half>()[
+                PingFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * fm * BLOCK_SIZE_I],
+            0,
+            mActual,
+            1,
+            0,
+            fn / BLOCK_SIZE_I - 1
+        );
+    }
+    PIPE_BARRIER(V);
+
+    AscendC::Muls(lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                  lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                  localTor,
+                  pSize);
+    PIPE_BARRIER(V);
+
+    if (maskType != 0) {
+        WAIT_FLAG(MTE1, V, PingFlag);
+        add_v<ArchType::ASCEND_V200, half>(lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                                           lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                                           maskUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                                           pSize / VECTOR_SIZE_I,
+                                           1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        SET_FLAG(V, MTE1, PingFlag);
+    }
+
+    if (n0Actual <= VECTOR_SIZE_I) {
+        if (n0Actual != VECTOR_SIZE_I) {
+            SetMask(n0Actual % VECTOR_SIZE_I);
+        }
+        cmax_v<ArchType::ASCEND_V200, half, AscendC::ReduceOrder::ORDER_ONLY_VALUE>(
+            lmUbufTensor,
+            lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            mActual, 1, 1, n0AlignBlock);
+        PIPE_BARRIER(V);
+    } else {
+        ub_to_ub<ArchType::ASCEND_V200, half>(
+            tvUbufTensor,
+            lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            0, mActual, 8, (fn - VECTOR_SIZE_I) / BLOCK_SIZE_I, 0);
+        PIPE_BARRIER(V);
+        if (n0Actual % VECTOR_SIZE_I != 0) {
+            SetMask(n0Actual % VECTOR_SIZE_I);
+        }
+        max_v<ArchType::ASCEND_V200, half>(
+            tvUbufTensor,
+            tvUbufTensor,
+            lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + VECTOR_SIZE_I],
+            mActual, 1, 1, 1, 8, 8, n0AlignBlock);
+        PIPE_BARRIER(V);
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        cmax_v<ArchType::ASCEND_V200, half, AscendC::ReduceOrder::ORDER_ONLY_VALUE>(
+            lmUbufTensor,
+            tvUbufTensor,
+            mActual, 1, 1, 8);
+        PIPE_BARRIER(V);
+    }
+    SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+    PIPE_BARRIER(V);
+
+    if (initGgDm == 0) {
+        max_v<ArchType::ASCEND_V200, half>(
+            hmUbufTensor,
+            lmUbufTensor,
+            gmUbufTensor[gmUOffset],
+            1, 1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        sub_v<ArchType::ASCEND_V200, half>(
+            dmUbufTensor[PingFlag * UB_HALF_LINE_SIZE_I],
+            gmUbufTensor[gmUOffset],
+            hmUbufTensor,
+            1, 1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        // Use fm * 2 because both values and indices are returned; 310P does not support ONLY_VALUE.
+        ub_to_ub<ArchType::ASCEND_V200, half>(
+            gmUbufTensor[gmUOffset],
+            hmUbufTensor,
+            0, 1, 2 * fm / BLOCK_SIZE_I, 0, 0);
+        PIPE_BARRIER(V);
+        ExpandToBlockHalf(tvUbufTensor, hmUbufTensor, fm * 2);
+    } else {
+        initGgDm = 0;
+        // Use fm * 2 because both values and indices are returned; 310P does not support ONLY_VALUE.
+        ub_to_ub<ArchType::ASCEND_V200, half>(
+            gmUbufTensor[gmUOffset],
+            lmUbufTensor,
+            0, 1, 2 * fm / BLOCK_SIZE_I, 0, 0);
+        PIPE_BARRIER(V);
+        ExpandToBlockHalf(tvUbufTensor, gmUbufTensor[gmUOffset], fm * 2);
+    }
+
+    if (fn < VECTOR_SIZE_I) {
+        SetMask(fn);
+    }
+    for (uint32_t vSubIdx = 0; vSubIdx < n0AlignVector; vSubIdx++) {
+        sub_v<ArchType::ASCEND_V200, half>(
+            lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + vSubIdx * VECTOR_SIZE_I],
+            lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + vSubIdx * VECTOR_SIZE_I],
+            tvUbufTensor,
+            mActual, 1, 1, 0, fn / BLOCK_SIZE_I, fn / BLOCK_SIZE_I, 2);
+    }
+    if (fn < VECTOR_SIZE_I) {
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    }
+
+    PIPE_BARRIER(V);
+    conv_v<ArchType::ASCEND_V200, half, float>(
+        ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        lsUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        pSizeAlignFloat, 1, 1, 8, 4);
+    PIPE_BARRIER(V);
+    exp_v<ArchType::ASCEND_V200, float>(
+        ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        pSizeAlignFloat, 1, 1, 8, 8);
+    PIPE_BARRIER(V);
+    WAIT_FLAG(MTE3, V, PingFlag);
+    conv_v<ArchType::ASCEND_V200, float, half>(
+        lpUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        pSizeAlignFloat, 1, 1, 4, 8);
+    PIPE_BARRIER(V);
+    SET_FLAG(V, MTE3, PingFlag);
+    SetMaskNorm();
+
+    if (n0Actual < FLOAT_VECTOR_SIZE_I) {
+        if (n0Actual != FLOAT_VECTOR_SIZE_I) {
+            SetVectorMask<int8_t>(0x0, ((long)1 << n0Actual) - 1);
+        }
+        cadd_v<ArchType::ASCEND_V200, float>(
+            llUbufTensor[PingFlag * UB_FLOAT_LINE_SIZE_I],
+            ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            mActual,
+            2,
+            1,
+            fn / BLOCK_SIZE_FLOAT);
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    } else {
+        for (int64_t vcalcIdx = 1; vcalcIdx < n0Actual / FLOAT_VECTOR_SIZE_I; vcalcIdx++) {
+            add_v<ArchType::ASCEND_V200, float>(
+                ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + vcalcIdx * FLOAT_VECTOR_SIZE_I],
+                mActual, 1, 1, 1, fn / BLOCK_SIZE_FLOAT, fn / BLOCK_SIZE_FLOAT, fn / BLOCK_SIZE_FLOAT);
+            PIPE_BARRIER(V);
+        }
+        if (n0Actual % FLOAT_VECTOR_SIZE_I != 0) {
+            SetMask(n0Actual % FLOAT_VECTOR_SIZE_I);
+            add_v<ArchType::ASCEND_V200, float>(
+                ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE +
+                    (n0Actual / FLOAT_VECTOR_SIZE_I) * FLOAT_VECTOR_SIZE_I],
+                mActual, 1, 1, 1, fn / BLOCK_SIZE_FLOAT, fn / BLOCK_SIZE_FLOAT, fn / BLOCK_SIZE_FLOAT);
+            PIPE_BARRIER(V);
+            SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        }
+        cadd_v<ArchType::ASCEND_V200, float>(
+            llUbufTensor[PingFlag * UB_FLOAT_LINE_SIZE_I],
+            ls32UbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            mActual, 2, 1, fn / BLOCK_SIZE_FLOAT);
+    }
+
+    PIPE_BARRIER(V);
+    SetMaskNorm();
+    SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    WAIT_FLAG(MTE1, MTE3, PingFlag);
+    WAIT_FLAG(V, MTE3, PingFlag);
+
+    if (mActual == 1) {
+        ub_to_l1<ArchType::ASCEND_V200, half>(
+            l1pPingBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            lpUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            1, fn / BLOCK_SIZE_I, 0, 0);
+    } else {
+        for (uint32_t fractalBlkIdx = 0; fractalBlkIdx < n0AlignBlock; fractalBlkIdx++) {
+            ub_to_l1<ArchType::ASCEND_V200, half>(
+                l1pPingBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I + fractalBlkIdx * fm * BLOCK_SIZE_I],
+                lpUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * BLOCK_SIZE_I],
+                mActual,
+                1,
+                fn / BLOCK_SIZE_I - 1,
+                0);
+        }
+    }
+
+    SET_FLAG(MTE3, V, PingFlag);
+    SET_FLAG(MTE3, MTE1, PingFlag);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::CalculateSoftmaxPong(
+    const uint32_t fm, const uint32_t bn,
+    const uint32_t mActual, const uint32_t n1Actual,
+    const uint32_t maskType, half localTor,
+    const uint32_t n1AlignVector, const uint32_t n1AlignBlock,
+    const uint32_t pSizeB, const uint32_t pSizeBAlignFloat,
+    const uint32_t gmUOffset,
+    AscendC::LocalTensor<half> &l1pPingBufTensor,
+    AscendC::LocalTensor<half> &l1pPongBufTensor)
+{
+    WAIT_FLAG(M, V, PongFlag);
+    l0c_to_ub<ArchType::ASCEND_V200, float, half>(
+        ls32UbufTensor.ReinterpretCast<half>()[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        l0cBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        1, pSizeB / CUBE_MATRIX_SIZE_I, 0, 0);
+
+    PIPE_BARRIER(V);
+    SET_FLAG(V, M, PongFlag);
+
+    // NZ->ND
+    for (uint32_t fractalBlkIdx = 0; fractalBlkIdx < n1AlignBlock; fractalBlkIdx++) {
+        ub_to_ub<ArchType::ASCEND_V200, half>(
+            lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * BLOCK_SIZE_I],
+            ls32UbufTensor.ReinterpretCast<half>()[
+                PongFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * fm * BLOCK_SIZE_I],
+            0,
+            mActual,
+            1,
+            0,
+            bn / BLOCK_SIZE_I - 1
+        );
+    }
+    PIPE_BARRIER(V);
+
+    AscendC::Muls(lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                  lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                  localTor,
+                  pSizeB);
+    PIPE_BARRIER(V);
+    if (maskType != 0) {
+        WAIT_FLAG(MTE1, V, PongFlag);
+        add_v<ArchType::ASCEND_V200, half>(lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                                           lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                                           maskUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                                           pSizeB / VECTOR_SIZE_I,
+                                           1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        SET_FLAG(V, MTE1, PongFlag);
+    }
+
+    if (n1Actual <= VECTOR_SIZE_I) {
+        if (n1Actual != VECTOR_SIZE_I) {
+            SetMask(n1Actual % VECTOR_SIZE_I);
+        }
+        cmax_v<ArchType::ASCEND_V200, half, AscendC::ReduceOrder::ORDER_ONLY_VALUE>(
+            lmUbufTensor,
+            lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            mActual, 1, 1, n1AlignBlock);
+        PIPE_BARRIER(V);
+    } else {
+        ub_to_ub<ArchType::ASCEND_V200, half>(
+            tvUbufTensor,
+            lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            0, mActual, 8, (bn - VECTOR_SIZE_I) / BLOCK_SIZE_I, 0);
+        PIPE_BARRIER(V);
+        if (n1Actual % VECTOR_SIZE_I != 0) {
+            SetMask(n1Actual % VECTOR_SIZE_I);
+        }
+        max_v<ArchType::ASCEND_V200, half>(
+            tvUbufTensor,
+            tvUbufTensor,
+            lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + VECTOR_SIZE_I],
+            mActual, 1, 1, 1, 8, 8, n1AlignBlock);
+        PIPE_BARRIER(V);
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        cmax_v<ArchType::ASCEND_V200, half, AscendC::ReduceOrder::ORDER_ONLY_VALUE>(
+            lmUbufTensor,
+            tvUbufTensor,
+            mActual, 1, 1, 8);
+        PIPE_BARRIER(V);
+    }
+    SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+
+    PIPE_BARRIER(V);
+    max_v<ArchType::ASCEND_V200, half>(
+        hmUbufTensor,
+        lmUbufTensor,
+        gmUbufTensor[gmUOffset],
+        1, 1, 1, 1, 8, 8, 8);
+    PIPE_BARRIER(V);
+    sub_v<ArchType::ASCEND_V200, half>(
+        dmUbufTensor[PongFlag * UB_HALF_LINE_SIZE_I],
+        gmUbufTensor[gmUOffset],
+        hmUbufTensor,
+        1, 1, 1, 1, 8, 8, 8);
+    PIPE_BARRIER(V);
+    ExpandToBlockHalf(tvUbufTensor, hmUbufTensor, 2 * fm);
+    ub_to_ub<ArchType::ASCEND_V200, half>(
+        gmUbufTensor[gmUOffset],
+        hmUbufTensor,
+        0, 1, 2 * fm / BLOCK_SIZE_I, 0, 0);
+    PIPE_BARRIER(V);
+
+    if (bn < VECTOR_SIZE_I) {
+        SetMask(bn);
+    }
+    for (uint32_t vSubIdx = 0; vSubIdx < n1AlignVector; vSubIdx++) {
+        sub_v<ArchType::ASCEND_V200, half>(
+            lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + vSubIdx * VECTOR_SIZE_I],
+            lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + vSubIdx * VECTOR_SIZE_I],
+            tvUbufTensor,
+            mActual, 1, 1, 0, bn / BLOCK_SIZE_I, bn / BLOCK_SIZE_I, 2);
+    }
+    if (bn < VECTOR_SIZE_I) {
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    }
+
+    PIPE_BARRIER(V);
+    conv_v<ArchType::ASCEND_V200, half, float>(
+        ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        lsUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        pSizeBAlignFloat, 1, 1, 8, 4);
+    PIPE_BARRIER(V);
+    exp_v<ArchType::ASCEND_V200, float>(
+        ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        pSizeBAlignFloat, 1, 1, 8, 8);
+    PIPE_BARRIER(V);
+    WAIT_FLAG(MTE3, V, PongFlag);
+    conv_v<ArchType::ASCEND_V200, float, half>(
+        lpUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        pSizeBAlignFloat, 1, 1, 4, 8);
+    PIPE_BARRIER(V);
+    SET_FLAG(V, MTE3, PongFlag);
+    SetMaskNorm();
+
+    if (n1Actual < FLOAT_VECTOR_SIZE_I) {
+        if (n1Actual != FLOAT_VECTOR_SIZE_I) {
+            SetVectorMask<int8_t>(0x0, ((long)1 << n1Actual) - 1);
+        }
+        cadd_v<ArchType::ASCEND_V200, float>(
+            llUbufTensor[PongFlag * UB_FLOAT_LINE_SIZE_I],
+            ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            mActual,
+            2,
+            1,
+            bn / BLOCK_SIZE_FLOAT);
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    } else {
+        for (int64_t vcalcIdx = 1; vcalcIdx < n1Actual / FLOAT_VECTOR_SIZE_I; vcalcIdx++) {
+            add_v<ArchType::ASCEND_V200, float>(
+                ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + vcalcIdx * FLOAT_VECTOR_SIZE_I],
+                mActual,
+                1,
+                1,
+                1,
+                bn / BLOCK_SIZE_FLOAT,
+                bn / BLOCK_SIZE_FLOAT,
+                bn / BLOCK_SIZE_FLOAT);
+            PIPE_BARRIER(V);
+        }
+        if (n1Actual % FLOAT_VECTOR_SIZE_I != 0) {
+            SetVectorMask<int8_t>(0x0, ((long)1 << (n1Actual % FLOAT_VECTOR_SIZE_I)) - 1);
+            add_v<ArchType::ASCEND_V200, float>(
+                ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+                ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE +
+                    (n1Actual / FLOAT_VECTOR_SIZE_I) * FLOAT_VECTOR_SIZE_I],
+                mActual,
+                1,
+                1,
+                1,
+                bn / BLOCK_SIZE_FLOAT,
+                bn / BLOCK_SIZE_FLOAT,
+                bn / BLOCK_SIZE_FLOAT);
+            PIPE_BARRIER(V);
+            SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        }
+        // Set dstRepStride to 2 to match cmax, because max also returns an index needed to update row sums.
+        cadd_v<ArchType::ASCEND_V200, float>(
+            llUbufTensor[PongFlag * UB_FLOAT_LINE_SIZE_I],
+            ls32UbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            mActual, 2, 1, bn / BLOCK_SIZE_FLOAT);
+    }
+
+    PIPE_BARRIER(V);
+    SetMaskNorm();
+    SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    WAIT_FLAG(MTE1, MTE3, PongFlag);
+    WAIT_FLAG(V, MTE3, PongFlag);
+
+    if (mActual == 1) {
+        ub_to_l1<ArchType::ASCEND_V200, half>(
+            l1pPongBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            lpUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            1, bn / BLOCK_SIZE_I, 0, 0);
+    } else {
+        for (uint32_t fractalBlkIdx = 0; fractalBlkIdx < n1AlignBlock; fractalBlkIdx++) {
+            ub_to_l1<ArchType::ASCEND_V200, half>(
+                l1pPingBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I + fractalBlkIdx * fm * BLOCK_SIZE_I],
+                lpUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * BLOCK_SIZE_I],
+                mActual,
+                1,
+                bn / BLOCK_SIZE_I - 1,
+                0);
+        }
+    }
+    SET_FLAG(MTE3, V, PongFlag);
+    SET_FLAG(MTE3, MTE1, PongFlag);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::CalculatePVPing(
+    const uint32_t fm, const uint32_t fn, const uint32_t fk,
+    const uint32_t mActual, const uint32_t n0Actual,
+    const uint32_t initKVE, const uint32_t n1Actual,
+    AscendC::LocalTensor<half> &l1pPingBufTensor)
+{
+    WAIT_FLAG(MTE3, MTE1, PingFlag);
+    WAIT_FLAG(M, MTE1, PingFlag);
+    if (mActual == 1) {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+            l0aBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            l1pPingBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            0, 1, 0, 1, 0, 0);
+    } else {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::NZ, DataFormatT::ZZ>(
+            l0aBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            l1pPingBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+            fm, fn, 0, 0, 0, 0);
+    }
+
+    SET_FLAG(MTE1, MTE3, PingFlag);
+    SET_FLAG(MTE1, M, PingFlag);
+    WAIT_FLAG(MTE1, M, PingFlag);
+    WAIT_FLAG(MTE1, M, PingFlag + 2);
+    WAIT_FLAG(V, M, PingFlag);
+
+    mmad<ArchType::ASCEND_V200, half, half, float, false>(
+        l0cBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        l0aBufTensor.ReinterpretCast<half>()[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        l0bBufTensor.ReinterpretCast<half>()[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        mActual, fk, n0Actual, 1);
+
+    SET_FLAG(M, MTE1, PingFlag);
+    SET_FLAG(M, MTE1, PingFlag + 2);
+    SET_FLAG(M, V, PingFlag);
+    if (initKVE) {
+        SET_FLAG(MTE1, MTE2, PingFlag);
+        if (n1Actual == 0) {
+            SET_FLAG(MTE1, MTE2, PongFlag);
+        }
+    }
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::CalculatePVPong(
+    const uint32_t fm, const uint32_t bn, const uint32_t fk,
+    const uint32_t mActual, const uint32_t n1Actual,
+    const uint32_t initKVE,
+    AscendC::LocalTensor<half> &l1pPingBufTensor,
+    AscendC::LocalTensor<half> &l1pPongBufTensor)
+{
+    WAIT_FLAG(MTE3, MTE1, PongFlag);
+    WAIT_FLAG(M, MTE1, PongFlag);
+    if (mActual == 1) {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::VECTOR, DataFormatT::VECTOR>(
+            l0aBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            l1pPongBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            0, 1, 0, 1, 0, 0);
+    } else {
+        l1_to_l0_a<ArchType::ASCEND_V200, half, false, DataFormatT::NZ, DataFormatT::ZZ>(
+            l0aBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            l1pPingBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            fm, bn, 0, 0, 0, 0);
+    }
+    SET_FLAG(MTE1, MTE3, PongFlag);
+    SET_FLAG(MTE1, M, PongFlag);
+    WAIT_FLAG(MTE1, M, PongFlag);
+    WAIT_FLAG(MTE1, M, PongFlag + 2);
+    WAIT_FLAG(V, M, PongFlag);
+
+    mmad<ArchType::ASCEND_V200, half, half, float, false>(
+        l0cBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        l0aBufTensor.ReinterpretCast<half>()[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        l0bBufTensor.ReinterpretCast<half>()[PongFlag * L0AB_HALF_BUF_SIZE_I],
+        mActual, fk, n1Actual, 1);
+
+    SET_FLAG(M, MTE1, PongFlag);
+    SET_FLAG(M, MTE1, PongFlag + 2);
+    SET_FLAG(M, V, PongFlag);
+    if (initKVE) {
+        SET_FLAG(MTE1, MTE2, PongFlag);
+    }
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::MovePVResultsToUb(
+    const uint32_t fm, const uint32_t fk,
+    const uint32_t mActual, const uint32_t oSize,
+    const uint32_t n1Actual)
+{
+    WAIT_FLAG(M, V, PingFlag);
+    l0c_to_ub<ArchType::ASCEND_V200, float, float>(
+        lsUbufTensor.ReinterpretCast<float>(),
+        l0cBufTensor[PingFlag * L0AB_HALF_BUF_SIZE_I],
+        1, oSize / CUBE_MATRIX_SIZE_I, 0, 0);
+    PIPE_BARRIER(V);
+
+    for (uint32_t fractalBlkIdx = 0; fractalBlkIdx < fk / BLOCK_SIZE_I; fractalBlkIdx++) {
+        ub_to_ub<ArchType::ASCEND_V200, float>(
+            loUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * BLOCK_SIZE_I],
+            lsUbufTensor.ReinterpretCast<float>()[fractalBlkIdx * fm * BLOCK_SIZE_I],
+            0,
+            mActual,
+            2,
+            0,
+            2 * fk / BLOCK_SIZE_I - 2
+        );
+    }
+    PIPE_BARRIER(V);
+
+    if (n1Actual != 0) {
+        WAIT_FLAG(M, V, PongFlag);
+        l0c_to_ub<ArchType::ASCEND_V200, float, float>(
+            lsUbufTensor.ReinterpretCast<float>()[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            l0cBufTensor[PongFlag * L0AB_HALF_BUF_SIZE_I],
+            1, oSize / CUBE_MATRIX_SIZE_I, 0, 0);
+        PIPE_BARRIER(V);
+
+        for (uint32_t fractalBlkIdx = 0; fractalBlkIdx < fk / BLOCK_SIZE_I; fractalBlkIdx++) {
+            ub_to_ub<ArchType::ASCEND_V200, float>(
+                loUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * BLOCK_SIZE_I],
+                lsUbufTensor.ReinterpretCast<float>()[
+                    PongFlag * LOCAL_STORAGE_BUFFER_SIZE + fractalBlkIdx * fm * BLOCK_SIZE_I],
+                0,
+                mActual,
+                2,
+                0,
+                2 * fk / BLOCK_SIZE_I - 2
+            );
+        }
+        PIPE_BARRIER(V);
+    }
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::UpdateOnlineSoftmaxPing(
+    const uint32_t fm, const uint32_t fk,
+    const uint32_t mActual, const uint32_t kAlignVector,
+    const uint32_t oSizeAlignFloat,
+    const uint32_t glUOffset, const uint32_t goUOffset,
+    uint32_t &initGgO)
+{
+    if (initGgO == 0) {
+        conv_v<ArchType::ASCEND_V200, half, float>(
+            tvUbufTensor.ReinterpretCast<float>(),
+            dmUbufTensor[PingFlag * UB_HALF_LINE_SIZE_I],
+            1, 1, 1, uint16_t(8), uint16_t(4));
+        PIPE_BARRIER(V);
+        exp_v<ArchType::ASCEND_V200, float>(
+            tvUbufTensor.ReinterpretCast<float>(),
+            tvUbufTensor.ReinterpretCast<float>(),
+            1, 1, 1, uint16_t(8), uint16_t(8));
+        PIPE_BARRIER(V);
+        SetMask(2 * fm);
+        mul_v<ArchType::ASCEND_V200, float>(
+            glUbufTensor[glUOffset],
+            tvUbufTensor.ReinterpretCast<float>(),
+            glUbufTensor[glUOffset],
+            1, 1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        add_v<ArchType::ASCEND_V200, float>(
+            glUbufTensor[glUOffset],
+            glUbufTensor[glUOffset],
+            llUbufTensor[PingFlag * UB_FLOAT_LINE_SIZE_I],
+            1, 1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        ExpandToBlockHalf(tvUbufTensor, dmUbufTensor[PingFlag * UB_HALF_LINE_SIZE_I], 2 * fm);
+
+        // (fm, 16) -> (fm, fk)
+        // Place it later in the buffer so the half-to-float conversion can run in place.
+        if (fk < VECTOR_SIZE_I) {
+            SetMask(fk % VECTOR_SIZE_I);
+        }
+        for (uint32_t mIdx = 0; mIdx < mActual; mIdx++) {
+            // Multiply by 2 because the max result contains both value and index parts.
+            adds_v<ArchType::ASCEND_V200, half>(
+                tvUbufTensor[L0AB_HALF_BUF_SIZE_I - fm * fk + mIdx * fk],
+                tvUbufTensor[mIdx * BLOCK_SIZE_I * 2],
+                0.0, kAlignVector, 1, 0, 8, 0);
+            PIPE_BARRIER(V);
+        }
+        if (fk < VECTOR_SIZE_I) {
+            SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        }
+
+        conv_v<ArchType::ASCEND_V200, half, float>(
+            tvUbufTensor.ReinterpretCast<float>(),
+            tvUbufTensor[L0AB_HALF_BUF_SIZE_I - fm * fk],
+            oSizeAlignFloat, 1, 1, uint16_t(8), uint16_t(4));
+        PIPE_BARRIER(V);
+        exp_v<ArchType::ASCEND_V200, float>(
+            tvUbufTensor.ReinterpretCast<float>(),
+            tvUbufTensor.ReinterpretCast<float>(),
+            oSizeAlignFloat, 1, 1, uint16_t(8), uint16_t(8));
+        PIPE_BARRIER(V);
+        if (vmPingPongFlag == 1) {
+            WAIT_FLAG(MTE3, V, EVENT_ID2);
+            vmPingPongFlag = 0;
+        }
+        mul_v<ArchType::ASCEND_V200, float>(
+            goUbufTensor[goUOffset],
+            goUbufTensor[goUOffset],
+            tvUbufTensor.ReinterpretCast<float>(),
+            oSizeAlignFloat, 1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+        add_v<ArchType::ASCEND_V200, float>(
+            goUbufTensor[goUOffset],
+            goUbufTensor[goUOffset],
+            loUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            oSizeAlignFloat, 1, 1, 1, 8, 8, 8);
+        PIPE_BARRIER(V);
+    } else {
+        ub_to_ub<ArchType::ASCEND_V200, float>(
+            glUbufTensor[glUOffset],
+            llUbufTensor[PingFlag * UB_FLOAT_LINE_SIZE_I],
+            0, 1, 2 * fm / BLOCK_SIZE_FLOAT, 0, 0);
+        PIPE_BARRIER(V);
+        if (vmPingPongFlag == 1) {
+            WAIT_FLAG(MTE3, V, EVENT_ID2);
+            vmPingPongFlag = 0;
+        }
+        ub_to_ub<ArchType::ASCEND_V200, float>(
+            goUbufTensor[goUOffset],
+            loUbufTensor[PingFlag * LOCAL_STORAGE_BUFFER_SIZE],
+            0, 1, fm * fk / BLOCK_SIZE_FLOAT, 0, 0);
+        PIPE_BARRIER(V);
+    }
+    PIPE_BARRIER(V);
+    initGgO = 0;
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::UpdateOnlineSoftmaxPong(
+    const uint32_t fm, const uint32_t fk,
+    const uint32_t mActual, const uint32_t kAlignVector,
+    const uint32_t oSizeAlignFloat,
+    const uint32_t n1Actual,
+    const uint32_t glUOffset, const uint32_t goUOffset)
+{
+    conv_v<ArchType::ASCEND_V200, half, float>(
+        tvUbufTensor.ReinterpretCast<float>(),
+        dmUbufTensor[PongFlag * UB_HALF_LINE_SIZE_I],
+        1, 1, 1, uint16_t(8), uint16_t(4));
+    PIPE_BARRIER(V);
+    exp_v<ArchType::ASCEND_V200, float>(
+        tvUbufTensor.ReinterpretCast<float>(),
+        tvUbufTensor.ReinterpretCast<float>(),
+        1, 1, 1, uint16_t(8), uint16_t(8));
+    PIPE_BARRIER(V);
+    SetMask(2 * fm);
+    mul_v<ArchType::ASCEND_V200, float>(
+        glUbufTensor[glUOffset],
+        tvUbufTensor.ReinterpretCast<float>(),
+        glUbufTensor[glUOffset],
+        1, 1, 1, 1, 8, 8, 8);
+    PIPE_BARRIER(V);
+    add_v<ArchType::ASCEND_V200, float>(
+        glUbufTensor[glUOffset],
+        glUbufTensor[glUOffset],
+        llUbufTensor[PongFlag * UB_FLOAT_LINE_SIZE_I],
+        1, 1, 1, 1, 8, 8, 8);
+    PIPE_BARRIER(V);
+    SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    ExpandToBlockHalf(tvUbufTensor, dmUbufTensor[PongFlag * UB_HALF_LINE_SIZE_I], 2 * fm);
+
+    if (fk < VECTOR_SIZE_I) {
+        SetMask(fk % VECTOR_SIZE_I);
+    }
+    for (uint32_t mIdx = 0; mIdx < mActual; mIdx++) {
+        adds_v<ArchType::ASCEND_V200, half>(
+            tvUbufTensor[L0AB_HALF_BUF_SIZE_I - fm * fk + mIdx * fk],
+            tvUbufTensor[mIdx * BLOCK_SIZE_I * 2],
+            0.0, kAlignVector, 1, 0, 8, 0);
+        PIPE_BARRIER(V);
+    }
+    if (fk < VECTOR_SIZE_I) {
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    }
+
+    conv_v<ArchType::ASCEND_V200, half, float>(
+        tvUbufTensor.ReinterpretCast<float>(),
+        tvUbufTensor[L0AB_HALF_BUF_SIZE_I - fm * fk],
+        oSizeAlignFloat, 1, 1, uint16_t(8), uint16_t(4));
+    PIPE_BARRIER(V);
+    exp_v<ArchType::ASCEND_V200, float>(
+        tvUbufTensor.ReinterpretCast<float>(),
+        tvUbufTensor.ReinterpretCast<float>(),
+        oSizeAlignFloat, 1, 1, uint16_t(8), uint16_t(8));
+    PIPE_BARRIER(V);
+
+    if (vmPingPongFlag == 1) {
+        WAIT_FLAG(MTE3, V, EVENT_ID2);
+        vmPingPongFlag = 0;
+    }
+
+    mul_v<ArchType::ASCEND_V200, float>(
+        goUbufTensor[goUOffset],
+        goUbufTensor[goUOffset],
+        tvUbufTensor.ReinterpretCast<float>(),
+        oSizeAlignFloat, 1, 1, 1, 8, 8, 8);
+
+    PIPE_BARRIER(V);
+    add_v<ArchType::ASCEND_V200, float>(
+        goUbufTensor[goUOffset],
+        goUbufTensor[goUOffset],
+        loUbufTensor[PongFlag * LOCAL_STORAGE_BUFFER_SIZE],
+        oSizeAlignFloat, 1, 1, 1, 8, 8, 8);
+    PIPE_BARRIER(V);
+    SET_FLAG(V, M, PongFlag);
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::NormalizeAndStoreOutput(
+    const uint32_t fm, const uint32_t fk,
+    const uint32_t mActual, const uint32_t oSizeAlignFloat,
+    const uint32_t glUOffset, const uint32_t goUOffset,
+    const uint32_t wrapO)
+{
+    if (wrapO == 1) {
+        SetMask(fm * 2);
+        conv_v<ArchType::ASCEND_V200, float, half>(
+            glUbufTensor[glUOffset].ReinterpretCast<half>(),
+            glUbufTensor[glUOffset],
+            1, 1, 1, uint16_t(4), uint16_t(8));
+        PIPE_BARRIER(V);
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        conv_v<ArchType::ASCEND_V200, float, half>(
+            goUbufTensor[goUOffset].ReinterpretCast<half>(),
+            goUbufTensor[goUOffset],
+            oSizeAlignFloat, 1, 1, uint16_t(4), uint16_t(8));
+        PIPE_BARRIER(V);
+        ExpandToBlockHalf(tvUbufTensor, glUbufTensor[glUOffset].ReinterpretCast<half>(), 2 * fm);
+
+        SetVectorMask<int8_t>(0x0, ((long)1 << (16)) - 1);
+
+        for (int32_t vdivIdx = 0; vdivIdx < (fk / BLOCK_SIZE_I); ++vdivIdx) { // Oi / li
+            div_v<ArchType::ASCEND_V200, half>(
+                goUbufTensor[goUOffset].ReinterpretCast<half>()[vdivIdx * BLOCK_SIZE_I],
+                goUbufTensor[goUOffset].ReinterpretCast<half>()[vdivIdx * BLOCK_SIZE_I],
+                tvUbufTensor,
+                mActual,
+                1,
+                1,
+                1,
+                fk / BLOCK_SIZE_I,
+                fk / BLOCK_SIZE_I,
+                2);
+            PIPE_BARRIER(V);
+        }
+        SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+        PIPE_BARRIER(V);
+        SET_FLAG(V, MTE3, EVENT_ID2);
+        WAIT_FLAG(V, MTE3, EVENT_ID2);
+
+        ub_to_gm<ArchType::ASCEND_V200, half>(
+                gmDstOTensor[(int64_t)dstoOffset],
+                goUbufTensor[goUOffset].ReinterpretCast<half>(),
+                0,
+                mActual,
+                fk / BLOCK_SIZE_I,
+                0,
+                (qHeadNum - 1) * fk / BLOCK_SIZE_I);
+
+        if (vmPingPongFlag == 0) {
+            SET_FLAG(MTE3, V, EVENT_ID2);
+            vmPingPongFlag = 1;
+        }
+    }
+}
+
+template<>
+__aicore__ inline void PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT>::ProcessKvBlockPair(
+    // fm      : Aligned Q-block length. mActual is rounded up to 16 for buffer sizing and loop bounds.
+    const uint32_t fm,
+    // fn      : Aligned first KV-block length. n0Actual is rounded up to 16 and defines the first QK^T width.
+    const uint32_t fn,
+    // fk      : Head dimension rounded up to 16. It determines the output matrix width.
+    const uint32_t fk,
+    // bn      : Aligned second KV-block length. n1Actual is rounded up to 16; valid when n1Actual > 0.
+    const uint32_t bn,
+    // mActual : Actual token count in the current Q block without padding; controls row-wise vector loops.
+    const uint32_t mActual,
+    // n0Actual: Actual token count in the first KV block; defines the matmul K range and valid softmax columns.
+    const uint32_t n0Actual,
+    // n1Actual: Actual token count in the second KV block, or 0 when this iteration has no second block.
+    const uint32_t n1Actual,
+    // maskType: Attention-mask switch. A nonzero value adds the preloaded mask to the attention scores.
+    const uint32_t maskType,
+    // initKVE : End flag. Set to 1 after the last Q head processes this KV block, allowing buffer release.
+    const uint32_t initKVE,
+    // headOffset: Q-head offset in the GQA group [0, groupNum - 1], used for Q, mask, and output UB offsets.
+    const uint32_t headOffset,
+    // initKV   : Whether K/V must be loaded from GM to L1. The first Q head loads; later heads reuse.
+    const uint32_t initKV,
+    // localTor : Local scale, usually 1/sqrt(d), used when scaleType is nonzero.
+    half localTor,
+    // scaleType: Scale selector. Use the global tor for 0 and the provided localTor otherwise.
+    const uint32_t scaleType)
+{
+    if (scaleType == 0) {
+        localTor = tor;
+    }
+
+    AscendC::LocalTensor<half> l1kPingBufTensor =
+        l1kBufAddrTensor.ReinterpretCast<uint8_t>()[PingFlag * 4 * L1_UINT8_BLOCK_SIZE].ReinterpretCast<half>();
+    AscendC::LocalTensor<half> l1kPongBufTensor =
+        l1kBufAddrTensor.ReinterpretCast<uint8_t>()[PongFlag * 4 * L1_UINT8_BLOCK_SIZE].ReinterpretCast<half>();
+    AscendC::LocalTensor<half> l1vPingBufTensor =
+        l1vBufAddrTensor.ReinterpretCast<uint8_t>()[PingFlag * 4 * L1_UINT8_BLOCK_SIZE].ReinterpretCast<half>();
+    AscendC::LocalTensor<half> l1vPongBufTensor =
+        l1vBufAddrTensor.ReinterpretCast<uint8_t>()[PongFlag * 4 * L1_UINT8_BLOCK_SIZE].ReinterpretCast<half>();
+    AscendC::LocalTensor<half> l1pPingBufTensor =
+        l1pBufAddrTensor.ReinterpretCast<uint8_t>()[PingFlag * 4 * L1_UINT8_BLOCK_SIZE].ReinterpretCast<half>();
+    AscendC::LocalTensor<half> l1pPongBufTensor =
+        l1pBufAddrTensor.ReinterpretCast<uint8_t>()[PongFlag * 4 * L1_UINT8_BLOCK_SIZE].ReinterpretCast<half>();
+
+    uint32_t oSize = fm * fk;
+    uint32_t kAlignFloat = (fk + FLOAT_VECTOR_SIZE_I - 1) / FLOAT_VECTOR_SIZE_I;
+    uint32_t oSizeAlignFloat = (oSize + FLOAT_VECTOR_SIZE_I - 1) / FLOAT_VECTOR_SIZE_I;
+    uint32_t kAlignVector = (fk + VECTOR_SIZE_I - 1) / VECTOR_SIZE_I;
+    uint32_t n0AlignVector = (fn + VECTOR_SIZE_I - 1) / VECTOR_SIZE_I;
+    uint32_t n1AlignVector = (bn + VECTOR_SIZE_I - 1) / VECTOR_SIZE_I;
+    uint32_t n0AlignBlock = (fn + BLOCK_SIZE_I - 1) / BLOCK_SIZE_I;
+    uint32_t n1AlignBlock = (bn + BLOCK_SIZE_I - 1) / BLOCK_SIZE_I;
+    uint32_t initGgDm = (initG == 1) ? 1 : 0;
+    uint32_t initGgO = (initG == 1) ? 1 : 0;
+    uint32_t initKVG = (initG && initKV) ? 1 : 0; // synchronization for head loop start
+    uint32_t qOffset = headOffset * fm * FLOAT_VECTOR_SIZE_I * kAlignFloat;
+    uint32_t gmUOffset = headOffset * fm * BLOCK_SIZE_I;
+    uint32_t glUOffset = gmUOffset;
+    uint32_t goUOffset = qOffset;
+
+    uint32_t pSize = fm * fn;
+    uint32_t pSizeB = fm * bn;
+    uint32_t pSizeAlignFloat = (pSize + FLOAT_VECTOR_SIZE_I - 1) / FLOAT_VECTOR_SIZE_I;
+    uint32_t pSizeBAlignFloat = (pSizeB + FLOAT_VECTOR_SIZE_I - 1) / FLOAT_VECTOR_SIZE_I;
+
+    // 1. ################ Bmm1 Ping Start #######################
+    LoadQueryAndAttentionMask(fm, fn, fk, bn, mActual, n1Actual, maskType, initGgO, initKVG, qOffset);
+
+    WAIT_FLAG(M, MTE1, PingFlag);
+    MoveQKPingToL0(fm, fn, fk, mActual, initGgO, initKV, qOffset, l1kPingBufTensor);
+
+    // 2. ################ Bmm1 Pong Starts #######################
+    // 2.1 ################ QK Pong PRELOAD ################
+    if (n1Actual != 0) {
+        MoveQKPongToL0(fm, bn, fk, mActual, n1Actual, initGgO, initKV, qOffset, l1kPongBufTensor);
+    }
+    // 1.2 ################ Bmm1 Ping + V PRELOAD ################
+    CalculateQKPingAndPrepareV(fm, fn, fk, mActual, n0Actual, initKV, l1vPingBufTensor);
+
+    // 1. ################ Bmm1 Ping Ends #######################
+    // 2.2 ################ Bmm1 Pong + V PRELOAD ################
+    if (n1Actual != 0) {
+        CalculateQKPongAndPrepareV(fm, bn, fk, mActual, n1Actual, initKV, l1vPongBufTensor);
+    }
+    // 2. ################ Bmm1 Pong Ends #######################
+    SetVectorMask<int8_t>(0xffffffffffffffff, 0xffffffffffffffff);
+    // 3. ################ Softmax Ping Starts #######################
+    CalculateSoftmaxPing(fm, fn, mActual, n0Actual, maskType, localTor,
+                        n0AlignVector, n0AlignBlock, pSize, pSizeAlignFloat,
+                        gmUOffset, initGgDm, l1pPingBufTensor);
+    // 3. ################ Softmax Ping Ends #######################
+    // 4. ################ Softmax Pong Starts #######################
+    if (n1Actual != 0) {
+        CalculateSoftmaxPong(fm, bn, mActual, n1Actual, maskType, localTor,
+                            n1AlignVector, n1AlignBlock, pSizeB, pSizeBAlignFloat,
+                            gmUOffset, l1pPingBufTensor, l1pPongBufTensor);
+    }
+    // 4. ################ Softmax Pong Ends #######################
+    // 5. ################ Bmm2 Ping Starts #######################
+    CalculatePVPing(fm, fn, fk, mActual, n0Actual, initKVE, n1Actual, l1pPingBufTensor);
+    // 5. ################ Bmm2 Ping Ends #######################
+    // 6. ################ Bmm2 Pong Starts #######################
+    if (n1Actual != 0) {
+        CalculatePVPong(fm, bn, fk, mActual, n1Actual, initKVE, l1pPingBufTensor, l1pPongBufTensor);
+    }
+    // 6. ################ Bmm2 Pong Ends #######################
+    // 7. ################ Move PV Results Starts #####################
+    MovePVResultsToUb(fm, fk, mActual, oSize, n1Actual);
+    // 7. ################ Move PV Results Ends #######################
+    // 8. ################ Update Ping Starts #######################
+    UpdateOnlineSoftmaxPing(fm, fk, mActual, kAlignVector, oSizeAlignFloat, glUOffset, goUOffset, initGgO);
+    // 8. ################ Update Ping Ends #######################
+    // 9. ################ Update Pong Starts #######################
+    if (n1Actual != 0) {
+        UpdateOnlineSoftmaxPong(fm, fk, mActual, kAlignVector, oSizeAlignFloat, n1Actual, glUOffset, goUOffset);
+    }
+    SET_FLAG(V, M, PingFlag);
+    // 9. ################ Update Pong Ends #######################
+    // 10. ################ Line Output Starts #####################
+    NormalizeAndStoreOutput(fm, fk, mActual, oSizeAlignFloat, glUOffset, goUOffset, wrapO);
+}
+
+template <typename IFAT>
+class PagedAttentionDecoderMask {
+public:
+    __aicore__ inline PagedAttentionDecoderMask(){};
+    __aicore__ inline void Init(
+        __gm__ uint8_t *query, __gm__ uint8_t *key, __gm__ uint8_t *value,
+        __gm__ uint8_t *attenMask, __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengths,
+        __gm__ uint8_t *blockTable,  __gm__ uint8_t *attentionOut,
+        __gm__ uint8_t *workspace, const typename IFAT::TilingType *__restrict tiling);
+    __aicore__ inline void Process();
+
+protected:
+    const typename IFAT::TilingType *__restrict tilingData_ = nullptr;
+
+    GlobalTensor<int64_t> promptLensGmTensor_;
+    GlobalTensor<int64_t> contextLensGmTensor_;
+    GlobalTensor<int32_t> blockTablesGmTensor_;
+    
+    uint32_t numTokens_ = 0;
+    uint32_t numHeads_ = 0;
+    uint32_t embeddingSize_ = 0;
+    uint32_t blockSize_ = 0;
+    uint32_t maxNumBlocksPerQuery_ = 0;
+    half tor_ = 0;
+    uint32_t kvHeads_ = 0;
+    uint32_t groupNum_ = 0;
+    uint32_t scaleType_ = 0;
+    uint32_t headSplit_ = 1;
+    uint32_t maskType_ = 0;
+    int64_t headMaskStride_ = 0;
+    int64_t batchMaskStride_ = 0;
+    uint32_t maxTokensQ_ = 1;
+    uint32_t maskKvLen_ = 0;
+
+    uint32_t seqStepQ_ = 0;
+    uint32_t startBatchId_ = 0;
+    uint32_t qBlkNumByStartBatch_ = 0;
+    uint32_t endBatchId_ = 0;
+
+    uint32_t startTaskId_ = 0;
+    uint32_t endTaskId_ = 0;
+    
+    __gm__ uint8_t *query_;
+    __gm__ uint8_t *key_;
+    __gm__ uint8_t *value_;
+    __gm__ uint8_t *attenMask_;
+    __gm__ uint8_t *attentionOut_;
+
+    template <typename NumT> __aicore__ inline NumT Align(NumT num, NumT rnd) const
+    {
+        return (((rnd) == 0) ? 0 : (((num) + (rnd) - 1) / (rnd) * (rnd)));
+    }
+
+    // ==========================================
+    // Offset Calculators
+    // ==========================================
+    __aicore__ inline uint32_t GetTndQueryPrefix(uint32_t batchId) const
+    {
+        uint32_t prefix = 0;
+        for (uint32_t b = 0; b < batchId; ++b) {
+            prefix += static_cast<uint32_t>(promptLensGmTensor_.GetValue(b));
+        }
+        return prefix;
+    }
+
+    __aicore__ inline uint64_t GetQOffsetTndVarlen(uint32_t batchId, uint32_t qSeqBlockIdx, uint32_t headId) const
+    {
+        uint32_t tokenStart = GetTndQueryPrefix(batchId) + qSeqBlockIdx * seqStepQ_;
+        return static_cast<uint64_t>(tokenStart) * numHeads_ * embeddingSize_ +
+               static_cast<uint64_t>(headId) * embeddingSize_;
+    }
+
+    __aicore__ inline uint64_t GetQOffset(uint32_t curBatch, uint32_t qSeqBlockIdx, uint32_t headId) const
+    {
+        return static_cast<uint64_t>(curBatch) * embeddingSize_ * numHeads_ * maxTokensQ_ +
+               static_cast<uint64_t>(qSeqBlockIdx) * seqStepQ_ * embeddingSize_ * numHeads_ +
+               static_cast<uint64_t>(headId) * embeddingSize_;
+    }
+
+    __aicore__ inline uint64_t GetMaskOffset(uint32_t curBatch, uint32_t qSeqBlockIdx, uint32_t nIdx, uint32_t headId) const
+    {
+        return static_cast<uint64_t>(curBatch) * batchMaskStride_ +
+               static_cast<uint64_t>(qSeqBlockIdx) * seqStepQ_ * maskKvLen_ +
+               static_cast<uint64_t>(nIdx) * blockSize_ +
+               static_cast<uint64_t>(headId) * headMaskStride_;
+    }
+
+    __aicore__ inline uint64_t GetBlockTableIndex(uint32_t curBatch, uint32_t nIdx) const
+    {
+        return static_cast<uint64_t>(curBatch) * maxNumBlocksPerQuery_ + nIdx;
+    }
+
+    // ==========================================
+    // Core Methods
+    // ==========================================
+    __aicore__ inline void LoadTilingParameters();
+    __aicore__ inline void LocateTaskRangeStart();
+    
+    __aicore__ inline bool AdvanceToNextBatch(uint32_t& curBatch, uint32_t& qBlkNumByCurBatch, uint32_t& qBlkNumCurBatch,
+                                        uint32_t& promptLenCurBatch, uint32_t& contextLenCurBatch, uint32_t& qSeqBlockNum) const 
+    {
+        curBatch += 1;
+        if (curBatch >= numTokens_) {
+            return false;
+        }
+        qBlkNumByCurBatch += qBlkNumCurBatch;
+        promptLenCurBatch = static_cast<uint32_t>(promptLensGmTensor_.GetValue(curBatch));
+        contextLenCurBatch = static_cast<uint32_t>(contextLensGmTensor_.GetValue(curBatch));
+        qSeqBlockNum = (promptLenCurBatch + seqStepQ_ - 1) / seqStepQ_;
+        qBlkNumCurBatch = qSeqBlockNum * numHeads_;
+        return true;
+    }
+
+    __aicore__ inline void ProcessAssignedTasks(PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT> &pa);
+
+    __aicore__ inline void InitializePipelineEvents()
+    {
+        SET_FLAG(M, MTE1, EVENT_ID0);
+        SET_FLAG(M, MTE1, EVENT_ID1);
+        SET_FLAG(M, MTE1, EVENT_ID2);
+        SET_FLAG(M, MTE1, EVENT_ID3);
+        SET_FLAG(V, M, EVENT_ID0);
+        SET_FLAG(V, M, EVENT_ID1);
+        SET_FLAG(V, M, EVENT_ID2);
+        SET_FLAG(V, M, EVENT_ID3);
+        SET_FLAG(V, MTE1, EVENT_ID0);
+        SET_FLAG(V, MTE1, EVENT_ID1);
+        SET_FLAG(MTE3, V, EVENT_ID0);
+        SET_FLAG(MTE3, V, EVENT_ID1);
+        SET_FLAG(MTE3, V, EVENT_ID2);
+        SET_FLAG(MTE3, V, EVENT_ID3);
+        SET_FLAG(MTE1, MTE3, EVENT_ID0);
+        SET_FLAG(MTE1, MTE3, EVENT_ID1);
+        SET_FLAG(MTE1, MTE2, EVENT_ID0);
+        SET_FLAG(MTE1, MTE2, EVENT_ID1);
+        SET_FLAG(MTE1, MTE2, EVENT_ID2);
+        SET_FLAG(MTE1, MTE2, EVENT_ID3);
+        SET_FLAG(MTE1, MTE2, EVENT_ID4);
+        SET_FLAG(MTE1, MTE2, EVENT_ID5);
+        SET_FLAG(MTE1, MTE2, EVENT_ID6);
+        SET_FLAG(MTE1, MTE2, EVENT_ID7);
+    }
+
+    __aicore__ inline void FinalizePipelineEvents()
+    {
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID0);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID1);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID2);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID3);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID4);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID5);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID6);
+        WAIT_FLAG(MTE1, MTE2, EVENT_ID7);
+        WAIT_FLAG(V, MTE1, EVENT_ID0);
+        WAIT_FLAG(V, MTE1, EVENT_ID1);
+        WAIT_FLAG(MTE1, MTE3, EVENT_ID0);
+        WAIT_FLAG(MTE1, MTE3, EVENT_ID1);
+        WAIT_FLAG(MTE3, V, EVENT_ID0);
+        WAIT_FLAG(MTE3, V, EVENT_ID1);
+        WAIT_FLAG(MTE3, V, EVENT_ID2);
+        WAIT_FLAG(MTE3, V, EVENT_ID3);
+        WAIT_FLAG(V, M, EVENT_ID0);
+        WAIT_FLAG(V, M, EVENT_ID1);
+        WAIT_FLAG(V, M, EVENT_ID2);
+        WAIT_FLAG(V, M, EVENT_ID3);
+        WAIT_FLAG(M, MTE1, EVENT_ID0);
+        WAIT_FLAG(M, MTE1, EVENT_ID1);
+        WAIT_FLAG(M, MTE1, EVENT_ID2);
+        WAIT_FLAG(M, MTE1, EVENT_ID3);
+        PIPE_BARRIER(ALL);
+    }
+};
+
+template <typename IFAT>
+__aicore__ inline void PagedAttentionDecoderMask<IFAT>::Init(
+    __gm__ uint8_t *query, __gm__ uint8_t *key, __gm__ uint8_t *value,
+    __gm__ uint8_t *attenMask, __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengths,
+    __gm__ uint8_t *blockTable, __gm__ uint8_t *attentionOut, __gm__ uint8_t *workspace,
+    const typename IFAT::TilingType *__restrict tiling)
+{
+    promptLensGmTensor_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(actualSeqLengthsQ));
+    contextLensGmTensor_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t *>(actualSeqLengths));
+    blockTablesGmTensor_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(blockTable));
+    ListTensorDesc keyListTensorDesc((__gm__ void *)key);
+    ListTensorDesc valueListTensorDesc((__gm__ void *)value);
+    
+    tilingData_ = tiling;
+    query_ = query;
+    key_ = (__gm__ uint8_t *)keyListTensorDesc.GetDataPtr<__gm__ uint8_t>(0);
+    value_ = (__gm__ uint8_t *)valueListTensorDesc.GetDataPtr<__gm__ uint8_t>(0);
+    attenMask_ = attenMask;
+    attentionOut_ = attentionOut;
+
+    LoadTilingParameters();
+}
+
+template <typename IFAT>
+__aicore__ inline void PagedAttentionDecoderMask<IFAT>::Process()
+{
+    SetMaskNorm();
+    SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+    SetLoadDataPaddingValue<uint64_t>(uint16_t(0));
+    SetAtomicNone();
+
+    PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT> pa(
+        query_, key_, value_, attenMask_, attentionOut_, tor_, blockSize_);
+
+    InitializePipelineEvents();
+    ProcessAssignedTasks(pa);
+    FinalizePipelineEvents();
+}
+
+template <typename IFAT>
+__aicore__ inline void PagedAttentionDecoderMask<IFAT>::LoadTilingParameters()
+{
+    uint32_t tmp_block_idx = GetBlockIdx();
+    startTaskId_ = tilingData_->tilingPerCore.startTaskId[tmp_block_idx];
+    endTaskId_ = tilingData_->tilingPerCore.endTaskId[tmp_block_idx];
+    numTokens_ = tilingData_->tilingBase.batchSize;
+    numHeads_ = tilingData_->tilingBase.qHeadNum;
+    embeddingSize_ = tilingData_->tilingBase.headSize;
+    blockSize_ = tilingData_->tilingBase.blockSize;
+    maxNumBlocksPerQuery_ = tilingData_->tilingBase.maxBlockNumPerBatch;
+    tor_ = tilingData_->tilingBase.scaleValue;
+    kvHeads_ = tilingData_->tilingBase.kvHeadNum;
+    maskType_ = tilingData_->tilingBase.attenMaskFlag;
+    headMaskStride_ = tilingData_->tilingPerCore.maskHeadStride;
+    batchMaskStride_ = tilingData_->tilingPerCore.maskBatchStride;
+    maxTokensQ_ = tilingData_->tilingPerCore.qTokens;
+    maskKvLen_ = tilingData_->tilingPerCore.maskKvLen;
+    seqStepQ_ = tilingData_->tilingBase.querySeqStep;
+    groupNum_ = numHeads_ / kvHeads_;
+
+    LocateTaskRangeStart();
+}
+
+template <typename IFAT>
+__aicore__ inline void PagedAttentionDecoderMask<IFAT>::LocateTaskRangeStart()
+{
+    bool startInit = false;
+    uint32_t qBlkNumByCurBatch = 0;
+
+    for (uint32_t bId = 0; bId < numTokens_; bId++) {
+        uint32_t qSeqBlock = ((uint32_t)(promptLensGmTensor_.GetValue(bId)) + seqStepQ_ - 1) / seqStepQ_;
+        uint32_t qBlkNumCurBatch = qSeqBlock * numHeads_;
+        if (!startInit && (qBlkNumByCurBatch + qBlkNumCurBatch > startTaskId_)) {
+            startBatchId_ = bId;
+            startInit = true;
+            qBlkNumByStartBatch_ = qBlkNumByCurBatch;
+        }
+        if (qBlkNumByCurBatch + qBlkNumCurBatch >= endTaskId_) {
+            endBatchId_ = bId;
+            break;
+        }
+        qBlkNumByCurBatch += qBlkNumCurBatch;
+    }
+}
+
+template <typename IFAT>
+__aicore__ inline void PagedAttentionDecoderMask<IFAT>::ProcessAssignedTasks(
+    PagedAttentionDecoder<CalcMode::CALC_MODE_DEFAULT> &pa)
+{
+    uint32_t curBatch = startBatchId_;
+    uint32_t qBlkNumByCurBatch = qBlkNumByStartBatch_;
+    uint32_t promptLenCurBatch = static_cast<uint32_t>(promptLensGmTensor_.GetValue(curBatch));
+    uint32_t contextLenCurBatch = static_cast<uint32_t>(contextLensGmTensor_.GetValue(curBatch));
+    uint32_t qSeqBlockNum = (promptLenCurBatch + seqStepQ_ - 1) / seqStepQ_;
+    uint32_t qBlkNumCurBatch = qSeqBlockNum * numHeads_;
+    
+    uint64_t strideKV = blockSize_ * embeddingSize_;
+
+    // Skip empty batches at the beginning.
+    while (curBatch < numTokens_ && qBlkNumCurBatch == 0) {
+        if (!AdvanceToNextBatch(curBatch, qBlkNumByCurBatch, qBlkNumCurBatch, promptLenCurBatch, contextLenCurBatch, qSeqBlockNum)) {
+            return;
+        }
+    }
+
+    for (uint32_t taskId = startTaskId_; taskId < endTaskId_; taskId++) {
+        while (taskId >= qBlkNumByCurBatch + qBlkNumCurBatch) {
+            if (!AdvanceToNextBatch(curBatch, qBlkNumByCurBatch, qBlkNumCurBatch, promptLenCurBatch, contextLenCurBatch, qSeqBlockNum)) {
+                return;
+            }
+            // Skip consecutive empty batches.
+            while (curBatch < numTokens_ && qBlkNumCurBatch == 0) {
+                if (!AdvanceToNextBatch(curBatch, qBlkNumByCurBatch, qBlkNumCurBatch, promptLenCurBatch, contextLenCurBatch, qSeqBlockNum)) {
+                    return;
+                }
+            }
+        }
+
+        uint32_t headId = (taskId - qBlkNumByCurBatch) / qSeqBlockNum;
+        uint32_t qSeqBlockIdx = (taskId - qBlkNumByCurBatch) % qSeqBlockNum;
+        uint32_t repeatLen = min(headSplit_, min(endTaskId_ - taskId, groupNum_ - headId % groupNum_));
+        uint32_t nLoop = (contextLenCurBatch + blockSize_ - 1) / blockSize_;
+        uint32_t tail = contextLenCurBatch % blockSize_ == 0 ? blockSize_ : contextLenCurBatch % blockSize_;
+        uint32_t mActual = (qSeqBlockIdx == qSeqBlockNum - 1) ? (promptLenCurBatch - qSeqBlockIdx * seqStepQ_) : seqStepQ_;
+        uint32_t roundM = Align<uint32_t>(mActual, 16);
+        uint32_t roundK = Align<uint32_t>(embeddingSize_, 16);
+        uint64_t kvHeadOffset = (headId / groupNum_) * strideKV;
+        half localTor = 0;
+
+        for (uint32_t nIdx = 0; nIdx < nLoop; nIdx += 2) {
+            uint64_t blockTableIdx0 = GetBlockTableIndex(curBatch, nIdx);
+            uint64_t numBlocksId0 = static_cast<uint64_t>(blockTablesGmTensor_.GetValue(blockTableIdx0));
+            uint64_t kvOffset0 = numBlocksId0 * blockSize_ * kvHeads_ * embeddingSize_ + kvHeadOffset;
+
+            uint64_t numBlocksId1 = 0;
+            uint64_t kvOffset1 = 0;
+            if ((nIdx + 1) != nLoop) {
+                uint64_t blockTableIdx1 = GetBlockTableIndex(curBatch, nIdx + 1);
+                numBlocksId1 = static_cast<uint64_t>(blockTablesGmTensor_.GetValue(blockTableIdx1));
+                kvOffset1 = numBlocksId1 * blockSize_ * kvHeads_ * embeddingSize_ + kvHeadOffset;
+            }
+
+            // Compute the causal boundary used to derive each query's valid length with a compressed mask.
+            int32_t historyKvLen = static_cast<int32_t>(contextLenCurBatch) - static_cast<int32_t>(promptLenCurBatch);
+            int32_t qGlobalIdxBase = static_cast<int32_t>(qSeqBlockIdx * seqStepQ_);
+            int32_t kvStart0 = static_cast<int32_t>(nIdx * blockSize_);
+            
+            int32_t baseCausalOffset0 = historyKvLen + qGlobalIdxBase - kvStart0 + 1;
+            int32_t baseCausalOffset1 = baseCausalOffset0 - static_cast<int32_t>(blockSize_);
+
+            int32_t cmRowPing = baseCausalOffset0 + seqStepQ_ - 1;
+            cmRowPing = (cmRowPing < 0) ? 0 : ((cmRowPing > blockSize_ + seqStepQ_ - 1) ? blockSize_ + seqStepQ_ - 1 : cmRowPing);
+            int32_t cmRowPong = baseCausalOffset1 + seqStepQ_ - 1;
+            cmRowPong = (cmRowPong < 0) ? 0 : ((cmRowPong > blockSize_ + seqStepQ_ - 1) ? blockSize_ + seqStepQ_ - 1 : cmRowPong);
+
+            uint32_t warpO = (nIdx == (nLoop - 1) || (nIdx + 1) == (nLoop - 1)) ? 1 : 0;
+            uint32_t initG = (nIdx == 0) ? 1 : 0;
+            uint32_t n0Actual = (nIdx == nLoop - 1) ? tail : blockSize_;
+            uint32_t n1Actual = ((nIdx + 1) == nLoop - 1) ? tail : blockSize_;
+            uint32_t roundN0 = Align<uint32_t>(n0Actual, 16);
+            uint32_t roundN1 = Align<uint32_t>(n1Actual, 16);
+            if ((nIdx + 1) == nLoop) {
+                n1Actual = 0;
+            }
+
+            uint64_t qOffset = 0;
+            if constexpr (IFAT::layout == LAYOUT::TND) {
+                qOffset = GetQOffsetTndVarlen(curBatch, qSeqBlockIdx, headId);
+            } else {
+                qOffset = GetQOffset(curBatch, qSeqBlockIdx, headId);
+            }
+            
+            uint64_t maskOffset = GetMaskOffset(curBatch, qSeqBlockIdx, nIdx, headId);
+
+            for (uint32_t headOffset = 0; headOffset < repeatLen; ++headOffset) {
+                uint32_t initKV = (headOffset == 0) ? 1 : 0;
+                uint32_t initKVE = (warpO && headOffset == repeatLen - 1) ? 1 : 0;
+
+                // NOTE(Shengyi): Keep passing the normal-mask offset for compatibility. Compressed masks ignore it.
+                pa.Init(qOffset, kvOffset0, kvOffset0, kvOffset1, kvOffset1, maskOffset, qOffset, initG, warpO,
+                        maskKvLen_, numHeads_, cmRowPing, cmRowPong);
+                pa.ProcessKvBlockPair(roundM, roundN0, roundK, roundN1, mActual, n0Actual, n1Actual, maskType_, initKVE,
+                          headOffset, initKV, localTor, scaleType_);
+
+                qOffset += embeddingSize_;
+                maskOffset += headMaskStride_;
+            }
+        }
+        taskId += repeatLen - 1;
+    }
+}
+#endif // UNPAD_PAGED_ATTENTION_DECODER_H

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -86,6 +86,7 @@ if [[ "$SOC_VERSION" =~ ^ascend310 ]]; then
         "recurrent_gated_delta_rule_v310"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"
+        "custom_fused_infer_attention_v310"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend310p"

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2088,18 +2088,18 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
 
     ops.def(
         "npu_custom_fused_infer_attention_v310(Tensor query, "
-        "                                       Tensor[] key, "
-        "                                       Tensor[] value, *, "
+        "                                       Tensor key, "
+        "                                       Tensor value, *, "
         "                                       Tensor? attn_mask=None, "
         "                                       SymInt[]? actual_seq_lengths_q=None, "
         "                                       SymInt[]? actual_seq_lengths_kv=None, "
         "                                       Tensor? block_table=None, "
         "                                       int num_heads=1, "
         "                                       float scale_value=1.0, "
-        "                                       str input_layout='BSH', "
+        "                                       str input_layout='BSND', "
         "                                       int num_key_value_heads=0, "
         "                                       int block_size=0, "
-        "                                       int inner_precise=1) -> Tensor");
+        "                                       int inner_precise=2) -> Tensor");
     ops.impl("npu_custom_fused_infer_attention_v310", torch::kPrivateUse1,
              &vllm_ascend::npu_custom_fused_infer_attention_v310);
 

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -46,6 +46,7 @@
 #include "moe/causal_conv1d_v310/causal_conv1d_310_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
+#include "attention/custom_fused_infer_attention_v310/custom_fused_infer_attention_v310_torch_adpt.h"
 #include "attention/sparse_attention_score/sparse_attention_score_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp"
@@ -2084,6 +2085,23 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                                   Tensor? num_accepted_tokens, "
         "                                   float scale_value=1.0) -> (Tensor output)");
     ops.impl("npu_recurrent_gated_delta_rule_310", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule_310);
+
+    ops.def(
+        "npu_custom_fused_infer_attention_v310(Tensor query, "
+        "                                       Tensor[] key, "
+        "                                       Tensor[] value, *, "
+        "                                       Tensor? attn_mask=None, "
+        "                                       SymInt[]? actual_seq_lengths_q=None, "
+        "                                       SymInt[]? actual_seq_lengths_kv=None, "
+        "                                       Tensor? block_table=None, "
+        "                                       int num_heads=1, "
+        "                                       float scale_value=1.0, "
+        "                                       str input_layout='BSH', "
+        "                                       int num_key_value_heads=0, "
+        "                                       int block_size=0, "
+        "                                       int inner_precise=1) -> Tensor");
+    ops.impl("npu_custom_fused_infer_attention_v310", torch::kPrivateUse1,
+             &vllm_ascend::npu_custom_fused_infer_attention_v310);
 
     ops.def(
         "chunk_gated_delta_rule_fwd_h(Tensor k, Tensor w, Tensor u, Tensor? g=None, *, Tensor? gk=None, Tensor? initial_state=None, bool? output_final_state=False, int? chunk_size=None, bool? save_new_value=True, int[]? cu_seqlens=None, int[]? chunk_indices=None, bool? use_exp2=False, bool? transpose_state_layout=False) -> (Tensor h_out, Tensor v_new_out, Tensor final_state_out)"

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -602,7 +602,7 @@ at::Tensor npu_recurrent_gated_delta_rule_310_meta(
 }
 
 at::Tensor npu_custom_fused_infer_attention_v310_meta(
-    const at::Tensor &query, at::TensorList key, at::TensorList value,
+    const at::Tensor &query, const at::Tensor &key, const at::Tensor &value,
     const c10::optional<at::Tensor> &attn_mask,
     c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_q,
     c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_kv,

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -601,6 +601,19 @@ at::Tensor npu_recurrent_gated_delta_rule_310_meta(
     return output;
 }
 
+at::Tensor npu_custom_fused_infer_attention_v310_meta(
+    const at::Tensor &query, at::TensorList key, at::TensorList value,
+    const c10::optional<at::Tensor> &attn_mask,
+    c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_q,
+    c10::OptionalArrayRef<c10::SymInt> actual_seq_lengths_kv,
+    const c10::optional<at::Tensor> &block_table,
+    int64_t num_heads, double scale_value, c10::string_view input_layout,
+    int64_t num_key_value_heads, int64_t block_size, int64_t inner_precise)
+{
+    at::Tensor output = at::empty_symint(query.sym_sizes(), query.options());
+    return output;
+}
+
 at::Tensor npu_recurrent_gated_delta_rule_meta(
     const at::Tensor& query,
     const at::Tensor& key,
@@ -1551,6 +1564,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_causal_conv1d_310", &vllm_ascend::meta::npu_causal_conv1d_310_meta);
     // npu_recurrent_gated_delta_rule_310
     ops.impl("npu_recurrent_gated_delta_rule_310", &vllm_ascend::meta::npu_recurrent_gated_delta_rule_310_meta);
+    // npu_custom_fused_infer_attention_v310
+    ops.impl("npu_custom_fused_infer_attention_v310", &vllm_ascend::meta::npu_custom_fused_infer_attention_v310_meta);
     // chunk_gated_delta_rule_fwd_h
     ops.impl("chunk_gated_delta_rule_fwd_h", &vllm_ascend::meta::chunk_gated_delta_rule_fwd_h_meta);
     // chunk_fwd_o

--- a/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
+++ b/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
@@ -148,13 +148,13 @@ def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
     query_lens_npu = query_lens_cpu_abs.npu()
 
     # Reshape KV cache to NZ layout expected by the operator
-    adn_k_cache = (
+    k_cache = (
         key_cache.reshape(key_cache.shape[0], key_cache.shape[1], -1)
         .reshape(key_cache.shape[0], key_cache.shape[1], -1, 16)
         .permute(0, 2, 1, 3)
         .contiguous()
     )
-    adn_v_cache = (
+    v_cache = (
         value_cache.reshape(value_cache.shape[0], value_cache.shape[1], -1)
         .reshape(value_cache.shape[0], value_cache.shape[1], -1, 16)
         .permute(0, 2, 1, 3)
@@ -163,8 +163,8 @@ def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
 
     attention_output_npu = custom_fused_infer_attention_v310(
         query=query,
-        key=adn_k_cache,
-        value=adn_v_cache,
+        key=k_cache,
+        value=v_cache,
         actual_seq_lengths_q=query_lens_npu.tolist(),
         actual_seq_lengths_kv=kv_seq_lens_npu.tolist(),
         block_table=block_table,

--- a/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
+++ b/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
@@ -26,10 +26,7 @@ def _generate_random_block_table(kv_seq_lens, block_size, total_physical_blocks)
         needed_blocks = (cur_kv_len + block_size - 1) // block_size
 
         if needed_blocks > len(available_blocks):
-            raise ValueError(
-                f"Not enough physical blocks: need {needed_blocks}, "
-                f"available {len(available_blocks)}"
-            )
+            raise ValueError(f"Not enough physical blocks: need {needed_blocks}, available {len(available_blocks)}")
 
         chosen_blocks = random.sample(available_blocks, needed_blocks)
         for cb in chosen_blocks:
@@ -40,8 +37,18 @@ def _generate_random_block_table(kv_seq_lens, block_size, total_physical_blocks)
 
 
 def _compute_golden_output_cpu(
-    query, key_cache, value_cache, num_heads, num_key_value_heads,
-    head_dim, block_size, block_table, query_lens_abs, kv_seq_lens, scale, layout,
+    query,
+    key_cache,
+    value_cache,
+    num_heads,
+    num_key_value_heads,
+    head_dim,
+    block_size,
+    block_table,
+    query_lens_abs,
+    kv_seq_lens,
+    scale,
+    layout,
 ):
     B = len(query_lens_abs)
     out_list = []
@@ -100,10 +107,13 @@ def _compute_golden_output_cpu(
         return padded_out.to(query.dtype)
 
 
-@pytest.mark.parametrize("layout,head_dim,block_size", [
-    ("TND", 128, 128),
-    ("BSND", 128, 128),
-])
+@pytest.mark.parametrize(
+    "layout,head_dim,block_size",
+    [
+        ("TND", 128, 128),
+        ("BSND", 128, 128),
+    ],
+)
 def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
     """Smoke test: one MHA case per layout+head_dim combo, eager mode."""
     random.seed(42)
@@ -111,32 +121,21 @@ def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
 
     dtype = torch.float16
     atol = 1e-4
-    scale = head_dim ** -0.5
+    scale = head_dim**-0.5
     num_heads = 4
     num_kv_heads = 4
     B = 2
 
-    query_lens_cpu_abs = torch.tensor(
-        [random.randint(1, 128) for _ in range(B)], dtype=torch.int64
-    )
-    kv_seq_lens_cpu = torch.tensor(
-        [random.randint(1, 256) for _ in range(B)], dtype=torch.int64
-    )
+    query_lens_cpu_abs = torch.tensor([random.randint(1, 128) for _ in range(B)], dtype=torch.int64)
+    kv_seq_lens_cpu = torch.tensor([random.randint(1, 256) for _ in range(B)], dtype=torch.int64)
 
-    total_needed_blocks = sum(
-        (seq_len.item() + block_size - 1) // block_size
-        for seq_len in kv_seq_lens_cpu
-    )
+    total_needed_blocks = sum((seq_len.item() + block_size - 1) // block_size for seq_len in kv_seq_lens_cpu)
     block_num = total_needed_blocks + 20
     block_table_cpu = _generate_random_block_table(kv_seq_lens_cpu, block_size, block_num)
     block_table = block_table_cpu.npu()
 
-    key_cache = torch.randn(
-        [block_num, block_size, num_kv_heads * head_dim], dtype=dtype
-    ).npu()
-    value_cache = torch.randn(
-        [block_num, block_size, num_kv_heads * head_dim], dtype=dtype
-    ).npu()
+    key_cache = torch.randn([block_num, block_size, num_kv_heads * head_dim], dtype=dtype).npu()
+    value_cache = torch.randn([block_num, block_size, num_kv_heads * head_dim], dtype=dtype).npu()
     kv_seq_lens_npu = kv_seq_lens_cpu.npu()
 
     if layout == "TND":
@@ -208,7 +207,4 @@ def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
     else:
         diff_mean = (npu_out - cpu_out).abs().mean()
 
-    assert diff_mean <= atol, (
-        f"layout={layout} hd={head_dim} bs={block_size}: "
-        f"mean_diff={diff_mean:.6f} > atol={atol}"
-    )
+    assert diff_mean <= atol, f"layout={layout} hd={head_dim} bs={block_size}: mean_diff={diff_mean:.6f} > atol={atol}"

--- a/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
+++ b/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
@@ -124,7 +124,8 @@ def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
     )
 
     total_needed_blocks = sum(
-        (l.item() + block_size - 1) // block_size for l in kv_seq_lens_cpu
+        (seq_len.item() + block_size - 1) // block_size
+        for seq_len in kv_seq_lens_cpu
     )
     block_num = total_needed_blocks + 20
     block_table_cpu = _generate_random_block_table(kv_seq_lens_cpu, block_size, block_num)

--- a/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
+++ b/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
@@ -1,0 +1,213 @@
+import random
+
+import pytest
+import torch
+import torch_npu
+
+from vllm_ascend._310p.ops.custom_fused_infer_attention import (
+    custom_fused_infer_attention_v310,
+)
+from vllm_ascend.utils import enable_custom_op
+
+
+@pytest.fixture(autouse=True)
+def _register_custom_op():
+    enable_custom_op()
+
+
+def _generate_random_block_table(kv_seq_lens, block_size, total_physical_blocks):
+    B = len(kv_seq_lens)
+    max_blocks_per_seq = int((max(kv_seq_lens) + block_size - 1) // block_size) + 2
+    block_table = torch.full([B, max_blocks_per_seq], -1, dtype=torch.int32)
+    available_blocks = list(range(total_physical_blocks))
+
+    for b in range(B):
+        cur_kv_len = kv_seq_lens[b].item()
+        needed_blocks = (cur_kv_len + block_size - 1) // block_size
+
+        if needed_blocks > len(available_blocks):
+            raise ValueError(
+                f"Not enough physical blocks: need {needed_blocks}, "
+                f"available {len(available_blocks)}"
+            )
+
+        chosen_blocks = random.sample(available_blocks, needed_blocks)
+        for cb in chosen_blocks:
+            available_blocks.remove(cb)
+        block_table[b, :needed_blocks] = torch.tensor(chosen_blocks, dtype=torch.int32)
+
+    return block_table
+
+
+def _compute_golden_output_cpu(
+    query, key_cache, value_cache, num_heads, num_key_value_heads,
+    head_dim, block_size, block_table, query_lens_abs, kv_seq_lens, scale, layout,
+):
+    B = len(query_lens_abs)
+    out_list = []
+    q_offset = 0
+
+    for b in range(B):
+        q_len = query_lens_abs[b].item()
+
+        if layout == "TND":
+            cur_query = query[q_offset : q_offset + q_len]
+            q_offset += q_len
+        elif layout == "BSND":
+            cur_query = query[b, :q_len]
+        else:
+            raise ValueError(f"Unsupported layout: {layout}")
+
+        cur_kv_len = kv_seq_lens[b].item()
+        cur_block_indices = block_table[b]
+        num_blocks_needed = (cur_kv_len + block_size - 1) // block_size
+
+        keys_list = []
+        values_list = []
+        for i in range(num_blocks_needed):
+            block_idx = cur_block_indices[i].item()
+            keys_list.append(key_cache[block_idx])
+            values_list.append(value_cache[block_idx])
+
+        full_keys = torch.cat(keys_list, dim=0)[:cur_kv_len, :]
+        full_values = torch.cat(values_list, dim=0)[:cur_kv_len, :]
+
+        full_keys = full_keys.view(cur_kv_len, num_key_value_heads, head_dim).permute(1, 0, 2)
+        full_values = full_values.view(cur_kv_len, num_key_value_heads, head_dim).permute(1, 0, 2)
+
+        if num_key_value_heads != num_heads:
+            group = num_heads // num_key_value_heads
+            full_keys = full_keys.repeat_interleave(group, dim=0)
+            full_values = full_values.repeat_interleave(group, dim=0)
+
+        q_trans = cur_query.transpose(0, 1).to(torch.float32)
+        k_trans = full_keys.transpose(-1, -2).to(torch.float32)
+        attn_scores = torch.matmul(q_trans, k_trans) * scale
+
+        attn_weights = torch.nn.functional.softmax(attn_scores, dim=-1)
+        cur_out = torch.matmul(attn_weights, full_values.to(torch.float32))
+
+        out_list.append(cur_out.transpose(0, 1))
+
+    if layout == "TND":
+        return torch.cat(out_list, dim=0).to(query.dtype)
+    elif layout == "BSND":
+        max_q_len = query.shape[1]
+        padded_out = torch.zeros([B, max_q_len, num_heads, head_dim], dtype=torch.float32)
+        for b in range(B):
+            q_len = query_lens_abs[b].item()
+            padded_out[b, :q_len] = out_list[b]
+        return padded_out.to(query.dtype)
+
+
+@pytest.mark.parametrize("layout,head_dim,block_size", [
+    ("TND", 128, 128),
+    ("BSND", 128, 128),
+])
+def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
+    """Smoke test: one MHA case per layout+head_dim combo, eager mode."""
+    random.seed(42)
+    torch.manual_seed(42)
+
+    dtype = torch.float16
+    atol = 1e-4
+    scale = head_dim ** -0.5
+    num_heads = 4
+    num_kv_heads = 4
+    B = 2
+
+    query_lens_cpu_abs = torch.tensor(
+        [random.randint(1, 128) for _ in range(B)], dtype=torch.int64
+    )
+    kv_seq_lens_cpu = torch.tensor(
+        [random.randint(1, 256) for _ in range(B)], dtype=torch.int64
+    )
+
+    total_needed_blocks = sum(
+        (l.item() + block_size - 1) // block_size for l in kv_seq_lens_cpu
+    )
+    block_num = total_needed_blocks + 20
+    block_table_cpu = _generate_random_block_table(kv_seq_lens_cpu, block_size, block_num)
+    block_table = block_table_cpu.npu()
+
+    key_cache = torch.randn(
+        [block_num, block_size, num_kv_heads * head_dim], dtype=dtype
+    ).npu()
+    value_cache = torch.randn(
+        [block_num, block_size, num_kv_heads * head_dim], dtype=dtype
+    ).npu()
+    kv_seq_lens_npu = kv_seq_lens_cpu.npu()
+
+    if layout == "TND":
+        T_q = query_lens_cpu_abs.sum().item()
+        query = torch.randn([T_q, num_heads, head_dim], dtype=dtype).npu()
+    elif layout == "BSND":
+        max_q_len = query_lens_cpu_abs.max().item()
+        query = torch.randn([B, max_q_len, num_heads, head_dim], dtype=dtype).npu()
+    query_lens_npu = query_lens_cpu_abs.npu()
+
+    # Reshape KV cache to NZ layout expected by the operator
+    adn_k_cache = (
+        key_cache.reshape(key_cache.shape[0], key_cache.shape[1], -1)
+        .reshape(key_cache.shape[0], key_cache.shape[1], -1, 16)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
+    adn_v_cache = (
+        value_cache.reshape(value_cache.shape[0], value_cache.shape[1], -1)
+        .reshape(value_cache.shape[0], value_cache.shape[1], -1, 16)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+    )
+
+    attention_output_npu = custom_fused_infer_attention_v310(
+        query=query,
+        key=adn_k_cache,
+        value=adn_v_cache,
+        actual_seq_lengths_q=query_lens_npu.tolist(),
+        actual_seq_lengths_kv=kv_seq_lens_npu.tolist(),
+        block_table=block_table,
+        num_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        block_size=block_size,
+        input_layout=layout,
+        scale_value=scale,
+        inner_precise=2,
+    )
+    torch_npu.npu.synchronize()
+
+    golden_output_cpu = _compute_golden_output_cpu(
+        query=query.detach().cpu(),
+        key_cache=key_cache.detach().cpu(),
+        value_cache=value_cache.detach().cpu(),
+        num_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        block_table=block_table_cpu,
+        query_lens_abs=query_lens_cpu_abs,
+        kv_seq_lens=kv_seq_lens_cpu,
+        scale=scale,
+        layout=layout,
+    )
+
+    npu_out = attention_output_npu.detach().cpu()
+    cpu_out = golden_output_cpu
+
+    if layout == "BSND":
+        valid_npu = []
+        valid_cpu = []
+        for b in range(B):
+            q_len = query_lens_cpu_abs[b].item()
+            valid_npu.append(npu_out[b, :q_len].flatten())
+            valid_cpu.append(cpu_out[b, :q_len].flatten())
+        npu_valid = torch.cat(valid_npu)
+        cpu_valid = torch.cat(valid_cpu)
+        diff_mean = (npu_valid - cpu_valid).abs().mean()
+    else:
+        diff_mean = (npu_out - cpu_out).abs().mean()
+
+    assert diff_mean <= atol, (
+        f"layout={layout} hd={head_dim} bs={block_size}: "
+        f"mean_diff={diff_mean:.6f} > atol={atol}"
+    )

--- a/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
+++ b/tests/ut/_310p/ops/test_custom_fused_infer_attention_310.py
@@ -172,7 +172,6 @@ def test_custom_fused_infer_attention_v310(layout, head_dim, block_size):
         block_size=block_size,
         input_layout=layout,
         scale_value=scale,
-        inner_precise=2,
     )
     torch_npu.npu.synchronize()
 

--- a/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
+++ b/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
@@ -73,30 +73,67 @@ def custom_fused_infer_attention_v310(
     block_table: torch.Tensor | None = None,
     num_heads: int = 1,
     scale_value: float = 1.0,
-    input_layout: str = "BSH",
+    input_layout: str = "BSND",
     num_key_value_heads: int = 0,
     block_size: int = 0,
-    inner_precise: int = 1,
 ) -> torch.Tensor:
-    """Ascend 310P custom fused infer attention.
+    """Ascend 310P custom fused infer attention (PagedAttention / incre-flash).
+
+    Wraps ``CustomFusedInferAttentionV310`` which is a 310P-specific attention
+    kernel supporting paged KV-cache with block-table addressing. ONLY head-dim
+    256 or 128 supported.
 
     Args:
-        query: query tensor.
-        key / value: key/value (single) cache tensors; passed as single-element
-            lists to the dynamic-list inputs of the custom op.
-        attn_mask: optional attention mask.
-        actual_seq_lengths_q / actual_seq_lengths_kv: optional per-batch actual
-            sequence lengths.
-        block_table: optional paged-attention block table.
-        num_heads: number of query heads.
-        scale_value: attention scale.
-        input_layout: input layout, e.g. ``"BSH"``/``"BSND"``/``"TND"``.
-        num_key_value_heads: number of key/value heads (GQA).
-        block_size: paged-attention block size.
-        inner_precise: inner-precise flag.
+        query: Query tensor.
+            - dtype: float16
+            - format: ND
+            - TND layout: shape ``(T_q, num_heads, head_dim)``
+            - BSND layout: shape ``(B, max_q_len, num_heads, head_dim)``
+        key: Key cache tensor (single layer).
+            - dtype: float16
+            - format: ND or FRACTAL_NZ
+            - ND shape: ``(num_blocks, C//16, block_size, 16)``
+              where ``C = num_key_value_heads * head_dim``
+            - NZ shape: same shape, format tag FRACTAL_NZ
+            - Internally wrapped as ``[key]`` for the TensorList input.
+        value: Value cache tensor (single layer). Same dtype/format/shape
+            constraints as ``key``.
+        attn_mask: Optional attention mask.
+            - dtype: float16
+            - format: ND
+            - ``None`` means no mask (causal or full attention depending on
+              the kernel path).
+        actual_seq_lengths_q: Per-batch actual query sequence lengths.
+            - List of ``B`` integers.
+            - Default ``None`` treated as all ones (decode).
+        actual_seq_lengths_kv: Per-batch actual KV sequence lengths.
+            - List of ``B`` integers.
+            - Default ``None`` treated as all ones.
+        block_table: Paged-attention block table.
+            - dtype: int32
+            - format: ND
+            - shape: ``(B, max_num_blocks_per_seq)``
+            - ``-1`` marks unused (padding) entries.
+        num_heads: Number of query heads. Must be >= num_key_value_heads and
+            ``num_heads % num_key_value_heads == 0``.
+        scale_value: Attention scale factor, typically ``head_dim ** -0.5``.
+        input_layout: Input tensor layout string. Must be ``"BSND"`` or
+            ``"TND"``.
+        num_key_value_heads: Number of key/value heads (GQA). Defaults to 0
+            (will be set to ``num_heads`` internally if not provided).
+        block_size: KV-cache block size in tokens. Must be a multiple of 16.
+            head_dim * block_size <= 128 * 128.
 
     Returns:
         Attention output tensor.
+            - dtype: float16, format: ND
+            - TND layout: shape ``(T_q, num_heads, head_dim)``
+            - BSND layout: shape ``(B, max_q_len, num_heads, head_dim)``
+
+    Note:
+        ``inner_precise`` is fixed to 2 (high-precision softmax accumulate)
+        and not exposed in this API.  It should not be changed without
+        verifying numerical correctness on 310P.
     """
     return torch.ops._C_ascend.npu_custom_fused_infer_attention_v310(
         query,
@@ -111,5 +148,5 @@ def custom_fused_infer_attention_v310(
         input_layout=input_layout,
         num_key_value_heads=num_key_value_heads,
         block_size=block_size,
-        inner_precise=inner_precise,
+        inner_precise=2,
     )

--- a/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
+++ b/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
@@ -135,8 +135,8 @@ def custom_fused_infer_attention_v310(
     """
     return torch.ops._C_ascend.npu_custom_fused_infer_attention_v310(
         query,
-        [key],
-        [value],
+        key,
+        value,
         attn_mask=attn_mask,
         actual_seq_lengths_q=actual_seq_lengths_q,
         actual_seq_lengths_kv=actual_seq_lengths_kv,

--- a/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
+++ b/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
@@ -1,0 +1,115 @@
+"""Ascend 310P custom fused infer attention (PagedAttention / incre-flash) op wrapper.
+
+This wraps the custom CANN operator ``CustomFusedInferAttentionV310`` (exposed as
+``torch.ops._C_ascend.npu_custom_fused_infer_attention_v310``) ported from the
+Ascend custom-op project. It also provides the staircase compress-mask generator
+used by the compress attention mode.
+"""
+
+import torch
+from torch._dynamo import allow_in_graph
+
+# head_dim -> (block_size, q_step) configuration for the compress staircase mask.
+_FIA_COMPRESS_MASK_CFG: dict[int, tuple[int, int]] = {
+    128: (128, 32),
+    256: (64, 16),
+}
+
+
+@allow_in_graph
+def gen_custom_fia_compress_mask(head_dim: int) -> torch.Tensor:
+    """Generate the staircase compress mask for ``custom_fused_infer_attention_v310``.
+
+    The mask controls attention during the compression stage. ``0.0`` keeps a
+    position, ``torch.finfo(torch.float16).min`` (i.e. -inf) masks it out.
+
+    Args:
+        head_dim: per-head dimension, only 128 or 256 are supported.
+            - head_dim = 128 -> block_size = 128, q_step = 32, shape (191, 128)
+            - head_dim = 256 -> block_size = 64,  q_step = 16, shape (95, 64)
+
+    Returns:
+        A float16 mask tensor of shape ``(q_step + block_size - 1 + q_step,
+        block_size)``.
+    """
+    if head_dim not in _FIA_COMPRESS_MASK_CFG:
+        raise ValueError(
+            f"Unsupported head_dim: {head_dim}. Only 128 or 256 are supported."
+        )
+    block_size, q_step = _FIA_COMPRESS_MASK_CFG[head_dim]
+
+    block_b_rows = block_size - 1
+    total_rows = q_step + block_b_rows + q_step
+
+    # Initialize everything to -inf (masked).
+    compress_mask = torch.full(
+        (total_rows, block_size),
+        torch.finfo(torch.float16).min,
+        dtype=torch.float16,
+    )
+
+    # Lower-left triangular staircase for the middle rows.
+    b_row_idx = torch.arange(block_b_rows).unsqueeze(1)  # (block_b_rows, 1)
+    b_col_idx = torch.arange(block_size).unsqueeze(0)  # (1, block_size)
+    staircase_mask = b_col_idx <= b_row_idx
+
+    staircase_start = q_step
+    staircase_end = q_step + block_b_rows
+    compress_mask[staircase_start:staircase_end][staircase_mask] = 0.0
+    # Bottom rows are fully kept.
+    compress_mask[staircase_end:] = 0.0
+
+    return compress_mask
+
+
+@allow_in_graph
+def custom_fused_infer_attention_v310(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    actual_seq_lengths_q: list[int] | None = None,
+    actual_seq_lengths_kv: list[int] | None = None,
+    block_table: torch.Tensor | None = None,
+    num_heads: int = 1,
+    scale_value: float = 1.0,
+    input_layout: str = "BSH",
+    num_key_value_heads: int = 0,
+    block_size: int = 0,
+    inner_precise: int = 1,
+) -> torch.Tensor:
+    """Ascend 310P custom fused infer attention.
+
+    Args:
+        query: query tensor.
+        key / value: key/value (single) cache tensors; passed as single-element
+            lists to the dynamic-list inputs of the custom op.
+        attn_mask: optional attention mask.
+        actual_seq_lengths_q / actual_seq_lengths_kv: optional per-batch actual
+            sequence lengths.
+        block_table: optional paged-attention block table.
+        num_heads: number of query heads.
+        scale_value: attention scale.
+        input_layout: input layout, e.g. ``"BSH"``/``"BSND"``/``"TND"``.
+        num_key_value_heads: number of key/value heads (GQA).
+        block_size: paged-attention block size.
+        inner_precise: inner-precise flag.
+
+    Returns:
+        Attention output tensor.
+    """
+    return torch.ops._C_ascend.npu_custom_fused_infer_attention_v310(
+        query,
+        [key],
+        [value],
+        attn_mask=attn_mask,
+        actual_seq_lengths_q=actual_seq_lengths_q,
+        actual_seq_lengths_kv=actual_seq_lengths_kv,
+        block_table=block_table,
+        num_heads=num_heads,
+        scale_value=scale_value,
+        input_layout=input_layout,
+        num_key_value_heads=num_key_value_heads,
+        block_size=block_size,
+        inner_precise=inner_precise,
+    )

--- a/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
+++ b/vllm_ascend/_310p/ops/custom_fused_infer_attention.py
@@ -33,9 +33,7 @@ def gen_custom_fia_compress_mask(head_dim: int) -> torch.Tensor:
         block_size)``.
     """
     if head_dim not in _FIA_COMPRESS_MASK_CFG:
-        raise ValueError(
-            f"Unsupported head_dim: {head_dim}. Only 128 or 256 are supported."
-        )
+        raise ValueError(f"Unsupported head_dim: {head_dim}. Only 128 or 256 are supported.")
     block_size, q_step = _FIA_COMPRESS_MASK_CFG[head_dim]
 
     block_b_rows = block_size - 1


### PR DESCRIPTION
## Summary

(1) This PR adds `CustomFusedInferAttentionV310`, a custom fused inference-attention operator for **non-casual cases** with Q_LEN >=1 on Ascend 310P, **super case-wise lightweight that only support FP16 specially for draft model**.

(2) It is intended for inference workloads in **DSpark** and **DFlash**. Ascend 310P does not provide an official bidirectional-attention operator, so this implementation supplies the required paged-attention capability. This operator is used **ONLY in these 2 features**, **and should never be used in any other cases**.

(3) This operator can be **temporary impl** before official CANN impl of 310P FIA come out, and can be deprecated when there is a official FIA on 310P.

## Co-development

Co-developed with [@CastleJ](https://github.com/CastleJ).

## Operator Interface

`custom_fused_infer_attention_v310` accepts the following main inputs:

| Parameter | Description |
| --- | --- |
| `query` | Query tensor. The unit test covers `TND` and `BSND` layouts. |
| `key`, `value` | Paged KV-cache tensors in the NZ layout expected by the operator. |
| `actual_seq_lengths_q` | Actual query length for each batch item. |
| `actual_seq_lengths_kv` | Actual KV-cache sequence length for each batch item. |
| `block_table` | Maps each logical KV-cache block to its physical cache block. |
| `num_heads` | Number of query heads. |
| `num_key_value_heads` | Number of key/value heads; supports GQA when it differs from `num_heads`. |
| `block_size` | Token count in one paged KV-cache block. |
| `input_layout` | Query layout, such as `TND` or `BSND`. |
| `scale_value` | Attention scaling factor, typically `head_dim ** -0.5`. |
| `attn_mask` | Optional attention mask. |

## Example

The following usage is aligned with the 310P unit test:

```python
scale = head_dim ** -0.5

attention_output_npu = custom_fused_infer_attention_v310(
    query=query,
    key=k_cache,
    value=v_cache,
    actual_seq_lengths_q=query_lens_npu.tolist(),
    actual_seq_lengths_kv=kv_seq_lens_npu.tolist(),
    block_table=block_table,
    num_heads=num_heads,
    num_key_value_heads=num_kv_heads,
    block_size=block_size,
    input_layout=layout,  # "TND" or "BSND"
    scale_value=scale,
)
```

### What this PR does / why we need it?
no

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
local machine tested. 1000 samples in TND/BSND cases, all passed. Test script and results are attached below.
Script: [test_vllm_custom_fia.py](https://github.com/user-attachments/files/30569461/test_vllm_custom_fia.py)
Result: [custom_fia_1000_cases_results_all_pass.txt](https://github.com/user-attachments/files/30569463/custom_fia_1000_cases_results_all_pass.txt)



- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
