### PR TITLE
[CI] Add A5/950 wheel build job

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile.buildwheel.a5
+++ b/.github/workflows/dockerfiles/Dockerfile.buildwheel.a5
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+ARG PY_VERSION=3.12 
+FROM quay.io/ascend/manylinux:9.0.1-950-manylinux_2_34-py${PY_VERSION}
+
+ARG SOC_VERSION="ascend950dt_9582"
+
+# Define environments
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SOC_VERSION=$SOC_VERSION
+RUN yum update -y && \
+    yum install -y python3-pip git vim wget net-tools gcc gcc-c++ make cmake numactl-devel && \
+    rm -rf /var/cache/yum
+
+WORKDIR /workspace
+
+COPY . /workspace/vllm-ascend/
+
+# Install req
+RUN python3 -m pip install -r vllm-ascend/requirements.txt --extra-index https://download.pytorch.org/whl/cpu/ --extra-index-url https://repo.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install twine attrs psutil
+
+# Install vllm-ascend
+RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/Ascend/ascend-toolkit/latest/`uname -i`-linux/devlib && \
+    cd vllm-ascend && \
+    python3 setup.py bdist_wheel && \
+    ls -l dist
+
+CMD ["/bin/bash"]

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -33,6 +33,7 @@ on:
         type: choice
         options:
           - main
+          - v0.23.0
           - v0.23.0rc1
           - v0.22.1rc1
           - v0.21.0rc1
@@ -339,9 +340,90 @@ jobs:
           path: dist/
 
 
+  build_and_release_wheel_a5:
+    name: build and release wheel (A5)
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout vllm-ascend
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: checkout vllm-ascend ${{ inputs.tag }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          ref: ${{ inputs.tag }}
+
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          docker-images: false
+
+      - name: Build wheel
+        run: |
+          ls
+          docker build -f ./.github/workflows/dockerfiles/Dockerfile.buildwheel.a5 \
+          --build-arg PY_VERSION=${{ matrix.python-version }} \
+          -t wheel-a5:v1 .
+          docker run --rm \
+          -u "$(id -u):$(id -g)" \
+          -v "$(pwd):/outpwd" \
+          wheel-a5:v1 \
+          bash -c "cp -r /workspace/vllm-ascend/dist /outpwd"
+          ls dist
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Repair wheels with auditwheel
+        run: |
+          python3 -m pip install auditwheel patchelf
+          python3 .github/workflows/scripts/wheel/auto_exclude.py dist
+          ls dist
+
+      - name: Verify automatic platform tags
+        run: |
+          cd dist
+          for wheel in *.whl; do
+            echo "verification file: $wheel"
+            auditwheel show "$wheel"
+          done
+
+      - name: Generate variant wheels
+        env:
+          WHEEL_FILE: dist
+          PROJECT_TOML: .github/workflows/scripts/wheel/pyproject.toml
+          OUTPUT_DIR: dist/variants
+        run: |
+          pip install build git+https://github.com/wheelnext/variantlib.git --quiet
+          mkdir -p dist/variants
+          python3 .github/workflows/scripts/wheel/make_variant.py \
+            -c .github/workflows/scripts/wheel/config.json \
+            -l 950
+          echo "Generated variant wheels:"
+          ls dist/variants/
+
+      - name: Archive wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: vllm-ascend-a5-${{ matrix.os }}-py${{ matrix.python-version }}-wheel
+          path: dist/
+
+
   generate_and_upload_variant_index:
     name: generate and upload variant index
-    needs: [build_and_release_wheel, build_and_release_wheel_a3, build_and_release_wheel_310p]
+    needs: [build_and_release_wheel, build_and_release_wheel_a3, build_and_release_wheel_310p, build_and_release_wheel_a5]
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/scripts/wheel/config.json
+++ b/.github/workflows/scripts/wheel/config.json
@@ -25,6 +25,13 @@
         "ascend :: npu_type :: a3"
       ],
       "skip_plugin_validation": true
+    },
+    {
+      "variant_label": "950",
+      "properties": [
+        "ascend :: npu_type :: 950"
+      ],
+      "skip_plugin_validation": true
     }
   ]
 }


### PR DESCRIPTION

### What this PR does / why we need it?

- Add build_and_release_wheel_a5 job to schedule_release_code_and_wheel.yml
- Add Dockerfile.buildwheel.a5 for A5/950 manylinux wheel build
- Add 950 variant config in wheel/config.json
- Add v0.23.0 tag option for workflow_dispatch input

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
