### PR TITLE
[Doc][Test][Feature] Add InternLM2-20B-Chat support

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -62,6 +62,7 @@ a2:
           - Qwen3-30B-A3B
           - Qwen3-VL-30B-A3B-Instruct
           - Qwen3-30B-A3B-W8A8
+          - InternLM2-20B-Chat
       - name: accuracy-group-4
         os: linux-aarch64-a2b3-4
         model_list:

--- a/docs/source/tutorials/models/InternLM2-20B-Chat.md
+++ b/docs/source/tutorials/models/InternLM2-20B-Chat.md
@@ -244,11 +244,17 @@ inter-token latency together with the hardware and software versions. Results
 from different context lengths or concurrency settings are not directly
 comparable.
 
-The TP=2 eager baseline measured on two 64 GB Ascend 910 NPUs is:
+The following TP=2 results were measured on two 64 GB Ascend 910 NPUs:
 
-| Requests | Success | Duration | Request throughput | Output throughput | Mean TTFT | Mean TPOT | Mean ITL |
-|----------|---------|----------|--------------------|-------------------|-----------|-----------|----------|
-| 100 | 100% | 166.51 s | 0.6005 req/s | 76.87 tok/s | 1295.02 ms | 91.43 ms | 91.43 ms |
+| Mode | Max model length | Max sequences | Requests | Success | Duration | Request throughput | Output throughput | Mean TTFT | Mean TPOT | Mean ITL |
+|------|-----------------:|--------------:|---------:|--------:|---------:|-------------------:|------------------:|----------:|----------:|---------:|
+| ACL Graph | 2,048 | 4 | 100 | 100% | 101.45 s | 0.9857 req/s | 126.17 tok/s | 4145.54 ms | 29.97 ms | 29.97 ms |
+| Eager | 32,768 | 16 | 100 | 100% | 166.51 s | 0.6005 req/s | 76.87 tok/s | 1295.02 ms | 91.43 ms | 91.43 ms |
+
+Both runs use the request workload shown above. They are operational baselines,
+not a strict graph-versus-eager A/B comparison, because the server-side maximum
+model length and sequence capacity differ. With `max-num-seqs=4`, the ACL Graph
+run queues part of the concurrency-8 burst, which increases TTFT.
 
 ## Troubleshooting
 

--- a/docs/source/tutorials/models/InternLM2-20B-Chat.md
+++ b/docs/source/tutorials/models/InternLM2-20B-Chat.md
@@ -256,6 +256,10 @@ not a strict graph-versus-eager A/B comparison, because the server-side maximum
 model length and sequence capacity differ. With `max-num-seqs=4`, the ACL Graph
 run queues part of the concurrency-8 burst, which increases TTFT.
 
+For the ACL Graph run, P99 TTFT, TPOT, and ITL were 5551.16 ms, 30.72 ms,
+and 125.66 ms, respectively. Graph capture completed in 12 seconds and used
+approximately 0.46 GiB of graph memory per NPU.
+
 ## Troubleshooting
 
 ### The model cannot be loaded without remote code

--- a/docs/source/tutorials/models/InternLM2-20B-Chat.md
+++ b/docs/source/tutorials/models/InternLM2-20B-Chat.md
@@ -18,9 +18,9 @@ development version.
 |---------|--------|-------|
 | BF16 inference | ✅ | Native model weight format |
 | Tensor parallelism | ✅ | TP=2 is recommended for the 20B BF16 model |
-| ACL Graph | ⚠️ | Requires an image with the complete Ascend custom-op package |
+| ACL Graph | ✅ | Verified with TP=2 and real weights at a 2,048-token model length |
 | Eager mode | ✅ | Available with `--enforce-eager` for troubleshooting |
-| 32K context | ✅ | Verified with TP=2, `max-num-seqs=16`, and a 32,002-token prompt |
+| 32K context | ✅ | Verified in eager mode with TP=2, `max-num-seqs=16`, and a 32,002-token prompt |
 | Pipeline parallelism | ✅ | Supported by the upstream vLLM model implementation |
 | LoRA | ✅ | Supported by the upstream vLLM model implementation |
 | Expert parallelism | N/A | InternLM2-20B-Chat is a dense model |
@@ -123,11 +123,10 @@ vllm serve /data/models/internlm2-chat-20b \
   --served-model-name internlm2-20b-chat \
   --tensor-parallel-size 2 \
   --dtype bfloat16 \
