### PR TITLE
[Feature][v0.26.0rc] Support Kimi K3 MLA DSpark speculative decoding on Ascend

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -833,6 +833,7 @@ estimated_times:
   tests/ut/eplb/core/a2/test_eplb_utils.py: 30
   tests/ut/kv_offload/a2/test_remote_decode_lifecycle.py: 60
   tests/ut/kv_offload/a2/test_remote_prefill_lifecycle.py: 60
+  tests/ut/ops/a2/test_fused_norm_gate.py: 30
   tests/ut/ops/a2/test_gdn_chunk_meta.py: 30
   tests/ut/ops/a2/test_gdn_layerwise_kv.py: 30
   tests/ut/ops/a2/test_token_dispatcher.py: 30

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch22/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch22/epilogue/block/block_epilogue_gdn_fwdh_vnew.hpp
@@ -223,8 +223,17 @@ public:
         if (rowEnd > mActual) {
             rowEnd = mActual;
         }
+        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         if (rowBegin >= mActual) {
             Arch::CrossCoreWaitFlag(cube1Done);
+            // Even an empty vector subblock owns this stream's workspace
+            // event. Normalize it for V2 before the stream can be reused.
+            if (waitWsFromMte3) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0 + pingpongFlag);
+            } else {
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0 + pingpongFlag);
             Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(vec1Done);
             return;
         }
@@ -232,7 +241,6 @@ public:
 
         AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
 
-        uint32_t pingpongFlag = isPing ? 0 : pongBaseEvent;
         AscendC::LocalTensor<UElementInput> uUbTensor = isPing ? uUbTensor_ping : uUbTensor_pong;
         AscendC::LocalTensor<float> wsUbTensor = isPing ? wsUbTensor_ping : wsUbTensor_pong;
         AscendC::LocalTensor<float> gUbTensor = isPing ? gUbTensor_ping : gUbTensor_pong;

--- a/tests/ut/_310p/ops/test_gdn_310.py
+++ b/tests/ut/_310p/ops/test_gdn_310.py
@@ -99,3 +99,43 @@ def test_builder310_pads_spec_decode_metadata_with_dummy_requests():
     assert spec_meta.cache_indices.data_ptr() == attn_metadata.spec_state_indices_tensor.data_ptr()
     assert spec_meta.num_accepted_tokens.data_ptr() == attn_metadata.num_accepted_tokens.data_ptr()
     assert attn_metadata.spec_decode_metadata.actual_seq_lengths.tolist() == [0, 4, 4, 0, 0]
+
+
+def test_builder310_refreshes_non_spec_decode_graph_metadata():
+    builder = object.__new__(AscendGDNAttentionMetadataBuilder310)
+    builder.non_spec_state_indices_tensor = torch.full((4,), 77, dtype=torch.int32)
+    builder.non_spec_query_start_loc = torch.full((5,), 77, dtype=torch.int32)
+    builder.non_spec_actual_seq_lengths = torch.full((5,), 77, dtype=torch.int32)
+    builder.use_full_cuda_graph = True
+    attn_metadata = SimpleNamespace(
+        num_prefills=0,
+        num_decodes=4,
+        num_decode_tokens=2,
+        num_spec_decodes=0,
+        non_spec_state_indices_tensor=torch.tensor(
+            [10, 11, 98, 99],
+            dtype=torch.int32,
+        ),
+        non_spec_query_start_loc=torch.tensor(
+            [0, 1, 2, 2, 2],
+            dtype=torch.int32,
+        ),
+    )
+
+    builder._pad_decode_metadata(attn_metadata, graph_batch_size=4)
+
+    assert attn_metadata.non_spec_state_indices_tensor.tolist() == [
+        10,
+        11,
+        NULL_BLOCK_ID,
+        NULL_BLOCK_ID,
+    ]
+    assert attn_metadata.non_spec_query_start_loc.tolist() == [0, 1, 2, 2, 2]
+    assert attn_metadata.non_spec_state_indices_tensor.data_ptr() == builder.non_spec_state_indices_tensor.data_ptr()
+    assert attn_metadata.non_spec_query_start_loc.data_ptr() == builder.non_spec_query_start_loc.data_ptr()
+    decode_meta = attn_metadata.non_spec_decode_metadata
+    conv_meta = decode_meta.causal_conv1d
+    assert conv_meta.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()
+    assert conv_meta.cache_indices.data_ptr() == attn_metadata.non_spec_state_indices_tensor.data_ptr()
+    assert decode_meta.actual_seq_lengths.data_ptr() == builder.non_spec_actual_seq_lengths.data_ptr()
+    assert decode_meta.actual_seq_lengths.tolist() == [0, 1, 1, 0, 0]

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -291,6 +291,7 @@ class TestAscendMLAMetadata(TestBase):
         self.assertEqual(metadata.head_dim, head_dim)
         self.assertEqual(metadata.attn_mask, attn_mask)
         self.assertEqual(metadata.attn_state, attn_state)
+        self.assertTrue(metadata.causal)
         self.assertEqual(metadata.decode, decode)
         self.assertEqual(metadata.prefill, prefill)
 
@@ -394,6 +395,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         common_metadata.query_start_loc = torch.Tensor([0, 1, 2, 4, 5]).int()
         common_metadata.query_start_loc_cpu = torch.Tensor([0, 1, 2, 4, 5]).int()
         common_metadata.positions = torch.Tensor([1, 2, 3, 4, 5, 6]).int()
+        common_metadata.causal = False
         block_table = torch.Tensor([[1, 0], [2, 0], [3, 0], [4, 0]]).int()
         common_metadata.block_table_tensor = block_table
         mock_get_cos_and_sin_mla.return_value = (torch.tensor([6, 6]), torch.Tensor([6, 6]))
@@ -401,6 +403,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
         self.assertEqual(metadata.decode.actual_seq_lengths_q, [1, 2, 4, 5, 6, 6, 7, 8])
         self.assertEqual(metadata.decode.block_table.shape[0], 8)
+        self.assertFalse(metadata.causal)
 
     def test_reorder_batch(self):
         ascend_config = MagicMock()

--- a/tests/ut/models/test_kimi_k3_dspark.py
+++ b/tests/ut/models/test_kimi_k3_dspark.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+from vllm_ascend.models.kimi_k3_dspark import K3DSparkForCausalLM, K3DSparkModel
+
+
+def test_k3_mla_draft_reports_non_causal_attention_per_layer():
+    draft_model = SimpleNamespace(layers=[object(), object(), object()])
+
+    assert K3DSparkModel.get_draft_attn_causal(draft_model) == [False, False, False]
+
+
+def test_k3_mla_causal_lm_forwards_attention_causality():
+    draft_model = SimpleNamespace(get_draft_attn_causal=lambda: [False, False])
+    causal_lm = SimpleNamespace(model=draft_model)
+
+    assert K3DSparkForCausalLM.get_draft_attn_causal(causal_lm) == [False, False]

--- a/tests/ut/ops/a2/test_fused_norm_gate.py
+++ b/tests/ut/ops/a2/test_fused_norm_gate.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.fused_norm_gate import fused_norm_gate_fwd_npu
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+
+@pytest.mark.parametrize("num_rows", [1, 64, 129])
+@pytest.mark.parametrize("norm_before_gate", [False, True])
+@torch.inference_mode()
+def test_kimi_k3_fused_rms_norm_sigmoid_gate(num_rows: int, norm_before_gate: bool):
+    init_device_properties_triton()
+    torch.manual_seed(42)
+    head_dim = 128
+    epsilon = 1e-5
+    x = torch.randn(num_rows, head_dim, dtype=torch.bfloat16, device="npu")
+    gate = torch.randn_like(x)
+    weight = torch.randn(head_dim, dtype=torch.bfloat16, device="npu")
+
+    actual, mean, rstd = fused_norm_gate_fwd_npu(
+        x,
+        gate,
+        weight,
+        None,
+        activation="sigmoid",
+        eps=epsilon,
+        is_rms_norm=True,
+        norm_before_gate=norm_before_gate,
+    )
+
+    x_fp32 = x.float()
+    gate_fp32 = gate.float().sigmoid()
+    if not norm_before_gate:
+        x_fp32 *= gate_fp32
+    expected = x_fp32 * torch.rsqrt(x_fp32.square().mean(-1, keepdim=True) + epsilon)
+    expected *= weight.float()
+    if norm_before_gate:
+        expected *= gate_fp32
+
+    assert mean is None
+    assert not torch.isnan(actual).any()
+    assert not torch.isnan(rstd).any()
+    torch.testing.assert_close(actual, expected.to(actual.dtype), rtol=2e-2, atol=2e-2)

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -818,6 +818,41 @@ def test_full_graph_without_runtime_spec_resets_captured_spec_inputs(
     assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) == 0
 
 
+def test_full_graph_idle_dummy_uses_zero_length_recurrent_metadata():
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=BatchSpec(
+            seq_lens=[8, 8, 8, 8],
+            query_lens=[0, 0, 0, 0],
+            name="full_graph_idle_dummy",
+        ),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor(
+        [10, 11, 98, 99],
+        dtype=torch.int32,
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    builder.spec_state_indices_tensor.fill_(77)
+    builder.spec_query_start_loc.fill_(77)
+    builder.non_spec_state_indices_tensor.fill_(77)
+    builder.non_spec_query_start_loc.fill_(77)
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert attn_metadata.num_actual_tokens == 0
+    assert attn_metadata.num_decode_tokens == 0
+    assert torch.count_nonzero(attn_metadata.non_spec_query_start_loc) == 0
+    assert torch.all(attn_metadata.non_spec_state_indices_tensor == NULL_BLOCK_ID)
+    assert torch.count_nonzero(builder.spec_query_start_loc[:5]) == 0
+    assert torch.all(builder.spec_state_indices_tensor[:4] == PAD_SLOT_ID)
+
+
 @pytest.mark.parametrize(
     ("num_speculative_tokens", "num_decode_draft_tokens_cpu"),
     [

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -732,7 +732,36 @@ def test_full_graph_k7_dummy_row_has_zero_length_and_valid_accepted_sentinel():
     )
 
 
-def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():
+@pytest.mark.parametrize(
+    ("replay_batch", "replay_num_accepted_tokens", "replay_num_decode_draft_tokens"),
+    [
+        pytest.param(
+            BatchSpec(
+                seq_lens=[1, 1, 0, 0],
+                query_lens=[1, 1, 0, 0],
+                name="full_graph_non_spec_decode_replay",
+            ),
+            torch.ones(4, dtype=torch.int32),
+            torch.full((4,), -1, dtype=torch.int32),
+            id="non_spec_decode",
+        ),
+        pytest.param(
+            BatchSpec(
+                seq_lens=[8, 8, 0, 0],
+                query_lens=[8, 8, 0, 0],
+                name="full_graph_dummy_prefill_replay",
+            ),
+            None,
+            None,
+            id="dummy_prefill",
+        ),
+    ],
+)
+def test_full_graph_without_runtime_spec_resets_captured_spec_inputs(
+    replay_batch: BatchSpec,
+    replay_num_accepted_tokens: torch.Tensor | None,
+    replay_num_decode_draft_tokens: torch.Tensor | None,
+):
     capture_batch = BatchSpec(
         seq_lens=[4, 4],
         query_lens=[4, 4],
@@ -766,11 +795,6 @@ def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():
     assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) > 0
     assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) > 0
 
-    replay_batch = BatchSpec(
-        seq_lens=[1, 1, 0, 0],
-        query_lens=[1, 1, 0, 0],
-        name="full_graph_replay_without_spec",
-    )
     replay_common_metadata = create_common_attn_metadata(
         batch_spec=replay_batch,
         block_size=16,
@@ -779,8 +803,8 @@ def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():
     replay_metadata = builder.build(
         0,
         replay_common_metadata,
-        num_accepted_tokens=torch.ones(4, dtype=torch.int32),
-        num_decode_draft_tokens_cpu=torch.full((4,), -1, dtype=torch.int32),
+        num_accepted_tokens=replay_num_accepted_tokens,
+        num_decode_draft_tokens_cpu=replay_num_decode_draft_tokens,
     )
 
     assert replay_metadata.spec_sequence_masks is None
@@ -831,6 +855,8 @@ def test_full_graph_non_spec_metadata_nulls_padded_state_indices(
     builder.non_spec_state_indices_tensor.fill_(77)
     builder.non_spec_query_start_loc.fill_(77)
     builder.non_spec_actual_seq_lengths.fill_(77)
+    if num_speculative_tokens == 0:
+        builder.spec_state_indices_tensor.fill_(77)
 
     attn_metadata = builder.build(
         0,
@@ -851,6 +877,10 @@ def test_full_graph_non_spec_metadata_nulls_padded_state_indices(
             dtype=torch.int32,
         ),
     )
+    if num_speculative_tokens == 0:
+        # A model without speculative decoding must not enter the captured
+        # spec-task reset path. Its real non-spec decode above remains live.
+        assert torch.all(builder.spec_state_indices_tensor == 77)
     decode_metadata = attn_metadata.non_spec_decode_metadata
     conv1d_metadata = decode_metadata.causal_conv1d
     assert conv1d_metadata.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -9,7 +9,7 @@ import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.third_party.flash_linear_attention.ops import index as _fla_index
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import MambaSpec
 
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
@@ -238,7 +238,9 @@ def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Te
         ascend_gdn_attn_builder._GDN_CUMSUM_WORKING_SET // (gdn_num_heads * ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
     )
     cumsum_chunk_size = 1 if cumsum_chunks <= 1 else 1 << (cumsum_chunks - 1).bit_length()
+    sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
 
+    assert chunk_meta.num_decodes == (sequence_lengths == 1).sum().item()
     assert torch.equal(
         chunk_meta.chunk_indices_chunk64,
         runtime_prepare_chunk_indices(cu_seqlens, ascend_gdn_attn_builder._GDN_CHUNK_SIZE),
@@ -440,6 +442,113 @@ def test_non_spec_prefill_metadata_uses_prefill_tail_for_chunk_metadata(
     )
 
 
+def test_mixed_spec_prefill_chunk_metadata_preserves_single_token_count(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    batch_spec = BatchSpec(
+        seq_lens=[1, 4, 8],
+        query_lens=[1, 4, 8],
+        name="mixed_spec_prefill_with_single_token_non_spec",
+    )
+    builder, _, attn_metadata = _build_attn_metadata(
+        batch_spec,
+        num_speculative_tokens=3,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 3, -1], dtype=torch.int32),
+    )
+
+    assert attn_metadata.num_decodes == 0
+    assert attn_metadata.num_prefills == 2
+    assert torch.equal(
+        attn_metadata.prefill_query_start_loc,
+        torch.tensor([0, 1, 9], dtype=torch.int32),
+    )
+    chunk_metadata = attn_metadata.non_spec_prefill_metadata.chunk
+    assert chunk_metadata.num_decodes == 1
+    _assert_chunk_meta_matches_runtime(
+        builder,
+        chunk_metadata,
+        attn_metadata.prefill_query_start_loc,
+    )
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_decodes", "expected_prefills"),
+    [
+        pytest.param(1, 0, 1, id="first_token_stays_prefill"),
+        pytest.param(5, 1, 0, id="stateful_token_becomes_decode"),
+    ],
+)
+def test_one_token_prefill_selection_respects_recurrent_state(
+    monkeypatch: pytest.MonkeyPatch,
+    seq_len: int,
+    expected_decodes: int,
+    expected_prefills: int,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[seq_len], query_lens=[1]),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    # Model a prompt chunk explicitly; the helper normally classifies a
+    # one-token row as decode when synthesizing test metadata.
+    common_attn_metadata.is_prefilling = torch.tensor([True])
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=0,
+    )
+
+    attn_metadata = builder.build(0, common_attn_metadata)
+
+    assert common_attn_metadata.is_prefilling.tolist() == [True]
+    assert attn_metadata.num_decodes == expected_decodes
+    assert attn_metadata.num_prefills == expected_prefills
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_spec_decodes", "expected_prefills"),
+    [
+        pytest.param(4, 0, 1, id="first_chunk_stays_prefill"),
+        pytest.param(8, 1, 0, id="stateful_chunk_folds_into_spec"),
+    ],
+)
+def test_spec_sized_prefill_fold_requires_recurrent_state(
+    monkeypatch: pytest.MonkeyPatch,
+    seq_len: int,
+    expected_spec_decodes: int,
+    expected_prefills: int,
+):
+    _patch_missing_runtime_cdiv(monkeypatch)
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[seq_len], query_lens=[4]),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+    )
+
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_accepted_tokens=torch.ones(1, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.full((1,), -1, dtype=torch.int32),
+    )
+
+    assert attn_metadata.num_spec_decodes == expected_spec_decodes
+    assert attn_metadata.num_prefills == expected_prefills
+    if expected_spec_decodes:
+        assert attn_metadata.spec_sequence_masks.tolist() == [True]
+        assert attn_metadata.num_accepted_tokens.tolist() == [4]
+    else:
+        assert attn_metadata.spec_sequence_masks is None
+        assert attn_metadata.num_accepted_tokens is None
+
+
 def test_spec_conv1d_args_use_device_cache_and_accepted_tokens():
     batch_spec = BatchSpec(
         seq_lens=[4, 4],
@@ -623,10 +732,86 @@ def test_full_graph_k7_dummy_row_has_zero_length_and_valid_accepted_sentinel():
     )
 
 
