### PR TITLE
[Feature][Attention] Support DSA prefill context parallelism

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2333,12 +2333,125 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         return q, qr, qr_pertoken_scale
 
+    def _project_q_and_maybe_write_swa(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        swa_kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor | None,
+        *,
+        is_prefill: bool,
+        write_swa_cache: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Project local Q and optionally update the stateless SWA cache."""
+        if self.multistream_dsv4_dsa_overlap:
+            if not write_swa_cache:
+                raise RuntimeError("DSA PCP cache replay is incompatible with multistream_dsv4_dsa_overlap.")
+            assert slot_mapping is not None
+            return self._mla_prolog_multistream(
+                hidden_states,
+                cos,
+                sin,
+                swa_kv_cache,
+                slot_mapping,
+                is_prefill=is_prefill,
+            )
+
+        share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
+        if share_hs_quant:
+            hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
+            q_a = torch_npu.npu_quant_matmul(
+                hs_int8,
+                self.wq_a.weight,
+                self.wq_a.weight_scale,
+                pertoken_scale=hs_pertoken_scale,
+                bias=self.wq_a.bias,
+                output_dtype=hidden_states.dtype,
+            )
+        else:
+            hs_int8 = None
+            hs_pertoken_scale = None
+            q_a = self.wq_a(hidden_states)
+
+        if _is_w8a8_dynamic(self.wq_b):
+            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                q_a,
+                self.q_norm.weight,
+                epsilon=self.eps,
+            )
+            q = torch_npu.npu_quant_matmul(
+                qr,
+                self.wq_b.weight,
+                self.wq_b.weight_scale,
+                pertoken_scale=qr_pertoken_scale,
+                bias=self.wq_b.bias,
+                output_dtype=hidden_states.dtype,
+            ).unflatten(-1, (self.n_local_heads, self.head_dim))
+        else:
+            qr = self.q_norm(q_a)
+            q = self.wq_b(qr).unflatten(
+                -1,
+                (self.n_local_heads, self.head_dim),
+            )
+            qr_pertoken_scale = None
+
+        q = DeviceOperator.apply_dsa_q_rms(
+            q,
+            self.eps,
+            self.q_norm_without_weight,
+        )
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            q.unsqueeze(1),
+            cos,
+            sin,
+            rotary_mode="interleave",
+            partial_slice=[self.nope_head_dim, self.head_dim],
+        )
+
+        if write_swa_cache:
+            assert slot_mapping is not None
+            if share_hs_quant:
+                assert hs_int8 is not None
+                assert hs_pertoken_scale is not None
+                kv = torch_npu.npu_quant_matmul(
+                    hs_int8,
+                    self.wkv.weight,
+                    self.wkv.weight_scale,
+                    pertoken_scale=hs_pertoken_scale,
+                    bias=self.wkv.bias,
+                    output_dtype=hidden_states.dtype,
+                )
+            else:
+                kv = self.wkv(hidden_states)
+            kv = self.kv_norm(kv)
+            assert self.rope_head_dim is not None
+            kv = kv.view(
+                -1,
+                1,
+                self.nope_head_dim + self.rope_head_dim,
+            )
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                kv.unsqueeze(1),
+                cos,
+                sin,
+                rotary_mode="interleave",
+                partial_slice=[self.nope_head_dim, self.head_dim],
+            )
+            DeviceOperator.dsa_kv_compress_scatter(
+                swa_kv_cache,
+                kv,
+                slot_mapping,
+            )
+        return q, qr, qr_pertoken_scale
+
     def _forward_prefill(
         self,
         layer_name,
         hidden_states: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: DSAMetadataList,
+        cache_is_prepared: bool = False,
     ):
         compress_common_attn_metadata = None
         (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
@@ -2371,79 +2484,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
         ori_win_right = 0 if swa_prefill_metadata.ori_win_right is None else swa_prefill_metadata.ori_win_right
 
-        if self.multistream_dsv4_dsa_overlap:
-            # mla prolog: q + kv dual-stream parallel
-            q, qr, _ = self._mla_prolog_multistream(
-                hidden_states, cos, sin, swa_kv_cache, swa_prefill_metadata.slot_mapping, is_prefill=True
-            )
-        else:
-            # mlaprolog
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
-            if share_hs_quant:
-                hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-                q_a = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wq_a.weight,
-                    self.wq_a.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wq_a.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                q_a = self.wq_a(hidden_states)
-
-            # q
-            if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-                    q_a, self.q_norm.weight, epsilon=self.eps
-                )
-                q = torch_npu.npu_quant_matmul(
-                    qr,
-                    self.wq_b.weight,
-                    self.wq_b.weight_scale,
-                    pertoken_scale=qr_pertoken_scale,
-                    bias=self.wq_b.bias,
-                    output_dtype=hidden_states.dtype,
-                ).unflatten(-1, (self.n_local_heads, self.head_dim))
-            else:
-                qr = self.q_norm(q_a)
-                q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr_pertoken_scale = None
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
-
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
-                q.unsqueeze(1),
-                cos,
-                sin,
-                rotary_mode="interleave",
-                partial_slice=[self.nope_head_dim, self.head_dim],
-            )
-            # win kv & tok_dis
-            if share_hs_quant:
-                kv = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wkv.weight,
-                    self.wkv.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wkv.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                kv = self.wkv(hidden_states)
-            kv = self.kv_norm(kv)
-            assert self.rope_head_dim is not None
-            kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
-                kv.unsqueeze(1),
-                cos,
-                sin,
-                rotary_mode="interleave",
-                partial_slice=[self.nope_head_dim, self.head_dim],
-            )
-
-            # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_prefill_metadata.slot_mapping)
+        q, qr, qr_pertoken_scale = self._project_q_and_maybe_write_swa(
+            hidden_states,
+            cos,
+            sin,
+            swa_kv_cache,
+            swa_prefill_metadata.slot_mapping,
+            is_prefill=True,
+            write_swa_cache=not cache_is_prepared,
+        )
 
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()
         extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
@@ -2486,7 +2535,18 @@ class AscendDSAImpl(DSAAttentionImpl):
                 if self.skip_topk:
                     compress_topk_idxs = self._get_indexcache_topk_indices(prefill_num_tokens, offset=prefill_offset)
                 else:
-                    if self.multistream_dsv4_dsa_overlap:
+                    if cache_is_prepared:
+                        compress_topk_idxs = self._indexer_query_qli(
+                            x=hidden_states,
+                            qr=qr,
+                            kv_cache=kv_cache,
+                            attn_metadata=attn_metadata,
+                            cos=cos,
+                            sin=sin,
+                            with_prefill=True,
+                            qr_pertoken_scale=qr_pertoken_scale,
+                        )
+                    elif self.multistream_dsv4_dsa_overlap:
                         indexer_q = self.cv_indexer_select_qli(  # multistream version
                             x=hidden_states,
                             qr=qr,
@@ -2511,82 +2571,86 @@ class AscendDSAImpl(DSAAttentionImpl):
                             qr_pertoken_scale=qr_pertoken_scale,
                         )
 
-            coff = 2 if self.compressor_overlap else 1
-            compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(
-                compressor_prefill_metadata,
-            )
-
-            # Inline compressor + scatter (c128, c4 non-dual)
-            compressed_kv = torch.ops._C_ascend.compressor(
-                hidden_states,
-                self.compressor_wkv.weight,
-                self.compressor_wgate.weight,
-                state_cache.squeeze(-2),
-                self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
-                state_block_table=compressor_state_prefill_metadata.block_table,
-                cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
-                start_pos=common_prefill_metadata.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
-                coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
-                cache_mode=1,
-            )
-
-            # For multistream_dsv4_dsa_overlap with compress_ratio=4:
-            # aux_stream: indexer_weights_proj (parallel with main q_quant + kv_scatter)
-            # main stream: compressed_kv -> q_quant -> kv_scatter -> wait aux_stream -> lightning_indexer
-            if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
-                main_stream = torch.npu.current_stream()
-                aux_stream = dsv4_dsa_overlap_stream()
-                e_compressed_kv_done = main_stream.record_event()
-                with npu_stream_switch(aux_stream, enabled=True):
-                    torch.npu.current_stream().wait_event(e_compressed_kv_done)
-                    weights_proj_output = self.weights_proj(hidden_states)
-                # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
-
-            # A zero-row compressor output has no KV writes. Skip scatter
-            # instead of passing None; A5 scatter dereferences x.view().
-            if compressed_kv.shape[0] > 0:
-                DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
-
-            if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
-                # Wait aux_stream weights_proj done, then compute dot
-                main_stream.wait_stream(aux_stream)
-                weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
-                # lightning_indexer
-                indexer_scale_prefill_metadata = _require_prefill_metadata(indexer_kv_scale_metadata)
-                qlens = indexer_scale_prefill_metadata.query_start_loc[1:]
-                kvlens = indexer_scale_prefill_metadata.seq_lens
-                block_table = indexer_scale_prefill_metadata.block_table
-                qli_metadata = indexer_scale_prefill_metadata.qli_metadata
-                compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
-                    query=q_quant,
-                    key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-                    actual_seq_lengths_query=qlens,
-                    actual_seq_lengths_key=kvlens,
-                    block_table=block_table,
-                    metadata=qli_metadata,
-                    query_quant_mode=0,
-                    key_quant_mode=0,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=self.index_topk,
-                    sparse_mode=3,
-                    pre_tokens=(1 << 63) - 1,
-                    next_tokens=(1 << 63) - 1,
-                    cmp_ratio=4,
-                    return_value=False,
+            if not cache_is_prepared:
+                coff = 2 if self.compressor_overlap else 1
+                (
+                    compress_cos,
+                    compress_sin,
+                    compress_slot_mapping,
+                ) = self._compute_compressor_metadata(
+                    compressor_prefill_metadata,
                 )
+
+                # Inline compressor + scatter (c128, c4 non-dual)
+                compressed_kv = torch.ops._C_ascend.compressor(
+                    hidden_states,
+                    self.compressor_wkv.weight,
+                    self.compressor_wgate.weight,
+                    state_cache.squeeze(-2),
+                    self.compressor_ape,
+                    self.compressor_norm.weight,
+                    compress_sin.view(-1, compress_sin.shape[-1]),
+                    compress_cos.view(-1, compress_cos.shape[-1]),
+                    state_block_table=compressor_state_prefill_metadata.block_table,
+                    cu_seqlens=actual_seq_lengths_query,
+                    seqused=None,
+                    start_pos=common_prefill_metadata.start_pos,
+                    rope_head_dim=self.rope_head_dim,
+                    cmp_ratio=self.compress_ratio,
+                    coff=coff,
+                    norm_eps=self.compressor_norm_eps,
+                    rotary_mode=2,
+                    cache_mode=1,
+                )
+
+                # For multistream_dsv4_dsa_overlap with compress_ratio=4:
+                # aux_stream: indexer_weights_proj (parallel with main
+                # q_quant + kv_scatter)
+                if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
+                    main_stream = torch.npu.current_stream()
+                    aux_stream = dsv4_dsa_overlap_stream()
+                    e_compressed_kv_done = main_stream.record_event()
+                    with npu_stream_switch(aux_stream, enabled=True):
+                        torch.npu.current_stream().wait_event(e_compressed_kv_done)
+                        weights_proj_output = self.weights_proj(hidden_states)
+                    q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+
+                if compressed_kv.shape[0] > 0:
+                    DeviceOperator.dsa_kv_compress_scatter(
+                        compress_kv_cache,
+                        compressed_kv,
+                        compress_slot_mapping,
+                    )
+
+                if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
+                    main_stream.wait_stream(aux_stream)
+                    weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
+                    indexer_scale_prefill_metadata = _require_prefill_metadata(indexer_kv_scale_metadata)
+                    qlens = indexer_scale_prefill_metadata.query_start_loc[1:]
+                    kvlens = indexer_scale_prefill_metadata.seq_lens
+                    block_table = indexer_scale_prefill_metadata.block_table
+                    qli_metadata = indexer_scale_prefill_metadata.qli_metadata
+                    compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+                        query=q_quant,
+                        key=indexer_k_cache,
+                        weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
+                        query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+                        key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                        actual_seq_lengths_query=qlens,
+                        actual_seq_lengths_key=kvlens,
+                        block_table=block_table,
+                        metadata=qli_metadata,
+                        query_quant_mode=0,
+                        key_quant_mode=0,
+                        layout_query="TND",
+                        layout_key="PA_BSND",
+                        sparse_count=self.index_topk,
+                        sparse_mode=3,
+                        pre_tokens=(1 << 63) - 1,
+                        next_tokens=(1 << 63) - 1,
+                        cmp_ratio=4,
+                        return_value=False,
+                    )
 
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=prefill_offset)
@@ -2651,6 +2715,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         hidden_states: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
         attn_metadata: DSAMetadataList,
+        cache_is_prepared: bool = False,
     ):
         assert attn_metadata[0].decode is not None
         compress_common_attn_metadata = None
@@ -2684,94 +2749,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         )
         ori_win_right = 0 if swa_decode_metadata.ori_win_right is None else swa_decode_metadata.ori_win_right
 
-        if self.multistream_dsv4_dsa_overlap:
-            # mla prolog: q + kv dual-stream parallel
-            q, qr, qr_pertoken_scale = self._mla_prolog_multistream(
-                hidden_states, cos, sin, swa_kv_cache, swa_decode_metadata.slot_mapping, is_prefill=False
-            )
-        else:
-            # Share one dynamic-quant of hidden_states between wq_a (main stream)
-            # and wkv (attention stream) when both sides are W8A8 dynamic.
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
-            if share_hs_quant:
-                hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-
-            # q
-            if _is_w8a8_dynamic(self.wq_b):
-                if share_hs_quant:
-                    q_a = torch_npu.npu_quant_matmul(
-                        hs_int8,
-                        self.wq_a.weight,
-                        self.wq_a.weight_scale,
-                        pertoken_scale=hs_pertoken_scale,
-                        bias=self.wq_a.bias,
-                        output_dtype=hidden_states.dtype,
-                    )
-                else:
-                    q_a = self.wq_a(hidden_states)
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-                    q_a, self.q_norm.weight, epsilon=self.eps
-                )
-                q = torch_npu.npu_quant_matmul(
-                    qr,
-                    self.wq_b.weight,
-                    self.wq_b.weight_scale,
-                    pertoken_scale=qr_pertoken_scale,
-                    bias=self.wq_b.bias,
-                    output_dtype=hidden_states.dtype,
-                ).unflatten(-1, (self.n_local_heads, self.head_dim))
-            else:
-                if share_hs_quant:
-                    q_a = torch_npu.npu_quant_matmul(
-                        hs_int8,
-                        self.wq_a.weight,
-                        self.wq_a.weight_scale,
-                        pertoken_scale=hs_pertoken_scale,
-                        bias=self.wq_a.bias,
-                        output_dtype=hidden_states.dtype,
-                    )
-                    qr = q = self.q_norm(q_a)
-                else:
-                    qr = q = self.q_norm(self.wq_a(hidden_states))
-                q = self.wq_b(q).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr_pertoken_scale = None
-
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
-
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
-                q.unsqueeze(1),
-                cos,
-                sin,
-                rotary_mode="interleave",
-                partial_slice=[self.nope_head_dim, self.head_dim],
-            )
-
-            # win kv & tok_dis
-            if share_hs_quant:
-                kv = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wkv.weight,
-                    self.wkv.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wkv.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                kv = self.wkv(hidden_states)
-            kv = self.kv_norm(kv)
-            assert self.rope_head_dim is not None
-            kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
-                kv.unsqueeze(1),
-                cos,
-                sin,
-                rotary_mode="interleave",
-                partial_slice=[self.nope_head_dim, self.head_dim],
-            )
-
-            # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_decode_metadata.slot_mapping)
+        q, qr, qr_pertoken_scale = self._project_q_and_maybe_write_swa(
+            hidden_states,
+            cos,
+            sin,
+            swa_kv_cache,
+            swa_decode_metadata.slot_mapping,
+            is_prefill=False,
+            write_swa_cache=not cache_is_prepared,
+        )
 
         if self.compress_ratio > 1:
             compressor_decode_metadata = _require_decode_metadata(compressor_attn_metadata)
@@ -2783,7 +2769,18 @@ class AscendDSAImpl(DSAAttentionImpl):
                 if self.skip_topk:
                     compress_topk_idxs = self._get_indexcache_topk_indices(decode_num_tokens, offset=0)
                 else:
-                    if self.multistream_dsv4_dsa_overlap:
+                    if cache_is_prepared:
+                        compress_topk_idxs = self._indexer_query_qli(
+                            x=hidden_states,
+                            qr=qr,
+                            kv_cache=kv_cache,
+                            attn_metadata=attn_metadata,
+                            cos=cos,
+                            sin=sin,
+                            with_prefill=False,
+                            qr_pertoken_scale=qr_pertoken_scale,
+                        )
+                    elif self.multistream_dsv4_dsa_overlap:
                         indexer_q = self.cv_indexer_select_qli(  # multistream version
                             x=hidden_states,
                             qr=qr,
@@ -2809,82 +2806,82 @@ class AscendDSAImpl(DSAAttentionImpl):
                             qr_pertoken_scale=qr_pertoken_scale,
                         )
 
-            coff = 2 if self.compressor_overlap else 1
-            compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(
-                compressor_decode_metadata,
-            )
-
-            # Inline compressor + scatter (c128, c4 non-dual)
-            compressed_kv = torch.ops._C_ascend.compressor(
-                hidden_states,
-                self.compressor_wkv.weight,
-                self.compressor_wgate.weight,
-                state_cache.squeeze(-2),
-                self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
-                state_block_table=compressor_state_decode_metadata.block_table,
-                cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
-                start_pos=common_decode_metadata.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
-                coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
-                cache_mode=1,
-            )
-
-            # For multistream_dsv4_dsa_overlap with compress_ratio=4:
-            # aux_stream: indexer_weights_proj (parallel with main q_quant + kv_scatter)
-            # main stream: compressed_kv -> q_quant -> kv_scatter -> wait aux_stream -> lightning_indexer
-            if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
-                main_stream = torch.npu.current_stream()
-                aux_stream = dsv4_dsa_overlap_stream()
-                e_compressed_kv_done = main_stream.record_event()
-                with npu_stream_switch(aux_stream, enabled=True):
-                    torch.npu.current_stream().wait_event(e_compressed_kv_done)
-                    weights_proj_output = self.weights_proj(hidden_states)
-                # Main stream: q_quant (between compressed_kv and kv_scatter)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
-
-            # A zero-row compressor output has no KV writes. Skip scatter
-            # instead of passing None; A5 scatter dereferences x.view().
-            if compressed_kv.shape[0] > 0:
-                DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
-
-            if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
-                # Wait aux_stream weights_proj done
-                main_stream.wait_stream(aux_stream)
-                weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
-                # lightning_indexer
-                indexer_scale_decode_metadata = _require_decode_metadata(indexer_kv_scale_metadata)
-                qlens = indexer_scale_decode_metadata.query_start_loc[1:]
-                kvlens = indexer_scale_decode_metadata.seq_lens
-                block_table = indexer_scale_decode_metadata.block_table
-                qli_metadata = indexer_scale_decode_metadata.qli_metadata
-                compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
-                    query=q_quant,
-                    key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-                    actual_seq_lengths_query=qlens,
-                    actual_seq_lengths_key=kvlens,
-                    block_table=block_table,
-                    metadata=qli_metadata,
-                    query_quant_mode=0,
-                    key_quant_mode=0,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=self.index_topk,
-                    sparse_mode=3,
-                    pre_tokens=(1 << 63) - 1,
-                    next_tokens=(1 << 63) - 1,
-                    cmp_ratio=4,
-                    return_value=False,
+            if not cache_is_prepared:
+                coff = 2 if self.compressor_overlap else 1
+                (
+                    compress_cos,
+                    compress_sin,
+                    compress_slot_mapping,
+                ) = self._compute_compressor_metadata(
+                    compressor_decode_metadata,
                 )
+
+                compressed_kv = torch.ops._C_ascend.compressor(
+                    hidden_states,
+                    self.compressor_wkv.weight,
+                    self.compressor_wgate.weight,
+                    state_cache.squeeze(-2),
+                    self.compressor_ape,
+                    self.compressor_norm.weight,
+                    compress_sin.view(-1, compress_sin.shape[-1]),
+                    compress_cos.view(-1, compress_cos.shape[-1]),
+                    state_block_table=compressor_state_decode_metadata.block_table,
+                    cu_seqlens=actual_seq_lengths_query,
+                    seqused=None,
+                    start_pos=common_decode_metadata.start_pos,
+                    rope_head_dim=self.rope_head_dim,
+                    cmp_ratio=self.compress_ratio,
+                    coff=coff,
+                    norm_eps=self.compressor_norm_eps,
+                    rotary_mode=2,
+                    cache_mode=1,
+                )
+
+                if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
+                    main_stream = torch.npu.current_stream()
+                    aux_stream = dsv4_dsa_overlap_stream()
+                    e_compressed_kv_done = main_stream.record_event()
+                    with npu_stream_switch(aux_stream, enabled=True):
+                        torch.npu.current_stream().wait_event(e_compressed_kv_done)
+                        weights_proj_output = self.weights_proj(hidden_states)
+                    q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+
+                if compressed_kv.shape[0] > 0:
+                    DeviceOperator.dsa_kv_compress_scatter(
+                        compress_kv_cache,
+                        compressed_kv,
+                        compress_slot_mapping,
+                    )
+
+                if self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk:
+                    main_stream.wait_stream(aux_stream)
+                    weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
+                    indexer_scale_decode_metadata = _require_decode_metadata(indexer_kv_scale_metadata)
+                    qlens = indexer_scale_decode_metadata.query_start_loc[1:]
+                    kvlens = indexer_scale_decode_metadata.seq_lens
+                    block_table = indexer_scale_decode_metadata.block_table
+                    qli_metadata = indexer_scale_decode_metadata.qli_metadata
+                    compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+                        query=q_quant,
+                        key=indexer_k_cache,
+                        weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
+                        query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
+                        key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
+                        actual_seq_lengths_query=qlens,
+                        actual_seq_lengths_key=kvlens,
+                        block_table=block_table,
+                        metadata=qli_metadata,
+                        query_quant_mode=0,
+                        key_quant_mode=0,
+                        layout_query="TND",
+                        layout_key="PA_BSND",
+                        sparse_count=self.index_topk,
+                        sparse_mode=3,
+                        pre_tokens=(1 << 63) - 1,
+                        next_tokens=(1 << 63) - 1,
+                        cmp_ratio=4,
+                        return_value=False,
+                    )
 
             if self.compress_ratio == 4 and self.use_index_cache:
                 self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
@@ -2958,6 +2955,66 @@ class AscendDSAImpl(DSAAttentionImpl):
                 **extra_attn_kwargs,
             )[0]
         return attn_output
+
+    def _indexer_query_qli(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: DSAMetadataList,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        *,
+        with_prefill: bool,
+        qr_pertoken_scale: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Run local indexer Q/QLI after PCP has prepared indexer caches."""
+        (
+            _,
+            indexer_k_cache,
+            indexer_scale_cache,
+            _,
+        ) = DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+        (_, _, _, indexer_kv_scale_metadata, _) = attn_metadata
+
+        if (
+            _is_w8a8_dynamic(self.inderxer_wq_b)
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        ):
+            q = torch_npu.npu_quant_matmul(
+                qr,
+                self.inderxer_wq_b.weight,
+                self.inderxer_wq_b.weight_scale,
+                pertoken_scale=qr_pertoken_scale,
+                bias=self.inderxer_wq_b.bias,
+                output_dtype=x.dtype,
+            )
+        else:
+            q = self.inderxer_wq_b(qr)
+        q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            q.unsqueeze(1),
+            cos,
+            sin,
+            rotary_mode="interleave",
+            partial_slice=[
+                self.indexcom_head_dim - self.rope_head_dim,
+                self.indexcom_head_dim,
+            ],
+        )
+        q = rotate_activation(q, indexer_kv_scale_metadata.hadamard)
+        q, q_scale = DeviceOperator.indexer_quantize_query(q)
+        weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
+        return self._indexer_qli(
+            q,
+            weights,
+            q_scale,
+            indexer_k_cache,
+            indexer_scale_cache,
+            indexer_kv_scale_metadata,
+            with_prefill,
+        )
 
     def _indexer_qkv_prepare(
         self,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -203,10 +203,16 @@ class AscendDSABackend(AttentionBackend):
     def get_builder_cls():
         from vllm_ascend.utils import enable_dsa_cp
 
-        if enable_dsa_cp():
+        use_dsa_cp = enable_dsa_cp()
+        use_pcp = get_current_vllm_config().parallel_config.prefill_context_parallel_size > 1
+        if use_dsa_cp and use_pcp:
+            raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
+        if use_dsa_cp:
             from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
 
             return AscendDSACPMetadataBuilder
+        if use_pcp:
+            return AscendDSAPCPMetadataBuilder
         return AscendDSAMetadataBuilder
 
     @staticmethod
@@ -250,10 +256,16 @@ class AscendDSABackend(AttentionBackend):
     def get_impl_cls() -> type["DSAAttentionImpl"]:
         from vllm_ascend.utils import enable_dsa_cp
 
-        if enable_dsa_cp():
+        use_dsa_cp = enable_dsa_cp()
+        use_pcp = get_current_vllm_config().parallel_config.prefill_context_parallel_size > 1
+        if use_dsa_cp and use_pcp:
+            raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
+        if use_dsa_cp:
             from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
 
             return AscendDSACPImpl
+        if use_pcp:
+            return AscendDSAPCPImpl
         return AscendDSAImpl
 
     @staticmethod
@@ -350,6 +362,20 @@ class AscendDSAPCPMetadata:
     block_size: int
     full_compress_sin: torch.Tensor | None = None
     full_compress_cos: torch.Tensor | None = None
+
+
+@dataclass
+class _DSACompressorReplayMetadata:
+    """Minimal compressor metadata for one ordered PCP segment."""
+
+    full_compress_sin: torch.Tensor
+    full_compress_cos: torch.Tensor
+    num_compressed_tokens: int
+    start_pos: torch.Tensor
+    query_start_loc: torch.Tensor
+    block_table: torch.Tensor
+    block_size: int
+    num_reqs_actual: int = 1
 
 
 @dataclass
@@ -1989,7 +2015,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
     def _compute_compressor_metadata(
         self,
-        metadata: AscendDSAPrefillMetadata | AscendDSADecodeMetadata,
+        metadata: (AscendDSAPrefillMetadata | AscendDSADecodeMetadata | _DSACompressorReplayMetadata),
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert metadata.full_compress_cos is not None
         assert metadata.full_compress_sin is not None
@@ -3403,3 +3429,479 @@ class AscendDSAImpl(DSAAttentionImpl):
         q = hadamard_scale(q_linear, q_shape, q_dim, scale=hidden_size**-0.5)
 
         return q
+
+
+class AscendDSAPCPImpl(AscendDSAImpl):
+    """DSA implementation with replicated-cache PCP execution."""
+
+    supports_pcp: bool = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.pcp_world_size <= 1:
+            raise ValueError("AscendDSAPCPImpl requires PCP size greater than one.")
+        if self.dcp_world_size != 1:
+            raise NotImplementedError("DSA PCP currently requires DCP size to be one.")
+        if not envs_vllm.VLLM_USE_V2_MODEL_RUNNER:
+            raise NotImplementedError("DSA PCP currently supports ModelRunner V2 only.")
+        if self.vllm_config.cache_config.enable_prefix_caching:
+            raise NotImplementedError("DSA PCP does not support prefix caching yet.")
+        # Stateful compressor replay must finish before local QLI/attention.
+        self.multistream_dsv4_dsa_overlap = False
+
+    @staticmethod
+    def _require_pcp_metadata(
+        metadata: AscendDSAMetadata,
+    ) -> AscendDSAPCPMetadata:
+        if metadata.pcp is None:
+            raise RuntimeError("DSA PCP attention metadata is missing.")
+        return metadata.pcp
+
+    @staticmethod
+    def _get_segment_hidden(
+        gathered_hidden_states: torch.Tensor,
+        pcp_metadata: AscendDSAPCPMetadata,
+        segment: AscendDSAPCPSegment,
+    ) -> torch.Tensor:
+        rank_start = segment.rank * pcp_metadata.local_num_input_tokens
+        token_start = rank_start + segment.token_start
+        return gathered_hidden_states[token_start : token_start + segment.num_tokens]
+
+    def _make_replay_metadata(
+        self,
+        pcp_metadata: AscendDSAPCPMetadata,
+        segment: AscendDSAPCPSegment,
+    ) -> _DSACompressorReplayMetadata:
+        if pcp_metadata.full_compress_cos is None:
+            raise RuntimeError("DSA PCP compressor cosine cache is missing.")
+        if pcp_metadata.full_compress_sin is None:
+            raise RuntimeError("DSA PCP compressor sine cache is missing.")
+        num_compressed_tokens = min(
+            segment.num_tokens,
+            segment.num_tokens // self.compress_ratio + 1,
+        )
+        return _DSACompressorReplayMetadata(
+            full_compress_sin=pcp_metadata.full_compress_sin,
+            full_compress_cos=pcp_metadata.full_compress_cos,
+            num_compressed_tokens=num_compressed_tokens,
+            start_pos=torch.tensor(
+                [segment.start_pos],
+                dtype=torch.int32,
+                device=pcp_metadata.raw_slot_mapping.device,
+            ),
+            query_start_loc=torch.tensor(
+                [0, segment.num_tokens],
+                dtype=torch.int32,
+                device=pcp_metadata.raw_slot_mapping.device,
+            ),
+            block_table=pcp_metadata.gathered_block_tables[
+                segment.rank,
+                segment.row : segment.row + 1,
+            ],
+            block_size=pcp_metadata.block_size,
+        )
+
+    def _replay_main_compressor(
+        self,
+        hidden_states: torch.Tensor,
+        segment: AscendDSAPCPSegment,
+        output_metadata: AscendDSAPCPMetadata,
+        state_metadata: AscendDSAPCPMetadata,
+        compress_kv_cache: torch.Tensor,
+        state_cache: torch.Tensor,
+    ) -> None:
+        replay_metadata = self._make_replay_metadata(
+            output_metadata,
+            segment,
+        )
+        state_block_table = state_metadata.gathered_block_tables[
+            segment.rank,
+            segment.row : segment.row + 1,
+        ]
+        compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(replay_metadata)
+        compressed_kv = torch.ops._C_ascend.compressor(
+            hidden_states,
+            self.compressor_wkv.weight,
+            self.compressor_wgate.weight,
+            state_cache.squeeze(-2),
+            self.compressor_ape,
+            self.compressor_norm.weight,
+            compress_sin.view(-1, compress_sin.shape[-1]),
+            compress_cos.view(-1, compress_cos.shape[-1]),
+            state_block_table=state_block_table,
+            cu_seqlens=replay_metadata.query_start_loc,
+            seqused=None,
+            start_pos=replay_metadata.start_pos,
+            rope_head_dim=self.rope_head_dim,
+            cmp_ratio=self.compress_ratio,
+            coff=2 if self.compressor_overlap else 1,
+            norm_eps=self.compressor_norm_eps,
+            rotary_mode=2,
+            cache_mode=1,
+        )
+        if compressed_kv.shape[0] > 0:
+            DeviceOperator.dsa_kv_compress_scatter(
+                compress_kv_cache,
+                compressed_kv,
+                compress_slot_mapping,
+            )
+
+    def _replay_indexer_compressor(
+        self,
+        hidden_states: torch.Tensor,
+        segment: AscendDSAPCPSegment,
+        output_metadata: AscendDSAPCPMetadata,
+        state_metadata: AscendDSAPCPMetadata,
+        indexer_state_cache: torch.Tensor,
+        indexer_k_cache: torch.Tensor,
+        indexer_scale_cache: torch.Tensor,
+        indexer_full_cache: torch.Tensor | None,
+        hadamard: torch.Tensor,
+    ) -> None:
+        expected_key_dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+        expected_scale_dtype = torch.float if get_ascend_device_type() == AscendDeviceType.A5 else torch.float16
+        if indexer_k_cache.dtype != expected_key_dtype:
+            raise TypeError(
+                f"DSA PCP indexer key cache dtype mismatch: expected {expected_key_dtype}, got {indexer_k_cache.dtype}."
+            )
+        if indexer_scale_cache.dtype != expected_scale_dtype:
+            raise TypeError(
+                "DSA PCP indexer scale cache dtype mismatch: "
+                f"expected {expected_scale_dtype}, got "
+                f"{indexer_scale_cache.dtype}."
+            )
+        replay_metadata = self._make_replay_metadata(
+            output_metadata,
+            segment,
+        )
+        state_block_table = state_metadata.gathered_block_tables[
+            segment.rank,
+            segment.row : segment.row + 1,
+        ]
+        compress_cos, compress_sin, indexer_slot_mapping = self._compute_compressor_metadata(replay_metadata)
+        kv = torch.ops._C_ascend.compressor(
+            hidden_states,
+            self.indexcom_wkv.weight,
+            self.indexcom_wgate.weight,
+            indexer_state_cache.squeeze(-2),
+            self.indexcom_ape,
+            self.indexcom_norm.weight,
+            compress_sin.view(-1, compress_sin.shape[-1]),
+            compress_cos.view(-1, compress_cos.shape[-1]),
+            state_block_table=state_block_table,
+            cu_seqlens=replay_metadata.query_start_loc,
+            seqused=None,
+            start_pos=replay_metadata.start_pos,
+            rope_head_dim=self.rope_head_dim,
+            cmp_ratio=self.compress_ratio,
+            coff=2 if self.compressor_overlap else 1,
+            norm_eps=self.compressor_norm_eps,
+            rotary_mode=2,
+            cache_mode=1,
+        )
+        if kv.numel() == 0:
+            return
+        if self.indexcom_rotate:
+            kv = rotate_activation(kv, hadamard)
+        _, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
+            kv,
+            indexer_k_cache,
+            indexer_full_cache,
+            indexer_slot_mapping,
+        )
+        if kv_scale is not None:
+            DeviceOperator.dsa_indexer_scatter_scale_part3(
+                kv_scale,
+                indexer_scale_cache,
+                indexer_slot_mapping,
+            )
+
+    def _prepare_pcp_caches(
+        self,
+        layer_name: str,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: DSAMetadataList,
+    ) -> None:
+        """Gather canonical tokens and replay DSA cache updates in global order.
+
+        Cache compressors are stateful, so all PCP ranks replay identical
+        segments before the rank-local attention calculation starts.
+        """
+        reference_pcp = self._require_pcp_metadata(attn_metadata[0])
+        local_num_input_tokens = reference_pcp.local_num_input_tokens
+        if hidden_states.shape[0] > local_num_input_tokens:
+            raise ValueError(
+                "DSA PCP hidden state rows exceed the padded local token count, "
+                f"got {hidden_states.shape[0]} and {local_num_input_tokens}."
+            )
+        padded_hidden_states = hidden_states.new_zeros((local_num_input_tokens, *hidden_states.shape[1:]))
+        padded_hidden_states[: hidden_states.shape[0]].copy_(hidden_states)
+        gathered_hidden_states = get_pcp_group().all_gather(
+            padded_hidden_states.contiguous(),
+            dim=0,
+        )
+
+        for metadata in attn_metadata[1:]:
+            pcp_metadata = self._require_pcp_metadata(metadata)
+            if (
+                pcp_metadata.local_num_input_tokens != local_num_input_tokens
+                or pcp_metadata.canonical_segments != reference_pcp.canonical_segments
+            ):
+                raise ValueError("DSA PCP metadata groups disagree on the canonical token layout.")
+
+        (
+            compress_kv_cache,
+            swa_kv_cache,
+            state_cache,
+            indexer_k_cache,
+            indexer_scale_cache,
+            indexer_full_cache,
+        ) = DeviceOperator.unpack_dsa_forward_kv_cache(
+            kv_cache,
+            self.compress_ratio,
+        )
+        if self.compress_ratio == 4:
+            (
+                compressor_attn_metadata,
+                compressor_kv_state_metadata,
+                indexer_kv_state_metadata,
+                indexer_kv_scale_metadata,
+                swa_metadata,
+            ) = attn_metadata
+        elif self.compress_ratio == 128:
+            (
+                compressor_attn_metadata,
+                compressor_kv_state_metadata,
+                swa_metadata,
+            ) = attn_metadata
+            indexer_kv_state_metadata = None
+            indexer_kv_scale_metadata = None
+        else:
+            (swa_metadata,) = attn_metadata
+            compressor_attn_metadata = None
+            compressor_kv_state_metadata = None
+            indexer_kv_state_metadata = None
+            indexer_kv_scale_metadata = None
+
+        swa_pcp = self._require_pcp_metadata(swa_metadata)
+        canonical_hidden_parts: list[torch.Tensor] = []
+        canonical_position_parts: list[torch.Tensor] = []
+        canonical_slot_parts: list[torch.Tensor] = []
+        rank_slot_mapping = swa_pcp.raw_slot_mapping.view(
+            self.pcp_world_size,
+            local_num_input_tokens,
+        )
+        for segment in reference_pcp.canonical_segments:
+            canonical_hidden_parts.append(
+                self._get_segment_hidden(
+                    gathered_hidden_states,
+                    reference_pcp,
+                    segment,
+                )
+            )
+            canonical_position_parts.append(
+                torch.arange(
+                    segment.start_pos,
+                    segment.start_pos + segment.num_tokens,
+                    dtype=torch.long,
+                    device=hidden_states.device,
+                )
+            )
+            segment_slot_mapping = rank_slot_mapping[
+                segment.rank,
+                segment.token_start : segment.token_start + segment.num_tokens,
+            ]
+            if bool(torch.any(segment_slot_mapping == PAD_SLOT_ID)):
+                raise ValueError("Canonical DSA PCP segment unexpectedly contains PAD slots.")
+            canonical_slot_parts.append(segment_slot_mapping)
+
+        if canonical_hidden_parts:
+            canonical_hidden_states = torch.cat(
+                canonical_hidden_parts,
+                dim=0,
+            )
+            canonical_positions = torch.cat(
+                canonical_position_parts,
+                dim=0,
+            )
+            canonical_slot_mapping = torch.cat(
+                canonical_slot_parts,
+                dim=0,
+            )
+            kv = self.kv_norm(self.wkv(canonical_hidden_states))
+            assert self.rope_head_dim is not None
+            kv = kv.view(
+                -1,
+                1,
+                self.nope_head_dim + self.rope_head_dim,
+            )
+            cos, sin = get_cos_and_sin_dsa(canonical_positions)
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                kv.unsqueeze(1),
+                cos[layer_name],
+                sin[layer_name],
+                rotary_mode="interleave",
+                partial_slice=[self.nope_head_dim, self.head_dim],
+            )
+            DeviceOperator.dsa_kv_compress_scatter(
+                swa_kv_cache,
+                kv,
+                DeviceOperator.format_dsa_slot_mapping(
+                    canonical_slot_mapping,
+                    swa_pcp.block_size,
+                ),
+            )
+
+        if self.compress_ratio <= 1:
+            return
+        assert compressor_attn_metadata is not None
+        assert compressor_kv_state_metadata is not None
+        assert compress_kv_cache is not None
+        assert state_cache is not None
+        compressor_pcp = self._require_pcp_metadata(compressor_attn_metadata)
+        compressor_state_pcp = self._require_pcp_metadata(compressor_kv_state_metadata)
+        for segment in reference_pcp.canonical_segments:
+            segment_hidden_states = self._get_segment_hidden(
+                gathered_hidden_states,
+                reference_pcp,
+                segment,
+            )
+            self._replay_main_compressor(
+                segment_hidden_states,
+                segment,
+                compressor_pcp,
+                compressor_state_pcp,
+                compress_kv_cache,
+                state_cache,
+            )
+
+        if self.compress_ratio != 4 or self.skip_topk:
+            return
+        assert indexer_kv_state_metadata is not None
+        assert indexer_kv_scale_metadata is not None
+        assert indexer_k_cache is not None
+        assert indexer_scale_cache is not None
+        (
+            indexer_state_cache,
+            _,
+            _,
+            _,
+        ) = DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+        indexer_state_pcp = self._require_pcp_metadata(indexer_kv_state_metadata)
+        indexer_output_pcp = self._require_pcp_metadata(indexer_kv_scale_metadata)
+        if indexer_kv_scale_metadata.hadamard is None:
+            raise RuntimeError("DSA PCP indexer Hadamard tensor is missing.")
+        for segment in reference_pcp.canonical_segments:
+            self._replay_indexer_compressor(
+                self._get_segment_hidden(
+                    gathered_hidden_states,
+                    reference_pcp,
+                    segment,
+                ),
+                segment,
+                indexer_output_pcp,
+                indexer_state_pcp,
+                indexer_state_cache,
+                indexer_k_cache,
+                indexer_scale_cache,
+                indexer_full_cache,
+                indexer_kv_scale_metadata.hadamard,
+            )
+
+    def forward(  # type: ignore[override]
+        self,
+        layer_name,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...] | None,
+        attn_metadata: DSAMetadataList,
+        need_gather_q_kv: bool = False,
+        output: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if output is None:
+            raise ValueError("Output tensor must be provided.")
+        if attn_metadata is None:
+            return super().forward(
+                layer_name,
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                need_gather_q_kv,
+                output,
+            )
+        if not isinstance(attn_metadata, list):
+            attn_metadata = [attn_metadata]
+        if kv_cache is None:
+            raise ValueError("kv_cache tensor tuple must be provided.")
+
+        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            hidden_states,
+            need_gather_q_kv,
+        )
+        reference_metadata = attn_metadata[0]
+        reference_pcp = self._require_pcp_metadata(reference_metadata)
+        actual_tokens = reference_metadata.num_actual_tokens
+        decode_tokens = reference_metadata.num_decode_tokens
+        local_num_input_tokens = reference_pcp.local_num_input_tokens
+        if not 0 <= actual_tokens <= local_num_input_tokens:
+            raise ValueError(
+                f"Invalid DSA PCP local token counts, actual={actual_tokens}, padded={local_num_input_tokens}."
+            )
+        if output.shape[0] != local_num_input_tokens:
+            raise ValueError(
+                "DSA PCP output rows must match padded local tokens, "
+                f"got {output.shape[0]} and {local_num_input_tokens}."
+            )
+
+        wait_for_kv_layer_from_connector(layer_name)
+        self._prepare_pcp_caches(
+            layer_name,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+        )
+        if actual_tokens == 0:
+            output.zero_()
+            notify_kv_cache_written(layer_name)
+            maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
+            return output
+
+        o_proj_input = hidden_states.new_zeros(
+            (
+                local_num_input_tokens,
+                self.n_local_heads,
+                self.head_dim,
+            )
+        )
+        if reference_metadata.num_prefills > 0:
+            output_prefill = self._forward_prefill(
+                layer_name,
+                hidden_states[decode_tokens:actual_tokens],
+                kv_cache,
+                attn_metadata,
+                cache_is_prepared=True,
+            )
+            o_proj_input[decode_tokens:actual_tokens] = output_prefill
+        if reference_metadata.num_decodes > 0:
+            output_decode = self._forward_decode(
+                layer_name,
+                hidden_states[:decode_tokens],
+                kv_cache,
+                attn_metadata,
+                cache_is_prepared=True,
+            )
+            o_proj_input[:decode_tokens] = output_decode
+
+        cos = reference_metadata.cos[layer_name]
+        sin = reference_metadata.sin[layer_name]
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            o_proj_input.unsqueeze(1),
+            cos,
+            -sin,
+            rotary_mode="interleave",
+            partial_slice=[self.nope_head_dim, self.head_dim],
+        )
+        self._forward_o_proj(o_proj_input, output)
+        output[actual_tokens:].zero_()
+        maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
+        return output

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1799,7 +1799,16 @@ class AscendDSAImpl(DSAAttentionImpl):
         assert output is not None, "Output tensor must be provided."
         output_padded = output
         forward_context = get_forward_context()