-  --max-model-len 32768 \
-  --max-num-seqs 16 \
-  --gpu-memory-utilization 0.90 \
+  --max-model-len 2048 \
+  --max-num-seqs 4 \
+  --gpu-memory-utilization 0.8 \
   --trust-remote-code \
-  --enforce-eager \
   --port 8000
 ```
 
@@ -135,16 +134,23 @@ Key parameters:
 
 - `--tensor-parallel-size 2` distributes the 20B BF16 checkpoint across two
   NPUs.
-- `--max-model-len 32768` enables the context length declared by the model.
-  Lower this value when the deployment must reserve more memory for
-  concurrent requests.
+- `--max-model-len 2048` and `--max-num-seqs 4` match the real-weight ACL
+  Graph validation. Increase them only after validating the target workload
+  and available KV-cache memory.
 - `--trust-remote-code` is required for the model repository's tokenizer and
   configuration code. vLLM still uses its native `InternLM2ForCausalLM`
   implementation for inference.
-- `--enforce-eager` is the verified fallback for source environments that do
-  not contain the complete Ascend custom-op package. With a complete official
-  image, remove it to enable ACL Graph and verify one request before production
-  rollout.
+
+With a complete Ascend custom-op package, the default command captures both
+PIECEWISE mixed prefill/decode graphs and FULL decode graphs. The real-weight
+TP=2 validation captured batch sizes 1, 2, and 4, then returned HTTP 200 from
+the models, completions, and chat-completions endpoints. This validation used
+a 2,048-token model length; it does not establish ACL Graph support at 32K.
+
+If graph compilation or a custom-op installation fails, add
+`--enforce-eager` as a troubleshooting fallback. The 32K capacity result and
+the C-Eval and performance numbers below were measured in eager mode and
+should not be presented as ACL Graph results.
 
 The service is ready when `GET /v1/models` returns HTTP 200 and lists
 `internlm2-20b-chat`:
@@ -204,7 +210,7 @@ pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
   --report-dir benchmarks/accuracy
 ```
 
-The real-weight TP=2 eager baseline is:
+The real-weight TP=2 eager accuracy baseline is:
 
 | Dataset | Shots | Metric | Value |
 |---------|------:|--------|------:|

