### PR TITLE
[BugFix] Align AscendStore with request hash granularity

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -16,7 +16,7 @@
 #
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
@@ -30,7 +30,30 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     RequestTracker,
     get_block_hashes,
+    resolve_request_hash_block_size,
 )
+
+
+class TestRequestHashBlockSize(unittest.TestCase):
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store."
+        "config_data.kv_cache_utils.resolve_kv_cache_block_sizes"
+    )
+    def test_uses_vllm_resolver(self, resolver):
+        vllm_config = object()
+        kv_cache_config = object()
+        resolver.return_value = (128, 8)
+
+        self.assertEqual(resolve_request_hash_block_size(vllm_config, kv_cache_config, 128), 8)
+        resolver.assert_called_once_with(kv_cache_config, vllm_config)
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store."
+        "config_data.kv_cache_utils.resolve_kv_cache_block_sizes"
+    )
+    def test_falls_back_without_kv_cache_config(self, resolver):
+        self.assertEqual(resolve_request_hash_block_size(object(), None, 128), 128)
+        resolver.assert_not_called()
 
 
 class TestKeyMetadata(unittest.TestCase):

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -100,12 +100,14 @@ def _make_vllm_config(
     enable_prefix_caching: bool,
     dcp: int,
     block_size: int = 16,
+    kv_transfer_config: object | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         cache_config=SimpleNamespace(
             block_size=block_size,
             enable_prefix_caching=enable_prefix_caching,
         ),
+        kv_transfer_config=kv_transfer_config,
         parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp,
         ),
@@ -124,20 +126,23 @@ def _make_coordinator_for_effective_block_size(
 
 
 @pytest.mark.parametrize(
-    ("enable_prefix_caching", "expected_hash_block_size"),
+    ("enable_prefix_caching", "connector_enabled", "expected_hash_block_size"),
     [
-        pytest.param(False, math.lcm(16, 32) * 2, id="dcp-without-prefix-caching"),
-        pytest.param(True, math.gcd(16, 32), id="dcp-with-prefix-caching"),
+        pytest.param(False, False, math.lcm(16, 32) * 2, id="dcp-without-hashing"),
+        pytest.param(False, True, math.gcd(16, 32), id="dcp-with-connector"),
+        pytest.param(True, False, math.gcd(16, 32), id="dcp-with-prefix-caching"),
     ],
 )
 def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     enable_prefix_caching: bool,
+    connector_enabled: bool,
     expected_hash_block_size: int,
 ) -> None:
     kv_cache_config = _make_hybrid_kv_cache_config(full_block_size=16, mamba_block_size=32)
     vllm_config = _make_vllm_config(
         enable_prefix_caching=enable_prefix_caching,
         dcp=2,
+        kv_transfer_config=object() if connector_enabled else None,
     )
 
     scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -126,23 +126,23 @@ def _make_coordinator_for_effective_block_size(
 
 
 @pytest.mark.parametrize(
-    ("enable_prefix_caching", "connector_enabled", "expected_hash_block_size"),
+    ("enable_prefix_caching", "kv_transfer_config", "expected_hash_block_size"),
     [
-        pytest.param(False, False, math.lcm(16, 32) * 2, id="dcp-without-hashing"),
-        pytest.param(False, True, math.gcd(16, 32), id="dcp-with-connector"),
-        pytest.param(True, False, math.gcd(16, 32), id="dcp-with-prefix-caching"),
+        pytest.param(False, None, math.lcm(16, 32) * 2, id="dcp-without-hashing"),
+        pytest.param(False, object(), math.gcd(16, 32), id="dcp-with-connector"),
+        pytest.param(True, None, math.gcd(16, 32), id="dcp-with-prefix-caching"),
     ],
 )
 def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     enable_prefix_caching: bool,
-    connector_enabled: bool,
+    kv_transfer_config: object | None,
     expected_hash_block_size: int,
 ) -> None:
     kv_cache_config = _make_hybrid_kv_cache_config(full_block_size=16, mamba_block_size=32)
     vllm_config = _make_vllm_config(
         enable_prefix_caching=enable_prefix_caching,
         dcp=2,
-        kv_transfer_config=object() if connector_enabled else None,
+        kv_transfer_config=kv_transfer_config,
     )
 
     scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import numpy as np
 import torch
+import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata, KVConnectorWorkerMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
@@ -13,6 +14,12 @@ from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashList
 from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_ascend.memcache_comm_fence import AttentionComputeStartGate
