### PR TITLE
[Feature]dsv4 dsa_cp support dspark

### DIFF
--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -35,8 +35,15 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
 @pytest.mark.parametrize("model_name", MODELS)
+@pytest.mark.parametrize(
+    "additional_config",
+    [
+        pytest.param({"enable_dsa_cp": False}, id="dsa-cp-disabled"),
+        pytest.param({"enable_dsa_cp": True}, id="dsa-cp-enabled"),
+    ],
+)
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_deepseek_v4_dspark_acceptance_tp4(model_name):
+def test_deepseek_v4_dspark_acceptance_tp4(model_name, additional_config):
     golden = [0.88, 0.74, 0.58, 0.49, 0.40]
 
     example_prompts = [
@@ -59,57 +66,7 @@ def test_deepseek_v4_dspark_acceptance_tp4(model_name):
             "num_speculative_tokens": 5,
             "enforce_eager": True,
         },
-        compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[6, 18]),
-    ) as spec_vllm_model:
-        _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
-        metrics = spec_vllm_model.model.get_metrics()
-
-    num_drafts = 0
-    num_accepted_tokens_per_pos = [0] * 5
-    for metric in metrics:
-        if metric.name == "vllm:spec_decode_num_drafts":
-            assert isinstance(metric, Counter)
-            num_drafts += metric.value
-        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
-            assert isinstance(metric, Vector)
-            for pos in range(len(metric.values)):
-                num_accepted_tokens_per_pos[pos] += metric.values[pos]
-
-    acceptance_per_pos = [num_accepted_tokens / num_drafts for num_accepted_tokens in num_accepted_tokens_per_pos]
-
-    match = all((a >= b) or (b - a < 0.03) for a, b in zip(acceptance_per_pos, golden))
-    assert match, (
-        f"acceptance_per_pos {acceptance_per_pos} is not greater than golden {golden} (num_drafts={num_drafts})"
-    )
-    cleanup_dist_env_and_memory()
-
-
-@pytest.mark.parametrize("model_name", MODELS)
-@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_deepseek_v4_dsa_cp_dspark_acceptance_tp4(model_name):
-    golden = [0.88, 0.74, 0.58, 0.49, 0.40]
-
-    example_prompts = [
-        "Hello, my name is",
-        "The president of the United States is",
-        "The capital of France is",
-        "The future of AI is",
-    ]
-
-    max_tokens = 1024
-
-    with VllmRunner(
-        model_name,
-        tensor_parallel_size=4,
-        max_model_len=4096,
-        enable_expert_parallel=True,
-        disable_log_stats=False,
-        speculative_config={
-            "method": "dspark",
-            "num_speculative_tokens": 5,
-            "enforce_eager": True,
-        },
-        additional_config={"enable_dsa_cp": True},
+        additional_config=additional_config,
         compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[6, 18]),
     ) as spec_vllm_model:
         _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -35,10 +35,26 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
 @pytest.mark.parametrize("model_name", MODELS)
+@pytest.mark.parametrize(
+    ("golden", "num_speculative_tokens", "additional_config"),
+    [
+        pytest.param(
+            [0.88, 0.74, 0.58, 0.49, 0.40], 5, {"enable_flashcomm1": False, "enable_dsa_cp": False},
+            id="dspark",
+        ),
+        pytest.param(
+            [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18], 7, {"enable_flashcomm1": True, "enable_dsa_cp": True},
+            id="dsa-cp-dspark",
+        ),
+    ],
+)
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_deepseek_v4_dspark_acceptance_tp4(model_name):
-    golden = [0.88, 0.74, 0.58, 0.49, 0.40]
-
+def test_deepseek_v4_dspark_acceptance_tp4(
+    model_name,
+    golden,
+    num_speculative_tokens,
+    additional_config,
+):
     example_prompts = [
         "Hello, my name is",
         "The president of the United States is",
@@ -56,67 +72,20 @@ def test_deepseek_v4_dspark_acceptance_tp4(model_name):
         disable_log_stats=False,
         speculative_config={
             "method": "dspark",
-            "num_speculative_tokens": 5,
+            "num_speculative_tokens": num_speculative_tokens,
             "enforce_eager": True,
         },
-        compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[6, 18]),
+        compilation_config=CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            cudagraph_capture_sizes=[6, 8, 16, 18],
+        ),
+        additional_config=additional_config,
     ) as spec_vllm_model:
         _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
         metrics = spec_vllm_model.model.get_metrics()
 
     num_drafts = 0
