### PR TITLE
[v0.24.0rc][BugFix] Restore synchronous AscendStore save

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -676,7 +676,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         kwargs["invalid_block_ids"].add(7)
         self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
 
-    def test_wait_for_save_enqueues_async(self):
+    def test_wait_for_save_waits_for_save(self):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()
 
@@ -692,7 +692,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.wait_for_save(meta)
         worker.kv_send_thread.add_stored_request.assert_called_with("r1")
         worker.kv_send_thread.add_request.assert_called_once()
-        worker.kv_send_thread.request_queue.join.assert_not_called()
+        worker.kv_send_thread.request_queue.join.assert_called_once()
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()
@@ -709,6 +709,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         meta.add_request(req)
         worker.wait_for_save(meta)
         worker.kv_send_thread.add_stored_request.assert_not_called()
+        worker.kv_send_thread.request_queue.join.assert_not_called()
 
     def test_get_finished_producer(self):
         worker = self._make_worker(kv_role="kv_producer")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1513,6 +1513,9 @@ class KVPoolWorker:
             send_thread.add_stored_request(request.req_id)
             send_thread.add_request(request)
 
+        if current_event is not None:
+            send_thread.request_queue.join()
+
     def retrieve_layer(
         self,
         request: ReqMeta,


### PR DESCRIPTION
### What this PR does / why we need it?

Forward-port #13024 to `releases/v0.24.0rc`.

Restore the `request_queue.join()` barrier in AscendStore `wait_for_save()`.

#12783 made non-layerwise saves asynchronous. Its full rollback together with #12819 restores the expected DeepSeek V4 prefix hit length, but that rollback also removes key-construction, mask, and store-skip changes, so it does not isolate the observed regression to asynchronous save.

This PR restores only the save barrier as the smallest A/B change. It also prevents a queued save from outliving `wait_for_save()` and using KV blocks after an accumulated completion notification allows the scheduler to release them. NPU validation is still required to determine whether this lifecycle path, or the remaining key/mask/skip path, causes the persistent 64K hit cap.

This change only restores the save barrier and leaves the key-construction, mask, and skip optimizations in place.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStore waits for queued saves to complete again before returning from `wait_for_save()`, trading asynchronous overlap for deterministic visibility to subsequent lookups.

### How was this patch tested?

- All 81 tests in `tests.ut.distributed.ascend_store.test_pool_worker` passed.
- All changed-file pre-commit hooks passed.
- `git diff --check` passed.

https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