-def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
+def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():
+    capture_batch = BatchSpec(
+        seq_lens=[4, 4],
+        query_lens=[4, 4],
+        name="full_graph_spec_capture",
+    )
+    capture_common_metadata = create_common_attn_metadata(
+        batch_spec=capture_batch,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    capture_common_metadata.num_reqs = 4
+    capture_common_metadata.block_table_tensor = torch.tensor(
+        [[10, 11, 12, 13], [20, 21, 22, 23]],
+        dtype=torch.int32,
+    )
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    captured_metadata = builder.build(
+        0,
+        capture_common_metadata,
+        num_accepted_tokens=torch.tensor([2, 4], dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([3, 3], dtype=torch.int32),
+    )
+    captured_spec_metadata = captured_metadata.spec_decode_metadata
+    captured_conv1d_metadata = captured_spec_metadata.spec_causal_conv1d
+
+    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) > 0
+    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) > 0
+
+    replay_batch = BatchSpec(
+        seq_lens=[1, 1, 0, 0],
+        query_lens=[1, 1, 0, 0],
+        name="full_graph_replay_without_spec",
+    )
+    replay_common_metadata = create_common_attn_metadata(
+        batch_spec=replay_batch,
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    replay_metadata = builder.build(
+        0,
+        replay_common_metadata,
+        num_accepted_tokens=torch.ones(4, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.full((4,), -1, dtype=torch.int32),
+    )
+
+    assert replay_metadata.spec_sequence_masks is None
+    assert replay_metadata.spec_decode_metadata is None
+    assert torch.equal(
+        captured_conv1d_metadata.cache_indices,
+        torch.full((4, 4), PAD_SLOT_ID, dtype=torch.int32),
+    )
+    assert torch.count_nonzero(captured_conv1d_metadata.query_start_loc) == 0
+    assert torch.count_nonzero(captured_conv1d_metadata.num_accepted_tokens) == 0
+    assert torch.count_nonzero(captured_spec_metadata.actual_seq_lengths) == 0
+
+
+@pytest.mark.parametrize(
+    ("num_speculative_tokens", "num_decode_draft_tokens_cpu"),
+    [
+        pytest.param(0, None, id="without_mtp"),
+        pytest.param(
+            3,
+            torch.full((4,), -1, dtype=torch.int32),
+            id="mtp_without_spec_requests",
+        ),
+    ],
+)
+def test_full_graph_non_spec_metadata_nulls_padded_state_indices(
+    num_speculative_tokens: int,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+):
     batch_spec = BatchSpec(
-        seq_lens=[1, 1],
-        query_lens=[1, 1],
+        seq_lens=[1, 1, 0, 0],
+        query_lens=[1, 1, 0, 0],
         name="full_graph_padded_non_spec_actual_seq_lengths",
     )
     common_attn_metadata = create_common_attn_metadata(
@@ -634,26 +819,45 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
         block_size=16,
         device=torch.device("cpu"),
     )
-    common_attn_metadata.num_actual_tokens = 4
+    # PCP can leave padded block-table rows untouched. Model stale valid
+    # state slots from a preceding decode batch.
+    common_attn_metadata.block_table_tensor[:, 0] = torch.tensor([10, 11, 98, 99])
     builder = _make_builder(
         device=torch.device("cpu"),
         num_heads=32,
-        num_speculative_tokens=0,
+        num_speculative_tokens=num_speculative_tokens,
         cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
     )
+    builder.non_spec_state_indices_tensor.fill_(77)
+    builder.non_spec_query_start_loc.fill_(77)
+    builder.non_spec_actual_seq_lengths.fill_(77)
 
-    attn_metadata = builder.build(0, common_attn_metadata)
+    attn_metadata = builder.build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+    )
 
+    assert attn_metadata.num_decodes == 4
+    assert attn_metadata.num_decode_tokens == 2
     assert torch.equal(
         attn_metadata.non_spec_query_start_loc,
         torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),
     )
-    assert (
-        attn_metadata.non_spec_decode_metadata.actual_seq_lengths.data_ptr()
-        == builder.non_spec_actual_seq_lengths.data_ptr()
-    )
     assert torch.equal(
-        attn_metadata.non_spec_decode_metadata.actual_seq_lengths,
+        attn_metadata.non_spec_state_indices_tensor,
+        torch.tensor(
+            [10, 11, NULL_BLOCK_ID, NULL_BLOCK_ID],
+            dtype=torch.int32,
+        ),
+    )
+    decode_metadata = attn_metadata.non_spec_decode_metadata
+    conv1d_metadata = decode_metadata.causal_conv1d
+    assert conv1d_metadata.query_start_loc.data_ptr() == attn_metadata.non_spec_query_start_loc.data_ptr()
+    assert conv1d_metadata.cache_indices.data_ptr() == attn_metadata.non_spec_state_indices_tensor.data_ptr()
+    assert decode_metadata.actual_seq_lengths.data_ptr() == builder.non_spec_actual_seq_lengths.data_ptr()
+    assert torch.equal(
+        decode_metadata.actual_seq_lengths,
         torch.tensor([0, 1, 1, 0, 0], dtype=torch.int32),
     )
 

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -275,7 +275,7 @@ def _schedule_body_ast(source: str) -> str:
 
     class _BalanceDeltaStripper(ast.NodeTransformer):
         def visit_BoolOp(self, node: ast.BoolOp):  # noqa: N802
-            node = self.generic_visit(node)
+            self.generic_visit(node)
             node.values = [value for value in node.values if "_use_consumer_partial_group_hits" not in ast.dump(value)]
             return node
 

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -20,11 +20,11 @@ What is guarded here (everything reachable from CPU UT):
 * the module-level class swaps actually took effect;
 * the upstream Scheduler/DPEngineCoreProc methods the patch calls/super-calls
   still exist;
-* the 3 balance deltas remain present in ``schedule()`` (intent lock);
+* the 4 platform deltas remain present in ``schedule()`` (intent lock);
 * the copied ``schedule()`` body stays a verbatim copy of the ``schedule()``
   at vllm-ascend's pinned vLLM release tag (read from
   ``.github/vllm-release-tag.commit`` -- the same file CI uses), modulo exactly
-  those 3 deltas. Reading the tag from the pin file means a pin advance
+  those 4 deltas. Reading the tag from the pin file means a pin advance
   auto-flips this guard to the new tag until the copy is re-synced.
 
 What is NOT guarded here (structurally unreachable without a real engine):
@@ -127,6 +127,39 @@ def test_balance_config_fallback_accepts_legacy_top_level_config():
         assert _balance_scheduling_enabled(vllm_config) is True
 
 
+@pytest.mark.parametrize(
+    ("use_consumer_partial_group_hits", "mamba_visible_during_schedule"),
+    [(False, False), (True, True)],
+)
+def test_disabled_balance_hides_mamba_only_from_producer_lookup(
+    monkeypatch,
+    use_consumer_partial_group_hits,
+    mamba_visible_during_schedule,
+):
+    observed = []
+
+    def fake_schedule(self, throttle_prefills=False):
+        observed.append(self.has_mamba_layers)
+        return "scheduled"
+
+    monkeypatch.setattr(BalanceScheduler.__bases__[0], "schedule", fake_schedule)
+    scheduler = BalanceScheduler.__new__(BalanceScheduler)
+    scheduler._balance_enabled = False
+    scheduler._use_consumer_partial_group_hits = use_consumer_partial_group_hits
+    scheduler.has_mamba_layers = True
+
+    assert scheduler.schedule() == "scheduled"
+    assert observed == [mamba_visible_during_schedule]
+    assert scheduler.has_mamba_layers is True
+
+
+def test_upstream_schedule_reads_mamba_flag_only_for_partial_group_lookup():
+    src = inspect.getsource(BalanceScheduler.__bases__[0].schedule)
+
+    assert src.count("self.has_mamba_layers") == 1
+    assert "find_longest_cache_hit_per_group" in src
+
+
 @pytest.mark.parametrize("balance_enabled", [False, True])
 def test_balance_scheduler_installs_short_request_first_queue(monkeypatch, balance_enabled):
     def fake_scheduler_init(self, *args, **kwargs):
@@ -216,7 +249,7 @@ def test_balance_scheduler_does_not_import_sfr_when_disabled(monkeypatch):
 
 
 def _schedule_body_ast(source: str) -> str:
-    """Canonical AST dump of a ``schedule`` method body with the 3 balance
+    """Canonical AST dump of a ``schedule`` method body with the 4 platform
     deltas stripped, so the remainder can be compared verbatim against the
     pinned release tag's ``schedule()``. AST-based on purpose: it is blind to
     comments and whitespace, so the only differences that surface are real code
@@ -231,6 +264,7 @@ def _schedule_body_ast(source: str) -> str:
         copy as ``if request_queue is None: break`` and in upstream as
         ``assert request_queue is not None``. Both are stripped so the two
         bodies align.
