### PR TITLE
[BugFix] Fix MTP draft model weight sync in RL training disaggregated mode

### DIFF
--- a/tests/ut/distributed/weight_transfer/test_hccl_engine_draft.py
+++ b/tests/ut/distributed/weight_transfer/test_hccl_engine_draft.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Unit tests for HCCL weight transfer draft-model sync helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.distributed.weight_transfer.hccl_engine import HCCLWeightTransferEngine
+
+
+def test_set_draft_model_and_start_also_initializes_draft():
+    engine = object.__new__(HCCLWeightTransferEngine)
+    engine.model = MagicMock()
+    engine._draft_model = None
+    engine._draft_model_config = None
+    draft = MagicMock()
+    draft_cfg = MagicMock()
+
+    engine.set_draft_model(draft, draft_cfg)
+
+    with patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload") as mock_initialize:
+        engine.start_weight_update()
+
+    assert mock_initialize.call_count == 2
+    mock_initialize.assert_any_call(engine.model)
+    mock_initialize.assert_any_call(draft)
+
+
+def test_finish_weight_update_finalizes_draft_with_draft_config():
+    engine = object.__new__(HCCLWeightTransferEngine)
+    engine.model = MagicMock()
+    engine.model_config = MagicMock(name="target_cfg")
+    draft = MagicMock()
+    draft_cfg = MagicMock(name="draft_cfg")
+    engine.set_draft_model(draft, draft_cfg)
+
+    with patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload") as mock_finalize:
+        engine.finish_weight_update()
+
+    assert mock_finalize.call_count == 2
+    mock_finalize.assert_any_call(engine.model, engine.model_config)
+    mock_finalize.assert_any_call(draft, draft_cfg)
+
+
+def test_load_weights_with_draft_loads_both_models():
+    engine = object.__new__(HCCLWeightTransferEngine)
+    engine.model = MagicMock()
+    draft = MagicMock()
+    engine.set_draft_model(draft, None)
+    weights = [("a.weight", torch.ones(2))]
+
+    engine._load_weights_with_draft(weights)
+
+    engine.model.load_weights.assert_called_once()
+    draft.load_weights.assert_called_once()
+    assert engine.model.load_weights.call_args.args[0] == weights
+    assert draft.load_weights.call_args.args[0] == weights
+
+
+def test_load_weights_with_draft_skips_when_no_draft():
+    engine = object.__new__(HCCLWeightTransferEngine)
+    engine.model = MagicMock()
+    engine.set_draft_model(None, None)
+    weights = [("a.weight", torch.ones(2))]
+
+    engine._load_weights_with_draft(weights)
+
+    engine.model.load_weights.assert_called_once_with(weights)

--- a/tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py
+++ b/tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py
@@ -143,6 +143,7 @@ def test_receive_weights_rebuilds_with_rebuild_npu_tensor():
     engine = object.__new__(NPUIPCWeightTransferEngine)
     received: dict[str, list[tuple[str, torch.Tensor]]] = {}
     engine.model = MagicMock()
+    engine._draft_model = None
     engine.device = MagicMock(index=device_index)
     engine.model.load_weights.side_effect = lambda weights: received.update(weights=weights)
 
@@ -162,6 +163,7 @@ def test_receive_weights_rebuilds_with_rebuild_npu_tensor():
 def test_start_weight_update_initializes_layerwise_reload():
     engine = object.__new__(NPUIPCWeightTransferEngine)
     engine.model = MagicMock()
+    engine._draft_model = None
 
     with patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload") as mock_initialize:
         engine.start_weight_update()
@@ -173,8 +175,72 @@ def test_finish_weight_update_finalizes_layerwise_reload():
     engine = object.__new__(NPUIPCWeightTransferEngine)
     engine.model = MagicMock()
     engine.model_config = MagicMock()
+    engine._draft_model = None
+    engine._draft_model_config = None
 
     with patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload") as mock_finalize:
         engine.finish_weight_update()
 
     mock_finalize.assert_called_once_with(engine.model, engine.model_config)