+
+
+def resolve_request_hash_block_size(vllm_config: Any, kv_cache_config: Any | None, fallback: int) -> int:
+    if kv_cache_config is None:
+        return fallback
+    return kv_cache_utils.resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)[1]
 
 
 @dataclass(frozen=True)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -42,6 +42,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     infer_group_cache_families,
     infer_tp_mismatch_info,
     normalize_block_ids_by_group,
+    resolve_request_hash_block_size,
 )
 
 
@@ -109,12 +110,11 @@ class KVPoolScheduler:
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
-        requested_hash_block_size = vllm_config.cache_config.prefix_match_unit
-        if not isinstance(requested_hash_block_size, int):
-            requested_hash_block_size = None
-        self.hash_block_size = (
-            requested_hash_block_size if requested_hash_block_size is not None else min(self.original_block_size)
-        ) * cp_scale
+        self.hash_block_size = resolve_request_hash_block_size(
+            vllm_config,
+            kv_cache_config,
+            self.grouped_block_size[0],
+        )
         for group_block_size in self.grouped_block_size:
             assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
         self._block_size = self.grouped_block_size[0]

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -45,6 +45,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     infer_cache_family_ratio,
     infer_group_cache_families,
     infer_tp_mismatch_info,
+    resolve_request_hash_block_size,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
     AscendStoreCoordinator,
@@ -144,12 +145,11 @@ class KVPoolWorker:
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
-        requested_hash_block_size = vllm_config.cache_config.prefix_match_unit
-        if not isinstance(requested_hash_block_size, int):
-            requested_hash_block_size = None
-        self.hash_block_size = (
-            requested_hash_block_size if requested_hash_block_size is not None else min(self.original_block_size)
-        ) * cp_scale
+        self.hash_block_size = resolve_request_hash_block_size(
+            vllm_config,
+            kv_cache_config,
+            self.grouped_block_size[0],
+        )
         for group_block_size in self.grouped_block_size:
             assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
         self.block_size = self.grouped_block_size[0]

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -48,7 +48,8 @@ def _ascend_resolve_kv_cache_block_sizes(
         # multiplied by the CP factors for proper alignment.
         group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp
-        if not cache_config.enable_prefix_caching:
+        connector_enabled = vllm_config.kv_transfer_config is not None
+        if not (cache_config.enable_prefix_caching or connector_enabled):
             return scheduler_block_size, scheduler_block_size
         hash_block_size = math.gcd(*group_block_sizes)
         return scheduler_block_size, hash_block_size

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -48,11 +48,9 @@ def _ascend_resolve_kv_cache_block_sizes(
         # multiplied by the CP factors for proper alignment.
         group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp
-        connector_enabled = vllm_config.kv_transfer_config is not None
-        if not (cache_config.enable_prefix_caching or connector_enabled):
+        if not (cache_config.enable_prefix_caching or vllm_config.kv_transfer_config is not None):
             return scheduler_block_size, scheduler_block_size
-        hash_block_size = math.gcd(*group_block_sizes)
-        return scheduler_block_size, hash_block_size
+        return scheduler_block_size, math.gcd(*group_block_sizes)
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -48,7 +48,7 @@ def _ascend_resolve_kv_cache_block_sizes(
         # multiplied by the CP factors for proper alignment.
         group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp
-        if not (cache_config.enable_prefix_caching or vllm_config.kv_transfer_config is not None):
+        if not (cache_config.enable_prefix_caching or getattr(vllm_config, "kv_transfer_config", None) is not None):
             return scheduler_block_size, scheduler_block_size
         return scheduler_block_size, math.gcd(*group_block_sizes)
 


### PR DESCRIPTION
### What this PR does / why we need it?

AscendStore independently derived `hash_block_size` from its physical KV cache
group sizes. That can disagree with the granularity used to populate
`Request.block_hashes`, especially for single-group fine-grained configuration
and hybrid cache groups with context parallelism.

This change:

- uses the patched public `resolve_kv_cache_block_sizes()` result as the single
  source of truth for request hash granularity in both scheduler and worker;
- keeps AscendStore's group block sizes, compressed-cache family granularity,
  and transfer alignment unchanged;
- keeps fine-grained hashes enabled for hybrid DCP when a KV connector is
  active, even if local prefix caching is disabled.

### Does this PR introduce _any_ user-facing change?

No API change. AscendStore now builds external keys with the same hash
granularity as `Request.block_hashes`.

### How was this patch tested?

- `tests/ut/distributed/ascend_store/test_config_data.py`: 51 passed
- `tests/ut/distributed/ascend_store/test_pool_scheduler.py` and
  `test_pool_worker.py`: 148 passed
- `tests/ut/patch/platform/test_prefix_cache_cp_patches.py`: 14 passed
- pre-commit hooks on all changed files

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
