### PR TITLE
feat(tokenization): port LoPT to RFC vLLM CANN

### DIFF
--- a/tests/ut/patch/platform/test_patch_lopt_tokenization.py
+++ b/tests/ut/patch/platform/test_patch_lopt_tokenization.py
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import vllm_ascend.patch.platform.patch_lopt_tokenization as lopt_patch
+
+
+class _Params:
+    @staticmethod
+    def get_encode_kwargs() -> dict[str, Any]:
+        return {"add_special_tokens": False}
+
+
+class _FakeLopt:
+    def __init__(self, usable: bool = True) -> None:
+        self.usable = usable
+        self.encoded_texts: list[str] = []
+
+    def can_use(self, text: str, encode_kwargs: dict[str, Any]) -> bool:
+        return self.usable
+
+    def encode(self, text: str, **encode_kwargs: Any) -> list[int]:
+        self.encoded_texts.append(text)
+        return [11, 12, 13]
+
+
+def test_attach_lopt_to_deepseek_v4_compatible_renderer(monkeypatch: pytest.MonkeyPatch) -> None:
+    tokenizer = SimpleNamespace(is_fast=True)
+    renderer = SimpleNamespace(tokenizer=tokenizer, mm_processor=None)
+    expected_lopt = object()
+
+    monkeypatch.setattr(
+        lopt_patch,
+        "_config_from_env",
+        lambda: SimpleNamespace(thread_workers=4),
+    )
+    monkeypatch.setattr(lopt_patch, "maybe_make_thread_pool", lambda tokenizer, copies: tokenizer)
+    monkeypatch.setattr(lopt_patch, "LosslessParallelTokenizer", lambda tokenizer, config: expected_lopt)
+
+    lopt_patch._attach_lopt(renderer)
+
+    assert renderer._ascend_lopt_tokenizer is expected_lopt
+
+
+@pytest.mark.parametrize(
+    ("tokenizer", "mm_processor"),
+    [
+        (None, None),
+        (SimpleNamespace(is_fast=False), None),
+        (SimpleNamespace(is_fast=True), object()),
+    ],
+)
+def test_attach_lopt_skips_unsupported_renderer(tokenizer: Any, mm_processor: Any) -> None:
+    renderer = SimpleNamespace(tokenizer=tokenizer, mm_processor=mm_processor)
+
+    lopt_patch._attach_lopt(renderer)
+
+    assert not hasattr(renderer, "_ascend_lopt_tokenizer")
+
+
+def test_deepseek_v4_sync_tokenization_uses_lopt() -> None:
+    lopt = _FakeLopt()
+    renderer = SimpleNamespace(_ascend_lopt_tokenizer=lopt)
+
+    result = lopt_patch._patched_deepseek_v4_renderer_tokenize_prompt(
+        renderer,
+        {"prompt": "a sufficiently long prompt"},
+        _Params(),
+    )
+
+    assert result["prompt_token_ids"] == [11, 12, 13]
+    assert lopt.encoded_texts == ["a sufficiently long prompt"]
+
+
+def test_deepseek_v4_async_tokenization_uses_lopt() -> None:
+    lopt = _FakeLopt()
+    renderer = SimpleNamespace(_ascend_lopt_tokenizer=lopt, _executor=None)
+
+    result = asyncio.run(
+        lopt_patch._patched_deepseek_v4_renderer_tokenize_prompt_async(
+            renderer,
+            {"prompt": "a sufficiently long prompt"},
+            _Params(),
+        )
+    )
+
+    assert result["prompt_token_ids"] == [11, 12, 13]
+    assert lopt.encoded_texts == ["a sufficiently long prompt"]
+
+
+def test_deepseek_v4_async_tokenization_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    lopt = _FakeLopt(usable=False)
+    renderer = SimpleNamespace(_ascend_lopt_tokenizer=lopt, _executor=None)
+    fallback_result = {"prompt": "short", "prompt_token_ids": [99]}
+
+    async def fallback(renderer, prompt, params):
+        return fallback_result
+
+    monkeypatch.setattr(lopt_patch, "_original_deepseek_v4_renderer_tokenize_prompt_async", fallback)
+
+    result = asyncio.run(
+        lopt_patch._patched_deepseek_v4_renderer_tokenize_prompt_async(
+            renderer,
+            {"prompt": "short"},
+            _Params(),
+        )
+    )
+
+    assert result is fallback_result
+    assert lopt.encoded_texts == []

