### PR TITLE
[BugFix][EC Connector] Fix EC Connector of ec_both roles (#13183)

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1788,7 +1788,7 @@ class NPUModelRunner(GPUModelRunner):
                     scheduler_output
                 )
 
-                if has_ec_transfer() and get_ec_transfer().is_producer:
+                if has_ec_transfer() and not get_ec_transfer().is_consumer:
                     self._start_dump_data()
                     with self.maybe_get_ec_connector_output(
                         scheduler_output,
@@ -4522,7 +4522,7 @@ class NPUModelRunner(GPUModelRunner):
             format. Layers that do not need KV cache are not included.
         """
 
-        if has_ec_transfer() and get_ec_transfer().is_producer:
+        if has_ec_transfer() and not get_ec_transfer().is_consumer:
             return {}
 
         kv_cache_spec: dict[str, list[KVCacheSpec]] = defaultdict(list)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR will cause startup failure when launching the service with the argument --ec-transfer-config '{ "ec_connector": "ECExampleConnector", "ec_role": "ec_both" }'. The vLLM community has already fixed this issue via PR https://github.com/vllm-project/vllm/pull/34783. This pull request ports the relevant fixes for adaptation.

This PR:

- Revised the overridden execute_model and get_kv_cache_spec methods in /vllm_ascend/worker/model_runner_v1.py. We align the processing logic under the ec_both role scenario with the official implementation from the upstream vLLM community.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- All repository pre-commit hooks passed, including ruff, formatting, spelling, custom Python checks, and commit sign-off validation.
- Python syntax compilation passed for the modified backend.
- Targeted checks passed for protocol whitespace, comments, missing environment variables, missing-file error propagation

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