-    num_accepted_tokens_per_pos = [0] * 5
-    for metric in metrics:
-        if metric.name == "vllm:spec_decode_num_drafts":
-            assert isinstance(metric, Counter)
-            num_drafts += metric.value
-        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
-            assert isinstance(metric, Vector)
-            for pos in range(len(metric.values)):
-                num_accepted_tokens_per_pos[pos] += metric.values[pos]
-
-    acceptance_per_pos = [num_accepted_tokens / num_drafts for num_accepted_tokens in num_accepted_tokens_per_pos]
-
-    match = all((a >= b) or (b - a < 0.03) for a, b in zip(acceptance_per_pos, golden))
-    assert match, (
-        f"acceptance_per_pos {acceptance_per_pos} is not greater than golden {golden} (num_drafts={num_drafts})"
-    )
-    cleanup_dist_env_and_memory()
-
-
-@pytest.mark.parametrize("model_name", MODELS)
-@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_deepseek_v4_dsa_cp_dspark_acceptance_tp4(model_name):
-    golden = [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18]
-
-    example_prompts = [
-        "Hello, my name is",
-        "The president of the United States is",
-        "The capital of France is",
-        "The future of AI is",
-    ]
-
-    max_tokens = 1024
-
-    with VllmRunner(
-        model_name,
-        tensor_parallel_size=4,
-        max_model_len=4096,
-        enable_expert_parallel=True,
-        disable_log_stats=False,
-        speculative_config={
-            "method": "dspark",
-            "num_speculative_tokens": 7,
-            "enforce_eager": True,
-        },
-        additional_config={"enable_flashcomm1": True, "enable_dsa_cp": True},
-        compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[8, 16]),
-    ) as spec_vllm_model:
-        _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
-        metrics = spec_vllm_model.model.get_metrics()
-
-    num_drafts = 0
-    num_accepted_tokens_per_pos = [0] * 7
+    num_accepted_tokens_per_pos = [0] * num_speculative_tokens
     for metric in metrics:
         if metric.name == "vllm:spec_decode_num_drafts":
             assert isinstance(metric, Counter)

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -82,3 +82,54 @@ def test_deepseek_v4_dspark_acceptance_tp4(model_name):
         f"acceptance_per_pos {acceptance_per_pos} is not greater than golden {golden} (num_drafts={num_drafts})"
     )
     cleanup_dist_env_and_memory()
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
+def test_deepseek_v4_dsa_cp_dspark_acceptance_tp4(model_name):
+    golden = [0.88, 0.74, 0.58, 0.49, 0.40]
+
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    max_tokens = 1024
+
+    with VllmRunner(
+        model_name,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        enable_expert_parallel=True,
+        disable_log_stats=False,
+        speculative_config={
+            "method": "dspark",
+            "num_speculative_tokens": 5,
+            "enforce_eager": True,
+        },
+        additional_config={"enable_dsa_cp": True},
+        compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[6, 18]),
+    ) as spec_vllm_model:
+        _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
+        metrics = spec_vllm_model.model.get_metrics()
+
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * 5
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [num_accepted_tokens / num_drafts for num_accepted_tokens in num_accepted_tokens_per_pos]
+
+    match = all((a >= b) or (b - a < 0.03) for a, b in zip(acceptance_per_pos, golden))
+    assert match, (
+        f"acceptance_per_pos {acceptance_per_pos} is not greater than golden {golden} (num_drafts={num_drafts})"
+    )
+    cleanup_dist_env_and_memory()

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -35,15 +35,8 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 
 @pytest.mark.parametrize("model_name", MODELS)
-@pytest.mark.parametrize(
-    "additional_config",
-    [
-        pytest.param({"enable_dsa_cp": False}, id="dsa-cp-disabled"),
-        pytest.param({"enable_dsa_cp": True}, id="dsa-cp-enabled"),
-    ],
-)
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
-def test_deepseek_v4_dspark_acceptance_tp4(model_name, additional_config):
+def test_deepseek_v4_dspark_acceptance_tp4(model_name):
     golden = [0.88, 0.74, 0.58, 0.49, 0.40]
 
     example_prompts = [
@@ -66,7 +59,6 @@ def test_deepseek_v4_dspark_acceptance_tp4(model_name, additional_config):
             "num_speculative_tokens": 5,
             "enforce_eager": True,
         },
