### PR TITLE
[BugFix] Clamp decoder active_tokens on release to prevent negative values

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -407,7 +407,7 @@ class SharedProxyScheduler:
             return
         entry = self._pool(role).servers[key]
         if active_tokens:
-            entry.active_tokens -= load
+            entry.active_tokens = max(0.0, entry.active_tokens - load)
         if kv_cache:
             entry.active_kv_cache = max(0.0, entry.active_kv_cache - load)
         self._push_heap(role, key)


### PR DESCRIPTION
### What this PR does / why we need it?

In `_release_load`, the `active_tokens` branch subtracts `load` **without a `max(0)` clamp**, while the adjacent `kv_cache` branch is clamped:

```python
if active_tokens:
    entry.active_tokens -= load                                   # can go negative
if kv_cache:
    entry.active_kv_cache = max(0.0, entry.active_kv_cache - load)  # clamped
```

If a decoder load is released more than once (e.g. a release on the normal path followed by another in a `finally`/recompute path), the second `-= load` drives `active_tokens` below zero. Since decoder priority is `entry.active_tokens` (lower = higher priority), a negative value makes that decoder the **most preferred** node in the heap, silently breaking load balancing — subsequent requests keep selecting that decoder while others stay idle.

This PR clamps `active_tokens` symmetrically with `kv_cache`:

```python
if active_tokens:
    entry.active_tokens = max(0.0, entry.active_tokens - load)
```

Closes #13214.

### Does this PR introduce _any_ user-facing change?

No behavior change for correct single-release paths. It only prevents `active_tokens` from going negative (which would otherwise silently corrupt load balancing) when a decoder load is released more than once.

### How was this patch tested?

- `python -m py_compile` passes.
- `ruff check` / `ruff format` pass.
- Normal release paths unchanged (the clamp is a no-op when `active_tokens >= load`).
