### PR TITLE
Support 512-token prefix cache via partial capability of C128 cache.

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -101,6 +101,19 @@
 # This will return a JSON object with the adding or removing info
 # and the current prefiller and decoder instances.
 #
+# Step 6: Dump Requests (Optional)
+# --------------------------------
+# Start writing incoming completion requests to the configured JSONL file:
+#
+#   curl -X POST http://localhost:9000/start_dump_req
+#
+# Stop writing requests:
+#
+#   curl -X POST http://localhost:9000/stop_dump_req
+#
+# Use --request-dump-file to choose the output file. Existing content is
+# preserved when request dumping is restarted.
+#
 # When adding instances, if the instances are not started,
 # the proxy will wait and try until the instances to be started
 # or exceeding the number of attempts
@@ -245,6 +258,10 @@ class SharedProxyScheduler:
     def __init__(self, prefiller_instances, decoder_instances):
         self._lock = threading.RLock()
         self.request_num = 0
+        self._request_dump_enabled = False
+        self._request_dump_file: str | None = None
+        self._request_dump_handle = None
+        self._dumped_request_num = 0
         self.waiting_nodes: dict[str, tuple[str, tuple[str, int], int]] = {}
         self._pools: dict[ServerRole, RolePools] = {
             ServerRole.PREFILL: RolePools(),
@@ -347,7 +364,64 @@ class SharedProxyScheduler:
                 "prefill_instances": len(self.prefillers),
                 "decode_instances": len(self.decoders),
                 "request_num": self.request_num,
+                "request_dump_enabled": self._request_dump_enabled,
             }
+
+    def start_request_dump(self, output_file: str) -> dict[str, Any]:
+        with self._lock:
+            if self._request_dump_enabled:
+                return {
+                    "status": "already_started",
+                    "output_file": self._request_dump_file,
+                    "dumped_request_num": self._dumped_request_num,
+                }
+
+            dump_path = Path(output_file).expanduser().resolve()
+            dump_path.parent.mkdir(parents=True, exist_ok=True)
+            if self._request_dump_handle is not None:
+                self._request_dump_handle.close()
+            self._request_dump_handle = dump_path.open("a", encoding="utf-8")
+            self._request_dump_file = str(dump_path)
+            self._dumped_request_num = 0
+            self._request_dump_enabled = True
+            logger.info("Started dumping requests to %s.", dump_path)
+            return {
+                "status": "started",
+                "output_file": self._request_dump_file,
+                "dumped_request_num": self._dumped_request_num,
+            }
+
+    def stop_request_dump(self) -> dict[str, Any]:
+        with self._lock:
+            status = "stopped" if self._request_dump_enabled else "already_stopped"
+            self._request_dump_enabled = False
+            if self._request_dump_handle is not None:
+                self._request_dump_handle.close()
+                self._request_dump_handle = None
+            logger.info("Stopped dumping requests to %s.", self._request_dump_file)
+            return {
+                "status": status,
+                "output_file": self._request_dump_file,
+                "dumped_request_num": self._dumped_request_num,
+            }
+
+    def dump_request(self, endpoint: str, request_data: Any) -> bool:
+        with self._lock:
+            if not self._request_dump_enabled or self._request_dump_handle is None:
+                return False
+            record = {
+                "timestamp": time.time(),
+                "endpoint": endpoint,
+                "request": request_data,
+            }
+            try:
+                self._request_dump_handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+                self._request_dump_handle.flush()
+                self._dumped_request_num += 1
+            except Exception as e:
+                logger.error("Failed to write request dump: %s", e)
+                return False
+            return True
 
     def _pick_server(
         self,
@@ -582,12 +656,10 @@ class NodeListener:
             for key, (instance_type, server, retries) in list(self.scheduler.get_waiting_nodes().items()):
                 host, port = server
                 is_valid = asyncio.run(self.check_instance_status(host, port))
-                print(f"Checking instance {key}...")
                 retries += 1
                 if is_valid:
                     self.scheduler.activate_waiting_instance(ServerRole(instance_type), host, port)
                 elif retries >= args.max_waiting_retries:
-                    print(f"Instance {key} was not added to the proxy.")
                     self.scheduler.drop_waiting_instance(key)
                 else:
                     self.scheduler.mark_waiting_retry(key, retries)
@@ -672,6 +744,12 @@ def parse_args() -> argparse.Namespace:
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Log level for the proxy server.",
+    )
+    parser.add_argument(
+        "--request-dump-file",
+        type=str,
+        default="request_dump.jsonl",
+        help="JSONL file used by the /start_dump_req endpoint.",
     )
     args = parser.parse_args()
     if len(args.prefiller_hosts) != len(args.prefiller_ports):
@@ -965,6 +1043,7 @@ async def handle_completions_impl(api: str, request: Request):
     try:
         req_data = await request.json()
         req_body = await request.body()
+        await runtime.schedule("dump_request", api, req_data)
         request_length = len(req_body)
         instance_info = await assign_instances(api, req_data, request_length, is_initial_request=True)
         stream_flag = bool(req_data.get("stream", False))
@@ -1182,6 +1261,17 @@ async def reset_prefix_cache(request: Request):
 @app.get("/healthcheck")
 async def healthcheck():
     return get_runtime().scheduler.healthcheck()
+
+
+@app.api_route("/start_dump_req", methods=["GET", "POST"])
+async def start_dump_req():
+    args = get_global_args()
+    return await get_runtime().schedule("start_request_dump", args.request_dump_file)
+
+
+@app.api_route("/stop_dump_req", methods=["GET", "POST"])
+async def stop_dump_req():
+    return await get_runtime().schedule("stop_request_dump")
 
 
 @app.post("/instances/add")

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -404,6 +404,26 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             b.register_buffer([100], [200])
             mock_te.register_buffer.assert_called_once()
 
+    def test_register_additional_buffer(self):
+        b = self._make_backend()
+        with (
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te"
+            ) as mock_te,
+            patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.get_ip"),
+        ):
+            b.register_additional_buffer([300], [400])
+            mock_te.register_additional_buffer.assert_called_once_with([300], [400])
+
+    def test_register_additional_buffer_is_noop_with_fabric_memory(self):
+        b = self._make_backend()
+        b._use_fabric_mem = True
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend.global_te"
+        ) as mock_te:
+            b.register_additional_buffer([300], [400])
+            mock_te.register_additional_buffer.assert_not_called()
+
 
 # =========================================================================
 # YuanrongBackend (mocked store)

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -17,12 +17,15 @@
 
 import hashlib
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     ChunkedTokenDatabase,
+    HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+    HybridCacheC128Config,
     KeyMetadata,
     LayerMultiBlockReqMeta,
     LayerPoolKey,
@@ -31,6 +34,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     RequestTracker,
     get_block_hashes,
+    resolve_hybrid_cache_c128_config,
 )
 
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
@@ -87,6 +91,29 @@ class TestPoolKey(unittest.TestCase):
         self.assertIn("@head_or_tp_rank:1", s)
         self.assertIn("@pp_rank:0", s)
         self.assertIn("hash1", s)
+
+    def test_default_key_string_is_unchanged(self):
+        k = PoolKey(self.meta, "hash1")
+        self.assertEqual(
+            k.to_string(),
+            "llama@pcp2@dcp3@head_or_tp_rank:1@pp_rank:0@group:0"
+            "@cache_role:kv@cache_family:default@hash1",
+        )
+
+    def test_transfer_namespace_and_range_are_part_of_key(self):
+        transfer_meta = KeyMetadata(
+            "llama",
+            1,
+            2,
+            3,
+            0,
+            transfer_namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            slot_start=4,
+            slot_end=8,
+        )
+        key = PoolKey(transfer_meta, "hash1")
+        self.assertIn("@transfer:hybrid_c128_chunk_v1@range:4_8@hash1", key.to_string())
+        self.assertNotEqual(hash(key), hash(PoolKey(self.meta, "hash1")))
 
     def test_split_layers(self):
         k = PoolKey(self.meta, "hash1")
@@ -171,6 +198,36 @@ class TestChunkedTokenDatabase(unittest.TestCase):
             [1000, 1001, 1002, 1003],
         )
 
+    def test_disabled_transfer_chunks_preserve_compressed_block_mapping(self):
+        db = ChunkedTokenDatabase(
+            [self.meta],
+            block_size=[8],
+            partitions=None,
+            hash_block_size=8,
+        )
+        db.set_group_buffers(
+            {0: [1000]},
+            {0: [80]},
+            group_cache_families={0: "c4"},
+        )
+        db.cache_coordinator = MagicMock()
+        db.cache_coordinator.transfer_value_block_range.side_effect = AssertionError(
+            "disabled transfer path must preserve legacy block-id mapping"
+        )
+
+        chunks = list(
+            db.process_transfer_chunks_with_block_ids(
+                64,
+                [f"h{index}" for index in range(8)],
+                [7, 11],
+            )
+        )
+
+        self.assertEqual([chunk.raw_start for chunk in chunks], [0, 8])
+        self.assertEqual([chunk.block_id for chunk in chunks], [7, 11])
+        addrs, sizes, block_id = db.prepare_transfer_value(chunks[1], [7, 11])
+        self.assertEqual((addrs, sizes, block_id), ([1000 + 11 * 80], [80], 11))
+
     def test_process_tokens_token_len_shorter_than_all_blocks(self):
         hashes = ["a", "b", "c", "d"]
         # token_len=32 means only first 2 blocks valid
@@ -254,6 +311,298 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(len(new_keys), 2)
         self.assertIn("@pp_rank:0", new_keys[0])
         self.assertIn("@pp_rank:1", new_keys[1])
