### PR TITLE
[Refactor] decouple flashcomm and shared expert dp

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -71,7 +71,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `refresh`                           | bool | `false` | Whether to refresh global Ascend configuration content. This is usually used by rlhf or ut/e2e test case. |
 | `dump_config`                       | dict | `None`  | Inline msprobe dump configuration. vLLM-Ascend will materialize it to a temporary JSON file and pass that file to the debugger. |
 | `dump_config_path`                  | str  | `None`  | Configuration file path for msprobe dump (compatible legacy option).                                      |
-| `enable_shared_expert_dp`           | bool | `False` | When the expert is shared in DP, it delivers better performance but consumes more memory. |
+| `enable_shared_expert_dp`           | bool | `False` | Replicate shared-expert weights across TP ranks and run the shared expert with data parallelism. This option is independent of `enable_flashcomm1`; it improves performance but consumes more memory. |
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
 | `enable_sleep_mode_extra_cleanup`   | bool | `False` | Enables extra sleep-mode cleanup for RL workloads, including HCCL process-group release and ACL graph workspace cleanup. Disabled by default because wakeup may need to restore HCCL and recapture ACL graphs. |

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -72,7 +72,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `refresh`                           | bool | `false` | Whether to refresh global Ascend configuration content. This is usually used by rlhf or ut/e2e test case. |
 | `dump_config`                       | dict | `None`  | Inline msprobe dump configuration. vLLM-Ascend will materialize it to a temporary JSON file and pass that file to the debugger. |
 | `dump_config_path`                  | str  | `None`  | Configuration file path for msprobe dump (compatible legacy option).                                      |
-| `enable_shared_expert_dp`           | bool | `False` | When the expert is shared in DP, it delivers better performance but consumes more memory. |
+| `enable_shared_expert_dp`           | bool | `False` | Replicate shared-expert weights across TP ranks and run the shared expert with data parallelism. This option is independent of `enable_flashcomm1`; it improves performance but consumes more memory. |
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
 | `enable_sleep_mode_extra_cleanup`   | bool | `False` | Enables extra sleep-mode cleanup for RL workloads, including HCCL process-group release and ACL graph workspace cleanup. Disabled by default because wakeup may need to restore HCCL and recapture ACL graphs. |

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -47,7 +47,11 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
         pytest.param(
             [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18],
             7,
-            {"enable_flashcomm1": True, "enable_dsa_cp": True},
+            {
+                "enable_flashcomm1": True,
+                "enable_shared_expert_dp": True,
+                "enable_dsa_cp": True,
+            },
             id="dsa-cp-dspark",
         ),
     ],

--- a/tests/e2e/pull_request/two_card/test_shared_expert_dp.py
+++ b/tests/e2e/pull_request/two_card/test_shared_expert_dp.py
@@ -14,22 +14,45 @@ PROMPTS = [
     "The future of AI is",
 ]
 
+FEATURE_CONFIGS = [
+    pytest.param(
+        {
+            "enable_flashcomm1": True,
+            "enable_shared_expert_dp": False,
+        },
+        id="flashcomm-only",
+    ),
+    pytest.param(
+        {
+            "enable_flashcomm1": False,
+            "enable_shared_expert_dp": True,
+        },
+        id="shared-expert-dp-only",
+    ),
+    pytest.param(
+        {
+            "enable_flashcomm1": True,
+            "enable_shared_expert_dp": True,
+        },
+        id="flashcomm-and-shared-expert-dp",
+    ),
+]
+
 
 @wait_until_npu_memory_free(0.7)
 @pytest.mark.parametrize("model", MODELS)
-def test_deepseek_v2_lite_enable_shared_expert_dp_tp2(model: str, monkeypatch) -> None:
+@pytest.mark.parametrize("feature_config", FEATURE_CONFIGS)
+def test_deepseek_v2_lite_flashcomm_shared_expert_dp_matrix_tp2(
+    model: str,
+    feature_config: dict[str, bool],
+    monkeypatch,
+) -> None:
     # FlashComm v1 / shared-expert-DP require HCCL_OP_EXPANSION_MODE to be unset.
     monkeypatch.delenv("HCCL_OP_EXPANSION_MODE", raising=False)
 
-    # FlashComm1 + shared-expert-DP must stay numerically consistent with the
-    # plain eager baseline.  `additional_config` is excluded from the baseline
-    # by compare_logprobs, so the baseline runs without either flag.
-    shared_expert_dp_config = {
-        "enable_flashcomm1": True,
-        "enable_shared_expert_dp": True,
-    }
-
-    # Eager mode: FlashComm1 + shared-expert-DP vs eager baseline.
+    # Each independent feature combination must stay numerically consistent
+    # with the plain eager baseline. `additional_config` is excluded from the
+    # baseline by compare_logprobs, so the baseline has both flags disabled.
     compare_logprobs(
         runner_kwargs={
             "model_name": model,
@@ -37,12 +60,11 @@ def test_deepseek_v2_lite_enable_shared_expert_dp_tp2(model: str, monkeypatch) -
             "enforce_eager": True,
             "tensor_parallel_size": 2,
             "enable_expert_parallel": True,
-            "additional_config": shared_expert_dp_config,
+            "additional_config": feature_config,
         },
         prompts=PROMPTS,
     )
 
-    # ACLGraph (FULL_DECODE_ONLY): FlashComm1 + shared-expert-DP vs eager baseline.
     compare_logprobs(
         runner_kwargs={
             "model_name": model,
@@ -53,7 +75,7 @@ def test_deepseek_v2_lite_enable_shared_expert_dp_tp2(model: str, monkeypatch) -
                 "cudagraph_capture_sizes": [1, 4, 8, 16],
                 "cudagraph_mode": "FULL_DECODE_ONLY",
             },
-            "additional_config": shared_expert_dp_config,
+            "additional_config": feature_config,
         },
         prompts=PROMPTS,
     )

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -358,7 +358,7 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
 def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_enabled, expected):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     runner.ascend_shared_experts = SimpleNamespace(
-        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON)
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON)
     )
     shared_output = object()
     monkeypatch.setattr(
@@ -375,11 +375,11 @@ def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_ena
 @pytest.mark.parametrize(
     ("mode", "fused_output_is_reduced", "reduce_shared"),
     [
-        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, False, False),
-        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, True, True),
-        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF, True, False),
-        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON, True, False),
-        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF, False, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF, True, True),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_OFF, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON, True, False),
     ],
 )
 def test_shared_output_reduction_depends_on_weight_layout(
@@ -415,10 +415,10 @@ def test_shared_output_reduction_depends_on_weight_layout(
 @pytest.mark.parametrize(
     ("mode", "reduce_routed"),
     [
-        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, False),
-        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF, False),
-        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON, True),
-        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF, False),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_OFF, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON, True),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON, False),
     ],
 )
 def test_local_shared_expert_dp_reduces_partial_routed_output(
@@ -768,12 +768,12 @@ def test_shared_experts_part2_applies_optional_gate(with_gate):
         "expected_mode",
     ),
     [
-        (False, False, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF),
-        (True, False, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF),
-        (False, True, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON),
-        (True, True, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
-        (False, True, True, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
-        (False, True, False, True, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+        (False, False, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF),
+        (True, False, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_OFF),
+        (False, True, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON),
+        (True, True, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON),
+        (False, True, True, False, SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON),
+        (False, True, False, True, SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON),
     ],
 )
 def test_shared_expert_parallel_mode_matches_activation_and_weight_layout(
@@ -876,7 +876,7 @@ def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     )
     shared_experts.multistream_overlap = False
     shared_experts.quant_type = QuantType.W8A8
-    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON)
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON)
     hidden_states = torch.randn(2, 4)
     part1_out = torch.randn(2, 8)
     shared_out = torch.randn(2, 4)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -841,11 +841,21 @@ def test_local_shared_expert_dp_pads_splits_gathers_and_unpads(num_tokens):
     tp_group.all_gather.assert_called_once_with(local_hidden_states, dim=0)
 
 
-def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output():
+@pytest.mark.parametrize(("num_shared_tokens", "pad_size"), [(4, 0), (3, 1)])
+def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output(
+    monkeypatch,
+    num_shared_tokens,
+    pad_size,
+):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    tp_group = MagicMock(world_size=2, rank_in_group=0)
+    shared_experts.moe_config = SimpleNamespace(tp_group=tp_group)
     hidden_states = torch.ones(2, 4)
     gathered_states = torch.ones(4, 4)
-    shared_out = torch.ones(4, 4)
-    reduced_states = torch.ones(2, 4)
+    shared_out = torch.ones(num_shared_tokens, 4)
+    reduced_states = torch.ones((num_shared_tokens + pad_size) // 2, 4)
+    tp_group.reduce_scatter.return_value = reduced_states
+    monkeypatch.setattr(shared_experts_module, "_EXTRA_CTX", SimpleNamespace(pad_size=pad_size))
 
     with (
         patch(
@@ -855,17 +865,20 @@ def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output():
         ) as all_gather,
         patch(
             "torch.ops.vllm.maybe_pad_and_reduce",
-            return_value=reduced_states,
             create=True,
-        ) as reduce_scatter,
+        ) as generic_reduce,
     ):
-        prepared = AscendSharedExperts._prepare_flashcomm_tp_input(hidden_states)
-        finalized = AscendSharedExperts._finalize_flashcomm_tp_output(shared_out)
+        prepared = shared_experts._prepare_flashcomm_tp_input(hidden_states)
+        finalized = shared_experts._finalize_flashcomm_tp_output(shared_out)
 
     assert prepared is gathered_states
     assert finalized is reduced_states
     all_gather.assert_called_once_with(hidden_states, True)
-    reduce_scatter.assert_called_once_with(shared_out)
+    generic_reduce.assert_not_called()
+    reduced_input = tp_group.reduce_scatter.call_args.args[0]
+    expected_input = F.pad(shared_out, (0, 0, 0, pad_size))
+    torch.testing.assert_close(reduced_input, expected_input)
+    assert tp_group.reduce_scatter.call_args.kwargs == {"dim": 0}
 
 
 def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
