### PR TITLE
[BugFix][Scheduler] Adapt BalanceScheduler to get_computed_blocks 3-tuple

### DIFF
--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -349,6 +349,25 @@ def test_balance_deltas_present_in_schedule():
     assert "if request_queue is None:" in src
 
 
+def test_get_computed_blocks_result_is_fully_unpacked():
+    """Keep the copied schedule body aligned with vLLM's 3-tuple API."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(BalanceScheduler.schedule)))
+    assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "get_computed_blocks"
+    ]
+
+    assert len(assignments) == 1
+    target = assignments[0].targets[0]
+    assert isinstance(target, ast.Tuple)
+    assert len(target.elts) == 3
+    assert ast.unparse(target.elts[2]) == "request.shared_prefix_boundary"
+
+
 # ---------------------------------------------------------------------------
 # 1c. copied schedule() body stays verbatim with the pinned release tag
 # ---------------------------------------------------------------------------

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -349,25 +349,6 @@ def test_balance_deltas_present_in_schedule():
     assert "if request_queue is None:" in src
 
 
-def test_get_computed_blocks_result_is_fully_unpacked():
-    """Keep the copied schedule body aligned with vLLM's 3-tuple API."""
-    tree = ast.parse(textwrap.dedent(inspect.getsource(BalanceScheduler.schedule)))
-    assignments = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Assign)
-        and isinstance(node.value, ast.Call)
-        and isinstance(node.value.func, ast.Attribute)
-        and node.value.func.attr == "get_computed_blocks"
-    ]
-
-    assert len(assignments) == 1
-    target = assignments[0].targets[0]
-    assert isinstance(target, ast.Tuple)
-    assert len(target.elts) == 3
-    assert ast.unparse(target.elts[2]) == "request.shared_prefix_boundary"
-
-
 # ---------------------------------------------------------------------------
 # 1c. copied schedule() body stays verbatim with the pinned release tag
 # ---------------------------------------------------------------------------

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -476,9 +476,11 @@ class BalanceScheduler(Scheduler):
                                 preempted=request.num_preemptions > 0,
                             )
                     else:
-                        new_computed_blocks, num_new_local_computed_tokens = self.kv_cache_manager.get_computed_blocks(
-                            request
-                        )
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            request.shared_prefix_boundary,
+                        ) = self.kv_cache_manager.get_computed_blocks(request)
 
                     # In case of hybrid models, obtain hint for Marconi-style APC logic
                     if self.has_mamba_layers:


### PR DESCRIPTION
## Based on

This PR is based on https://github.com/vllm-project/vllm-ascend/pull/13235 and re-submits the same production-code change on an independent branch. No additional functional changes are included.

## Why

The copied `BalanceScheduler.schedule()` implementation still expects two return values from `KVCacheManager.get_computed_blocks()`. After the upstream vLLM API change, the method returns three values, causing the balance-scheduling path to fail at runtime.

## Upstream change

Upstream PR: https://github.com/vllm-project/vllm/pull/47782

The upstream change extends `get_computed_blocks()` to return:

```python
(computed_blocks, num_computed_tokens, shared_prefix_boundary)
```

## Downstream changes

- Update `vllm_ascend/patch/platform/patch_balance_schedule.py` to unpack the third value into `request.shared_prefix_boundary`.

## Test plan

- Full validation is delegated to PR CI.

## User-facing change

No.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