--- a/tests/ut/tokenization/test_lopt_tokenizer.py
+++ b/tests/ut/tokenization/test_lopt_tokenizer.py
@@ -1,0 +1,625 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import vllm_ascend.tokenization.lopt_tokenizer as lopt_tokenizer_module
+from vllm_ascend.tokenization.lopt_tokenizer import (
+    ChunkEncoding,
+    LoptConfig,
+    LosslessParallelTokenizer,
+    _encode_chunk,
+    _find_position_overlap,
+    _merge_chunk_encodings,
+    _merge_chunk_token_ids,
+    _split_overlapping,
+)
+
+
+class CharacterTokenizer:
+    is_fast = True
+    truncation_side = "right"
+    bos_token_id = 1
+    eos_token_id = 2
+
+    def __init__(self) -> None:
+        self.chunk_call_count = 0
+
+    @staticmethod
+    def _content(text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        return [ord(char) + 10 for char in text], [(index, index + 1) for index in range(len(text))]
+
+    def __call__(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        self.chunk_call_count += 1
+        token_ids, offsets = self._content(text)
+        return {"input_ids": token_ids, "offset_mapping": offsets}
+
+    def prepare_for_model(
+        self,
+        token_ids: list[int],
+        *,
+        add_special_tokens: bool,
+        truncation: bool,
+        max_length: int | None,
+        **kwargs: Any,
+    ) -> dict[str, list[int]]:
+        ids = list(token_ids)
+        special_count = 2 if add_special_tokens else 0
+        if truncation and max_length is not None:
+            content_length = max(0, max_length - special_count)
+            ids = ids[-content_length:] if self.truncation_side == "left" else ids[:content_length]
+        if add_special_tokens:
+            ids = [self.bos_token_id, *ids, self.eos_token_id]
+        return {"input_ids": ids}
+
+    def encode(self, text: str, **kwargs: Any) -> list[int]:
+        token_ids, _ = self._content(text)
+        return self.prepare_for_model(token_ids, **kwargs)["input_ids"]
+
+
+class TokenizersBackendLikeTokenizer(CharacterTokenizer):
+    """Fast-tokenizer stub without the Transformers v4 post-processing API."""
+
+    prepare_for_model = None
+
+    def encode(self, text: str, **kwargs: Any) -> list[int]:
+        ids, _ = self._content(text)
+        add_special_tokens = bool(kwargs.get("add_special_tokens", True))
+        truncation = bool(kwargs.get("truncation", False))
+        max_length = kwargs.get("max_length")
+
+        if truncation and isinstance(max_length, int) and not isinstance(max_length, bool):
+            special_count = 2 if add_special_tokens else 0
+            content_length = max(0, max_length - special_count)
+            if len(ids) > content_length:
+                if self.truncation_side == "left":
+                    ids = ids[len(ids) - content_length :]
+                else:
+                    ids = ids[:content_length]
+        if add_special_tokens:
+            ids = [self.bos_token_id, *ids, self.eos_token_id]
+        return ids
+
+
+class PairTokenizer(CharacterTokenizer):
+    @staticmethod
+    def _content(text: str) -> tuple[list[int], list[tuple[int, int]]]:
+        token_ids: list[int] = []
+        offsets: list[tuple[int, int]] = []
+        for start in range(0, len(text), 2):
+            piece = text[start : start + 2]
+            token_ids.append(sum((index + 1) * ord(char) for index, char in enumerate(piece)) + 10)
+            offsets.append((start, start + len(piece)))
+        return token_ids, offsets
+
+
+class FailingOffsetTokenizer(CharacterTokenizer):
+    def __call__(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("offset mapping unavailable")
+
+
+class InvalidOffsetTokenizer(CharacterTokenizer):
+    def __call__(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        token_ids, offsets = self._content(text)
+        offsets[-1] = (len(text), len(text) + 1)
+        return {"input_ids": token_ids, "offset_mapping": offsets}
+
+
+class IncompatibleSpecialTokenizer(CharacterTokenizer):
+    def encode(self, text: str, **kwargs: Any) -> list[int]:
+        token_ids, _ = self._content(text)
+        if kwargs.get("add_special_tokens", True):
+            return [101, *token_ids, 102]
+        return token_ids
+
+
+class ConcurrentTokenizer(CharacterTokenizer):
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self._active = 0
+        self.max_active = 0
+
+    def __call__(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        with self._lock:
+            self._active += 1
+            self.max_active = max(self.max_active, self._active)
+        try:
+            time.sleep(0.02)
+            return super().__call__(text, **kwargs)
+        finally:
+            with self._lock:
+                self._active -= 1
+
+
+class BatchTokenizer(CharacterTokenizer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_call_count = 0
+
+    def __call__(self, text: str | list[str], **kwargs: Any) -> dict[str, Any]:
+        if isinstance(text, str):
+            return super().__call__(text, **kwargs)
+
+        self.batch_call_count += 1
+        encodings = [super(BatchTokenizer, self).__call__(item, **kwargs) for item in text]
+        return {
+            "input_ids": [encoding["input_ids"] for encoding in encodings],
+            "offset_mapping": [encoding["offset_mapping"] for encoding in encodings],
+        }
+
+
+class ChunkMismatchTokenizer(CharacterTokenizer):
+    def __call__(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        result = super().__call__(text, **kwargs)
+        if len(text) <= 6 and result["input_ids"]:
+            result["input_ids"][0] += 1
+        return result
+
+
+def make_config(**kwargs: Any) -> LoptConfig:
+    values = {
+        "enabled": True,
+        "thread_workers": 4,
+        "min_chars": 1,
+        "chunk_chars": 4,
+        "overlap_chars": 2,
+        "min_match_tokens": 2,
+        "max_retries": 2,
+        "verify": False,
+    }
+    values.update(kwargs)
+    return LoptConfig(**values)
+
+
+def encode_kwargs(**kwargs: Any) -> dict[str, Any]:
+    values = {"add_special_tokens": True, "truncation": False, "max_length": None}
+    values.update(kwargs)
+    return values
+
+
+def test_split_overlapping_uses_global_character_coordinates():
+    chunks = _split_overlapping("abcdefghij", chunk_chars=4, overlap_chars=2)
+
+    assert [(chunk.index, chunk.global_start, chunk.global_end, chunk.text) for chunk in chunks] == [
+        (0, 0, 6, "abcdef"),
+        (1, 4, 10, "efghij"),
+        (2, 8, 10, "ij"),
+    ]
+
+
+def test_encode_chunk_converts_unicode_offsets_to_global_coordinates():
+    tokenizer = CharacterTokenizer()
+    chunk = _split_overlapping("前缀🙂中文", chunk_chars=3, overlap_chars=2)[1]
+
+    encoding = _encode_chunk(tokenizer, chunk)
+
+    assert encoding.local_offsets == ((0, 1), (1, 2))
+    assert encoding.global_offsets == ((3, 4), (4, 5))
+
+
+def test_position_match_uses_offsets_instead_of_repeated_token_ids():
+    left = ChunkEncoding(
+        index=0,
+        global_start=0,
+        global_end=8,
+        token_ids=(7, 7, 7, 7, 7, 7, 7, 7),
+        local_offsets=tuple((index, index + 1) for index in range(8)),
+        global_offsets=tuple((index, index + 1) for index in range(8)),
+    )
+    right = ChunkEncoding(
+        index=1,
+        global_start=5,
+        global_end=10,
+        token_ids=(7, 7, 7, 7, 7),
+        local_offsets=tuple((index, index + 1) for index in range(5)),
+        global_offsets=tuple((index + 5, index + 6) for index in range(5)),
+    )
+
+    match = _find_position_overlap(left, right, min_match_tokens=2)
+
+    assert match is not None
+    assert (match.left_start, match.right_start, match.token_count) == (5, 0, 3)
+
+
+def test_position_match_supports_multiple_byte_tokens_with_the_same_character_offset():
+    left = ChunkEncoding(
+        index=0,
+        global_start=0,
+        global_end=4,
+        token_ids=(1, 20, 21, 30),
+        local_offsets=((0, 1), (2, 3), (2, 3), (3, 4)),
+        global_offsets=((0, 1), (2, 3), (2, 3), (3, 4)),
+    )
+    right = ChunkEncoding(
+        index=1,
+        global_start=2,
+        global_end=6,
+        token_ids=(20, 21, 30, 40),
+        local_offsets=((0, 1), (0, 1), (1, 2), (3, 4)),
+        global_offsets=((2, 3), (2, 3), (3, 4), (5, 6)),
+    )
+
+    match = _find_position_overlap(left, right, min_match_tokens=2)
+
+    assert match is not None
+    assert (match.left_start, match.right_start, match.token_count) == (1, 0, 3)
+
+
+def test_position_match_keeps_longest_run_after_earlier_run_stops():
+    offsets = tuple((index, index + 1) for index in range(6))
+    left = ChunkEncoding(
+        index=0,
+        global_start=0,
+        global_end=6,
+        token_ids=(10, 20, 30, 40, 50, 60),
+        local_offsets=offsets,
+        global_offsets=offsets,
+    )
+    right = ChunkEncoding(
+        index=1,
+        global_start=0,
+        global_end=6,
+        token_ids=(10, 99, 30, 40, 50, 98),
+        local_offsets=offsets,
+        global_offsets=offsets,
+    )
+
+    match = _find_position_overlap(left, right, min_match_tokens=2)
+
+    assert match is not None
+    assert (match.left_start, match.right_start, match.token_count) == (2, 2, 3)
+
+
+def test_position_match_does_not_reexpand_matched_suffixes(monkeypatch):
+    token_count = 100
+    offsets = tuple((index, index + 1) for index in range(token_count))
+    left = ChunkEncoding(
+        index=0,
+        global_start=0,
+        global_end=token_count,
+        token_ids=tuple(range(token_count)),
+        local_offsets=offsets,
+        global_offsets=offsets,
+    )
+    right = ChunkEncoding(
+        index=1,
+        global_start=0,
+        global_end=token_count,
+        token_ids=tuple(range(token_count)),
+        local_offsets=offsets,
+        global_offsets=offsets,
+    )
+    original_record = lopt_tokenizer_module._record
+    left_record_calls = 0
+
+    def tracking_record(encoding: ChunkEncoding, index: int) -> tuple[int, int, int]:
+        nonlocal left_record_calls
+        if encoding is left:
+            left_record_calls += 1
+        return original_record(encoding, index)
+
+    monkeypatch.setattr(lopt_tokenizer_module, "_record", tracking_record)
+
+    match = _find_position_overlap(left, right, min_match_tokens=2)
+
+    assert match is not None
+    assert match.token_count == token_count
+    assert left_record_calls <= token_count * 2
+
+
+def test_position_match_does_not_scan_tokens_before_overlap(monkeypatch):
+    left_token_count = 1_000
+    overlap_start = 997
+    right_token_count = 6
+    left = ChunkEncoding(
+        index=0,
+        global_start=0,
+        global_end=left_token_count,
+        token_ids=tuple(range(left_token_count)),
+        local_offsets=tuple((index, index + 1) for index in range(left_token_count)),
+        global_offsets=tuple((index, index + 1) for index in range(left_token_count)),
+    )
+    right = ChunkEncoding(
+        index=1,
+        global_start=overlap_start,
+        global_end=overlap_start + right_token_count,
+        token_ids=tuple(range(overlap_start, overlap_start + right_token_count)),
+        local_offsets=tuple((index, index + 1) for index in range(right_token_count)),
+        global_offsets=tuple(
+            (index, index + 1) for index in range(overlap_start, overlap_start + right_token_count)
+        ),
+    )
+    original_record = lopt_tokenizer_module._record
+    visited_left_indices: list[int] = []
+
+    def tracking_record(encoding: ChunkEncoding, index: int) -> tuple[int, int, int]:
+        if encoding is left:
+            visited_left_indices.append(index)
+        return original_record(encoding, index)
+
+    monkeypatch.setattr(lopt_tokenizer_module, "_record", tracking_record)
+
+    match = _find_position_overlap(left, right, min_match_tokens=2)
+
+    assert match is not None
+    assert (match.left_start, match.right_start, match.token_count) == (overlap_start, 0, 3)
+    assert visited_left_indices
+    assert min(visited_left_indices) >= overlap_start
+
+
+def test_merge_chunk_encodings_reuses_mutable_buffers(monkeypatch):
+    encodings = [
+        ChunkEncoding(
+            index=chunk_index,
+            global_start=start,
+            global_end=end,
+            token_ids=tuple(range(start, end)),
+            local_offsets=tuple((index, index + 1) for index in range(end - start)),
+            global_offsets=tuple((index, index + 1) for index in range(start, end)),
+        )
+        for chunk_index, start, end in ((0, 10, 16), (1, 14, 20), (2, 18, 22))
+    ]
+    original_merge_pair_into = lopt_tokenizer_module._merge_pair_into
+    token_buffer_ids: list[int] = []
+    offset_buffer_ids: list[int] = []
+
+    def tracking_merge_pair_into(merged, right, min_match_tokens):
+        token_buffer_ids.append(id(merged.token_ids))
+        offset_buffer_ids.append(id(merged.global_offsets))
+        original_merge_pair_into(merged, right, min_match_tokens)
+        assert id(merged.token_ids) == token_buffer_ids[-1]
+        assert id(merged.global_offsets) == offset_buffer_ids[-1]
+
+    monkeypatch.setattr(lopt_tokenizer_module, "_merge_pair_into", tracking_merge_pair_into)
+
+    merged = _merge_chunk_encodings(encodings, min_match_tokens=2)
+
+    assert merged.token_ids == tuple(range(10, 22))
+    assert merged.global_offsets == tuple((index, index + 1) for index in range(10, 22))
+    assert merged.local_offsets == tuple((index, index + 1) for index in range(12))
+    assert len(set(token_buffer_ids)) == 1
+    assert len(set(offset_buffer_ids)) == 1
+
+
+def test_direct_token_merge_matches_full_position_aware_merge():
+    encodings = [
+        ChunkEncoding(
+            index=chunk_index,
+            global_start=start,
+            global_end=end,
+            token_ids=tuple(range(start, end)),
+            local_offsets=tuple((index, index + 1) for index in range(end - start)),
+            global_offsets=tuple((index, index + 1) for index in range(start, end)),
+        )
+        for chunk_index, start, end in ((0, 10, 16), (1, 14, 20), (2, 18, 22))
+    ]
+
+    expected = _merge_chunk_encodings(encodings, min_match_tokens=2)
+    actual = _merge_chunk_token_ids(encodings, min_match_tokens=2)
+
+    assert actual == list(expected.token_ids)
+
+
+def test_lossless_merge_matches_standard_tokenization_for_unicode_and_repetition():
+    tokenizer = CharacterTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config())
+    text = "中文🙂abcabc   e\u0301" * 4
+
+    try:
+        actual = lopt.encode(text, **encode_kwargs())
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **encode_kwargs())
+
+
+def test_special_tokens_and_truncation_are_applied_once_after_merge():
+    tokenizer = CharacterTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config())
+    text = "abcdefghijklmnop"
+    kwargs = encode_kwargs(truncation=True, max_length=9)
+
+    try:
+        actual = lopt.encode(text, **kwargs)
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **kwargs)
+    assert actual[0] == tokenizer.bos_token_id
+    assert actual[-1] == tokenizer.eos_token_id
+    assert actual.count(tokenizer.bos_token_id) == 1
+    assert actual.count(tokenizer.eos_token_id) == 1
+
+
+@pytest.mark.parametrize(
+    ("truncation_side", "max_length"),
+    [("right", 5), ("left", 5), ("right", 0), ("left", 0)],
+)
+def test_truncation_without_special_tokens_does_not_require_prepare_for_model(
+    truncation_side: str,
+    max_length: int,
+):
+    tokenizer = TokenizersBackendLikeTokenizer()
+    tokenizer.truncation_side = truncation_side
+    lopt = LosslessParallelTokenizer(tokenizer, make_config())
+    text = "abcdefghijklmnop"
+    kwargs = encode_kwargs(
+        add_special_tokens=False,
+        truncation=True,
+        max_length=max_length,
+    )
+
+    try:
+        actual = lopt.encode(text, **kwargs)
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **kwargs)
+    assert tokenizer.chunk_call_count > 0
+
+
+def test_truncation_with_special_tokens_still_requires_prepare_for_model():
+    tokenizer = TokenizersBackendLikeTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config())
+    text = "abcdefghijklmnop"
+    kwargs = encode_kwargs(truncation=True, max_length=9)
+
+    try:
+        assert not lopt.can_use(text, kwargs)
+        actual = lopt.encode(text, **kwargs)
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **kwargs)
+    assert tokenizer.chunk_call_count == 0
+
+
+def test_dynamic_chunk_retry_recovers_from_boundary_phase_mismatch():
+    tokenizer = PairTokenizer()
+    config = make_config(chunk_chars=3, overlap_chars=3, min_match_tokens=1)
+    lopt = LosslessParallelTokenizer(tokenizer, config)
+    text = "abcdefghijklmnopqrstuvwxyz"
+    kwargs = encode_kwargs(add_special_tokens=False)
+
+    try:
+        actual, attempts, _ = lopt._encode_with_retries(text, kwargs)
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **kwargs)
+    assert attempts == 2
+    assert tokenizer.chunk_call_count > len(_split_overlapping(text, 3, 3))
+
+
+@pytest.mark.parametrize("tokenizer_cls", [FailingOffsetTokenizer, InvalidOffsetTokenizer])
+def test_offset_failures_fall_back_to_standard_tokenization(tokenizer_cls):
+    tokenizer = tokenizer_cls()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config())
+    text = "abcdefghijklmno"
+
+    try:
+        actual = lopt.encode(text, **encode_kwargs())
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **encode_kwargs())
+
+
+def test_incompatible_special_token_post_processor_disables_lopt():
+    tokenizer = IncompatibleSpecialTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config())
+    text = "abcdefghijklmno"
+
+    try:
+        actual = lopt.encode(text, **encode_kwargs())
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **encode_kwargs())
+    assert actual[0] == 101
+    assert actual[-1] == 102
+
+
+def test_verify_mode_discards_a_non_lossless_chunk_result():
+    tokenizer = ChunkMismatchTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config(verify=True))
+    text = "abcdefghijklmno"
+
+    try:
+        actual = lopt.encode(text, **encode_kwargs(add_special_tokens=False))
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **encode_kwargs(add_special_tokens=False))
+
+
+def test_verify_mode_logs_serial_and_lopt_timings(monkeypatch, caplog):
+    tokenizer = CharacterTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config(verify=True))
+    text = "abcdefghijklmno"
+    clock = iter([1.0, 1.01, 2.0, 2.025])
+    monkeypatch.setattr(lopt_tokenizer_module.time, "perf_counter", lambda: next(clock))
+    caplog.set_level(logging.INFO, logger=lopt_tokenizer_module.logger.name)
+
+    try:
+        actual = lopt.encode(text, **encode_kwargs(add_special_tokens=False))
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **encode_kwargs(add_special_tokens=False))
+    assert (
+        "LoPT timing comparison: characters=15 tokens=15 serial_ms=25.000 "
+        "lopt_ms=10.000 speedup=2.50x matched=True chunks=4 attempts=1"
+    ) in caplog.messages
+
+
+def test_chunk_tokenization_runs_concurrently():
+    tokenizer = ConcurrentTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config(thread_workers=4))
+
+    try:
+        actual = lopt.encode("abcdefghijklmnopqrstuvwxyz", **encode_kwargs(add_special_tokens=False))
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode("abcdefghijklmnopqrstuvwxyz", **encode_kwargs(add_special_tokens=False))
+    assert tokenizer.max_active > 1
+
+
+def test_fast_tokenizer_uses_native_batch_encoding_when_available():
+    tokenizer = BatchTokenizer()
+    lopt = LosslessParallelTokenizer(tokenizer, make_config(thread_workers=4))
+    text = "abcdefghijklmnopqrstuvwxyz"
+    kwargs = encode_kwargs(add_special_tokens=False)
+
+    try:
+        actual = lopt.encode(text, **kwargs)
+        repeated = lopt.encode(text, **kwargs)
+    finally:
+        lopt.shutdown()
+
+    assert actual == tokenizer.encode(text, **kwargs)
+    assert repeated == actual
+    assert tokenizer.batch_call_count == 3
+
+
+def test_slow_and_short_prompts_use_standard_path_without_chunk_calls():
+    tokenizer = CharacterTokenizer()
+    tokenizer.is_fast = False
+    lopt = LosslessParallelTokenizer(tokenizer, make_config(min_chars=20))
+
+    try:
+        assert lopt.encode("short", **encode_kwargs()) == tokenizer.encode("short", **encode_kwargs())
+    finally:
+        lopt.shutdown()
+
+    assert tokenizer.chunk_call_count == 0
+
+
+def test_merge_rejects_position_mismatch():
+    left = ChunkEncoding(0, 0, 4, (1, 2), ((0, 1), (1, 2)), ((0, 1), (1, 2)))
+    right = ChunkEncoding(1, 2, 6, (1, 2), ((0, 1), (1, 2)), ((2, 3), (3, 4)))
+
+    with pytest.raises(RuntimeError, match="position-aware overlap"):
+        _merge_chunk_encodings([left, right], min_match_tokens=1)

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -15,6 +15,16 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import os
+
+from . import envs
+
+# LoPT owns the outer chunk-level parallelism. Keep the tokenizer's internal
+# Rayon pool conservative unless the user explicitly tunes it.
+if envs.VLLM_ASCEND_LOPT_ENABLE:
+    os.environ.setdefault("RAYON_NUM_THREADS", "1")
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
 _GLOBAL_PATCH_APPLIED = False
 
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -66,6 +66,26 @@ env_variables: dict[str, Callable[[], Any]] = {
     # In this case, developers need to set this value to "0.9.0" to make sure
     # that the correct package is installed.
     "VLLM_VERSION": lambda: os.getenv("VLLM_VERSION", None),
+    # Whether to enable lossless overlapping parallel tokenization (LoPT)
+    # for long text prompts handled by the upstream vLLM HF renderer.
+    # This optimization is disabled by default and falls back to the standard
+    # tokenizer whenever lossless merging cannot be established.
+    "VLLM_ASCEND_LOPT_ENABLE": lambda: bool(int(os.getenv("VLLM_ASCEND_LOPT_ENABLE", "0"))),
+    # Number of long-lived worker threads used to tokenize overlapping chunks.
+    "VLLM_ASCEND_LOPT_THREAD_WORKERS": lambda: int(os.getenv("VLLM_ASCEND_LOPT_THREAD_WORKERS", "4")),
+    # Minimum prompt length, in Python Unicode characters, required for LoPT.
+    "VLLM_ASCEND_LOPT_MIN_CHARS": lambda: int(os.getenv("VLLM_ASCEND_LOPT_MIN_CHARS", "32768")),
+    # Non-overlapping body length of each LoPT text chunk, in characters.
+    "VLLM_ASCEND_LOPT_CHUNK_CHARS": lambda: int(os.getenv("VLLM_ASCEND_LOPT_CHUNK_CHARS", "32768")),
+    # Character overlap appended to adjacent LoPT chunks.
+    "VLLM_ASCEND_LOPT_OVERLAP_CHARS": lambda: int(os.getenv("VLLM_ASCEND_LOPT_OVERLAP_CHARS", "512")),
+    # Minimum number of position-identical tokens required to splice chunks.
+    "VLLM_ASCEND_LOPT_MIN_MATCH_TOKENS": lambda: int(os.getenv("VLLM_ASCEND_LOPT_MIN_MATCH_TOKENS", "2")),
+    # Maximum number of retries that double the LoPT chunk body length.
+    "VLLM_ASCEND_LOPT_MAX_RETRIES": lambda: int(os.getenv("VLLM_ASCEND_LOPT_MAX_RETRIES", "3")),
+    # Compare LoPT output with standard tokenization before returning it.
+    # This is intended for validation and has the cost of tokenizing twice.
+    "VLLM_ASCEND_LOPT_VERIFY": lambda: bool(int(os.getenv("VLLM_ASCEND_LOPT_VERIFY", "0"))),
     # Whether to enable MatmulAllReduce fusion kernel when tensor parallel is enabled.
     # this feature is supported in A2, and eager mode will get better performance.
     "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE", "0"))),

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,6 +16,8 @@
 
 import os
 
