### PR TITLE
[v0.24.0rc][BugFix] Fix AscendStore group block sizes

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -530,6 +530,19 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         self.assertEqual(len(worker.group_kv_caches_base_addr[0]), 2)
         worker.m_store.register_buffer.assert_called_once()
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.threading.Event")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreSendingThread")
+    def test_transfer_threads_use_grouped_block_sizes(self, mock_send_thread, mock_recv_thread, mock_event):
+        worker = self._make_worker(kv_role="kv_both", extra_config={"backend": "mooncake", "load_async": True})
+        worker.grouped_block_size = [128, 8, 32]
+
+        worker._start_kv_transfer_threads()
+
+        self.assertEqual(mock_send_thread.call_args.args[2], [128, 8, 32])
+        self.assertEqual(mock_recv_thread.call_args.args[2], [128, 8, 32])
+        mock_event.return_value.wait.assert_called()
+
     def test_start_load_kv_sync(self):
         worker = self._make_worker()
         worker.m_store.get = MagicMock()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -486,7 +486,7 @@ class KVPoolWorker:
                 self.kv_send_thread = KVCacheStoreSendingThread(
                     self.m_store,
                     self.token_database,
-                    self.block_size,
+                    self.grouped_block_size,
                     self.tp_rank,
                     self.tp_size,
                     self.dcp_size,
@@ -503,7 +503,7 @@ class KVPoolWorker:
                 self.kv_recv_thread = KVCacheStoreRecvingThread(
                     self.m_store,
                     self.token_database,
-                    self.block_size,
+                    self.grouped_block_size,
                     self.tp_rank,
                     self.tp_size,
                     self.dcp_size,


### PR DESCRIPTION
## Summary
- Cherry-pick #13110 (2c2b4b7f88ce4cfb76f359c388e9eafb0d0d8a7e) to `releases/v0.24.0rc`.
- Keep the patch scoped to AscendStore group block size handling and related UT coverage.
- Commit author/committer and Signed-off-by use zouyida2052 local git identity, per request.

## Validation
- git diff --check HEAD~1 HEAD
- ruff check tests/ut/distributed/ascend_store/test_pool_worker.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
- ruff format --check tests/ut/distributed/ascend_store/test_pool_worker.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q tests/ut/distributed/ascend_store/test_pool_worker.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
- Attempted targeted pytest; targeted pytest blocked locally because VLLM_VERSION is unset for a dev vllm checkout.
- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
