### PR TITLE
[BugFix] Remove -Werror from csrc CMakeLists.txt files

### DIFF
--- a/csrc/attention/compressor/op_host/CMakeLists.txt
+++ b/csrc/attention/compressor/op_host/CMakeLists.txt
@@ -19,7 +19,6 @@ add_ops_compile_options(
         OP_NAME Compressor
                 OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )
@@ -38,3 +37,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
     endforeach()
 
 endif()
+

--- a/csrc/attention/compressor_metadata/op_host/CMakeLists.txt
+++ b/csrc/attention/compressor_metadata/op_host/CMakeLists.txt
@@ -20,7 +20,6 @@ add_ops_compile_options(
     OP_NAME CompressorMetadata
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-aicore-hoist-movemask=false
             --op_relocatable_kernel_binary=true
 )
@@ -31,3 +30,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/fused_gdn_gating/op_host/CMakeLists.txt
+++ b/csrc/attention/fused_gdn_gating/op_host/CMakeLists.txt
@@ -12,7 +12,6 @@ add_ops_compile_options(
     OP_NAME FusedGdnGating
     OPTIONS --cce-auto-sync=on
             -Wno-deprecated-declarations
-            -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -21,3 +20,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/indexer_compress_epilog/op_host/CMakeLists.txt
+++ b/csrc/attention/indexer_compress_epilog/op_host/CMakeLists.txt
@@ -53,7 +53,6 @@ add_ops_compile_options(
         OP_NAME IndexerCompressEpilog
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/attention/indexer_compress_epilog_v2/op_host/CMakeLists.txt
+++ b/csrc/attention/indexer_compress_epilog_v2/op_host/CMakeLists.txt
@@ -54,7 +54,6 @@ add_ops_compile_options(
         OP_NAME IndexerCompressEpilogV2
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/CMakeLists.txt
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/CMakeLists.txt
@@ -64,7 +64,6 @@ add_ops_compile_options(
         OP_NAME InplacePartialRotaryMul
         OPTIONS --cce-auto-sync=on
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/attention/kv_compress_epilog/op_host/CMakeLists.txt
+++ b/csrc/attention/kv_compress_epilog/op_host/CMakeLists.txt
@@ -49,7 +49,6 @@ add_ops_compile_options(
         OP_NAME KvCompressEpilog
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/attention/kv_quant_sparse_attn_sharedkv/op_host/CMakeLists.txt
+++ b/csrc/attention/kv_quant_sparse_attn_sharedkv/op_host/CMakeLists.txt
@@ -20,7 +20,6 @@ add_ops_compile_options(
     OP_NAME KvQuantSparseAttnSharedkv
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-vf-remove-membar=false
             -mllvm -cce-aicore-hoist-movemask=false
 )

--- a/csrc/attention/kv_quant_sparse_flash_attention/op_host/CMakeLists.txt
+++ b/csrc/attention/kv_quant_sparse_flash_attention/op_host/CMakeLists.txt
@@ -22,7 +22,6 @@ add_ops_compile_options(
     OP_NAME KvQuantSparseFlashAttention
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-vf-remove-membar=false
             -mllvm -cce-aicore-hoist-movemask=false
 )
@@ -30,3 +29,4 @@ add_ops_compile_options(
 if (NOT BUILD_OPS_RTY_KERNEL)
     add_modules_sources(OPTYPE kv_quant_sparse_flash_attention ACLNNTYPE aclnn)
 endif()
+

--- a/csrc/attention/lightning_indexer/op_host/CMakeLists.txt
+++ b/csrc/attention/lightning_indexer/op_host/CMakeLists.txt
@@ -19,7 +19,6 @@ add_ops_compile_options(
     OP_NAME LightningIndexer
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-vf-remove-membar=false
             -mllvm -cce-aicore-hoist-movemask=false
 )
@@ -27,3 +26,4 @@ add_ops_compile_options(
 if (NOT BUILD_OPS_RTY_KERNEL)
     add_modules_sources(OPTYPE lightning_indexer ACLNNTYPE aclnn_inner)
 endif()
+

--- a/csrc/attention/lightning_indexer_quant/op_host/CMakeLists.txt
+++ b/csrc/attention/lightning_indexer_quant/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -mllvm -cce-aicore-hoist-movemask=false
         --op_relocatable_kernel_binary=true
 )
@@ -22,3 +21,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/lightning_indexer_vllm/op_host/CMakeLists.txt
+++ b/csrc/attention/lightning_indexer_vllm/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -mllvm -cce-aicore-hoist-movemask=false
         --op_relocatable_kernel_binary=true
 )
@@ -22,3 +21,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/load_index_kv_cache/op_host/CMakeLists.txt
+++ b/csrc/attention/load_index_kv_cache/op_host/CMakeLists.txt
@@ -53,7 +53,6 @@ add_ops_compile_options(
         OP_NAME LoadIndexKvCache
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/attention/ngram_spec_decode/op_host/CMakeLists.txt
+++ b/csrc/attention/ngram_spec_decode/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/recurrent_gated_delta_rule/op_host/CMakeLists.txt
+++ b/csrc/attention/recurrent_gated_delta_rule/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/recurrent_gated_delta_rule_v310/op_host/CMakeLists.txt
+++ b/csrc/attention/recurrent_gated_delta_rule_v310/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/reshape_and_cache_bnsd/op_host/CMakeLists.txt
+++ b/csrc/attention/reshape_and_cache_bnsd/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -mllvm -cce-aicore-hoist-movemask=false
         --op_relocatable_kernel_binary=true
 )
@@ -22,3 +21,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/rms_norm_dynamic_quant/op_host/CMakeLists.txt
+++ b/csrc/attention/rms_norm_dynamic_quant/op_host/CMakeLists.txt
@@ -50,7 +50,6 @@ add_ops_compile_options(
         OP_NAME RmsNormDynamicQuant
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )
@@ -59,3 +58,4 @@ add_ops_compile_options(
 if (NOT BUILD_OPS_RTY_KERNEL)
     add_modules_sources(OPTYPE rms_norm_dynamic_quant ACLNNTYPE aclnn)
 endif()
+

--- a/csrc/attention/sparse_attn_sharedkv/op_host/CMakeLists.txt
+++ b/csrc/attention/sparse_attn_sharedkv/op_host/CMakeLists.txt
@@ -19,7 +19,6 @@ add_ops_compile_options(
     OP_NAME SparseAttnSharedkv
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-vf-remove-membar=false
             -mllvm -cce-aicore-hoist-movemask=false
 )

--- a/csrc/attention/sparse_flash_attention/op_host/CMakeLists.txt
+++ b/csrc/attention/sparse_flash_attention/op_host/CMakeLists.txt
@@ -20,7 +20,6 @@ add_ops_compile_options(
     OP_NAME SparseFlashAttention
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-vf-remove-membar=false
             -mllvm -cce-aicore-hoist-movemask=false
 )
@@ -28,3 +27,4 @@ add_ops_compile_options(
 if (NOT BUILD_OPS_RTY_KERNEL)
     add_modules_sources(OPTYPE sparse_flash_attention ACLNNTYPE aclnn_inner)
 endif()
+

--- a/csrc/attention/store_kv_block/op_host/CMakeLists.txt
+++ b/csrc/attention/store_kv_block/op_host/CMakeLists.txt
@@ -19,7 +19,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -28,3 +27,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/attention/vllm_quant_lightning_indexer/op_host/CMakeLists.txt
+++ b/csrc/attention/vllm_quant_lightning_indexer/op_host/CMakeLists.txt
@@ -19,7 +19,6 @@ add_ops_compile_options(
     OP_NAME VllmQuantLightningIndexer
     OPTIONS --cce-auto-sync=off
             -Wno-deprecated-declarations
-            -Werror
             -mllvm -cce-vf-remove-membar=false
             -mllvm -cce-aicore-hoist-movemask=false
 )
@@ -27,3 +26,4 @@ add_ops_compile_options(
 if (NOT BUILD_OPS_RTY_KERNEL)
     add_modules_sources(OPTYPE vllm_quant_lightning_indexer ACLNNTYPE aclnn)
 endif()
+

--- a/csrc/gmm/grouped_matmul_swiglu_quant/op_host/CMakeLists.txt
+++ b/csrc/gmm/grouped_matmul_swiglu_quant/op_host/CMakeLists.txt
@@ -16,7 +16,6 @@ if (BUILD_OPEN_PROJECT)
         OP_NAME GroupedMatmulSwigluQuant
         OPTIONS --cce-auto-sync=on
                 -Wno-deprecated-declarations
-                -Werror
     )
 endif()
 
@@ -26,3 +25,4 @@ if(NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/gmm/grouped_matmul_swiglu_quant_v2/op_host/CMakeLists.txt
+++ b/csrc/gmm/grouped_matmul_swiglu_quant_v2/op_host/CMakeLists.txt
@@ -20,7 +20,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -29,3 +28,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/gmm/grouped_matmul_swiglu_quant_weight_nz_tensor_list/op_host/CMakeLists.txt
+++ b/csrc/gmm/grouped_matmul_swiglu_quant_weight_nz_tensor_list/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/mc2/dispatch_ffn_combine/op_host/CMakeLists.txt
+++ b/csrc/mc2/dispatch_ffn_combine/op_host/CMakeLists.txt
@@ -23,7 +23,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
         -DHCCL_COMM
         -DCATLASS_ARCH=2201
         ${_DISPATCH_FFN_INC_OPTS}
@@ -36,3 +35,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}/../op_kernel
     )
 endif()
+

--- a/csrc/mc2/dispatch_ffn_combine_bf16/op_host/CMakeLists.txt
+++ b/csrc/mc2/dispatch_ffn_combine_bf16/op_host/CMakeLists.txt
@@ -23,7 +23,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
         -DHCCL_COMM
         -DCATLASS_ARCH=2201
         ${_DISPATCH_FFN_INC_OPTS}
@@ -36,3 +35,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}/../op_kernel
     )
 endif()
+

--- a/csrc/mc2/dispatch_ffn_combine_w4_a8/op_host/CMakeLists.txt
+++ b/csrc/mc2/dispatch_ffn_combine_w4_a8/op_host/CMakeLists.txt
@@ -23,7 +23,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
         -DHCCL_COMM
         -DCATLASS_ARCH=2201
         ${_DISPATCH_FFN_INC_OPTS}
@@ -36,3 +35,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}/../op_kernel
     )
 endif()
+

--- a/csrc/mc2/dispatch_gmm_combine_decode/op_host/CMakeLists.txt
+++ b/csrc/mc2/dispatch_gmm_combine_decode/op_host/CMakeLists.txt
@@ -18,7 +18,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -DASCENDC_DUMP=0
         -DCATLASS_ARCH=2201
         ${_DISPATCH_GMM_INC_OPTS}
@@ -30,3 +29,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_SOURCE_DIR}/utils/inc/kernel
     )
 endif()