+
+    def test_hybrid_c128_transfer_chunks_use_non_cumulative_c128_ranges(self):
+        config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=1,
+            c128_slots_per_page=128,
+        )
+        metadata = [
+            KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=0),
+            KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=1),
+        ]
+        db = ChunkedTokenDatabase(
+            metadata,
+            block_size=[128, 128],
+            partitions=None,
+            use_hybrid=True,
+            hash_block_size=128,
+            hybrid_cache_c128_config=config,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [1280], 1: [1280]},
+            group_cache_families={0: "c4", 1: "c128"},
+        )
+        hashes = [f"h{index}" for index in range(132)]
+
+        chunks = list(db.process_transfer_chunks(16896, hashes, kv_cache_group_id=1))
+
+        self.assertEqual(len(chunks), 33)
+        self.assertEqual((chunks[0].value_start, chunks[0].value_end), (0, 4))
+        self.assertEqual((chunks[1].value_start, chunks[1].value_end), (4, 8))
+        self.assertEqual((chunks[31].value_start, chunks[31].value_end), (124, 128))
+        self.assertEqual((chunks[32].value_start, chunks[32].value_end), (0, 4))
+        self.assertEqual(chunks[31].target_block_index, 0)
+        self.assertEqual(chunks[32].target_block_index, 1)
+        self.assertIn("@range:0_4", chunks[0].key.to_string())
+        self.assertIn("@range:4_8", chunks[1].key.to_string())
+
+    def test_hybrid_c128_non_c128_chunk_prepares_one_complete_block(self):
+        config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=1,
+            c128_slots_per_page=128,
+        )
+        metadata = [
+            KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=0),
+            KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=1),
+        ]
+        db = ChunkedTokenDatabase(
+            metadata,
+            block_size=[128, 128],
+            partitions=None,
+            use_hybrid=True,
+            hash_block_size=128,
+            hybrid_cache_c128_config=config,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [1280], 1: [1280]},
+            group_cache_families={0: "c4", 1: "c128"},
+        )
+        hashes = ["h0", "h1", "h2", "h3"]
+        chunk = next(iter(db.process_transfer_chunks_with_block_ids(512, hashes, [7], kv_cache_group_id=0)))
+
+        addrs, sizes, block_id = db.prepare_transfer_value(chunk, [7], kv_cache_group_id=0)
+
+        self.assertEqual(block_id, 7)
+        self.assertEqual(addrs, [1000 + 7 * 1280])
+        self.assertEqual(sizes, [1280])
+        self.assertNotIn("@range:", chunk.key.to_string())
+
+    def test_hybrid_c128_block_size_64_uses_two_authoritative_slots_per_chunk(self):
+        config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=256,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=1,
+            c128_slots_per_page=64,
+        )
+        metadata = [
+            KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=0),
+            KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=1),
+        ]
+        db = ChunkedTokenDatabase(
+            metadata,
+            block_size=[64, 64],
+            partitions=None,
+            use_hybrid=True,
+            hash_block_size=64,
+            hybrid_cache_c128_config=config,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [640], 1: [640]},
+            group_cache_families={0: "c4", 1: "c128"},
+        )
+        hashes = [f"h{index}" for index in range(8)]
+
+        chunks = list(db.process_transfer_chunks(512, hashes, kv_cache_group_id=1))
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual([(chunk.value_start, chunk.value_end) for chunk in chunks], [(0, 2), (2, 4)])
+        self.assertEqual([chunk.target_block_index for chunk in chunks], [0, 0])
+        self.assertIn("@range:0_2", chunks[0].key.to_string())
+        self.assertIn("@range:2_4", chunks[1].key.to_string())
+
+    def test_hybrid_c128_block_ids_map_across_20k_prefix_pages(self):
+        config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=0,
+            c128_slots_per_page=128,
+        )
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("hybrid-model", 0, 0, 0, 0)],
+            block_size=[128],
+            partitions=None,
+            hash_block_size=128,
+            hybrid_cache_c128_config=config,
+        )
+        db.set_group_buffers(
+            {0: [1000]},
+            {0: [1280]},
+            group_cache_families={0: "c128"},
+        )
+        hashes = [f"h{index}" for index in range(160)]
+
+        chunks = list(
+            db.process_transfer_chunks_with_block_ids(
+                20 * 1024,
+                hashes,
+                [10, 11],
+            )
+        )
+
+        self.assertEqual(len(chunks), 40)
+        self.assertEqual([chunk.block_id for chunk in chunks[:32]], [10] * 32)
+        self.assertEqual([chunk.block_id for chunk in chunks[32:]], [11] * 8)
+        self.assertEqual((chunks[32].value_start, chunks[32].value_end), (0, 4))
+        self.assertEqual(chunks[32].target_block_index, 1)
+
+    def test_hybrid_c128_tail_block_ids_and_mask_num_map_second_page(self):
+        config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=0,
+            c128_slots_per_page=128,
+        )
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("hybrid-model", 0, 0, 0, 0)],
+            block_size=[128],
+            partitions=None,
+            hash_block_size=128,
+            hybrid_cache_c128_config=config,
+        )
+        db.set_group_buffers(
+            {0: [1000]},
+            {0: [1280]},
+            group_cache_families={0: "c128"},
+        )
+        hashes = [f"h{index}" for index in range(256)]
+
+        chunks = list(
+            db.process_transfer_chunks_with_block_ids(
+                32 * 1024,
+                hashes,
+                [21],
+                mask_num=17 * 1024,
+            )
+        )
+
+        self.assertEqual(len(chunks), 30)
+        self.assertEqual(chunks[0].raw_start, 17 * 1024)
+        self.assertEqual((chunks[0].value_start, chunks[0].value_end), (8, 12))
+        self.assertTrue(all(chunk.target_block_index == 1 for chunk in chunks))
+        self.assertTrue(all(chunk.block_id == 21 for chunk in chunks))
+
+    def test_hybrid_c128_skip_null_blocks_keeps_valid_second_page(self):
+        config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=0,
+            c128_slots_per_page=128,
+        )
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("hybrid-model", 0, 0, 0, 0)],
+            block_size=[128],
+            partitions=None,
+            hash_block_size=128,
+            hybrid_cache_c128_config=config,
+        )
+        db.set_group_buffers(
+            {0: [1000]},
+            {0: [1280]},
+            group_cache_families={0: "c128"},
+        )
+        hashes = [f"h{index}" for index in range(256)]
+
+        chunks = list(
+            db.process_transfer_chunks_with_block_ids(
+                32 * 1024,
+                hashes,
+                [0, 22],
+                skip_null_blocks=True,
+            )
+        )
+
+        self.assertEqual(len(chunks), 32)
+        self.assertEqual(chunks[0].raw_start, 16 * 1024)
+        self.assertTrue(all(chunk.target_block_index == 1 for chunk in chunks))
+        self.assertTrue(all(chunk.block_id == 22 for chunk in chunks))
+
+
+class TestHybridCacheC128Config(unittest.TestCase):
+    @staticmethod
+    def _config(enabled=True, *, backend="mooncake", load_async=False):
+        extra = {
+            "backend": backend,
+            "load_async": load_async,
+            "hybrid_cache_c128_chunk": enabled,
+        }
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(),
+                hf_config=SimpleNamespace(),
+            ),
+            kv_transfer_config=SimpleNamespace(kv_connector_extra_config=extra),
+        )
+
+    def _resolve(self, config, **overrides):
+        kwargs = {
+            "use_layerwise": False,
+            "group_block_sizes": [128, 128],
+            "group_cache_families": ["c4", "c128"],
+            "hash_block_size": 128,
+            "discard_partial_chunks": True,
+        }
+        kwargs.update(overrides)
+        return resolve_hybrid_cache_c128_config(config, **kwargs)
+
+    def test_missing_option_preserves_default_path(self):
+        config = self._config()
+        del config.kv_transfer_config.kv_connector_extra_config["hybrid_cache_c128_chunk"]
+        self.assertFalse(self._resolve(config).enabled)
+
+    def test_false_option_preserves_default_path(self):
+        self.assertFalse(self._resolve(self._config(False)).enabled)
+
+    def test_block_size_128_uses_512_tokens(self):
+        resolved = self._resolve(self._config())
+        self.assertTrue(resolved.enabled)
+        self.assertEqual(resolved.chunk_tokens, 512)
+        self.assertEqual(resolved.c128_group_id, 1)
+        self.assertEqual(resolved.c128_slots_per_page, 128)
+
+    def test_block_size_64_uses_256_tokens(self):
+        resolved = self._resolve(
+            self._config(),
+            group_block_sizes=[64, 64],
+            group_cache_families=["c4", "c128"],
+            hash_block_size=64,
+        )
+        self.assertEqual(resolved.chunk_tokens, 256)
+        self.assertEqual(resolved.c128_slots_per_page, 64)
+
+    def test_load_async_is_supported(self):
+        resolved = self._resolve(self._config(load_async=True))
+        self.assertTrue(resolved.enabled)
+
+    def test_invalid_values_fail_fast(self):
+        for value in (1, "true", None):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                self._resolve(self._config(value))
+
+    def test_unsupported_execution_modes_fail_fast(self):
+        cases = (
+            (self._config(backend="memcache"), {}),
+            (self._config(), {"use_layerwise": True}),
+            (self._config(), {"discard_partial_chunks": False}),
+            (self._config(), {"group_block_sizes": [256, 128]}),
+            (self._config(), {"group_block_sizes": [128], "group_cache_families": ["default"]}),
+        )
+        for config, overrides in cases:
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                self._resolve(config, **overrides)
 
 
 class TestLoadSpec(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -90,6 +90,37 @@ class _FakeCompressedManager:
 
 
 class TestAscendStoreCoordinator(unittest.TestCase):
+    def test_512_transfer_uses_common_prefix_across_c128_and_swa(self):
+        block_hashes = _hashes(8)
+        grouped_hashes = get_block_hashes(block_hashes, group_block_size=512, hash_block_size=128)
+        coord = AscendStoreCoordinator(
+            [
+                KVCacheGroupSpec(["layer.c128"], _full_spec(128)),
+                KVCacheGroupSpec(["layer.swa"], _sliding_spec(512, sliding_window=512)),
+            ],
+            scheduler_block_size=512,
+            hash_block_size=128,
+            group_block_sizes=[128, 512],
+            group_cache_families=["c128", "default"],
+            transfer_chunk_tokens=512,
+        )
+        exists = {
+            (0, bytes(grouped_hashes[0])),
+            (0, bytes(grouped_hashes[1])),
+            (1, bytes(grouped_hashes[0])),
+        }
+
+        _, hit_length = coord.find_longest_cache_hit(
+            block_hashes,
+            1024,
+            ExternalCachedBlockPool(exists),
+            apply_eagle=False,
+        )
+
+        self.assertEqual(coord.group_transfer_chunk_sizes, [512, 512])
+        self.assertEqual(coord.group_effective_block_sizes, [128 * 128, 512])
+        self.assertEqual(hit_length, 512)
+
     def test_compressed_group_hits_on_effective_granularity(self):
         block_hashes = _hashes(128)
         grouped_hash = get_block_hashes(block_hashes, group_block_size=128 * 128, hash_block_size=128)[0]
@@ -131,7 +162,7 @@ class TestAscendStoreCoordinator(unittest.TestCase):
                 ExternalCachedBlockPool({(0, bytes(grouped_hash))}),
             )
 
-        self.assertEqual(coord.group_effective_specs[0].compress_ratio, 1)
+        self.assertEqual(coord.attention_groups[0][0].compress_ratio, 1)
         self.assertEqual(hit_length, 128 * 128)
 
     def test_missing_required_group_returns_zero(self):
@@ -172,6 +203,44 @@ class TestAscendStoreCoordinator(unittest.TestCase):
             masks = coord.store_mask(512)
 
         self.assertEqual(masks, ([False, False, False, True],))
+
+    def test_store_mask_aggregates_native_blocks_into_one_transfer_chunk(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _sliding_spec(block_size=128, sliding_window=256))],
+            scheduler_block_size=512,
+            hash_block_size=128,
+            group_block_sizes=[128],
+            group_cache_families=["c1"],
+            transfer_chunk_tokens=512,
+        )
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+            return_value=[True, True, False, True],
+        ):
+            masks = coord.store_mask(512)
+
+        self.assertEqual(coord.group_effective_block_sizes, [128])
+        self.assertEqual(coord.group_transfer_chunk_sizes, [512])
+        self.assertEqual(masks, ([False],))
+
+    def test_store_mask_preserves_one_to_one_native_transfer_chunks(self):
+        coord = AscendStoreCoordinator(
+            [KVCacheGroupSpec(["layer.0"], _sliding_spec(block_size=512, sliding_window=512))],
+            scheduler_block_size=512,
+            hash_block_size=128,
+            group_block_sizes=[512],
+            group_cache_families=["c1"],
+            transfer_chunk_tokens=512,
+        )
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator._reachable_block_mask",
+            return_value=[True, False],
+        ):
+            masks = coord.store_mask(1024)
+
+        self.assertEqual(masks, ([True, False],))
 
     def test_store_mask_propagates_eagle_to_same_spec_siblings(self):
         calls = []

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -24,6 +24,9 @@ import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm.distributed.kv_events import BlockStored
 from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
+    ChunkedTokenDatabase,
+    HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+    HybridCacheC128Config,
     KeyMetadata,
     LayerMultiBlockReqMeta,
     LayerPoolKey,
@@ -370,6 +373,87 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         keys, _, _ = store.put_calls[0]
         self.assertEqual(len(keys), 1)
 
+    @staticmethod
+    def _make_hybrid_c128_thread():
+        store = FakeStore([0, 0])
+        transfer_config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=1,
+            c128_slots_per_page=128,
+        )
+        db = ChunkedTokenDatabase(
+            [
+                KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=0),
+                KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=1),
+            ],
+            block_size=[128, 128],
+            partitions=None,
+            use_hybrid=True,
+            hash_block_size=128,
+            hybrid_cache_c128_config=transfer_config,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [1280], 1: [1280]},
+            group_cache_families={0: "c4", 1: "c128"},
+        )
+        thread = KVCacheStoreSendingThread(
+            m_store=store,
+            token_database=db,
+            block_size=[128, 128],
+            tp_rank=0,
+            dcp_size=1,
+            put_step=1,
+            kv_role="kv_producer",
+            ready_event=threading.Event(),
+            group_uses_align_state=[False, False],
+        )
+        return thread, store
+
+    def test_hybrid_c128_put_publishes_only_complete_512_frontier(self):
+        thread, store = self._make_hybrid_c128_thread()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=1000,
+            block_ids_by_group=[[7], [9]],
+            block_hashes=[bytes([index]) * 32 for index in range(8)],
+            kv_cache_group_ids=[0, 1],
+        )
+        thread.add_stored_request(request.req_id)
+        thread.request_queue.put(request)
+
+        with self.assertLogs(level="DEBUG") as logs:
+            thread._handle_request(request)
+        self.assertTrue(any("kv Test put" in line for line in logs.output))
+
+        self.assertEqual(len(store.put_calls), 2)
+        self.assertEqual([len(keys) for keys, _, _ in store.put_calls], [1, 1])
+        self.assertIn("@range:0_4", store.put_calls[1][0][0])
+
+    def test_hybrid_c128_put_uses_non_cumulative_c128_keys_and_full_pages(self):
+        thread, store = self._make_hybrid_c128_thread()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=1024,
+            block_ids_by_group=[[7, 8], [9]],
+            block_hashes=[bytes([index]) * 32 for index in range(8)],
+            kv_cache_group_ids=[0, 1],
+        )
+        thread.add_stored_request(request.req_id)
+        thread.request_queue.put(request)
+
+        thread._handle_request(request)
+
+        self.assertEqual(len(store.put_calls), 2)
+        c128_keys, c128_addrs, c128_sizes = store.put_calls[1]
+        self.assertEqual(len(c128_keys), 2)
+        self.assertIn("@range:0_4", c128_keys[0])
+        self.assertIn("@range:4_8", c128_keys[1])
+        self.assertEqual(c128_addrs, [[2000 + 9 * 1280]] * 2)
+        self.assertEqual(c128_sizes, [[1280], [1280]])
+
 
 class TestKVCacheStoreRecvingThread(unittest.TestCase):
     def test_handle_request(self):