-        o_proj_input_shape = (forward_context.num_tokens, self.n_local_heads, self.head_dim)
+        num_forward_tokens = getattr(forward_context, "num_tokens", None)
+        if num_forward_tokens is None and forward_context.batch_descriptor is not None:
+            num_forward_tokens = forward_context.batch_descriptor.num_tokens
+        if num_forward_tokens is None:
+            num_forward_tokens = hidden_states.shape[0]
+        o_proj_input_shape = (
+            num_forward_tokens,
+            self.n_local_heads,
+            self.head_dim,
+        )
         if attn_metadata is None:
             # Profiling run: run o_proj on zero input so HCCL collectives are
             # captured by the ACL graph.  Non-OTP just zeros the output.

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -657,14 +657,21 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc
         num_reqs_actual = kwargs.get("num_reqs_actual")
+        # ModelRunner V1 passes caches shared by the ratio-specific attention
+        # groups. ModelRunner V2 does not currently expose those caches, so
+        # keep them local to this builder invocation. Supplied dictionaries
+        # retain the V1 sharing behavior.
         self.prefill_ratio_to_sas_metadata = kwargs.get("prefill_ratio_to_sas_metadata")
+        if self.prefill_ratio_to_sas_metadata is None:
+            self.prefill_ratio_to_sas_metadata = {}
         self.decode_ratio_to_sas_metadata = kwargs.get("decode_ratio_to_sas_metadata")
