### PR TITLE
[v0.23.0][Performance] Reuse grouped block hashes across AscendStore operations

### DIFF
--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -27,7 +27,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
     KeyMetadata,
-    RequestGroupedBlockHashCache,
     get_block_hashes,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
@@ -112,7 +111,7 @@ class TestAscendStoreCoordinator(unittest.TestCase):
             hash_block_size=8,
         )
         db.cache_coordinator = coord
-        grouped_hash_cache = RequestGroupedBlockHashCache(block_hashes, 8)
+        grouped_hash_cache = {}
 
         with patch.object(
             config_data,

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -111,7 +111,7 @@ class TestAscendStoreCoordinator(unittest.TestCase):
             hash_block_size=8,
         )
         db.cache_coordinator = coord
-        grouped_hash_cache = {}
+        grouped_hash_cache: config_data.GroupedBlockHashCache = {}
 
         with patch.object(
             config_data,

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -23,7 +23,13 @@ from unittest.mock import patch
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 import torch
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec, SlidingWindowSpec
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import get_block_hashes
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    RequestGroupedBlockHashCache,
+    get_block_hashes,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
     AscendStoreCoordinator,
     ExternalCachedBlockPool,
@@ -90,6 +96,51 @@ class _FakeCompressedManager:
 
 
 class TestAscendStoreCoordinator(unittest.TestCase):
+    def test_load_mask_grouped_hashes_are_reused_by_key_build(self):
+        block_hashes = _hashes(4)
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _full_spec(16))],
+            scheduler_block_size=16,
+            hash_block_size=8,
+            group_block_sizes=[16],
+            group_cache_families=["c1"],
+        )
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("model", 0, 0, 0, 0)],
+            block_size=[16],
+            partitions=None,
+            hash_block_size=8,
+        )
+        db.cache_coordinator = coord
+        grouped_hash_cache = RequestGroupedBlockHashCache(block_hashes, 8)
+
+        with patch.object(
+            config_data,
+            "_rehash_block_hash_group",
+            wraps=config_data._rehash_block_hash_group,
+        ) as rehash:
+            self.assertEqual(
+                db.load_mask(
+                    block_hashes,
+                    32,
+                    grouped_hash_cache=grouped_hash_cache,
+                ),
+                ([True, True],),
+            )
+            self.assertEqual(rehash.call_count, 2)
+
+            keys = list(
+                db.process_token_key_strings_with_block_ids(
+                    32,
+                    block_hashes,
+                    [10, 11],
+                    grouped_hash_cache=grouped_hash_cache,
+                )
+            )
+
+        self.assertEqual(len(keys), 2)
+        self.assertEqual(rehash.call_count, 2)
+
     def test_compressed_group_hits_on_effective_granularity(self):
         block_hashes = _hashes(128)
         grouped_hash = get_block_hashes(block_hashes, group_block_size=128 * 128, hash_block_size=128)[0]

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -75,7 +75,7 @@ class MaskedFakeTokenDatabase(FakeTokenDatabase):
     def store_mask(self, token_len, num_prompt_tokens=None):
         return self.masks
 
-    def load_mask(self, block_hashes, token_len):
+    def load_mask(self, block_hashes, token_len, grouped_hash_cache=None):
         return self.masks
 
     def mask_allows_chunk(self, masks, kv_cache_group_id, start):

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -17,12 +17,13 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm.distributed.kv_events import BlockStored
 from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
     KeyMetadata,
@@ -241,6 +242,49 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].block_hashes, [maybe_convert_block_hash(b"h1")])
         self.assertEqual(events[0].parent_block_hash, maybe_convert_block_hash(b"h0"))
+
+    def test_save_reuses_grouped_hashes_for_kv_events(self):
+        store = FakeStore([0, 0])
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("m", 0, 0, 0, 0)],
+            [16],
+            None,
+            hash_block_size=8,
+        )
+        db.set_group_buffers({0: [1000]}, {0: [16]}, {0: [1]}, group_num_layers={0: 1})
+        thread = KVCacheStoreSendingThread(
+            m_store=store,
+            token_database=db,
+            block_size=16,
+            tp_rank=0,
+            dcp_size=1,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=threading.Event(),
+            group_uses_align_state=[False],
+            enable_kv_event=True,
+        )
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids=[0, 1],
+            block_hashes=[b"h0", b"h1", b"h2", b"h3"],  # type: ignore[arg-type]
+            current_event=None,
+            token_ids=list(range(32)),
+            original_block_size=16,
+        )
+        thread.add_stored_request("r1")
+        thread.request_queue.put(request)
+
+        with patch.object(
+            config_data,
+            "_rehash_block_hash_group",
+            wraps=config_data._rehash_block_hash_group,
+        ) as rehash:
+            thread._handle_request(request)
+
+        self.assertEqual(rehash.call_count, 2)
+        self.assertEqual(len(thread.get_kv_events()), 2)
 
     def test_handle_request_consumer_role(self):
         t, store = self._make_thread([0], kv_role="kv_consumer")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -18,12 +18,23 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+# isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