-        additional_config=additional_config,
         compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[6, 18]),
     ) as spec_vllm_model:
         _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
@@ -74,6 +66,57 @@ def test_deepseek_v4_dspark_acceptance_tp4(model_name, additional_config):
 
     num_drafts = 0
     num_accepted_tokens_per_pos = [0] * 5
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [num_accepted_tokens / num_drafts for num_accepted_tokens in num_accepted_tokens_per_pos]
+
+    match = all((a >= b) or (b - a < 0.03) for a, b in zip(acceptance_per_pos, golden))
+    assert match, (
+        f"acceptance_per_pos {acceptance_per_pos} is not greater than golden {golden} (num_drafts={num_drafts})"
+    )
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+@patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
+def test_deepseek_v4_dsa_cp_dspark_acceptance_tp4(model_name):
+    golden = [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.20]
+
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    max_tokens = 1024
+
+    with VllmRunner(
+        model_name,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        enable_expert_parallel=True,
+        disable_log_stats=False,
+        speculative_config={
+            "method": "dspark",
+            "num_speculative_tokens": 7,
+            "enforce_eager": True,
+        },
+        additional_config={"enable_flashcomm1": True, "enable_dsa_cp": True},
+        compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[8, 16]),
+    ) as spec_vllm_model:
+        _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
+        metrics = spec_vllm_model.model.get_metrics()
+
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * 7
     for metric in metrics:
         if metric.name == "vllm:spec_decode_num_drafts":
             assert isinstance(metric, Counter)

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -39,11 +39,15 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
     ("golden", "num_speculative_tokens", "additional_config"),
     [
         pytest.param(
-            [0.88, 0.74, 0.58, 0.49, 0.40], 5, {"enable_flashcomm1": False, "enable_dsa_cp": False},
+            [0.88, 0.74, 0.58, 0.49, 0.40],
+            5,
+            {"enable_flashcomm1": False, "enable_dsa_cp": False},
             id="dspark",
         ),
         pytest.param(
-            [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18], 7, {"enable_flashcomm1": True, "enable_dsa_cp": True},
+            [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18],
+            7,
+            {"enable_flashcomm1": True, "enable_dsa_cp": True},
             id="dsa-cp-dspark",
         ),
     ],

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -87,7 +87,7 @@ def test_deepseek_v4_dspark_acceptance_tp4(model_name):
 @pytest.mark.parametrize("model_name", MODELS)
 @patch.dict(os.environ, {"HCCL_BUFFSIZE": "1024"})
 def test_deepseek_v4_dsa_cp_dspark_acceptance_tp4(model_name):
-    golden = [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.20]
+    golden = [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18]
 
     example_prompts = [
         "Hello, my name is",

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -13,6 +13,10 @@ from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuild
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
+from vllm_ascend.attention.dsa_v1 import (
+    build_dspark_swa_indices,
+    get_dspark_sparse_sas_window,
+)
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -59,13 +63,6 @@ def rotate_activation(x: torch.Tensor, hadamard: torch.Tensor) -> torch.Tensor:
     return hadamard_transform_ref(x, hadamard=hadamard, scale=hidden_size**-0.5)
 
 
-def _has_prefill(attn_state: AscendAttentionState) -> bool:
-    return attn_state not in {
-        AscendAttentionState.DecodeOnly,
-        AscendAttentionState.SpecDecoding,
-    }
-
-
 @dataclass
 class DSACPMetadata:
     """Context-parallel metadata for sequence-sharded DSA execution."""
@@ -107,6 +104,9 @@ class AscendDSAReqMetadata:
     qli_metadata: torch.Tensor = None
     cu_cmp_seqlen_list: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
+    ori_win_left: int | None = None
+    ori_win_right: int = 0
+    dspark_swa_indices: torch.Tensor | None = None
 
 
 @dataclass
@@ -290,7 +290,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.common_ratio_to_sas_metadata = common_ratio_to_sas_metadata
         self.num_actual_tokens = common_attn_metadata.num_actual_tokens
         attn_state = kwargs.get("attn_state", common_attn_metadata.attn_state)
-        has_prefill = _has_prefill(attn_state)
 
         num_input_tokens = common_attn_metadata.num_input_tokens
         if self.common_ratio_to_sas_metadata.get("input_positions", None) is None:
@@ -307,7 +306,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.common_ratio_to_sas_metadata["num_prefill_tokens"] = self.num_prefill_tokens
             input_positions = common_attn_metadata.positions[:num_input_tokens].long()
             self.common_ratio_to_sas_metadata["input_positions"] = input_positions
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=not has_prefill)
+            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=self.num_prefills == 0)
             self.common_ratio_to_sas_metadata["cos"] = cos
             self.common_ratio_to_sas_metadata["sin"] = sin
             self.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