-        assert self.prefill_ratio_to_sas_metadata is not None
-        assert self.decode_ratio_to_sas_metadata is not None
-        self.block_size = kwargs.get("block_size", 128)
+        if self.decode_ratio_to_sas_metadata is None:
+            self.decode_ratio_to_sas_metadata = {}
+        self.block_size = kwargs.get("block_size", self.kv_cache_spec.block_size)
 
         self.common_ratio_to_sas_metadata = kwargs.get("common_ratio_to_sas_metadata")
-        assert self.common_ratio_to_sas_metadata is not None
+        if self.common_ratio_to_sas_metadata is None:
+            self.common_ratio_to_sas_metadata = {}
 
         if self.common_ratio_to_sas_metadata.get("num_decodes", None) is None:
             self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -8,10 +8,11 @@ import torch.nn.functional as F
 import torch_npu
 import vllm.envs as envs_vllm
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_pcp_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport, AttentionMetadataBuilder
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -325,6 +326,32 @@ class AscendDSADecodeMetadata:
     dspark_swa_indices: torch.Tensor | None = None
 
 
+@dataclass(frozen=True)
+class AscendDSAPCPSegment:
+    """One canonical PCP token run in rank-major gathered hidden states."""
+
+    rank: int
+    row: int
+    token_start: int
+    num_tokens: int
+    start_pos: int
+
+
+@dataclass
+class AscendDSAPCPMetadata:
+    """Internal metadata used to replay DSA cache updates under PCP."""
+
+    local_num_input_tokens: int
+    local_num_actual_tokens: int
+    num_decode_reqs: int
+    canonical_segments: tuple[AscendDSAPCPSegment, ...]
+    gathered_block_tables: torch.Tensor
+    raw_slot_mapping: torch.Tensor
+    block_size: int
+    full_compress_sin: torch.Tensor | None = None
+    full_compress_cos: torch.Tensor | None = None
+
+
 @dataclass
 class AscendDSAMetadata:
     """Metadata for MLACommon.
@@ -363,6 +390,8 @@ class AscendDSAMetadata:
     hadamard: torch.Tensor | None = None
 
     start_pos: torch.Tensor | None = None
+
+    pcp: AscendDSAPCPMetadata | None = None
 
     def __post_init__(self):
         pass
@@ -675,7 +704,14 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         if self.common_ratio_to_sas_metadata.get("num_decodes", None) is None:
             self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (
-                split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+                split_decodes_and_prefills(
+                    common_attn_metadata,
+                    decode_threshold=self.decode_threshold,
+                    treat_short_extends_as_decodes=kwargs.get(
+                        "treat_short_extends_as_decodes",
+                        True,
+                    ),
+                )
             )
             self.common_ratio_to_sas_metadata["num_decodes"] = self.num_decodes
             self.common_ratio_to_sas_metadata["num_prefills"] = self.num_prefills
@@ -1488,6 +1524,328 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         assert attn_metadata is not None
         attn_metadata.attn_state = attn_state
         return attn_metadata
+
+
+class AscendDSAPCPMetadataBuilder(AscendDSAMetadataBuilder):
+    """DSA metadata builder for MRV2 prefill context parallelism."""
+
+    aclgraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.NEVER
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.NEVER
+
+    def __init__(
+        self,
+        kv_cache_spec: AscendMLAAttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+        metadata_cls: type[AscendDSAMetadata] | None = None,
+        supports_dcp_with_varlen: bool = False,
+    ):
+        parallel_config = vllm_config.parallel_config
+        if not envs_vllm.VLLM_USE_V2_MODEL_RUNNER:
+            raise NotImplementedError("DSA PCP currently supports ModelRunner V2 only.")
+        if parallel_config.prefill_context_parallel_size <= 1:
+            raise ValueError("AscendDSAPCPMetadataBuilder requires PCP size greater than one.")
+        if parallel_config.decode_context_parallel_size != 1:
+            raise NotImplementedError("DSA PCP currently requires DCP size to be one.")
+        if vllm_config.cache_config.enable_prefix_caching:
+            raise NotImplementedError("DSA PCP does not support prefix caching yet.")
+
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls,
+            supports_dcp_with_varlen,
+        )
+        self.pcp_world_size = parallel_config.prefill_context_parallel_size
+        self.pcp_rank = get_pcp_group().rank_in_group
+        self.segment_capacity = 2 * vllm_config.scheduler_config.max_num_seqs
+        self.start_pos_prefill = torch.zeros(
+            self.segment_capacity,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.start_pos_decode = torch.zeros(
+            self.segment_capacity,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    @classmethod
+    def get_cudagraph_support(
+        cls: type["AscendDSAPCPMetadataBuilder"],
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        return AttentionCGSupport.NEVER
+
+    def build_for_cudagraph_capture(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+    ) -> AscendDSAMetadata:
+        raise NotImplementedError("DSA PCP supports eager execution only.")
+
+    def _build_pcp_metadata(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+    ) -> AscendDSAPCPMetadata:
+        """Gather rank-local segments and plan the canonical PCP token order.
+
+        The resulting metadata separates the rank-local attention layout from
+        the global cache replay layout used by every PCP rank.
+        """
+        raw_slot_mapping = common_attn_metadata.slot_mapping
+        if raw_slot_mapping.ndim != 1:
+            raise ValueError(
+                f"DSA PCP expects a one-dimensional raw slot mapping, got shape {tuple(raw_slot_mapping.shape)}."
+            )
+        if raw_slot_mapping.shape[0] % self.pcp_world_size != 0:
+            raise ValueError(
+                "Expanded PCP slot mapping must be divisible by PCP size, "
+                f"got {raw_slot_mapping.shape[0]} and {self.pcp_world_size}."
+            )
+        local_num_input_tokens = raw_slot_mapping.shape[0] // self.pcp_world_size
+        num_reqs = common_attn_metadata.num_reqs
+        if num_reqs > self.segment_capacity:
+            raise ValueError(
+                f"DSA PCP local request segments exceed metadata capacity, got {num_reqs} and {self.segment_capacity}."
+            )
+
+        query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
+        query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+        seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to(
+            device="cpu",
+            dtype=torch.int32,
+        )
+        local_descriptors_cpu = torch.zeros(
+            (self.segment_capacity, 4),
+            dtype=torch.int32,
+        )
+        for row in range(num_reqs):
+            token_start = int(query_start_loc_cpu[row])
+            num_tokens = int(query_lens_cpu[row])
+            start_pos = int(seq_lens_cpu[row]) - num_tokens
+            if start_pos < 0:
+                raise ValueError(
+                    "DSA PCP segment has a negative start position, "
+                    f"row={row}, seq_len={int(seq_lens_cpu[row])}, "
+                    f"num_tokens={num_tokens}."
+                )
+            local_descriptors_cpu[row] = torch.tensor(
+                (token_start, num_tokens, start_pos, 1),
+                dtype=torch.int32,
+            )
+        local_descriptors = local_descriptors_cpu.to(self.device)
+        gathered_descriptors = (
+            get_pcp_group()
+            .all_gather(
+                local_descriptors,
+                dim=0,
+            )
+            .view(self.pcp_world_size, self.segment_capacity, 4)
+        )
+
+        block_table = common_attn_metadata.block_table_tensor
+        block_table_width = block_table.shape[1]
+        local_block_tables = block_table.new_zeros(
+            (self.segment_capacity, block_table_width),
+        )
+        local_block_tables[:num_reqs].copy_(block_table[:num_reqs])
+        gathered_block_tables = (
+            get_pcp_group()
+            .all_gather(
+                local_block_tables,
+                dim=0,
+            )
+            .view(
+                self.pcp_world_size,
+                self.segment_capacity,
+                block_table_width,
+            )
+        )
+
+        descriptors_cpu = gathered_descriptors.to("cpu")
+        slot_mapping_cpu = raw_slot_mapping.view(
+            self.pcp_world_size,
+            local_num_input_tokens,
+        ).to("cpu")
+
+        decode_counts: list[int] = []
+        for rank in range(1, self.pcp_world_size):
+            decode_count = 0
+            saw_prefill = False
+            for row in range(self.segment_capacity):
+                token_start, num_tokens, _, valid = (int(value) for value in descriptors_cpu[rank, row])
+                if not valid or num_tokens == 0:
+                    continue
+                token_end = token_start + num_tokens
+                segment_has_write = bool(torch.any(slot_mapping_cpu[rank, token_start:token_end] != PAD_SLOT_ID))
+                if segment_has_write:
+                    saw_prefill = True
+                else:
+                    if saw_prefill:
+                        raise ValueError("DSA PCP requires decode segments to precede prefill segments on every rank.")
+                    decode_count += 1
+            decode_counts.append(decode_count)
+        if not decode_counts or any(count != decode_counts[0] for count in decode_counts):
+            raise ValueError(f"DSA PCP could not derive a consistent replicated decode prefix, counts={decode_counts}.")
+        num_decode_reqs = decode_counts[0]
+
+        canonical_segments: list[AscendDSAPCPSegment] = []
+        for rank in range(self.pcp_world_size):
+            for row in range(self.segment_capacity):
+                token_start, num_tokens, start_pos, valid = (int(value) for value in descriptors_cpu[rank, row])
+                if not valid or num_tokens == 0:
+                    continue
+                valid_mask = (
+                    slot_mapping_cpu[
+                        rank,
+                        token_start : token_start + num_tokens,
+                    ]
+                    != PAD_SLOT_ID
+                )
+                run_start = 0
+                while run_start < num_tokens:
+                    while run_start < num_tokens and not bool(valid_mask[run_start]):
+                        run_start += 1
+                    if run_start == num_tokens:
+                        break
+                    run_end = run_start + 1
+                    while run_end < num_tokens and bool(valid_mask[run_end]):
+                        run_end += 1
+                    canonical_segments.append(
+                        AscendDSAPCPSegment(
+                            rank=rank,
+                            row=row,
+                            token_start=token_start + run_start,
+                            num_tokens=run_end - run_start,
+                            start_pos=start_pos + run_start,
+                        )
+                    )
+                    run_start = run_end
+        canonical_segments.sort(
+            key=lambda segment: (
+                segment.start_pos,
+                segment.rank,
+                segment.row,
+                segment.token_start,
+            )
+        )
+
+        full_compress_cos = None
+        full_compress_sin = None
+        if self.compressor_ratio > 1:
+            full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(f"c{self.compressor_ratio}")
+
+        return AscendDSAPCPMetadata(
+            local_num_input_tokens=local_num_input_tokens,
+            local_num_actual_tokens=common_attn_metadata.num_actual_tokens,
+            num_decode_reqs=num_decode_reqs,
+            canonical_segments=tuple(canonical_segments),
+            gathered_block_tables=gathered_block_tables,
+            raw_slot_mapping=raw_slot_mapping,
+            block_size=self.kv_cache_spec.block_size,
+            full_compress_sin=full_compress_sin,
+            full_compress_cos=full_compress_cos,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+        **kwargs,
+    ) -> AscendDSAMetadata:
+        pcp_metadata = self._build_pcp_metadata(common_attn_metadata)
+        local_num_input_tokens = pcp_metadata.local_num_input_tokens
+        local_num_actual_tokens = pcp_metadata.local_num_actual_tokens
+        num_reqs = common_attn_metadata.num_reqs
+
+        raw_slot_mapping = common_attn_metadata.slot_mapping
+        local_slot_mapping = raw_slot_mapping.view(
+            self.pcp_world_size,
+            local_num_input_tokens,
+        )[self.pcp_rank]
+        common_attn_metadata.slot_mapping = local_slot_mapping
+        common_attn_metadata.num_input_tokens = local_num_input_tokens
+
+        local_seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to(
+            device="cpu",
+            dtype=torch.int32,
+        )
+        common_attn_metadata.seq_lens_cpu = local_seq_lens_cpu
+        common_attn_metadata._seq_lens_cpu = local_seq_lens_cpu
+        common_attn_metadata.seq_lens_cpu_upper_bound = local_seq_lens_cpu
+        query_lens_cpu = (
+            common_attn_metadata.query_start_loc_cpu[1 : num_reqs + 1]
+            - common_attn_metadata.query_start_loc_cpu[:num_reqs]
+        )
+        common_attn_metadata.max_query_len = int(query_lens_cpu.max()) if query_lens_cpu.numel() else 0
+        if common_attn_metadata.is_prefilling is None:
+            is_prefilling = torch.ones(num_reqs, dtype=torch.bool)
+            is_prefilling[: pcp_metadata.num_decode_reqs] = False
+        else:
+            is_prefilling = common_attn_metadata.is_prefilling[:num_reqs].to(
+                device="cpu",
+                dtype=torch.bool,
+            )
+            if is_prefilling.shape[0] != num_reqs:
+                raise ValueError(
+                    "DSA PCP is_prefilling metadata does not cover every "
+                    f"local segment, got {is_prefilling.shape[0]} and {num_reqs}."
+                )
+            expected_is_prefilling = torch.ones(num_reqs, dtype=torch.bool)
+            expected_is_prefilling[: pcp_metadata.num_decode_reqs] = False
+            if not torch.equal(is_prefilling, expected_is_prefilling):
+                raise ValueError(
+                    "DSA PCP scheduler prefill flags disagree with the "
+                    "replicated decode prefix reconstructed from PAD slots."
+                )
+        common_attn_metadata.is_prefilling = is_prefilling
+
+        if local_num_actual_tokens == 0:
+            input_positions = common_attn_metadata.positions[:local_num_input_tokens].long()
+            cos, sin = get_cos_and_sin_dsa(input_positions)
+            metadata = self.metadata_cls(  # type: ignore[call-arg]
+                num_input_tokens=local_num_input_tokens,
+                num_actual_tokens=0,
+                query_lens=query_lens_cpu,
+                slot_mapping=None,
+                head_dim=self.model_config.get_head_size(),
+                num_decodes=0,
+                num_decode_tokens=0,
+                num_prefills=0,
+                attn_mask=None,
+                attn_state=common_attn_metadata.attn_state,
+                prefill=None,
+                decode=None,
+                query_start_loc=common_attn_metadata.query_start_loc,
+                block_tables=None,
+                seq_lens=common_attn_metadata.seq_lens[:num_reqs],
+                cos=cos,
+                sin=sin,
+                hadamard=AscendDSAMetadataBuilder.hadamard,
+                pcp=pcp_metadata,
+            )
+            common_attn_metadata.slot_mapping = raw_slot_mapping
+            return metadata
+
+        metadata = super().build(
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build,
+            prefill_ratio_to_sas_metadata={},
+            decode_ratio_to_sas_metadata={},
+            common_ratio_to_sas_metadata={},
+            block_size=self.kv_cache_spec.block_size,
+            treat_short_extends_as_decodes=False,
+            **kwargs,
+        )
+        metadata.pcp = pcp_metadata
+        common_attn_metadata.slot_mapping = raw_slot_mapping
+        return metadata
 
 
 class AscendDSAImpl(DSAAttentionImpl):

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -209,12 +209,41 @@ class AscendDSABackend(AttentionBackend):
         return AscendDSAMetadataBuilder
 
     @staticmethod
-    def get_kv_cache_shape(num_blocks: int, block_size: int, num_kv_heads: int, head_size: int) -> tuple[int, ...]:
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_type: str = "",
+    ) -> tuple[int, ...]:
         return num_blocks, block_size, num_kv_heads, head_size
 
     @staticmethod
     def get_scale_shape(num_blocks: int, block_size: int, scale_size: int) -> tuple[int, ...]:
         return num_blocks, block_size, scale_size
+
+    @staticmethod
+    def get_kv_cache_component_layout(
+        kv_cache_spec: AttentionSpec,
+    ) -> tuple[tuple[int, torch.dtype], ...]:
+        """Describe the physical cache tensors owned by a DSA cache layer.
+
+        DSA stores its SWA, compressor output and compressor state as one
+        combined vector.  The compressed indexer cache is the sole split
+        layout: quantized keys plus their per-token scale.  The MRV2 allocator
+        consumes this backend hook instead of assuming that every attention
+        cache is a conventional K/V pair.
+        """
+        scale_dim = int(getattr(kv_cache_spec, "scale_dim", 0))
+        if scale_dim:
+            scale_dtype = getattr(kv_cache_spec, "scale_dtype", None)
+            if scale_dtype is None:
+                raise ValueError("DSA indexer cache scale dtype is missing.")
+            return (
+                (kv_cache_spec.head_size, kv_cache_spec.dtype),
+                (scale_dim, scale_dtype),
+            )
+        return ((kv_cache_spec.head_size, kv_cache_spec.dtype),)
 
     @staticmethod
     def get_impl_cls() -> type["DSAAttentionImpl"]:

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -32,6 +32,18 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     cache_sparse_sfa_c8: bool = False
 
     @property
+    def storage_block_size(self) -> int:
+        """Return the physical block size consumed by Ascend kernels.
+
+        DeepSeek-V4's ``compress_ratio`` controls how many scheduler tokens
+        advance one compressed-cache token.  Ascend's cache manager and DSA
+        metadata already apply that mapping, so shrinking the physical page a
+        second time (the upstream MLA default) would under-allocate C4 caches
+        and reduce C128 pages to zero for a 32-token manager block.
+        """
+        return self.block_size
+
+    @property
     def page_size_bytes(self) -> int:
         return (
             self.block_size

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -1107,6 +1107,13 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
+        # MRV2 keeps platform extensions in a separate additional-kwargs map
+        # and does not publish input_ids there.  DSV4's hash-based expert
+        # selector still needs the current tokens, so attach them while the
+        # model owns the authoritative input tensor.
+        from vllm.forward_context import get_forward_context
+
+        get_forward_context().input_ids = input_ids
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -1145,12 +1152,11 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # MTP layers receive the full token set — otherwise only rank 0's
         # partition is valid and the rest of the buffer holds stale data,
         # leading to NaN values and low acceptance rate.
-        from vllm_ascend.ascend_forward_context import get_forward_context
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
-        forward_ctx = get_forward_context()
-        if forward_ctx is not None and forward_ctx.flash_comm_v1_enabled:
+        if _EXTRA_CTX.flash_comm_v1_enabled:
             h_states_flat = tensor_model_parallel_all_gather(hidden_states.flatten(1), dim=0)
-            pad_size = forward_ctx.pad_size
+            pad_size = _EXTRA_CTX.pad_size
             if pad_size > 0:
                 h_states_flat = h_states_flat[:-pad_size]
             num_tokens = h_states_flat.shape[0]

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.models.layer.attention.layer import DSAAttention
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -161,7 +162,7 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
         kv_cache: torch.Tensor | None = None,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        need_gather_q_kv = get_forward_context().flash_comm_v1_enabled
+        need_gather_q_kv = bool(_EXTRA_CTX.flash_comm_v1_enabled)
         output_shape = hidden_states.shape
 
         output = torch.empty(output_shape, dtype=hidden_states.dtype, device=hidden_states.device)

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -244,17 +244,22 @@ def _build_kv_cache(self, forward_context):
             compress_kv_cache = compress_kv_cache[virtual_engine]
     if self.compress_ratio == 4:
         indexer_state_cache = self.indexer.compressor.state_cache.kv_cache
+        indexer_cache_components = get_kvcache_components(
+            self.indexer.k_cache.kv_cache,
+        )
         if get_ascend_device_type() in {AscendDeviceType.A5}:
-            indexer_k_cache, indexer_scale_cache, indexer_full_cache = (
-                self.indexer.k_cache.kv_cache[0][0],
-                self.indexer.k_cache.kv_cache[0][1],
-                self.indexer.k_cache.kv_cache[0][2],
-            )
+            if len(indexer_cache_components) != 3:
+                raise ValueError(
+                    "A5 DSA indexer cache must expose key, scale and full "
+                    f"components, got {len(indexer_cache_components)}."
+                )
+            indexer_k_cache, indexer_scale_cache, indexer_full_cache = indexer_cache_components
         else:
-            indexer_k_cache, indexer_scale_cache = (
-                self.indexer.k_cache.kv_cache[0][0],
-                self.indexer.k_cache.kv_cache[0][1],
-            )
+            if len(indexer_cache_components) != 2:
+                raise ValueError(
+                    f"DSA indexer cache must expose key and scale components, got {len(indexer_cache_components)}."
+                )
+            indexer_k_cache, indexer_scale_cache = indexer_cache_components
 
     if get_ascend_device_type() in {AscendDeviceType.A5}:
         kv_cache = tuple(
@@ -292,3 +297,17 @@ def unfold_kvcache(kvcache):
     while isinstance(kvcache, list) and len(kvcache) == 1:
         kvcache = kvcache[0]
     return kvcache
+
+
+def get_kvcache_components(
+    kvcache: torch.Tensor | list | tuple,
+) -> tuple[torch.Tensor, ...]:
+    """Normalize legacy per-engine and MRV2 direct component bindings."""
+    kvcache = unfold_kvcache(kvcache)
+    if isinstance(kvcache, torch.Tensor):
+        return (kvcache,)
+    if isinstance(kvcache, (list, tuple)) and all(isinstance(component, torch.Tensor) for component in kvcache):
+        return tuple(kvcache)
+    raise TypeError(
+        f"Expected a KV cache tensor or a flat sequence of cache component tensors, got {type(kvcache).__name__}."
+    )

--- a/vllm_ascend/ops/fused_moe/experts_selector.py
+++ b/vllm_ascend/ops/fused_moe/experts_selector.py
@@ -21,7 +21,7 @@ import torch.nn.functional as F
 from vllm.distributed import get_tp_group
 from vllm.forward_context import get_forward_context
 
-from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import split_tensor_along_first_dim
 
@@ -250,13 +250,13 @@ def _select_experts_with_fusion_ops(
             input_ids = forward_context.input_ids.to(torch.int64)
             # tid2eid_ones = torch.ones(tid2eid.shape[0],tid2eid.shape[1],device=router_logits.device,dtype=torch.int32)
             tid2eid_ones = tid2eid.to(torch.int32)
-            if forward_context.moe_comm_type == MoECommType.ALLGATHER:
-                prepare_finalize = forward_context.moe_comm_method.prepare_finalize
+            if _EXTRA_CTX.moe_comm_type == MoECommType.ALLGATHER:
+                prepare_finalize = _EXTRA_CTX.moe_comm_method.prepare_finalize
                 input_ids = prepare_finalize.all_gather_input_id_with_dp_group(input_ids)
             else:
-                input_ids = forward_context.moe_comm_method.pad_and_split_input_ids(input_ids)
+                input_ids = _EXTRA_CTX.moe_comm_method.pad_and_split_input_ids(input_ids)
 
-            if forward_context.flash_comm_v1_enabled and forward_context.moe_comm_type != MoECommType.ALLGATHER:
+            if _EXTRA_CTX.flash_comm_v1_enabled and _EXTRA_CTX.moe_comm_type != MoECommType.ALLGATHER:
                 # Process for Flash Comm V1
                 tp_size = get_tp_group().world_size
                 tp_rank = get_tp_group().rank_in_group

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -26,7 +26,6 @@ from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -311,8 +310,7 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
         input_ids,
     ):
         if not self.replace_allreduce:
-            forward_context = get_forward_context()
-            target_pad_length = forward_context.padded_num_tokens
+            target_pad_length = _EXTRA_CTX.padded_num_tokens
             pad_size = target_pad_length - self.num_tokens
             if pad_size > 0 and not self.enable_shared_expert_dp:
                 input_ids = nn.functional.pad(input_ids, (0, pad_size))

--- a/vllm_ascend/patch/worker/patch_v2/patch_attn_utils.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_attn_utils.py
@@ -3,9 +3,11 @@ import vllm
 from vllm_ascend.worker.v2.attn_utils import (
     _allocate_kv_cache,
     _reshape_kv_cache_v2,
+    bind_kv_cache,
     get_kv_cache_spec,
 )
 
 vllm.v1.worker.gpu.attn_utils._allocate_kv_cache = _allocate_kv_cache
 vllm.v1.worker.gpu.attn_utils._reshape_kv_cache = _reshape_kv_cache_v2
+vllm.v1.worker.gpu.attn_utils.bind_kv_cache = bind_kv_cache
 vllm.v1.worker.gpu.model_runner.get_kv_cache_spec = get_kv_cache_spec

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -17,8 +17,10 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
+from math import prod
 from typing import Any
 
 import numpy as np
@@ -28,6 +30,7 @@ from vllm.config import VllmConfig, get_current_vllm_config, get_layers_from_vll
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention.mla_attention import MLAAttention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -38,7 +41,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
-from vllm.v1.worker.utils import AttentionGroup
+from vllm.v1.worker.utils import AttentionGroup, extract_layer_index
 
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -48,6 +51,41 @@ from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import calc_split_factor, vllm_version_is
 
 _ATTENTION_MASK_BUILDER = None
+
+
+def bind_kv_cache(
+    kv_caches: dict[
+        str,
+        torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    ],
+    forward_context: dict[str, AttentionLayerBase],
+    runner_kv_caches: list[torch.Tensor | tuple[torch.Tensor, torch.Tensor]],
+    num_attn_module: int = 1,
+) -> None:
+    """Bind all Ascend attention cache components to ModelRunner V2.
+
+    A single transformer layer may expose multiple cache-only attention
+    modules.  This is normal for backends such as DSA (SWA, compressor and
+    indexer caches), and future plugin backends can use the same layout.
+    Upstream currently rejects this case for non CUDA/XPU/CPU platforms even
+    though the generic binding itself is valid on NPU.
+    """
+    if runner_kv_caches:
+        raise ValueError("ModelRunner KV caches must be empty before binding.")
+
+    index_to_names: dict[int, list[str]] = defaultdict(list)
+    for layer_name in kv_caches:
+        layer_index = extract_layer_index(layer_name, num_attn_module)
+        index_to_names[layer_index].append(layer_name)
+
+    for layer_index in sorted(index_to_names):
+        for layer_name in index_to_names[layer_index]:
+            runner_kv_caches.append(kv_caches[layer_name])
+
+    for layer_name, kv_cache in kv_caches.items():
+        if layer_name not in forward_context:
+            raise KeyError(f"KV cache layer {layer_name} is missing from forward context.")
+        forward_context[layer_name].kv_cache = kv_cache
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
@@ -81,6 +119,19 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
                 dtype=dtype,
                 cache_dtype_str=cache_dtype_str,
             )
+            continue
+
+        # Cache-only attention modules (for example DeepSeek-V4's SWA,
+        # compressor-state and indexer caches) intentionally implement the
+        # AttentionLayerBase contract without inheriting Attention or
+        # MLAAttention.  Keep the special conversions above for the two generic
+        # layer types, then fall back to the backend-neutral cache-spec hook.
+        # This also lets future plugin attention backends participate in MRV2
+        # without growing another isinstance branch here.
+        get_kv_cache_spec_fn = getattr(attn_module, "get_kv_cache_spec", None)
+        if get_kv_cache_spec_fn is not None:
+            if spec := get_kv_cache_spec_fn(vllm_config):
+                kv_cache_spec[layer_name] = spec
 
     return kv_cache_spec
 
@@ -252,6 +303,44 @@ def _get_attention_kv_cache_dims(layer_name: str, kv_cache_spec: AttentionSpec) 
     return kv_cache_spec.head_size, head_size_v
 
 
+def _get_attention_kv_cache_component_layout(
+    layer_name: str,
+    kv_cache_spec: AttentionSpec,
+) -> tuple[tuple[int, torch.dtype], ...]:
+    """Return physical ``(last_dim, dtype)`` components for one cache layer.
+
+    Ascend historically split every cache into K/V tensors for KV transfer.
+    Plugin attention backends can override that assumption through
+    ``get_kv_cache_component_layout``.  This keeps allocation backend-neutral
+    and lets combined-vector or data/scale caches describe their real layout.
+    """
+    attn_layers = get_layers_from_vllm_config(get_current_vllm_config(), AttentionLayerBase, [layer_name])
+    attn_layer = attn_layers[layer_name]
+    backend = attn_layer.get_attn_backend()
+    layout_hook = getattr(backend, "get_kv_cache_component_layout", None)
+    if layout_hook is not None:
+        layout = tuple(layout_hook(kv_cache_spec))
+    else:
+        k_dim, v_dim = _get_attention_kv_cache_dims(layer_name, kv_cache_spec)
+        k_dtype = v_dtype = kv_cache_spec.dtype
+        vllm_config = get_current_vllm_config()
+        if enable_fa_quant(vllm_config, layer_name):
+            k_dtype, v_dtype = vllm_config.quant_config.get_kv_quant_dtype(
+                layer_name,
+                kv_cache_spec.dtype,
+                vllm_config.model_config,
+            )
+        layout = ((k_dim, k_dtype), (v_dim, v_dtype))
+
+    if not 1 <= len(layout) <= 2:
+        raise ValueError(
+            f"MRV2 Ascend cache layout for {layer_name} must contain one or two components, got {len(layout)}."
+        )
+    if any(dim <= 0 for dim, _ in layout):
+        raise ValueError(f"MRV2 Ascend cache layout for {layer_name} has a non-positive component dimension: {layout}.")
+    return layout
+
+
 def _align_memory(tensor: torch.Tensor, alignment: int) -> torch.Tensor:
     data_ptr = tensor.data_ptr()
     aligned_addr = (data_ptr + alignment - 1) // alignment * alignment
@@ -259,11 +348,84 @@ def _align_memory(tensor: torch.Tensor, alignment: int) -> torch.Tensor:
     return tensor[int(offset) :]
 
 
+def _view_cache_component(
+    raw_tensor: torch.Tensor,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    page_size_bytes: int,
+) -> torch.Tensor:
+    """View one raw cache component, preserving padded page strides."""
+    dtype_size = get_dtype_size(dtype)
+    required_bytes = prod(shape) * dtype_size
+    if raw_tensor.numel() == required_bytes:
+        return raw_tensor.view(dtype).view(shape)
+
+    if raw_tensor.numel() % page_size_bytes != 0:
+        raise ValueError(f"Cache allocation size {raw_tensor.numel()} is not divisible by page size {page_size_bytes}.")
+    num_pages = raw_tensor.numel() // page_size_bytes
+    if not shape or shape[0] != num_pages:
+        raise ValueError(
+            f"Only a num-pages-first cache layout can use padded pages: shape={shape}, num_pages={num_pages}."
+        )
+    if page_size_bytes % dtype_size:
+        raise ValueError(f"Cache page size {page_size_bytes} is not aligned to {dtype}.")
+
+    strides = list(torch.empty(shape).stride())
+    strides[0] = page_size_bytes // dtype_size
+    return torch.as_strided(
+        raw_tensor.view(dtype),
+        size=shape,
+        stride=tuple(strides),
+    )
+
+
+def _reshape_attention_cache(
+    layer_name: str,
+    kv_cache_spec: AttentionSpec,
+    raw_cache: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    kv_cache_shape: tuple[int, ...],
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    component_layout = _get_attention_kv_cache_component_layout(layer_name, kv_cache_spec)
+    if len(component_layout) == 1:
+        if not isinstance(raw_cache, torch.Tensor):
+            raise TypeError(f"Cache layer {layer_name} declares a single component but received a split allocation.")
+        dim, dtype = component_layout[0]
+        shape = (*kv_cache_shape[:-1], dim)
+        return _view_cache_component(
+            raw_cache,
+            dtype,
+            shape,
+            kv_cache_spec.page_size_bytes,
+        )
+
+    if not isinstance(raw_cache, tuple):
+        raise TypeError(f"Cache layer {layer_name} declares two components but received a single allocation.")
+    if isinstance(kv_cache_spec, (AscendMLAAttentionSpec, MLAAttentionSpec)):
+        component_prefix = kv_cache_shape[:-1]
+    else:
+        # Conventional attention backends include the K/V axis first.
+        if not kv_cache_shape or kv_cache_shape[0] != 2:
+            raise ValueError(f"Expected a leading K/V axis for {layer_name}, got shape {kv_cache_shape}.")
+        component_prefix = kv_cache_shape[1:-1]
+
+    components = []
+    for raw_tensor, (dim, dtype) in zip(raw_cache, component_layout):
+        components.append(
+            _view_cache_component(
+                raw_tensor,
+                dtype,
+                (*component_prefix, dim),
+                kv_cache_spec.page_size_bytes,
+            )
+        )
+    return components[0], components[1]
+
+
 def _allocate_kv_cache(
     kv_cache_config: KVCacheConfig,
     shared_layers: dict[str, str],
     device: torch.device,
-) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+) -> dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]]:
     """
     Initialize the KV cache buffer with the correct size. The buffer needs to be
     reshaped to the desired shape before being used by the models.