@@ -21,7 +22,11 @@ from vllm_ascend.ops.fused_moe.routed_experts import (
 from vllm_ascend.ops.fused_moe.router import fused_topk_router as fused_topk_router_module
 from vllm_ascend.ops.fused_moe.router.fused_topk_router import AscendFusedTopKRouter
 from vllm_ascend.ops.fused_moe.router.grouped_topk_router import AscendGroupedTopKRouter
-from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts, FusedMoEEvents
+from vllm_ascend.ops.fused_moe.shared_experts import (
+    AscendSharedExperts,
+    FusedMoEEvents,
+    SharedExpertParallelMode,
+)
 from vllm_ascend.quantization.quant_type import QuantType
 
 
@@ -352,6 +357,9 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
 )
 def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_enabled, expected):
     runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner.ascend_shared_experts = SimpleNamespace(
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON)
+    )
     shared_output = object()
     monkeypatch.setattr(
         fused_moe_module,
@@ -362,6 +370,92 @@ def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_ena
     assert runner.use_dp_chunking is False
     assert runner._fused_output_is_reduced is expected
     assert runner._maybe_reduce_shared_expert_output(shared_output) is shared_output
+
+
+@pytest.mark.parametrize(
+    ("mode", "fused_output_is_reduced", "reduce_shared"),
+    [
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, False, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, True, True),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON, True, False),
+    ],
+)
+def test_shared_output_reduction_depends_on_weight_layout(
+    monkeypatch,
+    mode,
+    fused_output_is_reduced,
+    reduce_shared,
+):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner.ascend_shared_experts = SimpleNamespace(parallel_mode=MagicMock(return_value=mode))
+    shared_output = torch.ones(2, 4)
+    reduced_output = shared_output + 1
+    all_reduce = MagicMock(return_value=reduced_output)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "tensor_model_parallel_all_reduce",
+        all_reduce,
+    )
+
+    result = runner._reduce_shared_output_if_needed(
+        shared_output,
+        fused_output_is_reduced,
+    )
+
+    if reduce_shared:
+        assert result is reduced_output
+        all_reduce.assert_called_once_with(shared_output)
+    else:
+        assert result is shared_output
+        all_reduce.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mode", "reduce_routed"),
+    [
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, False),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON, True),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON, False),
+    ],
+)
+def test_local_shared_expert_dp_reduces_partial_routed_output(
+    monkeypatch,
+    mode,
+    reduce_routed,
+):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner.ascend_shared_experts = SimpleNamespace(parallel_mode=MagicMock(return_value=mode))
+    runner.routed_output_transform = None
+    runner.moe_config = SimpleNamespace(
+        is_sequence_parallel=False,
+        tp_size=2,
+        ep_size=2,
+    )
+    routed_output = torch.ones(2, 4)
+    reduced_output = routed_output + 1
+    all_reduce = MagicMock(return_value=reduced_output)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "tensor_model_parallel_all_reduce",
+        all_reduce,
+    )
+
+    result, result_is_reduced = runner._maybe_reduce_routed_output_before_transform(
+        routed_output,
+        False,
+    )
+
+    if reduce_routed:
+        assert result is reduced_output
+        assert result_is_reduced
+        all_reduce.assert_called_once_with(routed_output)
+    else:
+        assert result is routed_output
+        assert not result_is_reduced
+        all_reduce.assert_not_called()
 
 
 def test_routed_experts_select_experts_validates_router_logits(monkeypatch):
@@ -540,7 +634,6 @@ def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_
         )
     )
     routed_experts.enable_npugraph_ex_static_kernel = False
-    routed_experts.enable_shared_expert_dp = False
     object.__setattr__(routed_experts, "quant_method", quant_method)
     topk_weights = torch.tensor([[0.25, 0.75], [0.6, 0.4]], dtype=torch.float32)
     topk_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int64)
@@ -612,7 +705,6 @@ def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_
         hidden_states=hidden_states,
         router_logits=router_logits,
         replace_allreduce=False,
-        enable_shared_expert_dp=False,
         quant_type=QuantType.NONE,
     )
     quant_method.apply.assert_called_once()
@@ -667,6 +759,115 @@ def test_shared_experts_part2_applies_optional_gate(with_gate):
     torch.testing.assert_close(output, expected)
 
 
+@pytest.mark.parametrize(
+    (
+        "enable_flashcomm1",
+        "weights_replicated",
+        "native_sequence_parallel",
+        "sp_by_pass",
+        "expected_mode",
+    ),
+    [
+        (False, False, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF),
+        (True, False, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF),
+        (False, True, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON),
+        (True, True, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+        (False, True, True, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+        (False, True, False, True, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+    ],
+)
+def test_shared_expert_parallel_mode_matches_activation_and_weight_layout(
+    monkeypatch,
+    enable_flashcomm1,
+    weights_replicated,
+    native_sequence_parallel,
+    sp_by_pass,
+    expected_mode,
+):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.weights_replicated = weights_replicated
+    shared_experts.moe_config = SimpleNamespace(
+        is_sequence_parallel=native_sequence_parallel,
+        tp_size=1,
+        tp_rank=0,
+        ep_size=2,
+        tp_group=SimpleNamespace(world_size=2, rank_in_group=1),
+    )
+    monkeypatch.setattr(
+        shared_experts_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(flash_comm_v1_enabled=enable_flashcomm1),
+    )
+    monkeypatch.setattr(
+        shared_experts_module,
+        "enable_sp_by_pass",
+        lambda: sp_by_pass,
+    )
+
+    assert shared_experts.parallel_mode() is expected_mode
+
+
+@pytest.mark.parametrize("num_tokens", [0, 5])
+def test_local_shared_expert_dp_pads_splits_gathers_and_unpads(num_tokens):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    tp_group = MagicMock(world_size=2, rank_in_group=1)
+    shared_experts.moe_config = SimpleNamespace(
+        tp_size=1,
+        tp_rank=0,
+        ep_size=2,
+        tp_group=tp_group,
+    )
+    hidden_states = torch.arange(num_tokens * 2, dtype=torch.float32).view(
+        num_tokens,
+        2,
+    )
+
+    local_hidden_states, metadata = shared_experts._prepare_local_dp_input(hidden_states)
+    pad_size = num_tokens % 2
+    padded_hidden_states = F.pad(hidden_states, (0, 0, 0, pad_size))
+    tp_group.all_gather.return_value = padded_hidden_states
+    result = shared_experts._finalize_local_dp_output(
+        local_hidden_states,
+        metadata,
+    )
+
+    assert metadata == (num_tokens, pad_size)
+    assert local_hidden_states.shape[0] == padded_hidden_states.shape[0] // 2
+    torch.testing.assert_close(
+        local_hidden_states,
+        padded_hidden_states[local_hidden_states.shape[0] :],
+    )
+    torch.testing.assert_close(result, hidden_states)
+    tp_group.all_gather.assert_called_once_with(local_hidden_states, dim=0)
+
+
+def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output():
+    hidden_states = torch.ones(2, 4)
+    gathered_states = torch.ones(4, 4)
+    shared_out = torch.ones(4, 4)
+    reduced_states = torch.ones(2, 4)
+
+    with (
+        patch(
+            "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
+            return_value=gathered_states,
+            create=True,
+        ) as all_gather,
+        patch(
+            "torch.ops.vllm.maybe_pad_and_reduce",
+            return_value=reduced_states,
+            create=True,
+        ) as reduce_scatter,
+    ):
+        prepared = AscendSharedExperts._prepare_flashcomm_tp_input(hidden_states)
+        finalized = AscendSharedExperts._finalize_flashcomm_tp_output(shared_out)
+
+    assert prepared is gathered_states
+    assert finalized is reduced_states
+    all_gather.assert_called_once_with(hidden_states, True)
+    reduce_scatter.assert_called_once_with(shared_out)
+
+
 def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
     shared_experts.layer = SimpleNamespace(
@@ -675,6 +876,7 @@ def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     )
     shared_experts.multistream_overlap = False
     shared_experts.quant_type = QuantType.W8A8
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON)
     hidden_states = torch.randn(2, 4)
     part1_out = torch.randn(2, 8)
     shared_out = torch.randn(2, 4)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -11,6 +11,7 @@ from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
 from vllm_ascend.ops.fused_moe.fused_moe import (
     AscendMoERunner,
     AscendUnquantizedFusedMoEMethod,
+    SharedExpertParallelMode,
     make_eplb_placement_config,
     use_multistage_eplb_load,
 )
@@ -166,6 +167,7 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
 )
 def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_enabled, expected):
     runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner._get_shared_expert_parallel_mode = MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON)
     shared_output = object()
     monkeypatch.setattr(
         fused_moe_module,
@@ -176,6 +178,194 @@ def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_ena
     assert runner.use_dp_chunking is False
     assert runner._fused_output_is_reduced is expected
     assert runner._maybe_reduce_shared_expert_output(shared_output) is shared_output
+
+
+@pytest.mark.parametrize(
+    ("mode", "fused_output_is_reduced", "reduce_shared"),
+    [
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, False, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, True, True),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON, True, False),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON, True, False),
+    ],
+)
+def test_shared_output_reduction_depends_on_weight_layout(
+    monkeypatch,
+    mode,
+    fused_output_is_reduced,
+    reduce_shared,
+):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner._get_shared_expert_parallel_mode = MagicMock(return_value=mode)
+    shared_output = torch.ones(2, 4)
+    reduced_output = shared_output + 1
+    all_reduce = MagicMock(return_value=reduced_output)
+    monkeypatch.setattr(fused_moe_module, "tensor_model_parallel_all_reduce", all_reduce)
+
+    result = runner._maybe_reduce_shared_expert_output(
+        shared_output,
+        fused_output_is_reduced,
+    )
+
+    if reduce_shared:
+        assert result is reduced_output
+        all_reduce.assert_called_once_with(shared_output)
+    else:
+        assert result is shared_output
+        all_reduce.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mode", "reduce_routed"),
+    [
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF, False),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF, False),
+        (SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON, True),
+        (SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON, False),
+    ],
+)
+def test_local_shared_expert_dp_reduces_partial_routed_output(
+    monkeypatch,
+    mode,
+    reduce_routed,
+):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner._get_shared_expert_parallel_mode = MagicMock(return_value=mode)
+    runner.routed_output_transform = None
+    runner.moe_config = SimpleNamespace(
+        is_sequence_parallel=False,
+        tp_size=2,
+        ep_size=2,
+    )
+    routed_output = torch.ones(2, 4)
+    reduced_output = routed_output + 1
+    all_reduce = MagicMock(return_value=reduced_output)
+    monkeypatch.setattr(fused_moe_module, "tensor_model_parallel_all_reduce", all_reduce)
+
+    result, result_is_reduced = runner._maybe_reduce_routed_output_before_transform(
+        routed_output,
+        False,
+    )
+
+    if reduce_routed:
+        assert result is reduced_output
+        assert result_is_reduced
+        all_reduce.assert_called_once_with(routed_output)
+    else:
+        assert result is routed_output
+        assert not result_is_reduced
+        all_reduce.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    (
+        "enable_flashcomm1",
+        "enable_shared_expert_dp",
+        "native_sequence_parallel",
+        "sp_by_pass",
+        "expected_mode",
+    ),
+    [
+        (False, False, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF),
+        (True, False, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF),
+        (False, True, False, False, SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON),
+        (True, True, False, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+        # Native SP and the SP compiler pass have the same effective layout as
+        # FlashComm + SEDP: sharded activations and replicated shared weights.
+        (False, False, True, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+        (False, True, True, False, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+        (False, False, False, True, SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON),
+    ],
+)
+def test_shared_expert_parallel_mode_matches_activation_and_weight_layout(
+    monkeypatch,
+    enable_flashcomm1,
+    enable_shared_expert_dp,
+    native_sequence_parallel,
+    sp_by_pass,
+    expected_mode,
+):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner.enable_shared_expert_dp = enable_shared_expert_dp
+    runner.shared_expert_weights_replicated = enable_shared_expert_dp or native_sequence_parallel or sp_by_pass
+    runner.moe_config = SimpleNamespace(
+        is_sequence_parallel=native_sequence_parallel,
+        tp_size=2,
+    )
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(flash_comm_v1_enabled=enable_flashcomm1),
+    )
+    monkeypatch.setattr(fused_moe_module, "enable_sp_by_pass", lambda: sp_by_pass)
+
+    assert runner._get_shared_expert_parallel_mode() is expected_mode
+
+
+def test_local_shared_expert_dp_pads_chunks_gathers_and_unpads():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    tp_group = MagicMock()
+    runner.moe_config = SimpleNamespace(
+        tp_size=2,
+        tp_rank=1,
+        tp_group=tp_group,
+    )
+    hidden_states = torch.arange(10, dtype=torch.float32).view(5, 2)
+
+    local_hidden_states, metadata = runner._prepare_local_shared_expert_dp_input(hidden_states)
+    padded_hidden_states = torch.cat(
+        (hidden_states, torch.zeros(1, hidden_states.shape[1])),
+        dim=0,
+    )
+    gathered_output = torch.cat(
+        (
+            padded_hidden_states[:3],
+            local_hidden_states,
+        ),
+        dim=0,
+    )
+    tp_group.all_gather.return_value = gathered_output
+    result = runner._finalize_local_shared_expert_dp_output(
+        local_hidden_states,
+        metadata,
+    )
+
+    assert metadata == (5, 1)
+    assert local_hidden_states.shape == (3, 2)
+    torch.testing.assert_close(local_hidden_states[:2], hidden_states[3:])
+    torch.testing.assert_close(local_hidden_states[2], torch.zeros(2))
+    assert result.shape == hidden_states.shape
+    torch.testing.assert_close(result, hidden_states)
+    tp_group.all_gather.assert_called_once_with(local_hidden_states, dim=0)
+
+
+def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    hidden_states = torch.ones(2, 4)
+    gathered_states = torch.ones(4, 4)
+    shared_out = torch.ones(4, 4)
+    reduced_states = torch.ones(2, 4)
+
+    with (
+        patch(
+            "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
+            return_value=gathered_states,
+            create=True,
+        ) as all_gather,
+        patch(
+            "torch.ops.vllm.maybe_pad_and_reduce",
+            return_value=reduced_states,
+            create=True,
+        ) as reduce_scatter,
+    ):
+        prepared = runner._prepare_flashcomm_shared_expert_tp_input(hidden_states)
+        finalized = runner._finalize_flashcomm_shared_expert_tp_output(shared_out)
+
+    assert prepared is gathered_states
+    assert finalized is reduced_states
+    all_gather.assert_called_once_with(hidden_states, True)
+    reduce_scatter.assert_called_once_with(shared_out)
 
 
 class _Projection(nn.Module):

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -255,9 +255,11 @@ class TestGetParallelOpShareExpert(unittest.TestCase):
     def setUp(self):
         self.mock_layer = MagicMock()
         self.mock_group = MagicMock()
+        self.mock_group.rank_in_group = 1
+        self.mock_group.world_size = 2
         self._patches = [
             patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=self.mock_group),
-            patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=True),
+            patch("vllm_ascend.ops.linear_op.enable_sp_by_pass", return_value=False),
         ]
         for p in self._patches:
             p.start()
