### PR TITLE
[BugFix][MRV2]Fix synchronous H2D in UvaBufferWrapper fallback path

### DIFF
--- a/vllm_ascend/patch/worker/patch_v2/patch_uva.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_uva.py
@@ -150,11 +150,15 @@ class UvaBufferWrapper:
     def uva(self):
         """Get the device data of the buffer."""
         if not is_uva_available() and self._modified_indices:
-            # Sort for better memory access locality
-            dirty_rows = sorted(self._modified_indices)
-            # can't use copy_ method, because copy_ for index tensor
-            #  will malloc new memory.
-            self._uva[dirty_rows] = self._cpu[dirty_rows].to(device="npu", non_blocking=True)
+            # copy_to_uva always writes a contiguous prefix dst[:n] = x,
+            # so dirty rows are always [0..n-1].  Use a contiguous slice
+            # copy_ (instead of indexed assignment) to:
+            #  1. keep the CPU source pinned (slice is a view, not a copy),
+            #     so non_blocking is not silently degraded.
+            #  2. avoid the intermediate tensor from .to() and the implicit
+            #     stream sync between .to() and __setitem__ on NPU.
+            n = len(self._modified_indices)
+            self._uva[:n].copy_(self._cpu[:n], non_blocking=True)
             self._modified_indices.clear()
         return self._uva
 

--- a/vllm_ascend/patch/worker/patch_v2/patch_uva.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_uva.py
@@ -158,17 +158,13 @@ class UvaBufferWrapper:
                 # dst[:n] = x.  Contiguous slice copy_ keeps the CPU source
                 # pinned and enables true async DMA without an intermediate
                 # tensor or stream sync.
-                self._uva[:n_dirty].copy_(
-                    self._cpu[:n_dirty], non_blocking=True
-                )
+                self._uva[:n_dirty].copy_(self._cpu[:n_dirty], non_blocking=True)
             else:
                 # Sparse modification pattern — fall back to indexed copy.
                 # Explicitly re-pin the CPU source so that non_blocking is
                 # not silently degraded.
                 src = self._cpu[dirty_rows].pin_memory()
-                self._uva[dirty_rows] = src.to(
-                    device="npu", non_blocking=True
-                )
+                self._uva[dirty_rows] = src.to(device="npu", non_blocking=True)
             self._modified_indices.clear()
         return self._uva
 

--- a/vllm_ascend/patch/worker/patch_v2/patch_uva.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_uva.py
@@ -150,15 +150,25 @@ class UvaBufferWrapper:
     def uva(self):
         """Get the device data of the buffer."""
         if not is_uva_available() and self._modified_indices:
-            # copy_to_uva always writes a contiguous prefix dst[:n] = x,
-            # so dirty rows are always [0..n-1].  Use a contiguous slice
-            # copy_ (instead of indexed assignment) to:
-            #  1. keep the CPU source pinned (slice is a view, not a copy),
-            #     so non_blocking is not silently degraded.
-            #  2. avoid the intermediate tensor from .to() and the implicit
-            #     stream sync between .to() and __setitem__ on NPU.
-            n = len(self._modified_indices)
-            self._uva[:n].copy_(self._cpu[:n], non_blocking=True)
+            dirty_rows = sorted(self._modified_indices)
+            n_dirty = len(dirty_rows)
+            if dirty_rows[0] == 0 and dirty_rows[-1] == n_dirty - 1:
+                # Common path: dirty rows are a contiguous prefix [0..n-1].
+                # This is always the case when copy_to_uva writes via
+                # dst[:n] = x.  Contiguous slice copy_ keeps the CPU source
+                # pinned and enables true async DMA without an intermediate
+                # tensor or stream sync.
+                self._uva[:n_dirty].copy_(
+                    self._cpu[:n_dirty], non_blocking=True
+                )
+            else:
+                # Sparse modification pattern — fall back to indexed copy.
+                # Explicitly re-pin the CPU source so that non_blocking is
+                # not silently degraded.
+                src = self._cpu[dirty_rows].pin_memory()
+                self._uva[dirty_rows] = src.to(
+                    device="npu", non_blocking=True
+                )
             self._modified_indices.clear()
         return self._uva
 


### PR DESCRIPTION
### What this PR does / why we need it?
When running MRV2 on NPU, the H2D copy in `UvaBufferWrapper.uva` fallback path is not truly asynchronous, causing CPU bubbles.

**Root cause**: The original code uses advanced indexing `self._cpu[dirty_rows]`, which creates an unpinned copy. This causes `.to(device="npu", non_blocking=True)` to silently degrade to a synchronous copy in PyTorch.

**Fix**: Since `copy_to_uva` always writes a contiguous prefix via `dst[:n] = x`, `dirty_rows` is always `[0..n-1]`. Replace the indexed assignment with a contiguous slice `copy_`:

```python
# Before
self._uva[dirty_rows] = self._cpu[dirty_rows].to(device="npu", non_blocking=True)

# After
n = len(self._modified_indices)
self._uva[:n].copy_(self._cpu[:n], non_blocking=True)
```
This resolves three issues:

Slice indexing preserves the pinned property of the CPU source, so non_blocking takes effect.
Avoids the intermediate NPU tensor allocation from .to().
Eliminates the implicit stream sync between .to() and __setitem__ on NPU.

### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?

NPU profiling: synchronous H2D copy and NPU bubble observed before the fix; async DMA and NPU bubble eliminated after the fix.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