@@ -281,7 +443,7 @@ def _allocate_kv_cache(
     vllm_config = get_current_vllm_config()
 
     # init kv cache tensors
-    kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+    kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]] = {}
     # prefill disaggregation need the addr of cache tensor be aligned with 2M
     alignment = 2 * 1024 * 1024
     layer_kv_cache_spec = _get_layer_kv_cache_specs(kv_cache_config)
@@ -289,38 +451,72 @@ def _allocate_kv_cache(
         if len(kv_cache_tensor.shared_by) == 0:
             continue
 
-        # NOTE: We need to init k_cache tensor (nope cache tensor in mla) and
-        # v_cache tensor (rope cache tensor in mla) separately to support
-        # prefill disaggregation, as it only supports the 0-dim of kv_cache is
-        # `num_blocks`.
-        # For deepseek mla, we need to spilt cache tensor accrodding to the nope
-        # head dim and rope head dim.
-        example_layer_name = kv_cache_tensor.shared_by[0]
-        example_kv_cache_spec = layer_kv_cache_spec[example_layer_name]
-        assert isinstance(example_kv_cache_spec, AttentionSpec)
-
-        k_dim, v_dim = _get_attention_kv_cache_dims(example_layer_name, example_kv_cache_spec)
-        assert k_dim > 0 and v_dim > 0
-        kv_head_dim_list = [k_dim, v_dim]
-        if enable_fa_quant(vllm_config):
-            k_tensor_split_factor, v_tensor_split_factor = vllm_config.quant_config.get_kv_quant_split_factor(
-                example_layer_name, kv_head_dim_list
-            )
-        else:
-            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
-        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+        layer_layouts: dict[str, tuple[tuple[int, torch.dtype], ...]] = {}
+        for layer_name in kv_cache_tensor.shared_by:
+            kv_cache_spec = layer_kv_cache_spec[layer_name]
+            assert isinstance(kv_cache_spec, AttentionSpec)
+            layer_layouts[layer_name] = _get_attention_kv_cache_component_layout(layer_name, kv_cache_spec)
 
         if vllm_config.kv_transfer_config is None:
-            k_tensor = torch.zeros(k_tensor_size, dtype=torch.int8, device=device)
-            v_tensor = torch.zeros(v_tensor_size, dtype=torch.int8, device=device)
+            # A scheduler KVCacheTensor may be reused by heterogeneous cache
+            # layers.  Keep one physical allocation and derive a layout-specific
+            # raw view for every layer instead of imposing the first layer's
+            # K/V structure on all aliases.
+            backing = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=device)
+            for layer_name, component_layout in layer_layouts.items():
+                if len(component_layout) == 1:
+                    kv_cache_raw_tensors[layer_name] = backing
+                    continue
+                component_bytes = [dim * get_dtype_size(dtype) for dim, dtype in component_layout]
+                split_factors = calc_split_factor(component_bytes)
+                first_size = int(kv_cache_tensor.size // split_factors[0])
+                second_size = kv_cache_tensor.size - first_size
+                kv_cache_raw_tensors[layer_name] = (
+                    backing[:first_size],
+                    backing[first_size : first_size + second_size],
+                )
+            continue
+
+        # KV transfer requires independently aligned component addresses.
+        # A shared physical allocation therefore cannot represent aliases with
+        # different component structures in that mode.
+        unique_layouts = set(layer_layouts.values())
+        if len(unique_layouts) != 1:
+            raise ValueError(
+                "KV transfer does not support a shared cache allocation with "
+                f"heterogeneous component layouts: {layer_layouts}."
+            )
+        component_layout = next(iter(unique_layouts))
+        if len(component_layout) == 1:
+            raw_tensor = torch.zeros(
+                kv_cache_tensor.size + alignment,
+                dtype=torch.int8,
+                device=device,
+            )
+            cache: torch.Tensor | tuple[torch.Tensor, torch.Tensor] = _align_memory(raw_tensor, alignment)[
+                : kv_cache_tensor.size
+            ]
         else:
-            k_tensor = torch.zeros(k_tensor_size + alignment, dtype=torch.int8, device=device)
-            v_tensor = torch.zeros(v_tensor_size + alignment, dtype=torch.int8, device=device)
-            k_tensor = _align_memory(k_tensor, alignment)[:k_tensor_size]
-            v_tensor = _align_memory(v_tensor, alignment)[:v_tensor_size]
+            component_bytes = [dim * get_dtype_size(dtype) for dim, dtype in component_layout]
+            split_factors = calc_split_factor(component_bytes)
+            first_size = int(kv_cache_tensor.size // split_factors[0])
+            second_size = kv_cache_tensor.size - first_size
+            first_tensor = torch.zeros(
+                first_size + alignment,
+                dtype=torch.int8,
+                device=device,
+            )
+            second_tensor = torch.zeros(
+                second_size + alignment,
+                dtype=torch.int8,
+                device=device,
+            )
+            cache = (
+                _align_memory(first_tensor, alignment)[:first_size],
+                _align_memory(second_tensor, alignment)[:second_size],
+            )
         for layer_name in kv_cache_tensor.shared_by:
-            kv_cache_raw_tensors[layer_name] = (k_tensor, v_tensor)
+            kv_cache_raw_tensors[layer_name] = cache
 
     layer_names = set()
     for group in kv_cache_config.kv_cache_groups:
@@ -335,12 +531,12 @@ def _allocate_kv_cache(
 
 def _reshape_kv_cache(
     kv_cache_config: KVCacheConfig,
-    kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]],
+    kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]],
     attn_backends: dict[str, AttentionBackend],
     cache_dtype: str,
     kernel_block_sizes: list[int] | None = None,
     shared_kv_cache_layers: dict[str, str] | None = None,
-) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+) -> dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]]:
     """
     Reshape the KV cache tensors to the desired shape and dtype.
 
@@ -352,9 +548,7 @@ def _reshape_kv_cache(
         dict[str, tuple[torch.Tensor, torch.Tensor]]: A map between layer names
             to their corresponding memory buffer for KV cache
     """
-    vllm_config = get_current_vllm_config()
-
-    kv_caches: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+    kv_caches: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]] = {}
     kernel_block_sizes = kernel_block_sizes or []
     for kv_cache_group_id, kv_cache_group_spec in enumerate(kv_cache_config.kv_cache_groups):
         for layer_name in kv_cache_group_spec.layer_names:
@@ -366,10 +560,12 @@ def _reshape_kv_cache(
             assert isinstance(kv_cache_spec, AttentionSpec)
 
             if isinstance(kv_cache_spec, AttentionSpec):
-                raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name]
-                assert raw_k_tensor is not None
-                assert raw_v_tensor is not None
-                sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
+                raw_cache = kv_cache_raw_tensors[layer_name]
+                sum_page_size_bytes = (
+                    raw_cache.numel()
+                    if isinstance(raw_cache, torch.Tensor)
+                    else sum(tensor.numel() for tensor in raw_cache)
+                )
                 assert sum_page_size_bytes % kv_cache_spec.page_size_bytes == 0
                 num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
 
