### PR TITLE
[Bugfix][0.24.0rc][EPLB] Fix(eplb): load redundant expert weights

### DIFF
--- a/tests/ut/patch/platform/test_patch_fused_moe.py
+++ b/tests/ut/patch/platform/test_patch_fused_moe.py
@@ -1,0 +1,70 @@
+# Copyright Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_ascend.patch.platform import patch_fused_moe
+
+
+def _set_eplb_config(monkeypatch, *, dynamic_eplb=True, num_redundant_experts=2):
+    eplb_config = SimpleNamespace(
+        dynamic_eplb=dynamic_eplb,
+        expert_map_path=None,
+        num_redundant_experts=num_redundant_experts,
+    )
+    monkeypatch.setattr(
+        patch_fused_moe,
+        "get_ascend_config",
+        lambda: SimpleNamespace(eplb_config=eplb_config),
+    )
+
+
+def test_expert_mapping_loads_all_ascend_redundant_slots(monkeypatch):
+    _set_eplb_config(monkeypatch)
+    model = MagicMock()
+    model.named_parameters.return_value = []
+
+    mapping = patch_fused_moe._ascend_fused_moe_make_expert_params_mapping(
+        model,
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        num_experts=8,
+        num_redundant_experts=0,
+    )
+
+    assert len(mapping) == (8 + 2) * 3
+    assert [entry[2] for entry in mapping[-6:]] == [8, 8, 8, 9, 9, 9]
+    assert all("experts.0." in entry[1] for entry in mapping[-6:-3])
+    assert all("experts.1." in entry[1] for entry in mapping[-3:])
+
+
+def test_redundancy_resolver_keeps_upstream_value_without_ascend_eplb(monkeypatch):
+    _set_eplb_config(monkeypatch, dynamic_eplb=False, num_redundant_experts=0)
+
+    assert patch_fused_moe._resolve_num_redundant_experts(4) == 4
+
+
+def test_redundancy_resolver_rejects_conflicting_counts(monkeypatch):
+    _set_eplb_config(monkeypatch, num_redundant_experts=2)
+
+    with pytest.raises(
+        ValueError,
+        match="Conflicting EPLB redundant expert counts: vLLM=4, Ascend=2",
+    ):
+        patch_fused_moe._resolve_num_redundant_experts(4)

--- a/vllm_ascend/patch/platform/patch_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_fused_moe.py
@@ -35,6 +35,7 @@ from vllm_ascend.utils import is_310p
 
 # Capture the real original before fused_moe.py's module-level code runs.
 _original_FusedMoE = _fused_moe_layer.FusedMoE
+_original_fused_moe_make_expert_params_mapping = _fused_moe_layer.fused_moe_make_expert_params_mapping
 
 if is_310p():
     from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310 as _DefaultAscendMoERunner
@@ -42,22 +43,29 @@ else:
     from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner as _DefaultAscendMoERunner
 
 
+def _resolve_num_redundant_experts(upstream_redundancy: int) -> int:
+    """Resolve one redundancy count for allocation and checkpoint loading."""
+    eplb_config = get_ascend_config().eplb_config
+    if not eplb_config.dynamic_eplb and eplb_config.expert_map_path is None:
+        return upstream_redundancy
+
+    configured_redundancy = eplb_config.num_redundant_experts
+    if configured_redundancy and upstream_redundancy not in (0, configured_redundancy):
+        raise ValueError(
+            f"Conflicting EPLB redundant expert counts: vLLM={upstream_redundancy}, Ascend={configured_redundancy}."
+        )
+    return configured_redundancy or upstream_redundancy
+
+
 def _ascend_FusedMoE(*args, runner_cls=None, runner_args=None, **kwargs):
     if runner_cls is None:
         runner_cls = _DefaultAscendMoERunner
     # RoutedExperts allocates its parameters before AscendMoERunner is
-    # constructed. Propagate Ascend EPLB capacity into the upstream factory so
-    # redundant expert slots are present when weights are created and loaded.
+    # constructed. Propagate Ascend EPLB capacity into the upstream factory.
     eplb_config = get_ascend_config().eplb_config
     if eplb_config.dynamic_eplb or eplb_config.expert_map_path is not None:
-        configured_redundancy = eplb_config.num_redundant_experts
-        upstream_redundancy = kwargs.get("num_redundant_experts", 0)
-        if configured_redundancy and upstream_redundancy not in (0, configured_redundancy):
-            raise ValueError(
-                f"Conflicting EPLB redundant expert counts: vLLM={upstream_redundancy}, Ascend={configured_redundancy}."
-            )
         kwargs["enable_eplb"] = True
-        kwargs["num_redundant_experts"] = configured_redundancy or upstream_redundancy
+        kwargs["num_redundant_experts"] = _resolve_num_redundant_experts(kwargs.get("num_redundant_experts", 0))
     # 'hash' is a DeepSeek V4 flag already consumed before FusedMoE is called;
     # 'tid2eid' is Ascend-specific and must reach AscendMoERunner via runner_args.
     kwargs.pop("hash", None)
@@ -68,5 +76,32 @@ def _ascend_FusedMoE(*args, runner_cls=None, runner_args=None, **kwargs):
     return _original_FusedMoE(*args, runner_cls=runner_cls, runner_args=runner_args, **kwargs)
 
 
+def _ascend_fused_moe_make_expert_params_mapping(
+    model,
+    ckpt_gate_proj_name: str,
+    ckpt_down_proj_name: str,
+    ckpt_up_proj_name: str,
+    num_experts: int,
+    num_redundant_experts: int = 0,
+    routed_experts_prefix: str = "routed_experts",
+):
+    # Model implementations read redundancy from vLLM's EPLB config, while
+    # Ascend dynamic EPLB is configured through additional_config. Use the
+    # same effective count as _ascend_FusedMoE so every allocated redundant
+    # physical slot receives the corresponding logical expert checkpoint.
+    num_redundant_experts = _resolve_num_redundant_experts(num_redundant_experts)
+    return _original_fused_moe_make_expert_params_mapping(
+        model,
+        ckpt_gate_proj_name,
+        ckpt_down_proj_name,
+        ckpt_up_proj_name,
+        num_experts,
+        num_redundant_experts,
+        routed_experts_prefix,
+    )
+
+
 _fused_moe_layer.FusedMoE = _ascend_FusedMoE
 _fused_moe_pkg.FusedMoE = _ascend_FusedMoE
+_fused_moe_layer.fused_moe_make_expert_params_mapping = _ascend_fused_moe_make_expert_params_mapping
+_fused_moe_pkg.fused_moe_make_expert_params_mapping = _ascend_fused_moe_make_expert_params_mapping


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aligns the redundant expert count resolution between parameter allocation (`_ascend_FusedMoE`) and checkpoint parameter mapping (`_ascend_fused_moe_make_expert_params_mapping`). It extracts the redundancy resolution logic into a helper function `_resolve_num_redundant_experts` and patches `fused_moe_make_expert_params_mapping` to use it. This ensures that every allocated redundant physical slot correctly receives the corresponding logical expert checkpoint when using Ascend dynamic EPLB.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added unit tests in `tests/ut/patch/platform/test_patch_fused_moe.py` to verify:
1. Expert mapping loads all Ascend redundant slots.
2. Redundancy resolver keeps upstream value without Ascend EPLB.
3. Redundancy resolver rejects conflicting counts.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