+      * delta 4 -- the consumer-only partial-group cache lookup gate.
     """
     tree = ast.parse(textwrap.dedent(source))
     func = next(
@@ -240,6 +274,11 @@ def _schedule_body_ast(source: str) -> str:
     assert func is not None, "no schedule() in source"
 
     class _BalanceDeltaStripper(ast.NodeTransformer):
+        def visit_BoolOp(self, node: ast.BoolOp):  # noqa: N802
+            node = self.generic_visit(node)
+            node.values = [value for value in node.values if "_use_consumer_partial_group_hits" not in ast.dump(value)]
+            return node
+
         def visit_If(self, node: ast.If):  # noqa: N802
             test = ast.dump(node.test)
             # delta 1: disabled-path early return.
@@ -347,6 +386,9 @@ def test_balance_deltas_present_in_schedule():
 
     # delta 3: `if request_queue is None: break` replaces upstream's assert.
     assert "if request_queue is None:" in src
+
+    # delta 4: producer schedulers never use the consumer-only per-group lookup.
+    assert "self._use_consumer_partial_group_hits" in src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -1,14 +1,37 @@
-from types import SimpleNamespace
-
-import pytest
 from transformers import Qwen3Config
 from vllm.config import SpeculativeConfig
 
-from vllm_ascend.patch.platform import patch_speculative_config
-from vllm_ascend.patch.platform.patch_speculative_config import (
-    _dspark_post_init,
-    hf_config_override,
-)
+from vllm_ascend.patch.platform.patch_speculative_config import hf_config_override
+from vllm_ascend.transformers_utils.configs.kimi_k3 import K3DSparkConfig
+
+
+def make_k3_dspark_config() -> K3DSparkConfig:
+    return K3DSparkConfig(
+        architectures=["K3DSparkModel"],
+        hidden_size=7168,
+        intermediate_size=14336,
+        kv_lora_rank=512,
+        markov_rank=256,
+        num_attention_heads=64,
+        num_hidden_layers=5,
+        num_target_layers=5,
+        q_lora_rank=1536,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        rms_norm_eps=1e-5,
+        rope_parameters={"rope_type": "yarn", "factor": 32},
+        target_hidden_size=7168,
+        v_head_dim=128,
+        vocab_size=163840,
+    )
+
+
+def test_k3_dspark_config_with_required_fields_supports_repr():
+    config = make_k3_dspark_config()
+
+    assert K3DSparkConfig.has_no_defaults_at_init is True
+    assert "K3DSparkConfig" in repr(config)
+    assert config.to_diff_dict()["hidden_size"] == 7168
 
 
 def test_legacy_qwen3_dspark_config_is_normalized_before_model_inspection():
@@ -31,77 +54,3 @@ def test_legacy_qwen3_dspark_config_is_normalized_before_model_inspection():
     assert normalized.target_layer_ids == [7, 23, 51, 67, 83]
     assert normalized.block_size == 7
     assert normalized.pad_token_id == 163839
-
-
-@pytest.mark.parametrize(
-    ("block_size", "num_speculative_tokens"),
-    [(7, 1), (7, 3), (7, 8), (5, 7)],
-)
-def test_qwen3_dspark_requires_num_speculative_tokens_to_match_checkpoint(
-    monkeypatch: pytest.MonkeyPatch,
-    block_size: int,
-    num_speculative_tokens: int,
-):
-    monkeypatch.setattr(patch_speculative_config, "_orig_post_init", lambda self: None)
-    draft_hf_config = SimpleNamespace(
-        model_type="qwen3",
-        architectures=["Qwen3DSparkModel"],
-        block_size=block_size,
-        mask_token_id=163824,
-        ptd_token_id=None,
-    )
-    config = SimpleNamespace(
-        use_dspark=lambda: True,
-        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
-        num_speculative_tokens=num_speculative_tokens,
-    )
-
-    with pytest.raises(ValueError, match=r"trained block_size"):
-        _dspark_post_init(config)
-
-
-@pytest.mark.parametrize("block_size", [5, 7])
-def test_qwen3_dspark_accepts_checkpoint_block_size(
-    monkeypatch: pytest.MonkeyPatch,
-    block_size: int,
-):
-    monkeypatch.setattr(patch_speculative_config, "_orig_post_init", lambda self: None)
-    draft_hf_config = SimpleNamespace(
-        model_type="qwen3",
-        architectures=["Qwen3DSparkModel"],
-        block_size=block_size,
-        mask_token_id=163824,
-        ptd_token_id=None,
-    )
-    config = SimpleNamespace(
-        use_dspark=lambda: True,
-        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
-        num_speculative_tokens=block_size,
-    )
-
-    _dspark_post_init(config)
-
-    assert draft_hf_config.ptd_token_id == 163824
-
-
-@pytest.mark.parametrize("block_size", [None, 0, -1, "7", True])
-def test_qwen3_dspark_requires_positive_integer_checkpoint_block_size(
-    monkeypatch: pytest.MonkeyPatch,
-    block_size,
-):
-    monkeypatch.setattr(patch_speculative_config, "_orig_post_init", lambda self: None)
-    draft_hf_config = SimpleNamespace(
-        model_type="qwen3",
-        architectures=["Qwen3DSparkModel"],
-        block_size=block_size,
-        mask_token_id=163824,
-        ptd_token_id=None,
-    )
-    config = SimpleNamespace(
-        use_dspark=lambda: True,
-        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
-        num_speculative_tokens=7,
-    )
-
-    with pytest.raises(ValueError, match=r"positive integer block_size"):
-        _dspark_post_init(config)

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1640,7 +1640,7 @@ class TestEagleProposerPropose:
                             'token_indices_to_sample', 'common_attn_metadata', 'target_model_batch_desc',
                             'sampling_metadata', 'mm_embed_inputs', 'req_scheduled_tokens', 'long_seq_metadata',
                             'num_prefill_reqs', 'num_decode_reqs', 'scheduler_output', 'num_scheduled_tokens',
-                            'num_rejected_tokens_gpu'
+                            'num_rejected_tokens_gpu', 'num_draft_tokens_cpu'
                         ]
 
 

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -732,6 +732,10 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
     def _make_proposer_for_init():
         proposer = AscendDSparkProposer.__new__(AscendDSparkProposer)
         proposer.vllm_config = SimpleNamespace()
+        # The real proposer constructor always sets this field.  These
+        # lightweight initializer tests bypass __init__, so preserve that
+        # production invariant with a generic non-K3 draft config.
+        proposer.draft_model_config = SimpleNamespace(hf_config=object())
         proposer.device = torch.device("cpu")
         return proposer
 
@@ -785,6 +789,10 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         proposer.model = SimpleNamespace(
             get_draft_kv_cache_layer_names=lambda: {"L0", "L1"}
         )
+        assert not isinstance(
+            proposer.draft_model_config.hf_config,
+            dspark_proposer_module.K3DSparkConfig,
+        )
         proposer.max_query_tokens = 8
         proposer.max_num_tokens = 16
         kv_cache_config = SimpleNamespace(
@@ -813,6 +821,63 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
             call.kwargs["kernel_block_size"]
             for call in create_builders.call_args_list
         ] == [128, 64]
+
+    def test_k3_initialization_enables_rope_on_mla_builders(self, monkeypatch):
+        class FakeK3Config:
+            pass
+
+        class FakeMLABuilder:
+            def __init__(self):
+                self.use_mla_rope = False
+
+        fake_builder = FakeMLABuilder()
+
+        def create_metadata_builders(group, *args, **kwargs):
+            del args, kwargs
+            group.metadata_builders = [fake_builder]
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.backend"
+        layer = MagicMock()
+        layer.get_attn_backend.return_value = backend
+        monkeypatch.setattr(
+            dspark_proposer_module,
+            "get_layers_from_vllm_config",
+            lambda *args, **kwargs: {"L0": layer},
+        )
+        monkeypatch.setattr(dspark_proposer_module, "K3DSparkConfig", FakeK3Config)
+        monkeypatch.setattr(
+            dspark_proposer_module,
+            "AscendMLAMetadataBuilder",
+            FakeMLABuilder,
+        )
+        monkeypatch.setattr(
+            AttentionGroup,
+            "create_metadata_builders",
+            create_metadata_builders,
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.draft_model_config = SimpleNamespace(hf_config=FakeK3Config())
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: {"L0"}
+        )
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        manager_spec = MagicMock()
+        manager_spec.block_size = 128
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=["L0"],
+                    kv_cache_spec=manager_spec,
+                )
+            ]
+        )
+
+        proposer.initialize_attn_backend(kv_cache_config)
+
+        assert fake_builder.use_mla_rope is dspark_proposer_module.K3_DSPARK_USE_MLA_ROPE
 
     def test_kernel_block_size_falls_back_to_cache_spec(self):
         proposer = self._make_proposer_for_init()

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -183,6 +183,21 @@ class TestQuaRotDraftBoundaries:
         torch.testing.assert_close(fc.weight, expected)
         torch.testing.assert_close(proposer._quarot_rotation, rotation)
 
+    def test_anti_rotates_k3_mla_context_projection(self, monkeypatch):
+        proposer = self._make_proposer()
+        rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])
+        context_proj = nn.Linear(10, 2, bias=False)
+        initial_weight = torch.arange(1.0, 21.0).reshape(2, 10)
+        context_proj.weight.data.copy_(initial_weight)
+        proposer.model = SimpleNamespace(model=SimpleNamespace(context_proj=context_proj))
+        monkeypatch.setattr(proposer, "_load_quarot_rotation", lambda _: rotation)
+
+        proposer._maybe_anti_rotate_fc()
+
+        expected = torch.matmul(initial_weight.reshape(2, 5, 2), rotation).reshape(2, 10)
+        torch.testing.assert_close(context_proj.weight, expected)
+        torch.testing.assert_close(proposer._quarot_rotation, rotation)
+
     def test_copies_unrotated_shared_weight_without_mutating_target(self):
         proposer = self._make_proposer()
         proposer._quarot_rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
+import torch.nn as nn
 from vllm.config import CUDAGraphMode
 
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
@@ -153,3 +155,92 @@ class TestDisableFlashCommV1Context:
         with pytest.raises(RuntimeError, match="boom"), _disable_flash_comm_v1_context():
             raise RuntimeError("boom")
         assert ctx.flash_comm_v1_enabled is True
+
+
+class TestQuaRotDraftBoundaries:
+    """CPU tests for QuaRot alignment at every draft-model boundary."""
+
+    @staticmethod
+    def _make_proposer() -> AscendSpecDecodeBaseProposer:
+        proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+        proposer.method = "dspark"
+        proposer.device = torch.device("cpu")
+        proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(model="target"))
+        return proposer
+
+    def test_anti_rotates_each_aux_hidden_state_fc_block(self, monkeypatch):
+        proposer = self._make_proposer()
+        rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])
+        fc = nn.Linear(10, 2, bias=False)
+        initial_weight = torch.arange(1.0, 21.0).reshape(2, 10)
+        fc.weight.data.copy_(initial_weight)
+        proposer.model = SimpleNamespace(model=SimpleNamespace(fc=fc))
+        monkeypatch.setattr(proposer, "_load_quarot_rotation", lambda _: rotation)
+
+        proposer._maybe_anti_rotate_fc()
+
+        expected = torch.matmul(initial_weight.reshape(2, 5, 2), rotation).reshape(2, 10)
+        torch.testing.assert_close(fc.weight, expected)
+        torch.testing.assert_close(proposer._quarot_rotation, rotation)
+
+    def test_copies_unrotated_shared_weight_without_mutating_target(self):
+        proposer = self._make_proposer()
+        proposer._quarot_rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])
+        target = nn.Linear(2, 3, bias=False)
+        draft = nn.Linear(2, 3, bias=False)
+        target_weight = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        target.weight.data.copy_(target_weight)
+        original_target = target.weight.detach().clone()
+
+        copied = proposer._copy_unrotated_shared_weight(draft, target, "draft embed_tokens.weight")
+
+        assert copied is True
+        torch.testing.assert_close(draft.weight, target_weight @ proposer._quarot_rotation.T)
+        torch.testing.assert_close(target.weight, original_target)
+
+    def test_shared_weight_shape_mismatch_keeps_draft_weight(self):
+        proposer = self._make_proposer()
+        proposer._quarot_rotation = torch.eye(2)
+        target = nn.Linear(2, 3, bias=False)
+        draft = nn.Linear(3, 3, bias=False)
+        original_draft = draft.weight.detach().clone()
+
+        copied = proposer._copy_unrotated_shared_weight(draft, target, "draft lm_head.weight")
+
+        assert copied is False
+        torch.testing.assert_close(draft.weight, original_draft)
+
+    def test_materializes_unrotated_layer_for_none_placeholder(self):
+        proposer = self._make_proposer()
+        proposer._quarot_rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])
+        target = nn.Linear(2, 3, bias=False)
+        target_weight = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        target.weight.data.copy_(target_weight)
+        original_target = target.weight.detach().clone()
+
+        prepared = proposer._prepare_unrotated_shared_layer(
+            None,
+            target,
+            "draft embed_tokens.weight",
+        )
+
+        assert prepared is not None
+        assert prepared is not target
+        torch.testing.assert_close(
+            prepared.weight,
+            target_weight @ proposer._quarot_rotation.T,
+        )
+        torch.testing.assert_close(target.weight, original_target)
+
+    def test_incompatible_quarot_shared_layer_fails_instead_of_aliasing(self):
+        proposer = self._make_proposer()
+        proposer._quarot_rotation = torch.eye(2)
+        target = nn.Linear(2, 3, bias=False)
+        draft = nn.Linear(3, 3, bias=False)
+
+        with pytest.raises(ValueError, match="refusing to alias"):
+            proposer._prepare_unrotated_shared_layer(
+                draft,
+                target,
+                "draft lm_head.weight",
+            )

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -232,6 +232,29 @@ class TestQuaRotDraftBoundaries:
         )
         torch.testing.assert_close(target.weight, original_target)
 
+    def test_materialized_layer_reuses_noncopyable_comm_group(self):
+        class NonCopyableCommGroup:
+            def __deepcopy__(self, memo):
+                del memo
+                raise TypeError("cannot pickle ProcessGroup")
+
+        proposer = self._make_proposer()
+        proposer._quarot_rotation = torch.eye(2)
+        target = nn.Linear(2, 3, bias=False)
+        target.comm_group = NonCopyableCommGroup()
+
+        prepared = proposer._prepare_unrotated_shared_layer(
+            None,
+            target,
+            "draft embed_tokens.weight",
+        )
+
+        assert prepared is not None
+        assert prepared.comm_group is target.comm_group
+        assert prepared.weight is not target.weight
+        assert prepared.weight.data_ptr() != target.weight.data_ptr()
+        torch.testing.assert_close(prepared.weight, target.weight)
+
     def test_incompatible_quarot_shared_layer_fails_instead_of_aliasing(self):
         proposer = self._make_proposer()
         proposer._quarot_rotation = torch.eye(2)

--- a/tests/ut/spec_decode/test_utils.py
+++ b/tests/ut/spec_decode/test_utils.py
@@ -187,42 +187,51 @@ def test_cpu_and_gpu_corrections_agree():
     np.testing.assert_array_equal(optimistic, gpu_seq_lens)
 
 
+def _finalize_with_reject(seq_lens_list, num_reqs, reject_cpu):
+    """Mirror the inline finalize performed by the Ascend attention backends.
+
+    ``build_parallel_draft_seq_lens_cpu`` now publishes optimistic+query_len;
+    the per-request reject count is subtracted from ``seq_lens_list`` at FIA
+    forward entry. This helper replicates that subtract so tests can verify the
+    two-phase composition matches the old single-phase exact result.
+    """
+    r = reject_cpu[:num_reqs].tolist()
+    for i in range(num_reqs):
+        seq_lens_list[i] -= r[i]
+
+
 def test_build_parallel_draft_seq_lens_cpu_mixed_acceptance():
     optimistic = torch.tensor([100, 200, 300], dtype=torch.int32)
-    actual = build_parallel_draft_seq_lens_cpu(
-        optimistic,
-        num_draft_tokens=[3, 3, 0],
-        valid_sampled_token_count_cpu=torch.tensor([4, 2, 1], dtype=torch.int64),
-        num_reqs=3,
-        query_len=4,
-    )
+    actual = build_parallel_draft_seq_lens_cpu(optimistic, num_reqs=3, query_len=4)
 
-    # req0 accepts all drafts; req1 rejects two; req2 did not speculate.
-    torch.testing.assert_close(actual, torch.tensor([104, 202, 304], dtype=torch.int32))
+    # Build phase: optimistic + query_len only (reject subtraction deferred).
+    torch.testing.assert_close(actual, torch.tensor([104, 204, 304], dtype=torch.int32))
     torch.testing.assert_close(optimistic, torch.tensor([100, 200, 300], dtype=torch.int32))
+
+    # Deferred finalize: req0 accepts all (reject 0); req1 rejects two; req2
+    # did not speculate. reject = num_draft_tokens + 1 - valid_counts (>0 else 0).
+    reject = torch.tensor([0, 2, 0], dtype=torch.int32)
+    seq_lens_list = actual.tolist()
+    _finalize_with_reject(seq_lens_list, num_reqs=3, reject_cpu=reject)
+    assert seq_lens_list == [104, 202, 304]
 
 
 def test_build_parallel_draft_seq_lens_cpu_first_pass():
     optimistic = torch.tensor([64, 128], dtype=torch.int32)
-    actual = build_parallel_draft_seq_lens_cpu(
-        optimistic,
-        num_draft_tokens=None,
-        valid_sampled_token_count_cpu=None,
-        num_reqs=2,
-        query_len=8,
-    )
+    actual = build_parallel_draft_seq_lens_cpu(optimistic, num_reqs=2, query_len=8)
 
+    # First pass: no prior draft -> no reject; optimistic + query_len is exact.
     torch.testing.assert_close(actual, torch.tensor([72, 136], dtype=torch.int32))
 
 
 def test_build_parallel_draft_seq_lens_cpu_preserves_unused_tail():
     optimistic = torch.tensor([10, 20, 999, 999], dtype=torch.int32)
-    actual = build_parallel_draft_seq_lens_cpu(
-        optimistic,
-        num_draft_tokens=[2, 2],
-        valid_sampled_token_count_cpu=torch.tensor([1, 3], dtype=torch.int64),
-        num_reqs=2,
-        query_len=3,
-    )
+    actual = build_parallel_draft_seq_lens_cpu(optimistic, num_reqs=2, query_len=3)
 
-    torch.testing.assert_close(actual, torch.tensor([11, 23, 999, 999], dtype=torch.int32))
+    torch.testing.assert_close(actual, torch.tensor([13, 23, 999, 999], dtype=torch.int32))
+
+    # Deferred finalize touches only [:num_reqs]; the unused tail is untouched.
+    reject = torch.tensor([1, 0], dtype=torch.int32)
+    seq_lens_list = actual.tolist()
+    _finalize_with_reject(seq_lens_list, num_reqs=2, reject_cpu=reject)
+    assert seq_lens_list == [12, 23, 999, 999]

--- a/tests/ut/spec_decode/test_utils.py
+++ b/tests/ut/spec_decode/test_utils.py
@@ -12,6 +12,7 @@ import numpy as np
 import torch
 
 from vllm_ascend.spec_decode.utils import (
+    build_parallel_draft_seq_lens_cpu,
     correct_optimistic_seq_lens_cpu,
     update_num_computed_tokens_for_batch_change,
 )
@@ -184,3 +185,44 @@ def test_cpu_and_gpu_corrections_agree():
     gpu_seq_lens = num_computed_gpu.numpy() + num_scheduled_step_n
 
     np.testing.assert_array_equal(optimistic, gpu_seq_lens)
+
+
+def test_build_parallel_draft_seq_lens_cpu_mixed_acceptance():
+    optimistic = torch.tensor([100, 200, 300], dtype=torch.int32)
+    actual = build_parallel_draft_seq_lens_cpu(
+        optimistic,
+        num_draft_tokens=[3, 3, 0],
+        valid_sampled_token_count_cpu=torch.tensor([4, 2, 1], dtype=torch.int64),
+        num_reqs=3,
+        query_len=4,
+    )
+
+    # req0 accepts all drafts; req1 rejects two; req2 did not speculate.
+    torch.testing.assert_close(actual, torch.tensor([104, 202, 304], dtype=torch.int32))
+    torch.testing.assert_close(optimistic, torch.tensor([100, 200, 300], dtype=torch.int32))
+
+
+def test_build_parallel_draft_seq_lens_cpu_first_pass():
+    optimistic = torch.tensor([64, 128], dtype=torch.int32)
+    actual = build_parallel_draft_seq_lens_cpu(
+        optimistic,
+        num_draft_tokens=None,
+        valid_sampled_token_count_cpu=None,
+        num_reqs=2,
+        query_len=8,
+    )
+
+    torch.testing.assert_close(actual, torch.tensor([72, 136], dtype=torch.int32))
+
+
+def test_build_parallel_draft_seq_lens_cpu_preserves_unused_tail():
+    optimistic = torch.tensor([10, 20, 999, 999], dtype=torch.int32)
+    actual = build_parallel_draft_seq_lens_cpu(
+        optimistic,
+        num_draft_tokens=[2, 2],
+        valid_sampled_token_count_cpu=torch.tensor([1, 3], dtype=torch.int64),
+        num_reqs=2,
+        query_len=3,
+    )
+
+    torch.testing.assert_close(actual, torch.tensor([11, 23, 999, 999], dtype=torch.int32))

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -16,6 +16,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
     MLAAttentionSpec,
 )
 from vllm.v1.request import Request
@@ -207,3 +208,86 @@ def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
 
     assert hit_length == 0
     assert hit_blocks == ([], [])
+
+
+def test_hybrid_coordinator_truncates_every_full_attention_group() -> None:
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=32,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full_a"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["full_b"],
+                    FullAttentionSpec(
+                        block_size=2 * block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=(1, 1),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=hash_block_size,
+        max_num_batched_tokens=8192,
+    )
+    request = _make_request(
+        "a",
+        [index // hash_block_size for index in range(24)],
+        hash_block_size,
+    )
+
+    for group_id in (0, 1):
+        group_block_size = block_size * (1 + group_id)
+        num_full_blocks = len(request.prompt_token_ids) // group_block_size
+        blocks = coordinator.block_pool.get_new_blocks(num_full_blocks)
+        coordinator.block_pool.cache_full_blocks(
+            request=request,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=num_full_blocks,
+            block_size=group_block_size,
+            kv_cache_group_id=group_id,
+        )
+
+    mamba_block = coordinator.block_pool.get_new_blocks(1)[0]
+    coordinator.block_pool.cache_partial_block(
+        request=request,
+        block=mamba_block,
+        num_tokens=6,
+        kv_cache_group_id=2,
+        block_size=block_size,
+    )
+
+    hit_blocks, hit_length, _ = coordinator.find_longest_cache_hit(
+        request.block_hashes,
+        max_cache_hit_length=len(request.prompt_token_ids),
+    )
+
+    assert hit_length == 6
+    assert [len(blocks) for blocks in hit_blocks] == [2, 1, 2]

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -786,7 +786,10 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
 
         runner.execute_model(scheduler_output)
 
-        runner._dummy_run.assert_called_once_with(1)
+        runner._dummy_run.assert_called_once_with(
+            1,
+            skip_gdn_state_update=True,
+        )
         runner._start_dump_data.assert_not_called()
 
     @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -533,7 +533,11 @@ class TestNPUWorker(TestBase):
             worker.execute_dummy_batch()
 
             # Verify call
-            mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
+            mock_model_runner._dummy_run.assert_called_once_with(
+                mock_uniform_decode_query_len,
+                uniform_decode=True,
+                skip_gdn_state_update=True,
+            )
 
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("torch.npu.reset_peak_memory_stats")

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -583,6 +583,7 @@ class NPUModelRunner310(NPUModelRunner):
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
+        skip_gdn_state_update: bool = False,
     ):
         temporary_context = self.temporary_modify_uniform_decode_query_len() if uniform_decode else nullcontext()
         # All the spec decoding cases has to run splitfuse op on 310P.
@@ -609,6 +610,7 @@ class NPUModelRunner310(NPUModelRunner):
                     is_graph_capturing=is_graph_capturing,
                     num_active_loras=num_active_loras,
                     profile_seq_lens=profile_seq_lens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
             finally:
                 self._spec_dummy_capture = False

--- a/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
+++ b/vllm_ascend/_310p/ops/gdn_attn_builder_310.py
@@ -177,30 +177,20 @@ class GDNAttentionMetadataBuilder310(AscendGDNAttentionMetadataBuilder):
         attn_metadata: GDNAttentionMetadata,
         graph_batch_size: int,
     ) -> None:
-        num_decodes = attn_metadata.num_decodes
         state_indices = attn_metadata.non_spec_state_indices_tensor
         query_start_loc = attn_metadata.non_spec_query_start_loc
         assert state_indices is not None
         assert query_start_loc is not None
 
-        self.non_spec_state_indices_tensor[:num_decodes].copy_(
+        (
+            attn_metadata.non_spec_state_indices_tensor,
+            attn_metadata.non_spec_query_start_loc,
+        ) = self._pad_non_spec_decode_graph_inputs(
             state_indices,
-            non_blocking=True,
-        )
-        attn_metadata.non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:graph_batch_size]
-        attn_metadata.non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
-
-        self.non_spec_query_start_loc[: num_decodes + 1].copy_(
             query_start_loc,
-            non_blocking=True,
+            num_decode_tokens=attn_metadata.num_decode_tokens,
+            graph_batch_size=graph_batch_size,
         )
-        attn_metadata.non_spec_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
-        query_padding = attn_metadata.non_spec_query_start_loc[num_decodes + 1 :]
-        if query_padding.numel() > 0:
-            query_padding.copy_(
-                query_start_loc[-1].expand_as(query_padding),
-                non_blocking=True,
-            )
         self._attach_non_spec_decode_metadata(
             attn_metadata,
             attn_metadata.non_spec_state_indices_tensor,

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -354,6 +354,7 @@ class AscendMLAMetadata:
     attn_mask: torch.Tensor = None
     # chunked prefill by default if no attn_states passed
     attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill
+    causal: bool = True
 
     decode: AscendMLADecodeMetadata | None = None
     prefill: AscendMLAPrefillMetadata | None = None
@@ -628,6 +629,7 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             num_prefills=self.num_prefills,
             attn_mask=self.attn_mask_builder.get_splitfuse_attn_mask(),
             attn_state=common_attn_metadata.attn_state,
+            causal=common_attn_metadata.causal,
             prefill=prefill_metadata,
             decode=decode_metadata,
             query_start_loc=query_start_loc,
@@ -1692,8 +1694,18 @@ class AscendMLAImpl(MLAAttentionImpl):
                 q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
             attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
-            sparse_mode = 3
-            attn_mask = attn_metadata.decode.attn_mask  # type:ignore
+            if not attn_metadata.causal:
+                # The DSpark MLA draft block is non-causal (bidirectional):
+                # every query token attends to the trailing context window plus
+                # all other query tokens in the draft block. On Ascend FIA this
+                # is sparse_mode=0 with NO atten_mask (a mask under sparse_mode=0
+                # is applied as defaultMask and would wrongly hide the upper
+                # triangle -- see vllm_ascend/attention/attention_mask.py).
+                sparse_mode = 0
+                attn_mask = None
+            else:
+                sparse_mode = 3
+                attn_mask = decode_meta.attn_mask
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
             if self.fa_quant_layer:
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -598,9 +598,15 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         self.query_lens = query_seq_lens_cpu[:num_reqs]
-        # Prefer _seq_lens_cpu (always available, updated during draft
-        # iterations) over seq_lens_cpu (None in async spec decode mode).
-        if common_attn_metadata._seq_lens_cpu is not None:
+        # Parallel drafting needs the exact post-rejection length. In async
+        # mode the regular CPU mirrors are optimistic; the proposer supplies
+        # an exact host copy reconstructed from accepted-token counts. Other
+        # paths retain the existing CPU-mirror contract.
+        if common_attn_metadata.parallel_draft_seq_lens_cpu is not None:
+            self.seq_lens = common_attn_metadata.parallel_draft_seq_lens_cpu[:num_reqs]
+        # Prefer _seq_lens_cpu (always available, updated during non-parallel
+        # draft iterations) over seq_lens_cpu (None in async spec mode).
+        elif common_attn_metadata._seq_lens_cpu is not None:
             self.seq_lens = common_attn_metadata._seq_lens_cpu[:num_reqs]
         elif common_attn_metadata.seq_lens_cpu is not None:
             self.seq_lens = common_attn_metadata.seq_lens_cpu[:num_reqs]

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -360,6 +360,17 @@ class AscendMLAMetadata:
     prefill: AscendMLAPrefillMetadata | None = None
     reshape_cache_event: torch.npu.Event = None
 
+    # Deferred parallel-draft reject finalize (dspark async spec decode). The
+    # builder copies these from AscendCommonAttentionMetadata when the proposer
+    # published an optimistic parallel_draft_seq_lens_cpu; _forward_decode
+    # synchronizes the event and subtracts the per-request reject count from
+    # ``decode.seq_lens_list`` exactly once (``reject_finalized`` guards re-entry
+    # across layers sharing this metadata object). None when no finalize is pending.
+    pending_reject_cpu: torch.Tensor = None
+    pending_reject_event: torch.npu.Event = None
+    pending_reject_num_reqs: int = 0
+    reject_finalized: bool = False
+
     def __post_init__(self):
         pass
         # supported_head_sizes = AscendMLABackend.get_supported_head_sizes()
@@ -598,10 +609,10 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         self.query_lens = query_seq_lens_cpu[:num_reqs]
-        # Parallel drafting needs the exact post-rejection length. In async
-        # mode the regular CPU mirrors are optimistic; the proposer supplies
-        # an exact host copy reconstructed from accepted-token counts. Other
-        # paths retain the existing CPU-mirror contract.
+        # Async parallel drafting publishes an optimistic host length here.
+        # The first FIA forward waits for the overlapped reject-count copy and
+        # applies the exact post-rejection correction before launching FIA.
+        # Other paths retain the existing CPU-mirror contract.
         if common_attn_metadata.parallel_draft_seq_lens_cpu is not None:
             self.seq_lens = common_attn_metadata.parallel_draft_seq_lens_cpu[:num_reqs]
         # Prefer _seq_lens_cpu (always available, updated during non-parallel
@@ -642,6 +653,10 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             block_tables=self.block_table,
             seq_lens=self.seq_lens,
             seq_lens_cpu=self.seq_lens,
+            pending_reject_cpu=common_attn_metadata.parallel_draft_num_reject_cpu,
+            pending_reject_event=common_attn_metadata.parallel_draft_num_reject_event,
+            pending_reject_num_reqs=common_attn_metadata.parallel_draft_num_reject_num_reqs,
+            reject_finalized=False,
         )
 
     def build_chunked_metadata(
@@ -1649,6 +1664,20 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
+        # Deferred parallel-draft reject finalize (dspark async spec decode):
+        # synchronize the side-stream D2H of num_rejected_tokens and subtract
+        # the per-request reject count from decode_meta.seq_lens_list -- the
+        # host list FIA consumes as actual_seq_kvlen. Runs once per metadata
+        # object; layers sharing this metadata skip via reject_finalized. The
+        # D2H was launched right after prepare_inputs_padded, so by the first
+        # attention layer the copy is typically already complete (sync no-op).
+        if attn_metadata.pending_reject_event is not None and not attn_metadata.reject_finalized:
+            attn_metadata.pending_reject_event.synchronize()
+            reject = attn_metadata.pending_reject_cpu[: attn_metadata.pending_reject_num_reqs].tolist()
+            seq_lens_list = decode_meta.seq_lens_list
+            for i in range(attn_metadata.pending_reject_num_reqs):
+                seq_lens_list[i] -= reject[i]
+            attn_metadata.reject_finalized = True
         # TODO: The CANN package is expected to support num_heads that are not
         # powers of 2 in 2026 Q2. Once supported, all padding operations under
         # `if self.head_padding > 0` in this function can be removed.

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -209,13 +209,25 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
     # E.g., tensor([128, 256, 64]) for 3 requests with different seq lengths.
     seq_lens_cpu: torch.Tensor = None
 
-    # Exact host-side sequence lengths for the current parallel-draft pass.
-    # Async scheduling keeps the regular CPU mirrors optimistic until the
-    # scheduler consumes the accepted-token counts. Ascend FIA needs exact
-    # lengths as a Python list, so the proposer reconstructs them from the
-    # asynchronously copied accepted-token counts without synchronizing the
-    # device ``seq_lens`` tensor.
+    # Optimistic host-side sequence lengths for the current parallel-draft
+    # pass: target optimistic lengths + the draft query block. Async scheduling
+    # keeps the regular CPU mirrors optimistic, and the post-rejection
+    # correction is deferred to the FIA forward entry so the reject-counts D2H
+    # can overlap with build + early draft forward. The exact lengths are
+    # reconstructed by subtracting ``parallel_draft_num_reject_cpu`` from the
+    # per-layer ``seq_lens_list`` at FIA time (see ``pending_reject_*`` on the
+    # backend metadata).
     parallel_draft_seq_lens_cpu: torch.Tensor = None
+
+    # Pending reject-counts for the deferred parallel-draft finalize. The
+    # proposer publishes the host mirror of ``num_rejected_tokens_gpu`` (copied
+    # on a side stream) plus its event and the request count; the backend
+    # metadata builder copies these into per-layer metadata, and the FIA forward
+    # entry synchronizes the event and subtracts the per-request reject count
+    # from ``seq_lens_list`` exactly once.
+    parallel_draft_num_reject_cpu: torch.Tensor = None
+    parallel_draft_num_reject_event: Any = None
+    parallel_draft_num_reject_num_reqs: int = 0
 
     # CPU tensor of already computed tokens count per request.
     # E.g., tensor([100, 200, 50]) means req0 has 100 tokens already computed.

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -209,6 +209,14 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
     # E.g., tensor([128, 256, 64]) for 3 requests with different seq lengths.
     seq_lens_cpu: torch.Tensor = None
 
+    # Exact host-side sequence lengths for the current parallel-draft pass.
+    # Async scheduling keeps the regular CPU mirrors optimistic until the
+    # scheduler consumes the accepted-token counts. Ascend FIA needs exact
+    # lengths as a Python list, so the proposer reconstructs them from the
+    # asynchronously copied accepted-token counts without synchronizing the
+    # device ``seq_lens`` tensor.
+    parallel_draft_seq_lens_cpu: torch.Tensor = None
+
     # CPU tensor of already computed tokens count per request.
     # E.g., tensor([100, 200, 50]) means req0 has 100 tokens already computed.
     num_computed_tokens_cpu: torch.Tensor = None

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -28,3 +28,7 @@ def register_model():
         "LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM"
     )
     ModelRegistry.register_model("Qwen3DSparkModel", "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM")
+    ModelRegistry.register_model(
+        "K3DSparkModel",
+        "vllm_ascend.models.kimi_k3_dspark:K3DSparkForCausalLM",
+    )

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kimi-K3 dense MLA draft model for DSpark speculative decoding (Ascend).
+
+The draft mirrors Kimi-K3's own MLA attention geometry (576-element latent KV
+per token) but flips the two K3-target constraints: the draft is trained WITH
+YaRN RoPE on the positional slice (``use_mla_rope=True``) and WITHOUT an
+output gate (``use_output_gate=False``, no ``g_proj``).
+
+Execution shape (v1 ``AscendDSparkProposer``):
+  * ``combine_hidden_states`` projects the target's concatenated aux hidden
+    states (5 x 7168) into the draft width (``context_proj`` + ``context_norm``).
+  * ``precompute_and_store_context_kv`` writes the projected context straight
+    into each draft layer's latent KV cache through the Ascend impl's
+    ``exec_kv_prefill`` (fused kv_a_layernorm + YaRN RoPE + paged-cache
+    insert). No attention is computed for context tokens.
+  * The (per request) 7-token draft block then runs one bidirectional forward:
+    the draft attention metadata's ``causal=False`` drives ``sparse_mode=0``
+    in ``mla_v1.py``, and the draft attention-group metadata builders are
+    flipped to ``use_mla_rope=True`` so the block's q_pe/k_pe receive the same
+    YaRN rotations as the precomputed context KV.
+"""
+
+import math
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.models.deepseek_v2 import DeepSeekV2FusedQkvAProjLinear
+from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
+
+from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
+from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    K3_DSPARK_HIDDEN_ACT,
+    K3_DSPARK_USE_MLA_ROPE,
+    K3DSparkConfig,
+)
+
+
+class K3DSparkMLAAttention(nn.Module):
+    """K3 MLA for the DSpark draft: RoPE enabled, output gate disabled.
+
+    Mirrors ``KimiK3MLAAttention`` (vllm_ascend/models/kimi_k3.py) but the
+    draft is trained with YaRN RoPE on the q/k positional slice and without
+    an output gate. All projection / RoPE / cache / attention work is
+    delegated to ``AscendMLAImpl`` through ``MultiHeadLatentAttentionWrapper``
+    (OOT-overridden by ``AscendMultiHeadLatentAttention``).
+    """
+
+    def __init__(
+        self,
+        config: K3DSparkConfig,
+        hidden_size: int,
+        num_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        cache_config,
+        quant_config,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.num_heads = num_heads
+        tp_size = get_tensor_model_parallel_world_size()
+        if num_heads % tp_size:
+            raise ValueError("num_attention_heads must be divisible by tensor parallel size")
+        self.num_local_heads = num_heads // tp_size
+        self.scaling = self.qk_head_dim**-0.5
+
+        # Fused q-down + kv-down projection; checkpoint keys ``q_a_proj`` and
+        # ``kv_a_proj_with_mqa`` map onto shards 0 and 1 (see WeightsMapper).
+        self.fused_qkv_a_proj = DeepSeekV2FusedQkvAProjLinear(
+            hidden_size,
+            [q_lora_rank, kv_lora_rank + qk_rope_head_dim],
+            quant_config=quant_config,
+            prefix=f"{prefix}.fused_qkv_a_proj",
+        )
+        self.q_a_layernorm = RMSNorm(q_lora_rank, eps=config.rms_norm_eps)
+        self.q_b_proj = ColumnParallelLinear(
+            q_lora_rank,
+            num_heads * self.qk_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_b_proj",
+        )
+        self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=config.rms_norm_eps)
+        self.kv_b_proj = ColumnParallelLinear(
+            kv_lora_rank,
+            num_heads * (qk_nope_head_dim + v_head_dim),
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.kv_b_proj",
+        )
+        # No output gate (draft: mla_use_output_gate=False).
+        self.o_proj = RowParallelLinear(
+            num_heads * v_head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        # YaRN RoPE on the positional slice (the draft is trained with RoPE,
+        # unlike the NoPE K3 target). Constructing the rotary emb instantiates
+        # AscendDeepseekScalingRotaryEmbedding, which records its cos/sin cache
+        # globally; get_cos_and_sin_mla reads it during metadata builds and the
+        # context-KV precompute. Keep the model default dtype (bf16) exactly as
+        # the in-tree DeepSeek MLA path does: the fused
+        # npu_kv_rmsnorm_rope_cache / npu_interleave_rope ops are validated
+        # against that dtype contract.
+        rope_parameters = dict(config.rope_parameters)
+        if rope_parameters["rope_type"] == "yarn":
+            # Route to DeepseekScalingRotaryEmbedding: the plain YaRN class
+            # does not record the MLA cos/sin cache on Ascend.
+            rope_parameters["rope_type"] = "deepseek_yarn"
+        self.rotary_emb = get_rope(
+            qk_rope_head_dim,
+            max_position=config.max_position_embeddings,
+            rope_parameters=rope_parameters,
+            is_neox_style=False,
+        )
+        if rope_parameters["rope_type"] == "deepseek_yarn":
+            scaling_factor = float(rope_parameters["factor"])
+            mscale_all_dim = float(rope_parameters["mscale_all_dim"])
+            if scaling_factor > 1 and mscale_all_dim:
+                mscale = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                self.scaling = self.scaling * mscale * mscale
+
+        mla_modules = MLAModules(
+            kv_a_layernorm=self.kv_a_layernorm,
+            kv_b_proj=self.kv_b_proj,
+            rotary_emb=self.rotary_emb,
+            o_proj=self.o_proj,
+            fused_qkv_a_proj=self.fused_qkv_a_proj,
+            kv_a_proj_with_mqa=None,
+            q_a_layernorm=self.q_a_layernorm,
+            q_b_proj=self.q_b_proj,
+            q_proj=None,
+            indexer=None,
+            is_sparse=False,
+            topk_indices_buffer=None,
+        )
+        # MLAModules is an upstream dataclass without these fields; the Ascend
+        # OOT wrapper reads them as dynamic attributes (see KimiK3MLAAttention).
+        mla_modules.use_output_gate = False
+        mla_modules.use_mla_rope = K3_DSPARK_USE_MLA_ROPE
+
+        self.mla_attn = MultiHeadLatentAttentionWrapper(
+            hidden_size,
+            self.num_local_heads,
+            self.scaling,
+            qk_nope_head_dim,
+            qk_rope_head_dim,
+            v_head_dim,
+            q_lora_rank,
+            kv_lora_rank,
+            mla_modules,
+            cache_config,
+            quant_config,
+            prefix,
+        )
+        # ``mla_attn`` is AscendMultiHeadLatentAttention; its ``.mla_attn`` is
+        # the inner MLAAttention (owns .impl / .kv_cache / .layer_name).
+        self.attn = self.mla_attn.mla_attn
+
+    @property
+    def layer_name(self) -> str:
+        return self.attn.layer_name
+
+    @property
+    def impl(self):
+        return self.attn.impl
+
+    @property
+    def kv_cache(self):
+        return self.attn.kv_cache
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.mla_attn(positions, hidden_states)
+
+
+class K3DSparkMLP(nn.Module):
+    """Dense SwiGLU MLP for the K3 DSpark draft."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size, intermediate_size],
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act != "silu":
+            raise ValueError(f"Unsupported K3 dspark activation: {hidden_act}. Only 'silu' is supported.")
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class K3DSparkDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: K3DSparkConfig,
+        layer_idx: int,
+        start_layer_id: int,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        # The K3 dspark draft checkpoint is bf16 (no quantization_config).
+        # vllm_config.quant_config carries the target's w4a8 scheme, whose
+        # layer descriptions do not cover the draft; inheriting it would break
+        # the draft's process_weights_after_loading on bf16 weights. The draft
+        # is always bf16, so force quant_config=None.
+        quant_config = None
+        self.self_attn = K3DSparkMLAAttention(
+            config=config,
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            cache_config=vllm_config.cache_config,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, f"layers.{start_layer_id + layer_idx}.self_attn"),
+        )
+        self.mlp = K3DSparkMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=K3_DSPARK_HIDDEN_ACT,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, f"layers.{start_layer_id + layer_idx}.mlp"),
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class K3DSparkModel(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        draft_model_config = vllm_config.speculative_config.draft_model_config
+        if draft_model_config is None:
+            raise ValueError("K3 DSpark requires a draft model config.")
+        draft_hf_config = draft_model_config.hf_config
+        if not isinstance(draft_hf_config, K3DSparkConfig):
+            raise TypeError(f"K3DSparkModel requires K3DSparkConfig, got {type(draft_hf_config).__name__}.")
+        self.config = draft_hf_config
+        # Draft is bf16 (see K3DSparkDecoderLayer); never inherit target quant.
+        self.quant_config = None
+
+        # Aliased to the target's embedding by the proposer's
+        # _maybe_share_embeddings (has_own_embed_tokens=False).
+        self.embed_tokens: nn.Module | None = None
+
+        self.context_proj = ReplicatedLinear(
+            self.config.target_hidden_size * self.config.num_target_layers,
+            self.config.hidden_size,
+            bias=False,
+            return_bias=False,
+            quant_config=self.quant_config,
+            prefix=maybe_prefix(prefix, "context_proj"),
+        )
+        self.context_norm = RMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps)
+
+        self.layers = nn.ModuleList(
+            [
+                K3DSparkDecoderLayer(
+                    vllm_config=vllm_config,
+                    config=self.config,
+                    layer_idx=layer_idx,
+                    start_layer_id=start_layer_id,
+                    prefix=prefix,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        self.final_norm = RMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps)
+        self.markov_head = DSparkMarkovHead(
+            self.config.vocab_size,
+            self.config.vocab_size,
+            self.config.markov_rank,
+            prefix=maybe_prefix(prefix, "markov_head"),
+        )
+
+    def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """main_x = context_norm(context_proj(concat of target aux hidden states)).
+
+        ``hidden_states`` is [T, target_hidden_size * num_target_layers].
+        """
+        return self.context_norm(self.context_proj(hidden_states))
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+        is_multimodal=None,
+    ) -> torch.Tensor:
+        """Embed draft input ids via the shared target embedding.
+
+        The v1 dspark proposer runs text-only speculative decoding even when the
+        K3 target is multimodal (it logs "Proceeding with text-only speculative
+        decoding" and passes multimodal_embeddings=is_multimodal=None), so the
+        SupportsMultiModal kwargs are accepted only to satisfy the call contract.
+        ``embed_tokens`` is aliased from the target by _maybe_share_embeddings.
+        """
+        assert self.embed_tokens is not None
+        return self.embed_tokens(input_ids)
+
+    @torch.inference_mode()
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: (
+            torch.Tensor | list[torch.Tensor | None] | tuple[torch.Tensor | None, ...] | None
+        ) = None,
+    ) -> None:
+        """Project target-derived context into each draft layer's latent cache.
+
+        Writes through the Ascend impl's ``exec_kv_prefill`` (fused
+        kv_a_layernorm + YaRN RoPE + paged-cache insert), using the draft's
+        recorded YaRN cos/sin. ``context_slot_mapping`` is a per-layer list
+        (the hybrid manager may place draft layers in different cache groups);
+        a ``None`` entry (or ``None`` overall, e.g. profiling) writes nothing.
+        """
+        if context_states.numel() == 0:
+            return
+        if isinstance(context_slot_mapping, (list, tuple)):
+            slot_mappings = tuple(context_slot_mapping)
+        else:
+            slot_mappings = (context_slot_mapping,) * len(self.layers)
+        if len(slot_mappings) != len(self.layers):
+            raise ValueError(
+                "context_slot_mapping must contain one entry per draft layer: "
+                f"got {len(slot_mappings)} entries for {len(self.layers)} layers"
+            )
+        cos, sin = get_cos_and_sin_mla(context_positions)
+        for layer_idx, layer in enumerate(self.layers):
+            attn = layer.self_attn
+            slot_mapping = slot_mappings[layer_idx]
+            if slot_mapping is None:
+                continue
+            qkv_lora = attn.fused_qkv_a_proj(context_states)[0]
+            # kv part only (drop the q_lora slice); raw, pre-norm -- the Ascend
+            # impl applies kv_a_layernorm + RoPE inside exec_kv_prefill.
+            kv_no_split = qkv_lora[..., attn.q_lora_rank :].contiguous()
+            attn.impl.exec_kv_prefill(
+                kv_no_split,
+                cos,
+                sin,
+                attn.kv_cache,
+                slot_mapping,
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            assert self.embed_tokens is not None
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_states, _ = self.final_norm(hidden_states, residual)
+        return hidden_states
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        # Inner MLAAttention.layer_name (e.g. "model.layers.N.self_attn.attn")
+        # -- the key used by the proposer for all_attn_layers / kv-cache groups
+        # / draft attn_metadata, and by mla_forward's attn_metadata lookup.
+        return [layer.self_attn.attn.layer_name for layer in self.layers]
+
+    def get_draft_attn_causal(self) -> list[bool]:
+        # K3 MLA drafts verify the speculative block bidirectionally. Keep the
+        # per-layer contract aligned with get_draft_kv_cache_layer_names().
+        return [False] * len(self.layers)
+
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.markov_head.embed(token_ids)
+
+    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.markov_head.bias(markov_embed, self.logits_processor)
+
+
+class K3DSparkForCausalLM(nn.Module):
+    # Draft shares the target's embedding / lm_head: the checkpoint carries a
+    # frozen copy of the target embedding and no lm_head at all.
+    has_own_embed_tokens = False
+    has_own_lm_head = False
+    # Full-vocab draft: draft ids are target ids, no remapping.
+    draft_id_to_target_id = None
+    # confidence_head is training-only; embed_tokens / lm_head are shared from
+    # the target, so skip any unloaded copies in the checkpoint.
+    checkpoint_skip_substrs = ("confidence_head", "embed_tokens", "lm_head")
+
+    # Checkpoint keys are in the model namespace without the ``model.`` prefix
+    # and with separate q_a_proj / kv_a_proj_with_mqa / gate_proj / up_proj;
+    # remap to the fused module names and prefix with ``model.``.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"": "model."},
+        orig_to_new_stacked={
+            ".gate_proj": (".gate_up_proj", 0),
+            ".up_proj": (".gate_up_proj", 1),
+            ".q_a_proj": (".fused_qkv_a_proj", 0),
+            ".kv_a_proj_with_mqa": (".fused_qkv_a_proj", 1),
+        },
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        self.draft_model_config = vllm_config.speculative_config.draft_model_config
+        if self.draft_model_config is None:
+            raise ValueError("K3 DSpark requires a draft model config.")
+        draft_hf_config = self.draft_model_config.hf_config
+        if not isinstance(draft_hf_config, K3DSparkConfig):
+            raise TypeError(f"K3DSparkForCausalLM requires K3DSparkConfig, got {type(draft_hf_config).__name__}.")
+        self.config = draft_hf_config
+        # Start draft layer names after the target's (93 for K3) so the MLA
+        # attention layers register under non-colliding static_forward_context
+        # keys.
+        target_layer_num = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.model = K3DSparkModel(
+            vllm_config=vllm_config,
+            start_layer_id=target_layer_num,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+
+        # Aliased from the target by _maybe_share_lm_head; keep no placeholder
+        # module to avoid a transient full-vocabulary allocation (163k vocab).
+        self.lm_head: nn.Module | None = None
+        self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        # The Markov head's bias() needs the logits_processor; thread it through.
+        self.model.logits_processor = self.logits_processor
+
+    # --- Hooks used by the v1 dspark proposer ------------------------------
+
+    def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.model.combine_hidden_states(hidden_states)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+        is_multimodal=None,
+    ) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids, multimodal_embeddings, is_multimodal)
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return self.model.get_draft_kv_cache_layer_names()
+
+    def get_draft_attn_causal(self) -> list[bool]:
+        return self.model.get_draft_attn_causal()
+
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: (
+            torch.Tensor | list[torch.Tensor | None] | tuple[torch.Tensor | None, ...] | None
+        ) = None,
+    ) -> None:
+        self.model.precompute_and_store_context_kv(context_states, context_positions, context_slot_mapping)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model(input_ids, positions, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.lm_head is not None
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_embed(token_ids)
+
+    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_bias(markov_embed)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=list(self.checkpoint_skip_substrs),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -712,6 +712,15 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 spec_sequence_indices,
             )
 
+        # A FULL graph may retain a captured speculative conv/recurrent task
+        # even when the current replay contains only non-spec prefill work.
+        # Refresh its stable inputs for every no-spec replay, not only for the
+        # pure non-spec decode branch below. Otherwise a DP idle dummy can
+        # replay the preceding request's state indices and mutate live Mamba
+        # checkpoints after that request has finished.
+        if self.use_full_cuda_graph and self.use_spec_decode and num_spec_decodes == 0:
+            self._reset_spec_decode_graph_inputs(m.num_reqs)
+
         chunk_indices: torch.Tensor | None = None
         chunk_offsets: torch.Tensor | None = None
         prefill_query_start_loc: torch.Tensor | None = None
@@ -837,8 +846,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
             graph_batch_size = m.num_reqs
-            if self.use_spec_decode:
-                self._reset_spec_decode_graph_inputs(graph_batch_size)
             (
                 non_spec_state_indices_tensor,
                 non_spec_query_start_loc,

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -26,6 +26,7 @@ from vllm.v1.attention.backends.gdn_attn import (
 )
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
+    PAD_SLOT_ID,
     compute_causal_conv1d_metadata,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
@@ -51,6 +52,32 @@ def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
     return torch.argsort(tensor, stable=True)
 
 
+def _treat_single_token_prefills_with_state_as_decodes(
+    common_attn_metadata: CommonAttentionMetadata,
+) -> CommonAttentionMetadata:
+    """Use decode metadata for one-token stateful prompt chunks.
+
+    A final one-token prompt chunk can replay the same fixed graph as an
+    ordinary decode.  Once recurrent state exists, both paths must construct
+    identical GDN metadata so the graph consumes the current state indices.
+    First-token prefills remain on the prefill path because they have no state
+    to update.
+    """
+    is_prefilling = common_attn_metadata.is_prefilling
+    seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+    if is_prefilling is None or seq_lens_cpu is None:
+        return common_attn_metadata
+
+    query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
+    prefill_to_decode = is_prefilling & (query_lens_cpu == 1) & (seq_lens_cpu > 1)
+    if not torch.any(prefill_to_decode).item():
+        return common_attn_metadata
+
+    is_prefilling = is_prefilling.clone()
+    is_prefilling[prefill_to_decode] = False
+    return common_attn_metadata.replace(is_prefilling=is_prefilling)
+
+
 @dataclass
 class GDNChunkedPrefillMetadata:
     cu_seqlens_host: tuple[int, ...]
@@ -61,7 +88,7 @@ class GDNChunkedPrefillMetadata:
     final_chunk_indices_chunk64: torch.Tensor
     chunk_indices_large_block: torch.Tensor
     block_indices_cumsum: torch.Tensor
-    num_decodes: int = 0
+    num_decodes: int
     cu_seqlens_kern: tuple[int, ...] | None = None
     keep_meta: torch.Tensor | None = None
 
@@ -171,6 +198,7 @@ def _build_non_spec_chunked_prefill_metadata(
     block_indices_cumsum = prepare_chunk_indices(cu_seqlens_cpu, cumsum_chunk_size)
 
     cu_seqlens_host = tuple(cu_seqlens_cpu.to(torch.int64).reshape(-1).tolist())
+    num_decodes = sum(1 for seq_start, seq_end in zip(cu_seqlens_host, cu_seqlens_host[1:]) if seq_end - seq_start == 1)
     # Pre-compute compact cu_seqlens for AscendC kernels so each layer
     # can reuse them instead of calling _compact_empty_segments again.
     cu_seqlens_kern, _, keep_meta = _compact_empty_segments(cu_seqlens_host, None, device=device)
@@ -188,6 +216,7 @@ def _build_non_spec_chunked_prefill_metadata(
         final_chunk_indices_chunk64=final_chunk_indices_chunk64.to(device=device, non_blocking=True),
         chunk_indices_large_block=chunk_indices_large_block.to(device=device, non_blocking=True),
         block_indices_cumsum=block_indices_cumsum.to(device=device, non_blocking=True),
+        num_decodes=num_decodes,
         cu_seqlens_kern=cu_seqlens_kern,
         keep_meta=keep_meta,
     )
@@ -300,6 +329,52 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
 
         return spec_indices, non_spec_indices
 
+    def _pad_non_spec_decode_graph_inputs(
+        self,
+        state_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        *,
+        num_decode_tokens: int,
+        graph_batch_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Refresh fixed buffers consumed by a non-spec decode graph.
+
+        ``num_decodes`` includes graph padding rows, while each real non-spec
+        decode contributes exactly one token.  Therefore
+        ``num_decode_tokens`` is the number of live rows to copy.  All other
+        state rows must be null and their repeated terminal offsets must
+        describe zero-length sequences.
+        """
+        assert num_decode_tokens <= graph_batch_size
+
+        padded_state_indices = self.non_spec_state_indices_tensor[:graph_batch_size]
+        padded_state_indices[num_decode_tokens:].fill_(NULL_BLOCK_ID)
+        padded_state_indices[:num_decode_tokens].copy_(
+            state_indices[:num_decode_tokens],
+            non_blocking=True,
+        )
+
+        padded_query_start_loc = self.non_spec_query_start_loc[: graph_batch_size + 1]
+        padded_query_start_loc[: num_decode_tokens + 1].copy_(
+            query_start_loc[: num_decode_tokens + 1],
+            non_blocking=True,
+        )
+        query_padding = padded_query_start_loc[num_decode_tokens + 1 :]
+        if query_padding.numel() > 0:
+            query_padding.copy_(
+                padded_query_start_loc[num_decode_tokens].expand_as(query_padding),
+                non_blocking=True,
+            )
+
+        return padded_state_indices, padded_query_start_loc
+
+    def _reset_spec_decode_graph_inputs(self, graph_batch_size: int) -> None:
+        """Make a captured speculative branch a no-op for this replay."""
+        self.spec_state_indices_tensor[:graph_batch_size].fill_(PAD_SLOT_ID)
+        self.spec_query_start_loc[: graph_batch_size + 1].zero_()
+        self.num_accepted_tokens[:graph_batch_size].zero_()
+        self.spec_actual_seq_lengths[: graph_batch_size + 1].zero_()
+
     def _attach_non_spec_prefill_metadata(
         self,
         attn_metadata: GDNAttentionMetadata,
@@ -408,6 +483,51 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         )
         return attn_metadata
 
+    def _fold_spec_sized_prefill_chunks_into_spec(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        spec_sequence_masks_cpu: torch.Tensor,
+        num_accepted_tokens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Advance stateful spec-width prompt chunks through live spec inputs.
+
+        A stateful prompt chunk of exactly ``num_spec + 1`` tokens is
+        shape-identical to a speculative decode row and can replay that graph.
+        Mark it speculative and accept the complete chunk so conv1d and
+        recurrent state advance over every token.  First prompt chunks stay on
+        the prefill path because they have no prior state.
+        """
+        is_prefilling = common_attn_metadata.is_prefilling
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+        if is_prefilling is None or seq_lens_cpu is None or num_accepted_tokens is None:
+            return spec_sequence_masks_cpu, num_accepted_tokens
+
+        # Common metadata tensors can include graph padding; only leading rows
+        # correspond to requests represented by the runtime spec mask.
+        num_reqs = min(
+            spec_sequence_masks_cpu.numel(),
+            is_prefilling.numel(),
+            seq_lens_cpu.numel(),
+        )
+        is_prefilling = is_prefilling[:num_reqs]
+        seq_lens_cpu = seq_lens_cpu[:num_reqs]
+        query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)[:num_reqs]
+        fold = (
+            is_prefilling
+            & ~spec_sequence_masks_cpu
+            & (query_lens_cpu == self.num_spec + 1)
+            & (seq_lens_cpu > query_lens_cpu)
+        )
+        fold_indices = fold.nonzero(as_tuple=True)[0]
+        if fold_indices.numel() == 0:
+            return spec_sequence_masks_cpu, num_accepted_tokens
+
+        spec_sequence_masks_cpu = spec_sequence_masks_cpu.clone()
+        spec_sequence_masks_cpu[fold_indices] = True
+        num_accepted_tokens = num_accepted_tokens.clone()
+        num_accepted_tokens[fold_indices.to(num_accepted_tokens.device)] = self.num_spec + 1
+        return spec_sequence_masks_cpu, num_accepted_tokens
+
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -416,7 +536,7 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
-        m = common_attn_metadata
+        m = _treat_single_token_prefills_with_state_as_decodes(common_attn_metadata)
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
@@ -443,6 +563,11 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 num_decode_draft_tokens_cpu,
                 0,
                 out=spec_sequence_masks_cpu,
+            )
+            spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
+                m,
+                spec_sequence_masks_cpu,
+                num_accepted_tokens,
             )
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
             if num_spec_decodes == 0:
@@ -645,8 +770,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
-        batch_size = m.num_actual_tokens
-
         if (
             self.use_full_cuda_graph
             and num_prefills == 0
@@ -713,22 +836,19 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[batch_size:].fill_(NULL_BLOCK_ID)
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+            graph_batch_size = m.num_reqs
+            if self.use_spec_decode:
+                self._reset_spec_decode_graph_inputs(graph_batch_size)
+            (
                 non_spec_state_indices_tensor,
-                non_blocking=True,
-            )
-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[:batch_size]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
-            non_spec_conv1d_cache_indices = non_spec_state_indices_tensor
-
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
                 non_spec_query_start_loc,
-                non_blocking=True,
+            ) = self._pad_non_spec_decode_graph_inputs(
+                non_spec_state_indices_tensor,
+                non_spec_query_start_loc,
+                num_decode_tokens=num_decode_tokens,
+                graph_batch_size=graph_batch_size,
             )
-            non_spec_num_query_tokens = non_spec_query_start_loc[-1]
-            non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
-            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
+            non_spec_conv1d_cache_indices = non_spec_state_indices_tensor
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -21,7 +21,7 @@ from vllm.config import get_current_vllm_config
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm, RMSNormGated
 
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
+from vllm_ascend.ops.triton.fused_norm_gate import layer_norm_fwd_npu
 from vllm_ascend.utils import enable_custom_op
 
 
@@ -147,6 +147,7 @@ class LayerNormFn(torch.autograd.Function):
             group_size=group_size,
             norm_before_gate=norm_before_gate,
             is_rms_norm=is_rms_norm,
+            activation=activation,
         )
         ctx.save_for_backward(x, weight, bias, mean, rstd, z)
         ctx.x_shape_og = x_shape_og
@@ -189,6 +190,7 @@ class AscendRMSNormGated(RMSNormGated):
         self.register_parameter("bias", None)
         self.group_size = group_size
         self.norm_before_gate = norm_before_gate
+        self.activation = activation
         self.reset_parameters()
 
     def reset_parameters(self):
@@ -196,4 +198,14 @@ class AscendRMSNormGated(RMSNormGated):
 
     def forward_oot(self, x, z=None):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
-        return LayerNormFn.apply(x, self.weight, self.bias, z, self.eps, self.group_size, self.norm_before_gate, True)
+        return LayerNormFn.apply(
+            x,
+            self.weight,
+            self.bias,
+            z,
+            self.eps,
+            self.group_size,
+            self.norm_before_gate,
+            True,
+            self.activation,
+        )

--- a/vllm_ascend/ops/triton/fused_norm_gate.py
+++ b/vllm_ascend/ops/triton/fused_norm_gate.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code adapted from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""Inference-only fused LayerNorm/RMSNorm and gate for Ascend Triton.
+
+Adapted from FLA's ``triton_ascend/fused_norm_gate.py``. The grid-stride
+row tiling keeps the norm parameters resident and caps the launch at the
+available vector-core count. Kimi K3 uses the RMSNorm + sigmoid-gate path.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.layernorm_gated import (
+    layer_norm_fwd_npu as legacy_layer_norm_fwd_npu,
+)
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+_ASCEND_910_UB_BYTES = 192 * 1024
+_UB_SAFETY_MARGIN = 0.85
+_BD_MEMORY_MULTIPLIER = 6.0
+# The K3 path can gate before normalization, keeping both the gate and
+# normalized-value tiles live. Ascend910 compilation measured just over 6x
+# [block_rows, block_feature] at D=128, so use the same conservative budget as
+# the single-row feature check instead of FLA's post-norm-only 3x budget.
+_FWD_MEMORY_MULTIPLIER = 6.0
+_LARGE_BD = 2048
+_LARGE_BD_MEMORY_MULTIPLIER = 4.0
+_MAX_BT = 128
+_ASCEND_MAX_GRID_DIM = 65535
+
+_ACTIVATION_SWISH = 0
+_ACTIVATION_SIGMOID = 1
+
+
+def _activation_id(activation: str) -> int:
+    if activation in ("swish", "silu"):
+        return _ACTIVATION_SWISH
+    if activation == "sigmoid":
+        return _ACTIVATION_SIGMOID
+    raise ValueError(f"Unsupported activation: {activation}")
+
+
+def _largest_power_of_two_at_most(value: int) -> int:
+    return 1 << max(0, value.bit_length() - 1)
+
+
+def _get_layer_norm_gated_tiles(feature_size: int) -> tuple[int, int]:
+    block_feature = triton.next_power_of_2(feature_size)
+    safe_bytes = int(_ASCEND_910_UB_BYTES * _UB_SAFETY_MARGIN)
+    max_feature = int(safe_bytes // (_BD_MEMORY_MULTIPLIER * 4))
+    if block_feature > max_feature:
+        raise RuntimeError(
+            f"LayerNormGated feature dim {feature_size} exceeds the UB-safe "
+            f"block size {_largest_power_of_two_at_most(max_feature)}."
+        )
+    row_multiplier = _LARGE_BD_MEMORY_MULTIPLIER if block_feature >= _LARGE_BD else _FWD_MEMORY_MULTIPLIER
+    max_rows = int(safe_bytes // (row_multiplier * block_feature * 4))
+    block_rows = min(_MAX_BT, _largest_power_of_two_at_most(max(1, max_rows)))
+    return block_feature, block_rows
+
+
+@triton.jit(do_not_specialize=["num_rows"])
+def _fused_norm_gate_kernel(
+    x,
+    gate,
+    output,
+    weight,
+    bias,
+    mean,
+    rstd,
+    eps,
+    num_rows,
+    num_programs,
+    feature_size: tl.constexpr,
+    block_feature: tl.constexpr,
+    block_rows: tl.constexpr,
+    activation: tl.constexpr,
+    norm_before_gate: tl.constexpr,
+    is_rms_norm: tl.constexpr,
+    has_bias: tl.constexpr,
+):
+    program_id = tl.program_id(0)
+    columns = tl.arange(0, block_feature)
+    column_mask = columns < feature_size
+    norm_weight = tl.load(weight + columns, mask=column_mask).to(tl.float32)
+    if has_bias:
+        norm_bias = tl.load(bias + columns, mask=column_mask, other=0.0).to(tl.float32)
+
+    num_tiles = tl.cdiv(num_rows, block_rows)
+    for tile_id in range(program_id, num_tiles, num_programs):
+        rows = tile_id * block_rows + tl.arange(0, block_rows)
+        row_mask = rows < num_rows
+        mask = row_mask[:, None] & column_mask[None, :]
+        offsets = rows[:, None] * feature_size + columns[None, :]
+
+        values = tl.load(x + offsets, mask=mask, other=0.0).to(tl.float32)
+        gate_values = tl.load(gate + offsets, mask=mask, other=0.0).to(tl.float32)
+        sigmoid_gate = tl.sigmoid(gate_values)
+        if activation == 0:
+            gate_multiplier = gate_values * sigmoid_gate
+        else:
+            gate_multiplier = sigmoid_gate
+        if not norm_before_gate:
+            values *= gate_multiplier
+        if not is_rms_norm:
+            row_mean = tl.sum(values, axis=1) / feature_size
+            centered = tl.where(mask, values - row_mean[:, None], 0.0)
+            variance = tl.sum(centered * centered, axis=1) / feature_size
+            tl.store(mean + rows, row_mean, mask=row_mask)
+        else:
+            variance = tl.sum(tl.where(mask, values * values, 0.0), axis=1) / feature_size
+        reciprocal_std = 1.0 / tl.sqrt(variance + eps)
+        tl.store(rstd + rows, reciprocal_std, mask=row_mask)
+
+        if is_rms_norm:
+            normalized = values * reciprocal_std[:, None]
+        else:
+            normalized = (values - row_mean[:, None]) * reciprocal_std[:, None]
+        normalized *= norm_weight[None, :]
+        if has_bias:
+            normalized += norm_bias[None, :]
+
+        if norm_before_gate:
+            normalized *= gate_multiplier
+        tl.store(output + offsets, normalized.to(output.dtype.element_ty), mask=mask)
+
+
+def fused_norm_gate_fwd_npu(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    *,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    is_rms_norm: bool = False,
+    norm_before_gate: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    num_rows, feature_size = x.shape
+    assert gate.shape == x.shape
+    assert x.stride(-1) == gate.stride(-1) == 1
+    assert weight.shape == (feature_size,)
+    if bias is not None:
+        assert bias.shape == (feature_size,)
+
+    output = torch.empty_like(x)
+    mean = None if is_rms_norm else torch.empty((num_rows,), dtype=torch.float32, device=x.device)
+    rstd = torch.empty((num_rows,), dtype=torch.float32, device=x.device)
+    block_feature, block_rows = _get_layer_norm_gated_tiles(feature_size)
+    num_tiles = triton.cdiv(num_rows, block_rows)
+    num_programs = max(
+        1,
+        min(get_vectorcore_num(), num_tiles, _ASCEND_MAX_GRID_DIM),
+    )
+    _fused_norm_gate_kernel[(num_programs,)](
+        x,
+        gate,
+        output,
+        weight,
+        bias,
+        mean,
+        rstd,
+        eps,
+        num_rows,
+        num_programs,
+        feature_size=feature_size,
+        block_feature=block_feature,
+        block_rows=block_rows,
+        activation=_activation_id(activation),
+        norm_before_gate=norm_before_gate,
+        is_rms_norm=is_rms_norm,
+        has_bias=bias is not None,
+    )
+    return output, mean, rstd
+
+
+def layer_norm_fwd_npu(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    eps: float,
+    z: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    group_size: int | None = None,
+    norm_before_gate: bool = True,
+    is_rms_norm: bool = False,
+    activation: str = "swish",
+):
+    if z is None or out is not None:
+        return legacy_layer_norm_fwd_npu(
+            x,
+            weight,
+            bias,
+            eps,
+            z=z,
+            out=out,
+            group_size=group_size,
+            norm_before_gate=norm_before_gate,
+            is_rms_norm=is_rms_norm,
+        )
+    if group_size not in (None, x.shape[-1]):
+        return legacy_layer_norm_fwd_npu(
+            x,
+            weight,
+            bias,
+            eps,
+            z=z,
+            group_size=group_size,
+            norm_before_gate=norm_before_gate,
+            is_rms_norm=is_rms_norm,
+        )
+    return fused_norm_gate_fwd_npu(
+        x,
+        z,
+        weight,
+        bias,
+        activation=activation,
+        eps=eps,
+        is_rms_norm=is_rms_norm,
+        norm_before_gate=norm_before_gate,
+    )

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -123,6 +123,10 @@ class BalanceScheduler(Scheduler):
             include_finished_set,
             log_stats,
         )
+        kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+        self._use_consumer_partial_group_hits = not bool(
+            kv_transfer_config is not None and kv_transfer_config.is_kv_producer
+        )
         short_request_first_config = init_ascend_config(vllm_config).scheduler_config.short_request_first_config
         if short_request_first_config.enabled:
             from vllm_ascend.core.short_request_first_scheduler import install_short_request_first_waiting_queue
@@ -163,6 +167,17 @@ class BalanceScheduler(Scheduler):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         if not self._balance_enabled:
+            if not self._use_consumer_partial_group_hits and self.has_mamba_layers:
+                # Upstream's per-group lookup is a remote-prefill consumer
+                # optimization that intentionally omits Mamba state. Producer
+                # requests must use the normal all-group lookup instead. The
+                # current upstream schedule reads has_mamba_layers only when
+                # selecting between these two lookup paths.
+                self.has_mamba_layers = False
+                try:
+                    return super().schedule(throttle_prefills)
+                finally:
+                    self.has_mamba_layers = True
             return super().schedule(throttle_prefills)
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -447,6 +462,7 @@ class BalanceScheduler(Scheduler):
                     # Get locally-cached tokens.
                     if (
                         self.connector is not None
+                        and self._use_consumer_partial_group_hits
                         and self.has_mamba_layers
                         and isinstance(
                             self.kv_cache_manager.coordinator,

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -364,15 +364,10 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        # NOTE(zxr): for deepseek-v4, there is two fullattn groups, but
-        # in this function, only the first fullattn group is truncate by
-        # the belowing codes(c4), c128 layer does not truncate, which may
-        # have prefix cache block hit.
-        # Due to slidingwindow attn, deepseek-v4 decode node can't have
-        # any prefix cache hit, because `hit_length` of SWA is 0.
-        spec, group_ids, _ = self.attention_groups[0]
-        if isinstance(spec, FullAttentionSpec):
+        # Truncate every full-attention group to the reconciled hit length.
+        for spec, group_ids, _ in self.attention_groups:
+            if not isinstance(spec, FullAttentionSpec):
+                continue
             num_blocks = cdiv(hit_length, self._get_effective_block_size(spec))
             for group_id in group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -177,18 +177,6 @@ def _dspark_post_init(self):
         # gqa backend dspark
         if getattr(draft_hf_config, "ptd_token_id", None) is None:  # type: ignore
             draft_hf_config.ptd_token_id = getattr(draft_hf_config, "mask_token_id", None)  # type: ignore
-        architectures = getattr(draft_hf_config, "architectures", ()) or ()
-        if getattr(draft_hf_config, "model_type", None) == "qwen3" and "Qwen3DSparkModel" in architectures:
-            block_size = getattr(draft_hf_config, "block_size", None)
-            if not isinstance(block_size, int) or isinstance(block_size, bool) or block_size <= 0:
-                raise ValueError("Qwen3/GQA DSpark requires a positive integer block_size in the draft config.")
-            if self.num_speculative_tokens != block_size:
-                raise ValueError(
-                    "Qwen3/GQA DSpark requires num_speculative_tokens to match "
-                    f"the trained block_size ({block_size}); got "
-                    f"{self.num_speculative_tokens}."
-                )
-
         # Upstream DSpark normalization rewrites the config's model_type and
         # architecture in place. The concrete config class remains intact, so
         # restore K3 from that explicit type contract instead of probing for
@@ -197,12 +185,6 @@ def _dspark_post_init(self):
             draft_hf_config.model_type = K3DSparkConfig.model_type
             draft_hf_config.architectures = ["K3DSparkModel"]
             self.update_arch_()
-            if self.num_speculative_tokens != draft_hf_config.block_size:
-                raise ValueError(
-                    "K3 dspark requires num_speculative_tokens to match the "
-                    f"trained block_size ({draft_hf_config.block_size}); got "
-                    f"{self.num_speculative_tokens}."
-                )
 
 
 SpeculativeConfig.hf_config_override = hf_config_override

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -3,6 +3,11 @@ from typing import TYPE_CHECKING, Any
 from vllm.config.speculative import SpeculativeConfig
 from vllm.utils.import_utils import LazyLoader
 
+from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    K3DSparkConfig,
+    register_k3_dspark_config,
+)
+
 _orig_post_init = SpeculativeConfig.__post_init__
 
 if TYPE_CHECKING:
@@ -12,6 +17,12 @@ else:
     PretrainedConfig = Any
 
     me_quant = LazyLoader("model_executor", globals(), "vllm.model_executor.layers.quantization")
+
+
+# This patch may be imported before the model plugin entry point runs. Register
+# the lightweight config here as well so ModelConfig can parse the draft before
+# speculative post-init normalizes its architecture.
+register_k3_dspark_config()
 
 
 def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
@@ -156,8 +167,10 @@ def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
 def _dspark_post_init(self):
     _orig_post_init(self)
     if self.use_dspark():
-        draft_model_config = getattr(self, "draft_model_config", None)
-        draft_hf_config = getattr(draft_model_config, "hf_config", None)
+        draft_model_config = self.draft_model_config
+        if draft_model_config is None:
+            raise ValueError("DSpark requires a draft model config.")
+        draft_hf_config = draft_model_config.hf_config
         # deepseek v4 dspark
         if getattr(draft_hf_config, "ptd_token_id", None) is None:  # type: ignore
             draft_hf_config.ptd_token_id = getattr(draft_hf_config, "dspark_noise_token_id", None)  # type: ignore
@@ -173,6 +186,21 @@ def _dspark_post_init(self):
                 raise ValueError(
                     "Qwen3/GQA DSpark requires num_speculative_tokens to match "
                     f"the trained block_size ({block_size}); got "
+                    f"{self.num_speculative_tokens}."
+                )
+
+        # Upstream DSpark normalization rewrites the config's model_type and
+        # architecture in place. The concrete config class remains intact, so
+        # restore K3 from that explicit type contract instead of probing for
+        # optional sentinel attributes shared by other draft families.
+        if isinstance(draft_hf_config, K3DSparkConfig):
+            draft_hf_config.model_type = K3DSparkConfig.model_type
+            draft_hf_config.architectures = ["K3DSparkModel"]
+            self.update_arch_()
+            if self.num_speculative_tokens != draft_hf_config.block_size:
+                raise ValueError(
+                    "K3 dspark requires num_speculative_tokens to match the "
+                    f"trained block_size ({draft_hf_config.block_size}); got "
                     f"{self.num_speculative_tokens}."
                 )
 

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -12,8 +12,13 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.mla_v1 import AscendMLAMetadataBuilder
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    K3_DSPARK_USE_MLA_ROPE,
+    K3DSparkConfig,
+)
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -208,6 +213,22 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
         self.kernel_block_size = self._per_group_kernel_block_sizes[self.kv_cache_gid]
+
+        # Kimi-K3 MLA dspark: the MLA metadata builder derives use_mla_rope
+        # from the TARGET's hf_text_config (K3 target is NoPE), so the draft
+        # groups' builders would emit identity cos/sin while the draft's
+        # context KV is written with real YaRN rotations -- silently breaking
+        # the draft's positional alignment. The builders created above serve
+        # draft layers only, so flip them to the draft's own RoPE setting.
+        draft_hf_config = self.draft_model_config.hf_config
+        if isinstance(draft_hf_config, K3DSparkConfig):
+            for attn_group in self.draft_attn_groups:
+                for builder in attn_group.metadata_builders:
+                    if not isinstance(builder, AscendMLAMetadataBuilder):
+                        raise TypeError(
+                            f"K3 DSpark requires Ascend MLA metadata builders, got {type(builder).__name__}."
+                        )
+                    builder.use_mla_rope = K3_DSPARK_USE_MLA_ROPE
 
         name_to_gid = {
             ln: gid

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -346,7 +346,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if getattr(self, "_quarot_rotation", None) is None:
             return None
         if draft_layer is None:
-            draft_layer = copy.deepcopy(target_layer)
+            # AscendVocabParallelEmbedding owns a GroupCoordinator whose
+            # device/cpu groups are torch.distributed.ProcessGroup objects.
+            # Those groups cannot be pickled by deepcopy, and they should not
+            # be cloned for a draft-owned copy anyway. Preserve the
+            # coordinator while independently cloning the module parameters.
+            comm_group = getattr(target_layer, "comm_group", None)
+            memo = {id(comm_group): comm_group} if comm_group is not None else None
+            draft_layer = copy.deepcopy(target_layer, memo)
         if not self._copy_unrotated_shared_weight(draft_layer, target_layer, label):
             raise ValueError(
                 f"QuaRot requires a compatible draft-owned {label}; refusing to alias the rotated target layer."
@@ -912,13 +919,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         batch_size: int,
         num_draft_tokens_cpu: list[int] | None,
     ) -> None:
-        """Publish exact host KV lengths for Ascend parallel-draft FIA.
+        """Publish optimistic host KV lengths for Ascend parallel-draft FIA.
 
         Async scheduling intentionally leaves the normal CPU sequence-length
-        mirrors optimistic. The accepted-token counts are already copied to a
-        pinned host buffer on a side stream. Wait only for that copy, then
-        reconstruct the current draft lengths on CPU; this avoids
-        ``seq_lens.tolist()`` synchronizing the whole NPU default stream.
+        mirrors optimistic. Rather than synchronizing the reject-counts D2H
+        here (on the draft critical path), publish the optimistic lengths plus
+        the draft query block and, for the padded+async path, stash the
+        side-stream reject-counts mirror + event. The per-layer attention
+        metadata copies them and the FIA forward entry synchronizes the event
+        and subtracts the per-request reject count from ``seq_lens_list`` --
+        by then the D2H has overlapped with metadata build and the early draft
+        forward.
+
+        Three cases (preserving prior behavior except for the padded+async
+        deferral): non-padded (``num_draft_tokens_cpu is None``) publishes
+        optimistic+query with no reject; padded+async publishes optimistic+query
+        plus the deferred reject fields; padded+non-async leaves
+        ``parallel_draft_seq_lens_cpu`` unset so the builder falls back to the
+        (already-exact) device ``seq_lens``.
         """
         if not self.parallel_drafting or not hasattr(self, "num_query_per_req"):
             return
@@ -931,23 +949,20 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if seq_lens_cpu is None:
             return
 
-        valid_counts_cpu = None
-        if num_draft_tokens_cpu is not None:
-            event = self.runner.valid_sampled_token_count_event
-            valid_counts_cpu = self.runner.valid_sampled_token_count_cpu
-            # Non-async callers do not maintain the side-stream host mirror;
-            # keep their existing device seq_lens fallback.
-            if event is None or valid_counts_cpu is None:
-                return
-            event.synchronize()
+        reject_event = getattr(self.runner, "num_rejected_tokens_event", None)
+        async_padded = num_draft_tokens_cpu is not None and reject_event is not None
 
-        common_attn_metadata.parallel_draft_seq_lens_cpu = build_parallel_draft_seq_lens_cpu(
-            seq_lens_cpu,
-            num_draft_tokens_cpu,
-            valid_counts_cpu,
-            batch_size,
-            self.num_query_per_req,
-        )
+        if num_draft_tokens_cpu is None or async_padded:
+            common_attn_metadata.parallel_draft_seq_lens_cpu = build_parallel_draft_seq_lens_cpu(
+                seq_lens_cpu,
+                batch_size,
+                self.num_query_per_req,
+            )
+            if async_padded:
+                common_attn_metadata.parallel_draft_num_reject_cpu = self.runner.num_rejected_tokens_cpu
+                common_attn_metadata.parallel_draft_num_reject_event = reject_event
+                common_attn_metadata.parallel_draft_num_reject_num_reqs = batch_size
+        # else: padded + non-async -> leave unset; builder falls back to device seq_lens.
 
     def _propose(
         self,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -57,6 +57,7 @@ from vllm_ascend.spec_decode.utils import (
     SlidingWindowAdapter,
     _disable_flash_comm_v1_context,
     _maybe_eager_context,
+    build_parallel_draft_seq_lens_cpu,
     patch_tensor_parallel_group,
 )
 from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable
@@ -905,6 +906,49 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
             self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
+    def _prepare_parallel_draft_seq_lens_cpu(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        batch_size: int,
+        num_draft_tokens_cpu: list[int] | None,
+    ) -> None:
+        """Publish exact host KV lengths for Ascend parallel-draft FIA.
+
+        Async scheduling intentionally leaves the normal CPU sequence-length
+        mirrors optimistic. The accepted-token counts are already copied to a
+        pinned host buffer on a side stream. Wait only for that copy, then
+        reconstruct the current draft lengths on CPU; this avoids
+        ``seq_lens.tolist()`` synchronizing the whole NPU default stream.
+        """
+        if not self.parallel_drafting or not hasattr(self, "num_query_per_req"):
+            return
+
+        seq_lens_cpu = common_attn_metadata._seq_lens_cpu
+        if seq_lens_cpu is None:
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        if seq_lens_cpu is None:
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+        if seq_lens_cpu is None:
+            return
+
+        valid_counts_cpu = None
+        if num_draft_tokens_cpu is not None:
+            event = self.runner.valid_sampled_token_count_event
+            valid_counts_cpu = self.runner.valid_sampled_token_count_cpu
+            # Non-async callers do not maintain the side-stream host mirror;
+            # keep their existing device seq_lens fallback.
+            if event is None or valid_counts_cpu is None:
+                return
+            event.synchronize()
+
+        common_attn_metadata.parallel_draft_seq_lens_cpu = build_parallel_draft_seq_lens_cpu(
+            seq_lens_cpu,
+            num_draft_tokens_cpu,
+            valid_counts_cpu,
+            batch_size,
+            self.num_query_per_req,
+        )
+
     def _propose(
         self,
         # [num_tokens]
@@ -927,6 +971,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         scheduler_output: SchedulerOutput = None,
         num_scheduled_tokens: int = 0,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
+        num_draft_tokens_cpu: list[int] | None = None,
     ) -> torch.Tensor:
         batch_size = common_attn_metadata.batch_size()
 
@@ -1046,6 +1091,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.block_table_tensor = self._adjust_tensor(
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
+
+        self._prepare_parallel_draft_seq_lens_cpu(
+            common_attn_metadata,
+            batch_size,
+            num_draft_tokens_cpu,
+        )
 
         if self.draft_window_size is not None:
             self.sliding_window.apply(common_attn_metadata)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -259,6 +259,149 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
+    def _maybe_anti_rotate_fc(self) -> None:
+        """Align the draft FC input basis with a QuaRot target."""
+        if self.method not in ("dflash", "dspark"):
+            return
+        target_model_path = self.vllm_config.model_config.model
+        rotation = self._load_quarot_rotation(target_model_path)
+        if rotation is None:
+            return
+
+        # Keep the full-precision rotation alive until the shared embedding and
+        # lm_head boundaries are fixed below. A draft without its own boundary
+        # modules must not directly consume rotated target tensors.
+        rotation = rotation.to(self.device, dtype=torch.float32)
+        self._quarot_rotation = rotation
+        draft_model = getattr(self.model, "model", None)
+        fc = getattr(draft_model, "fc", None) if draft_model is not None else None
+        if fc is None:
+            return
+
+        fc_weight = fc.weight
+        out_features, in_features = fc_weight.shape
+        hidden_size = rotation.shape[0]
+        if in_features % hidden_size != 0:
+            logger.warning(
+                "[spec_decode/quarot] fc in_features=%d is not divisible by rotation dim=%d; skipping FC alignment.",
+                in_features,
+                hidden_size,
+            )
+            return
+        num_features = in_features // hidden_size
+        fc_blocks = fc_weight.data.to(torch.float32).reshape(out_features, num_features, hidden_size)
+        aligned = torch.matmul(fc_blocks, rotation)
+        fc_weight.data.copy_(aligned.reshape(out_features, in_features).to(fc_weight.dtype))
+        logger.info(
+            "[spec_decode/quarot] Aligned draft fc.weight with target rotation (num_features=%d, fc=%s).",
+            num_features,
+            tuple(fc_weight.shape),
+        )
+
+    def _copy_unrotated_shared_weight(
+        self,
+        draft_layer: nn.Module,
+        target_layer: nn.Module,
+        label: str,
+    ) -> bool:
+        """Copy a rotated target weight into an unrotated draft-owned layer."""
+        rotation = getattr(self, "_quarot_rotation", None)
+        if rotation is None:
+            return False
+        draft_weight = getattr(draft_layer, "weight", None)
+        target_weight = getattr(target_layer, "weight", None)
+        if not isinstance(draft_weight, torch.Tensor) or not isinstance(target_weight, torch.Tensor):
+            logger.warning(
+                "[spec_decode/quarot] Cannot align shared %s: weight tensor missing.",
+                label,
+            )
+            return False
+        if draft_weight.shape != target_weight.shape or target_weight.shape[-1] != rotation.shape[0]:
+            logger.warning(
+                "[spec_decode/quarot] Cannot align shared %s: draft=%s, target=%s, rotation=%s.",
+                label,
+                tuple(draft_weight.shape),
+                tuple(target_weight.shape),
+                tuple(rotation.shape),
+            )
+            return False
+
+        unrotated = torch.matmul(target_weight.data.to(torch.float32), rotation.T)
+        draft_weight.data.copy_(unrotated.to(draft_weight.dtype))
+        logger.info(
+            "[spec_decode/quarot] Copied and aligned shared %s (weight=%s).",
+            label,
+            tuple(draft_weight.shape),
+        )
+        return True
+
+    def _prepare_unrotated_shared_layer(
+        self,
+        draft_layer: nn.Module | None,
+        target_layer: nn.Module,
+        label: str,
+    ) -> nn.Module | None:
+        """Return a draft-owned unrotated layer for a QuaRot target."""
+        if getattr(self, "_quarot_rotation", None) is None:
+            return None
+        if draft_layer is None:
+            draft_layer = copy.deepcopy(target_layer)
+        if not self._copy_unrotated_shared_weight(draft_layer, target_layer, label):
+            raise ValueError(
+                f"QuaRot requires a compatible draft-owned {label}; refusing to alias the rotated target layer."
+            )
+        return draft_layer
+
+    @staticmethod
+    def _load_quarot_rotation(target_model_path: str) -> torch.Tensor | None:
+        """Load the global rotation when the target has a QuaRot descriptor."""
+        import json
+        from pathlib import Path
+
+        from safetensors.torch import load_file
+
+        descriptor_path = Path(target_model_path) / "quant_model_description.json"
+        if not descriptor_path.exists():
+            logger.info(
+                "[spec_decode/quarot] No descriptor found at %s; treating the target as non-QuaRot.",
+                descriptor_path,
+            )
+            return None
+        try:
+            with open(descriptor_path) as descriptor_file:
+                descriptor = json.load(descriptor_file)
+            relative_path = (
+                descriptor.get("optional", {})
+                .get("quarot", {})
+                .get("rotation_map", {})
+                .get("global_rotation", "optional/quarot.safetensors")
+            )
+        except (ValueError, OSError) as error:
+            logger.warning(
+                "[spec_decode/quarot] Failed to read %s (%s); skipping draft alignment.",
+                descriptor_path,
+                error,
+            )
+            return None
+
+        rotation_path = Path(target_model_path) / relative_path
+        if not rotation_path.exists():
+            logger.warning(
+                "[spec_decode/quarot] Rotation file %s is missing; skipping draft alignment.",
+                rotation_path,
+            )
+            return None
+        logger.info("[spec_decode/quarot] Loading global rotation from %s.", rotation_path)
+        try:
+            return load_file(rotation_path)["global_rotation"]
+        except Exception as error:
+            logger.warning(
+                "[spec_decode/quarot] Failed to load rotation %s: %s",
+                rotation_path,
+                error,
+            )
+            return None
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -289,6 +432,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         with self.maybe_eager_context:
             self.model = self._get_model()
+
+        self._maybe_anti_rotate_fc()
 
         # Find draft layers (attention layers added by draft model)
         all_attn_layers = get_layers_from_vllm_config(
@@ -360,6 +505,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self._maybe_share_embeddings(target_language_model)
         self._maybe_share_topk_indices(target_language_model)
         self._maybe_share_lm_head(model)
+        # The draft FC, embedding, and lm_head boundaries are now aligned.
+        # Release the temporary full-precision rotation before graph capture.
+        self._quarot_rotation = None
 
         if (
             self.parallel_drafting
@@ -444,9 +592,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     )
 
             if share_embeddings:
-                if hasattr(self.model.model, "embed_tokens"):
-                    del self.model.model.embed_tokens
-                self.model.model.embed_tokens = target_embed_tokens
+                draft_embed_tokens = getattr(self.model.model, "embed_tokens", None)
+                unrotated_embed_tokens = self._prepare_unrotated_shared_layer(
+                    draft_embed_tokens,
+                    target_embed_tokens,
+                    "draft embed_tokens.weight",
+                )
+                if unrotated_embed_tokens is not None:
+                    self.model.model.embed_tokens = unrotated_embed_tokens
+                    logger.info(
+                        "[spec_decode/quarot] Keeping a draft-owned aligned embedding instead of aliasing the target."
+                    )
+                else:
+                    if hasattr(self.model.model, "embed_tokens"):
+                        del self.model.model.embed_tokens
+                    self.model.model.embed_tokens = target_embed_tokens
         else:
             logger.info(
                 "[spec_decode/base] PP>1: draft model loaded its own vocab embedding"
@@ -481,17 +641,31 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
             else:
                 logger.info("[spec_decode/base] Loading EAGLE/DFLASH LM head weights from the target model.")
+                target_lm_head = None
                 if hasattr(model, "lm_head"):
-                    self.model.lm_head = model.lm_head
+                    target_lm_head = model.lm_head
                 elif hasattr(model, "get_language_model") and hasattr(model.get_language_model(), "lm_head"):
-                    self.model.lm_head = model.get_language_model().lm_head
-                else:
+                    target_lm_head = model.get_language_model().lm_head
+                if target_lm_head is None:
                     logger.warning(
                         "[spec_decode/base] Target model has no accessible lm_head"
                         " for sharing. Draft model will use its own lm_head."
                         " This may cause incorrect logits if the draft lm_head"
                         " is not trained."
                     )
+                else:
+                    unrotated_lm_head = self._prepare_unrotated_shared_layer(
+                        getattr(self.model, "lm_head", None),
+                        target_lm_head,
+                        "draft lm_head.weight",
+                    )
+                    if unrotated_lm_head is None:
+                        self.model.lm_head = target_lm_head
+                    else:
+                        self.model.lm_head = unrotated_lm_head
+                        logger.info(
+                            "[spec_decode/quarot] Keeping a draft-owned aligned lm_head instead of aliasing the target."
+                        )
 
         if self.method == "mtp" and self.vllm_config.model_config.is_deepseek_mla:
             for _, layer_module in self.model.model.layers.items():

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -49,6 +49,7 @@ from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.deepseek_v4_dspark import DSparkDeepseekV4ForCausalLM
+from vllm_ascend.models.kimi_k3_dspark import K3DSparkForCausalLM
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
@@ -768,6 +769,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     Eagle3VwnLlamaForCausalLM,
                     Eagle3DeepseekV2ForCausalLM,
                     DSparkDeepseekV4ForCausalLM,
+                    K3DSparkForCausalLM,
                 ),
             )
             target_hidden_states = self.model.combine_hidden_states(target_hidden_states)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -261,7 +261,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
 
     def _maybe_anti_rotate_fc(self) -> None:
-        """Align the draft FC input basis with a QuaRot target."""
+        """Align the draft hidden-state projection with a QuaRot target."""
         if self.method not in ("dflash", "dspark"):
             return
         target_model_path = self.vllm_config.model_config.model
@@ -275,28 +275,43 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         rotation = rotation.to(self.device, dtype=torch.float32)
         self._quarot_rotation = rotation
         draft_model = getattr(self.model, "model", None)
-        fc = getattr(draft_model, "fc", None) if draft_model is not None else None
-        if fc is None:
+        projection_name = "fc"
+        projection = getattr(draft_model, projection_name, None) if draft_model is not None else None
+        if projection is None:
+            # K3 MLA DSpark names the projection used by
+            # combine_hidden_states() context_proj instead of fc. Its input is
+            # the same concatenation of target auxiliary hidden states, so
+            # each target-width block needs the same QuaRot basis alignment.
+            projection_name = "context_proj"
+            projection = getattr(draft_model, projection_name, None) if draft_model is not None else None
+        if projection is None:
             return
 
-        fc_weight = fc.weight
-        out_features, in_features = fc_weight.shape
+        projection_weight = projection.weight
+        out_features, in_features = projection_weight.shape
         hidden_size = rotation.shape[0]
         if in_features % hidden_size != 0:
             logger.warning(
-                "[spec_decode/quarot] fc in_features=%d is not divisible by rotation dim=%d; skipping FC alignment.",
+                "[spec_decode/quarot] %s in_features=%d is not divisible by rotation dim=%d; "
+                "skipping hidden-state projection alignment.",
+                projection_name,
                 in_features,
                 hidden_size,
             )
             return
         num_features = in_features // hidden_size
-        fc_blocks = fc_weight.data.to(torch.float32).reshape(out_features, num_features, hidden_size)
-        aligned = torch.matmul(fc_blocks, rotation)
-        fc_weight.data.copy_(aligned.reshape(out_features, in_features).to(fc_weight.dtype))
-        logger.info(
-            "[spec_decode/quarot] Aligned draft fc.weight with target rotation (num_features=%d, fc=%s).",
+        projection_blocks = projection_weight.data.to(torch.float32).reshape(
+            out_features,
             num_features,
-            tuple(fc_weight.shape),
+            hidden_size,
+        )
+        aligned = torch.matmul(projection_blocks, rotation)
+        projection_weight.data.copy_(aligned.reshape(out_features, in_features).to(projection_weight.dtype))
+        logger.info(
+            "[spec_decode/quarot] Aligned draft %s.weight with target rotation (num_features=%d, projection=%s).",
+            projection_name,
+            num_features,
+            tuple(projection_weight.shape),
         )
 
     def _copy_unrotated_shared_weight(

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -339,6 +339,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         scheduler_output: SchedulerOutput = None,
         num_scheduled_tokens: int = 0,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
+        num_draft_tokens_cpu: list[int] | None = None,
     ) -> torch.Tensor:
         self._last_draft_probs = None
         batch_size = common_attn_metadata.batch_size()

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -81,36 +81,23 @@ def correct_optimistic_seq_lens_cpu(
 
 def build_parallel_draft_seq_lens_cpu(
     seq_lens_cpu: torch.Tensor,
-    num_draft_tokens: list[int] | None,
-    valid_sampled_token_count_cpu: torch.Tensor | None,
     num_reqs: int,
     query_len: int,
 ) -> torch.Tensor:
-    """Build exact FIA KV lengths for one parallel-draft pass on the CPU.
+    """Build optimistic FIA KV lengths for one parallel-draft pass on the CPU.
 
-    ``seq_lens_cpu`` contains the target pass's optimistic lengths. For a
-    padded speculative batch, subtract tokens rejected by target verification,
-    then include the parallel draft query block that will be written to cache.
-    The source tensor is never modified.
+    ``seq_lens_cpu`` contains the target pass's optimistic lengths (async mode
+    assumes all prior drafts accepted). Add the parallel draft query block that
+    will be written to cache. The post-rejection correction is deferred to the
+    FIA forward entry (``pending_reject_*`` on the attention metadata), where
+    the asynchronously-copied reject counts are synchronized and subtracted
+    from ``seq_lens_list``; this lets the accepted-token-count D2H overlap with
+    metadata build and the early draft forward instead of synchronizing in the
+    proposer. The source tensor is never modified.
     """
-    exact_seq_lens_cpu = seq_lens_cpu.clone()
-    if num_draft_tokens is not None:
-        assert valid_sampled_token_count_cpu is not None
-        drafts = torch.as_tensor(
-            num_draft_tokens[:num_reqs],
-            dtype=exact_seq_lens_cpu.dtype,
-        )
-        valid_counts = valid_sampled_token_count_cpu[:num_reqs].to(
-            dtype=exact_seq_lens_cpu.dtype,
-        )
-        rejected = torch.where(
-            drafts > 0,
-            drafts + 1 - valid_counts,
-            torch.zeros_like(drafts),
-        )
-        exact_seq_lens_cpu[:num_reqs].sub_(rejected)
-    exact_seq_lens_cpu[:num_reqs].add_(query_len)
-    return exact_seq_lens_cpu
+    out = seq_lens_cpu.clone()
+    out[:num_reqs].add_(query_len)
+    return out
 
 
 class SlidingWindowAdapter:

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -79,6 +79,40 @@ def correct_optimistic_seq_lens_cpu(
     optimistic_seq_lens_cpu_np[:num_reqs] -= correction.astype(optimistic_seq_lens_cpu_np.dtype, copy=False)
 
 
+def build_parallel_draft_seq_lens_cpu(
+    seq_lens_cpu: torch.Tensor,
+    num_draft_tokens: list[int] | None,
+    valid_sampled_token_count_cpu: torch.Tensor | None,
+    num_reqs: int,
+    query_len: int,
+) -> torch.Tensor:
+    """Build exact FIA KV lengths for one parallel-draft pass on the CPU.
+
+    ``seq_lens_cpu`` contains the target pass's optimistic lengths. For a
+    padded speculative batch, subtract tokens rejected by target verification,
+    then include the parallel draft query block that will be written to cache.
+    The source tensor is never modified.
+    """
+    exact_seq_lens_cpu = seq_lens_cpu.clone()
+    if num_draft_tokens is not None:
+        assert valid_sampled_token_count_cpu is not None
+        drafts = torch.as_tensor(
+            num_draft_tokens[:num_reqs],
+            dtype=exact_seq_lens_cpu.dtype,
+        )
+        valid_counts = valid_sampled_token_count_cpu[:num_reqs].to(
+            dtype=exact_seq_lens_cpu.dtype,
+        )
+        rejected = torch.where(
+            drafts > 0,
+            drafts + 1 - valid_counts,
+            torch.zeros_like(drafts),
+        )
+        exact_seq_lens_cpu[:num_reqs].sub_(rejected)
+    exact_seq_lens_cpu[:num_reqs].add_(query_len)
+    return exact_seq_lens_cpu
+
+
 class SlidingWindowAdapter:
     """
     Sliding-window draft attention for the draft model (EAGLE3 and DFlash).
@@ -164,7 +198,12 @@ class SlidingWindowAdapter:
 
         # update CPU mirrors: recompute from each one's own CPU tensor -> stays on CPU,
         # no D2H sync. numerically identical to the NPU
-        for name in ("seq_lens_cpu", "_seq_lens_cpu", "seq_lens_cpu_upper_bound"):
+        for name in (
+            "seq_lens_cpu",
+            "_seq_lens_cpu",
+            "seq_lens_cpu_upper_bound",
+            "parallel_draft_seq_lens_cpu",
+        ):
             src = getattr(common_attn_metadata, name, None)
             if src is not None:
                 _windowed_cpu = src - ((src + k_future - w).clamp(min=0) // b) * b

--- a/vllm_ascend/transformers_utils/configs/__init__.py
+++ b/vllm_ascend/transformers_utils/configs/__init__.py
@@ -15,9 +15,10 @@
 # This file is a part of the vllm-ascend project.
 
 from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    K3DSparkConfig,
     KimiK3Config,
     KimiK3TextConfig,
     KimiK3VisionConfig,
 )
 
-__all__ = ["KimiK3Config", "KimiK3TextConfig", "KimiK3VisionConfig"]
+__all__ = ["K3DSparkConfig", "KimiK3Config", "KimiK3TextConfig", "KimiK3VisionConfig"]

--- a/vllm_ascend/transformers_utils/configs/kimi_k3.py
+++ b/vllm_ascend/transformers_utils/configs/kimi_k3.py
@@ -27,6 +27,11 @@ from transformers.configuration_utils import PretrainedConfig
 from vllm.logger import logger
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
+K3_DSPARK_BLOCK_SIZE = 7
+K3_DSPARK_HIDDEN_ACT = "silu"
+K3_DSPARK_MAX_POSITION_EMBEDDINGS = 32768
+K3_DSPARK_USE_MLA_ROPE = True
+
 
 class KimiK3TextConfig(KimiLinearConfig):
     """Kimi linear-text configuration with the K3 extensions."""
@@ -56,6 +61,34 @@ class KimiK3TextConfig(KimiLinearConfig):
         self.activation_situ_linear_beta = activation_situ_linear_beta
         self.routed_expert_hidden_size = routed_expert_hidden_size
         self.topk_method = topk_method
+
+
+class K3DSparkConfig(PretrainedConfig):
+    """Configuration contract for Kimi K3 MLA DSpark checkpoints."""
+
+    model_type = "k3_dspark"
+
+    # These defaults are part of the released draft architecture. Keeping
+    # them on the concrete config class preserves direct attribute access even
+    # when older checkpoints omit the corresponding serialized fields.
+    block_size: int = K3_DSPARK_BLOCK_SIZE
+    max_position_embeddings: int = K3_DSPARK_MAX_POSITION_EMBEDDINGS
+
+    hidden_size: int
+    intermediate_size: int
+    kv_lora_rank: int
+    markov_rank: int
+    num_attention_heads: int
+    num_hidden_layers: int
+    num_target_layers: int
+    q_lora_rank: int
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    rms_norm_eps: float
+    rope_parameters: dict[str, Any]
+    target_hidden_size: int
+    v_head_dim: int
+    vocab_size: int
 
 
 class KimiK3VisionConfig(PretrainedConfig):
@@ -208,3 +241,13 @@ def register_kimi_k3_config() -> None:
 
     vllm_config_module._CONFIG_REGISTRY["kimi_k3"] = KimiK3Config
     AutoConfig.register("kimi_k3", KimiK3Config, exist_ok=True)
+    register_k3_dspark_config()
+
+
+def register_k3_dspark_config() -> None:
+    """Register the standalone K3 MLA DSpark draft configuration."""
+    from transformers import AutoConfig
+    from vllm.transformers_utils import config as vllm_config_module
+
+    vllm_config_module._CONFIG_REGISTRY["k3_dspark"] = K3DSparkConfig
+    AutoConfig.register("k3_dspark", K3DSparkConfig, exist_ok=True)

--- a/vllm_ascend/transformers_utils/configs/kimi_k3.py
+++ b/vllm_ascend/transformers_utils/configs/kimi_k3.py
@@ -21,13 +21,12 @@ plugin so loading a K3 checkpoint never depends on executing model code from
 the checkpoint repository.
 """
 
-from typing import Any
+from typing import Any, ClassVar
 
 from transformers.configuration_utils import PretrainedConfig
 from vllm.logger import logger
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
-K3_DSPARK_BLOCK_SIZE = 7
 K3_DSPARK_HIDDEN_ACT = "silu"
 K3_DSPARK_MAX_POSITION_EMBEDDINGS = 32768
 K3_DSPARK_USE_MLA_ROPE = True
@@ -67,11 +66,11 @@ class K3DSparkConfig(PretrainedConfig):
     """Configuration contract for Kimi K3 MLA DSpark checkpoints."""
 
     model_type = "k3_dspark"
+    has_no_defaults_at_init: ClassVar[bool] = True
 
-    # These defaults are part of the released draft architecture. Keeping
-    # them on the concrete config class preserves direct attribute access even
-    # when older checkpoints omit the corresponding serialized fields.
-    block_size: int = K3_DSPARK_BLOCK_SIZE
+    # This default is part of the released draft architecture. Keeping it on
+    # the concrete config class preserves direct attribute access when older
+    # checkpoints omit the corresponding serialized field.
     max_position_embeddings: int = K3_DSPARK_MAX_POSITION_EMBEDDINGS
 
     hidden_size: int

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1455,16 +1455,18 @@ class NPUModelRunner(GPUModelRunner):
         metadata build and the early draft forward instead of synchronizing in
         the proposer.
         """
-        if self.num_rejected_tokens_event is None:
+        event = self.num_rejected_tokens_event
+        copy_stream = self.num_rejected_tokens_copy_stream
+        counts_cpu = self.num_rejected_tokens_cpu
+        if event is None:
             return
+        assert copy_stream is not None and counts_cpu is not None
         default_stream = torch.npu.current_stream()
-        with torch.npu.stream(self.num_rejected_tokens_copy_stream):
-            self.num_rejected_tokens_copy_stream.wait_stream(default_stream)
+        with torch.npu.stream(copy_stream):
+            copy_stream.wait_stream(default_stream)
             n = num_rejected_tokens_gpu.shape[0]
-            self.num_rejected_tokens_cpu[:n].copy_(
-                num_rejected_tokens_gpu[:n], non_blocking=True
-            )
-            self.num_rejected_tokens_event.record()
+            counts_cpu[:n].copy_(num_rejected_tokens_gpu[:n], non_blocking=True)
+            event.record()
 
     def propose_draft_token_ids(
         self,
@@ -2980,6 +2982,7 @@ class NPUModelRunner(GPUModelRunner):
             common_ratio_to_sas_metadata: dict,
             ubid: int | None = None,
         ) -> None:
+            assert num_reqs_padded is not None
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
             is_gdn_noop = skip_gdn_state_update and isinstance(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1624,6 +1624,11 @@ class NPUModelRunner(GPUModelRunner):
                 scheduler_output=scheduler_output,
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                num_draft_tokens_cpu=(
+                    spec_decode_metadata.num_draft_tokens
+                    if num_rejected_tokens_gpu is not None
+                    else None
+                ),
             )
             if get_pp_group().world_size > 1 and hasattr(
                 self.drafter, "take_last_draft_probs"

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -376,6 +376,12 @@ class NPUModelRunner(GPUModelRunner):
         )
 
         # reinit valid_sampled_token_count_cpu with torch.int64 dtype
+        # Declared unconditionally so the call site / method can guard with
+        # ``is None`` without AttributeError on the non-async path (the real
+        # stream/event/buffer are created only when async spec decode is on).
+        self.num_rejected_tokens_cpu: torch.Tensor | None = None
+        self.num_rejected_tokens_event: torch.npu.Event | None = None
+        self.num_rejected_tokens_copy_stream = None
         if self.use_async_scheduling and self.num_spec_tokens:
             self.valid_sampled_token_count_cpu = torch.empty(
                 self.max_num_reqs,
@@ -383,6 +389,19 @@ class NPUModelRunner(GPUModelRunner):
                 device="cpu",
                 pin_memory=self.pin_memory,
             )
+            # Side-stream host mirror of num_rejected_tokens_gpu (int32 to match
+            # the device tensor produced by prepare_inputs_padded). The draft
+            # FIA forward entry synchronizes this copy before subtracting the
+            # per-request reject count from seq_lens_list, overlapping the D2H
+            # with metadata build and the early draft forward.
+            self.num_rejected_tokens_cpu = torch.empty(
+                self.max_num_reqs,
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=self.pin_memory,
+            )
+            self.num_rejected_tokens_event = torch.npu.Event()
+            self.num_rejected_tokens_copy_stream = torch.npu.Stream()
 
         try:
             self.dcp_size = get_dcp_group().world_size
@@ -1426,6 +1445,27 @@ class NPUModelRunner(GPUModelRunner):
             self.valid_sampled_token_count_gpu = valid_sampled_tokens_count # type: ignore[no-redef]
         self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
 
+    def _copy_num_rejected_tokens(self, num_rejected_tokens_gpu: torch.Tensor) -> None:
+        """Async D2H the per-request reject counts onto a side stream.
+
+        Mirrors ``_copy_valid_sampled_token_count``: copy the device tensor into
+        a pinned host buffer on a side stream that waits on the default stream,
+        then record an event. The draft FIA forward entry synchronizes that
+        event before reading the host buffer, so the copy overlaps with draft
+        metadata build and the early draft forward instead of synchronizing in
+        the proposer.
+        """
+        if self.num_rejected_tokens_event is None:
+            return
+        default_stream = torch.npu.current_stream()
+        with torch.npu.stream(self.num_rejected_tokens_copy_stream):
+            self.num_rejected_tokens_copy_stream.wait_stream(default_stream)
+            n = num_rejected_tokens_gpu.shape[0]
+            self.num_rejected_tokens_cpu[:n].copy_(
+                num_rejected_tokens_gpu[:n], non_blocking=True
+            )
+            self.num_rejected_tokens_event.record()
+
     def propose_draft_token_ids(
         self,
         valid_sampled_token_ids: torch.Tensor | list[list[int]],
@@ -1601,6 +1641,8 @@ class NPUModelRunner(GPUModelRunner):
                             common_attn_metadata, spec_decode_metadata, valid_sampled_tokens_count
                         )
                     )
+                if num_rejected_tokens_gpu is not None and self.num_rejected_tokens_event is not None:
+                    self._copy_num_rejected_tokens(num_rejected_tokens_gpu)
                 target_token_ids = self.input_ids.gpu[token_indices]
                 target_positions = self._get_positions(token_indices)
                 if self.use_aux_hidden_state_outputs:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1825,7 +1825,7 @@ class NPUModelRunner(GPUModelRunner):
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
                         # is called into to avoid out of sync issues.
-                        self._dummy_run(1)
+                        self._dummy_run(1, skip_gdn_state_update=True)
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT
@@ -2794,6 +2794,7 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -2939,12 +2940,37 @@ class NPUModelRunner(GPUModelRunner):
         ) -> None:
             attn_group = self.attn_groups[kv_cache_gid][attn_gid]
             builder = attn_group.get_metadata_builder(ubid or 0)
+            is_gdn_noop = skip_gdn_state_update and isinstance(
+                builder,
+                GDNAttentionMetadataBuilder,
+            )
+            if is_gdn_noop:
+                # An idle DP dummy has a real tensor shape for model and
+                # collective execution, but no GDN tokens.  Keep the GDN
+                # query lengths at zero and make the host-side token count
+                # agree so the builder refreshes both captured recurrent
+                # branches without classifying the dummy as spec decode.
+                common_attn_metadata = common_attn_metadata.replace(
+                    query_start_loc=self.gdn_query_start_loc.gpu[
+                        : num_reqs_padded + 1
+                    ],
+                    query_start_loc_cpu=self.gdn_query_start_loc.cpu[
+                        : num_reqs_padded + 1
+                    ],
+                    num_actual_tokens=0,
+                    max_query_len=0,
+                    is_prefilling=(
+                        torch.zeros_like(common_attn_metadata.is_prefilling)
+                        if common_attn_metadata.is_prefilling is not None
+                        else None
+                    ),
+                )
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid] if cascade_attn_prefix_lens else 0
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder):
+            if use_spec_decode and isinstance(builder, GDNAttentionMetadataBuilder) and not is_gdn_noop:
                 assert ubid is None, "UBatching not supported with GDN yet"
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
@@ -3111,6 +3137,7 @@ class NPUModelRunner(GPUModelRunner):
         num_active_loras: int = 0,
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
+        skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3249,7 +3276,10 @@ class NPUModelRunner(GPUModelRunner):
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                 self.query_start_loc.copy_to_gpu()
                 if self._has_gdn:
-                    self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
+                    if skip_gdn_state_update:
+                        self.gdn_query_start_loc.np.fill(0)
+                    else:
+                        self.gdn_query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
                     self.gdn_query_start_loc.copy_to_gpu()
 
                 if not profile_cpp:
@@ -3281,6 +3311,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    skip_gdn_state_update=skip_gdn_state_update,
                 )
                 if not is_graph_capturing:
                     for kv_cache_gid in range(len(self.kv_cache_config.kv_cache_groups)):

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -983,7 +983,11 @@ class NPUWorker(WorkerBase):
     def execute_dummy_batch(self) -> None:
         self.log_memory_stats()
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
-        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        self.model_runner._dummy_run(
+            num_tokens,
+            uniform_decode=True,
+            skip_gdn_state_update=True,
+        )
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
## What this PR does / why we need it?