@@ -273,15 +275,27 @@ class TestGetParallelOpShareExpert(unittest.TestCase):
 
     def test_share_expert_disables_tp(self):
         """share_expert / shared_expert / shared_experts → (None, 0, 1)."""
-        for prefix in (
-            "model.layers.0.mlp.share_expert.gate_up_proj",
-            "model.layers.0.mlp.shared_expert.gate_up_proj",
-            "model.layers.0.mlp.shared_experts.gate_up_proj",
+        with patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=True):
+            for prefix in (
+                "model.layers.0.mlp.share_expert.gate_up_proj",
+                "model.layers.0.mlp.shared_expert.gate_up_proj",
+                "model.layers.0.mlp.shared_experts.gate_up_proj",
+            ):
+                custom_op, tp_rank, tp_size = self._call(prefix)
+                self.assertIsNone(custom_op)
+                self.assertEqual(tp_rank, 0)
+                self.assertEqual(tp_size, 1)
+
+    def test_share_expert_keeps_tp_when_only_flashcomm_is_enabled(self):
+        with (
+            patch("vllm_ascend.ops.linear_op.shared_expert_dp_enabled", return_value=False),
+            patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True),
         ):
-            custom_op, tp_rank, tp_size = self._call(prefix)
-            self.assertIsNone(custom_op)
-            self.assertEqual(tp_rank, 0)
-            self.assertEqual(tp_size, 1)
+            custom_op, tp_rank, tp_size = self._call("model.layers.0.mlp.shared_experts.gate_up_proj")
+
+        self.assertIsNone(custom_op)
+        self.assertEqual(tp_rank, 1)
+        self.assertEqual(tp_size, 2)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -85,7 +85,12 @@ class TestMoECommMethod(TestBase):
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=False,
+            quant_type=QuantType.NONE,
+        )
 
         # Test finalize method
         comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
@@ -126,7 +131,12 @@ class TestMoECommMethod(TestBase):
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=False,
+            quant_type=QuantType.NONE,
+        )
 
         # Test finalize method
         comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
@@ -165,7 +175,12 @@ class TestMoECommMethod(TestBase):
         _ = comm_impl.prepare(hidden_states, router_logits)
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=False,
+            quant_type=QuantType.NONE,
+        )
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -89,7 +89,12 @@ class TestMoECommMethod(TestBase):
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=False,
+            quant_type=QuantType.NONE,
+        )
 
         # Test finalize method
         comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
@@ -130,7 +135,12 @@ class TestMoECommMethod(TestBase):
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=False,
+            quant_type=QuantType.NONE,
+        )
 
         # Test finalize method
         comm_impl.finalize(h_out, reduce_results=True, padded_hidden_states_shape=padded_hidden_states_shape)
@@ -169,7 +179,12 @@ class TestMoECommMethod(TestBase):
         _ = comm_impl.prepare(hidden_states, router_logits)
 
         # Verify prepare was called with correct arguments
-        mock_pf_instance.prepare.assert_called_once_with(hidden_states, router_logits, False, False, QuantType.NONE)
+        mock_pf_instance.prepare.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=False,
+            quant_type=QuantType.NONE,
+        )
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -74,9 +74,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         hidden_states = torch.randn(4, 8)
         router_logits = torch.randn(4, 2)
 
-        prepare_output = layer.prepare(
-            hidden_states, router_logits, enable_shared_expert_dp=False, replace_allreduce=False
-        )
+        prepare_output = layer.prepare(hidden_states, router_logits, replace_allreduce=False)
         h_out = prepare_output.hidden_states
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 
@@ -125,9 +123,7 @@ class TestPrepareAndFinalize(unittest.TestCase):
         hidden_states = torch.randn(2, 8)
         router_logits = torch.randn(2, 2)
 
-        prepare_output = layer.prepare(
-            hidden_states, router_logits, enable_shared_expert_dp=False, replace_allreduce=False
-        )
+        prepare_output = layer.prepare(hidden_states, router_logits, replace_allreduce=False)
         h_out = prepare_output.hidden_states
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
 

--- a/tests/ut/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/ops/test_vocab_parallel_embedding.py
@@ -60,6 +60,7 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
 
         for p in self.patches:
             p.start()
+            self.addCleanup(p.stop)
 
     def _create_layer(self):
         # Patch methods and dependencies for VocabParallelEmbedding

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -621,7 +621,6 @@ class TestEagleProposerDummyRun(TestBase):
 
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=num_tokens, with_prefill=with_prefill)
 
             self.assertTrue(self.proposer._runnable.call_count == 1)
@@ -637,7 +636,6 @@ class TestEagleProposerDummyRun(TestBase):
         mock_context.return_value.__enter__.return_value = None
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=64, with_prefill=True, num_reqs=4)
             self.assertTrue(self.proposer._runnable.call_count == 1)
 
@@ -659,7 +657,6 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.use_cuda_graph = True
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=64, in_graph_capturing=True, aclgraph_runtime_mode=CUDAGraphMode.FULL)
             self.assertTrue(self.proposer._runnable.call_count == 1)
             mock_update_full_graph_params.assert_not_called()
@@ -684,7 +681,6 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.draft_attn_groups = [MagicMock()]
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=64, in_graph_capturing=False, aclgraph_runtime_mode=CUDAGraphMode.FULL)
             self.assertTrue(self.proposer._runnable.call_count == 1)
             self.assertTrue(mock_update_full_graph_params.call_count == 1)
@@ -775,12 +771,10 @@ class TestEagleProposerMaybePadAndGather:
         method,
         *,
         is_multimodal_model=False,
-        enable_shared_expert_dp=False,
     ):
         proposer = object.__new__(AscendEagleProposer)
         proposer.method = method
         proposer.is_multimodal_model = is_multimodal_model
-        proposer.enable_shared_expert_dp = enable_shared_expert_dp
         return proposer
 
     def _extra_ctx(self, flash_comm_v1_enabled):
@@ -868,7 +862,7 @@ class TestEagleProposerMaybePadAndGather:
         assert reduced_positions is model_positions
 
     @pytest.mark.parametrize(
-        "enable_shared_expert_dp,hidden_states_is_none,expect_gather",
+        "flash_comm_v1_enabled,hidden_states_is_none,expect_gather",
         [
             (True, False, True),
             (True, True, True),
@@ -877,11 +871,11 @@ class TestEagleProposerMaybePadAndGather:
     )
     def test_mtp_maybe_all_gather_and_unpad(
         self,
-        enable_shared_expert_dp,
+        flash_comm_v1_enabled,
         hidden_states_is_none,
         expect_gather,
     ):
-        proposer = self._new_proposer("mtp", enable_shared_expert_dp=enable_shared_expert_dp)
+        proposer = self._new_proposer("mtp")
         last_hidden_states = torch.arange(6, device=self.device, dtype=torch.float32).view(3, 2)
         positions = torch.tensor([10, 11, 12], device=self.device, dtype=torch.int64)
         hidden_states = None if hidden_states_is_none else last_hidden_states + 1000
@@ -890,11 +884,17 @@ class TestEagleProposerMaybePadAndGather:
             assert label is True
             return torch.cat((input_tensor, input_tensor + 100), dim=0)
 
-        with patch(
-            "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
-            side_effect=fake_all_gather_and_unpad,
-            create=True,
-        ) as mock_all_gather:
+        with (
+            patch(
+                "vllm_ascend.spec_decode.llm_base_proposer._EXTRA_CTX",
+                new=self._extra_ctx(flash_comm_v1_enabled),
+            ),
+            patch(
+                "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
+                side_effect=fake_all_gather_and_unpad,
+                create=True,
+            ) as mock_all_gather,
+        ):
             gathered_last_hidden_states, gathered_positions, gathered_hidden_states = (
                 proposer.maybe_all_gather_and_unpad(last_hidden_states, positions, hidden_states)
             )
@@ -2352,10 +2352,6 @@ class TestRunMergedDraft(TestBase):
         self.mock_supports_multimodal_inputs.start()
         self.mock_enable_sp = patch("vllm_ascend.spec_decode.llm_base_proposer.enable_sp", return_value=False)
         self.mock_enable_sp.start()
-        self.mock_shared_expert_dp = patch(
-            "vllm_ascend.spec_decode.llm_base_proposer.shared_expert_dp_enabled", return_value=False
-        )
-        self.mock_shared_expert_dp.start()
         self.mock_extra_ctx = patch("vllm_ascend.spec_decode.llm_base_proposer._EXTRA_CTX", new=MagicMock())
         self.mock_extra_ctx.start()
         set_current_vllm_config(self.vllm_config)
@@ -2375,7 +2371,6 @@ class TestRunMergedDraft(TestBase):
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
         self.mock_enable_sp.stop()
-        self.mock_shared_expert_dp.stop()
         self.mock_extra_ctx.stop()
         set_current_vllm_config(None)
 
@@ -2509,7 +2504,6 @@ class TestRunMergedDraft(TestBase):
         for attr in (
             "AscendSpecDecodeBaseProposer",
             "enable_sp",
-            "shared_expert_dp_enabled",
             "lmhead_tp_enable",
             "get_forward_context",
             "_EXTRA_CTX",

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -621,7 +621,6 @@ class TestEagleProposerDummyRun(TestBase):
 
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=num_tokens, with_prefill=with_prefill)
 
             self.assertTrue(self.proposer._runnable.call_count == 1)
@@ -637,7 +636,6 @@ class TestEagleProposerDummyRun(TestBase):
         mock_context.return_value.__enter__.return_value = None
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=64, with_prefill=True, num_reqs=4)
             self.assertTrue(self.proposer._runnable.call_count == 1)
 