+

--- a/csrc/mc2/matmul_allreduce_add_rmsnorm/op_host/CMakeLists.txt
+++ b/csrc/mc2/matmul_allreduce_add_rmsnorm/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/add_rms_norm_bias/op_host/CMakeLists.txt
+++ b/csrc/moe/add_rms_norm_bias/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/causal_conv1d/op_host/CMakeLists.txt
+++ b/csrc/moe/causal_conv1d/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/causal_conv1d_v310/op_host/CMakeLists.txt
+++ b/csrc/moe/causal_conv1d_v310/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/chunk_fwd_o/op_host/CMakeLists.txt
+++ b/csrc/moe/chunk_fwd_o/op_host/CMakeLists.txt
@@ -18,7 +18,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -I${CATLASS_INCLUDE_DIR_ABS}
         -I${COMMON_KERNEL_UTILS_DIR_ABS}
 )
@@ -30,3 +29,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CATLASS_INCLUDE_DIR_ABS}
     )
 endif()
+

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/CMakeLists.txt
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_host/CMakeLists.txt
@@ -18,7 +18,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -I${CATLASS_INCLUDE_DIR_ABS}
         -I${COMMON_KERNEL_UTILS_DIR_ABS}
 )
@@ -30,3 +29,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CATLASS_INCLUDE_DIR_ABS}
     )
 endif()