Adds the Kimi-K3 dense **MLA** draft model for **DSpark** speculative decoding
on Ascend, together with the correctness and asynchronous-scheduling fixes
required by MLA DSpark, Prefix Cache, ACLGraph, P/D, and QuaRot serving. The
target branch is `releases/v0.26.0rc`, on top of the Kimi-K3 support from
#12950.

This is deliberately an **MLA-only** PR:

- Kimi-K3 **GQA DSpark is out of scope**. The patch does not change the
  ordinary attention backend for GQA drafting.
- The Kimi-K3 **four-plane cache layout is out of scope**. Its implementation
  and history are absent from the rewritten branch.
- `vllm_ascend/attention/attention_v1.py` and its focused A2 unit test are
  unchanged from the release baseline.

The low-level MLA preprocess RoPE switch is already supplied by release PR
#13467, so this PR does not duplicate its C++ operator changes.

### Commit layout

| Commit | Scope |
|---|---|
| `069f3ee52` | Backport the net stateful GDN graph-replay fixes from #12027 and #12255, including the 310P path, without restoring their reverted ModelRunner approach. |
| `756a328fe` | Add the Ascend Triton fused norm-gate path used by Kimi-K3 sigmoid gating and focused A2 coverage. |
| `64a223a10` | Add and register `K3DSparkModel` / `K3DSparkForCausalLM`, MLA draft KV mapping, YaRN metadata, non-causal draft attention, and release-baseline proposer compatibility. |
| `9e91bd2bc` | Keep shared DSpark boundary weights in the correct coordinate space for QuaRot targets and fail closed on incompatible shapes. |
| `e9181131d` | Release the native KDA workspace event on the empty-Vnew return path. |
| `1f84ddedb` | Reset stale speculative state inputs before full-graph replay. |
| `20f7bb3c3` | Reconstruct exact MLA draft FIA KV lengths on the host and remove the early device `Tensor.tolist()` synchronization. |
| `46d2c0fd3` | Align the Step3.5 proposer override with the release interface. |
| `90697a039` | Trim Prefix Cache hits consistently across all full-attention groups. |
| `ceccb99ce` | Preserve producer-side Mamba Prefix Cache hits for P/D scheduling. |
| `3cd7136db` | Give idle dummy graph runs zero sequence length so GDN conv/KDA state updates are skipped. |
| `82ca7b4c5` | Defer rejected-token synchronization to the first MLA draft attention instead of blocking earlier in the proposer. |
| `be4dfdb69` | Align the five K3 MLA `context_proj` auxiliary hidden-state blocks with the target QuaRot basis. |
| `4fd628914` | Fix pre-commit mypy by narrowing optional rejected-token copy resources and the padded request count without changing runtime flow. |
| `214a56771` | Preserve the narrowed `ast.BoolOp` type in the balance-schedule AST test while keeping `generic_visit` behavior unchanged. |
| `840fe0dda` | Update the A2 Eagle proposer signature contract for the new draft-token host metadata parameter. |

