### PR TITLE
[Bugfix]Modify the VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS timeout duration.

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1251,6 +1251,15 @@ class NPUPlatform(Platform):
                 )
                 vllm_config.compilation_config.use_inductor_graph_partition = False
 
+        # ==================== 11. VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS ====================
+        if int(os.environ.get("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "300")) < 1836:
+            os.environ["VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"] = "3000"
+            logger.info(
+                "The timeout interval of the HCCL operator is 1836s. Timeout in "
+                "seconds for execute_model RPC calls in multiprocessing must be "
+                "greater than 1836s, Set VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000"
+            )
+
     @classmethod
     def use_custom_op_collectives(cls) -> bool:
         return True

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1252,8 +1252,8 @@ class NPUPlatform(Platform):
                 vllm_config.compilation_config.use_inductor_graph_partition = False
 
         # ==================== 11. VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS ====================
-        if int(os.environ.get("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "300")) < 1836:
-            os.environ["VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS"] = "3000"
+        if envs_vllm.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS < 1836:
+            envs_vllm.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS = 3000
             logger.info(
                 "The timeout interval of the HCCL operator is 1836s. Timeout in "
                 "seconds for execute_model RPC calls in multiprocessing must be "


### PR DESCRIPTION
### What this PR does / why we need it?
The timeout interval of the HCCL operator is 1836s. Timeout in seconds for execute_model RPC calls in multiprocessing must be greater than 1836s. The timeout interval of the HCCL operator is 1836s. Timeout in seconds for execute_model RPC calls in multiprocessing must be greater than 1836s. The timeout interval of the DP engine  is shorter than that of the collective communication (1836s). As a result, the communication times out and is suspended without logs.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