@@ -388,6 +387,12 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.num_decode_tokens = num_decode_tokens
         self.num_actual_tokens = common_attn_metadata.num_actual_tokens
         self.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
+        if common_attn_metadata._seq_lens_cpu is not None:
+            self.seq_lens_cpu = common_attn_metadata._seq_lens_cpu[:num_reqs]
+        elif common_attn_metadata.seq_lens_cpu is not None:
+            self.seq_lens_cpu = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        else:
+            self.seq_lens_cpu = self.seq_lens.cpu()
         self.block_size = kwargs.get("block_size", 128)
 
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
@@ -444,7 +449,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
-        has_prefill = _has_prefill(common_attn_metadata.attn_state)
+        is_noncausal = not common_attn_metadata.causal
+        has_prefill = self.num_prefills > 0
 
         (
             local_start,
@@ -463,8 +469,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         )
         local_query_start_loc = local_query_start_loc.clone()
         local_seq_lens = local_seq_lens.clone()
-        local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
-        local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
 
         _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu = self._build_local_token_metadata(
             num_reqs=num_reqs,
@@ -472,11 +476,54 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=query_start_loc_cpu,
             seq_lens=self.seq_lens_cpu[:num_reqs],
         )
+
+        if is_noncausal:
+            # Causal CP truncates the KV length at this rank's local query end.
+            # DSpark queries must see the whole query block, including tokens
+            # whose Q rows live on later CP ranks. Full KV is already written
+            # on every rank after the hidden-state all-gather in _forward().
+            local_query_lens = local_query_start_loc[1:] - local_query_start_loc[:-1]
+            local_seq_lens = torch.where(
+                local_query_lens > 0, self.seq_lens[:num_reqs], torch.zeros_like(self.seq_lens[:num_reqs])
+            )
+            local_query_lens_cpu = local_query_start_loc_cpu[1:] - local_query_start_loc_cpu[:-1]
+            local_seq_lens_cpu = torch.where(
+                local_query_lens_cpu > 0,
+                self.seq_lens_cpu[:num_reqs],
+                torch.zeros_like(self.seq_lens_cpu[:num_reqs]),
+            )
+
+        local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
+        local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
 
         start_pos = self.seq_lens[:num_reqs] - seq_lens_q
+
+        dspark_swa_indices = None
+        ori_win_left, ori_win_right = self.model_config.hf_config.sliding_window - 1, 0
+        if is_noncausal:
+            assert self.speculative_config is not None
+            global_dspark_indices, _ = build_dspark_swa_indices(
+                self.block_table[:num_reqs],
+                self.speculative_config.num_speculative_tokens,
+                self.model_config.hf_config.sliding_window,
+                self.block_size,
+                query_start_loc[: num_reqs + 1],
+                self.seq_lens[:num_reqs],
+                self.num_actual_tokens,
+            )
+            pad_rows = num_tokens_pad - global_dspark_indices.shape[0]
+            if pad_rows < 0:
+                raise ValueError(
+                    "DSpark CP metadata has fewer padded query rows than actual rows: "
+                    f"num_tokens_pad={num_tokens_pad}, actual={global_dspark_indices.shape[0]}"
+                )
+            if pad_rows:
+                global_dspark_indices = F.pad(global_dspark_indices, (0, 0, 0, 0, 0, pad_rows), value=-1)
+            dspark_swa_indices = global_dspark_indices[local_start:local_end_with_pad].contiguous()
+            ori_win_left, ori_win_right = get_dspark_sparse_sas_window(self.vllm_config)
 
         assert self.spec_slot_mapping is not None
         slot_mapping = self.spec_slot_mapping[draft_index - 1][: self.num_actual_tokens]