@@ -424,6 +508,90 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         t._handle_request(req)
         keys, _, _ = store.get_calls[0]
         self.assertEqual(len(keys), 1)
+
+    @staticmethod
+    def _make_hybrid_c128_thread():
+        store = FakeStore()
+        store.get = MagicMock(side_effect=lambda keys, _addrs, _sizes: [0] * len(keys))
+        transfer_config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+            c128_group_id=1,
+            c128_slots_per_page=128,
+        )
+        db = ChunkedTokenDatabase(
+            [
+                KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=0),
+                KeyMetadata("hybrid-model", 0, 0, 0, 0, kv_cache_group_id=1),
+            ],
+            block_size=[128, 128],
+            partitions=None,
+            use_hybrid=True,
+            hash_block_size=128,
+            hybrid_cache_c128_config=transfer_config,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [1280], 1: [1280]},
+            group_cache_families={0: "c4", 1: "c128"},
+        )
+        get_staging = MagicMock(return_value=([9000], [1280]))
+        merge_staging = MagicMock()
+        thread = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=[128, 128],
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+            get_c128_staging_value=get_staging,
+            merge_c128_staging_chunk=merge_staging,
+        )
+        return thread, store, get_staging, merge_staging
+
+    def test_hybrid_c128_async_load_uses_staging_and_merges_each_range(self):
+        thread, store, get_staging, merge_staging = self._make_hybrid_c128_thread()
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=1024, can_load=True, token_len=1024)
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=1024,
+            block_ids_by_group=[[7, 8], [9]],
+            block_hashes=[bytes([index]) * 32 for index in range(8)],
+            kv_cache_group_ids=[0, 1],
+            load_spec=load_spec,
+        )
+        thread.request_queue.put(request)
+
+        thread._handle_request(request)
+
+        self.assertEqual(store.get.call_count, 3)
+        self.assertEqual(get_staging.call_count, 2)
+        self.assertEqual([call.args[1].value_start for call in merge_staging.call_args_list], [0, 4])
+        self.assertEqual([call.args[1].value_end for call in merge_staging.call_args_list], [4, 8])
+        self.assertIn("r1", thread.get_and_clear_finished_requests())
+
+    def test_hybrid_c128_async_load_does_not_merge_failed_chunk(self):
+        thread, store, get_staging, merge_staging = self._make_hybrid_c128_thread()
+        store.get.side_effect = lambda keys, _addrs, _sizes: [1] * len(keys)
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=512, can_load=True, token_len=512)
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=512,
+            block_ids_by_group=[[], [9]],
+            block_hashes=[bytes([index]) * 32 for index in range(4)],
+            kv_cache_group_ids=[1],
+            load_spec=load_spec,
+        )
+        thread.request_queue.put(request)
+
+        thread._handle_request(request)
+
+        get_staging.assert_called_once_with(1)
+        merge_staging.assert_not_called()
+        self.assertIn("r1", thread.get_and_clear_finished_requests())
 
 
 class TestKVCacheStoreLayerSendingThread(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -19,10 +19,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+import torch
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
+    HybridCacheC128Config,
+    KeyMetadata,
     LoadSpec,
+    PoolKey,
     ReqMeta,
+    TransferChunkWithBlockId,
 )
 
 
@@ -106,9 +111,54 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         hits = [[16, 32, 48], [32, 48], [16, 32], [32, 48, 64]]
         self.assertEqual(32, cls._max_intersection_hit_position(hits))
 
+    @staticmethod
+    def _c128_chunk(value_start: int, value_end: int, block_id: int = 1):
+        return TransferChunkWithBlockId(
+            raw_start=value_start * 128,
+            raw_end=value_end * 128,
+            value_start=value_start,
+            value_end=value_end,
+            target_block_index=0,
+            key=PoolKey(KeyMetadata("hybrid-model", 0, 0, 0, 0), "hash"),
+            block_id=block_id,
+        )
+
+    def test_merge_c128_chunks_aggregates_authoritative_ranges(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.hybrid_cache_c128_config = HybridCacheC128Config(enabled=True, c128_slots_per_page=128)
+        target = torch.full((2, 128, 2), -1, dtype=torch.int64)
+        staging = torch.arange(256, dtype=torch.int64).view(1, 128, 2)
+        worker.group_kv_cache_tensors = {1: [target]}
+        worker.group_block_size_scales = {1: [1]}
+        worker.c128_staging_tensors = {1: [staging]}
+
+        worker._merge_c128_staging_chunk(1, self._c128_chunk(0, 4))
+        first_range = target[1, 0:4].clone()
+        staging.add_(1000)
+        worker._merge_c128_staging_chunk(1, self._c128_chunk(4, 8))
+
+        self.assertTrue(torch.equal(first_range, torch.arange(8).view(4, 2)))
+        self.assertTrue(torch.equal(target[1, 0:4], first_range))
+        self.assertTrue(torch.equal(target[1, 4:8], staging[0, 4:8]))
+        self.assertTrue(torch.all(target[1, 8:] == -1))
+        self.assertTrue(torch.all(target[0] == -1))
+
+    def test_merge_c128_chunk_rejects_invalid_range(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.hybrid_cache_c128_config = HybridCacheC128Config(enabled=True, c128_slots_per_page=128)
+        worker.group_kv_cache_tensors = {1: [torch.zeros((1, 128))]}
+        worker.group_block_size_scales = {1: [1]}
+        worker.c128_staging_tensors = {1: [torch.zeros((1, 128))]}
+
+        with self.assertRaises(ValueError):
+            worker._merge_c128_staging_chunk(1, self._c128_chunk(124, 132, block_id=0))
+
     def test_external_coordinator_lookup_disables_eagle_drop(self):
         cls = self._make_worker_class()
         worker = object.__new__(cls)
+        worker.hybrid_cache_c128_config = HybridCacheC128Config(enabled=True, c128_slots_per_page=128)
         worker.num_kv_cache_groups = 1
         worker.cache_coordinator = MagicMock()
         worker.cache_coordinator.find_longest_cache_hit.return_value = ((), 128)
@@ -119,15 +169,17 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         key.chunk_hash = "ab" * 32
         key.to_string.return_value = "key"
         worker.token_database = MagicMock()
-        worker.token_database.process_tokens.return_value = [(0, 128, key)]
+        worker.token_database.process_transfer_chunks.return_value = [MagicMock(key=key)]
 
-        hit = worker._lookup_with_coordinator(
-            128,
-            [b"h0"],
-            [0],
-            use_layerwise=False,
-            include_all_ranks=False,
-        )
+        with self.assertLogs(level="INFO") as logs:
+            hit = worker._lookup_with_coordinator(
+                128,
+                [b"h0"],
+                [0],
+                use_layerwise=False,
+                include_all_ranks=False,
+            )
+        self.assertTrue(any("kv Test lookup" in line for line in logs.output))
 
         self.assertEqual(hit, 128)
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
@@ -558,6 +610,27 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.register_kv_caches(kv_caches)
         self.assertEqual(len(worker.group_kv_caches_base_addr[0]), 2)
         worker.m_store.register_buffer.assert_called_once()
+        worker.m_store.register_additional_buffer.assert_not_called()
+
+    def test_register_kv_caches_registers_c128_staging_separately(self):
+        worker = self._make_worker()
+        worker.hybrid_cache_c128_config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace="hybrid_c128_chunk_v1",
+            c128_group_id=0,
+            c128_slots_per_page=128,
+        )
+        fake_cache = torch.zeros((2, 128), dtype=torch.uint8)
+
+        worker.register_kv_caches({"layer.0": fake_cache})
+
+        worker.m_store.register_buffer.assert_called_once()
+        staging = worker.c128_staging_tensors[0][0]
+        worker.m_store.register_additional_buffer.assert_called_once_with(
+            [staging.data_ptr()],
+            [staging.numel() * staging.element_size()],
+        )
 
     def test_start_load_kv_sync(self):
         worker = self._make_worker()
@@ -600,6 +673,123 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         self.assertEqual(addrs, [[1000 + 99 * 160]])
         self.assertEqual(sizes, [[160]])
 
+    def _make_c128_load_worker(self, get_result):
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import KVPoolWorker
+
+        worker = object.__new__(KVPoolWorker)
+        target = torch.full((2, 128, 2), -1, dtype=torch.int64)
+        staging = torch.zeros((1, 128, 2), dtype=torch.int64)
+        chunk = TransferChunkWithBlockId(
+            raw_start=0,
+            raw_end=512,
+            value_start=0,
+            value_end=4,
+            target_block_index=0,
+            key=PoolKey(KeyMetadata("hybrid-model", 0, 0, 0, 0), "hash"),
+            block_id=1,
+        )
+        worker.hybrid_cache_c128_config = HybridCacheC128Config(
+            enabled=True,
+            chunk_tokens=512,
+            namespace="hybrid_c128_chunk_v1",
+            c128_group_id=1,
+            c128_slots_per_page=128,
+        )
+        worker.cache_transfer_granularity = 512
+        worker.use_layerwise = False
+        worker.load_async = False
+        worker.group_uses_align_state = [False, False]
+        worker.tp_rank = 0
+        worker._invalid_block_ids = set()
+        worker.grouped_block_size = [512, 128]
+        worker.group_kv_cache_tensors = {1: [target]}
+        worker.group_block_size_scales = {1: [1]}
+        worker.c128_staging_tensors = {1: [staging]}
+        worker.token_database = MagicMock()
+        worker.token_database.load_mask.return_value = None
+        worker.token_database.mask_allows_chunk.return_value = True
+        worker.token_database.is_c128_group.return_value = True
+        worker.token_database.process_transfer_chunks_with_block_ids.return_value = [chunk]
+        worker.m_store = MagicMock()
+
+        def get(*_args):
+            if get_result == [0]:
+                staging.copy_(torch.arange(256, dtype=torch.int64).view(1, 128, 2))
+            return get_result
+
+        worker.m_store.get.side_effect = get
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=512,
+            block_ids_by_group=[[], [1]],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            load_spec=LoadSpec(0, 512, True),
+            kv_cache_group_ids=[1],
+        )
+        metadata = AscendConnectorMetadata(set(), set())
+        metadata.add_request(request)
+        return worker, target, metadata
+
+    def test_start_load_kv_c128_merges_only_after_successful_get(self):
+        worker, target, metadata = self._make_c128_load_worker([0])
+
+        with self.assertLogs(level="INFO") as logs:
+            worker.start_load_kv(metadata)
+        self.assertTrue(any("kv Test load" in line for line in logs.output))
+
+        self.assertTrue(torch.equal(target[1, 0:4], torch.arange(8).view(4, 2)))
+        self.assertTrue(torch.all(target[1, 4:] == -1))
+        self.assertTrue(torch.all(target[0] == -1))
+
+    def test_start_load_kv_c128_aggregates_two_chunks_into_one_page(self):
+        worker, target, metadata = self._make_c128_load_worker([0])
+        chunks = [
+            TransferChunkWithBlockId(
+                raw_start=0,
+                raw_end=512,
+                value_start=0,
+                value_end=4,
+                target_block_index=0,
+                key=PoolKey(KeyMetadata("hybrid-model", 0, 0, 0, 0), "hash0"),
+                block_id=1,
+            ),
+            TransferChunkWithBlockId(
+                raw_start=512,
+                raw_end=1024,
+                value_start=4,
+                value_end=8,
+                target_block_index=1,
+                key=PoolKey(KeyMetadata("hybrid-model", 0, 0, 0, 0), "hash1"),
+                block_id=1,
+            ),
+        ]
+        worker.token_database.process_transfer_chunks_with_block_ids.return_value = chunks
+        staging = worker.c128_staging_tensors[1][0]
+        staging_values = iter((11, 22))
+
+        def get(*_args):
+            staging.fill_(next(staging_values))
+            return [0]
+
+        worker.m_store.get.side_effect = get
+
+        worker.start_load_kv(metadata)
+
+        self.assertEqual(worker.m_store.get.call_count, 2)
+        self.assertTrue(torch.all(target[1, 0:4] == 11))
+        self.assertTrue(torch.all(target[1, 4:8] == 22))
+        self.assertTrue(torch.all(target[1, 8:] == -1))
+        self.assertTrue(torch.all(target[0] == -1))
+
+    def test_start_load_kv_c128_does_not_merge_failed_get(self):
+        for get_result in ([1], None):
+            with self.subTest(get_result=get_result):
+                worker, target, metadata = self._make_c128_load_worker(get_result)
+
+                worker.start_load_kv(metadata)
+
+                self.assertTrue(torch.all(target == -1))
+
     def test_start_load_kv_no_load(self):
         worker = self._make_worker()
         req = ReqMeta(
@@ -614,7 +804,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.start_load_kv(meta)
         # No get called since no load_spec
 
-    def test_wait_for_save(self):
+    @patch.object(torch, "npu", create=True)
+    def test_wait_for_save(self, mock_npu):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/backend.py
@@ -16,6 +16,10 @@ class Backend(ABC):
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
         pass
 
+    def register_additional_buffer(self, ptrs: list[int], lengths: list[int]):
+        """Register buffers allocated after the backend's initial registration."""
+        self.register_buffer(ptrs, lengths)
+
     @abstractmethod
     def exists(self, keys: list[str]) -> list[int]:
         pass

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -168,6 +168,12 @@ class MooncakeBackend(Backend):
             global_te.get_transfer_engine(local_hostname, device_name=None)
             global_te.register_buffer(ptrs, lengths)
 
+    def register_additional_buffer(self, ptrs: list[int], lengths: list[int]):
+        if not self._use_fabric_mem:
+            local_hostname = get_ip()
+            global_te.get_transfer_engine(local_hostname, device_name=None)
+            global_te.register_additional_buffer(ptrs, lengths)
+
     def exists(self, keys: list[str]) -> list[int]:
         if self._lazy_init and not self._store_initialized:
             logger.debug(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -15,6 +15,40 @@ from vllm.v1.core.sched.output import NewRequestData
 _GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
 _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 
+HYBRID_CACHE_C128_CHUNK_CONFIG_KEY = "hybrid_cache_c128_chunk"
+HYBRID_CACHE_C128_CHUNK_MULTIPLIER = 4
+HYBRID_CACHE_C128_TRANSFER_NAMESPACE = "hybrid_c128_chunk_v1"
+HYBRID_CACHE_C128_FAMILY = "c128"
+
+
+@dataclass(frozen=True)
+class HybridCacheC128Config:
+    """Connector-only hybrid C128 external transfer configuration."""
+
+    enabled: bool = False
+    chunk_tokens: int | None = None
+    namespace: str | None = None
+    c128_group_id: int | None = None
+    c128_slots_per_page: int | None = None
+
+
+@dataclass(frozen=True)
+class TransferChunk:
+    """One external key and its raw-token/cache-slot placement."""
+
+    raw_start: int
+    raw_end: int
+    value_start: int
+    value_end: int
+    target_block_index: int
+    key: PoolKey
+
+
+@dataclass(frozen=True)
+class TransferChunkWithBlockId(TransferChunk):
+    block_id: int
+    block_ids: tuple[int, ...] = ()
+
 
 # Parameters related to the key
 @dataclass
@@ -36,6 +70,12 @@ class KeyMetadata:
     cache_role: str = "kv"
     """ Family name for compress-aware hybrid cache layouts """
     cache_family: str = "default"
+    """ Versioned namespace for an opt-in external transfer layout """
+    transfer_namespace: str | None = None
+    """ First authoritative cache slot in a full-page value """
+    slot_start: int | None = None
+    """ Exclusive end of the authoritative cache-slot range """
+    slot_end: int | None = None
 
 
 @dataclass(order=True)
@@ -54,11 +94,19 @@ class PoolKey:
                 self.key_metadata.kv_cache_group_id,
                 self.key_metadata.cache_role,
                 self.key_metadata.cache_family,
+                self.key_metadata.transfer_namespace,
+                self.key_metadata.slot_start,
+                self.key_metadata.slot_end,
                 self.chunk_hash,
             )
         )
 
     def to_string(self):