+    ChunkedTokenDatabase,
+    KeyMetadata,
     LoadSpec,
     ReqMeta,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
+    AscendStoreCoordinator,
+)
+# isort: on
 
 
 class TestKVPoolWorkerHelpers(unittest.TestCase):
@@ -140,6 +151,47 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
         worker.token_database.process_tokens.assert_not_called()
+
+    def test_lookup_reuses_grouped_hashes_for_hit_resolution(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_kv_cache_groups = 1
+        worker.cache_coordinator = AscendStoreCoordinator(
+            [
+                KVCacheGroupSpec(
+                    ["layer.0"],
+                    FullAttentionSpec(
+                        block_size=16,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                )
+            ],
+            scheduler_block_size=16,
+            hash_block_size=8,
+            group_block_sizes=[16],
+            group_cache_families=["c1"],
+        )
+        worker.token_database = ChunkedTokenDatabase(
+            [KeyMetadata("model", 0, 0, 0, 0)],
+            block_size=[16],
+            partitions=None,
+            hash_block_size=8,
+        )
+        worker.m_store = MagicMock()
+        worker.m_store.exists.return_value = [1, 1]
+        block_hashes = [b"h0", b"h1", b"h2", b"h3"]
+
+        with patch.object(
+            config_data,
+            "_rehash_block_hash_group",
+            wraps=config_data._rehash_block_hash_group,
+        ) as rehash:
+            hit = worker.lookup(32, block_hashes, [0])
+
+        self.assertEqual(hit, 32)
+        self.assertEqual(rehash.call_count, 2)
 
 
 class TestKVPoolWorkerInit(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -142,6 +142,7 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
             [0],
             use_layerwise=False,
             include_all_ranks=False,
+            grouped_hash_cache={},
         )
 
         self.assertEqual(hit, 128)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -489,6 +489,7 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
         for start, end, hash_val, _ in self._iter_token_chunks(
@@ -498,6 +499,7 @@ class ChunkedTokenDatabase:
             kv_cache_group_id,
             cache_role,
             cache_family,
+            grouped_hash_cache=grouped_hash_cache,
         ):
             yield (
                 start,
@@ -517,6 +519,7 @@ class ChunkedTokenDatabase:
         mask_num: int = 0,
         kv_cache_group_id: int = 0,
         chunk_filter: Callable[[int], bool] | None = None,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, str, BlockHash | str]]:
         """Yield cache key strings directly without materializing PoolKey objects."""
         prefix = self._get_key_prefix(kv_cache_group_id)
@@ -526,6 +529,7 @@ class ChunkedTokenDatabase:
             mask_num,
             kv_cache_group_id,
             chunk_filter=chunk_filter,
+            grouped_hash_cache=grouped_hash_cache,
         ):
             yield start, end, prefix + block_hash_to_str(hash_val), hash_val
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -17,6 +17,8 @@ from vllm_ascend.memcache_comm_fence import AttentionComputeStartGate
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
+# ponytail: each operation owns a fresh dict, so block size is the only cache key.
+GroupedBlockHashCache = dict[int, Sequence[BlockHash | str]]
 
 
 # Parameters related to the key
@@ -267,7 +269,7 @@ class ChunkedTokenDatabase:
         self,
         block_hashes: list[BlockHash],
         token_len: int,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> tuple[list[bool], ...] | None:
         if self.cache_coordinator is None:
             return None
@@ -430,7 +432,7 @@ class ChunkedTokenDatabase:
         chunk_filter: Callable[[int], bool] | None = None,
         shard_rank: int | None = None,
         shard_size: int | None = None,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, BlockHash | str, int | None]]:
         if not block_hashes:
             return
@@ -489,7 +491,7 @@ class ChunkedTokenDatabase:
         kv_cache_group_id: int = 0,
         cache_role: str = "kv",
         cache_family: str | None = None,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, PoolKey]]:
         """Process the tokens and return the corresponding cache engine keys."""
         for start, end, hash_val, _ in self._iter_token_chunks(
@@ -519,7 +521,7 @@ class ChunkedTokenDatabase:
         mask_num: int = 0,
         kv_cache_group_id: int = 0,
         chunk_filter: Callable[[int], bool] | None = None,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, str, BlockHash | str]]:
         """Yield cache key strings directly without materializing PoolKey objects."""
         prefix = self._get_key_prefix(kv_cache_group_id)
@@ -544,7 +546,7 @@ class ChunkedTokenDatabase:
         chunk_filter: Callable[[int], bool] | None = None,
         shard_rank: int | None = None,
         shard_size: int | None = None,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
         """Yield cache key strings and resolved block ids without PoolKey allocation."""
         prefix = self._get_key_prefix(kv_cache_group_id)
