### PR TITLE
[Bugfix] pass return_lse into QuantSFA ops

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -304,7 +304,7 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["query"].shape, (3, 2, 48))
         self.assertEqual(call_kwargs["key_quant_mode"], 2)
         self.assertEqual(call_kwargs["tile_size"], 128)
-        self.assertTrue(call_kwargs["return_softmax_lse"])
+        self.assertEqual(call_kwargs["return_softmax_lse"], False)
 
     def test_prolog_v3_enables_packed_int8_kv_cache(self):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -750,7 +750,7 @@ class BaseDeviceAdaptor:
             key_quant_mode=2,
             value_quant_mode=2,
             rope_head_dim=getattr(sfa_impl, "qk_rope_head_dim", q_pe.shape[-1]),
-            return_softmax_lse=True,
+            return_softmax_lse=return_lse,
         )
         if not isinstance(result, tuple):
             if return_lse:


### PR DESCRIPTION
### What this PR does / why we need it?
This bug was introduced by #11981 by mistakes. We should pass `return_lse` into qsfa ops instead of `True` directly.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