@@ -401,28 +597,12 @@ def _reshape_kv_cache(
                     kv_cache_spec.head_size,
                     cache_dtype,
                 )
-                if not isinstance(kv_cache_spec, AscendMLAAttentionSpec):
-                    k_shape = kv_cache_shape[1:]
-                    if hasattr(kv_cache_spec, "head_size_v"):
-                        v_shape = (*kv_cache_shape[1:-1], kv_cache_spec.head_size_v)
-                    else:
-                        v_shape = k_shape
-                else:
-                    # k_cache: nope_cache    v_cache: rope_cache
-                    mla_num_blocks, mla_block_size, num_kv_heads, _ = kv_cache_shape
-                    k_dim, v_dim = _get_attention_kv_cache_dims(layer_name, kv_cache_spec)
-                    k_shape = (mla_num_blocks, mla_block_size, num_kv_heads, k_dim)
-                    v_shape = (mla_num_blocks, mla_block_size, num_kv_heads, v_dim)
-
-                k_cache_dtype = v_cache_dtype = kv_cache_spec.dtype
-                if enable_fa_quant(vllm_config):
-                    k_cache_dtype, v_cache_dtype = vllm_config.quant_config.get_kv_quant_dtype(
-                        layer_name, kv_cache_spec.dtype, vllm_config.model_config
-                    )
-
-                k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-                v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
-                kv_caches[layer_name] = (k_cache, v_cache)
+                kv_caches[layer_name] = _reshape_attention_cache(
+                    layer_name,
+                    kv_cache_spec,
+                    raw_cache,
+                    kv_cache_shape,
+                )
             else:
                 raise ValueError("Unknown KV cache spec type.")
 