+from vllm_ascend import envs
+
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
@@ -23,6 +25,9 @@ import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
 from vllm_ascend.utils import is_310p, vllm_version_is
+
+if envs.VLLM_ASCEND_LOPT_ENABLE:
+    import vllm_ascend.patch.platform.patch_lopt_tokenization  # noqa
 
 if not is_310p():
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa

--- a/vllm_ascend/patch/platform/patch_lopt_tokenization.py
+++ b/vllm_ascend/patch/platform/patch_lopt_tokenization.py
@@ -1,0 +1,288 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from functools import partial
+from typing import Any
+
+from vllm_ascend import envs
+
+# Rayon reads this setting when its global pool is initialized. Set conservative
+# defaults before importing vLLM's HF renderer when LoPT is enabled, while still
+# respecting explicit user tuning.
+if envs.VLLM_ASCEND_LOPT_ENABLE:
+    os.environ.setdefault("RAYON_NUM_THREADS", "1")
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+from vllm.inputs import TextPrompt, TokensPrompt  # noqa: E402
+from vllm.logger import init_logger  # noqa: E402
+from vllm.renderers.deepseek_v4 import DeepseekV4Renderer  # noqa: E402
+from vllm.renderers.hf import HfRenderer  # noqa: E402
+from vllm.renderers.params import ChatParams, TokenizeParams  # noqa: E402
+from vllm.tokenizers.hf import maybe_make_thread_pool  # noqa: E402
+
+from vllm_ascend.tokenization.lopt_tokenizer import (  # noqa: E402
+    LoptConfig,
+    LosslessParallelTokenizer,
+)
+
+logger = init_logger(__name__)
+
+_PATCH_APPLIED = False
+_original_hf_renderer_init = HfRenderer.__init__
+_original_hf_renderer_shutdown = HfRenderer.shutdown
+_original_hf_renderer_render_messages = HfRenderer.render_messages
+_original_hf_renderer_render_messages_async = HfRenderer.render_messages_async
+_original_hf_renderer_tokenize_prompt = HfRenderer._tokenize_prompt
+_original_hf_renderer_tokenize_prompt_async = HfRenderer._tokenize_prompt_async
+_original_deepseek_v4_renderer_init = DeepseekV4Renderer.__init__
+_original_deepseek_v4_renderer_shutdown = DeepseekV4Renderer.shutdown
+_original_deepseek_v4_renderer_render_messages = DeepseekV4Renderer.render_messages
+_original_deepseek_v4_renderer_render_messages_async = DeepseekV4Renderer.render_messages_async
+_original_deepseek_v4_renderer_tokenize_prompt = DeepseekV4Renderer._tokenize_prompt
+_original_deepseek_v4_renderer_tokenize_prompt_async = DeepseekV4Renderer._tokenize_prompt_async
+
+_LoptRenderer = HfRenderer | DeepseekV4Renderer
+
+
+def _config_from_env() -> LoptConfig:
+    return LoptConfig(
+        enabled=envs.VLLM_ASCEND_LOPT_ENABLE,
+        thread_workers=envs.VLLM_ASCEND_LOPT_THREAD_WORKERS,
+        min_chars=envs.VLLM_ASCEND_LOPT_MIN_CHARS,
+        chunk_chars=envs.VLLM_ASCEND_LOPT_CHUNK_CHARS,
+        overlap_chars=envs.VLLM_ASCEND_LOPT_OVERLAP_CHARS,
+        min_match_tokens=envs.VLLM_ASCEND_LOPT_MIN_MATCH_TOKENS,
+        max_retries=envs.VLLM_ASCEND_LOPT_MAX_RETRIES,
+        verify=envs.VLLM_ASCEND_LOPT_VERIFY,
+    )
+
+
+def _get_lopt(renderer: _LoptRenderer) -> LosslessParallelTokenizer | None:
+    return getattr(renderer, "_ascend_lopt_tokenizer", None)
+
+
+def _attach_lopt(renderer: _LoptRenderer) -> None:
+    tokenizer = renderer.tokenizer
+    is_fast = getattr(tokenizer, "is_fast", False) is True
+    is_multimodal = renderer.mm_processor is not None
+
+    if tokenizer is None:
+        return
+    if is_multimodal:
+        return
+    if not is_fast:
+        return
+
+    try:
+        config = _config_from_env()
+        maybe_make_thread_pool(tokenizer, config.thread_workers)
+        renderer._ascend_lopt_tokenizer = LosslessParallelTokenizer(
+            tokenizer,
+            config,
+        )
+    except Exception as exc:
+        logger.warning("LoPT initialization failed; standard tokenization will be used: %s", exc)
+
+
+def _patched_hf_renderer_init(self: HfRenderer, *args: Any, **kwargs: Any) -> None:
+    _original_hf_renderer_init(self, *args, **kwargs)
+    _attach_lopt(self)
+
+
+def _patched_deepseek_v4_renderer_init(self: DeepseekV4Renderer, *args: Any, **kwargs: Any) -> None:
+    _original_deepseek_v4_renderer_init(self, *args, **kwargs)
+    _attach_lopt(self)
+
+
+def _chat_params_for_lopt(renderer: _LoptRenderer, params: ChatParams) -> ChatParams:
+    if _get_lopt(renderer) is None:
+        return params
+
+    chat_template_kwargs = dict(params.chat_template_kwargs)
+    chat_template_kwargs["tokenize"] = False
+    return replace(params, chat_template_kwargs=chat_template_kwargs)
+
+
+def _select_lopt(
+    renderer: _LoptRenderer,
+    text: str,
+    encode_kwargs: dict[str, Any],
+) -> LosslessParallelTokenizer | None:
+    lopt = _get_lopt(renderer)
+    return lopt if lopt is not None and lopt.can_use(text, encode_kwargs) else None
+
+
+def _patched_hf_renderer_render_messages(self: HfRenderer, messages, params: ChatParams):
+    return _original_hf_renderer_render_messages(self, messages, _chat_params_for_lopt(self, params))
+
+
+async def _patched_hf_renderer_render_messages_async(self: HfRenderer, messages, params: ChatParams):
+    return await _original_hf_renderer_render_messages_async(
+        self,
+        messages,
+        _chat_params_for_lopt(self, params),
+    )
+
+
+def _patched_deepseek_v4_renderer_render_messages(
+    self: DeepseekV4Renderer,
+    messages,
+    params: ChatParams,
+):
+    return _original_deepseek_v4_renderer_render_messages(self, messages, _chat_params_for_lopt(self, params))
+
+
+async def _patched_deepseek_v4_renderer_render_messages_async(
+    self: DeepseekV4Renderer,
+    messages,
+    params: ChatParams,
+):
+    return await _original_deepseek_v4_renderer_render_messages_async(
+        self, messages, _chat_params_for_lopt(self, params)
+    )
+
+
+def _tokenize_prompt_with_lopt(
+    renderer: _LoptRenderer,
+    prompt: TextPrompt,
+    params: TokenizeParams,
+    standard_tokenize: Callable[..., TokensPrompt],
+) -> TokensPrompt:
+    encode_kwargs = params.get_encode_kwargs()
+    text = prompt["prompt"]
+    lopt = _select_lopt(renderer, text, encode_kwargs)
+    if lopt is None:
+        return standard_tokenize(renderer, prompt, params)
+
+    prompt_token_ids = lopt.encode(text, **encode_kwargs)
+    return TokensPrompt(prompt_token_ids=prompt_token_ids, **prompt)
+
+
+async def _tokenize_prompt_with_lopt_async(
+    renderer: _LoptRenderer,
+    prompt: TextPrompt,
+    params: TokenizeParams,
+    standard_tokenize: Callable[..., Awaitable[TokensPrompt]],
+) -> TokensPrompt:
+    encode_kwargs = params.get_encode_kwargs()
+    text = prompt["prompt"]
+    lopt = _select_lopt(renderer, text, encode_kwargs)
+    if lopt is None:
+        return await standard_tokenize(renderer, prompt, params)
+
+    encode = partial(lopt.encode, text, **encode_kwargs)
+    prompt_token_ids = await asyncio.get_running_loop().run_in_executor(renderer._executor, encode)
+    return TokensPrompt(prompt_token_ids=prompt_token_ids, **prompt)
+
+
+def _patched_hf_renderer_tokenize_prompt(
+    self: HfRenderer,
+    prompt: TextPrompt,
+    params: TokenizeParams,
+) -> TokensPrompt:
+    return _tokenize_prompt_with_lopt(
+        self,
+        prompt,
+        params,
+        _original_hf_renderer_tokenize_prompt,
+    )
+
+
+async def _patched_hf_renderer_tokenize_prompt_async(
+    self: HfRenderer,
+    prompt: TextPrompt,
+    params: TokenizeParams,
+) -> TokensPrompt:
+    return await _tokenize_prompt_with_lopt_async(
+        self,
+        prompt,
+        params,
+        _original_hf_renderer_tokenize_prompt_async,
+    )
+
+
+def _patched_deepseek_v4_renderer_tokenize_prompt(
+    self: DeepseekV4Renderer,
+    prompt: TextPrompt,
+    params: TokenizeParams,
+) -> TokensPrompt:
+    return _tokenize_prompt_with_lopt(
+        self,
+        prompt,
+        params,
+        _original_deepseek_v4_renderer_tokenize_prompt,
+    )
+
+
+async def _patched_deepseek_v4_renderer_tokenize_prompt_async(
+    self: DeepseekV4Renderer,
+    prompt: TextPrompt,
+    params: TokenizeParams,
+) -> TokensPrompt:
+    return await _tokenize_prompt_with_lopt_async(
+        self, prompt, params, _original_deepseek_v4_renderer_tokenize_prompt_async
+    )
+
+
+def _shutdown_lopt(
+    renderer: _LoptRenderer,
+    standard_shutdown: Callable[..., None],
+) -> None:
+    lopt = _get_lopt(renderer)
+    try:
+        if lopt is not None:
+            lopt.shutdown(wait=True)
+    finally:
+        standard_shutdown(renderer)
+
+
+def _patched_hf_renderer_shutdown(self: HfRenderer) -> None:
+    _shutdown_lopt(self, _original_hf_renderer_shutdown)
+
+
+def _patched_deepseek_v4_renderer_shutdown(self: DeepseekV4Renderer) -> None:
+    _shutdown_lopt(self, _original_deepseek_v4_renderer_shutdown)
+
+
+def apply_lopt_patch() -> None:
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return
+
+    HfRenderer.__init__ = _patched_hf_renderer_init
+    HfRenderer.shutdown = _patched_hf_renderer_shutdown
+    HfRenderer.render_messages = _patched_hf_renderer_render_messages
+    HfRenderer.render_messages_async = _patched_hf_renderer_render_messages_async
+    HfRenderer._tokenize_prompt = _patched_hf_renderer_tokenize_prompt
+    HfRenderer._tokenize_prompt_async = _patched_hf_renderer_tokenize_prompt_async
+
+    DeepseekV4Renderer.__init__ = _patched_deepseek_v4_renderer_init
+    DeepseekV4Renderer.shutdown = _patched_deepseek_v4_renderer_shutdown
+    DeepseekV4Renderer.render_messages = _patched_deepseek_v4_renderer_render_messages
+    DeepseekV4Renderer.render_messages_async = _patched_deepseek_v4_renderer_render_messages_async
+    DeepseekV4Renderer._tokenize_prompt = _patched_deepseek_v4_renderer_tokenize_prompt
+    DeepseekV4Renderer._tokenize_prompt_async = _patched_deepseek_v4_renderer_tokenize_prompt_async
+    _PATCH_APPLIED = True
+
+
+if envs.VLLM_ASCEND_LOPT_ENABLE:
+    apply_lopt_patch()

