### PR TITLE
[v0.25.1rc] Revert "[Performance] remove D2H sync in QLIMetadata builder for DSA_CP"

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -22,7 +22,7 @@ import pytest
 from vllm import SamplingParams
 from vllm.v1.metrics.reader import Counter, Vector
 
-from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+from tests.e2e.conftest import VllmRunner
 from tests.e2e.pull_request.one_card.model_runner_v2.utils import calculate_acceptance_per_pos
 from vllm_ascend.utils import vllm_version_is
 
@@ -154,7 +154,6 @@ def test_egale_spec_decoding(
     ],
 )
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
-@wait_until_npu_memory_free(target_free_percentage=0.8)
 def test_dflash_spec_decoding(
     model: str,
     dflash_model: str,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -686,7 +686,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         local_seq_lens_q = local_query_start_loc[1 : num_reqs + 1] - local_query_start_loc[:num_reqs]
         local_seq_lens_q_cpu = local_query_start_loc_cpu[1 : num_reqs + 1] - local_query_start_loc_cpu[:num_reqs]
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
-        max_local_seqlen = max(1, int(local_seq_lens_cpu.max().item()))
+        max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
 
         if num_reqs_actual is None:
             num_reqs_actual = num_reqs
@@ -720,8 +720,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=local_query_start_loc,
             seq_lens=local_seq_lens,
             seq_lens_q=local_seq_lens_q,
-            max_seqlen=max_local_seqlen,
-            max_seqlen_q=max_local_query_len,
+            max_query_len=max_local_query_len,
+            max_seq_lens=max_local_seq_lens,
             index_topk=index_topk,
             num_reqs=num_reqs,
             has_prefill=has_prefill,
@@ -733,8 +733,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             query_start_loc=local_query_start_loc,
             seq_lens=local_seq_lens,
             seq_lens_q=local_seq_lens_q,
-            max_seqlen=max_local_seqlen,
-            max_seqlen_q=max_local_query_len,
             num_reqs=num_reqs,
         )
 
@@ -882,8 +880,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         query_start_loc,
         seq_lens,
         seq_lens_q,
-        max_seqlen,
-        max_seqlen_q,
+        max_query_len,
+        max_seq_lens,
         index_topk,
         num_reqs,
         has_prefill,
@@ -921,8 +919,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
                 seqused_q=self.seqused_q,
                 seqused_kv=seq_lens,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_kv=max_seqlen,
+                max_seqlen_q=max_query_len,
+                max_seqlen_kv=max_seq_lens,
                 batch_size=num_reqs,
                 ori_mask_mode=4,
                 ori_win_left=self.model_config.hf_config.sliding_window - 1,
@@ -950,7 +948,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.req_sas_metadata[:1024] = metadata
         return self.req_sas_metadata[:1024]
 
-    def _build_qli_metadata(self, query_start_loc, seq_lens, seq_lens_q, max_seqlen, max_seqlen_q, num_reqs):
+    def _build_qli_metadata(self, query_start_loc, seq_lens, seq_lens_q, num_reqs):
         if self.compressor_ratio != 4:
             return None
 
@@ -958,6 +956,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
 
         if metadata is None:
+            max_seqlen_q = max(1, int(seq_lens_q.max().item()))
+            max_seqlen_k = max(1, int(seq_lens.max().item()))
             metadata = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
                 actual_seq_lengths_query=query_start_loc[1:].clone(),
                 actual_seq_lengths_key=seq_lens.clone(),
@@ -968,7 +968,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 key_quant_mode=0,
                 batch_size=num_reqs,
                 max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seqlen,
+                max_seqlen_k=max_seqlen_k,
                 layout_query="TND",
                 layout_key="PA_BSND",
                 sparse_count=self.model_config.hf_config.index_topk,


### PR DESCRIPTION
Reverts vllm-project/vllm-ascend#12536 on `releases/v0.25.1rc`.

Release-branch counterpart of #13290.

- Restores the D2H synchronization in the QLI metadata builder.
- Reverts the related DFlash test adjustment.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