@@ -435,18 +615,13 @@ def _reshape_kv_cache(
 
 def _reshape_kv_cache_v2(
     attn_groups: Sequence[AttentionGroup],
-    kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]],
+    kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]],
     cache_dtype: str,
     kernel_block_sizes: list[int],
     shared_kv_cache_layers: dict[str, str],
     kv_cache_config: "KVCacheConfig | None" = None,
-) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
-    vllm_config = get_current_vllm_config()
-    is_kv_consumer = (
-        vllm_config.kv_transfer_config.is_kv_consumer if vllm_config.kv_transfer_config is not None else False
-    )
-
-    kv_caches: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+) -> dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]]:
+    kv_caches: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]] = {}
     for group in attn_groups:
         if group.kv_cache_group_id >= len(kernel_block_sizes):
             continue
@@ -463,10 +638,12 @@ def _reshape_kv_cache_v2(
 
             assert isinstance(kv_cache_spec, AttentionSpec)
 
-            raw_k_tensor, raw_v_tensor = kv_cache_raw_tensors[layer_name]
-            assert raw_k_tensor is not None
-            assert raw_v_tensor is not None
-            sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
+            raw_cache = kv_cache_raw_tensors[layer_name]
+            sum_page_size_bytes = (
+                raw_cache.numel()
+                if isinstance(raw_cache, torch.Tensor)
+                else sum(tensor.numel() for tensor in raw_cache)
+            )
             assert sum_page_size_bytes % kv_cache_spec.page_size_bytes == 0
             num_blocks = sum_page_size_bytes // kv_cache_spec.page_size_bytes
 
@@ -481,27 +658,12 @@ def _reshape_kv_cache_v2(
                 cache_dtype,
             )
 
-            if not isinstance(kv_cache_spec, (AscendMLAAttentionSpec, MLAAttentionSpec)):
-                k_shape = kv_cache_shape[1:]
-                if hasattr(kv_cache_spec, "head_size_v"):
-                    v_shape = (*kv_cache_shape[1:-1], kv_cache_spec.head_size_v)
-                else:
-                    v_shape = k_shape
-            else:
-                mla_num_blocks, mla_block_size, num_kv_heads, _ = kv_cache_shape
-                k_dim, v_dim = _get_attention_kv_cache_dims(layer_name, kv_cache_spec)
-                k_shape = (mla_num_blocks, mla_block_size, num_kv_heads, k_dim)
-                v_shape = (mla_num_blocks, mla_block_size, num_kv_heads, v_dim)
-
-            k_cache_dtype = v_cache_dtype = kv_cache_spec.dtype
-            if is_kv_consumer and enable_fa_quant(vllm_config):
-                k_cache_dtype, v_cache_dtype = vllm_config.quant_config.get_kv_quant_dtype(
-                    layer_name, kv_cache_spec.dtype, vllm_config.model_config
-                )
-
-            k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape)
-            v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape)
-            kv_caches[layer_name] = (k_cache, v_cache)
+            kv_caches[layer_name] = _reshape_attention_cache(
+                layer_name,
+                kv_cache_spec,
+                raw_cache,
+                kv_cache_shape,
+            )
 
     for layer_name, target_layer_name in shared_kv_cache_layers.items():
         kv_caches[layer_name] = kv_caches[target_layer_name]

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -166,14 +166,16 @@ def build_attn_metadata(
     attn_state: Any | None = None,
     graph_pad_size: int = -1,
     num_input_tokens: int = 0,
+    is_prefilling: torch.Tensor | None = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
     causal: bool | Mapping[int, bool] = True,
 ) -> dict[str, Any]:
     """Build attention metadata for Ascend NPUs."""
     # TODO(Ronald1995): optimize AscendCommonAttentionMetadata.