@@ -659,7 +657,6 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.use_cuda_graph = True
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=64, in_graph_capturing=True, aclgraph_runtime_mode=CUDAGraphMode.FULL)
             self.assertTrue(self.proposer._runnable.call_count == 1)
             mock_update_full_graph_params.assert_not_called()
@@ -684,7 +681,6 @@ class TestEagleProposerDummyRun(TestBase):
         self.proposer.draft_attn_groups = [MagicMock()]
         # cpu does not support `torch.ops.vllm.maybe_pad_and_reduce`
         with set_current_vllm_config(self.vllm_config):
-            self.proposer.enable_shared_expert_dp = False
             self.proposer.dummy_run(num_tokens=64, in_graph_capturing=False, aclgraph_runtime_mode=CUDAGraphMode.FULL)
             self.assertTrue(self.proposer._runnable.call_count == 1)
             self.assertTrue(mock_update_full_graph_params.call_count == 1)
@@ -775,12 +771,10 @@ class TestEagleProposerMaybePadAndGather:
         method,
         *,
         is_multimodal_model=False,
-        enable_shared_expert_dp=False,
     ):
         proposer = object.__new__(AscendEagleProposer)
         proposer.method = method
         proposer.is_multimodal_model = is_multimodal_model
-        proposer.enable_shared_expert_dp = enable_shared_expert_dp
         return proposer
 
     def _extra_ctx(self, flash_comm_v1_enabled):
@@ -868,7 +862,7 @@ class TestEagleProposerMaybePadAndGather:
         assert reduced_positions is model_positions
 
     @pytest.mark.parametrize(
-        "enable_shared_expert_dp,hidden_states_is_none,expect_gather",
+        "flash_comm_v1_enabled,hidden_states_is_none,expect_gather",
         [
             (True, False, True),
             (True, True, True),
@@ -877,11 +871,11 @@ class TestEagleProposerMaybePadAndGather:
     )
     def test_mtp_maybe_all_gather_and_unpad(
         self,
-        enable_shared_expert_dp,
+        flash_comm_v1_enabled,
         hidden_states_is_none,
         expect_gather,
     ):
-        proposer = self._new_proposer("mtp", enable_shared_expert_dp=enable_shared_expert_dp)
+        proposer = self._new_proposer("mtp")
         last_hidden_states = torch.arange(6, device=self.device, dtype=torch.float32).view(3, 2)
         positions = torch.tensor([10, 11, 12], device=self.device, dtype=torch.int64)
         hidden_states = None if hidden_states_is_none else last_hidden_states + 1000
@@ -890,11 +884,17 @@ class TestEagleProposerMaybePadAndGather:
             assert label is True
             return torch.cat((input_tensor, input_tensor + 100), dim=0)
 
-        with patch(
-            "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
-            side_effect=fake_all_gather_and_unpad,
-            create=True,
-        ) as mock_all_gather:
+        with (
+            patch(
+                "vllm_ascend.spec_decode.llm_base_proposer._EXTRA_CTX",
+                new=self._extra_ctx(flash_comm_v1_enabled),
+            ),
+            patch(
+                "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
+                side_effect=fake_all_gather_and_unpad,
+                create=True,
+            ) as mock_all_gather,
+        ):
             gathered_last_hidden_states, gathered_positions, gathered_hidden_states = (
                 proposer.maybe_all_gather_and_unpad(last_hidden_states, positions, hidden_states)
             )
@@ -2340,10 +2340,6 @@ class TestRunMergedDraft(TestBase):
         self.mock_supports_multimodal_inputs.start()
         self.mock_enable_sp = patch("vllm_ascend.spec_decode.llm_base_proposer.enable_sp", return_value=False)
         self.mock_enable_sp.start()
-        self.mock_shared_expert_dp = patch(
-            "vllm_ascend.spec_decode.llm_base_proposer.shared_expert_dp_enabled", return_value=False
-        )
-        self.mock_shared_expert_dp.start()
         self.mock_extra_ctx = patch("vllm_ascend.spec_decode.llm_base_proposer._EXTRA_CTX", new=MagicMock())
         self.mock_extra_ctx.start()
         set_current_vllm_config(self.vllm_config)
@@ -2363,7 +2359,6 @@ class TestRunMergedDraft(TestBase):
         self.mock_cpugpubuffer.stop()
         self.mock_supports_multimodal_inputs.stop()
         self.mock_enable_sp.stop()
-        self.mock_shared_expert_dp.stop()
         self.mock_extra_ctx.stop()
         set_current_vllm_config(None)
 
@@ -2497,7 +2492,6 @@ class TestRunMergedDraft(TestBase):
         for attr in (
             "AscendSpecDecodeBaseProposer",
             "enable_sp",
-            "shared_expert_dp_enabled",
             "lmhead_tp_enable",
             "get_forward_context",
             "_EXTRA_CTX",

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -32,7 +32,7 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
-from vllm_ascend.utils import clear_enable_sp, enable_sp
+from vllm_ascend.utils import clear_enable_sp, enable_sp, shared_expert_dp_enabled
 
 
 class TestAscendConfig(TestBase):
@@ -437,6 +437,41 @@ class TestAscendConfig(TestBase):
             patch("vllm.config.get_current_vllm_config", side_effect=AssertionError),
         ):
             self.assertTrue(enable_sp())
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_flashcomm_and_shared_expert_dp_are_independent(self, mock_check_and_update_config):
+        for enable_flashcomm1, enable_shared_expert_dp in (
+            (False, False),
+            (True, False),
+            (False, True),
+            (True, True),
+        ):
+            with self.subTest(
+                enable_flashcomm1=enable_flashcomm1,
+                enable_shared_expert_dp=enable_shared_expert_dp,
+            ):
+                clear_ascend_config()
+                clear_enable_sp()
+                test_vllm_config = VllmConfig()
+                test_vllm_config.parallel_config.tensor_parallel_size = 2
+                test_vllm_config.parallel_config.enable_expert_parallel = True
+                test_vllm_config.additional_config = {
+                    "enable_flashcomm1": enable_flashcomm1,
+                    "enable_shared_expert_dp": enable_shared_expert_dp,
+                }
+
+                ascend_config = init_ascend_config(test_vllm_config)
+
+                self.assertEqual(enable_sp(test_vllm_config), enable_flashcomm1)
+                self.assertEqual(
+                    ascend_config.enable_shared_expert_dp,
+                    enable_shared_expert_dp,
+                )
+                self.assertEqual(
+                    shared_expert_dp_enabled(),
+                    enable_shared_expert_dp,
+                )
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -29,7 +29,7 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
-from vllm_ascend.utils import clear_enable_sp, enable_sp
+from vllm_ascend.utils import clear_enable_sp, enable_sp, shared_expert_dp_enabled
 
 
 class TestAscendConfig(TestBase):
@@ -404,6 +404,41 @@ class TestAscendConfig(TestBase):
             patch("vllm.config.get_current_vllm_config", side_effect=AssertionError),
         ):
             self.assertTrue(enable_sp())
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_flashcomm_and_shared_expert_dp_are_independent(self, mock_check_and_update_config):
+        for enable_flashcomm1, enable_shared_expert_dp in (
+            (False, False),
+            (True, False),
+            (False, True),
+            (True, True),
+        ):
+            with self.subTest(
+                enable_flashcomm1=enable_flashcomm1,
+                enable_shared_expert_dp=enable_shared_expert_dp,
+            ):
+                clear_ascend_config()
+                clear_enable_sp()
+                test_vllm_config = VllmConfig()
+                test_vllm_config.parallel_config.tensor_parallel_size = 2
+                test_vllm_config.parallel_config.enable_expert_parallel = True
+                test_vllm_config.additional_config = {
+                    "enable_flashcomm1": enable_flashcomm1,
+                    "enable_shared_expert_dp": enable_shared_expert_dp,
+                }
+
+                ascend_config = init_ascend_config(test_vllm_config)
+
+                self.assertEqual(enable_sp(test_vllm_config), enable_flashcomm1)
+                self.assertEqual(
+                    ascend_config.enable_shared_expert_dp,
+                    enable_shared_expert_dp,
+                )
+                self.assertEqual(
+                    shared_expert_dp_enabled(),
+                    enable_shared_expert_dp,
+                )
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -108,9 +108,6 @@ class AscendConfig:
         )
         from vllm_ascend.utils import enable_sp
 
-        if self.enable_shared_expert_dp:
-            assert enable_sp(vllm_config=vllm_config, enable_shared_expert_dp=True)
-
         if vllm_config.parallel_config.prefill_context_parallel_size > 1 and enable_sp(vllm_config=vllm_config):
             tp_pcp_size = (
                 vllm_config.parallel_config.tensor_parallel_size

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -105,9 +105,6 @@ class AscendConfig:
         )
         from vllm_ascend.utils import enable_sp
 