@@ -515,8 +562,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             batch_size=num_reqs,
             cmp_ratio=1,
             ori_mask_mode=4,
-            ori_win_left=self.model_config.hf_config.sliding_window - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             has_ori_kv=True,
@@ -548,6 +595,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             sas_metadata=sas_metadata,
             qli_metadata=None,
             cu_cmp_seqlen_list=None,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
+            dspark_swa_indices=dspark_swa_indices,
         )
 
     def _num_compressor_metadata_rows(
@@ -632,7 +682,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
     ) -> AscendDSAReqMetadata:
         """Build a single unified metadata for all requests (prefill + decode)."""
         num_reqs = common_attn_metadata.num_reqs
-        has_prefill = _has_prefill(attn_state)
+        has_prefill = self.num_prefills > 0
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 
@@ -1393,7 +1443,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
         actual_seq_lengths_query = req_metadata.query_start_loc
         local_seq_lengths_query = cp_metadata.local_query_start_loc
         local_seq_lengths_key = cp_metadata.local_seq_lens
-        has_prefill = _has_prefill(common_attn_metadata.attn_state)
+        has_prefill = common_attn_metadata.num_prefills > 0
+        swa_req_metadata = swa_metadata.req_metadata
         hidden_states_cache = hidden_states[: common_attn_metadata.num_actual_tokens]
 
         if (not isinstance(self.wq_b.quant_method, AscendUnquantizedLinearMethod)) and isinstance(
@@ -1529,6 +1580,11 @@ class AscendDSACPImpl(DSAAttentionImpl):
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
                 extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
             )
+        if swa_req_metadata.dspark_swa_indices is not None:
+            extra_attn_kwargs["ori_sparse_indices"] = swa_req_metadata.dspark_swa_indices
+
+        ori_win_left = self.window_size - 1 if swa_req_metadata.ori_win_left is None else swa_req_metadata.ori_win_left
+        ori_win_right = 0 if swa_req_metadata.ori_win_right is None else swa_req_metadata.ori_win_right
 
         common_attn_kwargs = dict(
             cu_seqlens_q=local_seq_lengths_query,
@@ -1537,8 +1593,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
             softmax_scale=self.softmax_scale,
             cmp_ratio=max(self.compress_ratio, 1),
             ori_mask_mode=4,
-            ori_win_left=self.window_size - 1,
-            ori_win_right=0,
+            ori_win_left=ori_win_left,
+            ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
             **extra_attn_kwargs,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -13,11 +13,11 @@ from vllm.v1.attention.backend import AttentionCGSupport, AttentionMetadataBuild
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention.abstract import DSAAttentionImpl
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (
     build_dspark_swa_indices,
     get_dspark_sparse_sas_window,
 )
-from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     maybe_save_kv_layer_to_connector,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -899,9 +899,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         if is_noncausal:
             local_query_lens = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
-            local_seq_lens[:num_reqs].copy_(
-                torch.where(local_query_lens > 0, seq_lens[:num_reqs], 0)
-            )
+            local_seq_lens[:num_reqs].copy_(torch.where(local_query_lens > 0, seq_lens[:num_reqs], 0))
         return (
             local_start,
             local_end,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -306,7 +306,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.common_ratio_to_sas_metadata["num_prefill_tokens"] = self.num_prefill_tokens
             input_positions = common_attn_metadata.positions[:num_input_tokens].long()
             self.common_ratio_to_sas_metadata["input_positions"] = input_positions
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=self.num_prefills == 0)
+            has_prefill = self.num_prefills > 0
+            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=not has_prefill)
             self.common_ratio_to_sas_metadata["cos"] = cos
             self.common_ratio_to_sas_metadata["sin"] = sin
             self.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
@@ -466,35 +467,20 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             local_query_start_loc=self.spec_local_query_start_loc[draft_index - 1],
             local_seq_lens=self.spec_local_seq_lens[draft_index - 1],
+            is_noncausal=is_noncausal,
         )
         local_query_start_loc = local_query_start_loc.clone()
         local_seq_lens = local_seq_lens.clone()