+        transfer_suffix = ""
+        if self.key_metadata.transfer_namespace is not None:
+            transfer_suffix += f"@transfer:{self.key_metadata.transfer_namespace}"
+        if self.key_metadata.slot_start is not None and self.key_metadata.slot_end is not None:
+            transfer_suffix += f"@range:{self.key_metadata.slot_start}_{self.key_metadata.slot_end}"
         return (
             f"{self.key_metadata.model_name}"
             f"@pcp{self.key_metadata.pcp_rank}@dcp{self.key_metadata.dcp_rank}"
@@ -67,6 +115,7 @@ class PoolKey:
             f"@group:{self.key_metadata.kv_cache_group_id}"
             f"@cache_role:{self.key_metadata.cache_role}"
             f"@cache_family:{self.key_metadata.cache_family}"
+            f"{transfer_suffix}"
             f"@{self.chunk_hash}"
         )
 
@@ -100,12 +149,20 @@ class LayerPoolKey(PoolKey):
                 self.key_metadata.kv_cache_group_id,
                 self.key_metadata.cache_role,
                 self.key_metadata.cache_family,
+                self.key_metadata.transfer_namespace,
+                self.key_metadata.slot_start,
+                self.key_metadata.slot_end,
                 self.chunk_hash,
                 self.layer_id,
             )
         )
 
     def to_string(self):
+        transfer_suffix = ""
+        if self.key_metadata.transfer_namespace is not None:
+            transfer_suffix += f"@transfer:{self.key_metadata.transfer_namespace}"
+        if self.key_metadata.slot_start is not None and self.key_metadata.slot_end is not None:
+            transfer_suffix += f"@range:{self.key_metadata.slot_start}_{self.key_metadata.slot_end}"
         return (
             f"{self.key_metadata.model_name}"
             f"@pcp{self.key_metadata.pcp_rank}@dcp{self.key_metadata.dcp_rank}"
@@ -113,6 +170,7 @@ class LayerPoolKey(PoolKey):
             f"@group:{self.key_metadata.kv_cache_group_id}"
             f"@cache_role:{self.key_metadata.cache_role}"
             f"@cache_family:{self.key_metadata.cache_family}"
+            f"{transfer_suffix}"
             f"@layer_id:{self.layer_id}"
             f"@{self.chunk_hash}"
         )
@@ -135,6 +193,86 @@ def infer_cache_family_ratio(cache_family: str | None) -> int:
 
 def get_cache_family_granularity(block_size: int, cache_family: str | None) -> int:
     return block_size * infer_cache_family_ratio(cache_family)
+
+
+def resolve_hybrid_cache_c128_config(
+    vllm_config: Any,
+    *,
+    use_layerwise: bool,
+    group_block_sizes: Sequence[int],
+    group_cache_families: Sequence[str],
+    hash_block_size: int,
+    discard_partial_chunks: bool,
+) -> HybridCacheC128Config:
+    """Parse and validate the opt-in connector-only hybrid C128 path."""
+    kv_transfer_config = vllm_config.kv_transfer_config
+    extra_config = kv_transfer_config.kv_connector_extra_config
+    enabled = extra_config.get(HYBRID_CACHE_C128_CHUNK_CONFIG_KEY, False)
+    if not isinstance(enabled, bool):
+        raise ValueError(f"{HYBRID_CACHE_C128_CHUNK_CONFIG_KEY} must be a boolean.")
+    if not enabled:
+        return HybridCacheC128Config()
+
+    config_key = HYBRID_CACHE_C128_CHUNK_CONFIG_KEY
+    if str(extra_config.get("backend", "mooncake")).lower() != "mooncake":
+        raise ValueError(f"{config_key} requires the Mooncake backend.")
+    if use_layerwise:
+        raise ValueError(f"{config_key} does not support layerwise transfer.")
+    if not discard_partial_chunks:
+        raise ValueError(f"{config_key} requires discard_partial_chunks=true.")
+    if len(group_block_sizes) != len(group_cache_families):
+        raise ValueError("KV cache group sizes and cache families must have the same length.")
+
+    c128_group_id: int | None = None
+    c128_block_size: int | None = None
+    for group_id, (block_size, family) in enumerate(
+        zip(group_block_sizes, group_cache_families, strict=True)
+    ):
+        if family == HYBRID_CACHE_C128_FAMILY:
+            if c128_group_id is not None:
+                raise ValueError(f"{config_key} requires exactly one C128 cache group.")
+            c128_group_id = group_id
+            c128_block_size = block_size
+
+    if c128_group_id is None or c128_block_size is None:
+        raise ValueError(f"{config_key} requires exactly one C128 cache group.")
+
+    # Four C128 compressed-slot groups form one external transfer chunk.  The
+    # physical block size is deliberately taken from the actual group spec so
+    # block_size=128 yields 512 raw tokens and block_size=64 yields 256.
+    chunk_tokens = c128_block_size * HYBRID_CACHE_C128_CHUNK_MULTIPLIER
+    if chunk_tokens % hash_block_size != 0:
+        raise ValueError(
+            f"{config_key} chunk size ({chunk_tokens}) must be divisible by "
+            f"hash_block_size ({hash_block_size})."
+        )
+    c128_ratio = infer_cache_family_ratio(HYBRID_CACHE_C128_FAMILY)
+    if chunk_tokens % c128_ratio != 0:
+        raise ValueError(
+            f"{config_key} chunk size ({chunk_tokens}) must be divisible by "
+            f"the C128 compression ratio ({c128_ratio})."
+        )
+
+    for group_id, (block_size, family) in enumerate(
+        zip(group_block_sizes, group_cache_families, strict=True)
+    ):
+        if family == HYBRID_CACHE_C128_FAMILY:
+            continue
+        raw_tokens_per_block = get_cache_family_granularity(block_size, family)
+        if chunk_tokens % raw_tokens_per_block != 0:
+            raise ValueError(
+                f"{config_key} chunk size ({chunk_tokens}) must be divisible by "
+                "every non-C128 group's raw tokens per physical block; "
+                f"group {group_id} ({family}) maps {raw_tokens_per_block}."
+            )
+
+    return HybridCacheC128Config(
+        enabled=True,
+        chunk_tokens=chunk_tokens,
+        namespace=HYBRID_CACHE_C128_TRANSFER_NAMESPACE,
+        c128_group_id=c128_group_id,
+        c128_slots_per_page=c128_block_size,
+    )
 
 
 def _get_layer_compress_ratio(
@@ -207,6 +345,7 @@ class ChunkedTokenDatabase:
         partitions: list[int] | None,
         use_hybrid: bool = False,
         hash_block_size: int | None = None,
+        hybrid_cache_c128_config: HybridCacheC128Config | None = None,
     ):
         self.metadata = metadata
         self.block_size = block_size
@@ -224,6 +363,7 @@ class ChunkedTokenDatabase:
         self.partitions = partitions
         self.use_hybrid = use_hybrid
         self.hash_block_size = self.block_size[0] if hash_block_size is None else hash_block_size
+        self.hybrid_cache_c128_config = hybrid_cache_c128_config or HybridCacheC128Config()
         self.cache_coordinator: Any | None = None
 
     def set_cache_coordinator(self, cache_coordinator: Any | None) -> None:
@@ -256,7 +396,11 @@ class ChunkedTokenDatabase:
         if masks is None or kv_cache_group_id >= len(masks):
             return True
         group_mask = masks[kv_cache_group_id]
-        block_idx = start // self.get_block_size(kv_cache_group_id)
+        if self.hybrid_cache_c128_config.enabled:
+            assert self.hybrid_cache_c128_config.chunk_tokens is not None
+            block_idx = start // self.hybrid_cache_c128_config.chunk_tokens
+        else:
+            block_idx = start // self.get_block_size(kv_cache_group_id)
         return block_idx < len(group_mask) and group_mask[block_idx]
 
     def _make_key_by_hash(
@@ -266,6 +410,9 @@ class ChunkedTokenDatabase:
         cache_role: str = "kv",
         cache_family: str | None = None,
         layer_id: int | None = None,
+        transfer_namespace: str | None = None,
+        slot_start: int | None = None,
+        slot_end: int | None = None,
     ):
         assert self.metadata is not None
         if cache_family is None:
@@ -281,9 +428,19 @@ class ChunkedTokenDatabase:
                 kv_cache_group_id=kv_cache_group_id,
                 cache_role=cache_role,
                 cache_family=cache_family,
+                transfer_namespace=transfer_namespace,
+                slot_start=slot_start,
+                slot_end=slot_end,
             ),
             chunk_hash,
         )
+
+    def is_hybrid_cache_c128_enabled(self) -> bool:
+        return self.hybrid_cache_c128_config.enabled
+
+    def is_c128_group(self, kv_cache_group_id: int) -> bool:
+        config = self.hybrid_cache_c128_config
+        return config.enabled and config.c128_group_id == kv_cache_group_id
 
     def get_block_size(self, kv_cache_group_id: int) -> int:
         if kv_cache_group_id >= len(self.block_size):