+

--- a/csrc/moe/copy_and_expand_eagle_inputs/op_host/CMakeLists.txt
+++ b/csrc/moe/copy_and_expand_eagle_inputs/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/dequant_swiglu_quant/op_host/CMakeLists.txt
+++ b/csrc/moe/dequant_swiglu_quant/op_host/CMakeLists.txt
@@ -19,7 +19,6 @@ add_ops_compile_options(
         OP_NAME DequantSwigluQuant
         OPTIONS --cce-auto-sync=on
                 -Wno-deprecated-declarations
-                -Werror
 )
 
 

--- a/csrc/moe/hamming_dist_top_k/op_host/CMakeLists.txt
+++ b/csrc/moe/hamming_dist_top_k/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
         -mllvm -cce-aicore-hoist-movemask=false
         --op_relocatable_kernel_binary=true
 )
@@ -27,3 +26,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/hc_post/op_host/CMakeLists.txt
+++ b/csrc/moe/hc_post/op_host/CMakeLists.txt
@@ -54,7 +54,6 @@ add_ops_compile_options(
         OP_NAME HcPost
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/moe/hc_pre/op_host/CMakeLists.txt
+++ b/csrc/moe/hc_pre/op_host/CMakeLists.txt
@@ -50,7 +50,6 @@ if (BUILD_OPEN_PROJECT)
                 OP_NAME HcPre
                 OPTIONS --cce-auto-sync=off
                         -Wno-deprecated-declarations
-                        -Werror
                         -mllvm -cce-aicore-hoist-movemask=false
                         --op_relocatable_kernel_binary=true
         )
