### PR TITLE
[bugfix]修复PD分离场景下，D节点取kv前报错导致的P节点KV不释放

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1640,6 +1640,46 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertFalse(delay_free)
         self.assertIsNone(params)
 
+    def test_request_finished_remote_prefill_rejection_enqueue_empty_recv(self):
+        request = MockRequest(
+            "req_reject",
+            kv_transfer_params={
+                "do_remote_prefill": True,
+                "remote_block_ids": ([10, 11, 12], [20]),
+                "remote_engine_id": "prefill_engine",
+                "remote_request_id": "prefill_req",
+                "remote_host": "127.0.0.1",
+                "remote_port": 5000,
+            },
+            status=RequestStatus.FINISHED_ABORTED,
+        )
+        delay_free, params = self.scheduler.request_finished(request, [])
+        self.assertFalse(delay_free)
+        self.assertIsNone(params)
+        self.assertFalse(request.kv_transfer_params["do_remote_prefill"])
+        self.assertIn("req_reject", self.scheduler._reqs_need_recv)
+        req, local_blocks, full_blocks, num_external = self.scheduler._reqs_need_recv["req_reject"]
+        self.assertIs(req, request)
+        self.assertEqual(local_blocks, ([], []))
+        self.assertEqual(full_blocks, tuple())
+        self.assertEqual(num_external, 0)
+
+        meta = self.scheduler.build_connector_meta(MockSchedulerOutput())
+        self.assertIn("req_reject", meta.requests)
+        self.assertEqual(meta.requests["req_reject"].local_block_ids, ([], []))
+        self.assertEqual(meta.requests["req_reject"].num_external_tokens, 0)
+        self.assertEqual(len(self.scheduler._reqs_need_recv), 0)
+
+    def test_empty_local_block_ids_for_rejection_fallback(self):
+        self.assertEqual(
+            self.scheduler._empty_local_block_ids_for_rejection({"remote_block_ids": [1, 2, 3]}),
+            ([],),
+        )
+        self.assertEqual(
+            self.scheduler._empty_local_block_ids_for_rejection({}),
+            ([],),
+        )
+
     def test_get_transfer_block_ids_trims_attention_mtp_blocks(self):
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(  # type: ignore[list-item]

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1892,11 +1892,25 @@ class MooncakeConnectorScheduler:
             "MooncakeConnector request_finished, request_status=%s, kv_transfer_params=%s", request.status, params
         )
 
-        if (
-            params is None
-            or not params.get("do_remote_decode")
-            or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
-        ):
+        if params is None:
+            return False, None
+
+        if params.get("do_remote_prefill"):
+            empty_block_ids = self._empty_local_block_ids_for_rejection(params)
+            self._reqs_need_recv[request.request_id] = (
+                request,
+                empty_block_ids,
+                tuple(),
+                0,
+            )
+            params["do_remote_prefill"] = False
+            logger.info(
+                "Decode rejection/abort for request %s: enqueue empty recv to notify Prefill release",
+                request.request_id,
+            )
+            return False, None
+
+        if not params.get("do_remote_decode") or request.status != RequestStatus.FINISHED_LENGTH_CAPPED:
             return False, None
 
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)
@@ -1924,6 +1938,17 @@ class MooncakeConnectorScheduler:
             num_prompt_blocks=num_prompt_blocks,
             remote_block_size=self.block_size,
         )
+
+    @staticmethod
+    def _empty_local_block_ids_for_rejection(params: dict[str, Any]) -> BlockIds:
+        remote_block_ids = params.get("remote_block_ids")
+        if (
+            isinstance(remote_block_ids, (list, tuple))
+            and remote_block_ids
+            and isinstance(remote_block_ids[0], (list, tuple))
+        ):
+            return tuple([] for _ in remote_block_ids)
+        return ([],)
 
     def _port_offset_from_handshake_metadata(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