@@ -375,6 +532,233 @@ class ChunkedTokenDatabase:
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list, block_id
+
+    def process_transfer_chunks(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+    ) -> Iterable[TransferChunk]:
+        """Return explicit raw-token and physical-value coordinates."""
+        config = self.hybrid_cache_c128_config
+        if not config.enabled:
+            group_block_size = self.get_block_size(kv_cache_group_id)
+            for start, end, key in self.process_tokens(
+                token_len,
+                block_hashes,
+                mask_num,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                cache_family=cache_family,
+            ):
+                yield TransferChunk(
+                    raw_start=start,
+                    raw_end=end,
+                    value_start=start,
+                    value_end=end,
+                    target_block_index=start // group_block_size,
+                    key=key,
+                )
+            return
+
+        if not block_hashes:
+            return
+        assert config.chunk_tokens is not None
+        assert config.namespace is not None
+        chunk_tokens = config.chunk_tokens
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        physical_block_size = self.get_block_size(kv_cache_group_id)
+        raw_tokens_per_page = physical_block_size * family_ratio
+        chunk_hashes = get_block_hashes(block_hashes, chunk_tokens, self.hash_block_size)
+        if not chunk_hashes:
+            return
+
+        for chunk_id, hash_value in enumerate(chunk_hashes):
+            raw_start = chunk_id * chunk_tokens
+            raw_end = raw_start + chunk_tokens
+            if raw_end > token_len:
+                break
+            if raw_start < mask_num:
+                continue
+            if not isinstance(hash_value, str):
+                hash_value = hash_value.hex()
+            target_block_index = raw_start // raw_tokens_per_page
+            value_start = (raw_start % raw_tokens_per_page) // family_ratio
+            value_end = value_start + min(chunk_tokens, raw_tokens_per_page) // family_ratio
+            slot_start = value_start if self.is_c128_group(kv_cache_group_id) else None
+            slot_end = value_end if self.is_c128_group(kv_cache_group_id) else None
+            yield TransferChunk(
+                raw_start=raw_start,
+                raw_end=raw_end,
+                value_start=value_start,
+                value_end=value_end,
+                target_block_index=target_block_index,
+                key=self._make_key_by_hash(
+                    hash_value,
+                    kv_cache_group_id=kv_cache_group_id,
+                    cache_role=cache_role,
+                    cache_family=cache_family,
+                    transfer_namespace=config.namespace,
+                    slot_start=slot_start,
+                    slot_end=slot_end,
+                ),
+            )
+
+    def process_transfer_chunks_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes: BlockHashList | list[str],
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+        cache_family: str | None = None,
+    ) -> Iterable[TransferChunkWithBlockId]:
+        if not self.hybrid_cache_c128_config.enabled:
+            group_block_size = self.get_block_size(kv_cache_group_id)
+            for start, end, key, block_id in self.process_tokens_with_block_ids(
+                token_len,
+                block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=kv_cache_group_id,
+                skip_null_blocks=skip_null_blocks,
+                cache_role=cache_role,
+                cache_family=cache_family,
+            ):
+                yield TransferChunkWithBlockId(
+                    raw_start=start,
+                    raw_end=end,
+                    value_start=start,
+                    value_end=end,
+                    target_block_index=start // group_block_size,
+                    key=key,
+                    block_id=block_id,
+                    block_ids=(block_id,),
+                )
+            return
+
+        all_chunks = list(
+            self.process_transfer_chunks(
+                token_len,
+                block_hashes,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                cache_family=cache_family,
+            )
+        )
+        if not all_chunks:
+            return
+        if cache_family is None:
+            cache_family = self.group_cache_families.get(cache_role, {}).get(kv_cache_group_id, "default")
+        family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+        raw_tokens_per_page = self.get_block_size(kv_cache_group_id) * family_ratio
+        # A C128 chunk addresses a range inside a full physical page, so a
+        # partial final page still needs to participate in the tail offset.
+        # Other groups only publish complete transfer chunks and their block
+        # IDs therefore correspond to complete native pages at this frontier.
+        if self.is_c128_group(kv_cache_group_id):
+            num_logical_blocks = cdiv(token_len, raw_tokens_per_page)
+        else:
+            num_logical_blocks = token_len // raw_tokens_per_page
+        block_id_offset = max(num_logical_blocks - len(block_ids), 0)
+        for chunk in all_chunks:
+            if chunk.raw_start < mask_num:
+                continue
+            if self.is_c128_group(kv_cache_group_id):
+                block_start = chunk.target_block_index
+                block_end = block_start + 1
+            elif self.cache_coordinator is not None:
+                block_start, block_end = self.cache_coordinator.transfer_value_block_range(
+                    kv_cache_group_id,
+                    chunk.raw_start,
+                    chunk.raw_end,
+                )
+            else:
+                block_start = chunk.target_block_index
+                block_end = block_start + 1
+            block_start -= block_id_offset
+            block_end -= block_id_offset
+            if block_start < 0 or block_end > len(block_ids):
+                continue
+            chunk_block_ids = tuple(block_ids[block_start:block_end])
+            if skip_null_blocks and any(block_id <= 0 for block_id in chunk_block_ids):
+                continue
+            yield TransferChunkWithBlockId(
+                raw_start=chunk.raw_start,
+                raw_end=chunk.raw_end,
+                value_start=chunk.value_start,
+                value_end=chunk.value_end,
+                target_block_index=chunk.target_block_index,
+                key=chunk.key,
+                block_id=chunk_block_ids[0],
+                block_ids=chunk_block_ids,
+            )
+
+    def prepare_transfer_value(
+        self,
+        chunk: TransferChunkWithBlockId,
+        block_ids: list[int],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+    ):
+        if not self.hybrid_cache_c128_config.enabled:
+            return self.prepare_value(
+                chunk.value_start,
+                chunk.value_end,
+                block_ids,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                block_id=chunk.block_id,
+            )
+
+        if self.is_c128_group(kv_cache_group_id):
+            # Mooncake stores a complete physical C128 page.  The key's
+            # authoritative slot range is applied after load by the staging
+            # merge path; ordinary groups use their complete transfer block.
+            value_start = 0
+            value_end = self.get_block_size(kv_cache_group_id)
+            return self.prepare_value(
+                value_start,
+                value_end,
+                block_ids,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                block_id=chunk.block_id,
+            )
+
+        chunk_block_ids = chunk.block_ids or (chunk.block_id,)
+        values = [
+            self.prepare_value(
+                0,
+                self.get_block_size(kv_cache_group_id),
+                block_ids,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+                block_id=block_id,
+            )
+            for block_id in chunk_block_ids
+        ]
+        if not values or not values[0][0]:
+            return [], [], chunk.block_id
+        num_buffers = len(values[0][0])
+        addr_list = [
+            values[block][0][buffer]
+            for buffer in range(num_buffers)
+            for block in range(len(values))
+        ]
+        size_list = [
+            values[block][1][buffer]
+            for buffer in range(num_buffers)
+            for block in range(len(values))
+        ]
+        return addr_list, size_list, chunk.block_id
 
     def process_tokens(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/coordinator.py
@@ -63,6 +63,7 @@ class AscendStoreCoordinator:
         hash_block_size: int,
         group_block_sizes: list[int],
         group_cache_families: list[str],
+        transfer_chunk_tokens: int | None = None,
         use_eagle: bool = False,
         retention_interval: int | None = None,
     ) -> None:
@@ -83,11 +84,26 @@ class AscendStoreCoordinator:
             _cache_family_granularity(block_size, family)
             for block_size, family in zip(group_block_sizes, group_cache_families, strict=True)
         ]
-        for effective_block_size in self.group_effective_block_sizes:
+        self.group_transfer_chunk_sizes = (
+            [transfer_chunk_tokens] * len(group_block_sizes)
+            if transfer_chunk_tokens is not None
+            else self.group_effective_block_sizes.copy()
+        )
+        for effective_block_size, transfer_size, family in zip(
+            self.group_effective_block_sizes,
+            self.group_transfer_chunk_sizes,
+            group_cache_families,
+            strict=True,
+        ):
             assert effective_block_size % hash_block_size == 0, "block_size must be divisible by hash_block_size"
