### PR TITLE
[CI] Sync runtime env during AOP bisect

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -319,13 +319,19 @@ jobs:
           eval "$(awk '
             /^vLLM Git information$/        { sec="vllm"; next }
             /^vLLM-Ascend Git information$/ { sec="vllm_ascend"; next }
+            /^CANN Version: /                { print "CANN_VERSION="$3; next }
+            /^torch-npu Version: /           { print "TORCH_NPU_VERSION="$3; next }
             sec && /^Commit hash: / {
               print "HASH_" sec "=" $NF
               sec=""
             }
           ' "$LEADER_TMP")"
-          echo "vllm_hash=${HASH_vllm:-N/A}" >> "$GITHUB_OUTPUT"
-          echo "vllm_ascend_hash=${HASH_vllm_ascend:-N/A}" >> "$GITHUB_OUTPUT"
+          {
+            echo "vllm_hash=${HASH_vllm:-N/A}"
+            echo "vllm_ascend_hash=${HASH_vllm_ascend:-N/A}"
+            echo "cann_version=${CANN_VERSION:-unknown}"
+            echo "torch_npu_version=${TORCH_NPU_VERSION:-unknown}"
+          } >> "$GITHUB_OUTPUT"
           rm -f "$LEADER_TMP"
 
       - name: Update good_table.csv on success
@@ -345,7 +351,9 @@ jobs:
             --run-link  "$RUN_LINK" \
             --vllm-ascend-dir "." \
             --vllm-ascend-version "${{ steps.stream_logs.outputs.vllm_ascend_hash }}" \
-            --vllm-version "${{ steps.stream_logs.outputs.vllm_hash }}"
+            --vllm-version "${{ steps.stream_logs.outputs.vllm_hash }}" \
+            --cann-version "${{ steps.stream_logs.outputs.cann_version }}" \
+            --torch-npu-version "${{ steps.stream_logs.outputs.torch_npu_version }}"
 
       - name: Fetch benchmark results from PVC
         if: always()

--- a/.github/workflows/_e2e_nightly_multi_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node_560t.yaml
@@ -357,13 +357,19 @@ jobs:
           eval "$(awk '
             /^vLLM Git information$/        { sec="vllm"; next }
             /^vLLM-Ascend Git information$/ { sec="vllm_ascend"; next }
+            /^CANN Version: /                { print "CANN_VERSION="$3; next }
+            /^torch-npu Version: /           { print "TORCH_NPU_VERSION="$3; next }
             sec && /^Commit hash: / {
               print "HASH_" sec "=" $NF
               sec=""
             }
           ' "$LEADER_TMP")"
-          echo "vllm_hash=${HASH_vllm:-N/A}" >> "$GITHUB_OUTPUT"
-          echo "vllm_ascend_hash=${HASH_vllm_ascend:-N/A}" >> "$GITHUB_OUTPUT"
+          {
+            echo "vllm_hash=${HASH_vllm:-N/A}"
+            echo "vllm_ascend_hash=${HASH_vllm_ascend:-N/A}"
+            echo "cann_version=${CANN_VERSION:-unknown}"
+            echo "torch_npu_version=${TORCH_NPU_VERSION:-unknown}"
+          } >> "$GITHUB_OUTPUT"
           rm -f "$LEADER_TMP"
 
       - name: Fetch benchmark results from PVC

