### PR TITLE
[Community][Misc] Refresh maintainer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@
 # /vllm_ascend/core
 /vllm_ascend/device @weijinqian0 @zzzzwwjj
 /vllm_ascend/device_allocator @weijinqian0
-/vllm_ascend/distributed @MengqingCao @LCAIZJ
+/vllm_ascend/distributed @LCAIZJ
 # /vllm_ascend/eplb
 /vllm_ascend/kv_offload @nalinaly
 /vllm_ascend/lora @paulyu12

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -5,20 +5,31 @@
 | Name | GitHub ID | Date |
 |:-----------:|:-----:|:-----:|
 | Xiyuan Wang | [@wangxiyuan](https://github.com/wangxiyuan) | 2025/01 |
-| Yikun Jiang| [@Yikun](https://github.com/Yikun) | 2025/02 |
-| Yi Gan| [@ganyi1996ppo](https://github.com/ganyi1996ppo) | 2025/02 |
-| Shoujian Zheng| [@jianzs](https://github.com/jianzs) | 2025/06 |
+| Yikun Jiang | [@Yikun](https://github.com/Yikun) | 2025/02 |
+| Shoujian Zheng | [@jianzs](https://github.com/jianzs) | 2025/06 |
 | Wengang Chen | [@ApsarasX](https://github.com/ApsarasX) | 2025/08 |
-| Mengqing Cao | [@MengqingCao](https://github.com/MengqingCao) | 2025/08 |
-| Peng Yu| [@paulyu12](https://github.com/paulyu12) | 2025/10 |
-| Yizhou Liu| [@yiz-liu](https://github.com/yiz-liu) | 2025/10 |
+| Peng Yu | [@paulyu12](https://github.com/paulyu12) | 2025/10 |
+| Yizhou Liu | [@yiz-liu](https://github.com/yiz-liu) | 2025/10 |
 | Jinqian Wei | [@weijinqian0](https://github.com/weijinqian0) | 2025/10 |
 | Chuanyu Qin | [@nalinaly](https://github.com/nalinaly) | 2025/10 |
-| Jie Wen| [@zzzzwwjj](https://github.com/zzzzwwjj) | 2025/12 |
-| Chao Lei| [@LCAIZJ](https://github.com/LCAIZJ) | 2025/12 |
-| JiaXu Liu| [@realliujiaxu](https://github.com/realliujiaxu) | 2025/12 |
-| HeXiang Wang| [@whx-sjtu](https://github.com/whx-sjtu) | 2026/01 |
-| LinFeng Yuan| [@linfeng-yuan](https://github.com/linfeng-yuan) | 2026/05 |
+| Jie Wen | [@zzzzwwjj](https://github.com/zzzzwwjj) | 2025/12 |
+| Chao Lei | [@LCAIZJ](https://github.com/LCAIZJ) | 2025/12 |
+| JiaXu Liu | [@realliujiaxu](https://github.com/realliujiaxu) | 2025/12 |
+| LinFeng Yuan | [@linfeng-yuan](https://github.com/linfeng-yuan) | 2026/05 |
+| Jun Han | [@ningjingbengxiaohai](https://github.com/ningjingbengxiaohai) | 2026/06 |
+| Shaoxu Cheng | [@Tflowers-0129](https://github.com/Tflowers-0129) | 2026/07 |
+| Kunpeng Wang | [@kunpengW-code](https://github.com/kunpengW-code) | 2026/07 |
+| Tian Zeng | [@ZT-AIA](https://github.com/ZT-AIA) | 2026/07 |
+| Guihua Wei | [@weiguihua2](https://github.com/weiguihua2) | 2026/07 |
+| Kai Xiong | [@HF-001](https://github.com/HF-001) | 2026/07 |
+
+## Emeritus Committers
+
+| Name | GitHub ID | Date |
+|:-----------:|:-----:|:-----:|
+| Yi Gan | [@ganyi1996ppo](https://github.com/ganyi1996ppo) | 2026/07 |
+| HeXiang Wang | [@whx-sjtu](https://github.com/whx-sjtu) | 2026/07 |
+| Mengqing Cao | [@MengqingCao](https://github.com/MengqingCao) | 2026/07 |
 
 ## Contributors
 <!-- last_commit: edcae83da32af8e1f1b7b97c7e19e8114e0535a5 -->

--- a/docs/source/community/governance.md
+++ b/docs/source/community/governance.md
@@ -49,3 +49,7 @@ Maintainers will be granted write access to the [vllm-project/vllm-ascend](https
 
 - Nomination: Anyone can nominate a candidate to become a maintainer, including self-nominations. All existing maintainers are responsible for reviewing and evaluating each nomination. The nominator should provide relevant information about the nominee's qualifications—such as review quality, quality contribution, and community involvement—among other strengths.
 - Removal: Anyone may nominate an individual for removal from the maintainer role, including self-nominations. All current maintainers are responsible for reviewing and evaluating such nominations. The nominator should provide relevant information about the nominee—such as prolonged inactivity, misalignment with the project's overall direction, or other factors that may render them unsuitable for the maintainer position.
+
+### Maintainer Emeritus
+
+When a maintainer is no longer able to actively maintain vLLM Ascend due to job changes, personal reasons, voluntary resignation, prolonged inactivity, or any other active or passive factors, they may retire and be moved to the **emeritus** list. Emeritus maintainers retain their historical recognition and maintainer permissions, and are always welcome to return to active contribution at any time—no re-confirmation needed. The transition to emeritus status can be initiated by the maintainer themselves (self-nomination) or by any other maintainer, and is confirmed by a simple majority vote among active maintainers.


### PR DESCRIPTION
docs: add maintainer emeritus mechanism and retire ganyi1996ppo, whx-sjtu, MengqingCao

- Add Maintainer Emeritus section in governance.md describing retirement process, retained permissions, and welcome-back policy

- Move ganyi1996ppo, whx-sjtu, MengqingCao from active Committers to Emeritus Committers in contributors.md

---

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
