### PR TITLE
[MRV2][BugFix] Fix token distribution in make_dummy for AscendInputBatch

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -205,6 +205,7 @@ def test_dflash_spec_decoding(
     ],
 )
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_dspark_spec_decoding(
     model: str,
     dspark_model: str,
@@ -252,6 +253,7 @@ def test_dspark_spec_decoding(
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [True])
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_mtp_spec_decoding(
     model: str,
     max_tokens: int,
@@ -300,6 +302,7 @@ def test_mtp_spec_decoding(
     ],
 )
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_qwen3_dense_graph_mode(
     model: str,
     max_tokens: int,

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -87,9 +87,15 @@ class AscendInputBatch(InputBatch):
             num_tokens,
             input_buffers,
         )
-        # seq_len equals to query_len
-        input_buffers.seq_lens_np[:num_reqs] = num_tokens // num_reqs
-        input_buffers.seq_lens_np[num_reqs - 1] += num_tokens % num_reqs
+        # Evenly distribute num_tokens across requests instead of dumping the
+        # whole remainder on the last request.
+        # The old distribution could make the last dummy request's seq_len
+        # exceed max_model_len, causing attention kernels to read block-table
+        # entries past the tensor end (garbage page IDs / illegal memory access).
+        base_tokens = num_tokens // num_reqs
+        num_extra = num_tokens % num_reqs
+        input_buffers.seq_lens_np[: num_reqs - num_extra] = base_tokens
+        input_buffers.seq_lens_np[num_reqs - num_extra : num_reqs] = base_tokens + 1
         # Pad for full CUDA graph mode.
         input_buffers.seq_lens_np[num_reqs:] = 0
         seq_lens_np = input_buffers.seq_lens_np[:num_reqs]

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -120,7 +120,7 @@ class NPUModelRunner(GPUModelRunner):
             pin_memory=True,
         )
 
-        # NOTE: In GPUModelRunner, decode_query_len is initialized in execute_model(),
+        # NOTE: In GPUModelRunner, decode_query_len is initialized in load_model(),
         # +1 is hardcoded here but not in vllm.
         self.decode_query_len = self.num_speculative_steps + 1
         # Set _mc2_tokens_capacity and _reserved_mc2_mask for MoE communication optimization.
@@ -369,26 +369,6 @@ class NPUModelRunner(GPUModelRunner):
 
         return input_batch
 
-    def postprocess(
-        self,
-        input_batch,
-        sampled_tokens,
-        num_sampled,
-        num_rejected,
-    ):
-        """Override GPUModelRunner.postprocess for Ascend NPUs.
-        npu attention backends need seq_lens_cpu to work.
-        so we need to copy num_computed_tokens back to cpu here.
-        """
-        super().postprocess(
-            input_batch,
-            sampled_tokens,
-            num_sampled,
-            num_rejected,
-        )
-
-        self._copy_num_computed_tokens_to_cpu()
-
     def postprocess_sampled(
         self,
         idx_mapping,
@@ -397,7 +377,10 @@ class NPUModelRunner(GPUModelRunner):
         num_rejected,
         query_start_loc=None,
     ):
-        """Override GPUModelRunner.postprocess_sampled for Ascend NPUs."""
+        """Override GPUModelRunner.postprocess_sampled for Ascend NPUs.
+        npu attention backends need seq_lens_cpu to work.
+        so we need to copy num_computed_tokens back to cpu here.
+        """
         super().postprocess_sampled(
             idx_mapping,
             sampled_tokens,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aligns the dummy input generation logic in `AscendInputBatch.make_dummy` with the upstream vLLM implementation. Previously, any remaining tokens (`num_tokens % num_reqs`) were accumulated entirely onto the last request. This PR distributes the extra tokens evenly across the last `num_extra` requests, ensuring that each request receives either `base_tokens` or `base_tokens + 1` tokens. [49751](https://github.com/vllm-project/vllm/pull/49751)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI passed with existing tests.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