@@ -602,52 +604,23 @@ def normalize_block_ids_by_group(block_ids: tuple[list[int], ...] | list[int] | 
     raise ValueError(f"Unsupported block_ids type {type(block_ids)}")
 
 
-class RequestGroupedBlockHashCache:
-    """Cache grouped block hashes for one request."""
-
-    def __init__(
-        self,
-        block_hashes: Sequence[BlockHash | str],
-        hash_block_size: int,
-    ) -> None:
-        self._block_hashes = block_hashes
-        self._hash_block_size = hash_block_size
-        self._grouped_hashes: dict[int, Sequence[BlockHash | str]] = {}
-
-    def get(
-        self,
-        block_hashes: Sequence[BlockHash | str],
-        group_block_size: int,
-        hash_block_size: int,
-    ) -> Sequence[BlockHash | str]:
-        if block_hashes is not self._block_hashes or hash_block_size != self._hash_block_size:
-            raise ValueError("RequestGroupedBlockHashCache cannot be shared across requests")
-        if group_block_size == hash_block_size:
-            return block_hashes
-        assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
-        grouped_hashes = self._grouped_hashes.get(group_block_size)
-        if grouped_hashes is None:
-            grouped_hashes = _LazyGroupedBlockHashList(
-                block_hashes,
-                group_block_size // hash_block_size,
-                memoize=True,
-            )
-            self._grouped_hashes[group_block_size] = grouped_hashes
-        return grouped_hashes
-
-
 def get_block_hashes(
     block_hashes: BlockHashList | list[str],
     group_block_size: int,
     hash_block_size: int,
-    grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+    grouped_hash_cache: GroupedBlockHashCache | None = None,
 ) -> Sequence[BlockHash | str]:
-    if grouped_hash_cache is not None:
-        return grouped_hash_cache.get(block_hashes, group_block_size, hash_block_size)
     if group_block_size == hash_block_size:
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
-    return _LazyGroupedBlockHashList(block_hashes, group_block_size // hash_block_size)
+    if grouped_hash_cache is None:
+        return _LazyGroupedBlockHashList(block_hashes, group_block_size // hash_block_size)
+    if group_block_size not in grouped_hash_cache:
+        grouped_hash_cache[group_block_size] = _LazyGroupedBlockHashList(
+            block_hashes,
+            group_block_size // hash_block_size,
+        )
+    return grouped_hash_cache[group_block_size]
 
 
 class _LazyGroupedBlockHashList(Sequence[BlockHash]):
@@ -655,12 +628,11 @@ class _LazyGroupedBlockHashList(Sequence[BlockHash]):
         self,
         block_hashes: Sequence[BlockHash | str],
         scale_factor: int,
-        memoize: bool = False,
     ) -> None:
         self._block_hashes = block_hashes
         self._scale_factor = scale_factor
         self._length = len(block_hashes) // scale_factor
-        self._cache: dict[int, BlockHash] | None = {} if memoize else None
+        self._cache: dict[int, BlockHash] = {}
 
     def __len__(self) -> int:
         return self._length
@@ -672,12 +644,11 @@ class _LazyGroupedBlockHashList(Sequence[BlockHash]):
             index += self._length
         if index < 0 or index >= self._length:
             raise IndexError(index)
-        if self._cache is not None and index in self._cache:
+        if index in self._cache:
             return self._cache[index]
         start = index * self._scale_factor
         grouped_hash = _rehash_block_hash_group(self._block_hashes[start : start + self._scale_factor])
-        if self._cache is not None:
-            self._cache[index] = grouped_hash
+        self._cache[index] = grouped_hash
         return grouped_hash
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -267,10 +267,15 @@ class ChunkedTokenDatabase:
         self,
         block_hashes: list[BlockHash],
         token_len: int,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> tuple[list[bool], ...] | None:
         if self.cache_coordinator is None:
             return None
-        return self.cache_coordinator.load_mask(block_hashes, token_len)
+        return self.cache_coordinator.load_mask(
+            block_hashes,
+            token_len,
+            grouped_hash_cache=grouped_hash_cache,
+        )
 
     def mask_allows_chunk(
         self,
@@ -425,6 +430,7 @@ class ChunkedTokenDatabase:
         chunk_filter: Callable[[int], bool] | None = None,
         shard_rank: int | None = None,
         shard_size: int | None = None,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, BlockHash | str, int | None]]:
         if not block_hashes:
             return
@@ -433,7 +439,12 @@ class ChunkedTokenDatabase:
             cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
         cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
         effective_block_size = base_block_size * cache_family_ratio
-        grouped_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
+        grouped_hashes = get_block_hashes(
+            block_hashes,
+            effective_block_size,
+            self.hash_block_size,
+            grouped_hash_cache=grouped_hash_cache,
+        )
         if not grouped_hashes:
             return
         num_logical_blocks = min(len(grouped_hashes), cdiv(token_len, effective_block_size)) if token_len > 0 else 0
@@ -529,6 +540,7 @@ class ChunkedTokenDatabase:
         chunk_filter: Callable[[int], bool] | None = None,
         shard_rank: int | None = None,
         shard_size: int | None = None,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> Iterable[tuple[int, int, str, BlockHash | str, int]]:
         """Yield cache key strings and resolved block ids without PoolKey allocation."""
         prefix = self._get_key_prefix(kv_cache_group_id)
@@ -542,6 +554,7 @@ class ChunkedTokenDatabase:
             chunk_filter=chunk_filter,
             shard_rank=shard_rank,
             shard_size=shard_size,
+            grouped_hash_cache=grouped_hash_cache,
         ):
             assert block_id is not None
             yield start, end, prefix + block_hash_to_str(hash_val), hash_val, block_id
