### PR TITLE
[v0.23.0][Ops][BugFix] Enable thinking_token_budget enforcement on NPU

### DIFF
--- a/tests/ut/worker/test_npu_input_batch_thinking_budget.py
+++ b/tests/ut/worker/test_npu_input_batch_thinking_budget.py
@@ -1,0 +1,127 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Regression tests for thinking_token_budget enforcement on NPU.
+
+These tests verify that ``NPUInputBatch`` correctly creates the
+``thinking_budget_state_holder`` when a ``reasoning_config`` is provided,
+instead of hardcoding it to ``None`` (which silently disabled the
+``thinking_token_budget`` hard truncation mechanism).
+
+See https://github.com/vllm-project/vllm-ascend/issues/13060
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+from vllm.config.reasoning import ReasoningConfig
+from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
+
+from vllm_ascend.worker.npu_input_batch import NPUInputBatch
+
+
+def _make_input_batch(
+    reasoning_config: ReasoningConfig | None = None,
+    num_speculative_tokens: int = 0,
+) -> NPUInputBatch:
+    """Create a minimal NPUInputBatch on CPU for testing.
+
+    Mocks the distributed group accessors so that ``MultiGroupBlockTable``
+    can be constructed without a real distributed environment.
+    """
+    mock_group = MagicMock()
+    mock_group.world_size = 1
+    mock_group.rank_in_group = 0
+    with (
+        patch("vllm_ascend.worker.block_table.get_dcp_group", return_value=mock_group),
+        patch("vllm_ascend.worker.block_table.get_pcp_group", return_value=mock_group),
+    ):
+        return NPUInputBatch(
+            max_num_reqs=4,
+            max_model_len=128,
+            max_num_batched_tokens=128,
+            device=torch.device("cpu"),
+            pin_memory=False,
+            vocab_size=1024,
+            block_sizes=[16],
+            kernel_block_sizes=[[16]],
+            num_speculative_tokens=num_speculative_tokens,
+            reasoning_config=reasoning_config,
+        )
+
+
+class TestThinkingBudgetStateHolder(unittest.TestCase):
+    """Tests that NPUInputBatch creates the thinking budget state holder."""
+
+    def test_holder_is_none_without_reasoning_config(self):
+        """Without reasoning_config, holder should be None (thinking disabled)."""
+        batch = _make_input_batch(reasoning_config=None)
+        self.assertIsNone(batch.thinking_budget_state_holder)
+
+    def test_holder_created_with_reasoning_config(self):
+        """With reasoning_config, holder should be a ThinkingBudgetStateHolder.
+
+        This is the regression test for issue #13060: previously the holder
+        was hardcoded to None, silently disabling thinking_token_budget.
+        """
+        reasoning_config = ReasoningConfig(
+            reasoning_parser="qwen3",
+            reasoning_start_str="<think>",
+            reasoning_end_str="</think>",
+        )
+        batch = _make_input_batch(reasoning_config=reasoning_config)
+        self.assertIsNotNone(batch.thinking_budget_state_holder)
+        self.assertIsInstance(batch.thinking_budget_state_holder, ThinkingBudgetStateHolder)
+
+    def test_holder_is_enabled_with_reasoning_config(self):
+        """The created holder should report is_enabled=True."""
+        reasoning_config = ReasoningConfig(
+            reasoning_parser="qwen3",
+            reasoning_start_str="<think>",
+            reasoning_end_str="</think>",
+        )
+        batch = _make_input_batch(reasoning_config=reasoning_config)
+        self.assertTrue(batch.thinking_budget_state_holder.is_enabled)
+
+    def test_holder_spec_mode_flag(self):
+        """Holder should reflect speculative decoding mode."""
+        reasoning_config = ReasoningConfig(
+            reasoning_parser="qwen3",
+            reasoning_start_str="<think>",
+            reasoning_end_str="</think>",
+        )
+        batch = _make_input_batch(reasoning_config=reasoning_config, num_speculative_tokens=2)
+        holder = batch.thinking_budget_state_holder
+        self.assertIsNotNone(holder)
+        self.assertTrue(holder.in_spec_mode)
+        self.assertEqual(holder.num_spec_tokens, 2)
+
+    def test_holder_has_no_tracked_requests_initially(self):
+        """A freshly created holder should have no tracked requests."""
+        reasoning_config = ReasoningConfig(
+            reasoning_parser="qwen3",
+            reasoning_start_str="<think>",
+            reasoning_end_str="</think>",
+        )
+        batch = _make_input_batch(reasoning_config=reasoning_config)
+        holder = batch.thinking_budget_state_holder
+        self.assertFalse(holder.has_tracked_requests())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -566,6 +566,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.vllm_config.speculative_config.num_speculative_tokens if self.vllm_config.speculative_config else 0
             ),
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
+            reasoning_config=self.vllm_config.reasoning_config,
         )
         self.num_draft_tokens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
         # here we use int32
