### PR TITLE
[releases/v0.25.1rc][CI] Open MRV2 e2e for releases/v0.25.1

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -24,7 +24,6 @@ from vllm.v1.metrics.reader import Counter, Vector
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.one_card.model_runner_v2.utils import calculate_acceptance_per_pos
-from vllm_ascend.utils import vllm_version_is
 
 MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]
 
@@ -35,12 +34,6 @@ DFLASH_MODELS = ["z-lab/Qwen3-8B-DFlash-b16"]
 DSPARK_MAIN_MODEL = ["Qwen/Qwen3-8B"]
 DSPARK_MODELS = ["deepseek-ai/dspark_qwen3_8b_block7"]
 MTP_MODELS = ["wemaster/deepseek_mtp_main_random_bf16"]
-
-# TODO: drop this skip when v0.25.1 maintenance is removed.
-_SKIP_V025_MRV2_SPEC_DECODE = pytest.mark.skipif(
-    vllm_version_is("0.25.1"),
-    reason="MRV2 speculative decoding is only supported on the verified vLLM main commit",
-)
 
 
 @pytest.mark.parametrize("model", MODELS)
@@ -80,7 +73,6 @@ def test_qwen3_dense_eager_mode(
         runner.generate(prompts, sampling_params)
 
 
-@_SKIP_V025_MRV2_SPEC_DECODE
 @pytest.mark.parametrize("model", MAIN_MODELS)
 @pytest.mark.parametrize("eagle_model", EGALE_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
@@ -138,7 +130,6 @@ def test_egale_spec_decoding(
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
 
 
-@_SKIP_V025_MRV2_SPEC_DECODE
 @pytest.mark.parametrize("model", DFLASH_MAIN_MODEL)
 @pytest.mark.parametrize("dflash_model", DFLASH_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
@@ -199,7 +190,6 @@ def test_dflash_spec_decoding(
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
 
 
-@_SKIP_V025_MRV2_SPEC_DECODE
 @pytest.mark.parametrize("model", DSPARK_MAIN_MODEL)
 @pytest.mark.parametrize("dspark_model", DSPARK_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
@@ -258,7 +248,6 @@ def test_dspark_spec_decoding(
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
 
 
-@_SKIP_V025_MRV2_SPEC_DECODE
 @pytest.mark.parametrize("model", MTP_MODELS)
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("enforce_eager", [True])


### PR DESCRIPTION
### What this PR does / why we need it?

 Delete MRV2 e2e skip for releases/v0.25.1

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
