### PR TITLE
[BugFix] Report async KV load failures to scheduler

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -586,6 +586,31 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.start_load_kv(meta)
         # No get called since no load_spec
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread")
+    def test_async_recv_thread_shares_invalid_block_state(self, mock_recv_thread_cls):
+        worker = self._make_worker(
+            kv_role="kv_consumer",
+            extra_config={"backend": "mooncake", "load_async": True},
+        )
+        recv_thread = MagicMock()
+
+        def create_recv_thread(*args, **kwargs):
+            args[6].set()
+            return recv_thread
+
+        mock_recv_thread_cls.side_effect = create_recv_thread
+
+        worker._start_kv_transfer_threads()
+
+        kwargs = mock_recv_thread_cls.call_args.kwargs
+        self.assertIs(kwargs["invalid_block_ids"], worker._invalid_block_ids)
+        self.assertIs(
+            kwargs["invalid_block_ids_lock"],
+            worker._invalid_block_ids_lock,
+        )
+        kwargs["invalid_block_ids"].add(7)
+        self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
+
     def test_wait_for_save_enqueues_async(self):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -517,6 +517,8 @@ class KVPoolWorker:
                     self.tp_size,
                     self.dcp_size,
                     ready_event,
+                    invalid_block_ids=self._invalid_block_ids,
+                    invalid_block_ids_lock=self._invalid_block_ids_lock,
                 )
                 self.kv_recv_thread.start()
                 ready_event.wait()


### PR DESCRIPTION
### What this PR does / why we need it?

Forward-port #13099 to `main`.

When AscendStore runs with `load_async=true`, `KVCacheStoreRecvingThread` was created without the worker's shared invalid-block set and lock. The receive thread therefore recorded backend load failures in a private set, while `KVPoolWorker.get_block_ids_with_load_errors()` returned an empty set. As a result, `kv_load_failure_policy=recompute` did not reach the scheduler recovery path.

This PR passes the worker-owned invalid-block set and lock into the async receive thread and adds a regression test covering the factory wiring and worker-visible failure state.

### Does this PR introduce _any_ user-facing change?

Yes. For non-layerwise AscendStore with `load_async=true`, failed KV loads are now reported to the scheduler so requests can be rescheduled when `kv_load_failure_policy=recompute` is configured.

### How was this patch tested?

- All 82 tests in `tests.ut.distributed.ascend_store.test_pool_worker` passed.
- Changed-file code quality hooks passed; the gitleaks hook could not run locally because `wget` is unavailable.
- `git diff --check` passed.

https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
