### PR TITLE
[BugFix] fix mtp and dcp bug

### DIFF
--- a/tests/ut/worker/test_dcp_manager.py
+++ b/tests/ut/worker/test_dcp_manager.py
@@ -231,6 +231,52 @@ def test_prepare_spec_decode_drafting_metadata_transitions_to_decode() -> None:
     )
 
 
+def test_prepare_spec_decode_drafting_metadata_rebuilds_gqa_mask() -> None:
+    """A short extend becomes a decode after the first MTP draft step."""
+    manager = object.__new__(DCPManager)
+    manager.dcp_world_rank = 0
+    manager.speculative_config = SimpleNamespace(num_speculative_tokens=8)
+    manager._get_dcp_local_seq_lens = MagicMock(return_value=torch.tensor([[4, 3], [6, 5]], dtype=torch.int32))
+    rebuilt_mask = torch.ones((2, 1, 16), dtype=torch.bool)
+    manager.generate_mtp_attention_mask_for_decode = MagicMock(return_value=rebuilt_mask)
+    manager.dcp_mtp_attn_mask = MagicMock()
+    manager.dcp_mtp_attn_mask.np = np.zeros((2, 9, 16), dtype=np.bool_)
+    manager.dcp_mtp_attn_mask.gpu = torch.zeros((2, 9, 16), dtype=torch.bool)
+    original_mask = torch.zeros((1, 9, 16), dtype=torch.bool)
+    common_attn_metadata = SimpleNamespace(
+        context_parallel_metadata=AscendDCPMetadata(
+            num_computed_tokens_of_dcp=[[3, 2], [5, 4]],
+            query_lens_cpu=torch.tensor([8, 1], dtype=torch.int32),
+            max_query_len=8,
+            dcp_mtp_attn_mask=original_mask,
+        ),
+        query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+        is_prefilling=torch.tensor([False, True]),
+    )
+
+    with patch.object(DCPManager, "_is_mla_kv_cache_spec", return_value=False):
+        manager.prepare_spec_decode_drafting_cp_metadata(
+            common_attn_metadata=common_attn_metadata,
+            kv_cache_spec=object(),
+            seq_lens=torch.tensor([6, 10], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([6, 10], dtype=torch.int32),
+            draft_index=1,
+        )
+
+    draft_metadata = common_attn_metadata.context_parallel_metadata
+    manager.generate_mtp_attention_mask_for_decode.assert_called_once()
+    histories, query_lens = manager.generate_mtp_attention_mask_for_decode.call_args.args
+    assert histories == [7, 11]
+    np.testing.assert_array_equal(
+        query_lens,
+        np.array([1, 1], dtype=np.int32),
+    )
+    assert manager.generate_mtp_attention_mask_for_decode.call_args.kwargs["num_decode_reqs"] == 2
+    manager.dcp_mtp_attn_mask.copy_to_gpu.assert_called_once_with(2)
+    assert draft_metadata.dcp_mtp_attn_mask.shape[0] == 2
+    assert not torch.any(common_attn_metadata.is_prefilling)
+
+
 def test_update_spec_decode_drafting_metadata_requires_mla_decode() -> None:
     manager = object.__new__(DCPManager)
     attn_metadata = SimpleNamespace(decode=None)

--- a/tests/ut/worker/test_dcp_manager.py
+++ b/tests/ut/worker/test_dcp_manager.py
@@ -171,6 +171,42 @@ def test_update_spec_decode_drafting_metadata_skips_prefill() -> None:
     assert attn_metadata.decode_meta is None
 
 
+def test_update_spec_decode_drafting_metadata_preserves_full_graph_rows() -> None:
+    manager = object.__new__(DCPManager)
+    manager.dcp_world_rank = 0
+    local_seq_lens = torch.tensor(
+        [[4, 3], [6, 5], [1, 1], [1, 1]],
+        dtype=torch.int32,
+    )
+    manager._get_dcp_local_seq_lens = MagicMock(return_value=local_seq_lens)
+    attn_metadata = SimpleNamespace(
+        decode_meta=SimpleNamespace(
+            num_computed_tokens_of_dcp=np.zeros((4, 2), dtype=np.int32),
+        )
+    )
+
+    with (
+        patch.object(DCPManager, "_is_mla_kv_cache_spec", return_value=False),
+        patch.object(DCPManager, "_is_sfa_dcp_metadata_builder", return_value=False),
+    ):
+        manager.update_spec_decode_drafting_cp_metadata(
+            attn_metadata=attn_metadata,
+            kv_cache_spec=object(),
+            seq_lens=torch.tensor([6, 10], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([6, 10], dtype=torch.int32),
+            draft_index=1,
+        )
+
+    assert torch.equal(
+        manager._get_dcp_local_seq_lens.call_args.args[0],
+        torch.tensor([8, 12, 2, 2], dtype=torch.int32),
+    )
+    np.testing.assert_array_equal(
+        attn_metadata.decode_meta.num_computed_tokens_of_dcp,
+        local_seq_lens.numpy(),
+    )
+
+
 def test_prepare_spec_decode_drafting_metadata_transitions_to_decode() -> None:
     manager = object.__new__(DCPManager)
     manager.dcp_world_rank = 1
@@ -275,6 +311,58 @@ def test_prepare_spec_decode_drafting_metadata_rebuilds_gqa_mask() -> None:
     manager.dcp_mtp_attn_mask.copy_to_gpu.assert_called_once_with(2)
     assert draft_metadata.dcp_mtp_attn_mask.shape[0] == 2
     assert not torch.any(common_attn_metadata.is_prefilling)
+
+
+def test_prepare_spec_decode_drafting_metadata_pads_full_graph_rows() -> None:
+    """FULL graph decode rows must have matching DCP lengths and masks."""
+    manager = object.__new__(DCPManager)
+    manager.dcp_world_rank = 0
+    manager.speculative_config = SimpleNamespace(num_speculative_tokens=8)
+    manager._get_dcp_local_seq_lens = MagicMock(
+        return_value=torch.tensor(
+            [[4, 3], [6, 5], [1, 1], [1, 1]],
+            dtype=torch.int32,
+        )
+    )
+    rebuilt_mask = torch.ones((4, 1, 16), dtype=torch.bool)
+    manager.generate_mtp_attention_mask_for_decode = MagicMock(return_value=rebuilt_mask)
+    manager.dcp_mtp_attn_mask = MagicMock()
+    manager.dcp_mtp_attn_mask.np = np.zeros((4, 9, 16), dtype=np.bool_)
+    manager.dcp_mtp_attn_mask.gpu = torch.zeros((4, 9, 16), dtype=torch.bool)
+    common_attn_metadata = SimpleNamespace(
+        context_parallel_metadata=AscendDCPMetadata(
+            num_computed_tokens_of_dcp=[[3, 2], [5, 4]],
+            query_lens_cpu=torch.tensor([8, 8], dtype=torch.int32),
+            max_query_len=8,
+        ),
+        # Two real requests are followed by two FULL graph decode-padding rows.
+        query_start_loc_cpu=torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32),
+        is_prefilling=torch.tensor([False, False, False, False]),
+    )
+
+    with patch.object(DCPManager, "_is_mla_kv_cache_spec", return_value=False):
+        manager.prepare_spec_decode_drafting_cp_metadata(
+            common_attn_metadata=common_attn_metadata,
+            kv_cache_spec=object(),
+            seq_lens=torch.tensor([6, 10], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([6, 10], dtype=torch.int32),
+            draft_index=1,
+        )
+
+    manager._get_dcp_local_seq_lens.assert_called_once()
+    assert torch.equal(
+        manager._get_dcp_local_seq_lens.call_args.args[0],
+        torch.tensor([8, 12, 2, 2], dtype=torch.int32),
+    )
+    histories, query_lens = manager.generate_mtp_attention_mask_for_decode.call_args.args
+    assert histories == [7, 11, 1, 1]
+    np.testing.assert_array_equal(query_lens, np.ones(4, dtype=np.int32))
+    assert manager.generate_mtp_attention_mask_for_decode.call_args.kwargs["num_decode_reqs"] == 4
+    draft_metadata = common_attn_metadata.context_parallel_metadata
+    assert draft_metadata.num_computed_tokens_of_dcp.shape[0] == 4
+    assert draft_metadata.dcp_mtp_attn_mask.shape[0] == 4
+    assert torch.equal(draft_metadata.query_lens_cpu, torch.ones(4, dtype=torch.int32))
+    manager.dcp_mtp_attn_mask.copy_to_gpu.assert_called_once_with(4)
 
 
 def test_update_spec_decode_drafting_metadata_requires_mla_decode() -> None:

--- a/tests/ut/worker/test_dcp_manager.py
+++ b/tests/ut/worker/test_dcp_manager.py
@@ -118,10 +118,32 @@ def test_generate_mtp_attention_mask_for_decode(dcp_rank: int) -> None:
     local_visible = (positions + 1 + 1 - dcp_rank) // 2
     expected = torch.arange(local_k_len)[None, :] >= local_visible[:, None]
 
+    assert actual.shape == (1, num_scheduled, local_k_len)
     assert torch.equal(
         actual[0, :num_scheduled, :local_k_len],
         expected,
     )
+
+
+def test_copy_mtp_attention_mask_uses_fia_shape_and_partial_copy() -> None:
+    manager = object.__new__(DCPManager)
+    manager.kernel_block_size = 4
+    manager.dcp_mtp_attn_mask = MagicMock()
+    manager.dcp_mtp_attn_mask.gpu = torch.ones((4, 9, 32), dtype=torch.bool)
+    mask = torch.zeros((2, 1, 5), dtype=torch.bool)
+    block_table = torch.zeros((2, 4), dtype=torch.int32)
+
+    actual = manager._copy_mtp_attention_mask_to_gpu(
+        mask,
+        num_decode_reqs=2,
+        block_table_tensor=block_table,
+    )
+
+    assert actual.shape == (2, 1, 16)
+    assert not torch.any(actual[:, :, :5])
+    # Only the populated local-K prefix is transferred. Values outside each
+    # request's actual KV length are ignored by FIA's actual_seq_lengths_kv.
+    assert torch.all(actual[:, :, 5:])
 
 
 def test_generate_dcp_mtp_input_fills_query_start_loc_tail() -> None:
@@ -278,6 +300,12 @@ def test_prepare_spec_decode_drafting_metadata_rebuilds_gqa_mask() -> None:
     manager.dcp_mtp_attn_mask = MagicMock()
     manager.dcp_mtp_attn_mask.np = np.zeros((2, 9, 16), dtype=np.bool_)
     manager.dcp_mtp_attn_mask.gpu = torch.zeros((2, 9, 16), dtype=torch.bool)
+    manager.dcp_mtp_draft_attn_masks = [
+        SimpleNamespace(
+            cpu=torch.zeros((2, 1, 16), dtype=torch.bool),
+            gpu=torch.zeros((2, 1, 16), dtype=torch.bool),
+        )
+    ]
     original_mask = torch.zeros((1, 9, 16), dtype=torch.bool)
     common_attn_metadata = SimpleNamespace(
         context_parallel_metadata=AscendDCPMetadata(
@@ -288,7 +316,9 @@ def test_prepare_spec_decode_drafting_metadata_rebuilds_gqa_mask() -> None:
         ),
         query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
         is_prefilling=torch.tensor([False, True]),
+        block_table_tensor=torch.zeros((2, 4), dtype=torch.int32),
     )
+    manager.kernel_block_size = 4
 
     with patch.object(DCPManager, "_is_mla_kv_cache_spec", return_value=False):
         manager.prepare_spec_decode_drafting_cp_metadata(
@@ -308,8 +338,8 @@ def test_prepare_spec_decode_drafting_metadata_rebuilds_gqa_mask() -> None:
         np.array([1, 1], dtype=np.int32),
     )
     assert manager.generate_mtp_attention_mask_for_decode.call_args.kwargs["num_decode_reqs"] == 2
-    manager.dcp_mtp_attn_mask.copy_to_gpu.assert_called_once_with(2)
-    assert draft_metadata.dcp_mtp_attn_mask.shape[0] == 2
+    assert draft_metadata.dcp_mtp_attn_mask.shape == (2, 1, 16)
+    assert torch.all(draft_metadata.dcp_mtp_attn_mask)
     assert not torch.any(common_attn_metadata.is_prefilling)
 
 
@@ -329,6 +359,12 @@ def test_prepare_spec_decode_drafting_metadata_pads_full_graph_rows() -> None:
     manager.dcp_mtp_attn_mask = MagicMock()
     manager.dcp_mtp_attn_mask.np = np.zeros((4, 9, 16), dtype=np.bool_)
     manager.dcp_mtp_attn_mask.gpu = torch.zeros((4, 9, 16), dtype=torch.bool)
+    manager.dcp_mtp_draft_attn_masks = [
+        SimpleNamespace(
+            cpu=torch.zeros((4, 1, 16), dtype=torch.bool),
+            gpu=torch.zeros((4, 1, 16), dtype=torch.bool),
+        )
+    ]
     common_attn_metadata = SimpleNamespace(
         context_parallel_metadata=AscendDCPMetadata(
             num_computed_tokens_of_dcp=[[3, 2], [5, 4]],
@@ -338,7 +374,9 @@ def test_prepare_spec_decode_drafting_metadata_pads_full_graph_rows() -> None:
         # Two real requests are followed by two FULL graph decode-padding rows.
         query_start_loc_cpu=torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32),
         is_prefilling=torch.tensor([False, False, False, False]),
+        block_table_tensor=torch.zeros((4, 4), dtype=torch.int32),
     )
+    manager.kernel_block_size = 4
 
     with patch.object(DCPManager, "_is_mla_kv_cache_spec", return_value=False):
         manager.prepare_spec_decode_drafting_cp_metadata(
@@ -360,9 +398,9 @@ def test_prepare_spec_decode_drafting_metadata_pads_full_graph_rows() -> None:
     assert manager.generate_mtp_attention_mask_for_decode.call_args.kwargs["num_decode_reqs"] == 4
     draft_metadata = common_attn_metadata.context_parallel_metadata
     assert draft_metadata.num_computed_tokens_of_dcp.shape[0] == 4
-    assert draft_metadata.dcp_mtp_attn_mask.shape[0] == 4
+    assert draft_metadata.dcp_mtp_attn_mask.shape == (4, 1, 16)
     assert torch.equal(draft_metadata.query_lens_cpu, torch.ones(4, dtype=torch.int32))
-    manager.dcp_mtp_attn_mask.copy_to_gpu.assert_called_once_with(4)
+    assert torch.all(draft_metadata.dcp_mtp_attn_mask)
 
 
 def test_update_spec_decode_drafting_metadata_requires_mla_decode() -> None:

--- a/vllm_ascend/worker/dcp_utils.py
+++ b/vllm_ascend/worker/dcp_utils.py
@@ -508,8 +508,6 @@ class DCPManager:
         original_is_prefilling = common_attn_metadata.is_prefilling
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-        dcp_metadata.query_lens_cpu = query_lens_cpu
-        dcp_metadata.max_query_len = int(query_lens_cpu.max().item()) if query_lens_cpu.numel() else 0
 
         is_mla = self._is_mla_kv_cache_spec(kv_cache_spec)
         if is_mla:
@@ -536,11 +534,31 @@ class DCPManager:
             seq_lens_for_dcp = dcp_metadata.draft_base_seq_lens
         else:
             seq_lens_for_dcp = seq_lens_cpu if seq_lens_cpu is not None else seq_lens
+
+        # PR #13252 rebuilds the MTP mask for GQA as well as MLA. Under FULL
+        # graph mode, every padded token is represented as a one-token decode
+        # row: common_attn_metadata.num_reqs and query_start_loc therefore use
+        # the captured token count (for example, 90 rows for 10 real requests
+        # with 9 MTP tokens). Extend the saved real-request sequence lengths
+        # with zero-history graph rows so every DCP tensor uses that same batch
+        # dimension. Non-FULL execution already has equal sizes and is unchanged.
+        num_draft_reqs = query_lens_cpu.shape[0]
+        if seq_lens_for_dcp.shape[0] < num_draft_reqs:
+            seq_lens_for_dcp = torch.nn.functional.pad(
+                seq_lens_for_dcp,
+                (0, num_draft_reqs - seq_lens_for_dcp.shape[0]),
+            )
+            if is_mla:
+                dcp_metadata.draft_base_seq_lens = seq_lens_for_dcp
+        else:
+            seq_lens_for_dcp = seq_lens_for_dcp[:num_draft_reqs]
+        query_lens_cpu = query_lens_cpu[:num_draft_reqs]
+        dcp_metadata.query_lens_cpu = query_lens_cpu
+        dcp_metadata.max_query_len = int(query_lens_cpu.max().item()) if query_lens_cpu.numel() else 0
         local_seq_lens = self._get_dcp_local_seq_lens(seq_lens_for_dcp + draft_index + 1)
         dcp_metadata.num_computed_tokens_of_dcp = local_seq_lens
         dcp_metadata.draft_cp_seq_len = local_seq_lens[:, self.dcp_world_rank]
         if getattr(self, "speculative_config", None) is not None:
-            num_draft_reqs = query_lens_cpu.shape[0]
             draft_base_seq_lens = dcp_metadata.draft_base_seq_lens if is_mla else seq_lens_for_dcp
             assert draft_base_seq_lens is not None
             draft_histories = (draft_base_seq_lens[:num_draft_reqs] + draft_index).to("cpu")
@@ -579,6 +597,17 @@ class DCPManager:
         seq_lens_for_dcp = seq_lens
         if seq_lens_cpu is not None:
             seq_lens_for_dcp = seq_lens_cpu
+        if attn_metadata.decode_meta is not None:
+            # Do not collapse the FULL graph rows materialized by the builder
+            # back to the number of real requests during this second update.
+            num_decode_rows = len(attn_metadata.decode_meta.num_computed_tokens_of_dcp)
+            if seq_lens_for_dcp.shape[0] < num_decode_rows:
+                seq_lens_for_dcp = torch.nn.functional.pad(
+                    seq_lens_for_dcp,
+                    (0, num_decode_rows - seq_lens_for_dcp.shape[0]),
+                )
+            else:
+                seq_lens_for_dcp = seq_lens_for_dcp[:num_decode_rows]
         local_seq_lens = self._get_dcp_local_seq_lens(seq_lens_for_dcp + draft_index + 1)
         rank_seq_lens = local_seq_lens[:, self.dcp_world_rank]
 

--- a/vllm_ascend/worker/dcp_utils.py
+++ b/vllm_ascend/worker/dcp_utils.py
@@ -539,9 +539,11 @@ class DCPManager:
         local_seq_lens = self._get_dcp_local_seq_lens(seq_lens_for_dcp + draft_index + 1)
         dcp_metadata.num_computed_tokens_of_dcp = local_seq_lens
         dcp_metadata.draft_cp_seq_len = local_seq_lens[:, self.dcp_world_rank]
-        if is_mla and getattr(self, "speculative_config", None) is not None:
+        if getattr(self, "speculative_config", None) is not None:
             num_draft_reqs = query_lens_cpu.shape[0]
-            draft_histories = (dcp_metadata.draft_base_seq_lens[:num_draft_reqs] + draft_index).to("cpu")
+            draft_base_seq_lens = dcp_metadata.draft_base_seq_lens if is_mla else seq_lens_for_dcp
+            assert draft_base_seq_lens is not None
+            draft_histories = (draft_base_seq_lens[:num_draft_reqs] + draft_index).to("cpu")
             mask = self.generate_mtp_attention_mask_for_decode(
                 draft_histories.tolist(),
                 query_lens_cpu[:num_draft_reqs].numpy(),

--- a/vllm_ascend/worker/dcp_utils.py
+++ b/vllm_ascend/worker/dcp_utils.py
@@ -95,6 +95,9 @@ class DCPManager:
         self.use_sparse = use_sparse
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1 + (self.speculative_config.num_speculative_tokens if self.speculative_config else 0)
+        from vllm_ascend.attention.attention_v1 import AscendAttentionBackend
+
+        self.kernel_block_size = AscendAttentionBackend.get_supported_kernel_block_sizes()[0]
         self.pd_decode_recompute_scheduler_enabled = is_pd_decode_recompute_scheduler_enabled(vllm_config)
         self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         self.max_num_reqs = max_num_reqs
@@ -112,9 +115,11 @@ class DCPManager:
             pin_memory=pin_memory,
         )
         self.mtp_slot_mapping: torch.Tensor | None = None
+        max_graph_rows = vllm_config.compilation_config.max_cudagraph_capture_size
+        max_mask_rows = max(max_num_reqs, max_graph_rows)
         self.dcp_mtp_attn_mask = CpuGpuBuffer(
             (
-                max_num_reqs,
+                max_mask_rows,
                 self.decode_threshold,
                 vllm_config.model_config.max_model_len,
             ),
@@ -122,6 +127,28 @@ class DCPManager:
             device=device,
             pin_memory=pin_memory,
         )
+        num_followup_drafts = (
+            max(self.speculative_config.num_speculative_tokens - 1, 0)
+            if self.speculative_config is not None and self.speculative_config.method == "mtp"
+            else 0
+        )
+        # Each follow-up MTP pass has one query token per graph row. Keep a
+        # distinct CPU/GPU buffer per pass so building a later pass cannot
+        # overwrite either a mask referenced by an earlier graph node or its
+        # pinned staging memory while a non-blocking H2D copy is in flight.
+        self.dcp_mtp_draft_attn_masks = [
+            CpuGpuBuffer(
+                (
+                    max_mask_rows,
+                    1,
+                    vllm_config.model_config.max_model_len,
+                ),
+                dtype=torch.bool,
+                device=device,
+                pin_memory=pin_memory,
+            )
+            for _ in range(num_followup_drafts)
+        ]
         self.async_rebuild_req_indices: np.ndarray | None = None
         self.async_rebuild_cu_num_tokens: np.ndarray | None = None
         self.async_rebuild_num_tokens = 0
@@ -562,14 +589,25 @@ class DCPManager:
             draft_base_seq_lens = dcp_metadata.draft_base_seq_lens if is_mla else seq_lens_for_dcp
             assert draft_base_seq_lens is not None
             draft_histories = (draft_base_seq_lens[:num_draft_reqs] + draft_index).to("cpu")
+            if not 0 < draft_index <= len(self.dcp_mtp_draft_attn_masks):
+                raise ValueError(
+                    "Invalid MTP draft index for DCP attention-mask buffers: "
+                    f"{draft_index}, available follow-up steps: "
+                    f"{len(self.dcp_mtp_draft_attn_masks)}"
+                )
+            draft_mask_buffer = self.dcp_mtp_draft_attn_masks[draft_index - 1]
             mask = self.generate_mtp_attention_mask_for_decode(
                 draft_histories.tolist(),
                 query_lens_cpu[:num_draft_reqs].numpy(),
                 num_decode_reqs=num_draft_reqs,
+                output_buffer=draft_mask_buffer.cpu,
             )
-            self.dcp_mtp_attn_mask.np[:num_draft_reqs] = mask
-            self.dcp_mtp_attn_mask.copy_to_gpu(num_draft_reqs)
-            dcp_metadata.dcp_mtp_attn_mask = self.dcp_mtp_attn_mask.gpu[:num_draft_reqs]
+            dcp_metadata.dcp_mtp_attn_mask = self._copy_mtp_attention_mask_to_gpu(
+                mask,
+                num_draft_reqs,
+                common_attn_metadata.block_table_tensor,
+                gpu_buffer=draft_mask_buffer.gpu,
+            )
         common_attn_metadata.context_parallel_metadata = dcp_metadata
 
         if common_attn_metadata.is_prefilling is not None:
@@ -665,10 +703,14 @@ class DCPManager:
                 else:
                     decode_computed = input_batch.num_computed_tokens_cpu[: self.num_decode_reqs].tolist()
                 mask = self.generate_mtp_attention_mask_for_decode(decode_computed, decode_scheduled)
-                self.dcp_mtp_attn_mask.np[: self.num_decode_reqs] = mask
-                self.dcp_mtp_attn_mask.copy_to_gpu(self.num_decode_reqs)
+                metadata.dcp_mtp_attn_mask = self._copy_mtp_attention_mask_to_gpu(
+                    mask,
+                    self.num_decode_reqs,
+                    block_table_tensor,
+                )
             mask_count = self.num_decode_reqs if self.num_decode_reqs > 0 else num_reqs
-            metadata.dcp_mtp_attn_mask = self.dcp_mtp_attn_mask.gpu[:mask_count]
+            if metadata.dcp_mtp_attn_mask is None:
+                metadata.dcp_mtp_attn_mask = self.dcp_mtp_attn_mask.gpu[:mask_count]
 
         self.long_seq_metadata = metadata
         return metadata, block_table_tensor
@@ -678,6 +720,7 @@ class DCPManager:
         decode_num_computed_tokens: list[int],
         decode_num_scheduled_tokens: np.ndarray,
         num_decode_reqs: int | None = None,
+        output_buffer: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Build interleave-aware causal masks for DCP speculative decode."""
         if num_decode_reqs is None:
@@ -695,13 +738,21 @@ class DCPManager:
             interleave_size,
         )[:, self.dcp_world_rank]
         valid = k_lens > 0
-        output = self.dcp_mtp_attn_mask.cpu[:num_decode_reqs]
-        output.zero_()
+        if output_buffer is None:
+            output_buffer = self.dcp_mtp_attn_mask.cpu
+        if num_decode_reqs > output_buffer.shape[0]:
+            raise ValueError(
+                "DCP MTP decode rows exceed the CPU attention-mask capacity: "
+                f"{num_decode_reqs} > {output_buffer.shape[0]}"
+            )
+        output = output_buffer[:num_decode_reqs]
         if not valid.any():
-            return output
+            return output[:, :0, :0]
 
         max_q = int(q_lens[valid].max().item())
         max_k = int(k_lens[valid].max().item())
+        output = output[:, :max_q, :max_k]
+        output.zero_()
         q_indices = torch.arange(max_q, dtype=torch.int32)
         k_indices = torch.arange(max_k, dtype=torch.int32)
         valid_q = valid[:, None] & (q_indices[None, :] < q_lens[:, None])
@@ -722,3 +773,53 @@ class DCPManager:
         )
         output[:num_decode_reqs, :max_q, :max_k] = full_mask
         return output
+
+    def _copy_mtp_attention_mask_to_gpu(
+        self,
+        mask: torch.Tensor,
+        num_decode_reqs: int,
+        block_table_tensor: torch.Tensor,
+        gpu_buffer: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Copy only the populated mask and expose the FIA-compatible view.
+
+        FIA's BSND mask uses the actual query width, while its key width is
+        determined by the block-table capacity rather than the current
+        sequence length. The backing buffer remains fixed for graph capture,
+        but only the causally relevant prefix is transferred each step.
+        """
+        if gpu_buffer is None:
+            gpu_buffer = self.dcp_mtp_attn_mask.gpu
+        if num_decode_reqs > gpu_buffer.shape[0]:
+            raise ValueError(
+                f"DCP MTP decode rows exceed the attention-mask capacity: {num_decode_reqs} > {gpu_buffer.shape[0]}"
+            )
+        if block_table_tensor.ndim != 2:
+            raise ValueError(f"DCP MTP expects a 2-D block table, got shape {tuple(block_table_tensor.shape)}")
+
+        mask_q_len = mask.shape[1]
+        mask_k_len = block_table_tensor.shape[1] * self.kernel_block_size
+        if mask.shape[2] > mask_k_len:
+            raise ValueError(
+                f"DCP MTP local KV length exceeds the block-table capacity: {mask.shape[2]} > {mask_k_len}"
+            )
+        if mask_q_len > gpu_buffer.shape[1]:
+            raise ValueError(
+                f"DCP MTP query length exceeds the attention-mask buffer: {mask_q_len} > {gpu_buffer.shape[1]}"
+            )
+        if mask_k_len > gpu_buffer.shape[2]:
+            raise ValueError(
+                f"DCP MTP block-table capacity exceeds the attention-mask buffer: {mask_k_len} > {gpu_buffer.shape[2]}"
+            )
+
+        target = gpu_buffer[
+            :num_decode_reqs,
+            :mask_q_len,
+            : mask.shape[2],
+        ]
+        target.copy_(mask, non_blocking=True)
+        return gpu_buffer[
+            :num_decode_reqs,
+            :mask_q_len,
+            :mask_k_len,
+        ]


### PR DESCRIPTION
### What this PR does / why we need it?
Resolve the issue of qwen3.6+mtp+dcp startup error， error info
```
File "/vllm-workspace/vllm-ascend/vllm_ascend/attention/context_parallel/attention_cp.py", line 541, in forward_impl
(Worker_TP1_DCP1 pid=96931) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP6_DCP0 pid=96936) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]   File "/vllm-workspace/vllm/vllm/model_executor/layers/attention/kv_transfer_utils.py", line 40, in wrapper
(Worker_TP7_DCP1 pid=96937) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]   File "/vllm-workspace/vllm/vllm/model_executor/layers/attention/kv_transfer_utils.py", line 40, in wrapper
(Worker_TP3_DCP1 pid=96933) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]         TraceBack (most recent call last):
(Worker_TP5_DCP1 pid=96935) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]         TraceBack (most recent call last):
(Worker_TP2_DCP0 pid=96932) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]         TraceBack (most recent call last):
(Worker_TP4_DCP0 pid=96934) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_DCP0 pid=96930) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]     output_decode = self._forward_decode_dcp(decode_query, attn_metadata)
(Worker_TP1_DCP1 pid=96931) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]   File "/vllm-workspace/vllm/vllm/model_executor/layers/attention/attention.py", line 830, in unified_attention_with_output
(Worker_TP6_DCP0 pid=96936) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]     return func(*args, **kwargs)
(Worker_TP7_DCP1 pid=96937) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]     return func(*args, **kwargs)
(Worker_TP3_DCP1 pid=96933) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]        FusedInferAttentionScore do tiling failed, ret is -1.
(Worker_TP5_DCP1 pid=96935) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]        FusedInferAttentionScore do tiling failed, ret is -1.
(Worker_TP2_DCP0 pid=96932) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]         [CheckAttentionMask] atten_mask layout is BS1S2, shape is [9, 9, 32768], expected shape is [10, 1, 16896], axis B(9) should be == expected 10.[FUNC:CompareShape][FILE:fia_tiling_shape.cpp][LINE:342]

 Solution: 1. Check whether this port has been occupied by another process. If yes, you can make adjustment using the environment variable HCCL_IF_BASE_PORT and use sysctl -w net.ipv4.ip_local_reserved_ports=****-**** to adjust the scope of reserved ports. 2. Check whether the service process is started multiple times on a device during this service.
(Worker_TP0_DCP0 pid=96930) ERROR 07-31 03:18:59 [multiproc_executor.py:1004] 
(Worker_TP1_DCP1 pid=96931) ERROR 07-31 03:18:59 [multiproc_executor.py:1004]         TraceBack (most recent call last):
(Worker_TP6_DCP0 pid=96936) ERROR 07-31 03:18:59 [multiproc_executor.py:1004] [PID: 96936] 2026-07-31-03:02:09.620.059 Communication_Error_Bind_IP_Port(EI0019): Failed to enable listening for the host network adapter socket. Reason: The IP address 172.61.12.97 and port 65536 have already been bound.

File "/vllm-workspace/vllm-ascend/vllm_ascend/spec_decode/llm_base_proposer.py", line 1693, in attn_update_stack_num_spec_norm
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]     dcp_manager.prepare_spec_decode_drafting_cp_metadata(
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/dcp_utils.py", line 549, in prepare_spec_decode_drafting_cp_metadata
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]     mask = self.generate_mtp_attention_mask_for_decode(
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]   File "/vllm-workspace/vllm-ascend/vllm_ascend/worker/dcp_utils.py", line 664, in generate_mtp_attention_mask_for_decode
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]     total_lens = histories + q_lens
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004]                  ~~~~~~~~~~^~~~~~~~
(Worker_TP5_DCP1 pid=154647) ERROR 07-31 07:06:56 [multiproc_executor.py:1004] RuntimeError: The size of tensor a (10) must match the size of tensor b (90) at non-singleton dimension 0
```

### How was this patch tested?
test result
<img width="451" height="631" alt="image" src="https://github.com/user-attachments/assets/30fa8c83-6045-4fa8-9714-0be4a0f81de7" />

```
export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15

vllm serve /nas/disk1/Qwen3.6-27B --port 8898 --dtype bfloat16  \
--tensor-parallel-size 8 --gpu-memory-utilization 0.8 \
--max-model-len 32768 --trust-remote-code \
--no-enable-prefix-caching \
--decode-context-parallel-size 2 \
--speculative_config '{"method":"mtp", "num_speculative_tokens":8}' \
--compilation-config '{"max_cudagraph_capture_size": 128}'
```

```
vllm bench serve \
  --port 8898 \
  --backend vllm \
  --model /nas/disk1/Qwen3.6-27B \
  --endpoint /v1/completions \
  --dataset-name sonnet \
  --dataset-path /vllm/benchmarks/sonnet.txt \
  --max-concurrency 5\
  --sonnet-input-len 1024 \
  --sonnet-output-len 100 \
  --sonnet-prefix-len 10 \
  --num-prompts 10 \
  --ignore-eos \
  --percentile-metrics "ttft,tpot,itl,e2el" \
  --seed 1234 \
  --temperature 0.01
```


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