## Does this PR introduce _any_ user-facing change?

Yes. Kimi-K3 can use an MLA DSpark draft model on Ascend in colocated and P/D
serving, including Prefix Cache, ACLGraph `FULL_DECODE_ONLY`, asynchronous
scheduling, and QuaRot targets. This PR intentionally does not add Kimi-K3 GQA
DSpark or the former four-plane cache layout.

## How was this patch tested?

### Focused unit and source checks

- `tests/ut/models/test_kimi_k3_dspark.py` and
  `tests/ut/spec_decode/test_dspark_proposer.py`: **33 passed** on Ascend A3.
- Ruff format/check, codespell, typos, clang-format, Markdown/workflow/shell
  lint, Python compile checks, and `git diff --check`: passed.
- The local validation environment lacks the gitleaks bootstrap dependency, so
  the gitleaks hook is left to GitHub CI.
- The ordinary GQA attention implementation and focused test match
  `releases/v0.26.0rc`; no four-plane layout symbols remain in the patch.

### Fast MLA functional validation at rewritten head

Validated commit: `be4dfdb69a9292b3aea38aa0dfcd51644cee7711`.

The smoke target used a reduced 16-expert Kimi-K3 W4A8 checkpoint and an MLA
DSpark draft checkpoint, with TP16, Prefix Cache enabled, asynchronous
scheduling enabled by default, and ACLGraph `FULL_DECODE_ONLY` at capture size
16.

#### Colocated

- 6/6 smoke requests completed: identity, GSM8K, two shared-prefix requests,
  and two concurrent requests.
- 38 draft steps, 266 draft tokens, 106 accepted tokens: **39.85%** per-token
  acceptance.
- Prefix Cache: 5,893 queried tokens, 1,920 hits.

#### Disaggregated prefill/decode

- 6/6 smoke requests completed through one producer, one consumer, and the
  standard load-balancing proxy.
- Consumer logs recorded real Mooncake KV transfers across TP ranks.
- Consumer: 37 draft steps, 259 draft tokens, 108 accepted tokens: **41.70%**
  per-token acceptance.
- Consumer external Prefix Cache: 3,973 queried tokens, 3,967 hits.

Both modes completed without a request traceback, transfer error, literal
`None`, replacement-character output, or binary/mojibake corruption. The
reduced 16-expert checkpoint is a feature-path smoke target, not a semantic
accuracy gate; full-checkpoint answer quality is therefore not inferred from
this run. All validation services and the proxy were stopped afterward.

Made with [Cursor](https://cursor.com)

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
