### PR TITLE
fix(scheduler): propagate EC transfer params

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
+import inspect
+import textwrap
 from collections import defaultdict
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -110,3 +113,37 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
             client_index=request.client_index,
         )
     ]
+
+
+def test_finished_request_propagates_all_transfer_params():
+    """Guard the vLLM _free_request and EngineCoreOutput protocol."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(RecomputeScheduler.update_from_output)))
+
+    free_request_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "_free_request"
+    ]
+    assert len(free_request_assignments) == 1
+    target = free_request_assignments[0].targets[0]
+    assert isinstance(target, ast.Tuple)
+    assert [ast.unparse(element) for element in target.elts] == [
+        "kv_transfer_params",
+        "ec_transfer_params",
+    ]
+
+    output_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "EngineCoreOutput"
+        and any(keyword.arg == "kv_transfer_params" for keyword in node.keywords)
+    ]
+    assert len(output_calls) == 1
+    output_keywords = {keyword.arg: ast.unparse(keyword.value) for keyword in output_calls[0].keywords}
+    assert output_keywords["kv_transfer_params"] == "kv_transfer_params"
+    assert output_keywords["ec_transfer_params"] == "ec_transfer_params"

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -1044,6 +1044,7 @@ class RecomputeScheduler(Scheduler):
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
+            ec_transfer_params = None
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
 
@@ -1112,7 +1113,7 @@ class RecomputeScheduler(Scheduler):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
-                    kv_transfer_params = self._free_request(request)
+                    kv_transfer_params, ec_transfer_params = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -1128,7 +1129,7 @@ class RecomputeScheduler(Scheduler):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
-            if new_token_ids or pooler_output is not None or kv_transfer_params or stopped:
+            if new_token_ids or pooler_output is not None or kv_transfer_params or ec_transfer_params or stopped:
                 # Add EngineCoreOutput for this Request.
                 outputs[request.client_index].append(
                     EngineCoreOutput(
@@ -1142,6 +1143,7 @@ class RecomputeScheduler(Scheduler):
                         events=request.take_events(),
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,


### PR DESCRIPTION
Adapt RecomputeScheduler to the vLLM _free_request two-value return and forward ec_transfer_params through EngineCoreOutput. Add a regression guard for the serialization protocol.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