-    # ModelRunner V2 callers can omit this legacy Ascend field. The scheduled
-    # token count is the valid positions and rotary-embedding extent.
+    # MRV2 callers currently omit this legacy Ascend field. In eager mode the
+    # scheduled token count is also the valid positions/cos-sin extent; PCP
+    # builders can still replace it with their fixed local padded extent.
     if num_input_tokens <= 0:
         num_input_tokens = num_tokens
 
@@ -214,6 +216,7 @@ def build_attn_metadata(
             attn_state=attn_state,
             graph_pad_size=graph_pad_size,
             num_input_tokens=num_input_tokens,
+            is_prefilling=is_prefilling,
             max_seq_len=max_seq_len,
             causal=group_causal,
             **common_attn_metadata_extra_kwargs,

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -172,6 +172,10 @@ def build_attn_metadata(
 ) -> dict[str, Any]:
     """Build attention metadata for Ascend NPUs."""
     # TODO(Ronald1995): optimize AscendCommonAttentionMetadata.
+    # ModelRunner V2 callers can omit this legacy Ascend field. The scheduled
+    # token count is the valid positions and rotary-embedding extent.
+    if num_input_tokens <= 0:
+        num_input_tokens = num_tokens
 
     # seq_lens_np is used for ascend npus, it maybe None in spec_decode case,
     # we fill it with max_seq_len in case `attn_metadata_builder.build` raise

--- a/vllm_ascend/worker/v2/block_table.py
+++ b/vllm_ascend/worker/v2/block_table.py
@@ -132,7 +132,8 @@ def _compute_slot_mappings_kernel(
     end_idx = tl.load(query_start_loc + batch_idx + 1)
     for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
         offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
-        positions = tl.load(pos + offset, mask=offset < end_idx, other=0)
+        first_position = tl.load(pos + i)
+        positions = tl.load(pos + offset, mask=offset < end_idx, other=first_position)
 
         # Type conversion of 'position' to int32 to be compatible with npu
         # otherwise, it will degrade to scalar computation
@@ -144,12 +145,22 @@ def _compute_slot_mappings_kernel(
         # replace the % operation with sub and mul instead
         block_offsets = positions - (block_size * CP_SIZE) * block_indices
 
-        # The 'block_indics' variable results in non-contiguous memory assess,
-        # which triggers degradation toscalar computation.
-        # Mitigate this by loading the complete data block and extracting the required data with tl.gather
-        block_numbers = tl.load(block_table_ptr + req_state_idx * block_table_stride + tl.arange(0, TOTAL_BLOCK_SIZE))
+        # The 'block_indices' variable results in non-contiguous memory access,
+        # which triggers degradation to scalar computation. Mitigate this by
+        # loading a contiguous window and extracting the requested data with
+        # tl.gather. Shift the window for long contexts so block indices beyond
+        # TOTAL_BLOCK_SIZE remain in range without increasing NPU UB usage.
+        first_block_index = first_position.to(tl.int32) // (block_size * CP_SIZE)
+        block_table_window_start = first_block_index // TOTAL_BLOCK_SIZE * TOTAL_BLOCK_SIZE
+        block_table_offsets = tl.arange(0, TOTAL_BLOCK_SIZE)
+        absolute_block_table_offsets = block_table_window_start + block_table_offsets
+        block_numbers = tl.load(
+            block_table_ptr + req_state_idx * block_table_stride + absolute_block_table_offsets,
+            mask=absolute_block_table_offsets < block_table_stride,
+            other=0,
+        )
         block_numbers = block_numbers.to(tl.float32)
-        block_numbers = tl.gather(block_numbers, block_indices, 0)
+        block_numbers = tl.gather(block_numbers, block_indices - block_table_window_start, 0)
 
         if CP_SIZE == 1:
             # Common case: Context parallelism is not used.

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -72,6 +72,7 @@ class AscendModelState(DefaultModelState):
             seq_lens_np=input_batch.seq_lens_np,
             positions=input_batch.positions,
             attn_state=input_batch.attn_state,
+            is_prefilling=torch.from_numpy(input_batch.is_prefilling_np),
             for_cudagraph_capture=for_capture,
         )
         return self.attn_metadata


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds ModelRunner V2 support for DSA and implements prefill context parallelism for the DSA attention backend.

- Define backend-owned DSA KV-cache layouts and propagate the required ModelRunner V2 execution context.
- Add DSA PCP metadata planning and separate cache updates from rank-local attention.
- Replay compressor caches in canonical token order and route DSA to PCP when prefill context parallelism is enabled.
- Keep the existing DSA-CP path for compatibility.

### Does this PR introduce _any_ user-facing change?

Yes. DSA models can use `--prefill-context-parallel-size > 1` with ModelRunner V2. No new CLI option is introduced.

### How was this patch tested?

Manual NPU end-to-end validation compared `main + MRV1`, `branch + MRV1`, and `branch + MRV2`; accuracy and performance were comparable across the three configurations. No new unit test was added because this path depends on distributed NPU attention and cache behavior.