--- a/vllm_ascend/patch/platform/patch_lopt_tokenization.py
+++ b/vllm_ascend/patch/platform/patch_lopt_tokenization.py
@@ -190,7 +190,8 @@ async def _tokenize_prompt_with_lopt_async(
         return await standard_tokenize(renderer, prompt, params)
 
     encode = partial(lopt.encode, text, **encode_kwargs)
-    prompt_token_ids = await asyncio.get_running_loop().run_in_executor(renderer._executor, encode)
+    executor = getattr(renderer, "_executor", None)
+    prompt_token_ids = await asyncio.get_running_loop().run_in_executor(executor, encode)
     return TokensPrompt(prompt_token_ids=prompt_token_ids, **prompt)
 
 

--- a/vllm_ascend/patch/platform/patch_lopt_tokenization.py
+++ b/vllm_ascend/patch/platform/patch_lopt_tokenization.py
@@ -117,7 +117,7 @@ def _chat_params_for_lopt(renderer: _LoptRenderer, params: ChatParams) -> ChatPa
     if _get_lopt(renderer) is None:
         return params
 
-    chat_template_kwargs = dict(params.chat_template_kwargs)
+    chat_template_kwargs = dict(params.chat_template_kwargs or {})
     chat_template_kwargs["tokenize"] = False
     return replace(params, chat_template_kwargs=chat_template_kwargs)
 

--- a/vllm_ascend/tokenization/__init__.py
+++ b/vllm_ascend/tokenization/__init__.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .lopt_tokenizer import (
+    ChunkEncoding,
+    LoptConfig,
+    LosslessParallelTokenizer,
+    OverlapMatch,
+    TextChunk,
+)
+
+__all__ = [
+    "ChunkEncoding",
+    "LoptConfig",
+    "LosslessParallelTokenizer",
+    "OverlapMatch",
+    "TextChunk",
+]

--- a/vllm_ascend/tokenization/lopt_tokenizer.py
+++ b/vllm_ascend/tokenization/lopt_tokenizer.py
@@ -1,0 +1,850 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from bisect import bisect_left
+from collections import defaultdict
+from collections.abc import Sequence
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from itertools import islice
+from numbers import Integral
+from typing import Any, Protocol, overload
+
+logger = logging.getLogger(__name__)
+
+_BATCH_PROBE_CHARS = 256
+
+
+class _Tokenizer(Protocol):
+    is_fast: bool
+
+    def __call__(self, text: str | list[str], **kwargs: Any) -> Any: ...
+
+    def encode(self, text: str, **kwargs: Any) -> list[int]: ...
+
+
+class _PositionEncoding(Protocol):
+    @property
+    def index(self) -> int: ...
+
+    @property
+    def global_start(self) -> int: ...
+
+    @property
+    def global_end(self) -> int: ...
+
+    @property
+    def token_ids(self) -> Sequence[int]: ...
+
+    @property
+    def global_offsets(self) -> Sequence[tuple[int, int]]: ...
+
+
+@dataclass(frozen=True)
+class LoptConfig:
+    enabled: bool = False
+    thread_workers: int = 4
+    min_chars: int = 32768
+    chunk_chars: int = 32768
+    overlap_chars: int = 512
+    min_match_tokens: int = 2
+    max_retries: int = 3
+    verify: bool = False
+
+    def __post_init__(self) -> None:
+        if self.thread_workers < 1:
+            raise ValueError("LoPT thread_workers must be at least 1")
+        if self.min_chars < 1:
+            raise ValueError("LoPT min_chars must be at least 1")
+        if self.chunk_chars < 1:
+            raise ValueError("LoPT chunk_chars must be at least 1")
+        if not 0 < self.overlap_chars <= self.chunk_chars:
+            raise ValueError("LoPT overlap_chars must be in [1, chunk_chars]")
+        if self.min_match_tokens < 1:
+            raise ValueError("LoPT min_match_tokens must be at least 1")
+        if self.max_retries < 0:
+            raise ValueError("LoPT max_retries cannot be negative")
+
+
+@dataclass(frozen=True)
+class TextChunk:
+    index: int
+    global_start: int
+    global_end: int
+    text: str
+
+
+@dataclass(frozen=True)
+class ChunkEncoding:
+    index: int
+    global_start: int
+    global_end: int
+    token_ids: tuple[int, ...]
+    local_offsets: tuple[tuple[int, int], ...]
+    global_offsets: tuple[tuple[int, int], ...]
+
+
+class _GlobalOffsetView(Sequence[tuple[int, int]]):
+    """Translate tokenizer-local offsets to global positions on demand."""
+
+    def __init__(self, local_offsets: Sequence[Any], global_start: int) -> None:
+        self._local_offsets = local_offsets
+        self._global_start = global_start
+
+    def __len__(self) -> int:
+        return len(self._local_offsets)
+
+    @overload
+    def __getitem__(self, index: int) -> tuple[int, int]: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[tuple[int, int]]: ...
+
+    def __getitem__(self, index: int | slice) -> tuple[int, int] | Sequence[tuple[int, int]]:
+        if isinstance(index, slice):
+            indices = range(*index.indices(len(self)))
+            return [self[item_index] for item_index in indices]
+        start, end = self._local_offsets[index]
+        return self._global_start + start, self._global_start + end
+
+
+@dataclass(frozen=True)
+class _ChunkEncodingView:
+    """Batch-tokenizer output that avoids eagerly copying IDs and offsets."""
+
+    index: int
+    global_start: int
+    global_end: int
+    token_ids: Sequence[int]
+    global_offsets: Sequence[tuple[int, int]]
+
+
+@dataclass
+class _ChunkEncodingBuilder:
+    """Mutable merge state that avoids copying accumulated tuple prefixes."""
+
+    index: int
+    global_start: int
+    global_end: int
+    token_ids: list[int]
+    global_offsets: list[tuple[int, int]]
+
+
+@dataclass(frozen=True)
+class OverlapMatch:
+    left_start: int
+    right_start: int
+    token_count: int
+    char_start: int
+    char_end: int
+
+
+class LoptError(RuntimeError):
+    """Base exception for a safely recoverable LoPT failure."""
+
+
+class ChunkEncodingError(LoptError):
+    """A tokenizer failed to produce a valid offset-aware chunk encoding."""
+
+
+class OverlapMatchError(LoptError):
+    """Adjacent chunks could not be joined without ambiguity."""
+
+
+def _split_overlapping(text: str, chunk_chars: int, overlap_chars: int) -> list[TextChunk]:
+    if chunk_chars < 1:
+        raise ValueError("chunk_chars must be positive")
+    if not 0 < overlap_chars <= chunk_chars:
+        raise ValueError("overlap_chars must be in [1, chunk_chars]")
+
+    chunks: list[TextChunk] = []
+    start = 0
+    index = 0
+    while start < len(text):
+        end = min(len(text), start + chunk_chars + overlap_chars)
+        chunks.append(
+            TextChunk(
+                index=index,
+                global_start=start,
+                global_end=end,
+                text=text[start:end],
+            )
+        )
+        start += chunk_chars
+        index += 1
+    return chunks
+
+
+def _as_token_id_list(value: Any) -> list[int]:
+    try:
+        values = value if isinstance(value, list) else list(value)
+    except TypeError as exc:
+        raise ChunkEncodingError("tokenizer input_ids is not a sequence") from exc
+
+    if values and isinstance(values[0], (list, tuple)):
+        raise ChunkEncodingError("tokenizer unexpectedly returned batched input_ids")
+
+    converted_values: list[int] | None = None
+    for index, token_id in enumerate(values):
+        if not isinstance(token_id, Integral):
+            raise ChunkEncodingError("tokenizer returned a non-integer token ID")
+        if not isinstance(token_id, int):
+            if converted_values is None:
+                converted_values = list(values)
+            converted_values[index] = int(token_id)
+    return converted_values if converted_values is not None else values
+
+
+def _as_token_ids(value: Any) -> tuple[int, ...]:
+    return tuple(_as_token_id_list(value))
+
+
+def _as_offsets(value: Any, text_length: int) -> tuple[tuple[int, int], ...]:
+    try:
+        values = list(value)
+    except TypeError as exc:
+        raise ChunkEncodingError("tokenizer offset_mapping is not a sequence") from exc
+
+    offsets: list[tuple[int, int]] = []
+    previous_start = 0
+    previous_end = 0
+    for raw_offset in values:
+        if not isinstance(raw_offset, (list, tuple)) or len(raw_offset) != 2:
+            raise ChunkEncodingError("tokenizer returned an invalid offset pair")
+        start, end = raw_offset
+        if not isinstance(start, Integral) or not isinstance(end, Integral):
+            raise ChunkEncodingError("tokenizer returned a non-integer offset")
+        start = int(start)
+        end = int(end)
+        if not 0 <= start <= end <= text_length:
+            raise ChunkEncodingError("tokenizer returned an out-of-range offset")
+        if start < previous_start or end < previous_end:
+            raise ChunkEncodingError("tokenizer offsets are not monotonic")
+        offsets.append((start, end))
+        previous_start = start
+        previous_end = end
+    return tuple(offsets)
+
+
+def _encoding_value(encoded: Any, key: str) -> Any:
+    try:
+        return encoded[key]
+    except (KeyError, TypeError):
+        value = getattr(encoded, key, None)
+        if value is None:
+            raise ChunkEncodingError(f"tokenizer result does not contain {key}") from None
+        return value
+
+
+def _build_chunk_encoding(chunk: TextChunk, input_ids: Any, offset_mapping: Any) -> ChunkEncoding:
+    token_ids = _as_token_ids(input_ids)
+    local_offsets = _as_offsets(offset_mapping, len(chunk.text))
+    if len(token_ids) != len(local_offsets):
+        raise ChunkEncodingError("input_ids and offset_mapping lengths differ")
+
+    global_offsets = tuple(
+        (chunk.global_start + start, chunk.global_start + end) for start, end in local_offsets
+    )
+    return ChunkEncoding(
+        index=chunk.index,
+        global_start=chunk.global_start,
+        global_end=chunk.global_end,
+        token_ids=token_ids,
+        local_offsets=local_offsets,
+        global_offsets=global_offsets,
+    )
+
+
+def _as_sequence(value: Any, name: str) -> Sequence[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return value
+    try:
+        return list(value)
+    except TypeError as exc:
+        raise ChunkEncodingError(f"tokenizer {name} is not a sequence") from exc
+
+
+def _build_chunk_encoding_view(chunk: TextChunk, input_ids: Any, offset_mapping: Any) -> _ChunkEncodingView:
+    token_ids = _as_sequence(input_ids, "input_ids")
+    local_offsets = _as_sequence(offset_mapping, "offset_mapping")
+    if len(token_ids) != len(local_offsets):
+        raise ChunkEncodingError("input_ids and offset_mapping lengths differ")
+    if token_ids and isinstance(token_ids[0], (list, tuple)):
+        raise ChunkEncodingError("tokenizer unexpectedly returned batched input_ids")
+
+    return _ChunkEncodingView(
+        index=chunk.index,
+        global_start=chunk.global_start,
+        global_end=chunk.global_end,
+        token_ids=token_ids,
+        global_offsets=_GlobalOffsetView(local_offsets, chunk.global_start),
+    )
+
+
+def _encode_chunk(tokenizer: _Tokenizer, chunk: TextChunk) -> ChunkEncoding:
+    try:
+        encoded = tokenizer(
+            chunk.text,
+            add_special_tokens=False,
+            return_offsets_mapping=True,
+            return_attention_mask=False,
+            return_token_type_ids=False,
+        )
+    except Exception as exc:
+        raise ChunkEncodingError(f"chunk {chunk.index} tokenization failed") from exc
+
+    return _build_chunk_encoding(
+        chunk,
+        _encoding_value(encoded, "input_ids"),
+        _encoding_value(encoded, "offset_mapping"),
+    )
+
+
+def _batch_encode_chunks(
+    tokenizer: _Tokenizer,
+    chunks: list[TextChunk],
+    *,
+    validate: bool = True,
+) -> list[_PositionEncoding]:
+    """Encode all chunks in one call so fast tokenizers can parallelize in native code."""
+    try:
+        encoded = tokenizer(
+            [chunk.text for chunk in chunks],
+            add_special_tokens=False,
+            return_offsets_mapping=True,
+            return_attention_mask=False,
+            return_token_type_ids=False,
+        )
+        input_ids = list(_encoding_value(encoded, "input_ids"))
+        offset_mappings = list(_encoding_value(encoded, "offset_mapping"))
+    except Exception as exc:
+        raise ChunkEncodingError("batch chunk tokenization failed") from exc
+
+    if len(input_ids) != len(chunks) or len(offset_mappings) != len(chunks):
+        raise ChunkEncodingError("batch tokenizer result size differs from chunk count")
+    builder = _build_chunk_encoding if validate else _build_chunk_encoding_view
+    return [
+        builder(chunk, chunk_input_ids, chunk_offsets)
+        for chunk, chunk_input_ids, chunk_offsets in zip(chunks, input_ids, offset_mappings, strict=True)
+    ]
+
+
+def _parallel_encode_chunks(
+    tokenizer: _Tokenizer,
+    chunks: list[TextChunk],
+    executor: Executor,
+) -> list[ChunkEncoding]:
+    futures: list[Future[ChunkEncoding]] = [executor.submit(_encode_chunk, tokenizer, chunk) for chunk in chunks]
+    try:
+        encodings = [future.result() for future in futures]
+    except Exception as exc:
+        for future in futures:
+            future.cancel()
+        if isinstance(exc, LoptError):
+            raise
+        raise ChunkEncodingError("parallel chunk tokenization failed") from exc
+
+    encodings.sort(key=lambda encoding: encoding.index)
+    return encodings
+
+
+def _record(encoding: _PositionEncoding, index: int) -> tuple[int, int, int]:
+    start, end = encoding.global_offsets[index]
+    return start, end, encoding.token_ids[index]
+
+
+def _in_overlap(record: tuple[int, int, int], overlap_start: int, overlap_end: int) -> bool:
+    start, end, _ = record
+    return end > start and start >= overlap_start and end <= overlap_end
+
+
+def _overlap_token_range(encoding: _PositionEncoding, overlap_start: int, overlap_end: int) -> range:
+    """Return token indices whose starts may fall within the overlap."""
+    first = bisect_left(encoding.global_offsets, (overlap_start, overlap_start))
+    stop = bisect_left(encoding.global_offsets, (overlap_end, overlap_end), lo=first)
+    return range(first, stop)
+
+
+def _find_position_overlap(
+    left: _PositionEncoding,
+    right: _PositionEncoding,
+    min_match_tokens: int,
+) -> OverlapMatch | None:
+    overlap_start = max(left.global_start, right.global_start)
+    overlap_end = min(left.global_end, right.global_end)
+    if overlap_start >= overlap_end:
+        return None
+
+    right_candidates: dict[tuple[int, int, int], list[int]] = defaultdict(list)
+    for right_index in _overlap_token_range(right, overlap_start, overlap_end):
+        record = _record(right, right_index)
+        if _in_overlap(record, overlap_start, overlap_end):
+            right_candidates[record].append(right_index)
+
+    def rank(match: OverlapMatch) -> tuple[int, int, int]:
+        safety_margin = min(match.char_start - overlap_start, overlap_end - match.char_end)
+        return match.token_count, safety_margin, match.char_end - match.char_start
+
+    best_match: OverlapMatch | None = None
+    best_rank: tuple[int, int, int] | None = None
+    best_is_ambiguous = False
+    # A later start on the same matched diagonal can only produce a shorter
+    # suffix, so do not expand that suffix a second time.
+    matched_pairs: set[tuple[int, int]] = set()
+    for left_index in _overlap_token_range(left, overlap_start, overlap_end):
+        first_record = _record(left, left_index)
+        if not _in_overlap(first_record, overlap_start, overlap_end):
+            continue
+        for right_index in right_candidates.get(first_record, ()):
+            if (left_index, right_index) in matched_pairs:
+                continue
+
+            token_count = 0
+            char_end = first_record[1]
+            while left_index + token_count < len(left.token_ids) and right_index + token_count < len(right.token_ids):
+                left_record = _record(left, left_index + token_count)
+                right_record = _record(right, right_index + token_count)
+                if left_record != right_record or not _in_overlap(left_record, overlap_start, overlap_end):
+                    break
+                matched_pairs.add((left_index + token_count, right_index + token_count))
+                char_end = max(char_end, left_record[1])
+                token_count += 1
+
+            if token_count >= min_match_tokens and char_end > first_record[0]:
+                candidate = OverlapMatch(
+                    left_start=left_index,
+                    right_start=right_index,
+                    token_count=token_count,
+                    char_start=first_record[0],
+                    char_end=char_end,
+                )
+                candidate_rank = rank(candidate)
+                if best_rank is None or candidate_rank > best_rank:
+                    best_match = candidate
+                    best_rank = candidate_rank
+                    best_is_ambiguous = False
+                elif candidate_rank == best_rank:
+                    best_is_ambiguous = True
+
+    if best_match is None or best_is_ambiguous:
+        return None
+    return best_match
+
+
+def _new_encoding_builder(encoding: _PositionEncoding) -> _ChunkEncodingBuilder:
+    return _ChunkEncodingBuilder(
+        index=encoding.index,
+        global_start=encoding.global_start,
+        global_end=encoding.global_end,
+        token_ids=list(encoding.token_ids),
+        global_offsets=list(encoding.global_offsets),
+    )
+
+
+def _freeze_encoding_builder(builder: _ChunkEncodingBuilder) -> ChunkEncoding:
+    token_ids = tuple(builder.token_ids)
+    global_offsets = tuple(builder.global_offsets)
+    if not token_ids or len(token_ids) != len(global_offsets):
+        raise OverlapMatchError("merged chunk encoding is empty or inconsistent")
+
+    local_offsets = tuple(
+        (start - builder.global_start, end - builder.global_start) for start, end in global_offsets
+    )
+    return ChunkEncoding(
+        index=builder.index,
+        global_start=builder.global_start,
+        global_end=builder.global_end,
+        token_ids=token_ids,
+        local_offsets=local_offsets,
+        global_offsets=global_offsets,
+    )
+
+
+def _merge_pair_into(
+    merged: _ChunkEncodingBuilder,
+    right: _PositionEncoding,
+    min_match_tokens: int,
+) -> None:
+    """Merge ``right`` into reusable mutable buffers."""
+
+    match = _find_position_overlap(merged, right, min_match_tokens)
+    if match is None:
+        raise OverlapMatchError(
+            f"no unambiguous position-aware overlap between chunks {merged.index} and {right.index}"
+        )
+
+    left_end = match.left_start + match.token_count
+    right_end = match.right_start + match.token_count
+    del merged.token_ids[left_end:]
+    del merged.global_offsets[left_end:]
+    merged.token_ids.extend(islice(right.token_ids, right_end, None))
+    merged.global_offsets.extend(islice(right.global_offsets, right_end, None))
+    if not merged.token_ids or len(merged.token_ids) != len(merged.global_offsets):
+        raise OverlapMatchError("merged chunk encoding is empty or inconsistent")
+
+    merged.index = right.index
+    merged.global_start = min(merged.global_start, right.global_start)
+    merged.global_end = max(merged.global_end, right.global_end)
+
+
+def _merge_pair(left: ChunkEncoding, right: ChunkEncoding, min_match_tokens: int) -> ChunkEncoding:
+    builder = _new_encoding_builder(left)
+    _merge_pair_into(builder, right, min_match_tokens)
+    return _freeze_encoding_builder(builder)
+
+
+def _merge_chunk_encoding_builder(
+    encodings: Sequence[_PositionEncoding], min_match_tokens: int
+) -> _ChunkEncodingBuilder:
+    if not encodings:
+        raise OverlapMatchError("cannot merge an empty chunk list")
+
+    merged = _new_encoding_builder(encodings[0])
+    for encoding in encodings[1:]:
+        _merge_pair_into(merged, encoding, min_match_tokens)
+    return merged
+
+
+def _merge_chunk_encodings(encodings: list[ChunkEncoding], min_match_tokens: int) -> ChunkEncoding:
+    if len(encodings) == 1:
+        return encodings[0]
+    merged = _merge_chunk_encoding_builder(encodings, min_match_tokens)
+    return _freeze_encoding_builder(merged)
+
+
+def _find_adjacent_matches(
+    encodings: Sequence[_PositionEncoding], min_match_tokens: int
+) -> list[OverlapMatch]:
+    matches: list[OverlapMatch] = []
+    for left, right in zip(encodings, encodings[1:]):
+        match = _find_position_overlap(left, right, min_match_tokens)
+        if match is None:
+            raise OverlapMatchError(
+                f"no unambiguous position-aware overlap between chunks {left.index} and {right.index}"
+            )
+        matches.append(match)
+    return matches
+
+
+def _merge_chunk_token_ids(
+    encodings: Sequence[_PositionEncoding], min_match_tokens: int
+) -> list[int]:
+    """Join token ranges after independently locating every adjacent seam."""
+    if not encodings:
+        raise OverlapMatchError("cannot merge an empty chunk list")
+    if len(encodings) == 1:
+        return list(encodings[0].token_ids)
+
+    matches = _find_adjacent_matches(encodings, min_match_tokens)
+    token_ids: list[int] = []
+    for index, encoding in enumerate(encodings):
+        start = 0 if index == 0 else matches[index - 1].right_start + matches[index - 1].token_count
+        stop = (
+            len(encoding.token_ids)
+            if index == len(encodings) - 1
+            else matches[index].left_start + matches[index].token_count
+        )
+        if start > stop:
+            raise OverlapMatchError(f"overlap seams cross within chunk {encoding.index}")
+        token_ids.extend(islice(encoding.token_ids, start, stop))
+
+    if not token_ids:
+        raise OverlapMatchError("merged chunk encoding is empty")
+    return token_ids
+
+
+class LosslessParallelTokenizer:
+    """Offset-aware overlapping parallel tokenization with safe fallback."""
+
+    _SUPPORTED_ENCODE_KWARGS = frozenset({"add_special_tokens", "truncation", "max_length"})
+
+    def __init__(
+        self,
+        tokenizer: _Tokenizer,
+        config: LoptConfig,
+        executor: Executor | None = None,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.config = config
+        self._executor = executor or ThreadPoolExecutor(
+            max_workers=config.thread_workers,
+            thread_name_prefix="vllm-ascend-lopt",
+        )
+        self._owns_executor = executor is None
+        self._state_lock = threading.Lock()
+        self._shutdown = False
+        self._compatibility: dict[tuple[bool, bool, int | None], bool] = {}
+        self._warned_fallbacks: set[str] = set()
+        self._batch_encoding_supported: bool | None = None
+
+    def can_use(self, text: str, encode_kwargs: dict[str, Any] | None = None) -> bool:
+        encode_kwargs = encode_kwargs or {}
+        with self._state_lock:
+            is_shutdown = self._shutdown
+        if is_shutdown or not self.config.enabled:
+            return False
+        if getattr(self.tokenizer, "is_fast", False) is not True:
+            return False
+        if len(text) < self.config.min_chars:
+            return False
+        if len(text) <= self.config.chunk_chars + self.config.overlap_chars:
+            return False
+        if set(encode_kwargs) - self._SUPPORTED_ENCODE_KWARGS:
+            return False
+        if (
+            encode_kwargs.get("truncation", False)
+            and encode_kwargs.get("add_special_tokens", True)
+            and not callable(getattr(self.tokenizer, "prepare_for_model", None))
+        ):
+            return False
+        if not callable(getattr(self.tokenizer, "encode", None)) or not callable(self.tokenizer):
+            return False
+        return self._is_compatible(encode_kwargs)
+
+    def encode(self, text: str, **encode_kwargs: Any) -> list[int]:
+        if not self.can_use(text, encode_kwargs):
+            return self._standard_encode(text, encode_kwargs)
+
+        lopt_started_at = time.perf_counter() if self.config.verify else None
+        try:
+            token_ids, attempts, chunk_count = self._encode_with_retries(text, encode_kwargs)
+        except Exception as exc:
+            failed_lopt_stopped_at = time.perf_counter() if self.config.verify else None
+            self._log_fallback_once(
+                type(exc).__name__,
+                "LoPT tokenization failed (%s); using standard tokenization",
+                exc,
+            )
+            serial_started_at = time.perf_counter() if self.config.verify else None
+            standard_ids = self._standard_encode(text, encode_kwargs)
+            if self.config.verify:
+                assert lopt_started_at is not None
+                assert failed_lopt_stopped_at is not None
+                assert serial_started_at is not None
+                failed_lopt_ms = (failed_lopt_stopped_at - lopt_started_at) * 1000
+                serial_ms = (time.perf_counter() - serial_started_at) * 1000
+                logger.warning(
+                    "LoPT timing comparison failed: characters=%d tokens=%d serial_ms=%.3f "
+                    "failed_lopt_ms=%.3f error=%s",
+                    len(text),
+                    len(standard_ids),
+                    serial_ms,
+                    failed_lopt_ms,
+                    exc,
+                )
+            return standard_ids
+
+        if self.config.verify:
+            assert lopt_started_at is not None
+            lopt_ms = (time.perf_counter() - lopt_started_at) * 1000
+            serial_started_at = time.perf_counter()
+            standard_ids = self._standard_encode(text, encode_kwargs)
+            serial_ms = (time.perf_counter() - serial_started_at) * 1000
+            matched = token_ids == standard_ids
+            speedup = serial_ms / lopt_ms if lopt_ms > 0 else 0.0
+            logger.info(
+                "LoPT timing comparison: characters=%d tokens=%d serial_ms=%.3f "
+                "lopt_ms=%.3f speedup=%.2fx matched=%s chunks=%d attempts=%d",
+                len(text),
+                len(standard_ids),
+                serial_ms,
+                lopt_ms,
+                speedup,
+                matched,
+                chunk_count,
+                attempts,
+            )
+            if not matched:
+                self._log_fallback_once("verification", "LoPT verification failed; using standard tokenization")
+                return standard_ids
+
+        return token_ids
+
+    def shutdown(self, wait: bool = True) -> None:
+        with self._state_lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+        if self._owns_executor:
+            self._executor.shutdown(wait=wait, cancel_futures=True)
+
+    def _standard_encode(self, text: str, encode_kwargs: dict[str, Any]) -> list[int]:
+        return list(self.tokenizer.encode(text, **encode_kwargs))
+
+    def _log_fallback_once(self, key: str, message: str, *args: Any) -> None:
+        with self._state_lock:
+            first_occurrence = key not in self._warned_fallbacks
+            self._warned_fallbacks.add(key)
+        if first_occurrence:
+            logger.warning(message, *args)
+
+    def _is_compatible(self, encode_kwargs: dict[str, Any]) -> bool:
+        add_special_tokens = bool(encode_kwargs.get("add_special_tokens", True))
+        truncation = bool(encode_kwargs.get("truncation", False))
+        max_length = encode_kwargs.get("max_length")
+        key = (add_special_tokens, truncation, max_length)
+        with self._state_lock:
+            cached = self._compatibility.get(key)
+        if cached is not None:
+            return cached
+
+        probe = "LoPT compatibility probe: ASCII 中文 🙂 e\u0301 0123456789. " * 2
+        probe_kwargs: dict[str, Any] = {
+            "add_special_tokens": add_special_tokens,
+            "truncation": truncation,
+            "max_length": None,
+        }
+        if truncation:
+            probe_kwargs["max_length"] = min(max_length, 16) if isinstance(max_length, int) else 16
+
+        try:
+            chunk = TextChunk(index=0, global_start=0, global_end=len(probe), text=probe)
+            content_ids = _encode_chunk(self.tokenizer, chunk).token_ids
+            prepared_ids = self._prepare_for_model(content_ids, probe_kwargs)
+            standard_ids = self._standard_encode(probe, probe_kwargs)
+            compatible = prepared_ids == standard_ids
+        except Exception:
+            compatible = False
+
+        with self._state_lock:
+            self._compatibility[key] = compatible
+        if not compatible:
+            self._log_fallback_once(
+                f"compatibility-{key}",
+                "LoPT compatibility probe failed for add_special_tokens=%s, truncation=%s; using standard tokenization",
+                add_special_tokens,
+                truncation,
+            )
+        return compatible
+
+    def _encode_chunks(self, chunks: list[TextChunk]) -> list[_PositionEncoding]:
+        with self._state_lock:
+            batch_encoding_supported = self._batch_encoding_supported
+
+        if batch_encoding_supported is None:
+            probe_chunks = [
+                TextChunk(
+                    index=chunk.index,
+                    global_start=chunk.global_start,
+                    global_end=chunk.global_start + min(len(chunk.text), _BATCH_PROBE_CHARS),
+                    text=chunk.text[:_BATCH_PROBE_CHARS],
+                )
+                for chunk in chunks[:2]
+            ]
+            try:
+                _batch_encode_chunks(self.tokenizer, probe_chunks, validate=True)
+            except ChunkEncodingError:
+                batch_encoding_supported = False
+            else:
+                batch_encoding_supported = True
+            with self._state_lock:
+                self._batch_encoding_supported = batch_encoding_supported
+
+        if batch_encoding_supported:
+            try:
+                encodings = _batch_encode_chunks(self.tokenizer, chunks, validate=False)
+            except ChunkEncodingError:
+                with self._state_lock:
+                    self._batch_encoding_supported = False
+            else:
+                return encodings
+
+        return _parallel_encode_chunks(self.tokenizer, chunks, self._executor)
+
+    def _encode_with_retries(
+        self,
+        text: str,
+        encode_kwargs: dict[str, Any],
+    ) -> tuple[list[int], int, int]:
+        chunk_chars = self.config.chunk_chars
+        last_error: OverlapMatchError | None = None
+
+        for attempt in range(self.config.max_retries + 1):
+            chunks = _split_overlapping(text, chunk_chars, self.config.overlap_chars)
+            if len(chunks) < 2:
+                raise LoptError("prompt does not produce multiple chunks")
+
+            encodings = self._encode_chunks(chunks)
+            try:
+                merged_token_ids = _merge_chunk_token_ids(encodings, self.config.min_match_tokens)
+            except OverlapMatchError as exc:
+                last_error = exc
+                chunk_chars *= 2
+                continue
+
+            token_ids = self._prepare_for_model(merged_token_ids, encode_kwargs)
+            return token_ids, attempt + 1, len(chunks)
+
+        raise last_error or OverlapMatchError("LoPT overlap matching failed")
+
+    def _prepare_for_model(self, token_ids: Sequence[int], encode_kwargs: dict[str, Any]) -> list[int]:
+        add_special_tokens = bool(encode_kwargs.get("add_special_tokens", True))
+        truncation = bool(encode_kwargs.get("truncation", False))
+        max_length = encode_kwargs.get("max_length")
+        ids = list(token_ids)
+
+        # DeepSeekV4 chat templates already contain their control tokens and
+        # vLLM encodes them with add_special_tokens=False. In this case,
+        # truncating the complete merged token sequence is equivalent to
+        # tokenizer-level truncation.
+        if not add_special_tokens:
+            if not truncation:
+                return ids
+
+            if (
+                not isinstance(max_length, int)
+                or isinstance(max_length, bool)
+                or max_length < 0
+            ):
+                raise LoptError("truncation requires a non-negative integer max_length")
+
+            if len(ids) <= max_length:
+                return ids
+
+            truncation_side = getattr(self.tokenizer, "truncation_side", "right")
+            if truncation_side == "right":
+                return ids[:max_length]
+            if truncation_side == "left":
+                # ids[-0:] returns the complete list instead of an empty list.
+                return ids[len(ids) - max_length :]
+
+            raise LoptError(f"unsupported truncation_side: {truncation_side!r}")
+
+        prepare_for_model = getattr(self.tokenizer, "prepare_for_model", None)
+        if callable(prepare_for_model):
+            prepared = prepare_for_model(
+                ids,
+                add_special_tokens=True,
+                truncation=truncation,
+                max_length=max_length,
+                padding=False,
+                return_attention_mask=False,
+                return_token_type_ids=False,
+            )
+            return _as_token_id_list(_encoding_value(prepared, "input_ids"))
+
+        if truncation:
+            raise LoptError("tokenizer cannot reproduce truncation with special tokens")
+
+        build_inputs = getattr(self.tokenizer, "build_inputs_with_special_tokens", None)
+        if not callable(build_inputs):
+            raise LoptError("tokenizer cannot add special tokens to merged IDs")
+        return list(build_inputs(ids))

--- a/vllm_ascend/tokenization/lopt_tokenizer.py
+++ b/vllm_ascend/tokenization/lopt_tokenizer.py
@@ -352,9 +352,12 @@ def _parallel_encode_chunks(
     chunks: list[TextChunk],
     executor: Executor,
 ) -> list[ChunkEncoding]:
+    from concurrent.futures import as_completed
     futures: list[Future[ChunkEncoding]] = [executor.submit(_encode_chunk, tokenizer, chunk) for chunk in chunks]
+    encodings: list[ChunkEncoding] = []
     try:
-        encodings = [future.result() for future in futures]
+        for future in as_completed(futures):
+            encodings.append(future.result())
     except Exception as exc:
         for future in futures:
             future.cancel()


### PR DESCRIPTION
Add lossless parallel tokenization on the rfc/vllm_cann baseline with vLLM 0.23 renderer integration, focused tests, one reproducible benchmark, and reduced LoPT/trace logging noise.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
