### PR TITLE
[Doc][Misc] Update Ascend PyTorch Profiler guide

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
+++ b/docs/source/developer_guide/performance_and_debug/service_profiling_guide.md
@@ -36,8 +36,6 @@ No additional packages need to be installed; it can be enabled through command-l
 Start the online service and set the `--profiler-config` parameter to control the path for saving performance files. After the parameter is set, the collection function is enabled.
 
 ```bash
-export VLLM_PROMPT_SEQ_BUCKET_MAX=128
-export VLLM_PROMPT_SEQ_BUCKET_MIN=128
 python3 -m vllm.entrypoints.openai.api_server \
 --port 8080 \
 --model "facebook/opt-125m" \
@@ -51,6 +49,10 @@ python3 -m vllm.entrypoints.openai.api_server \
 > Note: **January 19, 2026: The vLLM mainline has deprecated the VLLM_TORCH_PROFILER_DIR environment variable.** [Related PR](https://github.com/vllm-project/vllm-ascend/pull/5928)  When using the vLLM Ascend mainline code to collect profiler data, remember to use the `--profiler-config` (online) parameter or the `profiler_config` (offline) parameter.
 
 ### 2. Start Collection
+
+!!! note
+
+    The `/start_profile` and `/stop_profile` endpoints are **only registered** when the server is launched with `--profiler-config` set (profiler field non-empty). If you forget to set `--profiler-config`, these endpoints will not exist and `curl` will return **404 Not Found**.
 
 Performance collection is controlled by sending API requests. You can start collection after stabilizing the actual business data and collect profiling for a few seconds before stopping; or you can start collection first, then send business requests, and finally stop.
 
@@ -111,6 +113,30 @@ After analysis, the `*ascend_pt` directory will contain many files, with the mai
 - `step_trace_time.csv`: Scheduling data
 
 - `trace_view.json`: Chrome tracing format data, can be opened with [MindStudio Insight](https://www.hiascend.com/document/detail/zh/mindstudio/81RC1/GUI_baseddevelopmenttool/msascendinsightug/Insight_userguide_0002.html)
+
+### Supplementary: Profiling in PD Disaggregation Scenarios
+
+In PD (Prefill-Decode) disaggregation deployments, the Prefiller and Decoder are **separate vLLM instances**, each with its own API server. Profiling must be configured and controlled **independently** on each node:
+
+1. **Both P and D** must launch with `--profiler-config` (pointing to different directories to avoid overwriting).
+
+2. The main PD load-balance proxy (`load_balance_proxy_server_example.py`) does **not** forward `/start_profile` or `/stop_profile`. You must curl **each node's HTTP port directly**:
+
+```bash
+# Start profiling on both P and D
+curl -X POST http://<prefiller_ip>:<prefiller_port>/start_profile
+curl -X POST http://<decoder_ip>:<decoder_port>/start_profile
+
+# Send business requests through the proxy...
+
+# Stop profiling on both P and D
+curl -X POST http://<prefiller_ip>:<prefiller_port>/stop_profile
+curl -X POST http://<decoder_ip>:<decoder_port>/stop_profile
+```
+
+!!! note
+
+    The EPD proxy (`epd_load_balance_proxy_layerwise_server_example.py`) **does** support broadcasting profiling commands to all E/P/D instances.
 
 ---
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the Ascend PyTorch Profiler guide to:
- Remove deprecated/invalid `VLLM_PROMPT_SEQ_BUCKET_MAX` and `VLLM_PROMPT_SEQ_BUCKET_MIN` environment variables from the online service startup example.
- Add a new section "Profiling in PD Disaggregation Scenarios" explaining how to configure and control profiling independently on Prefiller and Decoder nodes, including direct `curl` commands since the main PD load-balance proxy does not forward profiling requests.
- Clarify that the EPD proxy does support broadcasting profiling commands.
- Add a note that `/start_profile` and `/stop_profile` endpoints return 404 Not Found if `--profiler-config` is not set.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Tested by verifying the documentation changes and checking the proxy server implementations (`load_balance_proxy_server_example.py` and `epd_load_balance_proxy_layerwise_server_example.py`) to ensure the documented behavior is accurate.
- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