+
+
+def test_set_draft_model_and_start_also_initializes_draft():
+    engine = object.__new__(NPUIPCWeightTransferEngine)
+    engine.model = MagicMock()
+    engine._draft_model = None
+    engine._draft_model_config = None
+    draft = MagicMock()
+    draft_cfg = MagicMock()
+
+    engine.set_draft_model(draft, draft_cfg)
+    assert engine._draft_model is draft
+    assert engine._draft_model_config is draft_cfg
+
+    with patch("vllm.model_executor.model_loader.reload.initialize_layerwise_reload") as mock_initialize:
+        engine.start_weight_update()
+
+    assert mock_initialize.call_count == 2
+    mock_initialize.assert_any_call(engine.model)
+    mock_initialize.assert_any_call(draft)
+
+
+def test_finish_weight_update_finalizes_draft_with_draft_config():
+    engine = object.__new__(NPUIPCWeightTransferEngine)
+    engine.model = MagicMock()
+    engine.model_config = MagicMock(name="target_cfg")
+    draft = MagicMock()
+    draft_cfg = MagicMock(name="draft_cfg")
+    engine.set_draft_model(draft, draft_cfg)
+
+    with patch("vllm.model_executor.model_loader.reload.finalize_layerwise_reload") as mock_finalize:
+        engine.finish_weight_update()
+
+    assert mock_finalize.call_count == 2
+    mock_finalize.assert_any_call(engine.model, engine.model_config)
+    mock_finalize.assert_any_call(draft, draft_cfg)
+
+
+def test_load_weights_with_draft_loads_both_models():
+    engine = object.__new__(NPUIPCWeightTransferEngine)
+    engine.model = MagicMock()
+    draft = MagicMock()
+    engine.set_draft_model(draft, None)
+    weights = [("a.weight", torch.ones(2))]
+
+    engine._load_weights_with_draft(weights)
+
+    engine.model.load_weights.assert_called_once()
+    draft.load_weights.assert_called_once()
+    assert engine.model.load_weights.call_args.args[0] == weights
+    assert draft.load_weights.call_args.args[0] == weights
+
+
+def test_load_weights_with_draft_skips_when_no_draft():
+    engine = object.__new__(NPUIPCWeightTransferEngine)
+    engine.model = MagicMock()
+    engine.set_draft_model(None, None)
+    weights = [("a.weight", torch.ones(2))]
+
+    engine._load_weights_with_draft(weights)
+
+    engine.model.load_weights.assert_called_once_with(weights)

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -1489,3 +1489,69 @@ class TestNPUWorkerWeightUpdate(TestBase):
         worker.shutdown()
 
         engine.shutdown.assert_called_once()
+
+    def test_get_draft_model_returns_none_without_drafter(self):
+        worker = self._make_worker(engine=MagicMock())
+        worker.model_runner.drafter = None
+        self.assertIsNone(worker._get_draft_model())
+
+    def test_get_draft_model_prefers_proposer_get_model(self):
+        worker = self._make_worker(engine=MagicMock())
+        draft = MagicMock()
+        draft.load_weights = MagicMock()
+        drafter = MagicMock()
+        drafter.get_model.return_value = draft
+        worker.model_runner.drafter = drafter
+
+        self.assertIs(worker._get_draft_model(), draft)
+        drafter.get_model.assert_called_once()
+
+    def test_get_draft_model_falls_back_to_drafter_model(self):
+        worker = self._make_worker(engine=MagicMock())
+        draft = MagicMock()
+        draft.load_weights = MagicMock()
+        # No get_model on proposer.
+        drafter = MagicMock(spec=["model"])
+        drafter.model = draft
+        worker.model_runner.drafter = drafter
+
+        self.assertIs(worker._get_draft_model(), draft)
+
+    def test_get_draft_model_rejects_model_without_load_weights(self):
+        worker = self._make_worker(engine=MagicMock())
+        draft = object()
+        drafter = MagicMock()
+        drafter.get_model.return_value = draft
+        worker.model_runner.drafter = drafter
+
+        self.assertIsNone(worker._get_draft_model())
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_binds_draft_via_set_draft_model(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        draft = MagicMock()
+        draft.load_weights = MagicMock()
+        draft_cfg = MagicMock()
+        drafter = MagicMock()
+        drafter.get_model.return_value = draft
+        drafter.draft_model_config = draft_cfg
+        worker.model_runner.drafter = drafter
+        worker.vllm_config = MagicMock()
+
+        worker.start_weight_update()
+
+        engine.set_draft_model.assert_called_once_with(draft, draft_cfg)
+        engine.start_weight_update.assert_called_once_with()
+        self.assertTrue(worker._weight_update_active)
+
+    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
+    def test_start_weight_update_binds_none_when_no_draft(self):
+        engine = MagicMock()
+        worker = self._make_worker(engine=engine)
+        worker.model_runner.drafter = None
+        worker.vllm_config = MagicMock(speculative_config=None)
+
+        worker.start_weight_update()
+
+        engine.set_draft_model.assert_called_once_with(None, None)

--- a/vllm_ascend/distributed/weight_transfer/hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_engine.py
@@ -130,6 +130,10 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
         )
 
         initialize_layerwise_reload(self.model)