@@ -585,11 +598,48 @@ def normalize_block_ids_by_group(block_ids: tuple[list[int], ...] | list[int] | 
     raise ValueError(f"Unsupported block_ids type {type(block_ids)}")
 
 
+class RequestGroupedBlockHashCache:
+    """Cache grouped block hashes for one request."""
+
+    def __init__(
+        self,
+        block_hashes: Sequence[BlockHash | str],
+        hash_block_size: int,
+    ) -> None:
+        self._block_hashes = block_hashes
+        self._hash_block_size = hash_block_size
+        self._grouped_hashes: dict[int, Sequence[BlockHash | str]] = {}
+
+    def get(
+        self,
+        block_hashes: Sequence[BlockHash | str],
+        group_block_size: int,
+        hash_block_size: int,
+    ) -> Sequence[BlockHash | str]:
+        if block_hashes is not self._block_hashes or hash_block_size != self._hash_block_size:
+            raise ValueError("RequestGroupedBlockHashCache cannot be shared across requests")
+        if group_block_size == hash_block_size:
+            return block_hashes
+        assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
+        grouped_hashes = self._grouped_hashes.get(group_block_size)
+        if grouped_hashes is None:
+            grouped_hashes = _LazyGroupedBlockHashList(
+                block_hashes,
+                group_block_size // hash_block_size,
+                memoize=True,
+            )
+            self._grouped_hashes[group_block_size] = grouped_hashes
+        return grouped_hashes
+
+
 def get_block_hashes(
     block_hashes: BlockHashList | list[str],
     group_block_size: int,
     hash_block_size: int,
+    grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
 ) -> Sequence[BlockHash | str]:
+    if grouped_hash_cache is not None:
+        return grouped_hash_cache.get(block_hashes, group_block_size, hash_block_size)
     if group_block_size == hash_block_size:
         return block_hashes
     assert group_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
@@ -597,10 +647,16 @@ def get_block_hashes(
 
 
 class _LazyGroupedBlockHashList(Sequence[BlockHash]):
-    def __init__(self, block_hashes: Sequence[BlockHash | str], scale_factor: int) -> None:
+    def __init__(
+        self,
+        block_hashes: Sequence[BlockHash | str],
+        scale_factor: int,
+        memoize: bool = False,
+    ) -> None:
         self._block_hashes = block_hashes
         self._scale_factor = scale_factor
         self._length = len(block_hashes) // scale_factor
+        self._cache: dict[int, BlockHash] | None = {} if memoize else None
 
     def __len__(self) -> int:
         return self._length
@@ -612,8 +668,13 @@ class _LazyGroupedBlockHashList(Sequence[BlockHash]):
             index += self._length
         if index < 0 or index >= self._length:
             raise IndexError(index)
+        if self._cache is not None and index in self._cache:
+            return self._cache[index]
         start = index * self._scale_factor
-        return _rehash_block_hash_group(self._block_hashes[start : start + self._scale_factor])
+        grouped_hash = _rehash_block_hash_group(self._block_hashes[start : start + self._scale_factor])
+        if self._cache is not None:
+            self._cache[index] = grouped_hash
+        return grouped_hash
 
 
 def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -16,7 +16,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
-    RequestGroupedBlockHashCache,
+    GroupedBlockHashCache,
     block_hash_to_bytes,
     get_block_hashes,
 )
@@ -144,7 +144,7 @@ class AscendStoreCoordinator:
         cached_block_pool: ExternalCachedBlockPool,
         *,
         apply_eagle: bool = True,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> tuple[tuple[list[bool], ...], int]:
         blocks_per_group, hit_length = self._find_hit_blocks(
             block_hashes,
@@ -160,7 +160,7 @@ class AscendStoreCoordinator:
         self,
         block_hashes: list[BlockHash],
         token_len: int,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> tuple[list[bool], ...]:
         masks, _ = self.find_longest_cache_hit(
             block_hashes,
@@ -227,7 +227,7 @@ class AscendStoreCoordinator:
         self,
         block_hashes: list[BlockHash],
         spec: KVCacheSpec,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> BlockHashList:
         if spec.block_size == self.hash_block_size:
             return block_hashes
@@ -248,7 +248,7 @@ class AscendStoreCoordinator:
         cached_block_pool: ExternalCachedBlockPool,
         *,
         apply_eagle: bool = True,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache | None = None,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         eagle_indices = self.eagle_attn_group_indices if apply_eagle else set()
         if len(self.attention_groups) == 1:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -16,6 +16,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    RequestGroupedBlockHashCache,
     block_hash_to_bytes,
     get_block_hashes,
 )
@@ -143,12 +144,14 @@ class AscendStoreCoordinator:
         cached_block_pool: ExternalCachedBlockPool,
         *,
         apply_eagle: bool = True,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> tuple[tuple[list[bool], ...], int]:
         blocks_per_group, hit_length = self._find_hit_blocks(
             block_hashes,
             max_length,
             cached_block_pool,
             apply_eagle=apply_eagle,
+            grouped_hash_cache=grouped_hash_cache,
         )
         masks = tuple([block is not cached_block_pool.null_block for block in blocks] for blocks in blocks_per_group)
         return masks, hit_length
@@ -157,12 +160,14 @@ class AscendStoreCoordinator:
         self,
         block_hashes: list[BlockHash],
         token_len: int,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> tuple[list[bool], ...]:
         masks, _ = self.find_longest_cache_hit(
             block_hashes,
             token_len,
             ExternalCachedBlockPool(),
             apply_eagle=False,
+            grouped_hash_cache=grouped_hash_cache,
         )
         return tuple(
             [True] * _num_chunks(token_len, self.group_effective_block_sizes[group_id])
@@ -218,10 +223,23 @@ class AscendStoreCoordinator:
                 assert len(mask) == num_chunks
         return tuple(None if mask is None or all(mask) else mask for _, mask in masks)
 
-    def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: KVCacheSpec) -> BlockHashList:
+    def block_hashes_for_spec(
+        self,
+        block_hashes: list[BlockHash],
+        spec: KVCacheSpec,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+    ) -> BlockHashList:
         if spec.block_size == self.hash_block_size:
             return block_hashes
-        return cast(BlockHashList, get_block_hashes(block_hashes, spec.block_size, self.hash_block_size))
+        return cast(
+            BlockHashList,
+            get_block_hashes(
+                block_hashes,
+                spec.block_size,
+                self.hash_block_size,
+                grouped_hash_cache=grouped_hash_cache,
+            ),
+        )
 
     def _find_hit_blocks(
         self,
@@ -230,11 +248,12 @@ class AscendStoreCoordinator:
         cached_block_pool: ExternalCachedBlockPool,
         *,
         apply_eagle: bool = True,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         eagle_indices = self.eagle_attn_group_indices if apply_eagle else set()
         if len(self.attention_groups) == 1:
             spec, group_ids, manager_cls = self.attention_groups[0]
-            hashes = self.block_hashes_for_spec(block_hashes, spec)
+            hashes = self.block_hashes_for_spec(block_hashes, spec, grouped_hash_cache)
             hit_blocks = _find_longest_cache_hit(
                 manager_cls,
                 block_hashes=hashes,
@@ -270,7 +289,7 @@ class AscendStoreCoordinator:
                 max_group_length = curr_hit_length
                 if drop_eagle_block:
                     max_group_length = min(curr_hit_length + spec.block_size, max_length)
-                hashes = self.block_hashes_for_spec(block_hashes, spec)
+                hashes = self.block_hashes_for_spec(block_hashes, spec, grouped_hash_cache)
                 hit_blocks = _find_longest_cache_hit(
                     manager_cls,
                     block_hashes=hashes,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -25,6 +25,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
+    RequestGroupedBlockHashCache,
     SharedBlockData,
 )
 # isort: on
@@ -871,7 +872,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         key_list = []
         block_id_list: list[int] = []
         group_ids = req_meta.kv_cache_group_ids or [0]
-        load_masks = self.token_database.load_mask(req_meta.block_hashes, token_len)
+        grouped_hash_cache = RequestGroupedBlockHashCache(
+            req_meta.block_hashes,
+            self.token_database.hash_block_size,
+        )
+        load_masks = self.token_database.load_mask(
+            req_meta.block_hashes,
+            token_len,
+            grouped_hash_cache=grouped_hash_cache,
+        )
         for group_id in group_ids:
             block_ids = req_meta.block_ids_by_group[group_id]
             group_block_size = self._get_block_size(group_id)
@@ -892,6 +901,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 kv_cache_group_id=group_id,
                 skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
                 chunk_filter=chunk_filter,
+                grouped_hash_cache=grouped_hash_cache,
             ):
                 addr, size, block_id = self._prepare_value(
                     start,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -684,6 +684,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
         def should_skip(start: int, end: int) -> bool:
             return skip_end > skip_start and start >= skip_start and end <= skip_end
 
+        grouped_hash_cache = RequestGroupedBlockHashCache(
+            req_meta.block_hashes,
+            self.token_database.hash_block_size,
+        )
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
             cache_family = self.token_database.group_cache_families["kv"].get(group_id)
@@ -740,6 +744,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 chunk_filter=chunk_filter,
                 shard_rank=self.tp_rank % self.put_step if pre_shard else None,
                 shard_size=self.put_step if pre_shard else None,
+                grouped_hash_cache=grouped_hash_cache,
             )
             for start, end, key, _block_hash, block_id in iterator:
                 starts.append(start)
@@ -784,6 +789,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         token_len,
                         req_meta.block_hashes,
                         kv_cache_group_id=group_id,
+                        grouped_hash_cache=grouped_hash_cache,
                     )
                 ]
                 if self.enable_kv_event

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -18,6 +18,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend im
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
+    GroupedBlockHashCache,
     infer_cache_family_ratio,
     LayerBatchReqMeta,
     LayerBlockRange,
@@ -683,7 +684,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         def should_skip(start: int, end: int) -> bool:
             return skip_end > skip_start and start >= skip_start and end <= skip_end
 
-        grouped_hash_cache = {}
+        grouped_hash_cache: GroupedBlockHashCache = {}
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
             cache_family = self.token_database.group_cache_families["kv"].get(group_id)
@@ -874,7 +875,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         key_list = []
         block_id_list: list[int] = []
         group_ids = req_meta.kv_cache_group_ids or [0]
-        grouped_hash_cache = {}
+        grouped_hash_cache: GroupedBlockHashCache = {}
         load_masks = self.token_database.load_mask(
             req_meta.block_hashes,
             token_len,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -25,7 +25,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
-    RequestGroupedBlockHashCache,
     SharedBlockData,
 )
 # isort: on
@@ -684,10 +683,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         def should_skip(start: int, end: int) -> bool:
             return skip_end > skip_start and start >= skip_start and end <= skip_end
 
-        grouped_hash_cache = RequestGroupedBlockHashCache(
-            req_meta.block_hashes,
-            self.token_database.hash_block_size,
-        )
+        grouped_hash_cache = {}
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
             cache_family = self.token_database.group_cache_families["kv"].get(group_id)
@@ -878,10 +874,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         key_list = []
         block_id_list: list[int] = []
         group_ids = req_meta.kv_cache_group_ids or [0]
-        grouped_hash_cache = RequestGroupedBlockHashCache(
-            req_meta.block_hashes,
-            self.token_database.hash_block_size,
-        )
+        grouped_hash_cache = {}
         load_masks = self.token_database.load_mask(
             req_meta.block_hashes,
             token_len,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -792,7 +792,7 @@ class KVPoolWorker:
             size_list = []
             key_list = []
             block_id_list: list[int] = []
-            grouped_hash_cache = {}
+            grouped_hash_cache: GroupedBlockHashCache = {}
             load_masks = self.token_database.load_mask(
                 request.block_hashes,
                 token_len,
@@ -1675,7 +1675,7 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            grouped_hash_cache = {}
+            grouped_hash_cache: GroupedBlockHashCache = {}
             coordinator_hit = self._lookup_with_coordinator(
                 token_len,
                 block_hashes,
@@ -1884,7 +1884,7 @@ class KVPoolWorker:
             hits: list[list[int]] = []
             max_hit_position = self.max_model_len
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            grouped_hash_cache = {}
+            grouped_hash_cache: GroupedBlockHashCache = {}
             coordinator_hit = self._lookup_with_coordinator(
                 token_len,
                 block_hashes,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -38,6 +38,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
+    RequestGroupedBlockHashCache,
     block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
@@ -791,7 +792,15 @@ class KVPoolWorker:
             size_list = []
             key_list = []
             block_id_list: list[int] = []
-            load_masks = self.token_database.load_mask(request.block_hashes, token_len)
+            grouped_hash_cache = RequestGroupedBlockHashCache(
+                request.block_hashes,
+                self.token_database.hash_block_size,
+            )
+            load_masks = self.token_database.load_mask(
+                request.block_hashes,
+                token_len,
+                grouped_hash_cache=grouped_hash_cache,
+            )
             for group_id in load_group_ids:
                 if group_id >= len(request.block_ids_by_group):
                     continue
@@ -817,6 +826,7 @@ class KVPoolWorker:
                     kv_cache_group_id=group_id,
                     skip_null_blocks=skip_null,
                     chunk_filter=chunk_filter,
+                    grouped_hash_cache=grouped_hash_cache,
                 ):
                     addr, size, block_id = self.token_database.prepare_value(
                         start,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -32,13 +32,13 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
     ChunkedTokenDatabase,
+    GroupedBlockHashCache,
     KeyMetadata,
     LayerBlockRange,
     LayerLoadTask,
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
-    RequestGroupedBlockHashCache,
     block_hash_to_bytes,
     block_hash_to_str,
     get_block_hashes,
@@ -792,10 +792,7 @@ class KVPoolWorker:
             size_list = []
             key_list = []
             block_id_list: list[int] = []
-            grouped_hash_cache = RequestGroupedBlockHashCache(
-                request.block_hashes,
-                self.token_database.hash_block_size,
-            )
+            grouped_hash_cache = {}
             load_masks = self.token_database.load_mask(
                 request.block_hashes,
                 token_len,
@@ -1636,7 +1633,7 @@ class KVPoolWorker:
         block_hashes: list[BlockHash],
         group_id: int,
         use_layerwise: bool,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
+        grouped_hash_cache: GroupedBlockHashCache,
     ) -> tuple[list[str], list[int], list[int]]:
         keys: list[str] = []
         starts: list[int] = []
@@ -1678,10 +1675,7 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            grouped_hash_cache = RequestGroupedBlockHashCache(
-                block_hashes,
-                self.token_database.hash_block_size,
-            )
+            grouped_hash_cache = {}
             coordinator_hit = self._lookup_with_coordinator(
                 token_len,
                 block_hashes,
@@ -1781,19 +1775,13 @@ class KVPoolWorker:
         kv_cache_group_ids: list[int],
         use_layerwise: bool,
         include_all_ranks: bool,
+        grouped_hash_cache: GroupedBlockHashCache,
         hbm_hit_tokens: int = 0,
-        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> int | None:
         if self.cache_coordinator is None or use_layerwise:
             return None
         if sorted(kv_cache_group_ids) != list(range(self.num_kv_cache_groups)):
             return None
-        if grouped_hash_cache is None:
-            grouped_hash_cache = RequestGroupedBlockHashCache(
-                block_hashes,
-                self.token_database.hash_block_size,
-            )
-
         exists: set[tuple[int, bytes]] = set()
         aligned_len = (
             (token_len + self.cache_coordinator.lcm_block_size - 1)
@@ -1896,10 +1884,7 @@ class KVPoolWorker:
             hits: list[list[int]] = []
             max_hit_position = self.max_model_len
             kv_cache_group_ids = kv_cache_group_ids or [0]
-            grouped_hash_cache = RequestGroupedBlockHashCache(
-                block_hashes,
-                self.token_database.hash_block_size,
-            )
+            grouped_hash_cache = {}
             coordinator_hit = self._lookup_with_coordinator(
                 token_len,
                 block_hashes,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1636,20 +1636,27 @@ class KVPoolWorker:
         block_hashes: list[BlockHash],
         group_id: int,
         use_layerwise: bool,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> tuple[list[str], list[int], list[int]]:
         keys: list[str] = []
         starts: list[int] = []
         ends: list[int] = []
         if use_layerwise:
             for start, end, pool_key in self.token_database.process_tokens(
-                token_len, block_hashes, kv_cache_group_id=group_id
+                token_len,
+                block_hashes,
+                kv_cache_group_id=group_id,
+                grouped_hash_cache=grouped_hash_cache,
             ):
                 keys.extend(item.to_string() for item in pool_key.split_layers(self.num_layers))
                 starts.append(start)
                 ends.append(end)
         else:
             for start, end, key_string, _ in self.token_database.process_token_key_strings(
-                token_len, block_hashes, kv_cache_group_id=group_id
+                token_len,
+                block_hashes,
+                kv_cache_group_id=group_id,
+                grouped_hash_cache=grouped_hash_cache,
             ):
                 keys.append(key_string)
                 starts.append(start)
@@ -1671,17 +1678,28 @@ class KVPoolWorker:
         try:
             hits = []
             kv_cache_group_ids = kv_cache_group_ids or [0]
+            grouped_hash_cache = RequestGroupedBlockHashCache(
+                block_hashes,
+                self.token_database.hash_block_size,
+            )
             coordinator_hit = self._lookup_with_coordinator(
                 token_len,
                 block_hashes,
                 kv_cache_group_ids,
                 use_layerwise,
                 include_all_ranks=False,
+                grouped_hash_cache=grouped_hash_cache,
             )
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
-                keys, starts, ends = self._build_lookup_keys(token_len, block_hashes, group_id, use_layerwise)
+                keys, starts, ends = self._build_lookup_keys(
+                    token_len,
+                    block_hashes,
+                    group_id,
+                    use_layerwise,
+                    grouped_hash_cache,
+                )
 
                 if not keys:
                     hits.append(0)
@@ -1764,11 +1782,17 @@ class KVPoolWorker:
         use_layerwise: bool,
         include_all_ranks: bool,
         hbm_hit_tokens: int = 0,
+        grouped_hash_cache: RequestGroupedBlockHashCache | None = None,
     ) -> int | None:
         if self.cache_coordinator is None or use_layerwise:
             return None
         if sorted(kv_cache_group_ids) != list(range(self.num_kv_cache_groups)):
             return None
+        if grouped_hash_cache is None:
+            grouped_hash_cache = RequestGroupedBlockHashCache(
+                block_hashes,
+                self.token_database.hash_block_size,
+            )
 
         exists: set[tuple[int, bytes]] = set()
         aligned_len = (
@@ -1787,7 +1811,10 @@ class KVPoolWorker:
             effective_block_size = get_cache_family_granularity(base_block_size, cache_family)
             if hbm_hit_tokens:
                 grouped_hashes = get_block_hashes(
-                    block_hashes, effective_block_size, self.token_database.hash_block_size
+                    block_hashes,
+                    effective_block_size,
+                    self.token_database.hash_block_size,
+                    grouped_hash_cache=grouped_hash_cache,
                 )
                 exists.update(
                     (group_id, block_hash_to_bytes(chunk_hash))
@@ -1810,6 +1837,7 @@ class KVPoolWorker:
                 mask_num=lookup_start,
                 kv_cache_group_id=group_id,
                 chunk_filter=chunk_filter,
+                grouped_hash_cache=grouped_hash_cache,
             ):
                 variants = self._expand_lookup_key_variants(key_string, group_id, include_all_ranks)
                 keys.extend(variants)
@@ -1841,6 +1869,7 @@ class KVPoolWorker:
             token_len,
             ExternalCachedBlockPool(exists),
             apply_eagle=False,
+            grouped_hash_cache=grouped_hash_cache,
         )
         logger.debug(
             "KV pool coordinator lookup final token_len=%d groups=%s hit=%d",
@@ -1867,6 +1896,10 @@ class KVPoolWorker:
             hits: list[list[int]] = []
             max_hit_position = self.max_model_len
             kv_cache_group_ids = kv_cache_group_ids or [0]
+            grouped_hash_cache = RequestGroupedBlockHashCache(
+                block_hashes,
+                self.token_database.hash_block_size,
+            )
             coordinator_hit = self._lookup_with_coordinator(
                 token_len,
                 block_hashes,
@@ -1874,11 +1907,18 @@ class KVPoolWorker:
                 use_layerwise,
                 include_all_ranks=True,
                 hbm_hit_tokens=hbm_hit_tokens,
+                grouped_hash_cache=grouped_hash_cache,
             )
             if coordinator_hit is not None:
                 return coordinator_hit
             for group_id in kv_cache_group_ids:
-                keys, starts, ends = self._build_lookup_keys(token_len, block_hashes, group_id, use_layerwise)
+                keys, starts, ends = self._build_lookup_keys(
+                    token_len,
+                    block_hashes,
+                    group_id,
+                    use_layerwise,
+                    grouped_hash_cache,
+                )
 
                 if not keys:
                     return 0


### PR DESCRIPTION
### What this PR does / why we need it?

AscendStore repeatedly computes the same grouped block hashes within query, save, and load operations. Long contexts and compressed cache families make this repeated SHA256 aggregation host-bound.

This PR introduces request-scoped grouped block hash caches:

- Query reuses hashes across key construction, HBM-prefix processing, cache groups, and final hit resolution.
- Save reuses hashes across cache groups and KV event generation.
- Load reuses hashes between load-mask discovery and key construction.

Each operation creates and releases its own cache. No cache is shared across scheduler/worker processes, transfer threads, requests, or operation lifetimes. KV keys and transfer behavior remain unchanged.

Regression tests verify that query, save, and load compute each grouped hash once and reuse it on subsequent passes.

### Does this PR introduce _any_ user-facing change?

No. This only avoids repeated host-side hash computation.

### How was this patch tested?

- `python -m unittest tests.ut.distributed.ascend_store.test_config_data tests.ut.distributed.ascend_store.test_coordinator tests.ut.distributed.ascend_store.test_kv_transfer tests.ut.distributed.ascend_store.test_pool_worker.TestKVPoolWorkerHelpers tests.ut.distributed.ascend_store.test_pool_worker.TestKVPoolWorkerInit -q` (113 tests, 10 skipped)
- Targeted synchronous KV load and grouped-block-size worker tests (3 passed)
- Query, save, and load grouped-rehash reuse regression tests (3 passed)
- Repository pre-commit hooks

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