-        if self.enable_shared_expert_dp:
-            assert enable_sp(vllm_config=vllm_config, enable_shared_expert_dp=True)
-
         if vllm_config.parallel_config.prefill_context_parallel_size > 1 and enable_sp(vllm_config=vllm_config):
             tp_pcp_size = (
                 vllm_config.parallel_config.tensor_parallel_size

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -16,7 +16,12 @@
 #
 import torch
 import torch.nn.functional as F
-from vllm.distributed import get_dp_group, get_ep_group, get_tp_group
+from vllm.distributed import (
+    get_dp_group,
+    get_ep_group,
+    get_tp_group,
+    tensor_model_parallel_all_reduce,
+)
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
 
@@ -24,7 +29,10 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.moe_comm_method import setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
-from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts
+from vllm_ascend.ops.fused_moe.shared_experts import (
+    AscendSharedExperts,
+    SharedExpertParallelMode,
+)
 
 
 class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
@@ -97,12 +105,30 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # handles it for the shared output. Signal this to the upstream
         # MoERunner.forward() so _maybe_reduce_final_output does not apply a
         # second TP all-reduce (which would double-count the contributions).
-        moe_comm_type = _EXTRA_CTX.moe_comm_type
-        return moe_comm_type in {
+        return _EXTRA_CTX.moe_comm_type in {
             MoECommType.ALLTOALL,
             MoECommType.MC2,
             MoECommType.FUSED_MC2,
-        } or (moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
+        } or (_EXTRA_CTX.moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
+
+    def _get_shared_expert_parallel_mode(self) -> SharedExpertParallelMode:
+        shared_experts = getattr(self, "ascend_shared_experts", None)
+        if shared_experts is None or not hasattr(shared_experts, "parallel_mode"):
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+        return shared_experts.parallel_mode()
+
+    def _reduce_shared_output_if_needed(
+        self,
+        shared_output: torch.Tensor | None,
+        fused_output_is_reduced: bool,
+    ) -> torch.Tensor | None:
+        if (
+            shared_output is not None
+            and fused_output_is_reduced
+            and self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+        ):
+            shared_output = tensor_model_parallel_all_reduce(shared_output)
+        return shared_output
 
     @property
     def local_num_experts(self) -> int:
@@ -113,24 +139,51 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     def ep_rank(self) -> int:
         return self.moe_config.ep_rank
 
+    # Shared-expert layout-specific communication is handled by
+    # AscendSharedExperts, so only standard TP weights need a separate
+    # all-reduce when routed output has already been reduced.
     def _maybe_reduce_shared_expert_output(  # type: ignore[misc]
         self,
         shared_output: torch.Tensor | None,
         fused_output_is_reduced: bool | None = None,
     ) -> torch.Tensor | None:
-        # Ascend handles shared expert reduction in
-        # _forward_shared_experts; the upstream kwarg is unused here.
-        _ = fused_output_is_reduced
-        return shared_output
+        if fused_output_is_reduced is None:
+            fused_output_is_reduced = self._fused_output_is_reduced
+        return self._reduce_shared_output_if_needed(
+            shared_output,
+            fused_output_is_reduced,
+        )
 
+    def _maybe_reduce_routed_output_before_transform(
+        self,
+        fused_output: torch.Tensor,
+        fused_output_is_reduced: bool,
+    ) -> tuple[torch.Tensor, bool]:
+        fused_output, fused_output_is_reduced = super()._maybe_reduce_routed_output_before_transform(
+            fused_output,
+            fused_output_is_reduced,
+        )
+
+        if (
+            self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON
+            and not fused_output_is_reduced
+        ):
+            fused_output = tensor_model_parallel_all_reduce(fused_output)
+            fused_output_is_reduced = True
+        return fused_output, fused_output_is_reduced
+
+    # Ascend already handles reduction in its own dispatch path, so
+    # the upstream kwarg is accepted for interface alignment only.
     def _maybe_reduce_final_output(  # type: ignore[misc]
         self,
         states: torch.Tensor,
         trunc_size: int | None,
         output_is_reduced: bool | None = None,
     ) -> torch.Tensor:
-        _ = output_is_reduced
-        states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
+        if output_is_reduced is None:
+            output_is_reduced = self._fused_output_is_reduced
+        if not output_is_reduced:
+            states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
         if trunc_size is not None and trunc_size > 0:
             return states[..., :trunc_size]
         return states

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -114,7 +114,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     def _get_shared_expert_parallel_mode(self) -> SharedExpertParallelMode:
         shared_experts = getattr(self, "ascend_shared_experts", None)
         if shared_experts is None or not hasattr(shared_experts, "parallel_mode"):
-            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF
         return shared_experts.parallel_mode()
 
     def _reduce_shared_output_if_needed(
@@ -125,7 +125,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         if (
             shared_output is not None
             and fused_output_is_reduced
-            and self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+            and self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF
         ):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
@@ -165,7 +165,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         )
 
         if (
-            self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON
+            self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON
             and not fused_output_is_reduced
         ):
             fused_output = tensor_model_parallel_all_reduce(fused_output)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -18,6 +18,7 @@
 from collections.abc import Callable
 from copy import copy
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from functools import wraps
 from types import SimpleNamespace
 
@@ -48,9 +49,9 @@ from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_NZ,
+    enable_sp_by_pass,
     maybe_trans_nz,
     npu_stream_switch,
-    shared_expert_dp_enabled,
     shared_experts_calculation_stream,
 )
 
@@ -85,6 +86,19 @@ class FusedMoEEvents:
     swiglu_limit: float = 0.0
     swiglu_alpha: float = 1.0
     swiglu_beta: float = 0.0
+
+
+class SharedExpertParallelMode(Enum):
+    """Effective FlashComm/SEDP state for one shared-expert forward.
+
+    Native MoE sequence parallelism and the SP compiler pass are normalized to
+    FLASHCOMM_ON_SEDP_ON because they produce the same activation/weight layout.
+    """
+
+    FLASHCOMM_OFF_SEDP_OFF = auto()  # Full activations, TP-sharded weights.
+    FLASHCOMM_ON_SEDP_OFF = auto()  # Sharded activations, TP-sharded weights.
+    FLASHCOMM_OFF_SEDP_ON = auto()  # Full activations, replicated weights.
+    FLASHCOMM_ON_SEDP_ON = auto()  # Sharded activations, replicated weights.
 
 
 def mock_false():
@@ -395,6 +409,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             )
 
         self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
+        # Native vLLM MoE sequence parallelism also constructs shared-expert
+        # linears with disable_tp=True. Keep weight-layout state separate from
+        # FlashComm: FlashComm alone must retain standard TP-sharded weights.
+        self.shared_expert_weights_replicated = (
+            self.enable_shared_expert_dp or self.moe_config.is_sequence_parallel or enable_sp_by_pass()
+        )
         self.multistream_overlap_shared_expert = (
             ascend_config.multistream_overlap_shared_expert and shared_experts is not None
         )
@@ -599,20 +619,51 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     def _maybe_reduce_shared_expert_output(
         self,
         shared_output: torch.Tensor | None,
+        fused_output_is_reduced: bool | None = None,
     ) -> torch.Tensor | None:
-        # _forward_shared_experts already handles shared expert TP all-reduce
-        # for MC2/ALLTOALL/FUSED_MC2. For AllGather the reduction is done
-        # via _maybe_reduce_final_output on the combined (shared + routed)
-        # output. Skip any additional reduction here.
+        if fused_output_is_reduced is None:
+            fused_output_is_reduced = self._fused_output_is_reduced
+        if (
+            shared_output is not None
+            and fused_output_is_reduced
+            and self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+        ):
+            shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
+
+    def _maybe_reduce_routed_output_before_transform(
+        self,
+        fused_output: torch.Tensor,
+        fused_output_is_reduced: bool,
+    ) -> tuple[torch.Tensor, bool]:
+        fused_output, fused_output_is_reduced = super()._maybe_reduce_routed_output_before_transform(
+            fused_output,
+            fused_output_is_reduced,
+        )
+        # Local shared-expert DP gathers a complete shared_output. If the
+        # routed backend produced TP partials, reduce routed_output before the
+        # two branches are added; otherwise a final all-reduce would multiply
+        # the replicated shared output by TP size. FlashComm/native SP already
+        # return sequence-sharded routed output and do not use this boundary.
+        if (
+            self._get_shared_expert_parallel_mode() is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON
+            and not fused_output_is_reduced
+        ):
+            fused_output = tensor_model_parallel_all_reduce(fused_output)
+            fused_output_is_reduced = True
+        return fused_output, fused_output_is_reduced
 
     def _maybe_reduce_final_output(
         self,
         states: torch.Tensor,
-        trunc_size: int,
+        trunc_size: int | None,
+        output_is_reduced: bool | None = None,
     ) -> torch.Tensor:
-        states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
-        return states[..., :trunc_size]
+        if output_is_reduced is None:
+            output_is_reduced = self._fused_output_is_reduced
+        if not output_is_reduced:
+            states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
+        return states[..., :trunc_size] if trunc_size is not None else states
 
     def set_lora_context(self, lora_context):
         self.routed_experts._ascend_moe_lora_context = lora_context
@@ -640,7 +691,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             hidden_states=hidden_states,
             router_logits=router_logits,
             replace_allreduce=_EXTRA_CTX.flash_comm_v1_enabled,
-            enable_shared_expert_dp=self.enable_shared_expert_dp,
             quant_type=self.quant_type,
         )
         hidden_states = prepare_output.hidden_states
@@ -721,15 +771,105 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             # The vLLM FusedMoE forward_impl does not return events.
             return routed_out
 