+        local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
+        local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
 
         _, _, _, _, local_query_start_loc_cpu, local_seq_lens_cpu = self._build_local_token_metadata(
             num_reqs=num_reqs,
             num_input_tokens=num_input_tokens,
             query_start_loc=query_start_loc_cpu,
             seq_lens=self.seq_lens_cpu[:num_reqs],
+            is_noncausal=is_noncausal,
         )
-
-        if is_noncausal:
-            # Causal CP truncates the KV length at this rank's local query end.
-            # DSpark queries must see the whole query block, including tokens
-            # whose Q rows live on later CP ranks. Full KV is already written
-            # on every rank after the hidden-state all-gather in _forward().
-            local_query_lens = local_query_start_loc[1:] - local_query_start_loc[:-1]
-            local_seq_lens = torch.where(
-                local_query_lens > 0, self.seq_lens[:num_reqs], torch.zeros_like(self.seq_lens[:num_reqs])
-            )
-            local_query_lens_cpu = local_query_start_loc_cpu[1:] - local_query_start_loc_cpu[:-1]
-            local_seq_lens_cpu = torch.where(
-                local_query_lens_cpu > 0,
-                self.seq_lens_cpu[:num_reqs],
-                torch.zeros_like(self.seq_lens_cpu[:num_reqs]),
-            )
-
-        local_cos = cos.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
-        local_sin = sin.pad_to(num_tokens_pad)[local_start:local_end_with_pad]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
@@ -828,6 +814,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         local_query_start_loc=None,
         local_seq_lens=None,
         start_pos_out=None,
+        is_noncausal=False,
     ):
         """
         For example:
@@ -910,6 +897,11 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 seq_lens_q = query_start_loc[1:] - query_start_loc[:-1]
                 start_pos_out[:num_reqs] = seq_lens[:num_reqs] - seq_lens_q
 
+        if is_noncausal:
+            local_query_lens = local_query_start_loc[1: num_reqs + 1] - local_query_start_loc[:num_reqs]
+            local_seq_lens.copy_(torch.where(
+                local_query_lens > 0, seq_lens[:num_reqs], torch.zeros_like(seq_lens[:num_reqs])
+            ))
         return (
             local_start,
             local_end,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -898,10 +898,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 start_pos_out[:num_reqs] = seq_lens[:num_reqs] - seq_lens_q
 
         if is_noncausal:
-            local_query_lens = local_query_start_loc[1: num_reqs + 1] - local_query_start_loc[:num_reqs]
-            local_seq_lens[:num_reqs].copy_(torch.where(
-                local_query_lens > 0, seq_lens[:num_reqs], torch.zeros_like(seq_lens[:num_reqs])
-            ))
+            local_query_lens = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
+            local_seq_lens[:num_reqs].copy_(
+                torch.where(local_query_lens > 0, seq_lens[:num_reqs], torch.zeros_like(seq_lens[:num_reqs]))
+            )
         return (
             local_start,
             local_end,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -899,7 +899,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         if is_noncausal:
             local_query_lens = local_query_start_loc[1: num_reqs + 1] - local_query_start_loc[:num_reqs]
-            local_seq_lens.copy_(torch.where(
+            local_seq_lens[:num_reqs].copy_(torch.where(
                 local_query_lens > 0, seq_lens[:num_reqs], torch.zeros_like(seq_lens[:num_reqs])
             ))
         return (

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -900,7 +900,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if is_noncausal:
             local_query_lens = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
             local_seq_lens[:num_reqs].copy_(
-                torch.where(local_query_lens > 0, seq_lens[:num_reqs], torch.zeros_like(seq_lens[:num_reqs]))
+                torch.where(local_query_lens > 0, seq_lens[:num_reqs], 0)
             )
         return (
             local_start,


### PR DESCRIPTION
### What this PR does / why we need it?
dsv4 dsa_cp supports the integration of the dspark feature.  
1. Identify DSpark query blocks with causal=False, allowing each CP rank to use the full KV length for valid queries, no longer truncating according to causal rules.  
2. Construct "historical SWA window + complete draft block" ori_sparse_indices for each draft token.  
3. Expand the SWA window to window_size + draft_block_size and pass the sparse indices into the attention operator to achieve non-causal attention within the draft block.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
