### PR TITLE
[BugFix][Core] Truncate all full-attention groups

### DIFF
--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -7,6 +7,7 @@ from math import lcm
 import vllm
 import vllm.envs as envs_vllm
 import vllm.v1.core.kv_cache_coordinator as vllm_kv_cache_coordinator
+from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_coordinator import (
     HybridKVCacheCoordinator,
@@ -340,9 +341,13 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         # have prefix cache block hit.
         # Due to slidingwindow attn, deepseek-v4 decode node can't have
         # any prefix cache hit, because `hit_length` of SWA is 0.
-        spec, group_ids, _ = self.attention_groups[0]
-        if isinstance(spec, FullAttentionSpec):
-            num_blocks = hit_length // self._get_effective_block_size(spec)
+        for spec, group_ids, _ in self.attention_groups:
+            if not isinstance(spec, FullAttentionSpec):
+                continue
+            num_blocks = cdiv(
+                hit_length,
+                self._get_effective_block_size(spec),
+            )
             for group_id in group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]


### PR DESCRIPTION
### What this PR does / why we need it?

Backports the full-attention-group truncation fix from #12761 to `releases/v0.23.0`.

DeepSeek-V4 has two full-attention groups, C4 and C128. The release branch currently truncates only the first group after hybrid cache-hit reconciliation, which can leave C128 prefix-cache blocks beyond the final `hit_length`. This change iterates over every full-attention group and truncates it using that group's effective block size.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-V4 hybrid prefix-cache lookup no longer retains full-attention blocks beyond the final reconciled cache-hit length.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