+    def _get_shared_expert_parallel_mode(self) -> SharedExpertParallelMode:
+        """Resolve the effective activation/weight layout for this forward.
+
+        FlashComm is a runtime decision, so a model configured with both
+        features can switch between FLASHCOMM_ON_SEDP_ON and
+        FLASHCOMM_OFF_SEDP_ON across forwards.
+        """
+        if self.moe_config.tp_size <= 1:
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+
+        activations_sharded = (
+            _EXTRA_CTX.flash_comm_v1_enabled or self.moe_config.is_sequence_parallel or enable_sp_by_pass()
+        )
+        weights_replicated = self.shared_expert_weights_replicated
+
+        if activations_sharded and weights_replicated:
+            return SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON
+        if activations_sharded:
+            return SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF
+        if weights_replicated:
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON
+        return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+
+    def _prepare_local_shared_expert_dp_input(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, tuple[int, int]]:
+        original_num_tokens = hidden_states.shape[0]
+        pad_size = (self.moe_config.tp_size - original_num_tokens % self.moe_config.tp_size) % self.moe_config.tp_size
+        if pad_size > 0:
+            hidden_states = F.pad(hidden_states, (0, 0, 0, pad_size))
+        # 手动做token分片
+        hidden_states = torch.chunk(
+            hidden_states,
+            self.moe_config.tp_size,
+            dim=0,
+        )[self.moe_config.tp_rank]
+        return hidden_states, (original_num_tokens, pad_size)
+
+    def _finalize_local_shared_expert_dp_output(
+        self,
+        shared_out: torch.Tensor,
+        metadata: tuple[int, int],
+    ) -> torch.Tensor:
+        original_num_tokens, pad_size = metadata
+        shared_out = self.moe_config.tp_group.all_gather(shared_out, dim=0)
+        if pad_size > 0:
+            shared_out = shared_out[:original_num_tokens]
+        return shared_out
+
+    def _prepare_flashcomm_shared_expert_tp_input(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        # AG
+        return torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            hidden_states,
+            True,
+        )
+
+    def _finalize_flashcomm_shared_expert_tp_output(
+        self,
+        shared_out: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.vllm.maybe_pad_and_reduce(shared_out)
+
     def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
         if self._shared_experts is None:
             return None
+
+        mode = self._get_shared_expert_parallel_mode()
+        shared_expert_dp_metadata = None
 
         def maybe_wait_event(evt: torch.npu.Event | None):
             if evt is not None:
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
+            if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON:
+                # Full activations + replicated weights:
+                # chunk tokens -> DP MLP -> all-gather outputs.
+                maybe_wait_event(fused_moe_evts.before_routed_experts)
+                hidden_states, shared_expert_dp_metadata = self._prepare_local_shared_expert_dp_input(hidden_states)
+            elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF:
+                # Standard TP weights require every rank to see the same token
+                # slice. Gather the FlashComm sequence shard before the shared
+                # MLP; its TP partial output is reduce-scattered below.
+                maybe_wait_event(fused_moe_evts.before_routed_experts)
+                hidden_states = self._prepare_flashcomm_shared_expert_tp_input(hidden_states)
+            elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON:
+                # Sequence-sharded activations already match replicated
+                # weights. Each rank computes its local token shard directly.
+                pass
+            elif mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF:
+                # Full activations already match standard TP-sharded weights.
+                pass
+            else:
+                raise AssertionError(f"Unsupported shared expert mode: {mode}")
+
             # Only used for int quantization
             has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
                 self._shared_experts.down_proj, "weight_scale"
@@ -823,14 +963,22 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         if self.multistream_overlap_shared_expert:
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
-        # NOTE: This is exactly the opposite of
-        # `maybe_all_reduce_tensor_model_parallel`
-        moe_comm_type = _EXTRA_CTX.moe_comm_type
-        if (
-            moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
-            and not shared_expert_dp_enabled()
-        ):
-            shared_out = tensor_model_parallel_all_reduce(shared_out)
+        if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON:
+            assert shared_expert_dp_metadata is not None
+            shared_out = self._finalize_local_shared_expert_dp_output(
+                shared_out,
+                shared_expert_dp_metadata,
+            )
+        elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF:
+            shared_out = self._finalize_flashcomm_shared_expert_tp_output(shared_out)
+        # Keep identity modes separate so all four layouts remain explicit.
+        elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON:  # noqa: SIM114
+            pass
+        elif mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF:
+            pass
+        else:
+            raise AssertionError(f"Unsupported shared expert mode: {mode}")
+
         return shared_out
 
     def shared_forward_impl(  # type: ignore[override]

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -95,16 +95,14 @@ class MoECommMethod(ABC):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type: QuantType = QuantType.NONE,
     ) -> MoEPrepareOutput:
         return self.prepare_finalize.prepare(
-            hidden_states,
-            router_logits,
-            enable_shared_expert_dp,
-            replace_allreduce,
-            quant_type,
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=replace_allreduce,
+            quant_type=quant_type,
         )
 
     def finalize(

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -109,16 +109,14 @@ class MoECommMethod(ABC):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type: QuantType = QuantType.NONE,
     ) -> MoEPrepareOutput:
         return self.prepare_finalize.prepare(
-            hidden_states,
-            router_logits,
-            enable_shared_expert_dp,
-            replace_allreduce,
-            quant_type,
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=replace_allreduce,
+            quant_type=quant_type,
         )
 
     def finalize(

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -59,7 +59,6 @@ class PrepareAndFinalize(ABC):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type: QuantType = QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -72,7 +71,6 @@ class PrepareAndFinalize(ABC):
         Args:
             hidden_states (torch.Tensor): Input features, shape [num_tokens, hidden_size]
             router_logits (torch.Tensor): Router outputs, shape [num_tokens, num_experts]
-            enable_shared_expert_dp (bool): Skip DP communication for shared experts
             replace_allreduce (bool): Bypass default all-reduce behavior
             quant_type: none, w8a8, w4a8, mxfp8, or mxfp4
 
@@ -129,7 +127,6 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -139,16 +136,15 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
           2. If TP > 1, split along token dim and select current TP rank's slice.
           3. Save splits for later all-gather in finalize.
 
-        Skips if `enable_shared_expert_dp` or `replace_allreduce` is True.
+        Skips if `replace_allreduce` is True.
 
         Returns:
             MoEPrepareOutput where `mc2_mask` is None for All2All path.
         """
         self.replace_allreduce = replace_allreduce
-        self.enable_shared_expert_dp = enable_shared_expert_dp
 
         padded_hidden_states_shape = hidden_states.shape
-        if not (self.replace_allreduce or self.enable_shared_expert_dp):
+        if not self.replace_allreduce:
             self.num_tokens, _ = hidden_states.shape
             pad_size = self.tp_size - self.num_tokens  # Pad to TP size (cyclic)
             if self.lora_context is not None:
@@ -184,7 +180,7 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
         self,
         input_ids,
     ):
-        if not (self.replace_allreduce or self.enable_shared_expert_dp):
+        if not self.replace_allreduce:
             pad_size = self.tp_size - self.num_tokens
             if pad_size > 0:
                 input_ids = nn.functional.pad(input_ids, (0, pad_size))
@@ -206,10 +202,10 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
           2. Unpad to original token count.
           3. Return [original_num_tokens, hidden_size] tensor.
 
-        Skips if `enable_shared_expert_dp` or `replace_allreduce` is True.
+        Skips if `replace_allreduce` is True.
         """
 
-        if not (self.enable_shared_expert_dp or self.replace_allreduce):
+        if not self.replace_allreduce:
             if self.tp_size > 1:
                 assert padded_hidden_states_shape is not None
                 # Cannot reuse `split_hidden_states` from prepare phase as it
@@ -254,7 +250,6 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -265,13 +260,12 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
           3. If TP > 1, split tensors along token dimension and select current TP rank's slice.
           4. Split and return corresponding `mc2_mask`.
 
-        Skips padding/slicing if `enable_shared_expert_dp` or `replace_allreduce` is True.
+        Skips padding/slicing if `replace_allreduce` is True.
 
         Returns:
             MoEPrepareOutput, possibly sliced/padded.
         """
         self.replace_allreduce = replace_allreduce
-        self.enable_shared_expert_dp = enable_shared_expert_dp
         mc2_mask = _EXTRA_CTX.mc2_mask
         if self.tp_size > 1:
             # Also slice mc2_mask
@@ -284,14 +278,13 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
             target_pad_length = _EXTRA_CTX.padded_num_tokens
             pad_size = target_pad_length - self.num_tokens
 
-            # Pad if necessary (unless shared expert DP is enabled)
-            if pad_size > 0 and not self.enable_shared_expert_dp:
+            if pad_size > 0:
                 hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, pad_size))
                 router_logits = nn.functional.pad(router_logits, (0, 0, 0, pad_size))
                 padded_hidden_states_shape = hidden_states.shape
 
             # Slice across TP ranks
-            if self.tp_size > 1 and not self.enable_shared_expert_dp:
+            if self.tp_size > 1:
                 split_hidden_states = torch.tensor_split(hidden_states, self.tp_size, dim=0)
                 split_router_logits = torch.tensor_split(router_logits, self.tp_size, dim=0)
                 hidden_states = split_hidden_states[self.tp_rank]
@@ -312,10 +305,10 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
         if not self.replace_allreduce:
             target_pad_length = _EXTRA_CTX.padded_num_tokens
             pad_size = target_pad_length - self.num_tokens
-            if pad_size > 0 and not self.enable_shared_expert_dp:
+            if pad_size > 0:
                 input_ids = nn.functional.pad(input_ids, (0, pad_size))
 
-            if self.tp_size > 1 and not self.enable_shared_expert_dp:
+            if self.tp_size > 1:
                 input_ids = torch.tensor_split(input_ids, self.tp_size, dim=0)
                 input_ids = input_ids[self.tp_rank]
         return input_ids
@@ -358,7 +351,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -372,7 +364,7 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         if self._use_ep_sequence_parallel():
             return self._prepare_with_ep_group(hidden_states, router_logits, quant_type)
 
-        return self._prepare_with_dp_group(hidden_states, router_logits, enable_shared_expert_dp, replace_allreduce)
+        return self._prepare_with_dp_group(hidden_states, router_logits, replace_allreduce)
 
     def _prepare_with_ep_group(
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor, quant_type=QuantType.NONE
@@ -434,7 +426,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -447,7 +438,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         Returns:
             MoEPrepareOutput with global tensors.
         """
-        self.enable_shared_expert_dp = enable_shared_expert_dp
         if self.moe_config.dp_size > 1:
             max_tokens_across_dp = _EXTRA_CTX.max_tokens_across_dp
 
@@ -547,7 +537,7 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
             hidden_states = hidden_states[: self.num_tokens_pcp]
 
-        if self.moe_config.dp_size > 1 and not self.enable_shared_expert_dp:
+        if self.moe_config.dp_size > 1:
             hidden_states = get_dp_group().reduce_scatter(hidden_states, 0)
             hidden_states = hidden_states[: self.num_tokens]
         return hidden_states

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -60,7 +60,6 @@ class PrepareAndFinalize(ABC):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type: QuantType = QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -73,7 +72,6 @@ class PrepareAndFinalize(ABC):
         Args:
             hidden_states (torch.Tensor): Input features, shape [num_tokens, hidden_size]
             router_logits (torch.Tensor): Router outputs, shape [num_tokens, num_experts]
-            enable_shared_expert_dp (bool): Skip DP communication for shared experts
             replace_allreduce (bool): Bypass default all-reduce behavior
             quant_type: none, w8a8, w4a8, mxfp8, or mxfp4
 
@@ -130,7 +128,6 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -140,16 +137,15 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
           2. If TP > 1, split along token dim and select current TP rank's slice.
           3. Save splits for later all-gather in finalize.
 
-        Skips if `enable_shared_expert_dp` or `replace_allreduce` is True.
+        Skips if `replace_allreduce` is True.
 
         Returns:
             MoEPrepareOutput where `mc2_mask` is None for All2All path.
         """
         self.replace_allreduce = replace_allreduce
-        self.enable_shared_expert_dp = enable_shared_expert_dp
 
         padded_hidden_states_shape = hidden_states.shape
-        if not (self.replace_allreduce or self.enable_shared_expert_dp):
+        if not self.replace_allreduce:
             self.num_tokens, _ = hidden_states.shape
             pad_size = self.tp_size - self.num_tokens  # Pad to TP size (cyclic)
             if self.lora_context is not None:
@@ -185,7 +181,7 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
         self,
         input_ids,
     ):
-        if not (self.replace_allreduce or self.enable_shared_expert_dp):
+        if not self.replace_allreduce:
             pad_size = self.tp_size - self.num_tokens
             if pad_size > 0:
                 input_ids = nn.functional.pad(input_ids, (0, pad_size))
@@ -207,10 +203,10 @@ class PrepareAndFinalizeWithAll2All(PrepareAndFinalize):
           2. Unpad to original token count.
           3. Return [original_num_tokens, hidden_size] tensor.
 
-        Skips if `enable_shared_expert_dp` or `replace_allreduce` is True.
+        Skips if `replace_allreduce` is True.
         """
 
-        if not (self.enable_shared_expert_dp or self.replace_allreduce):
+        if not self.replace_allreduce:
             if self.tp_size > 1:
                 assert padded_hidden_states_shape is not None
                 # Cannot reuse `split_hidden_states` from prepare phase as it
@@ -255,7 +251,6 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -266,13 +261,12 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
           3. If TP > 1, split tensors along token dimension and select current TP rank's slice.
           4. Split and return corresponding `mc2_mask`.
 
-        Skips padding/slicing if `enable_shared_expert_dp` or `replace_allreduce` is True.
+        Skips padding/slicing if `replace_allreduce` is True.
 
         Returns:
             MoEPrepareOutput, possibly sliced/padded.
         """
         self.replace_allreduce = replace_allreduce
-        self.enable_shared_expert_dp = enable_shared_expert_dp
         mc2_mask = _EXTRA_CTX.mc2_mask
         if self.tp_size > 1:
             # Also slice mc2_mask
@@ -285,14 +279,13 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
             target_pad_length = _EXTRA_CTX.padded_num_tokens
             pad_size = target_pad_length - self.num_tokens
 
-            # Pad if necessary (unless shared expert DP is enabled)
-            if pad_size > 0 and not self.enable_shared_expert_dp:
+            if pad_size > 0:
                 hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, pad_size))
                 router_logits = nn.functional.pad(router_logits, (0, 0, 0, pad_size))
                 padded_hidden_states_shape = hidden_states.shape
 
             # Slice across TP ranks
-            if self.tp_size > 1 and not self.enable_shared_expert_dp:
+            if self.tp_size > 1:
                 split_hidden_states = torch.tensor_split(hidden_states, self.tp_size, dim=0)
                 split_router_logits = torch.tensor_split(router_logits, self.tp_size, dim=0)
                 hidden_states = split_hidden_states[self.tp_rank]
@@ -314,10 +307,10 @@ class PrepareAndFinalizeWithMC2(PrepareAndFinalizeWithAll2All):
             forward_context = get_forward_context()
             target_pad_length = forward_context.padded_num_tokens
             pad_size = target_pad_length - self.num_tokens
-            if pad_size > 0 and not self.enable_shared_expert_dp:
+            if pad_size > 0:
                 input_ids = nn.functional.pad(input_ids, (0, pad_size))
 
-            if self.tp_size > 1 and not self.enable_shared_expert_dp:
+            if self.tp_size > 1:
                 input_ids = torch.tensor_split(input_ids, self.tp_size, dim=0)
                 input_ids = input_ids[self.tp_rank]
         return input_ids
@@ -349,7 +342,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -363,7 +355,7 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         if enable_sp() or enable_sp_by_pass():
             return self._prepare_with_ep_group(hidden_states, router_logits, quant_type)
 
-        return self._prepare_with_dp_group(hidden_states, router_logits, enable_shared_expert_dp, replace_allreduce)
+        return self._prepare_with_dp_group(hidden_states, router_logits, replace_allreduce)
 
     def _prepare_with_ep_group(
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor, quant_type=QuantType.NONE
@@ -425,7 +417,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        enable_shared_expert_dp: bool = False,
         replace_allreduce: bool = False,
         quant_type=QuantType.NONE,
     ) -> MoEPrepareOutput:
@@ -438,7 +429,6 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
         Returns:
             MoEPrepareOutput with global tensors.
         """
-        self.enable_shared_expert_dp = enable_shared_expert_dp
         if self.moe_config.dp_size > 1:
             max_tokens_across_dp = _EXTRA_CTX.max_tokens_across_dp
 
@@ -538,7 +528,7 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
             hidden_states = hidden_states[: self.num_tokens_pcp]
 
-        if self.moe_config.dp_size > 1 and not self.enable_shared_expert_dp:
+        if self.moe_config.dp_size > 1:
             hidden_states = get_dp_group().reduce_scatter(hidden_states, 0)
             hidden_states = hidden_states[: self.num_tokens]
         return hidden_states

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -228,7 +228,6 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         self.n_shared_experts = n_shared_experts
         self.mix_placement = getattr(ascend_config, "mix_placement", False)
         self.enable_npugraph_ex_static_kernel = ascend_config.ascend_compilation_config.enable_static_kernel
-        self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
         self._use_v2_model_runner = bool(vllm_config.use_v2_model_runner)
         self.dynamic_eplb = False
         self.multi_stage = False
@@ -516,7 +515,6 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             hidden_states=hidden_states,
             router_logits=router_logits,
             replace_allreduce=_EXTRA_CTX.flash_comm_v1_enabled,
-            enable_shared_expert_dp=self.enable_shared_expert_dp,
             quant_type=self.quant_type,
         )
         hidden_states = prepare_output.hidden_states

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -205,9 +205,15 @@ class AscendSharedExperts:
     def _prepare_flashcomm_tp_input(hidden_states: torch.Tensor) -> torch.Tensor:
         return torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, True)
 