+        draft_model = getattr(self, "draft_model", None)
+        if draft_model is not None:
+            # Also prepare MTP/eagle draft model for layerwise reload.
+            initialize_layerwise_reload(draft_model)
 
     def finish_weight_update(self) -> None:
         from vllm.model_executor.model_loader.reload import (
@@ -137,6 +141,19 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
         )
 
         finalize_layerwise_reload(self.model, self.model_config)
+        draft_model = getattr(self, "draft_model", None)
+        if draft_model is not None:
+            draft_cfg = getattr(self, "draft_model_config", None) or self.model_config
+            finalize_layerwise_reload(draft_model, draft_cfg)
+
+    def _load_weights_with_draft(self, weights):
+        """Load weights into target model and MTP draft model when present."""
+        weights_list = list(weights)
+        self.model.load_weights(weights_list)
+        draft_model = getattr(self, "draft_model", None)
+        if draft_model is not None:
+            # Draft load_weights filters by name; MTP-only params go to draft.
+            draft_model.load_weights(weights_list)
 
     def init_transfer_engine(self, init_info: HCCLWeightTransferInitInfo) -> None:
         """
@@ -195,7 +212,7 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
                 iterator=state_dict_info_iterator(),
                 group=self.model_update_group,
                 src=0,
-                post_unpack_func=self.model.load_weights,
+                post_unpack_func=self._load_weights_with_draft,
                 buffer_size_bytes=update_info.packed_buffer_size_bytes,
                 num_buffers=update_info.packed_num_buffers,
             )
@@ -205,7 +222,7 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
                 dtype = getattr(torch, dtype_name)
                 weight = torch.empty(shape, dtype=dtype, device="npu")
                 self.model_update_group.broadcast(weight, src=0, stream=torch.npu.current_stream())
-                self.model.load_weights([(name, weight)])
+                self._load_weights_with_draft([(name, weight)])
                 del weight
 
     def shutdown(self) -> None:

--- a/vllm_ascend/distributed/weight_transfer/hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_engine.py
@@ -123,6 +123,17 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
     ) -> None:
         super().__init__(config, vllm_config, device, model)
         self.model_update_group: PyHcclCommunicator | None = None  # type: ignore[no-redef]
+        self._draft_model: torch.nn.Module | None = None
+        self._draft_model_config = None
+
+    def set_draft_model(
+        self,
+        draft_model: torch.nn.Module | None,
+        draft_model_config=None,
+    ) -> None:
+        """Bind optional MTP/eagle draft model for weight-update cycles."""
+        self._draft_model = draft_model
+        self._draft_model_config = draft_model_config
 
     def start_weight_update(self) -> None:
         from vllm.model_executor.model_loader.reload import (
@@ -130,10 +141,9 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
         )
 
         initialize_layerwise_reload(self.model)
-        draft_model = getattr(self, "draft_model", None)
-        if draft_model is not None:
+        if self._draft_model is not None:
             # Also prepare MTP/eagle draft model for layerwise reload.
-            initialize_layerwise_reload(draft_model)
+            initialize_layerwise_reload(self._draft_model)
 
     def finish_weight_update(self) -> None:
         from vllm.model_executor.model_loader.reload import (
@@ -141,19 +151,17 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
         )
 
         finalize_layerwise_reload(self.model, self.model_config)
-        draft_model = getattr(self, "draft_model", None)
-        if draft_model is not None:
-            draft_cfg = getattr(self, "draft_model_config", None) or self.model_config
-            finalize_layerwise_reload(draft_model, draft_cfg)
+        if self._draft_model is not None:
+            draft_cfg = self._draft_model_config or self.model_config
+            finalize_layerwise_reload(self._draft_model, draft_cfg)
 
     def _load_weights_with_draft(self, weights):
         """Load weights into target model and MTP draft model when present."""
         weights_list = list(weights)
         self.model.load_weights(weights_list)
-        draft_model = getattr(self, "draft_model", None)
-        if draft_model is not None:
+        if self._draft_model is not None:
             # Draft load_weights filters by name; MTP-only params go to draft.
-            draft_model.load_weights(weights_list)
+            self._draft_model.load_weights(weights_list)
 
     def init_transfer_engine(self, init_info: HCCLWeightTransferInitInfo) -> None:
         """

--- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
@@ -163,6 +163,10 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
         )
 
         initialize_layerwise_reload(self.model)
+        draft_model = getattr(self, "draft_model", None)
+        if draft_model is not None:
+            # Also prepare MTP/eagle draft model for layerwise reload.
+            initialize_layerwise_reload(draft_model)
 
     def finish_weight_update(self) -> None:
         """Finalize layerwise reloading after all weights have been received."""
@@ -171,6 +175,19 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
         )
 
         finalize_layerwise_reload(self.model, self.model_config)
+        draft_model = getattr(self, "draft_model", None)
+        if draft_model is not None:
+            draft_cfg = getattr(self, "draft_model_config", None) or self.model_config
+            finalize_layerwise_reload(draft_model, draft_cfg)
+
+    def _load_weights_with_draft(self, weights):
+        """Load weights into target model and MTP draft model when present."""
+        weights_list = list(weights)
+        self.model.load_weights(weights_list)
+        draft_model = getattr(self, "draft_model", None)
+        if draft_model is not None:
+            # Draft load_weights filters by name; MTP-only params go to draft.
+            draft_model.load_weights(weights_list)
 
     def receive_weights(
         self,
@@ -197,7 +214,7 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
                 tensor_sizes=update_info.tensor_sizes,
                 device_index=device_index,
             )
-            self.model.load_weights(weights)
+            self._load_weights_with_draft(weights)
         else:
             # Lazy import: ``rebuild_npu_tensor`` lives in ``torch_npu`` and
             # must not be imported at module load time on non-NPU hosts.
@@ -227,7 +244,7 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
                 weight = rebuild_npu_tensor(*list_args)
                 weights.append((name, weight))
 
-            self.model.load_weights(weights)
+            self._load_weights_with_draft(weights)
 
     def shutdown(self) -> None:
         pass

--- a/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/npu_ipc_engine.py
@@ -126,6 +126,17 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
         model: torch.nn.Module,
     ) -> None:
         super().__init__(config, vllm_config, device, model)