--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -67,6 +67,7 @@ show_vllm_info() {
     cd "$WORKSPACE"
     echo "Installed vLLM-related Python packages:"
     pip list | grep vllm || echo "No vllm packages found."
+    echo "torch-npu Version: $(pip show torch_npu 2>/dev/null | awk '/^Version:/{print $2}' || true)"
 
     echo ""
     echo "============================"
@@ -110,7 +111,11 @@ show_vllm_info() {
 check_npu_info() {
     echo "====> Check NPU info"
     npu-smi info
-    cat "/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/ascend_toolkit_install.info"
+    local info_file="/usr/local/Ascend/ascend-toolkit/latest/$(uname -i)-linux/ascend_toolkit_install.info"
+    if [ -f "$info_file" ]; then
+        cat "$info_file"
+        echo "CANN Version: $(grep '^version=' "$info_file" | head -n1 | cut -d= -f2 | tr -d '\"')"
+    fi
 }
 
 check_and_config() {
@@ -268,6 +273,10 @@ run_tests_with_log() {
 aop_pipeline() {
     local rules="$WORKSPACE/vllm-ascend/tests/e2e/nightly/scripts/rules-env.txt"
     local table="${GOOD_TABLE:-}"
+    local env_table=""
+    if [ -n "$table" ]; then
+        env_table="${ENV_TABLE:-$(dirname "$table")/env_table.csv}"
+    fi
     # Strip branch prefix from BENCHMARK_JOB_NAME (e.g. "main-Qwen3.5-27B-w8a8-A2" → "Qwen3.5-27B-w8a8-A2")
     local case_name="${BENCHMARK_JOB_NAME#*-}"
     if [ -z "$case_name" ] || [ "$case_name" = "$BENCHMARK_JOB_NAME" ]; then
@@ -280,6 +289,7 @@ aop_pipeline() {
     echo "  Case name   : ${case_name}"
     echo "  Rules file  : ${rules}"
     echo "  Table file  : ${table}"
+    echo "  Env table   : ${env_table:-N/A}"
     echo "  Log prefix  : ${LOG_PREFIX}"
     echo "  BENCHMARK_JOB_NAME: ${BENCHMARK_JOB_NAME:-}"
     echo "============================================"
@@ -404,6 +414,19 @@ aop_pipeline() {
     local coord="${COORD_DIR:-/root/.cache/nightly_bisect/coord}"
     echo "  Coord dir   : ${coord}"
 
+    if [ -n "$env_table" ]; then
+        local run_link="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-vllm-project/vllm-ascend}/actions/runs/${GITHUB_RUN_ID:-unknown}"
+        echo "  Recording current failure runtime environment: ${env_table}"
+        python tests/e2e/nightly/scripts/update_good_table.py \
+            --cache-csv "$table" \
+            --env-table "$env_table" \
+            --status failure \
+            --test-name "$case_name" \
+            --test-path "${CONFIG_YAML_PATH}" \
+            --scene multi_node \
+            --run-link "$run_link" || true
+    fi
+
     # Wait for all workers to signal ready
     echo "  Waiting for workers..."
     for i in $(seq 1 30); do
@@ -418,13 +441,16 @@ aop_pipeline() {
 
     cd "$WORKSPACE/vllm-ascend"
     local bisect_rc=0
+    local env_table_args=()
+    [ -n "$env_table" ] && env_table_args=(--env-table "$env_table")
     python -m tools.bisect.auto_bisect \
         --scene multi_node \
         --config-yaml "${CONFIG_YAML_PATH}" \
         --bad-commit HEAD \
         --good-table "${table}" \
         --name "${case_name}" \
-        --coord-dir "${coord}" || bisect_rc=$?
+        --coord-dir "${coord}" \
+        "${env_table_args[@]}" || bisect_rc=$?
     echo "  bisect completed (exit code: ${bisect_rc})"
     echo "=== AOP Pipeline (Pod) - END ==="
     return 1

--- a/tests/e2e/nightly/scripts/aop_process.sh
+++ b/tests/e2e/nightly/scripts/aop_process.sh
@@ -74,6 +74,24 @@ if [ -z "$NAME" ] && [ "$SCENE" = "single_node" ]; then
 fi
 
 GOOD_TABLE="${GOOD_TABLE:-}"
+if [ -n "$GOOD_TABLE" ]; then
+  ENV_TABLE="${ENV_TABLE:-$(dirname "$GOOD_TABLE")/env_table.csv}"
+else
+  ENV_TABLE="${ENV_TABLE:-}"
+fi
+RUN_LINK="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-vllm-project/vllm-ascend}/actions/runs/${GITHUB_RUN_ID:-unknown}"
+
+if [ -n "$GOOD_TABLE" ] && [ -n "$NAME" ]; then
+  echo "Recording current failure runtime environment: ${ENV_TABLE}"
+  python tests/e2e/nightly/scripts/update_good_table.py \
+    --cache-csv "$GOOD_TABLE" \
+    --env-table "$ENV_TABLE" \
+    --status failure \
+    --test-name "$NAME" \
+    --test-path "${CONFIG:-$TESTS}" \
+    --scene "$SCENE" \
+    --run-link "$RUN_LINK" || true
+fi
 
 BISECT_CMD=(
   python -m tools.bisect.auto_bisect
@@ -84,6 +102,7 @@ BISECT_CMD=(
 
 [ -n "$CONFIG" ]    && BISECT_CMD+=(--config-yaml "$CONFIG")
 [ -n "$NAME" ] && BISECT_CMD+=(--name "$NAME")
+[ -n "$ENV_TABLE" ] && BISECT_CMD+=(--env-table "$ENV_TABLE")
 [ -n "$NUM_NODES" ] && BISECT_CMD+=(--num-nodes "$NUM_NODES")
 [ -n "$COORD_DIR" ] && BISECT_CMD+=(--coord-dir "$COORD_DIR")
 

--- a/tests/e2e/nightly/scripts/update_good_table.py
+++ b/tests/e2e/nightly/scripts/update_good_table.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-"""Update /root/.cache/vllm-ascend/main/nightly/good_table.csv with a
-successful test entry.  Creates the file (with header) if it does not exist;
-replaces the existing row for the same test name if it does.
+"""Update nightly status helper tables.
+
+On success, updates good_table.csv with the latest passing vllm-ascend commit.
+For every status (success/failure), updates env_table.csv so auto-bisect can
+replay the runtime vLLM/CANN/torch-npu environment that paired with a commit.
 
 CSV columns:
     name, yaml/path, link, status,
@@ -27,6 +29,7 @@ CSV columns:
 import argparse
 import csv
 import os
+import platform
 import subprocess
 from datetime import datetime, timedelta, timezone
 
@@ -37,6 +40,18 @@ HEADER = [
     "status",
     "vLLM Git information",
     "vLLM-Ascend Git information",
+    "time",
+]
+
+ENV_HEADER = [
+    "name",
+    "yaml/path",
+    "link",
+    "status",
+    "vLLM Git information",
+    "vLLM-Ascend Git information",
+    "CANN Version",
+    "torch-npu Version",
     "time",
 ]
 
@@ -60,23 +75,23 @@ def current_timestamp() -> str:
     return ts[:-2] + ":" + ts[-2:]
 
 
-def load_rows(csv_path: str) -> list[list[str]]:
+def load_rows(csv_path: str, header: list[str]) -> list[list[str]]:
     if not os.path.isfile(csv_path):
         return []
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.reader(f)
         rows = list(reader)
     # Drop the header row if present
-    if rows and rows[0] == HEADER:
+    if rows and rows[0] == header:
         rows = rows[1:]
     return rows
 
 
-def save_rows(csv_path: str, rows: list[list[str]]) -> None:
+def save_rows(csv_path: str, rows: list[list[str]], header: list[str]) -> None:
     os.makedirs(os.path.dirname(csv_path), exist_ok=True)
     with open(csv_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
-        writer.writerow(HEADER)
+        writer.writerow(header)
         writer.writerows(rows)
 
 
@@ -112,9 +127,59 @@ def resolve_test_path(
     return f"{_DEFAULT_SINGLE_NODE_CONFIG_BASE}/{test_path}"
 
 
+def _installed_package_version(package: str) -> str:
+    try:
+        out = subprocess.check_output(
+            ["python3", "-m", "pip", "show", package],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except Exception:
+        return ""
+    for line in out.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def current_torch_npu_version() -> str:
+    return _installed_package_version("torch_npu") or _installed_package_version("torch-npu") or "unknown"
+
+
+def current_cann_version() -> str:
+    env = os.getenv("CANN_VERSION")
+    if env:
+        return env.strip()
+    ascend_home = os.getenv("ASCEND_HOME_PATH", "/usr/local/Ascend/ascend-toolkit/latest")
+    machine = platform.machine()
+    candidates = [
+        os.path.join(ascend_home, f"{machine}-linux", "ascend_toolkit_install.info"),
+        os.path.join(ascend_home, "ascend_toolkit_install.info"),
+    ]
+    for info_file in candidates:
+        if not os.path.isfile(info_file):
+            continue
+        with open(info_file, encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if line.startswith("version="):
+                    return line.split("=", 1)[1].strip().strip('"')
+    return "unknown"
+
+
+def update_env_table(env_csv: str, row: list[str]) -> None:
+    rows = load_rows(env_csv, ENV_HEADER)
+    test_name = row[0]
+    vllm_ascend_hash = row[5]
+    rows = [r for r in rows if not (len(r) > 5 and r[0] == test_name and r[5] == vllm_ascend_hash)]
+    rows.append(row)
+    save_rows(env_csv, rows, ENV_HEADER)
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Update good_table.csv on test success")
+    parser = argparse.ArgumentParser(description="Update nightly good/env tables")
     parser.add_argument("--cache-csv", required=True)
+    parser.add_argument("--env-table", default="")
+    parser.add_argument("--status", default="success")
     parser.add_argument("--test-name", required=True)
     parser.add_argument("--test-path", required=True)
     parser.add_argument("--config-base-path", default="")
@@ -124,28 +189,54 @@ def main() -> None:
     parser.add_argument("--vllm-ascend-dir", default="/vllm-workspace/vllm-ascend")
     parser.add_argument("--vllm-ascend-version", default="")
     parser.add_argument("--vllm-version", default="")
+    parser.add_argument("--cann-version", default="")
+    parser.add_argument("--torch-npu-version", default="")
     args = parser.parse_args()
 
     vllm_hash = args.vllm_version.strip() or git_head(args.vllm_dir)
     vllm_ascend_hash = args.vllm_ascend_version.strip() or git_head(args.vllm_ascend_dir)
+    cann_version = args.cann_version.strip() or current_cann_version()
+    torch_npu_version = args.torch_npu_version.strip() or current_torch_npu_version()
     timestamp = current_timestamp()
     test_path = resolve_test_path(args.test_path, args.config_base_path, args.scene, args.vllm_ascend_dir)
+
+    status = args.status.strip() or "success"
+    env_table = args.env_table.strip() or os.path.join(os.path.dirname(args.cache_csv), "env_table.csv")
+    env_row = [
+        args.test_name,
+        test_path,
+        args.run_link,
+        status,
+        vllm_hash,
+        vllm_ascend_hash,
+        cann_version,
+        torch_npu_version,
+        timestamp,
+    ]
+    update_env_table(env_table, env_row)
+    print(
+        f">>> Updated {env_table}: name={args.test_name} status={status} "
+        f"vllm={vllm_hash} cann={cann_version} torch-npu={torch_npu_version}"
+    )
+
+    if status.lower() != "success":
+        return
 
     new_row = [
         args.test_name,
         test_path,
         args.run_link,
-        "success",
+        status,
         vllm_hash,
         vllm_ascend_hash,
         timestamp,
     ]
 
     is_new = not os.path.isfile(args.cache_csv)
-    rows = load_rows(args.cache_csv)
+    rows = load_rows(args.cache_csv, HEADER)
     rows = [r for r in rows if r and r[0] != args.test_name]
     rows.append(new_row)
-    save_rows(args.cache_csv, rows)
+    save_rows(args.cache_csv, rows, HEADER)
 
     action = "Created" if is_new else "Updated"
     print(f">>> {action} {args.cache_csv}: name={args.test_name} status=success time={timestamp}")

--- a/tests/ut/tools/bisect/test_coordinator.py
+++ b/tests/ut/tools/bisect/test_coordinator.py
@@ -18,7 +18,17 @@ def test_publish_command_and_wait_command_round_trip(tmp_path: Path):
         "commit": "abcdef1234567890",
         "rebuild": True,
         "action": "RUN",
+        "env": None,
     }
+
+
+def test_publish_command_can_include_runtime_env(tmp_path: Path):
+    coord = Coordinator(str(tmp_path), num_nodes=2, node_index=1)
+    env = {"vllm_ref": "vllm-sha", "cann_version": "9.0.1", "torch_npu_version": "2.6.0"}
+
+    coord.publish_command(1, "abcdef1234567890", rebuild=True, env=env)
+
+    assert coord.wait_command(1, timeout_s=0.1)["env"] == env
 
 
 def test_wait_command_ignores_stale_done_when_since_ts_is_newer(tmp_path: Path):

--- a/tests/ut/tools/bisect/test_env_table.py
+++ b/tests/ut/tools/bisect/test_env_table.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from textwrap import dedent
+
+from tools.bisect.config import BisectInput, Candidate
+from tools.bisect.env_table import EnvTable
+
+HEADER = (
+    "name,yaml/path,link,status,vLLM Git information,vLLM-Ascend Git information,CANN Version,torch-npu Version,time"
+)
+
+
+def _candidate(commit: str) -> Candidate:
+    return Candidate(commit=commit, pr_number=None, subject=commit)
+
+
+def test_env_table_prefers_exact_commit_row(tmp_path: Path, monkeypatch):
+    table = tmp_path / "env_table.csv"
+    table.write_text(
+        dedent(
+            f"""
+            {HEADER}
+            case,cases/case.yaml,old,success,vllm-old,aaa111,9.0.0,2.5.0,2026-01-01 01:00:00 +08:00
+            case,cases/case.yaml,new,failure,vllm-new,bbb222,9.0.1,2.6.0,2026-01-02 01:00:00 +08:00
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tools.bisect.git_ops.is_ancestor", lambda _repo, ancestor, target: ancestor == target)
+
+    resolved = EnvTable(str(table)).resolve_for_commits(
+        tmp_path,
+        BisectInput(scene="single_node", config_yaml="case.yaml", bad_commit="bbb222", name="case"),
+        [_candidate("bbb222")],
+    )
+
+    assert resolved["bbb222"].vllm_ref == "vllm-new"
+    assert resolved["bbb222"].cann_version == "9.0.1"
+    assert resolved["bbb222"].torch_npu_version == "2.6.0"
+
+
+def test_env_table_uses_closest_preceding_status_row(tmp_path: Path, monkeypatch):
+    table = tmp_path / "env_table.csv"
+    table.write_text(
+        dedent(
+            f"""
+            {HEADER}
+            case,cases/case.yaml,old,success,vllm-old,aaa,9.0.0,2.5.0,2026-01-01 01:00:00 +08:00
+            case,cases/case.yaml,new,success,vllm-new,ccc,9.0.1,2.6.0,2026-01-02 01:00:00 +08:00
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    ancestry = {
+        ("aaa", "bbb"): True,
+        ("ccc", "bbb"): False,
+        ("aaa", "ccc"): True,
+    }
+
+    def is_ancestor(_repo: Path, ancestor: str, target: str) -> bool:
+        return ancestry[(ancestor, target)]
+
+    monkeypatch.setattr("tools.bisect.git_ops.is_ancestor", is_ancestor)
+
+    resolved = EnvTable(str(table)).resolve_for_commits(
+        tmp_path,
+        BisectInput(scene="single_node", config_yaml="case.yaml", bad_commit="bbb", name="case"),
+        [_candidate("bbb")],
+    )
+
+    assert resolved["bbb"].vllm_ref == "vllm-old"

--- a/tools/bisect/README.md
+++ b/tools/bisect/README.md
@@ -31,9 +31,14 @@ trigger (case FAIL)
 * **Compile only on C++ changes**: by default (`--native-check per-commit`) a
   rebuild happens only when that commit's own diff touches
   `*.cpp/*.cc/*.cu/*.h/*.hpp/*.cuh`, `csrc/**`, `CMakeLists.txt`, or `setup.py`.
-  Pure `.py`/yaml changes are picked up live by the editable install (vLLM is
-  never touched). `--native-check since-build` widens the check to all changes
-  since the last build (safer across bisect jumps).
+  Pure `.py`/yaml changes are picked up live by the editable install.
+  `--native-check since-build` widens the check to all changes since the last
+  build (safer across bisect jumps).
+* **Runtime env follows the status table**: the paired vLLM, CANN and torch-npu
+  versions are read from `env_table.csv`. If the current container env differs,
+  auto-bisect switches it at runtime before building/testing the candidate. vLLM
+  is always installed from source (`/vllm-workspace/vllm` by default) so rc/dev
+  refs can be tested.
 * **SKIP semantics**: a flaky/unconfirmed FAIL, a build failure, or a collection
   error (pytest rc 2/3/4/5, e.g. a conftest ImportError) becomes `SKIP` instead
   of a misleading FAIL — like `git bisect skip`.
@@ -50,6 +55,19 @@ For the requested case (matched by `--name` or by `--config-yaml` against
 `yaml/path`), the good commit is the `vLLM-Ascend Git information` of the most
 recent row whose `status` is `success`. Point `--good-table` at it (or
 `$BISECT_GOOD_TABLE`). See `good_table.sample.csv`.
+
+## Runtime environment table
+
+The environment table is a separate CSV, defaulting to `env_table.csv` beside
+the good table (override with `--env-table` / `$BISECT_ENV_TABLE`):
+
+```csv
+name,yaml/path,link,status,vLLM Git information,VLLM-Ascend Git information,CANN Version,torch-npu Version,time
+```
+
+For each candidate commit, auto-bisect first looks for an exact yaml status row.
+If none exists, it uses the closest preceding status row for the same yaml/name
+in first-parent history. See `env_table.sample.csv`.
 
 ## Usage
 

--- a/tools/bisect/auto_bisect.py
+++ b/tools/bisect/auto_bisect.py
@@ -36,6 +36,7 @@ from tools.bisect import git_ops, report
 from tools.bisect.build_manager import BuildError, BuildManager
 from tools.bisect.config import (
     DEFAULT_COORD_DIR,
+    DEFAULT_ENV_TABLE,
     DEFAULT_GOOD_TABLE,
     DEFAULT_WORK_DIR,
     REPO_ROOT,
@@ -47,6 +48,8 @@ from tools.bisect.config import (
     TrialResult,
     Verdict,
 )
+from tools.bisect.env_manager import EnvSwitchError
+from tools.bisect.env_table import EnvTable
 from tools.bisect.good_table import GoodTable
 from tools.bisect.state import BisectState
 from tools.bisect.verdict import evaluate
@@ -98,14 +101,14 @@ class Bisector:
                 log_path=str(log_path),
                 note=note,
             )
-        except BuildError as exc:
+        except (BuildError, EnvSwitchError) as exc:
             result = TrialResult(
                 candidate=candidate,
                 verdict="SKIP",
                 duration_s=time.time() - start,
                 rebuilt=True,
                 log_path=str(log_path),
-                note=f"build failed -> SKIP: {exc}".splitlines()[0],
+                note=f"deploy/env failed -> SKIP: {exc}".splitlines()[0],
             )
         finally:
             self.runner.teardown()
@@ -223,6 +226,8 @@ class Bisector:
 
         candidates = git_ops.candidate_list(self.repo, good.commit, bad.commit)
         logger.info("Search space: %d commits", len(candidates))
+        env_by_commit = EnvTable(self.opt.env_table_path).resolve_for_commits(self.repo, self.inp, [good, *candidates])
+        self.opt.env_by_commit = {commit: env.to_dict() for commit, env in env_by_commit.items()}
 
         state = BisectState.load(self.state_path, good=good.commit, bad=bad.commit) or BisectState(
             good=good.commit, bad=bad.commit, hi=len(candidates) - 1
@@ -300,6 +305,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--good-commit", default=None, help="override; else read from good table")
     p.add_argument("--config-base-path", default=os.getenv("CONFIG_BASE_PATH"))
     p.add_argument("--good-table", default=DEFAULT_GOOD_TABLE)
+    p.add_argument("--env-table", default=DEFAULT_ENV_TABLE)
     p.add_argument("--work-dir", default=DEFAULT_WORK_DIR)
     p.add_argument("--repo-dir", default=str(REPO_ROOT))
     p.add_argument(
@@ -400,6 +406,7 @@ def main(argv: list[str] | None = None) -> int:
         work_dir=args.work_dir,
         coord_dir=args.coord_dir,
         good_table_path=args.good_table,
+        env_table_path=args.env_table,
         fail_confirm_retries=args.fail_confirm_retries,
         verify_good=not args.no_verify_good,
         verify_bad=not args.no_verify_bad,

--- a/tools/bisect/build_manager.py
+++ b/tools/bisect/build_manager.py
@@ -116,6 +116,11 @@ class BuildManager:
             reason=f"no native/cpp changes ({scope}) -> editable install, no compile",
         )
 
+    def invalidate_build_baseline(self, reason: str) -> None:
+        """Force the next prepare() to rebuild against a changed runtime env."""
+        logger.info("[build] invalidating build baseline: %s", reason)
+        self.last_built_commit = None
+
     # ------------------------------------------------------------- prepare
     def prepare(self, target_commit: str, log_file: Path | None = None) -> BuildDecision:
         """Checkout ``target_commit`` and rebuild/reinstall as needed.

--- a/tools/bisect/config.py
+++ b/tools/bisect/config.py
@@ -50,6 +50,10 @@ DEFAULT_GOOD_TABLE = os.getenv(
     "BISECT_GOOD_TABLE",
     "/root/.cache/nightly_bisect/good_table.csv",
 )
+DEFAULT_ENV_TABLE = os.getenv(
+    "BISECT_ENV_TABLE",
+    str(Path(DEFAULT_GOOD_TABLE).with_name("env_table.csv")),
+)
 SAMPLE_GOOD_TABLE = str(Path(__file__).resolve().parent / "good_table.sample.csv")
 
 # Where per-run artifacts (logs, state, final report) are written.
@@ -166,6 +170,8 @@ class BisectOptions:
     work_dir: str = DEFAULT_WORK_DIR
     coord_dir: str = DEFAULT_COORD_DIR
     good_table_path: str = DEFAULT_GOOD_TABLE
+    env_table_path: str = DEFAULT_ENV_TABLE
+    env_by_commit: dict[str, dict[str, str]] = field(default_factory=dict)
     # Re-confirm a FAIL this many extra times before trusting it (flaky guard).
     fail_confirm_retries: int = 1
     # Verify the endpoints before searching (good must PASS, bad must FAIL).

--- a/tools/bisect/coordinator.py
+++ b/tools/bisect/coordinator.py
@@ -77,13 +77,23 @@ class Coordinator:
         return self.root / "DONE"
 
     # ------------------------------------------------------- master writes
-    def publish_command(self, rnd: int, commit: str, rebuild: bool, action: str = "RUN") -> None:
-        """Publish the per-round command. ``action`` is "RUN" (deploy + run the
-        distributed test) or "SKIP" (this commit is pre-skipped, e.g. vLLM
-        mismatch -- workers consume the command but do not deploy/run, keeping
-        leader/worker rounds in lockstep)."""
+    def publish_command(
+        self,
+        rnd: int,
+        commit: str,
+        rebuild: bool,
+        action: str = "RUN",
+        env: dict[str, str] | None = None,
+    ) -> None:
+        """Publish the per-round command.
+
+        ``action`` is "RUN" (switch env + deploy + run the distributed test) or
+        "SKIP" (pre-skipped by the leader, e.g. target env cannot be activated).
+        Workers consume SKIP commands without deploy/run, keeping rounds in
+        lockstep.
+        """
         path = self._round_dir(rnd) / "command.json"
-        path.write_text(json.dumps({"round": rnd, "commit": commit, "rebuild": rebuild, "action": action}))
+        path.write_text(json.dumps({"round": rnd, "commit": commit, "rebuild": rebuild, "action": action, "env": env}))
         logger.info("[coord] published command round=%d commit=%s action=%s", rnd, commit[:12], action)
 
     def publish_verdict(self, rnd: int, verdict: str) -> None:

--- a/tools/bisect/env_manager.py
+++ b/tools/bisect/env_manager.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+"""Runtime environment switching for auto-bisect."""
+
+import importlib.metadata
+import logging
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.bisect.env_table import UNKNOWN_VALUES, RuntimeEnv
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VLLM_REPO_DIR = "/vllm-workspace/vllm"
+DEFAULT_VLLM_REMOTE_URL = "https://github.com/vllm-project/vllm.git"
+
+
+class EnvSwitchError(RuntimeError):
+    pass
+
+
+def _run(cmd: list[str], log_file: Path | None, label: str, cwd: Path | None = None) -> None:
+    logger.info("[env] running: %s", " ".join(cmd))
+    if log_file is not None:
+        with open(log_file, "a", encoding="utf-8") as out:
+            out.write(f"\n$ {' '.join(cmd)}\n")
+            out.flush()
+            proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None, stdout=out, stderr=subprocess.STDOUT, text=True)
+        tail = "(see env/build log)"
+    else:
+        proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True)
+        tail = (proc.stdout or proc.stderr or "")[-2000:]
+    if proc.returncode != 0:
+        raise EnvSwitchError(f"{label} failed (rc={proc.returncode}):\n{tail}")
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> str:
+    proc = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        raise EnvSwitchError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def _known(value: str) -> bool:
+    return value.strip() not in UNKNOWN_VALUES
+
+
+def _same_ref(current: str, target: str) -> bool:
+    current = current.strip()
+    target = target.strip()
+    return bool(current and target and (current.startswith(target) or target.startswith(current)))
+
+
+def _installed_package_version(*package_names: str) -> str:
+    for name in package_names:
+        try:
+            return importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return ""
+
+
+def _read_cann_version_from_info(info_file: Path) -> str:
+    if not info_file.exists():
+        return ""
+    for line in info_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if line.startswith("version="):
+            return line.split("=", 1)[1].strip().strip('"')
+    return ""
+
+
+def _installed_cann_version() -> str:
+    env = os.getenv("CANN_VERSION")
+    if env:
+        return env.strip()
+    machine = platform.machine()
+    ascend_home = Path(os.getenv("ASCEND_HOME_PATH", "/usr/local/Ascend/ascend-toolkit/latest"))
+    for info_file in (
+        ascend_home / f"{machine}-linux" / "ascend_toolkit_install.info",
+        ascend_home / "ascend_toolkit_install.info",
+    ):
+        version = _read_cann_version_from_info(info_file)
+        if version:
+            return version
+    return ""
+
+
+def _source_env_file(source_file: Path) -> None:
+    script = f"source {source_file} >/dev/null 2>&1; env -0"
+    proc = subprocess.run(["bash", "-c", script], capture_output=True)
+    if proc.returncode != 0:
+        raise EnvSwitchError(f"source CANN env failed: {source_file}")
+    for chunk in proc.stdout.split(b"\0"):
+        if not chunk or b"=" not in chunk:
+            continue
+        key, value = chunk.split(b"=", 1)
+        os.environ[key.decode()] = value.decode(errors="ignore")
+
+
+def _cann_source_candidates(version: str) -> list[Path]:
+    roots = [
+        Path(f"/usr/local/Ascend/cann-{version}"),
+        Path(f"/usr/local/Ascend/ascend-toolkit/{version}"),
+        Path("/usr/local/Ascend/ascend-toolkit/latest"),
+    ]
+    candidates: list[Path] = []
+    for root in roots:
+        candidates.extend(
+            [
+                root / "set_env.sh",
+                root / "ascend-toolkit" / "set_env.sh",
+                root / "share" / "info" / "ascendnpu-ir" / "bin" / "set_env.sh",
+            ]
+        )
+    return candidates
+
+
+def _is_shallow_repo(repo: Path) -> bool:
+    return _git(repo, "rev-parse", "--is-shallow-repository", check=False).strip() == "true"
+
+
+def _current_vllm_ref(vllm_repo: Path) -> str:
+    if vllm_repo.exists():
+        current = _git(vllm_repo, "rev-parse", "HEAD", check=False)
+        if current:
+            return current
+    return os.getenv("VLLM_VERSION", "")
+
+
+class EnvironmentManager:
+    def __init__(self, vllm_repo_dir: str | None = None, vllm_remote_url: str | None = None):
+        self.vllm_repo = Path(vllm_repo_dir or os.getenv("VLLM_REPO_DIR", DEFAULT_VLLM_REPO_DIR))
+        self.vllm_remote_url = vllm_remote_url or os.getenv("VLLM_REMOTE_URL", DEFAULT_VLLM_REMOTE_URL)
+
+    def ensure(self, target: RuntimeEnv | None, log_file: Path | None = None) -> bool:
+        """Make the current process env match ``target``.
+
+        Returns True when something changed, so callers can rebuild vllm-ascend
+        against the newly selected runtime.
+        """
+        if target is None or target.is_empty:
+            return False
+        changed = False
+        changed |= self._ensure_cann(target.cann_version)
+        changed |= self._ensure_torch_npu(target.torch_npu_version, log_file)
+        changed |= self._ensure_vllm(target.vllm_ref, log_file)
+        return changed
+
+    def _ensure_vllm(self, target_ref: str, log_file: Path | None) -> bool:
+        if not _known(target_ref):
+            return False
+        current = _current_vllm_ref(self.vllm_repo)
+        if _same_ref(current, target_ref):
+            logger.info("[env] vLLM already matches %s", target_ref[:12])
+            return False
+        if not self.vllm_repo.exists():
+            self.vllm_repo.parent.mkdir(parents=True, exist_ok=True)
+            _run(["git", "clone", self.vllm_remote_url, str(self.vllm_repo)], log_file, "clone vLLM")
+        _git(self.vllm_repo, "fetch", "--tags", "origin", check=False)
+        if _is_shallow_repo(self.vllm_repo):
+            _git(self.vllm_repo, "fetch", "--unshallow", "origin", check=False)
+        _git(self.vllm_repo, "fetch", "origin", target_ref, check=False)
+        try:
+            _git(self.vllm_repo, "checkout", "--force", target_ref)
+        except EnvSwitchError:
+            _git(self.vllm_repo, "checkout", "--force", "FETCH_HEAD")
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                str(self.vllm_repo),
+                "--no-input",
+                "--disable-pip-version-check",
+            ],
+            log_file,
+            "install vLLM from source",
+        )
+        os.environ["VLLM_VERSION"] = target_ref
+        return True
+
+    def _ensure_torch_npu(self, version: str, log_file: Path | None) -> bool:
+        if not _known(version):
+            return False
+        current = _installed_package_version("torch-npu", "torch_npu")
+        if current == version:
+            logger.info("[env] torch-npu already matches %s", version)
+            return False
+        package = os.getenv("BISECT_TORCH_NPU_PACKAGE", "torch-npu")
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                f"{package}=={version}",
+                "--force-reinstall",
+                "--no-input",
+                "--disable-pip-version-check",
+            ],
+            log_file,
+            "install torch-npu",
+        )
+        os.environ["TORCH_NPU_VERSION"] = version
+        return True
+
+    def _ensure_cann(self, version: str) -> bool:
+        if not _known(version):
+            return False
+        current = _installed_cann_version()
+        if current == version:
+            logger.info("[env] CANN already matches %s", version)
+            return False
+        for source_file in _cann_source_candidates(version):
+            if source_file.exists():
+                _source_env_file(source_file)
+                os.environ["CANN_VERSION"] = version
+                logger.info("[env] sourced CANN %s from %s", version, source_file)
+                return True
+        raise EnvSwitchError(
+            f"CANN {version} is not available under /usr/local/Ascend; "
+            "the daily image cannot be changed, so mount/install this CANN runtime before bisecting"
+        )

--- a/tools/bisect/env_table.py
+++ b/tools/bisect/env_table.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+"""Read the nightly environment table used by auto-bisect."""
+
+import csv
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.bisect import git_ops
+from tools.bisect.config import BisectInput, Candidate
+
+logger = logging.getLogger(__name__)
+
+COL_NAME = "name"
+COL_PATH = "yaml/path"
+COL_LINK = "link"
+COL_STATUS = "status"
+COL_VLLM = "vLLM Git information"
+COL_VLLM_ASCEND = "vLLM-Ascend Git information"
+COL_CANN = "CANN Version"
+COL_TORCH_NPU = "torch-npu Version"
+COL_TIME = "time"
+
+HEADER = [
+    COL_NAME,
+    COL_PATH,
+    COL_LINK,
+    COL_STATUS,
+    COL_VLLM,
+    COL_VLLM_ASCEND,
+    COL_CANN,
+    COL_TORCH_NPU,
+    COL_TIME,
+]
+
+UNKNOWN_VALUES = {"", "N/A", "n/a", "unknown", "None", "none"}
+
+
+@dataclass(frozen=True)
+class RuntimeEnv:
+    vllm_ref: str = ""
+    cann_version: str = ""
+    torch_npu_version: str = ""
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.vllm_ref or self.cann_version or self.torch_npu_version)
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "vllm_ref": self.vllm_ref,
+            "cann_version": self.cann_version,
+            "torch_npu_version": self.torch_npu_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | None) -> "RuntimeEnv | None":
+        if not data:
+            return None
+        env = cls(
+            vllm_ref=str(data.get("vllm_ref") or ""),
+            cann_version=str(data.get("cann_version") or ""),
+            torch_npu_version=str(data.get("torch_npu_version") or ""),
+        )
+        return None if env.is_empty else env
+
+
+@dataclass(frozen=True)
+class EnvEntry:
+    name: str
+    path: str
+    link: str
+    status: str
+    vllm_commit: str
+    vllm_ascend_commit: str
+    cann_version: str
+    torch_npu_version: str
+    time: str
+
+    @property
+    def runtime_env(self) -> RuntimeEnv:
+        return RuntimeEnv(
+            vllm_ref="" if self.vllm_commit in UNKNOWN_VALUES else self.vllm_commit,
+            cann_version="" if self.cann_version in UNKNOWN_VALUES else self.cann_version,
+            torch_npu_version="" if self.torch_npu_version in UNKNOWN_VALUES else self.torch_npu_version,
+        )
+
+
+def _coerce(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ",".join(str(v) for v in value).strip()
+    return str(value).strip()
+
+
+def _norm(row: dict[str | None, object]) -> dict[str, str]:
+    normalised: dict[str, str] = {}
+    for key, value in row.items():
+        if key is None:
+            continue
+        normalised[key.strip().lower()] = _coerce(value)
+    return normalised
+
+
+def _matches(entry: EnvEntry, name: str | None, config_yaml: str | None) -> bool:
+    if name:
+        return entry.name == name
+    if config_yaml:
+        p = entry.path.rstrip("/")
+        q = config_yaml.rstrip("/")
+        return p.endswith(q) or Path(p).name == Path(q).name
+    return False
+
+
+def _same_commit(lhs: str, rhs: str) -> bool:
+    lhs = lhs.strip()
+    rhs = rhs.strip()
+    return bool(lhs and rhs and (lhs.startswith(rhs) or rhs.startswith(lhs)))
+
+
+class EnvTable:
+    """Read-only accessor over the nightly runtime environment CSV."""
+
+    def __init__(self, path: str):
+        self.path = Path(path)
+
+    def _read_all(self) -> list[EnvEntry]:
+        if not self.path.exists():
+            logger.warning("Environment table not found at %s", self.path)
+            return []
+        entries: list[EnvEntry] = []
+        with self.path.open(newline="", encoding="utf-8-sig") as f:
+            for raw in csv.DictReader(f):
+                row = _norm(raw)
+                name = row.get(COL_NAME.lower(), "")
+                vllm_ascend_commit = row.get(COL_VLLM_ASCEND.lower(), "")
+                if not name and not vllm_ascend_commit:
+                    continue
+                entries.append(
+                    EnvEntry(
+                        name=name,
+                        path=row.get(COL_PATH.lower(), ""),
+                        link=row.get(COL_LINK.lower(), ""),
+                        status=row.get(COL_STATUS.lower(), ""),
+                        vllm_commit=row.get(COL_VLLM.lower(), ""),
+                        vllm_ascend_commit=vllm_ascend_commit,
+                        cann_version=row.get(COL_CANN.lower(), ""),
+                        torch_npu_version=row.get(COL_TORCH_NPU.lower(), ""),
+                        time=row.get(COL_TIME.lower(), ""),
+                    )
+                )
+        return entries
+
+    @staticmethod
+    def _closest_ancestor(repo: Path, target_commit: str, entries: list[EnvEntry]) -> EnvEntry | None:
+        best: EnvEntry | None = None
+        for entry in entries:
+            commit = entry.vllm_ascend_commit
+            if not commit or commit in UNKNOWN_VALUES:
+                continue
+            try:
+                is_ancestor = git_ops.is_ancestor(repo, commit, target_commit)
+            except Exception as exc:  # noqa: BLE001 - stale table rows should not abort bisect
+                logger.warning("Ignoring env row with unresolved commit %s: %s", commit, exc)
+                continue
+            if not is_ancestor:
+                continue
+            if best is None or git_ops.is_ancestor(repo, best.vllm_ascend_commit, commit):
+                best = entry
+        return best
+
+    def resolve_for_commits(
+        self,
+        repo: Path,
+        inp: BisectInput,
+        commits: list[Candidate],
+    ) -> dict[str, RuntimeEnv]:
+        """Resolve the runtime env for each commit from yaml status rows.
+
+        Exact rows win. For commits that do not have their own nightly status
+        row, use the closest preceding row for the same yaml/name in the
+        first-parent history. This matches the daily-image model: the env active
+        at the latest observed yaml status is used until a newer status row says
+        otherwise.
+        """
+        rows = [entry for entry in self._read_all() if _matches(entry, inp.name, inp.config_yaml)]
+        if not rows:
+            logger.warning("No environment rows match name=%r config_yaml=%r", inp.name, inp.config_yaml)
+            return {}
+
+        resolved: dict[str, RuntimeEnv] = {}
+        for candidate in commits:
+            exact = next((entry for entry in rows if _same_commit(entry.vllm_ascend_commit, candidate.commit)), None)
+            entry = exact or self._closest_ancestor(repo, candidate.commit, rows)
+            if entry is not None:
+                env = entry.runtime_env
+                if not env.is_empty:
+                    resolved[candidate.commit] = env
+
+        logger.info(
+            "Resolved runtime env for %d/%d bisect commits from %s",
+            len(resolved),
+            len(commits),
+            self.path,
+        )
+        return resolved

--- a/tools/bisect/env_table.sample.csv
+++ b/tools/bisect/env_table.sample.csv
@@ -1,0 +1,3 @@
+name,yaml/path,link,status,vLLM Git information,vLLM-Ascend Git information,CANN Version,torch-npu Version,time
+DeepSeek-R1-0528-W8A8,tests/e2e/nightly/single_node/models/configs/DeepSeek-R1-0528-W8A8.yaml,https://github.com/vllm-project/vllm-ascend/actions/runs/27500000000/job/80000000001,success,ad7125a431e176d4161099480a66f0169609a690,46356897b4d8000000000000000000000aaaa,9.0.1,2.6.0,2026-06-15 03:40:00 +08:00
+DeepSeek-R1-0528-W8A8,tests/e2e/nightly/single_node/models/configs/DeepSeek-R1-0528-W8A8.yaml,https://github.com/vllm-project/vllm-ascend/actions/runs/27571160772/job/81510428999,failure,bd40f6e2b0c423d77c06dbd689aad69d32f1cb8a,b545857e2983000000000000000000000000bbbb,9.0.1,2.6.0,2026-06-16 03:46:00 +08:00

--- a/tools/bisect/runner.py
+++ b/tools/bisect/runner.py
@@ -45,8 +45,9 @@ from tools.bisect.config import (
     Candidate,
 )
 from tools.bisect.coordinator import Coordinator
+from tools.bisect.env_manager import EnvironmentManager, EnvSwitchError
+from tools.bisect.env_table import RuntimeEnv
 from tools.bisect.verdict import RunOutcome
-from tools.bisect.vllm_compat import check_compatible, check_compatible_at
 
 logger = logging.getLogger(__name__)
 
@@ -55,10 +56,7 @@ _INTERNAL_DP_TEST = "tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi
 _EXTERNAL_DP_TEST = "tests/e2e/nightly/multi_node/external_dp/scripts/test_external_dp.py"
 
 # Ascend toolkit env files sourced before launching multi-node pytest.
-_ENV_SOURCE_FILES = (
-    "/usr/local/Ascend/ascend-toolkit/set_env.sh",
-    "/usr/local/Ascend/nnal/atb/set_env.sh",
-)
+_ATB_ENV_SOURCE_FILE = "/usr/local/Ascend/nnal/atb/set_env.sh"
 
 
 def _safe_name(name: str) -> str:
@@ -93,6 +91,7 @@ class BaseRunner:
         self.opt = opt
         self.builder = builder
         self.repo = opt.repo_dir
+        self.env_manager = EnvironmentManager()
 
     def _base_env(self) -> dict[str, str]:
         env = dict(os.environ)
@@ -109,21 +108,15 @@ class BaseRunner:
         path.mkdir(parents=True, exist_ok=True)
         return path
 
-    def _vllm_skip_outcome(self, rebuilt: bool) -> RunOutcome | None:
-        """After checkout, SKIP the commit if its pinned vLLM != the installed one.
+    def _target_env(self, candidate: Candidate) -> RuntimeEnv | None:
+        return RuntimeEnv.from_dict(self.opt.env_by_commit.get(candidate.commit))
 
-        Returns a SKIP RunOutcome on a confident mismatch, else None (proceed).
-        Avoids wasting a full pytest run on a commit that can only fail to
-        collect/import against the container's vLLM.
-        """
-        compatible, reason = check_compatible(self.repo)
-        if compatible:
-            logger.info("[vllm-compat] %s", reason)
-            return None
-        logger.warning("[vllm-compat] %s -> SKIP", reason)
-        outcome = RunOutcome(exit_code=0, infra_error=True, skip_reason=reason)
-        outcome.rebuilt = rebuilt  # type: ignore[attr-defined]
-        return outcome
+    def _ensure_runtime_env(self, candidate: Candidate, log_path: Path) -> RuntimeEnv | None:
+        target_env = self._target_env(candidate)
+        changed = self.env_manager.ensure(target_env, log_path)
+        if changed:
+            self.builder.invalidate_build_baseline("runtime env changed for bisect candidate")
+        return target_env
 
     def validate(self, candidate: Candidate, round_idx: int, log_dir: Path) -> RunOutcome:
         raise NotImplementedError
@@ -138,13 +131,8 @@ class BaseRunner:
 class SingleNodeRunner(BaseRunner):
     def validate(self, candidate: Candidate, round_idx: int, log_dir: Path) -> RunOutcome:
         log_path = log_dir / f"round{round_idx}_{candidate.short}.log"
+        self._ensure_runtime_env(candidate, log_path)
         decision = self.builder.prepare(candidate.commit, log_path)  # may raise BuildError
-
-        # vLLM/vllm-ascend version skew check: a commit pinned to a different
-        # vLLM than the container's cannot be validly tested -> SKIP cleanly.
-        skip = self._vllm_skip_outcome(decision.rebuild)
-        if skip is not None:
-            return skip
 
         # Run the WHOLE yaml (all test_cases): nightly cannot select a single
         # case, so we don't pass -k. Each case writes its own benchmark JSON
@@ -188,35 +176,33 @@ class MultiNodeRunner(BaseRunner):
 
     def validate(self, candidate: Candidate, round_idx: int, log_dir: Path) -> RunOutcome:
         log_path = log_dir / f"round{round_idx}_{candidate.short}.log"
-        decision = self.builder.decide(candidate.commit)
-
-        # 1) vLLM/vllm-ascend version skew: read this commit's pinned vLLM tag
-        # *without* checking it out (same container vLLM on every node, so the
-        # decision is identical cluster-wide). On a mismatch publish a SKIP
-        # command so workers consume the round and stay in lockstep, but neither
-        # side deploys or runs.
-        compatible, reason = check_compatible_at(self.repo, candidate.commit)
-        if not compatible:
-            logger.warning("[vllm-compat] %s -> SKIP", reason)
-            self.coord.publish_command(round_idx, candidate.commit, decision.rebuild, action="SKIP")
-            outcome = RunOutcome(exit_code=0, infra_error=True, skip_reason=reason)
+        try:
+            target_env = self._ensure_runtime_env(candidate, log_path)
+        except EnvSwitchError as exc:
+            env_payload = None
+            if (target_env := self._target_env(candidate)) is not None:
+                env_payload = target_env.to_dict()
+            self.coord.publish_command(round_idx, candidate.commit, rebuild=False, action="SKIP", env=env_payload)
+            outcome = RunOutcome(exit_code=0, infra_error=True, skip_reason=str(exc).splitlines()[0])
             outcome.rebuilt = False  # type: ignore[attr-defined]
             return outcome
-        logger.info("[vllm-compat] %s", reason)
 
-        # 2) tell every node to deploy this commit, then deploy locally too.
-        self.coord.publish_command(round_idx, candidate.commit, decision.rebuild, action="RUN")
+        decision = self.builder.decide(candidate.commit)
+        env_payload = target_env.to_dict() if target_env is not None else None
+
+        # Tell every node to switch env and deploy this commit, then deploy locally too.
+        self.coord.publish_command(round_idx, candidate.commit, decision.rebuild, action="RUN", env=env_payload)
         try:
             self.builder.prepare(candidate.commit, log_path)
         except BuildError:
             self.coord.publish_verdict(round_idx, "SKIP")
             raise
 
-        # 3) barrier: every node deployed the same commit before any test starts
+        # Barrier: every node deployed the same commit before any test starts.
         self.coord.signal_ready(round_idx, git_ops.current_commit(self.repo))
         self.coord.wait_all_ready(round_idx, candidate.commit, self.opt.barrier_timeout_s)
 
-        # 4) launch the multi-node pytest on master and read the verdict
+        # Launch the multi-node pytest on master and read the verdict.
         job = _safe_name(self.inp.config_yaml)
         results_dir = self._reset_dir(Path("/root/.cache/benchmark_results") / job)
         rc = self._run_multi_pytest(log_path, job)
@@ -240,7 +226,7 @@ class MultiNodeRunner(BaseRunner):
         env.setdefault("LWS_WORKER_INDEX", str(self.opt.node_index))
         # Source the Ascend toolkit env then exec pytest (mirrors run.sh, but
         # without its broad python3 kill which would take down this driver).
-        sources = " ; ".join(f"source {f} 2>/dev/null || true" for f in _ENV_SOURCE_FILES)
+        sources = ascend_source_cmd(env)
         pytest_cmd = f"python -m pytest -sv --show-capture=no {self._test_path()}"
         bash_cmd = f"set -e ; {sources} ; exec {pytest_cmd}"
         logger.info("[multi] running: %s", pytest_cmd)
@@ -277,3 +263,10 @@ def build_runner(inp: BisectInput, opt: BisectOptions, builder: BuildManager):
 
 # Keep MULTI_NODE_RUN_SH referenced for docs/tools that grep for the entry.
 _NIGHTLY_ENTRIES = (SINGLE_NODE_TEST_PATH, MULTI_NODE_RUN_SH)
+
+
+def ascend_source_cmd(env: dict[str, str]) -> str:
+    ascend_home = env.get("ASCEND_HOME_PATH")
+    toolkit = f"{ascend_home}/set_env.sh" if ascend_home else "/usr/local/Ascend/ascend-toolkit/set_env.sh"
+    files = (toolkit, _ATB_ENV_SOURCE_FILE)
+    return " ; ".join(f"source {f} 2>/dev/null || true" for f in files)

--- a/tools/bisect/worker_agent.py
+++ b/tools/bisect/worker_agent.py
@@ -34,6 +34,8 @@ from tools.bisect import git_ops, runner
 from tools.bisect.build_manager import BuildError, BuildManager
 from tools.bisect.config import BisectInput, BisectOptions
 from tools.bisect.coordinator import Coordinator
+from tools.bisect.env_manager import EnvironmentManager, EnvSwitchError
+from tools.bisect.env_table import RuntimeEnv
 
 logger = logging.getLogger("bisect.worker")
 
@@ -54,7 +56,7 @@ def _launch_pytest(inp: BisectInput, opt: BisectOptions, log_path: Path) -> int:
         if "external_dp/config" in base or "external_dp/config" in inp.config_yaml
         else runner._INTERNAL_DP_TEST
     )
-    sources = " ; ".join(f"source {f} 2>/dev/null || true" for f in runner._ENV_SOURCE_FILES)
+    sources = runner.ascend_source_cmd(env)
     bash_cmd = f"set -e ; {sources} ; exec python -m pytest -sv --show-capture=no {test_path}"
     with open(log_path, "a", encoding="utf-8") as out:
         out.write(f"\n$ {bash_cmd}\n")
@@ -77,6 +79,7 @@ def _launch_pytest(inp: BisectInput, opt: BisectOptions, log_path: Path) -> int:
 def run_worker(inp: BisectInput, opt: BisectOptions) -> int:
     coord = Coordinator(opt.coord_dir, opt.num_nodes, opt.node_index)
     builder = BuildManager(opt)
+    env_manager = EnvironmentManager()
     log_dir = Path(opt.work_dir) / "worker_logs" / f"node{opt.node_index}"
     log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -93,8 +96,8 @@ def run_worker(inp: BisectInput, opt: BisectOptions) -> int:
             return 0
 
         commit = cmd["commit"]
-        # A SKIP command (e.g. vLLM mismatch decided by the leader) is consumed
-        # to keep rounds in lockstep, but the worker neither deploys nor runs.
+        # A SKIP command is consumed to keep rounds in lockstep, but the worker
+        # neither switches env, deploys, nor runs.
         if cmd.get("action") == "SKIP":
             logger.info("[worker] round %d: SKIP %s (no deploy/run)", rnd, commit[:12])
             continue
@@ -102,12 +105,15 @@ def run_worker(inp: BisectInput, opt: BisectOptions) -> int:
         log_path = log_dir / f"round{rnd}_{commit[:12]}.log"
         logger.info("[worker] round %d: deploying %s", rnd, commit[:12])
         try:
+            changed = env_manager.ensure(RuntimeEnv.from_dict(cmd.get("env")), log_path)
+            if changed:
+                builder.invalidate_build_baseline("runtime env changed for bisect candidate")
             builder.prepare(commit, log_path)
-        except BuildError as exc:
+        except (BuildError, EnvSwitchError) as exc:
             # Don't block the barrier; report our (built) HEAD so the master can
             # detect inconsistency. The master will likely hit the same build
             # failure and record SKIP.
-            logger.error("[worker] build failed for %s: %s", commit[:12], exc)
+            logger.error("[worker] deploy/env failed for %s: %s", commit[:12], exc)
 
         coord.signal_ready(rnd, git_ops.current_commit(opt.repo_dir))
         # Launch the worker test; it returns when the master's trial completes.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the nightly AOP auto-bisect flow so the runtime environment follows the commit being tested.

It adds an `env_table.csv` that records vLLM, vLLM-Ascend, CANN, and torch-npu versions for both successful and failed nightly statuses. Auto-bisect uses that table to switch vLLM/CANN/torch-npu before building and running each candidate, and multi-node bisect now sends the selected env through the coordinator so workers stay in lockstep with the master.

### Does this PR introduce _any_ user-facing change?

No user-facing serving behavior change. It adds/updates CI and bisect tool behavior, plus the `--env-table` option for the auto-bisect utility.

### How was this patch tested?

- `python -m ruff check tools/bisect tests/e2e/nightly/scripts/update_good_table.py tests/ut/tools/bisect`
- `python -m compileall -q tools\bisect tests\e2e\nightly\scripts\update_good_table.py tests\ut\tools\bisect`
- `git diff --check`
- `bash -n tests/e2e/nightly/scripts/aop_process.sh tests/e2e/nightly/multi_node/scripts/run.sh`
- Smoke-tested `update_good_table.py` for success and failure env-table writes.

Full `pytest tests/ut/tools/bisect` could not be run in this local environment because `tests/ut/conftest.py` imports `vllm`, which is not installed here.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