-    @staticmethod
-    def _finalize_flashcomm_tp_output(shared_out: torch.Tensor) -> torch.Tensor:
-        return torch.ops.vllm.maybe_pad_and_reduce(shared_out)
+    def _finalize_flashcomm_tp_output(self, shared_out: torch.Tensor) -> torch.Tensor:
+        # Multimodal draft-model inputs intentionally bypass the usual
+        # maybe_pad_and_reduce path. This output is different: its input was
+        # explicitly TP all-gathered above for TP-sharded weights, so reduce it
+        # directly with the physical TP group.
+        pad_size = _EXTRA_CTX.pad_size
+        if pad_size > 0:
+            shared_out = F.pad(shared_out, (0, 0, 0, pad_size))
+        return self.moe_config.tp_group.reduce_scatter(shared_out, dim=0)
 
     def forward(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
         mode = self.parallel_mode()

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -49,10 +49,10 @@ class FusedMoEEvents:
 class SharedExpertParallelMode(Enum):
     """Effective activation and weight layout for a shared-expert forward."""
 
-    FLASHCOMM_OFF_SEDP_OFF = auto()  # Full activations, TP-sharded weights.
-    FLASHCOMM_ON_SEDP_OFF = auto()  # Sharded activations, TP-sharded weights.
-    FLASHCOMM_OFF_SEDP_ON = auto()  # Full activations, replicated weights.
-    FLASHCOMM_ON_SEDP_ON = auto()  # Sharded activations, replicated weights.
+    FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF = auto()  # Full activations, TP-sharded weights.
+    FLASHCOMM_ON_SHARED_EXPERT_DP_OFF = auto()  # Sharded activations, TP-sharded weights.
+    FLASHCOMM_OFF_SHARED_EXPERT_DP_ON = auto()  # Full activations, replicated weights.
+    FLASHCOMM_ON_SHARED_EXPERT_DP_ON = auto()  # Sharded activations, replicated weights.
 
 
 class AscendSharedExperts:
@@ -158,18 +158,18 @@ class AscendSharedExperts:
         # group, so their layout must be derived from that group instead.
         tp_size = self.moe_config.tp_group.world_size
         if tp_size <= 1:
-            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF
 
         activations_sharded = (
             _EXTRA_CTX.flash_comm_v1_enabled or self.moe_config.is_sequence_parallel or enable_sp_by_pass()
         )
         if activations_sharded and self.weights_replicated:
-            return SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON
+            return SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON
         if activations_sharded:
-            return SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF
+            return SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_OFF
         if self.weights_replicated:
-            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON
-        return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON
+        return SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF
 
     def _prepare_local_dp_input(
         self,
@@ -218,19 +218,19 @@ class AscendSharedExperts:
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap):
-            if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON:
+            if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON:
                 # Full activations + replicated weights: shard tokens locally,
                 # run the MLP, then gather its complete output.
                 maybe_wait_event(fused_moe_evts.before_routed_experts)
                 hidden_states, local_dp_metadata = self._prepare_local_dp_input(hidden_states)
-            elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF:
+            elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_OFF:
                 # TP-sharded weights need the full activation slice. Gather the
                 # FlashComm shard before the MLP and reduce-scatter afterwards.
                 maybe_wait_event(fused_moe_evts.before_routed_experts)
                 hidden_states = self._prepare_flashcomm_tp_input(hidden_states)
             elif mode not in {
-                SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON,
-                SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF,
+                SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON,
+                SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF,
             }:
                 raise AssertionError(f"Unsupported shared expert mode: {mode}")
 
@@ -330,14 +330,14 @@ class AscendSharedExperts:
         if self.multistream_overlap:
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
-        if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON:
+        if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_ON:
             assert local_dp_metadata is not None
             shared_out = self._finalize_local_dp_output(shared_out, local_dp_metadata)
-        elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF:
+        elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_OFF:
             shared_out = self._finalize_flashcomm_tp_output(shared_out)
         elif mode not in {
-            SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON,
-            SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF,
+            SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON,
+            SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF,
         }:
             raise AssertionError(f"Unsupported shared expert mode: {mode}")
         return shared_out

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -15,24 +15,24 @@
 # limitations under the License.
 #
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from functools import wraps
 
 import torch
 import torch.nn.functional as F
 import torch_npu
-from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoEMethodBase
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.lora.fused_moe import has_lora
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     AscendDeviceType,
+    enable_sp_by_pass,
     get_ascend_device_type,
     npu_stream_switch,
-    shared_expert_dp_enabled,
     shared_experts_calculation_stream,
 )
 
@@ -44,6 +44,15 @@ class FusedMoEEvents:
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
+
+
+class SharedExpertParallelMode(Enum):
+    """Effective activation and weight layout for a shared-expert forward."""
+
+    FLASHCOMM_OFF_SEDP_OFF = auto()  # Full activations, TP-sharded weights.
+    FLASHCOMM_ON_SEDP_OFF = auto()  # Sharded activations, TP-sharded weights.
+    FLASHCOMM_OFF_SEDP_ON = auto()  # Full activations, replicated weights.
+    FLASHCOMM_ON_SEDP_ON = auto()  # Sharded activations, replicated weights.
 
 
 class AscendSharedExperts:
@@ -62,6 +71,7 @@ class AscendSharedExperts:
         quant_method: FusedMoEMethodBase,
     ):
         self.layer = layer
+        self.moe_config = moe_config
         self.hidden_size = moe_config.hidden_dim
         self.in_dtype = moe_config.in_dtype
         self.swiglu_limit = 0.0 if moe_config.swiglu_limit is None else moe_config.swiglu_limit
@@ -71,6 +81,12 @@ class AscendSharedExperts:
         self.lora_context = None
         ascend_config = get_ascend_config()
         self.multistream_overlap = ascend_config.multistream_overlap_shared_expert
+        # Native MoE sequence parallelism and the SP compiler pass also build
+        # shared-expert linears with replicated weights. Keep this weight-layout
+        # state independent from the runtime FlashComm decision.
+        self.weights_replicated = (
+            ascend_config.enable_shared_expert_dp or moe_config.is_sequence_parallel or enable_sp_by_pass()
+        )
 
         if self.multistream_overlap:
             # Wrap the quant_method's process_weights_after_loading to validate that
@@ -135,12 +151,89 @@ class AscendSharedExperts:
             shared_out = F.sigmoid(gate_out) * shared_out
         return shared_out
 