-            assert scheduler_block_size % effective_block_size == 0, (
-                "scheduler_block_size must be a multiple of each group's effective block_size"
+            assert transfer_size % hash_block_size == 0, "transfer chunk size must be divisible by hash_block_size"
+            assert scheduler_block_size % transfer_size == 0, (
+                "scheduler_block_size must be a multiple of each group's transfer chunk size"
             )
+            if _uses_reachable_mask(family):
+                assert scheduler_block_size % effective_block_size == 0, (
+                    "scheduler_block_size must be a multiple of each reachable group's effective block size"
+                )
 
         self.eagle_group_ids = {i for i, group in enumerate(kv_cache_groups) if group.is_eagle_group}
         if use_eagle and not self.eagle_group_ids:
@@ -101,25 +117,26 @@ class AscendStoreCoordinator:
 
         for group_id, group in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(group.kv_cache_spec)
+            transfer_spec = _copy_spec_with_block_size(spec, self.group_transfer_chunk_sizes[group_id])
             effective_spec = _copy_spec_with_block_size(spec, self.group_effective_block_sizes[group_id])
             if (
                 not _uses_reachable_mask(self.group_cache_families[group_id])
-                and getattr(effective_spec, "compress_ratio", 1) > 1
+                and getattr(transfer_spec, "compress_ratio", 1) > 1
             ):
                 # The cache family already folds the compression ratio into
                 # the external key granularity. Avoid applying it again inside
                 # CompressAttentionManager.find_longest_cache_hit().
-                effective_spec = replace(effective_spec, compress_ratio=1)
+                transfer_spec = replace(transfer_spec, compress_ratio=1)
             self.group_effective_specs.append(effective_spec)
             manager_cls = _get_manager_class(spec)
 
             for existing_spec, group_ids, existing_cls in attention_groups:
-                if existing_spec == effective_spec:
+                if existing_spec == transfer_spec:
                     assert manager_cls is existing_cls, "Expected same manager class for identical KV cache specs."
                     group_ids.append(group_id)
                     break
             else:
-                attention_groups.append((effective_spec, [group_id], manager_cls))
+                attention_groups.append((transfer_spec, [group_id], manager_cls))
 
         self.attention_groups = sorted(
             attention_groups,
@@ -165,7 +182,7 @@ class AscendStoreCoordinator:
             apply_eagle=False,
         )
         return tuple(
-            [True] * _num_chunks(token_len, self.group_effective_block_sizes[group_id])
+            [True] * _num_chunks(token_len, self.group_transfer_chunk_sizes[group_id])
             if not _uses_reachable_mask(self.group_cache_families[group_id])
             else mask
             for group_id, mask in enumerate(masks)
@@ -181,9 +198,12 @@ class AscendStoreCoordinator:
         )
         masks: list[list[bool]] = []
         for group_id, spec in enumerate(self.group_effective_specs):
-            num_chunks = aligned_token_len // self.group_effective_block_sizes[group_id]
+            transfer_size = self.group_transfer_chunk_sizes[group_id]
+            effective_block_size = self.group_effective_block_sizes[group_id]
+            num_chunks = aligned_token_len // effective_block_size
+            transfer_num_chunks = aligned_token_len // transfer_size
             if not _uses_reachable_mask(self.group_cache_families[group_id]):
-                masks.append([True] * num_chunks)
+                masks.append([True] * transfer_num_chunks)
                 continue
             manager_cls = _get_manager_class(_unwrap_spec(self.kv_cache_groups[group_id].kv_cache_spec))
             mask = _reachable_block_mask(
@@ -196,8 +216,35 @@ class AscendStoreCoordinator:
                 retention_interval=self.retention_interval,
                 num_prompt_tokens=num_prompt_tokens,
             )
-            masks.append([True] * num_chunks if mask is None else mask)
+            if mask is None:
+                masks.append([True] * transfer_num_chunks)
+                continue
+            transfer_mask: list[bool] = []
+            for chunk_id in range(transfer_num_chunks):
+                raw_start = chunk_id * transfer_size
+                raw_end = min(raw_start + transfer_size, aligned_token_len)
+                block_start, block_end = self.transfer_value_block_range(group_id, raw_start, raw_end)
+                block_mask = mask[block_start:block_end]
+                transfer_mask.append(len(block_mask) == block_end - block_start and all(block_mask))
+            masks.append(transfer_mask)
         return tuple(masks)
+
+    def transfer_value_block_range(self, group_id: int, raw_start: int, raw_end: int) -> tuple[int, int]:
+        """Map one external chunk to the complete native blocks it needs."""
+        effective_block_size = self.group_effective_block_sizes[group_id]
+        block_end = _num_chunks(raw_end, effective_block_size)
+        if not _uses_reachable_mask(self.group_cache_families[group_id]):
+            block_start = raw_start // effective_block_size
+            return block_start, block_end
+
+        spec = self.group_effective_specs[group_id]
+        sliding_window = getattr(spec, "sliding_window", None)
+        if sliding_window is None:
+            block_start = raw_start // effective_block_size
+        else:
+            window_blocks = _num_chunks(sliding_window, effective_block_size)
+            block_start = max(raw_start // effective_block_size, block_end - window_blocks)
+        return block_start, block_end
 
     def block_hashes_for_spec(self, block_hashes: list[BlockHash], spec: KVCacheSpec) -> BlockHashList:
         if spec.block_size == self.hash_block_size:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1,6 +1,7 @@
 import queue
 import threading
 from collections import defaultdict
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -16,6 +17,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ChunkedTokenDatabase,
     LayerMultiBlockReqMeta,
     ReqMeta,
+    TransferChunkWithBlockId,
     get_block_hashes,
 )
 # isort: on
@@ -197,6 +199,79 @@ class KVTransferThread(threading.Thread):
         except TypeError:
             return self.token_database.prepare_value(start, end, block_ids)
 
+    def _process_transfer_chunks_with_block_ids(
+        self,
+        token_len: int,
+        block_hashes,
+        block_ids: list[int],
+        mask_num: int = 0,
+        kv_cache_group_id: int = 0,
+        skip_null_blocks: bool = False,
+        cache_role: str = "kv",
+    ):
+        process_transfer_chunks = getattr(
+            self.token_database,
+            "process_transfer_chunks_with_block_ids",
+            None,
+        )
+        if process_transfer_chunks is not None:
+            return process_transfer_chunks(
+                token_len,
+                block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=kv_cache_group_id,
+                skip_null_blocks=skip_null_blocks,
+                cache_role=cache_role,
+            )
+
+        def iter_legacy_chunks():
+            group_block_size = self._get_block_size(kv_cache_group_id)
+            for start, end, key, block_id in self._process_tokens_with_block_ids(
+                token_len,
+                block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=kv_cache_group_id,
+                skip_null_blocks=skip_null_blocks,
+                cache_role=cache_role,
+            ):
+                yield TransferChunkWithBlockId(
+                    raw_start=start,
+                    raw_end=end,
+                    value_start=start,
+                    value_end=end,
+                    target_block_index=start // group_block_size,
+                    key=key,
+                    block_id=block_id,
+                )
+
+        return iter_legacy_chunks()
+
+    def _prepare_transfer_value(
+        self,
+        chunk: TransferChunkWithBlockId,
+        block_ids: list[int],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+    ):
+        prepare_transfer_value = getattr(self.token_database, "prepare_transfer_value", None)
+        if prepare_transfer_value is not None:
+            return prepare_transfer_value(
+                chunk,
+                block_ids,
+                kv_cache_group_id=kv_cache_group_id,
+                cache_role=cache_role,
+            )
+        return self._prepare_value(
+            chunk.value_start,
+            chunk.value_end,
+            block_ids,
+            kv_cache_group_id=kv_cache_group_id,
+            cache_role=cache_role,
+            block_id=chunk.block_id,
+        )
+
     def _decode_adaptor_prefill_pp(
         self,
         keys: list[str],
@@ -307,59 +382,51 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
             store_masks = self._store_mask(req_meta)
             for group_id in req_meta.kv_cache_group_ids or [0]:
-                starts = []
-                ends = []
-                keys = []
-                block_hashes = []
-                key_block_ids = []
                 block_ids = req_meta.block_ids_by_group[group_id]
                 group_block_size = self._get_block_size(group_id)
+                transfer_config = getattr(self.token_database, "hybrid_cache_c128_config", None)
+                event_granularity = (
+                    transfer_config.chunk_tokens
+                    if transfer_config is not None and transfer_config.enabled
+                    else group_block_size
+                )
+                assert event_granularity is not None
                 group_block_hashes = get_block_hashes(
                     req_meta.block_hashes,
-                    group_block_size,
+                    event_granularity,
                     getattr(self.token_database, "hash_block_size", group_block_size),
                 )
-
-                for start, end, key, block_id in self._process_tokens_with_block_ids(
-                    token_len,
-                    req_meta.block_hashes,
-                    block_ids,
-                    kv_cache_group_id=group_id,
-                    skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
-                ):
-                    if not self._mask_allows_chunk(store_masks, group_id, start):
-                        continue
-                    starts.append(start)
-                    ends.append(end)
-                    keys.append(key.to_string())
-                    block_hashes.append(group_block_hashes[start // group_block_size])
-                    key_block_ids.append(block_id)
+                chunks = [
+                    chunk
+                    for chunk in self._process_transfer_chunks_with_block_ids(
+                        token_len,
+                        req_meta.block_hashes,
+                        block_ids,
+                        kv_cache_group_id=group_id,
+                        skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+                    )
+                    if self._mask_allows_chunk(store_masks, group_id, chunk.raw_start)
+                ]
 
                 if (
                     not self.dcp_size > 1
                     and not req_meta.disable_tp_key_sharding
                     and not self.group_uses_align_state[group_id]
                 ):
-                    starts = starts[self.tp_rank % self.put_step :: self.put_step]
-                    ends = ends[self.tp_rank % self.put_step :: self.put_step]
-                    keys = keys[self.tp_rank % self.put_step :: self.put_step]
-                    block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
-                    key_block_ids = key_block_ids[self.tp_rank % self.put_step :: self.put_step]
+                    chunks = chunks[self.tp_rank % self.put_step :: self.put_step]
 
-                if not keys:
+                if not chunks:
                     continue
 
+                keys = [chunk.key.to_string() for chunk in chunks]
                 exists_states = self.lookup(keys)
                 missing_indices = [index for index, exists in enumerate(exists_states) if not exists]
 
                 if not missing_indices:
                     continue
 
-                starts = [starts[index] for index in missing_indices]
-                ends = [ends[index] for index in missing_indices]
+                chunks = [chunks[index] for index in missing_indices]
                 keys = [keys[index] for index in missing_indices]
-                block_hashes = [block_hashes[index] for index in missing_indices]
-                key_block_ids = [key_block_ids[index] for index in missing_indices]
 
                 logger.info(
                     "Storing KV cache for %d out of %d blocks (missing_count=%d) for request %s in group %d",
@@ -369,38 +436,40 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     req_id,
                     group_id,
                 )
-                logger.debug(
-                    "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
-                    req_id,
-                    group_id,
-                    token_len,
-                    len(keys),
-                    keys[:3],
-                )
-
                 addrs = []
                 sizes = []
                 stored_events: list[BlockStored] = []
                 prev_key = None
-                new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
-                for index, start in enumerate(starts):
-                    addr, size, _ = self._prepare_value(
-                        start,
-                        ends[index],
+                new_block_hashes = [
+                    maybe_convert_block_hash(
+                        group_block_hashes[chunk.raw_start // event_granularity]
+                    )
+                    for chunk in chunks
+                ]
+                for index, chunk in enumerate(chunks):
+                    addr, size, _ = self._prepare_transfer_value(
+                        chunk,
                         block_ids,
                         kv_cache_group_id=group_id,
-                        block_id=key_block_ids[index],
                     )
                     addrs.append(addr)
                     sizes.append(size)
 
                     # Create KV event
                     if self.enable_kv_event:
-                        token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
+                        token_ids = (
+                            req_meta.token_ids[chunk.raw_start : chunk.raw_end]
+                            if req_meta.token_ids is not None
+                            else None
+                        )
                         block_size = (
-                            req_meta.original_block_size[group_id]
-                            if isinstance(req_meta.original_block_size, list)
-                            else req_meta.original_block_size
+                            transfer_config.chunk_tokens
+                            if transfer_config is not None and transfer_config.enabled
+                            else (
+                                req_meta.original_block_size[group_id]
+                                if isinstance(req_meta.original_block_size, list)
+                                else req_meta.original_block_size
+                            )
                         )
                         if block_size is not None:
                             stored_event = BlockStored(
@@ -449,14 +518,23 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         ready_event: threading.Event,
         invalid_block_ids: set[int],
         invalid_block_ids_lock: threading.Lock,
+        get_c128_staging_value: Callable[[int], tuple[list[int], list[int]]] | None = None,
+        merge_c128_staging_chunk: Callable[[int, TransferChunkWithBlockId], None] | None = None,
     ):
         super().__init__(
             m_store, token_database, block_size, tp_rank, dcp_size, ready_event, name="KVCacheStoreRecvingThread"
         )
         self._invalid_block_ids = invalid_block_ids
         self._invalid_block_ids_lock = invalid_block_ids_lock
+        self._get_c128_staging_value = get_c128_staging_value
+        self._merge_c128_staging_chunk = merge_c128_staging_chunk
 
     def _handle_request(self, req_meta: ReqMeta):
+        transfer_config = getattr(self.token_database, "hybrid_cache_c128_config", None)
+        if transfer_config is not None and transfer_config.enabled:
+            self._handle_hybrid_c128_request(req_meta)
+            return
+
         token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
         req_id = req_meta.req_id
         addr_list = []
@@ -552,6 +630,108 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             req_meta.kv_cache_group_ids or [0],
             len(key_list_c),
         )
+        self.set_finished_request(req_id)
+        self.request_queue.task_done()
+
+    def _record_load_failures(
+        self,
+        req_meta: ReqMeta,
+        block_ids: list[int],
+        results: list[int] | None,
+    ) -> None:
+        if results is None:
+            results = [1] * len(block_ids)
+        if not any(result != 0 for result in results):
+            return
+        missing_block_ids = record_failed_blocks(block_ids, results)
+        if len(req_meta.block_ids_by_group) == 1:
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(missing_block_ids)
+        elif missing_block_ids:
+            logger.error(
+                "KV load failed for hybrid request %s. "
+                "Skip invalid-block fallback to avoid scheduler crash. "
+                "failed_blocks=%s",
+                req_meta.req_id,
+                missing_block_ids,
+            )
+
+    def _handle_hybrid_c128_request(self, req_meta: ReqMeta) -> None:
+        transfer_config = self.token_database.hybrid_cache_c128_config
+        assert transfer_config.chunk_tokens is not None
+        if self._get_c128_staging_value is None or self._merge_c128_staging_chunk is None:
+            raise RuntimeError("Hybrid C128 asynchronous load requires registered staging callbacks.")
+
+        token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
+        req_id = req_meta.req_id
+        group_ids = req_meta.kv_cache_group_ids or [0]
+        load_masks = self._load_mask(req_meta, token_len)
+        addr_list: list[list[int]] = []
+        size_list: list[list[int]] = []
+        key_list: list[str] = []
+        block_id_list: list[int] = []
+        c128_chunks: list[tuple[int, TransferChunkWithBlockId]] = []
+        mask_num = (
+            req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
+            // transfer_config.chunk_tokens
+            * transfer_config.chunk_tokens
+        )
+
+        for group_id in group_ids:
+            if group_id >= len(req_meta.block_ids_by_group):
+                continue
+            block_ids = req_meta.block_ids_by_group[group_id]
+            for chunk in self._process_transfer_chunks_with_block_ids(
+                token_len,
+                req_meta.block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=group_id,
+                skip_null_blocks=self._skip_null_blocks(req_meta, group_id),
+            ):
+                if not self._mask_allows_chunk(load_masks, group_id, chunk.raw_start):
+                    continue
+                if self.token_database.is_c128_group(group_id):
+                    c128_chunks.append((group_id, chunk))
+                    continue
+                addr, size, block_id = self._prepare_transfer_value(
+                    chunk,
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                key_list.append(chunk.key.to_string())
+                addr_list.append(addr)
+                size_list.append(size)
+                block_id_list.append(block_id)
+
+        if not key_list and not c128_chunks:
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
+
+        if key_list:
+            rotation = self.tp_rank % len(key_list)
+            key_list = key_list[rotation:] + key_list[:rotation]
+            addr_list = addr_list[rotation:] + addr_list[:rotation]
+            size_list = size_list[rotation:] + size_list[:rotation]
+            block_id_list = block_id_list[rotation:] + block_id_list[:rotation]
+            results = self.m_store.get(key_list, addr_list, size_list)
+            self._record_load_failures(req_meta, block_id_list, results)
+
+        for group_id, chunk in c128_chunks:
+            staging_addrs, staging_sizes = self._get_c128_staging_value(group_id)
+            results = self.m_store.get(
+                [chunk.key.to_string()],
+                [staging_addrs],
+                [staging_sizes],
+            )
+            if results is not None and len(results) == 1 and results[0] == 0:
+                # The callback copies only the authoritative range and waits for
+                # that NPU copy before the single staging page is reused.
+                self._merge_c128_staging_chunk(group_id, chunk)
+            else:
+                self._record_load_failures(req_meta, [chunk.block_id], results)
+
         self.set_finished_request(req_id)
         self.request_queue.task_done()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -32,6 +32,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     get_cache_family_granularity,
     infer_group_cache_families,
     normalize_block_ids_by_group,
+    resolve_hybrid_cache_c128_config,
 )
 
 
@@ -102,14 +103,27 @@ class KVPoolScheduler:
             assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
         self._block_size = self.grouped_block_size[0]
         self.lcm_block_size = math.lcm(*self.grouped_block_size)
-        self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
-        # request_id -> full_token_ids
-        self._request_trackers: dict[str, RequestTracker] = {}
-        self._preempted_req_ids: set[str] = set()
-        # Whether to discard partial chunks
         self._discard_partial_chunks = vllm_config.kv_transfer_config.get_from_extra_config(
             "discard_partial_chunks", True
         )
+        self.hybrid_cache_c128_config = resolve_hybrid_cache_c128_config(
+            vllm_config,
+            use_layerwise=self.use_layerwise,
+            group_block_sizes=self.grouped_block_size,
+            group_cache_families=self.kv_cache_group_families,
+            hash_block_size=self.hash_block_size,
+            discard_partial_chunks=self._discard_partial_chunks,
+        )
+        self.cache_transfer_granularity = (
+            self.hybrid_cache_c128_config.chunk_tokens
+            if self.hybrid_cache_c128_config.enabled
+            else self._infer_cache_transfer_granularity()
+        )
+        assert self.cache_transfer_granularity is not None
+
+        # request_id -> full_token_ids
+        self._request_trackers: dict[str, RequestTracker] = {}
+        self._preempted_req_ids: set[str] = set()
         self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._unfinished_request_ids: set[str] = set()
         self._block_pool: BlockPool | None = None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -30,9 +30,11 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     KeyMetadata,
     LayerMultiBlockReqMeta,
     ReqMeta,
+    TransferChunkWithBlockId,
     get_block_hashes,
     get_cache_family_granularity,
     infer_group_cache_families,
+    resolve_hybrid_cache_c128_config,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
     AscendStoreCoordinator,
@@ -129,7 +131,23 @@ class KVPoolWorker:
         self.num_kv_cache_groups = len(self.grouped_block_size)
         self.kv_cache_group_families = self._infer_group_families()
         self.group_uses_align_state = self._infer_group_uses_align_state()
-        self.cache_transfer_granularity = self._infer_cache_transfer_granularity()
+        discard_partial_chunks = vllm_config.kv_transfer_config.get_from_extra_config(
+            "discard_partial_chunks", True
+        )
+        self.hybrid_cache_c128_config = resolve_hybrid_cache_c128_config(
+            vllm_config,
+            use_layerwise=self.use_layerwise,
+            group_block_sizes=self.grouped_block_size,
+            group_cache_families=self.kv_cache_group_families,
+            hash_block_size=self.hash_block_size,
+            discard_partial_chunks=discard_partial_chunks,
+        )
+        self.cache_transfer_granularity = (
+            self.hybrid_cache_c128_config.chunk_tokens
+            if self.hybrid_cache_c128_config.enabled
+            else self._infer_cache_transfer_granularity()
+        )
+        assert self.cache_transfer_granularity is not None
         if self.use_layerwise and self.num_kv_cache_groups > 1:
             raise NotImplementedError("AscendStore layerwise mode does not yet support hybrid KV cache groups.")
 
@@ -197,7 +215,12 @@ class KVPoolWorker:
             )
 
         self.token_database = ChunkedTokenDatabase(
-            self.metadata, self.grouped_block_size, partitions, self.use_hybrid, self.hash_block_size
+            self.metadata,
+            self.grouped_block_size,
+            partitions,
+            self.use_hybrid,
+            self.hash_block_size,
+            self.hybrid_cache_c128_config,
         )
         self.cache_coordinator = self._build_cache_coordinator(vllm_config)
         self.token_database.set_cache_coordinator(self.cache_coordinator)
@@ -244,6 +267,7 @@ class KVPoolWorker:
             hash_block_size=self.hash_block_size,
             group_block_sizes=self.grouped_block_size,
             group_cache_families=self.kv_cache_group_families,
+            transfer_chunk_tokens=self.hybrid_cache_c128_config.chunk_tokens,
             use_eagle=use_eagle,
             retention_interval=retention_interval,
         )
@@ -352,18 +376,291 @@ class KVPoolWorker:
         group_addrs: list[int] = []
         group_block_lens: list[int] = []
         group_block_strides: list[int] = []
+        group_tensors: list[torch.Tensor] = []
+        group_block_size_scales: list[int] = []
         for layer_name in layer_names:
             cache_or_caches = self.kv_caches[layer_name]
             for cache in self._as_cache_tuple(cache_or_caches):
                 base_addr = cache.data_ptr()
-                block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+                block_len, block_stride, _, block_size_scale = self._get_cache_block_metadata(cache)
                 group_addrs.append(base_addr)
                 group_block_lens.append(block_len)
                 group_block_strides.append(block_stride)
+                group_tensors.append(cache)
+                group_block_size_scales.append(block_size_scale)
         self.group_kv_caches_base_addr[group_id] = group_addrs
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides
+        self.group_kv_cache_tensors[group_id] = group_tensors
+        self.group_block_size_scales[group_id] = group_block_size_scales
         self.group_num_layers[group_id] = len(layer_names)
+
+    def _create_c128_staging_buffers(self) -> tuple[list[int], list[int]]:
+        """Create one reusable full-page staging value for every C128 tensor."""
+        self.c128_staging_tensors: dict[int, list[torch.Tensor]] = {}
+        config = self.hybrid_cache_c128_config
+        if not config.enabled:
+            return [], []
+        assert config.c128_group_id is not None
+        if config.c128_slots_per_page is None:
+            raise RuntimeError("C128 slot geometry is missing from the hybrid cache configuration.")
+        group_id = config.c128_group_id
+        if group_id not in self.group_kv_cache_tensors:
+            raise RuntimeError(f"C128 cache group {group_id} has no registered KV cache tensors.")
+        staging_tensors: list[torch.Tensor] = []
+        ptrs: list[int] = []
+        lengths: list[int] = []
+        for cache, block_size_scale in zip(
+            self.group_kv_cache_tensors[group_id],
+            self.group_block_size_scales[group_id],
+            strict=True,
+        ):
+            first_page = cache.narrow(0, 0, block_size_scale)
+            if not first_page.is_contiguous():
+                raise ValueError("hybrid C128 transfer requires contiguous external KV cache pages.")
+            if first_page.numel() % config.c128_slots_per_page != 0:
+                raise ValueError(
+                    "The C128 external page cannot be divided into "
+                    f"{config.c128_slots_per_page} cache slots."
+                )
+            staging = torch.empty_like(first_page, memory_format=torch.contiguous_format)
+            if not staging.is_contiguous():
+                raise ValueError("hybrid C128 transfer requires a contiguous staging page.")
+            staging_tensors.append(staging)
+            ptrs.append(staging.data_ptr())
+            lengths.append(staging.numel() * staging.element_size())
+        self.c128_staging_tensors[group_id] = staging_tensors
+        return ptrs, lengths
+
+    def _get_c128_staging_value(self, group_id: int) -> tuple[list[int], list[int]]:
+        staging_tensors = self.c128_staging_tensors.get(group_id)
+        if not staging_tensors:
+            raise RuntimeError(f"C128 staging buffers are not registered for cache group {group_id}.")
+        return (
+            [tensor.data_ptr() for tensor in staging_tensors],
+            [tensor.numel() * tensor.element_size() for tensor in staging_tensors],
+        )
+
+    def _merge_c128_staging_chunk(self, group_id: int, chunk: TransferChunkWithBlockId) -> None:
+        """Copy only the key-authoritative slots from staging into a target page."""
+        slots_per_page = self.hybrid_cache_c128_config.c128_slots_per_page
+        if slots_per_page is None:
+            raise RuntimeError("C128 slot geometry is missing from the hybrid cache configuration.")
+        if chunk.value_start < 0 or chunk.value_end > slots_per_page:
+            raise ValueError(
+                "Invalid C128 authoritative range "
+                f"[{chunk.value_start}, {chunk.value_end}) for {slots_per_page} slots."
+            )
+        if chunk.value_start >= chunk.value_end:
+            raise ValueError("The C128 authoritative range must not be empty.")
+
+        target_tensors = self.group_kv_cache_tensors[group_id]
+        block_size_scales = self.group_block_size_scales[group_id]
+        staging_tensors = self.c128_staging_tensors[group_id]
+        for target_cache, block_size_scale, staging in zip(
+            target_tensors,
+            block_size_scales,
+            staging_tensors,
+            strict=True,
+        ):
+            target_start = chunk.block_id * block_size_scale
+            if target_start < 0 or target_start + block_size_scale > target_cache.shape[0]:
+                raise ValueError(f"C128 target block id {chunk.block_id} is outside the KV cache allocation.")
+            target_page = target_cache.narrow(0, target_start, block_size_scale)
+            if not target_page.is_contiguous():
+                raise ValueError("hybrid C128 transfer requires contiguous target pages.")
+            if target_page.numel() != staging.numel():
+                raise ValueError("C128 target and staging pages must have identical sizes.")
+            if target_page.numel() % slots_per_page != 0:
+                raise ValueError(
+                    f"The C128 external page cannot be divided into {slots_per_page} cache slots."
+                )
+
+            elements_per_slot = target_page.numel() // slots_per_page
+            element_offset = chunk.value_start * elements_per_slot
+            element_count = (chunk.value_end - chunk.value_start) * elements_per_slot
+            target_page.view(-1).narrow(0, element_offset, element_count).copy_(
+                staging.view(-1).narrow(0, element_offset, element_count)
+            )
+
+        # copy_ is asynchronous on NPU. A single staging page is reused by the
+        # next Mooncake get, so its authoritative range must be consumed first.
+        if staging_tensors and staging_tensors[0].device.type == "npu":
+            torch.npu.current_stream().synchronize()
+
+    def _record_sync_load_failures(
+        self,
+        request: ReqMeta,
+        block_ids: list[int],
+        results: list[int] | None,
+    ) -> None:
+        if results is None:
+            results = [1] * len(block_ids)
+        if not any(result != 0 for result in results):
+            return
+        missing_block_ids = record_failed_blocks(block_ids, results)
+        if len(request.block_ids_by_group) == 1:
+            self._invalid_block_ids.update(missing_block_ids)
+        elif missing_block_ids:
+            logger.error(
+                "KV load failed for hybrid request %s. "
+                "Skip invalid-block fallback to avoid scheduler crash. "
+                "failed_blocks=%s",
+                request.req_id,
+                missing_block_ids,
+            )
+
+    def _build_sync_load_group_plan(
+        self,
+        request: ReqMeta,
+        load_group_ids: list[int],
+    ) -> list[tuple[int, list[int], int, bool, bool]]:
+        """Precompute group-level sync load state once per request."""
+        load_spec = request.load_spec
+        assert load_spec is not None
+        is_c128_enabled = self.hybrid_cache_c128_config.enabled
+        c128_mask_num = 0
+        if is_c128_enabled:
+            c128_chunk_tokens = self.hybrid_cache_c128_config.chunk_tokens
+            assert c128_chunk_tokens is not None
+            c128_mask_num = (
+                load_spec.vllm_cached_tokens // c128_chunk_tokens * c128_chunk_tokens
+            )
+
+        group_plan: list[tuple[int, list[int], int, bool, bool]] = []
+        for group_id in load_group_ids:
+            if group_id >= len(request.block_ids_by_group):
+                continue
+            block_ids = request.block_ids_by_group[group_id]
+            if is_c128_enabled:
+                mask_num = c128_mask_num
+            else:
+                group_block_size = self.grouped_block_size[group_id]
+                mask_num = (
+                    load_spec.vllm_cached_tokens // group_block_size * group_block_size
+                )
+            skip_null = (
+                group_id < len(self.group_uses_align_state)
+                and self.group_uses_align_state[group_id]
+            )
+            is_c128_group = (
+                is_c128_enabled and self.token_database.is_c128_group(group_id)
+            )
+            group_plan.append(
+                (group_id, block_ids, mask_num, skip_null, is_c128_group)
+            )
+        return group_plan
+
+    def _collect_sync_load_chunks(
+        self,
+        request: ReqMeta,
+        token_len: int,
+        load_group_ids: list[int],
+    ) -> tuple[
+        list[str],
+        list[list[int]],
+        list[list[int]],
+        list[int],
+        dict[int, list[TransferChunkWithBlockId]],
+        int,
+    ]:
+        key_list: list[str] = []
+        addr_list: list[list[int]] = []
+        size_list: list[list[int]] = []
+        block_id_list: list[int] = []
+        c128_load_plan: dict[int, list[TransferChunkWithBlockId]] = {}
+        c128_total_chunks = 0
+        load_masks = self.token_database.load_mask(request.block_hashes, token_len)
+        for (
+            group_id,
+            block_ids,
+            mask_num,
+            skip_null,
+            is_c128_group,
+        ) in self._build_sync_load_group_plan(request, load_group_ids):
+            for chunk in self.token_database.process_transfer_chunks_with_block_ids(
+                token_len,
+                request.block_hashes,
+                block_ids,
+                mask_num,
+                kv_cache_group_id=group_id,
+                skip_null_blocks=skip_null,
+            ):
+                if not self.token_database.mask_allows_chunk(
+                    load_masks, group_id, chunk.raw_start
+                ):
+                    continue
+                if is_c128_group:
+                    c128_load_plan.setdefault(group_id, []).append(chunk)
+                    c128_total_chunks += 1
+                    continue
+                addr, size, block_id = self.token_database.prepare_transfer_value(
+                    chunk,
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                key_list.append(chunk.key.to_string())
+                addr_list.append(addr)
+                size_list.append(size)
+                block_id_list.append(block_id)
+        return (
+            key_list,
+            addr_list,
+            size_list,
+            block_id_list,
+            c128_load_plan,
+            c128_total_chunks,
+        )
+
+    def _load_direct_sync_chunks(
+        self,
+        request: ReqMeta,
+        token_len: int,
+        load_group_ids: list[int],
+        key_list: list[str],
+        addr_list: list[list[int]],
+        size_list: list[list[int]],
+        block_id_list: list[int],
+    ) -> None:
+        rotation = self.tp_rank % len(key_list)
+        key_list_c = key_list[rotation:] + key_list[:rotation]
+        addr_list_c = addr_list[rotation:] + addr_list[:rotation]
+        size_list_c = size_list[rotation:] + size_list[:rotation]
+        block_id_list_c = block_id_list[rotation:] + block_id_list[:rotation]
+        logger.debug(
+            "KV pool worker calls backend get request=%s token_len=%d groups=%s keys=%d sample_keys=%s",
+            request.req_id,
+            token_len,
+            load_group_ids,
+            len(key_list_c),
+            key_list_c[:3],
+        )
+        ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
+        self._record_sync_load_failures(request, block_id_list_c, ret)
+
+    def _load_c128_sync_chunks(
+        self,
+        request: ReqMeta,
+        c128_load_plan: dict[int, list[TransferChunkWithBlockId]],
+    ) -> None:
+        for group_id, page_chunks in c128_load_plan.items():
+            staging_addrs, staging_sizes = self._get_c128_staging_value(group_id)
+            for chunk in page_chunks:
+                # A C128 group currently has one reusable staging page per worker.
+                # Each get overwrites that page, so get and merge must stay
+                # sequential unless multiple staging pages are introduced.
+                ret = self.m_store.get(
+                    [chunk.key.to_string()],
+                    [staging_addrs],
+                    [staging_sizes],
+                )
+                if ret is not None and len(ret) == 1 and ret[0] == 0:
+                    # Mooncake's synchronous get returns the completed byte
+                    # count/status. The merge then synchronizes its NPU copy
+                    # before this staging page is reused.
+                    self._merge_c128_staging_chunk(group_id, chunk)
+                else:
+                    self._record_sync_load_failures(request, [chunk.block_id], ret)
 
     def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
         """
@@ -396,6 +693,8 @@ class KVPoolWorker:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
+        self.group_kv_cache_tensors: dict[int, list[torch.Tensor]] = {}
+        self.group_block_size_scales: dict[int, list[int]] = {}
         self.kv_caches = kv_caches
         self.group_kv_cache_families: dict[int, str] = {
             group_id: self._get_group_family(self.kv_cache_group_families, group_id)
@@ -436,6 +735,8 @@ class KVPoolWorker:
         else:
             self._infer_cache_group_metadata(0, list(kv_caches.keys()))
 
+        staging_ptrs, staging_lengths = self._create_c128_staging_buffers()
+
         # group_num_layers is computed from the actual kv_caches dict which
         # includes ALL attention layers (main + MTP), so it is the authoritative
         # layer count for this worker.
@@ -449,6 +750,8 @@ class KVPoolWorker:
             )
 
         self.m_store.register_buffer(ptrs, lengths)
+        if staging_ptrs:
+            self.m_store.register_additional_buffer(staging_ptrs, staging_lengths)
         self.token_database.set_group_buffers(
             self.group_kv_caches_base_addr,
             self.group_block_len,
@@ -515,6 +818,8 @@ class KVPoolWorker:
                     ready_event,
                     self._invalid_block_ids,
                     self._invalid_block_ids_lock,
+                    self._get_c128_staging_value,
+                    self._merge_c128_staging_chunk,
                 )
                 self.kv_recv_thread.start()
                 ready_event.wait()
@@ -562,93 +867,34 @@ class KVPoolWorker:
                     request,
                 )
             else:
-                addr_list = []
-                size_list = []
-                key_list = []
-                block_id_list: list[int] = []
-                load_masks = self.token_database.load_mask(request.block_hashes, token_len)
-                for group_id in load_group_ids:
-                    if group_id >= len(request.block_ids_by_group):
-                        continue
-                    block_ids = request.block_ids_by_group[group_id]
-                    group_block_size = self.grouped_block_size[group_id]
-                    mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
-                    skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
-                    for start, end, key, block_id in self.token_database.process_tokens_with_block_ids(
-                        token_len,
-                        request.block_hashes,
-                        block_ids,
-                        mask_num,
-                        kv_cache_group_id=group_id,
-                        skip_null_blocks=skip_null,
-                    ):
-                        if not self.token_database.mask_allows_chunk(load_masks, group_id, start):
-                            continue
-                        addr, size, block_id = self.token_database.prepare_value(
-                            start,
-                            end,
-                            block_ids,
-                            kv_cache_group_id=group_id,
-                            block_id=block_id,
-                        )
-                        key_list.append(key.to_string())
-                        addr_list.append(addr)
-                        size_list.append(size)
-                        block_id_list.append(block_id)
-                if not key_list:
+                (
+                    key_list,
+                    addr_list,
+                    size_list,
+                    block_id_list,
+                    c128_load_plan,
+                    c128_total_chunks,
+                ) = self._collect_sync_load_chunks(request, token_len, load_group_ids)
+                if not key_list and not c128_load_plan:
                     continue
-                key_list_c = key_list[self.tp_rank % len(key_list) :] + key_list[: self.tp_rank % len(key_list)]
-                addr_list_c = addr_list[self.tp_rank % len(addr_list) :] + addr_list[: self.tp_rank % len(addr_list)]
-                size_list_c = size_list[self.tp_rank % len(size_list) :] + size_list[: self.tp_rank % len(size_list)]
-                block_id_list_c = (
-                    block_id_list[self.tp_rank % len(block_id_list) :]
-                    + block_id_list[: self.tp_rank % len(block_id_list)]
-                )
-                logger.debug(
-                    "KV pool worker calls backend get request=%s token_len=%d groups=%s keys=%d sample_keys=%s",
-                    request.req_id,
-                    token_len,
-                    load_group_ids,
-                    len(key_list_c),
-                    key_list_c[:3],
-                )
-                ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
-                if ret is not None and any(r != 0 for r in ret):
-                    missing_block_ids = record_failed_blocks(
-                        block_id_list_c,
-                        ret,
+                if key_list:
+                    self._load_direct_sync_chunks(
+                        request,
+                        token_len,
+                        load_group_ids,
+                        key_list,
+                        addr_list,
+                        size_list,
+                        block_id_list,
                     )
-                    if len(request.block_ids_by_group) == 1:
-                        self._invalid_block_ids.update(missing_block_ids)
-                    elif missing_block_ids:
-                        logger.error(
-                            "KV load failed for hybrid request %s. "
-                            "Skip invalid-block fallback to avoid scheduler crash. "
-                            "failed_blocks=%s",
-                            request.req_id,
-                            missing_block_ids,
-                        )
-                elif ret is None:
-                    missing_block_ids = record_failed_blocks(
-                        block_id_list_c,
-                        [1] * len(block_id_list_c),
-                    )
-                    if len(request.block_ids_by_group) == 1:
-                        self._invalid_block_ids.update(missing_block_ids)
-                    elif missing_block_ids:
-                        logger.error(
-                            "KV load failed for hybrid request %s. "
-                            "Skip invalid-block fallback to avoid scheduler crash. "
-                            "failed_blocks=%s",
-                            request.req_id,
-                            missing_block_ids,
-                        )
+                if c128_load_plan:
+                    self._load_c128_sync_chunks(request, c128_load_plan)
                 logger.debug(
                     "KV pool worker backend get returned request=%s token_len=%d groups=%s keys=%d",
                     request.req_id,
                     token_len,
                     load_group_ids,
-                    len(key_list_c),
+                    len(key_list) + c128_total_chunks,
                 )
 
     def wait_for_layer_load(self) -> None:
@@ -959,11 +1205,12 @@ class KVPoolWorker:
                 keys = []
                 starts = []
                 ends = []
-                for start, end, key in self.token_database.process_tokens(
+                for chunk in self.token_database.process_transfer_chunks(
                     token_len,
                     block_hashes,
                     kv_cache_group_id=group_id,
                 ):
+                    start, end, key = chunk.raw_start, chunk.raw_end, chunk.key
                     if use_layerwise:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:
@@ -1073,11 +1320,12 @@ class KVPoolWorker:
             keys: list[str] = []
             chunk_hashes: list[str] = []
             variant_counts: list[int] = []
-            for _, _, key in self.token_database.process_tokens(
+            for chunk in self.token_database.process_transfer_chunks(
                 token_len,
                 block_hashes,
                 kv_cache_group_id=group_id,
             ):
+                key = chunk.key
                 variants = self._expand_lookup_key_variants(key.to_string(), group_id, include_all_ranks)
                 keys.extend(variants)
                 chunk_hashes.append(key.chunk_hash)
@@ -1109,7 +1357,7 @@ class KVPoolWorker:
             ExternalCachedBlockPool(exists),
             apply_eagle=False,
         )
-        logger.debug(
+        logger.info(
             "KV pool coordinator lookup final token_len=%d groups=%s hit=%d",
             token_len,
             kv_cache_group_ids,
@@ -1146,11 +1394,12 @@ class KVPoolWorker:
                 keys = []
                 starts = []
                 ends = []
-                for start, end, key in self.token_database.process_tokens(
+                for chunk in self.token_database.process_transfer_chunks(
                     token_len,
                     block_hashes,
                     kv_cache_group_id=group_id,
                 ):
+                    start, end, key = chunk.raw_start, chunk.raw_end, chunk.key
                     if use_layerwise:
                         keys_multi_layer = key.split_layers(self.num_layers)
                         for item in keys_multi_layer:

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -5,6 +5,7 @@ class GlobalTE:
     def __init__(self):
         self.transfer_engine = None
         self.is_register_buffer: bool = False
+        self.additional_registered_buffers: set[tuple[int, int]] = set()
         self.transfer_engine_lock = threading.Lock()
         self.register_buffer_lock = threading.Lock()
 
@@ -38,6 +39,22 @@ class GlobalTE:
                 if ret_value != 0:
                     raise RuntimeError("Mooncake memory registration failed.")
             self.is_register_buffer = True
+
+    def register_additional_buffer(self, ptrs: list[int], sizes: list[int]):
+        """Register buffers allocated after the initial KV cache registration."""
+        with self.register_buffer_lock:
+            assert self.transfer_engine is not None, "Transfer engine must be initialized"
+            for ptr, size in zip(ptrs, sizes, strict=True):
+                region = (ptr, size)
+                if region in self.additional_registered_buffers:
+                    continue
+                ret_value = self.transfer_engine.register_memory(ptr, size)
+                if ret_value != 0:
+                    raise RuntimeError(
+                        "Mooncake additional memory registration failed: "
+                        f"ptr={ptr}, size={size}, ret={ret_value}"
+                    )
+                self.additional_registered_buffers.add(region)
 
 
 global_te = GlobalTE()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces support for hybrid cache C128 external transfer using the Mooncake backend. It adds `HybridCacheC128Config` to handle C128 external transfer configuration, staging buffers, and asynchronous/synchronous loading and merging of C128 chunks. It also adds a request dumping feature to the load balance proxy server example (`/start_dump_req` and `/stop_dump_req` endpoints) to allow writing incoming completion requests to a JSONL file.

### Does this PR introduce _any_ user-facing change?

Yes, it adds new endpoints `/start_dump_req` and `/stop_dump_req` and a new command-line argument `--request-dump-file` to the load balance proxy server example. It also introduces a new configuration option `hybrid_cache_c128_chunk` under `kv_connector_extra_config` for Mooncake backend users.

### How was this patch tested?

The changes are covered by extensive new unit tests added in `tests/ut/distributed/ascend_store/`, `tests/ut/distributed/kv_transfer/`, and `tests/ut/examples/`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