@@ -60,3 +59,4 @@ if(NOT BUILD_OPS_RTY_KERNEL)
     message(STATUS "=== Debug: BUILD is NOT BUILD_OPS_RTY_KERNEL")
     add_modules_sources(OPTYPE hc_pre ACLNNTYPE aclnn)
 endif()
+

--- a/csrc/moe/hc_pre_inv_rms/op_host/CMakeLists.txt
+++ b/csrc/moe/hc_pre_inv_rms/op_host/CMakeLists.txt
@@ -52,7 +52,6 @@ add_ops_compile_options(
         OP_NAME HcPreInvRms
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/moe/hc_pre_sinkhorn/op_host/CMakeLists.txt
+++ b/csrc/moe/hc_pre_sinkhorn/op_host/CMakeLists.txt
@@ -52,7 +52,6 @@ add_ops_compile_options(
         OP_NAME HcPreSinkhorn
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )

--- a/csrc/moe/moe_gating_top_k/op_host/CMakeLists.txt
+++ b/csrc/moe/moe_gating_top_k/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/moe_gating_top_k_hash/op_host/CMakeLists.txt
+++ b/csrc/moe/moe_gating_top_k_hash/op_host/CMakeLists.txt
@@ -50,7 +50,6 @@ if (BUILD_OPEN_PROJECT)
         OP_NAME MoeGatingTopKHash
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
     )
@@ -60,3 +59,4 @@ if(NOT BUILD_OPS_RTY_KERNEL)
     message(STATUS "=== Debug: BUILD is NOT BUILD_OPS_RTY_KERNEL")
     add_modules_sources(OPTYPE moe_gating_top_k_hash ACLNNTYPE aclnn)
 endif()
+

--- a/csrc/moe/moe_grouped_matmul/op_host/CMakeLists.txt
+++ b/csrc/moe/moe_grouped_matmul/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/moe_init_routing_custom/op_host/CMakeLists.txt
+++ b/csrc/moe/moe_init_routing_custom/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=on
         -Wno-deprecated-declarations
-        -Werror
 )
 
 if (NOT BUILD_OPS_RTY_KERNEL)
@@ -20,3 +19,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+

--- a/csrc/moe/scatter_nd_update_v2/op_host/CMakeLists.txt
+++ b/csrc/moe/scatter_nd_update_v2/op_host/CMakeLists.txt
@@ -24,7 +24,6 @@ add_ops_compile_options(
         OP_NAME ScatterNdUpdateV2
         OPTIONS --cce-auto-sync=on
                 -Wno-deprecated-declarations
-                -Werror
 )
 
 

--- a/csrc/moe/swiglu_group_quant/op_host/CMakeLists.txt
+++ b/csrc/moe/swiglu_group_quant/op_host/CMakeLists.txt
@@ -50,7 +50,6 @@ if (BUILD_OPEN_PROJECT)
         OP_NAME SwigluGroupQuant
         OPTIONS --cce-auto-sync=off
                 -Wno-deprecated-declarations
-                -Werror
                 -mllvm -cce-aicore-hoist-movemask=false
                 --op_relocatable_kernel_binary=true
 )
@@ -59,3 +58,4 @@ endif()
 if(NOT BUILD_OPS_RTY_KERNEL)
     add_modules_sources(OPTYPE swiglu_group_quant ACLNNTYPE aclnn)
 endif()
+

--- a/csrc/moe/transpose_kv_cache_by_block/op_host/CMakeLists.txt
+++ b/csrc/moe/transpose_kv_cache_by_block/op_host/CMakeLists.txt
@@ -11,7 +11,6 @@ add_ops_compile_options(
     OPTIONS
         --cce-auto-sync=off
         -Wno-deprecated-declarations
-        -Werror
         -mllvm -cce-aicore-hoist-movemask=false
         --op_relocatable_kernel_binary=true
 )
@@ -22,3 +21,4 @@ if (NOT BUILD_OPS_RTY_KERNEL)
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+


### PR DESCRIPTION
## Motivation
In the new version of CANN, alarms will be generated. Using -werror will cause the alarms to be treated as errors, resulting in installation failure.
The `-Werror` flag in `csrc/**/op_host/CMakeLists.txt` files treats all compiler warnings as fatal errors. This blocks local development builds when the CANN compiler emits benign warnings (e.g., deprecated-declarations that are already silenced via `-Wno-deprecated-declarations`). Warnings should be reviewed and fixed, but they should not be fatal during development iteration.

## Modifications

Removed the `-Werror` flag from all AscendC custom op `CMakeLists.txt` files under `csrc/`. This is a pure build-flag change — no source code or kernel logic is touched.

- **43 files changed**, 43 deletions (one `-Werror` line per file)
- The `-Wno-deprecated-declarations` flag and all other compile options remain unchanged

## Test

No functional change. Build verification on target CANN toolchain recommended.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