--- a/docs/source/tutorials/models/InternLM2-20B-Chat.md
+++ b/docs/source/tutorials/models/InternLM2-20B-Chat.md
@@ -1,0 +1,267 @@
+# InternLM2-20B-Chat
+
+## Introduction
+
+InternLM2-20B-Chat is a 20-billion-parameter bilingual chat model from the
+InternLM team. It uses a dense decoder-only architecture with grouped-query
+attention (GQA), BF16 weights, and dynamic RoPE scaling for a context length
+of up to 32,768 tokens.
+
+This tutorial shows how to deploy `internlm/internlm2-chat-20b` with
+vLLM Ascend, verify the OpenAI-compatible API, and run the repository's
+end-to-end accuracy test. The instructions target the current vLLM Ascend
+development version.
+
+## Supported Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| BF16 inference | ✅ | Native model weight format |
+| Tensor parallelism | ✅ | TP=2 is recommended for the 20B BF16 model |
+| ACL Graph | ⚠️ | Requires an image with the complete Ascend custom-op package |
+| Eager mode | ✅ | Available with `--enforce-eager` for troubleshooting |
+| 32K context | ✅ | Verified with TP=2, `max-num-seqs=16`, and a 32,002-token prompt |
+| Pipeline parallelism | ✅ | Supported by the upstream vLLM model implementation |
+| LoRA | ✅ | Supported by the upstream vLLM model implementation |
+| Expert parallelism | N/A | InternLM2-20B-Chat is a dense model |
+| Multimodal input | N/A | InternLM2-20B-Chat is a text-only model |
+| MTP | ⚠️ | Checkpoint missing: the model does not provide MTP draft weights |
+
+For the project-wide model and feature matrices, see
+[Supported Models](../../user_guide/support_matrix/supported_models.md) and
+[Supported Features](../../user_guide/support_matrix/supported_features.md).
+
+## Environment Preparation
+
+### Model Weight
+
+The BF16 checkpoint contains approximately 39.7 GB (37.0 GiB) of safetensors
+weights. Inference also requires memory for the runtime and KV cache, so TP=2
+is recommended on 64 GB NPUs, especially for long-context workloads and ACL
+Graph capture.
+
+- [Hugging Face: internlm/internlm2-chat-20b](https://huggingface.co/internlm/internlm2-chat-20b)
+- [ModelScope: Shanghai_AI_Laboratory/internlm2-chat-20b](https://modelscope.cn/models/Shanghai_AI_Laboratory/internlm2-chat-20b)
+
+The repository's accuracy workflow uses ModelScope, so its E2E configuration
+references the `Shanghai_AI_Laboratory/internlm2-chat-20b` mirror.
+
+Download the checkpoint to a local or shared directory before starting the
+service. The following example uses ModelScope:
+
+```bash
+python -m pip install modelscope
+modelscope download \
+  --model Shanghai_AI_Laboratory/internlm2-chat-20b \
+  --local_dir /data/models/internlm2-chat-20b
+```
+
+### Installation
+
+Use a vLLM Ascend image whose vLLM, PyTorch, torch-npu, CANN, and driver
+versions follow the compatibility matrix in the
+[installation guide](../../installation.md).
+
+=== "Atlas A2 inference products"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
+
+    docker run --rm -it \
+      --name internlm2-20b-chat \
+      --shm-size=16g \
+      --net host \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /data/models:/data/models \
+      "$IMAGE" bash
+    ```
+
+=== "Atlas A3 inference products"
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+
+    docker run --rm -it \
+      --name internlm2-20b-chat \
+      --shm-size=16g \
+      --net host \
+      --device /dev/davinci0 \
+      --device /dev/davinci1 \
+      --device /dev/davinci_manager \
+      --device /dev/devmm_svm \
+      --device /dev/hisi_hdc \
+      -v /usr/local/dcmi:/usr/local/dcmi \
+      -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+      -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+      -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+      -v /etc/ascend_install.info:/etc/ascend_install.info \
+      -v /data/models:/data/models \
+      "$IMAGE" bash
+    ```
+
+Inside the container, verify that both NPUs are visible:
+
+```bash
+npu-smi info
+```
+
+## Online Service Deployment
+
+Start the OpenAI-compatible server with two NPUs:
+
+```bash
+vllm serve /data/models/internlm2-chat-20b \
+  --served-model-name internlm2-20b-chat \
+  --tensor-parallel-size 2 \
+  --dtype bfloat16 \
+  --max-model-len 32768 \
+  --max-num-seqs 16 \
+  --gpu-memory-utilization 0.90 \
+  --trust-remote-code \
+  --enforce-eager \
+  --port 8000
+```
+
+Key parameters:
+
+- `--tensor-parallel-size 2` distributes the 20B BF16 checkpoint across two
+  NPUs.
+- `--max-model-len 32768` enables the context length declared by the model.
+  Lower this value when the deployment must reserve more memory for
+  concurrent requests.
+- `--trust-remote-code` is required for the model repository's tokenizer and
+  configuration code. vLLM still uses its native `InternLM2ForCausalLM`
+  implementation for inference.
+- `--enforce-eager` is the verified fallback for source environments that do
+  not contain the complete Ascend custom-op package. With a complete official
+  image, remove it to enable ACL Graph and verify one request before production
+  rollout.
+
+The service is ready when `GET /v1/models` returns HTTP 200 and lists
+`internlm2-20b-chat`:
+
+```bash
+curl -f http://127.0.0.1:8000/v1/models
+```
+
+## Functional Verification
+
+Send a deterministic chat request:
+
+```bash
+curl -f http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "internlm2-20b-chat",
+    "messages": [
+      {"role": "user", "content": "Explain why the sky appears blue in one sentence."}
+    ],
+    "temperature": 0,
+    "max_tokens": 64
+  }'
+```
+
+A successful response has HTTP status 200, contains a non-empty
+`choices[0].message.content` field, and does not contain NaN or Inf values in
+the server log.
+
+The completions endpoint can be checked independently:
+
+```bash
+curl -f http://127.0.0.1:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "internlm2-20b-chat",
+    "prompt": "Shanghai is",
+    "temperature": 0,
+    "max_tokens": 32
+  }'
+```
+
+## Accuracy Evaluation
+
+The repository provides the end-to-end configuration at
+`tests/e2e/models/configs/InternLM2-20B-Chat.yaml`. It evaluates the model on
+the C-Eval validation split with the same harness used by vLLM Ascend CI.
+
+Install the evaluation dependencies, then run:
+
+```bash
+export VLLM_USE_MODELSCOPE=True
+
+pytest -sv tests/e2e/models/test_lm_eval_correctness.py \
+  --config tests/e2e/models/configs/InternLM2-20B-Chat.yaml \
+  --tp-size 2 \
+  --report-dir benchmarks/accuracy
+```
+
+The real-weight TP=2 eager baseline is:
+
+| Dataset | Shots | Metric | Value |
+|---------|------:|--------|------:|
+| ceval-valid | 5 | acc,none | 0.6226 |
+
+The test compares measured metrics with the checked-in baseline using the
+repository's relative tolerance and writes a Markdown report under
+`benchmarks/accuracy/`.
+
+## Performance Evaluation
+
+Use `vllm bench serve` against the running server. Keep input length, output
+length, request count, and concurrency fixed when comparing configurations:
+
+```bash
+vllm bench serve \
+  --backend vllm \
+  --base-url http://127.0.0.1:8000 \
+  --model internlm2-20b-chat \
+  --tokenizer /data/models/internlm2-chat-20b \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 128 \
+  --num-prompts 100 \
+  --max-concurrency 8 \
+  --ignore-eos
+```
+
+Report request throughput, output-token throughput, time to first token, and
+inter-token latency together with the hardware and software versions. Results
+from different context lengths or concurrency settings are not directly
+comparable.
+
+The TP=2 eager baseline measured on two 64 GB Ascend 910 NPUs is:
+
+| Requests | Success | Duration | Request throughput | Output throughput | Mean TTFT | Mean TPOT | Mean ITL |
+|----------|---------|----------|--------------------|-------------------|-----------|-----------|----------|
+| 100 | 100% | 166.51 s | 0.6005 req/s | 76.87 tok/s | 1295.02 ms | 91.43 ms | 91.43 ms |
+
+## Troubleshooting
+
+### The model cannot be loaded without remote code
+
+Keep `--trust-remote-code` enabled. The checkpoint references custom
+configuration and tokenizer modules even though the model architecture is
+natively registered in vLLM.
+
+### Out of memory during graph capture or long-context startup
+
+First confirm that TP=2 is active. Then reduce `--max-num-seqs`, lower
+`--max-model-len`, or reduce `--gpu-memory-utilization` to leave headroom for
+non-vLLM processes. Use `--enforce-eager` only to determine whether the extra
+memory is specific to ACL Graph capture.
+
+### The server starts but chat requests fail
+
+Check `/v1/models`, confirm that the request's `model` matches
+`--served-model-name`, and verify that all tokenizer files were downloaded.
+Test `/v1/completions` to separate tokenizer/chat-template problems from the
+model execution path.

--- a/docs/source/tutorials/models/index.md
+++ b/docs/source/tutorials/models/index.md
@@ -1,3 +1,5 @@
 # Model Tutorials
 
 This section provides tutorials for different models of vLLM Ascend.
+
+- [InternLM2-20B-Chat](InternLM2-20B-Chat.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,6 +223,7 @@ nav:
         - tutorials/models/Qwen3-ASR-1.7B.md
         - tutorials/models/Qwen2.5-Math-RM-72B.md
         - tutorials/models/InternVL3.5.md
+        - tutorials/models/InternLM2-20B-Chat.md
     - Feature Tutorials:
         - tutorials/features/index.md
         - tutorials/features/pd_colocated_mooncake_multi_instance.md

--- a/tests/e2e/models/configs/InternLM2-20B-Chat.yaml
+++ b/tests/e2e/models/configs/InternLM2-20B-Chat.yaml
@@ -8,7 +8,6 @@ serve:
   max_model_len: 2048
   gpu_memory_utilization: 0.8
   trust_remote_code: true
-  enforce_eager: true
 
 tasks:
 - name: "ceval-valid"

--- a/tests/e2e/models/configs/InternLM2-20B-Chat.yaml
+++ b/tests/e2e/models/configs/InternLM2-20B-Chat.yaml
@@ -1,0 +1,22 @@
+model_name: "Shanghai_AI_Laboratory/internlm2-chat-20b"
+model_type: "vllm"
+hardware: "Atlas A2 Series"
+
+serve:
+  tensor_parallel_size: 2
+  dtype: "bfloat16"
+  max_model_len: 2048
+  gpu_memory_utilization: 0.8
+  trust_remote_code: true
+  enforce_eager: true
+
+tasks:
+- name: "ceval-valid"
+  metrics:
+  - name: "acc,none"
+    value: 0.6226
+
+num_fewshot: 5
+apply_chat_template: false
+fewshot_as_multiturn: false
+batch_size: "auto"

--- a/tests/e2e/models/configs/accuracy.txt
+++ b/tests/e2e/models/configs/accuracy.txt
@@ -8,6 +8,7 @@ InternVL3_5-8B-hf.yaml
 ERNIE-4.5-21B-A3B-PT.yaml
 gemma-3-4b-it.yaml
 internlm3-8b-instruct.yaml
+InternLM2-20B-Chat.yaml
 Molmo-7B-D-0924.yaml
 llava-onevision-qwen2-0.5b-ov-hf.yaml
 Llama-3.2-3B-Instruct.yaml


### PR DESCRIPTION
### What this PR does / why we need it?

Adds InternLM2-20B-Chat to the Ascend model E2E suite and documentation:

- Adds the full C-Eval E2E configuration and accuracy baseline.
- Runs the E2E configuration with the default ACL Graph path.
- Includes the model in nightly model coverage.
- Adds an Ascend deployment tutorial and navigation entries.
- Documents ModelScope usage with the CI-compatible namespace.

Upstream vLLM already registers `InternLM2ForCausalLM`. Source analysis and real-weight execution confirmed that its GQA attention, tensor-parallel linear layers, RMSNorm, SwiGLU, RoPE, embeddings, and LM head use the existing generic Ascend path. Therefore, no model-specific Python, C++, kernel, or model-runner patch is needed.

Closes #10673
Related to #9079

### Does this PR introduce _any_ user-facing change?

Yes. Users get a documented and nightly-tested configuration for serving `Shanghai_AI_Laboratory/internlm2-chat-20b` on Ascend with TP=2 and ACL Graph. Eager mode remains documented as a troubleshooting fallback.

### How was this patch tested?

Local quality gates:

- `./format.sh ci`: passed, including ruff, codespell, markdownlint, actionlint, gitleaks, and shellcheck hooks.
- `mkdocs build --strict`: passed.
- YAML parsing and targeted serve-field assertions: passed; the config no longer sets `enforce_eager`.
- `git diff --check`: passed.
- The current local quality environment did not include pytest, so the targeted collection command was not rerun for the follow-up commit; the existing E2E config collection evidence is unchanged.

Real-weight ACL Graph validation:

- Model: real InternLM2-20B-Chat BF16 weights, all 21 safetensors shards.
- Configuration: TP=2, `max_model_len=2048`, `max_num_seqs=4`, `gpu_memory_utilization=0.8`, without `--enforce-eager`.
- Engine configuration reported `enforce_eager=False`, `AscendCompiler`, `CUDAGraphMode.FULL_AND_PIECEWISE`, and capture sizes `[1, 2, 4]`.
- Both ranks completed compilation for range `(1, 2048)`; `torch.compile` took 76.76 seconds.
- Mixed prefill/decode PIECEWISE capture completed 3/3 and decode FULL capture completed 3/3. The server reported `Graph capturing finished in 7 secs`, using about 0.48 GiB graph memory per NPU.
- `/v1/models`, `/v1/completions`, and `/v1/chat/completions` returned HTTP 200 with valid non-empty output. The chat response correctly answered that China's capital is Beijing.
- An additional four concurrent completion requests all returned HTTP 200 with non-empty output, exercising the captured batch-size-4 path.
- The final log contained no traceback, custom-op import failure, `AddRmsNormBias` error, NaN, or Inf.
- After validation, the service root process was terminated with TERM; port 8000 was released and no NPU process remained.

Additional eager-mode baselines retained from the original validation:

- TP=2 eager real-weight serving: all three OpenAI-compatible endpoints returned HTTP 200 with valid non-empty output.
- 32K context: a 32,002-token prompt completed successfully in 23.529 seconds.
- Full C-Eval validation: 52 subjects, 1,346 questions, 5-shot, no limit; `acc,none=0.6226 ± 0.0125`.
- ACL Graph serving benchmark (1024 input / 128 output, 100 prompts, concurrency 8): 100/100 successful, 0.9857 req/s, 126.17 output tok/s, mean TTFT 4145.54 ms, mean TPOT 29.97 ms. This used the documented 2,048-token, max-num-seqs-4 graph configuration; concurrency above four is queued.\n- Eager serving baseline with the same request workload: 100/100 successful, 0.6005 req/s, 76.87 output tok/s, mean TTFT 1295.02 ms, mean TPOT 91.43 ms.

The ACL Graph results above are scoped to a 2,048-token model length. The 32K and C-Eval results remain eager-mode baselines and are not presented as 32K ACL Graph validation. The ACL Graph and eager performance runs use different server-side maximum model lengths and sequence capacities, so they are operational baselines rather than a strict graph-versus-eager A/B comparison.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
