### PR TITLE
[BugFix][Scheduler] Propagate EC transfer params in RecomputeScheduler

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
+import inspect
+import textwrap
 from collections import defaultdict
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -110,3 +113,37 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
             client_index=request.client_index,
         )
     ]
+
+
+def test_finished_request_propagates_all_transfer_params():
+    """Guard the vLLM _free_request and EngineCoreOutput protocol."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(RecomputeScheduler.update_from_output)))
+
+    free_request_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "_free_request"
+    ]
+    assert len(free_request_assignments) == 1
+    target = free_request_assignments[0].targets[0]
+    assert isinstance(target, ast.Tuple)
+    assert [ast.unparse(element) for element in target.elts] == [
+        "kv_transfer_params",
+        "ec_transfer_params",
+    ]
+
+    output_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "EngineCoreOutput"
+        and any(keyword.arg == "kv_transfer_params" for keyword in node.keywords)
+    ]
+    assert len(output_calls) == 1
+    output_keywords = {keyword.arg: ast.unparse(keyword.value) for keyword in output_calls[0].keywords}
+    assert output_keywords["kv_transfer_params"] == "kv_transfer_params"
+    assert output_keywords["ec_transfer_params"] == "ec_transfer_params"

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -1044,6 +1044,7 @@ class RecomputeScheduler(Scheduler):
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
+            ec_transfer_params = None
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
 
@@ -1112,7 +1113,7 @@ class RecomputeScheduler(Scheduler):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
-                    kv_transfer_params = self._free_request(request)
+                    kv_transfer_params, ec_transfer_params = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -1128,7 +1129,7 @@ class RecomputeScheduler(Scheduler):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
-            if new_token_ids or pooler_output is not None or kv_transfer_params or stopped:
+            if new_token_ids or pooler_output is not None or kv_transfer_params or ec_transfer_params or stopped:
                 # Add EngineCoreOutput for this Request.
                 outputs[request.client_index].append(
                     EngineCoreOutput(
@@ -1142,6 +1143,7 @@ class RecomputeScheduler(Scheduler):
                         events=request.take_events(),
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,


### PR DESCRIPTION
## Based on

This PR is based on https://github.com/vllm-project/vllm-ascend/pull/13239 and re-submits the same production-code and UT changes on an independent branch. No additional functional changes are included.

## Why

Upstream vLLM changed `Scheduler._free_request()` to return both KV-transfer and EC-transfer parameters. The copied `RecomputeScheduler.update_from_output()` path still treats the return value as a single KV-transfer payload, so finished requests can fail to propagate EC connector parameters.

## Upstream change

Upstream PR: https://github.com/vllm-project/vllm/pull/42433

The upstream change updates `_free_request()` to return:

```python
(kv_transfer_params, ec_transfer_params)
```

and forwards both values through `EngineCoreOutput`.

## Downstream changes

- Initialize `ec_transfer_params` for each request.
- Unpack both return values from `_free_request()`.
- Include EC-transfer parameters in the output-emission condition.
- Forward `ec_transfer_params` to `EngineCoreOutput`.
- Add the same AST regression guard from #13239.

## Test plan

- Targeted UT added in `tests/ut/core/test_recompute_scheduler.py`.
- Full validation is delegated to PR CI.

## User-facing change

No.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