@@ -4754,6 +4755,7 @@ class NPUModelRunner(GPUModelRunner):
                 max_num_blocks_per_req=max_num_blocks,
                 kv_cache_groups=kv_cache_config.kv_cache_groups,
                 cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
+                reasoning_config=self.vllm_config.reasoning_config,
             )
 
     def initialize_attn_backend(self, kv_cache_config: KVCacheConfig) -> None:

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -19,12 +19,14 @@
 
 import numpy as np
 import torch
+from vllm.config.reasoning import ReasoningConfig
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.pool.metadata import PoolingStates
 from vllm.v1.sample.logits_processor import BatchUpdateBuilder, LogitsProcessors
+from vllm.v1.sample.thinking_budget_state import maybe_create_thinking_budget_state_holder
 from vllm.v1.worker.gpu_input_batch import InputBatch
 
 from vllm_ascend.worker.block_table import MultiGroupBlockTable
@@ -49,13 +51,20 @@ class NPUInputBatch(InputBatch):
         num_speculative_tokens: int = 0,
         cp_kv_cache_interleave_size: int = 1,
         kv_cache_groups: list[KVCacheGroupSpec] | None = None,
+        reasoning_config: ReasoningConfig | None = None,
     ):
         self.is_pooling_model = is_pooling_model
         self.is_spec_decode = is_spec_decode
-        # Added for compatibility with InputBatch methods that reference these
-        # attributes after PR vllm-project/vllm#34668. NPU does not use
-        # thinking budget, so the holder is always None.
-        self.thinking_budget_state_holder = None
+        # Create the thinking budget state holder so that
+        # thinking_token_budget hard truncation is enforced on NPU, mirroring
+        # the upstream GPU InputBatch behavior.
+        self.thinking_budget_state_holder = maybe_create_thinking_budget_state_holder(
+            reasoning_config,
+            max_num_reqs,
+            num_speculative_tokens,
+            device,
+            pin_memory,
+        )
         self.thinking_token_budget_reqs: set[str] = set()
         self.max_num_reqs = max_num_reqs
         self.max_model_len = max_model_len


### PR DESCRIPTION
### What this PR does / why we need it?

`NPUInputBatch` hardcoded `thinking_budget_state_holder` to `None`, which silently disabled the `thinking_token_budget` hard truncation mechanism introduced in upstream vLLM v0.23.0 (`ThinkingBudgetStateHolder` replaced the old `ThinkingTokenBudgetLogitsProcessor` path).

When a user sets `thinking_token_budget=50`, the model was expected to truncate its reasoning output at ~50 tokens. Instead, the full reasoning was generated (~370 tokens) because the holder was always `None`, causing the `if holder is not None` check in the sampler to always skip the truncation logic.

This patch mirrors the upstream GPU `InputBatch` behavior by:
- Adding a `reasoning_config` parameter to `NPUInputBatch.__init__`
- Creating the holder via `maybe_create_thinking_budget_state_holder()` instead of hardcoding `None`
- Passing `self.vllm_config.reasoning_config` at both `NPUInputBatch` instantiation sites in `model_runner_v1.py`

Fixes #13060

### Does this PR introduce _any_ user-facing change?

Yes. `thinking_token_budget` now correctly truncates reasoning output on NPU, matching GPU behavior. Users who set `thinking_token_budget` will see the reasoning section truncated at the specified token count instead of being ignored.

### How was this patch tested?

- Added unit test `tests/ut/worker/test_npu_input_batch_thinking_budget.py` verifying:
  - holder is `None` when `reasoning_config` is not provided
  - holder is created as `ThinkingBudgetStateHolder` when `reasoning_config` is provided
  - holder reports `is_enabled=True`
  - holder correctly reflects speculative decoding mode
  - holder has no tracked requests initially
- All pre-commit hooks passed on changed files.
- Verified on NPU hardware: `pytest -sv tests/ut/worker/test_npu_input_batch_thinking_budget.py` — 5 passed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389