+        self._draft_model: torch.nn.Module | None = None
+        self._draft_model_config = None
+
+    def set_draft_model(
+        self,
+        draft_model: torch.nn.Module | None,
+        draft_model_config=None,
+    ) -> None:
+        """Bind optional MTP/eagle draft model for weight-update cycles."""
+        self._draft_model = draft_model
+        self._draft_model_config = draft_model_config
 
     def parse_update_info(self, update_dict: dict[str, Any]) -> NPUIPCWeightTransferUpdateInfo:
         """Parse update dict, deserializing pickled IPC handles if present.
@@ -163,10 +174,9 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
         )
 
         initialize_layerwise_reload(self.model)
-        draft_model = getattr(self, "draft_model", None)
-        if draft_model is not None:
+        if self._draft_model is not None:
             # Also prepare MTP/eagle draft model for layerwise reload.
-            initialize_layerwise_reload(draft_model)
+            initialize_layerwise_reload(self._draft_model)
 
     def finish_weight_update(self) -> None:
         """Finalize layerwise reloading after all weights have been received."""
@@ -175,19 +185,17 @@ class NPUIPCWeightTransferEngine(WeightTransferEngine[NPUIPCWeightTransferInitIn
         )
 
         finalize_layerwise_reload(self.model, self.model_config)
-        draft_model = getattr(self, "draft_model", None)
-        if draft_model is not None:
-            draft_cfg = getattr(self, "draft_model_config", None) or self.model_config
-            finalize_layerwise_reload(draft_model, draft_cfg)
+        if self._draft_model is not None:
+            draft_cfg = self._draft_model_config or self.model_config
+            finalize_layerwise_reload(self._draft_model, draft_cfg)
 
     def _load_weights_with_draft(self, weights):
         """Load weights into target model and MTP draft model when present."""
         weights_list = list(weights)
         self.model.load_weights(weights_list)
-        draft_model = getattr(self, "draft_model", None)
-        if draft_model is not None:
+        if self._draft_model is not None:
             # Draft load_weights filters by name; MTP-only params go to draft.
-            draft_model.load_weights(weights_list)
+            self._draft_model.load_weights(weights_list)
 
     def receive_weights(
         self,

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -20,6 +20,7 @@
 import copy
 import gc
 import logging
+from contextlib import suppress
 from types import NoneType
 from typing import Any
 
@@ -300,8 +301,39 @@ class NPUWorker(WorkerBase):
                 "VLLM_ASCEND_ENABLE_NZ=0."
             )
 
-    def start_weight_update(self) -> None:
-        """Begin a new weight update; prepares the model for layerwise reload."""
+    def _get_draft_model(self):
+        """Return the MTP/eagle draft model for weight update, or None."""
+        drafter = getattr(self.model_runner, "drafter", None)
+        if drafter is None:
+            return None
+        # AscendEagleProposer stores the draft model in .model (may be wrapped)
+        draft_model = getattr(drafter, "model", None)
+        if draft_model is None:
+            return None
+        # Unwrap ACLGraphWrapper if present
+        if hasattr(drafter, "get_model"):
+            with suppress(Exception):
+                draft_model = drafter.get_model()
+        # Draft model must have load_weights for checkpoint-format update
+        if not hasattr(draft_model, "load_weights"):
+            return None
+        return draft_model
+
+    def _bind_draft_model_to_engine(self) -> None:
+        """Attach MTP draft model to the transfer engine for this update cycle."""
+        assert self.weight_transfer_engine is not None
+        draft_model = self._get_draft_model()
+        self.weight_transfer_engine.draft_model = draft_model
+        drafter = getattr(self.model_runner, "drafter", None)
+        self.weight_transfer_engine.draft_model_config = getattr(drafter, "draft_model_config", None)
+
+    def start_weight_update(self, is_checkpoint_format: bool | None = None) -> None:
+        """Begin a new weight update; prepares the model for layerwise reload.
+
+        ``is_checkpoint_format`` is accepted for RL-client compatibility but
+        ignored: checkpoint-format handling belongs to each transfer engine
+        after the weight-transfer lifecycle refactor (#12876).
+        """
         self._check_weight_transfer_engine()
 
         if self._weight_update_active:
@@ -312,6 +344,7 @@ class NPUWorker(WorkerBase):
         self._check_nz_disabled()
 
         assert self.weight_transfer_engine is not None
+        self._bind_draft_model_to_engine()
         self.weight_transfer_engine.start_weight_update()
         self._weight_update_active = True
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -302,30 +302,45 @@ class NPUWorker(WorkerBase):
             )
 
     def _get_draft_model(self):
-        """Return the MTP/eagle draft model for weight update, or None."""
+        """Return the MTP/eagle draft model for weight update, or None.
+
+        Prefer ``drafter.get_model()`` (e.g. EagleProposer). Fall back to
+        ``drafter.model`` only when ``get_model`` is absent.
+        """
         drafter = getattr(self.model_runner, "drafter", None)
         if drafter is None:
             return None
-        # AscendEagleProposer stores the draft model in .model (may be wrapped)
+        # Prefer proposer.get_model() to unwrap ACLGraphWrapper when present.
+        if hasattr(drafter, "get_model") and callable(drafter.get_model):
+            with suppress(Exception):
+                draft_model = drafter.get_model()
+                if draft_model is not None and hasattr(draft_model, "load_weights"):
+                    return draft_model
+            # get_model is authoritative when present; do not fall back.
+            return None
         draft_model = getattr(drafter, "model", None)
         if draft_model is None:
             return None
-        # Unwrap ACLGraphWrapper if present
-        if hasattr(drafter, "get_model"):
+        # Fallback: unwrap wrapper stored on the model itself.
+        if hasattr(draft_model, "get_model") and callable(draft_model.get_model):
             with suppress(Exception):
-                draft_model = drafter.get_model()
-        # Draft model must have load_weights for checkpoint-format update
+                draft_model = draft_model.get_model()
         if not hasattr(draft_model, "load_weights"):
             return None
         return draft_model
 
     def _bind_draft_model_to_engine(self) -> None:
-        """Attach MTP draft model to the transfer engine for this update cycle."""
+        """Pass MTP draft model into the transfer engine via explicit API."""
         assert self.weight_transfer_engine is not None
         draft_model = self._get_draft_model()
-        self.weight_transfer_engine.draft_model = draft_model
         drafter = getattr(self.model_runner, "drafter", None)
-        self.weight_transfer_engine.draft_model_config = getattr(drafter, "draft_model_config", None)
+        draft_cfg = getattr(drafter, "draft_model_config", None)
+        if draft_cfg is None:
+            spec_cfg = getattr(self.vllm_config, "speculative_config", None)
+            draft_cfg = getattr(spec_cfg, "draft_model_config", None)
+        set_draft = getattr(self.weight_transfer_engine, "set_draft_model", None)
+        if callable(set_draft):
+            set_draft(draft_model, draft_cfg)
 
     def start_weight_update(self, is_checkpoint_format: bool | None = None) -> None:
         """Begin a new weight update; prepares the model for layerwise reload.


### PR DESCRIPTION
### What this PR does / why we need it?
In RL disaggregated training, weight sync only updated the target model and skipped the MTP draft (`model_runner.drafter`). After the first update, draft stayed at HF init while target moved, so MTP acceptance dropped to 0% and rollout became garbage.

After [#12876](https://github.com/vllm-project/vllm-ascend/pull/12876), weight load lives in transfer engines; this PR wires draft sync through that path:

- `NPUWorker`: `_get_draft_model()` / `_bind_draft_model_to_engine()`; on `start_weight_update` bind draft via `engine.set_draft_model(...)`
- `HCCLWeightTransferEngine` / `NPUIPCWeightTransferEngine`: explicit `set_draft_model`; start/finish/`_load_weights_with_draft` also update draft when present
- `is_checkpoint_format` kept on worker `start_weight_update` for RL-client compat but ignored (engine owns format handling)

Non-MTP models unchanged (`_get_draft_model()` returns `None`).

Companion vime fix: https://github.com/vllm-project/vime/pull/375

### Does this PR introduce _any_ user-facing change?
No. Fixes RL weight-sync for MTP on NPU; non-MTP / non-RL paths unchanged.

### How was this patch tested?
**Unit tests**
- `tests/ut/worker/a2/test_worker_v1.py`: draft unwrap + `set_draft_model` bind on start
- `tests/ut/distributed/weight_transfer/test_npu_ipc_engine.py`: draft start/finish/load
- `tests/ut/distributed/weight_transfer/test_hccl_engine_draft.py`: HCCL draft helpers

**E2E** with vime disaggregated RL on 8x Ascend 910B1, GLM-4.7-Flash (30B-A3B MoE + MTP), 4 train + 4 rollout, TP=4 (together with vime#375):

| Metric | Before | After |
|--------|--------|-------|
| MTP acceptance rate | 0% | ~30% |
| rollout_time | 1289.6s (garbage) | 847.4s |
| tokens/gpu/sec | 32.0 | 74.13 |
| grad_norm | 6.95 | 0.128 |
| update_weights_time | 91.3s | 9.3s |

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485