+    def parallel_mode(self) -> SharedExpertParallelMode:
+        """Resolve the effective activation/weight layout for this forward."""
+        # EP rewrites FusedMoEParallelConfig.tp_size to 1 because each routed
+        # expert is local. Shared-expert linears still span the physical TP
+        # group, so their layout must be derived from that group instead.
+        tp_size = self.moe_config.tp_group.world_size
+        if tp_size <= 1:
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+
+        activations_sharded = (
+            _EXTRA_CTX.flash_comm_v1_enabled or self.moe_config.is_sequence_parallel or enable_sp_by_pass()
+        )
+        if activations_sharded and self.weights_replicated:
+            return SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON
+        if activations_sharded:
+            return SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF
+        if self.weights_replicated:
+            return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON
+        return SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF
+
+    def _prepare_local_dp_input(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, tuple[int, int]]:
+        original_num_tokens = hidden_states.shape[0]
+        # See parallel_mode(): moe_config.tp_size describes routed experts in
+        # EP, while this token split follows the shared-expert TP group.
+        tp_group = self.moe_config.tp_group
+        tp_size = tp_group.world_size
+        pad_size = (tp_size - original_num_tokens % tp_size) % tp_size
+        if pad_size > 0:
+            hidden_states = F.pad(hidden_states, (0, 0, 0, pad_size))
+        hidden_states = torch.tensor_split(
+            hidden_states,
+            tp_size,
+            dim=0,
+        )[tp_group.rank_in_group]
+        return hidden_states, (original_num_tokens, pad_size)
+
+    def _finalize_local_dp_output(
+        self,
+        shared_out: torch.Tensor,
+        metadata: tuple[int, int],
+    ) -> torch.Tensor:
+        original_num_tokens, pad_size = metadata
+        shared_out = self.moe_config.tp_group.all_gather(shared_out, dim=0)
+        if pad_size > 0:
+            shared_out = shared_out[:original_num_tokens]
+        return shared_out
+
+    @staticmethod
+    def _prepare_flashcomm_tp_input(hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, True)
+
+    @staticmethod
+    def _finalize_flashcomm_tp_output(shared_out: torch.Tensor) -> torch.Tensor:
+        return torch.ops.vllm.maybe_pad_and_reduce(shared_out)
+
     def forward(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
+        mode = self.parallel_mode()
+        local_dp_metadata = None
+
         def maybe_wait_event(evt: torch.npu.Event | None):
             if evt is not None:
                 torch.npu.current_stream().wait_event(evt)
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap):
+            if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON:
+                # Full activations + replicated weights: shard tokens locally,
+                # run the MLP, then gather its complete output.
+                maybe_wait_event(fused_moe_evts.before_routed_experts)
+                hidden_states, local_dp_metadata = self._prepare_local_dp_input(hidden_states)
+            elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF:
+                # TP-sharded weights need the full activation slice. Gather the
+                # FlashComm shard before the MLP and reduce-scatter afterwards.
+                maybe_wait_event(fused_moe_evts.before_routed_experts)
+                hidden_states = self._prepare_flashcomm_tp_input(hidden_states)
+            elif mode not in {
+                SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON,
+                SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF,
+            }:
+                raise AssertionError(f"Unsupported shared expert mode: {mode}")
+
             # Only used for int quantization
             has_quantized_shared_without_lora = (
                 not has_lora(self.lora_context)
@@ -237,12 +330,14 @@ class AscendSharedExperts:
         if self.multistream_overlap:
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
-        # NOTE: This is exactly the opposite of
-        # `maybe_all_reduce_tensor_model_parallel`
-        moe_comm_type = _EXTRA_CTX.moe_comm_type
-        if (
-            moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
-            and not shared_expert_dp_enabled()
-        ):
-            shared_out = tensor_model_parallel_all_reduce(shared_out)
+        if mode is SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_ON:
+            assert local_dp_metadata is not None
+            shared_out = self._finalize_local_dp_output(shared_out, local_dp_metadata)
+        elif mode is SharedExpertParallelMode.FLASHCOMM_ON_SEDP_OFF:
+            shared_out = self._finalize_flashcomm_tp_output(shared_out)
+        elif mode not in {
+            SharedExpertParallelMode.FLASHCOMM_ON_SEDP_ON,
+            SharedExpertParallelMode.FLASHCOMM_OFF_SEDP_OFF,
+        }:
+            raise AssertionError(f"Unsupported shared expert mode: {mode}")
         return shared_out

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -63,6 +63,7 @@ from vllm_ascend.distributed.parallel_state import (
 from vllm_ascend.utils import (
     enable_dsa_cp,
     enable_sp,
+    enable_sp_by_pass,
     is_vl_model,
     mlp_tp_enable,
     oproj_tp_enable,
@@ -452,6 +453,10 @@ def _should_skip_sp_for_multimodal_encoder(prefix: str) -> bool:
     return any(part in prefix for part in _MULTIMODAL_ENCODER_PREFIX_PARTS)
 
 
+def _is_shared_expert_layer(prefix: str) -> bool:
+    return "shared_experts" in prefix or "shared_expert" in prefix or "share_expert" in prefix
+
+
 def _get_column_parallel_op(
     prefix, layer
 ) -> MLPColumnParallelOp | DSV4OProjColumnParallelOp | SequenceColumnParallelOp | ShardedCPColumnParallelOp | None:
@@ -462,8 +467,7 @@ def _get_column_parallel_op(
     if "gate_up_proj" in prefix and mlp_tp_enable() and not is_moe_layer(prefix):
         return MLPColumnParallelOp(layer)
     if enable_sp() and not _should_skip_sp_for_multimodal_encoder(prefix):
-        # "share_expert" added for Step3p5
-        if "shared_expert" in prefix or "share_expert" in prefix:
+        if _is_shared_expert_layer(prefix):
             return None
         sp_column_prefix = [
             "gate_up_proj",  # first MLP of most LLMs
@@ -491,8 +495,7 @@ def _get_row_parallel_op(
     if "o_proj" in prefix and oproj_tp_enable():
         return OProjRowParallelOp(layer)
     if enable_sp() and not _should_skip_sp_for_multimodal_encoder(prefix):
-        # "share_expert" added for Step3p5
-        if "shared_expert" in prefix or "share_expert" in prefix:
+        if _is_shared_expert_layer(prefix):
             return None
         sp_row_prefixes = [
             "o_proj",  # attn output linear of most LLMs
@@ -509,12 +512,10 @@ def _get_row_parallel_op(
 
 
 def get_parallel_op(disable_tp, prefix, layer, direct):
-    if (
-        disable_tp
-        or ("shared_experts" in prefix and shared_expert_dp_enabled())
-        or ("shared_expert" in prefix and shared_expert_dp_enabled())
-        or ("share_expert" in prefix and shared_expert_dp_enabled())  # "share_expert" added for Step3p5
-    ):
+    shared_expert_weights_replicated = _is_shared_expert_layer(prefix) and (
+        shared_expert_dp_enabled() or enable_sp_by_pass()
+    )
+    if disable_tp or shared_expert_weights_replicated:
         return None, 0, 1
     custom_op: (
         MLPColumnParallelOp

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -60,7 +60,7 @@ from vllm_ascend.spec_decode.utils import (
     _maybe_eager_context,
     patch_tensor_parallel_group,
 )
-from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -163,8 +163,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
         self.decode_threshold = 1 + self.num_speculative_tokens
         self.query_start_loc = self.runner._make_buffer(self.runner.max_num_reqs + 2, dtype=torch.int32)
-
-        self.enable_shared_expert_dp = shared_expert_dp_enabled()
 
         self.dcp_size = self.runner.dcp_size
 
@@ -2094,7 +2092,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         hidden_states: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if self.method == "mtp":
-            if self.enable_shared_expert_dp:
+            if _EXTRA_CTX.flash_comm_v1_enabled:
                 last_hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                     last_hidden_states.contiguous(), True
                 )

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -58,7 +58,7 @@ from vllm_ascend.spec_decode.utils import (
     _maybe_eager_context,
     patch_tensor_parallel_group,
 )
-from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -143,8 +143,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.decode_threshold = 1 + self.num_speculative_tokens
         self.query_start_loc = self.runner._make_buffer(self.runner.max_num_reqs + 2, dtype=torch.int32)
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
-
-        self.enable_shared_expert_dp = shared_expert_dp_enabled()
 
         self.dcp_size = self.runner.dcp_size
 
@@ -2025,7 +2023,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         hidden_states: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         if self.method == "mtp":
-            if self.enable_shared_expert_dp:
+            if _EXTRA_CTX.flash_comm_v1_enabled:
                 last_hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                     last_hidden_states.contiguous(), True
                 )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -811,7 +811,7 @@ def enable_sp_by_pass():
     return get_ascend_config().enable_sp_by_pass
 
 
-def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
+def enable_sp(vllm_config=None) -> bool:
     global _ENABLE_SP
     if vllm_config is None:
         try:
@@ -833,16 +833,12 @@ def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
             except RuntimeError:
                 _ENABLE_SP = envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
 
-        if not _ENABLE_SP and enable_shared_expert_dp:
-            _ENABLE_SP = True
-            logger.info("shared_expert_dp requires enable_sp=True. enable_sp has been set to True.")
-
     return bool(_ENABLE_SP)
 
 
 # TODO remove it after vllm has this func
 def shared_expert_dp_enabled() -> bool:
-    return get_ascend_config().enable_shared_expert_dp or enable_sp() or enable_sp_by_pass()
+    return get_ascend_config().enable_shared_expert_dp
 
 
 def is_moe_model(vllm_config: VllmConfig):

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -856,7 +856,7 @@ def enable_sp_by_pass():
     return get_ascend_config().enable_sp_by_pass
 
 
-def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
+def enable_sp(vllm_config=None) -> bool:
     global _ENABLE_SP
     if vllm_config is None:
         try:
@@ -878,16 +878,12 @@ def enable_sp(vllm_config=None, enable_shared_expert_dp: bool = False) -> bool:
             except RuntimeError:
                 _ENABLE_SP = envs_ascend.VLLM_ASCEND_ENABLE_FLASHCOMM1
 
-        if not _ENABLE_SP and enable_shared_expert_dp:
-            _ENABLE_SP = True
-            logger.info("shared_expert_dp requires enable_sp=True. enable_sp has been set to True.")
-
     return bool(_ENABLE_SP)
 
 
 # TODO remove it after vllm has this func
 def shared_expert_dp_enabled() -> bool:
-    return get_ascend_config().enable_shared_expert_dp or enable_sp() or enable_sp_by_pass()
+    return get_ascend_config().enable_shared_expert_dp
 
 
 def is_moe_model(vllm_config: VllmConfig):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR decouples `enable_flashcomm1` from `enable_shared_expert_dp` for MoE shared-expert execution.

Previously, enabling shared-expert DP implicitly relied on FlashComm-related behavior, so the two features could not be configured and validated independently. This change introduces layout-aware handling for the four supported combinations:

- FlashComm off / shared-expert DP off
- FlashComm on / shared-expert DP off
- FlashComm off / shared-expert DP on
- FlashComm on / shared-expert DP on

It also fixes the TP+EP case: under expert parallelism, `FusedMoEParallelConfig.tp_size` describes routed-expert sharding and becomes `1`, while shared-expert communication still needs the physical TP group size/rank. Shared-expert mode selection and local SEDP token splitting now use `tp_group.world_size` and `tp_group.rank_in_group`.

### Does this PR introduce *any* user-facing change?

Yes. `enable_flashcomm1` and `enable_shared_expert_dp` can now be enabled independently through `additional_config`, and all four combinations are supported for shared-expert MoE models.

No new user-facing flags are introduced.

### How was this patch tested?

Unit tests:

```bash
pytest -q \
  tests/ut/test_ascend_config.py \
  tests/ut/ops/test_fused_moe.py \
  tests/ut/ops/test_linear.py \
  tests/ut/ops/test_moe_comm_method.py \
  tests/ut/ops/test_prepare_finalize.py \
  tests/ut/spec_decode/a2/test_eagle_proposer.py
```

Result:

```text
176 passed, 13 skipped
```

E2E validation used `vllm serve` and OpenAI-compatible `/v1/completions` requests with `temperature=0`, `max_tokens=3`, and `logprobs=20`.

The full four-state matrix was verified on Qwen3.5-35B-A3B with TP=2 and EP enabled:

| FlashComm | Shared-expert DP | Startup | Inference | Repeated output | Token match |
|---|---|---|---|---|---|
| off | off | pass | pass | pass | pass |
| on | off | pass | pass | pass | pass |
| off | on | pass | pass | pass | pass |
| on | on | pass | pass | pass | pass |

Regression E2E was also completed with Qwen, DeepSeek, MiniMax, and Kimi local MoE models. All tested configurations started successfully and produced matching greedy-decoding tokens. Each service was stopped and NPU processes were confirmed cleared before starting the next configuration.

### Performance validation

We evaluated the decoupled FlashComm path with Shared Experts DP disabled.

| Item | Configuration |
|---|---|
| Model | Qwen3.5-35B-A3B, BF16 |
| Parallelism | TP=2 + EP |
| Output length | 1 token/request |
| Prefix caching | Disabled |
| Baseline | `enable_flashcomm=False`, `enable_shared_experts_dp=False` |
| FlashComm | `enable_flashcomm=True`, `enable_shared_experts_dp=False` |
| Samples | 4 samples per configuration |

The request shape below is represented as `concurrency × input length`. Each row presents either 8K or 32K input tokens per full scheduling wave.

| Max batched tokens | Request shape | FlashComm disabled | FlashComm enabled | Throughput change | Mean TTFT change | Result |
|---:|---:|---:|---:|---:|---:|---|
| 8,192 | 4 × 2048 | 15.20K tok/s | 14.87K tok/s | **-2.15%** | +2.28% | Regression |
| 8,192 | 8 × 1024 | 13.90K tok/s | 13.65K tok/s | **-1.80%** | +1.89% | Regression |
| 8,192 | 16 × 512 | 13.28K tok/s | 13.06K tok/s | **-1.61%** | +1.69% | Regression |
| 8,192 | 128 × 64 | 8.64K tok/s | 8.70K tok/s | +0.65% | +0.30% | Within measurement noise |
| 32,768 | 128 × 256 | 17.80K tok/s | 19.48K tok/s | **+9.43%** | **-8.40%** | **Stable improvement** |

For the 32K-token workload, all four paired measurements showed positive throughput improvements. The paired mean improvement was +9.46%, with a 95% confidence interval of [+0.31%, +18.60%].

These results were obtained using the current implementation, without reusing the routed-expert AllGather for the shared-expert path or merging their final ReduceScatter.

The 8K-token results confirm that the additional shared-expert communication has a measurable cost: FlashComm regresses by 1.61%–2.15% for the long/medium-prefill workloads, while the +0.65% result for the short-prompt workload is smaller than the measurement variation and is not considered a reliable gain.

However, at 32K tokens per scheduling wave, the savings from sequence-sharded computation and memory access outweigh the additional communication, resulting in a net throughput improvement of 9.43% and an 8.40% reduction in mean TTFT.

Therefore, the benefit is workload-dependent. For this model and TP=2 setup, the break-even point lies between the tested 8K and 32K token batches. Communication reuse and ReduceScatter merging remain potential follow-up optimizations to lower this break-even point.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
