### PR TITLE
[CI][Cherry-pick][releases/v0.24.0rc] Backport RoutedExperts MoE   layer detection and compressed tensors scheme fixes (#12495,   #12665)

### DIFF
--- a/tests/ut/quantization/test_compressed_tensors_config.py
+++ b/tests/ut/quantization/test_compressed_tensors_config.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
+import torch
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.linear import RowParallelLinear, UnquantizedLinearMethod
 
 from tests.ut.base import TestBase
@@ -91,6 +93,48 @@ class TestAscendCompressedTensorsConfigGetQuantMethod(TestBase):
         result = self.config.get_quant_method(layer, "lm_head")
         self.assertEqual(layer.ascend_quant_method, COMPRESSED_TENSORS_METHOD)
         self.assertTrue(isinstance(result, UnquantizedLinearMethod))
+
+    def test_adds_routed_experts_target_for_linear_scheme(self):
+        linear_scheme = self.config.target_scheme_map["Linear"]
+
+        self.config._add_fused_moe_to_target_scheme_map()
+
+        self.assertIs(self.config.target_scheme_map["RoutedExperts"], linear_scheme)
+
+    @patch("vllm_ascend.quantization.compressed_tensors_config.find_matched_target", return_value=None)
+    def test_get_scheme_dict_returns_none_for_unmatched_target(self, _mock_find_target):
+        layer = MagicMock(spec=Attention)
+
+        result = self.config.get_scheme_dict(layer, "model.layers.0.self_attn.attn")
+
+        self.assertIsNone(result)
+
+    @patch(
+        "vllm_ascend.quantization.compressed_tensors_config.find_matched_target",
+        return_value="Linear",
+    )
+    def test_get_scheme_dict_returns_none_for_none_scheme(self, _mock_find_target):
+        self.config.target_scheme_map["Linear"] = None
+        layer = MagicMock(spec=Attention)
+
+        result = self.config.get_scheme_dict(layer, "model.layers.0.self_attn.attn")
+
+        self.assertIsNone(result)
+
+    @patch("vllm_ascend.quantization.method_adapters.AscendFusedMoEMethod")
+    def test_get_routed_experts_quant_method(self, mock_method):
+        layer = RoutedExperts.__new__(RoutedExperts)
+        torch.nn.Module.__init__(layer)
+        layer.moe_config = MagicMock()
+        moe_scheme = MagicMock()
+
+        with patch.object(self.config, "_get_moe_scheme", return_value=moe_scheme):
+            result = self.config.get_quant_method(layer, "model.layers.0.mlp.experts")
+
+        self.assertIs(result, mock_method.return_value)
+        self.assertEqual(layer.ascend_quant_method, COMPRESSED_TENSORS_METHOD)
+        self.assertIs(layer.scheme, moe_scheme)
+        mock_method.assert_called_once_with(moe_scheme, layer.moe_config, None)
 
     def test_no_quant_method(self):
         layer = MagicMock(spec=Attention)

--- a/vllm_ascend/quantization/compressed_tensors_config.py
+++ b/vllm_ascend/quantization/compressed_tensors_config.py
@@ -22,7 +22,7 @@ from typing import Any, Optional, cast
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy, QuantizationType
 from vllm.logger import logger
-from vllm.model_executor.layers.fused_moe import MoERunner
+from vllm.model_executor.layers.fused_moe import MoERunner, RoutedExperts
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS, register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
@@ -39,7 +39,7 @@ from .methods import AscendLinearScheme, AscendMoEScheme
 
 
 def _is_fused_moe_layer(layer: torch.nn.Module) -> bool:
-    return isinstance(layer, MoERunner)
+    return isinstance(layer, (MoERunner, RoutedExperts))
 
 
 # Remove the original compressed_tensors method to replace with our implementation

--- a/vllm_ascend/quantization/compressed_tensors_config.py
+++ b/vllm_ascend/quantization/compressed_tensors_config.py
@@ -93,13 +93,13 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
     def _add_fused_moe_to_target_scheme_map(self):
         """
         Helper function to update target_scheme_map
-        since linear layers get fused into FusedMoE
+        since linear layers get fused into MoE modules
         targeting 'Linear' needs to also match
-        FusedMoE modules.
+        RoutedExperts modules.
         """
-        if "Linear" not in self.target_scheme_map or "FusedMoE" in self.target_scheme_map:
+        if "Linear" not in self.target_scheme_map or "RoutedExperts" in self.target_scheme_map:
             return
-        self.target_scheme_map["FusedMoE"] = self.target_scheme_map["Linear"]
+        self.target_scheme_map["RoutedExperts"] = self.target_scheme_map["Linear"]
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "AscendCompressedTensorsConfig":
@@ -292,7 +292,11 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
                 targets=self.target_scheme_map.keys(),
                 fused_mapping=self.packed_modules_mapping,
             )
+            if matched_target is None:
+                return None
             scheme_dict = self.target_scheme_map[matched_target]
+            if scheme_dict is None:
+                return None
             if scheme_dict.get("format") is None:
                 scheme_dict["format"] = self.quant_format
             return scheme_dict

--- a/vllm_ascend/quantization/fp8_config.py
+++ b/vllm_ascend/quantization/fp8_config.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, cast
 import torch
 from compressed_tensors.quantization import QuantizationArgs
 from vllm.logger import logger
-from vllm.model_executor.layers.fused_moe import MoERunner
+from vllm.model_executor.layers.fused_moe import MoERunner, RoutedExperts
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS, register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
@@ -14,7 +14,7 @@ from .methods import get_scheme_class
 
 
 def _is_fused_moe_layer(layer: torch.nn.Module) -> bool:
-    return isinstance(layer, MoERunner)
+    return isinstance(layer, (MoERunner, RoutedExperts))
 
 
 QUANTIZATION_SCHEME_MAP_TYPE = dict[str, dict[str, QuantizationArgs] | None]


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the Ascend quantization configurations (`compressed_tensors_config.py` and `fp8_config.py`) to support `RoutedExperts` alongside `MoERunner` for fused MoE layers. It maps `RoutedExperts` to the `Linear` target scheme and handles potential `None` values returned during target matching.

Feedback: A potential `TypeError` was identified in `_add_fused_moe_to_target_scheme_map` if `self.target_scheme_map` is `None` or empty. A guard condition has been suggested to prevent potential runtime crashes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit tests were added in `tests/ut/quantization/test_compressed_tensors_config.py` to verify the mapping of `RoutedExperts` and handling of unmatched targets or `None` schemes.


- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
