### PR TITLE
[BugFix][Core] Align Mamba block split call with vLLM

### DIFF
--- a/tests/ut/patch/platform/test_balance_mamba_source.py
+++ b/tests/ut/patch/platform/test_balance_mamba_source.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level guards for Mamba handling in ``BalanceScheduler``."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+def _schedule_tree() -> ast.FunctionDef:
+    repo_root = Path(__file__).resolve().parents[4]
+    source = (
+        repo_root / "vllm_ascend" / "patch" / "platform" / "patch_balance_schedule.py"
+    ).read_text(encoding="utf-8")
+    module = ast.parse(source)
+    scheduler = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "BalanceScheduler"
+    )
+    return next(
+        node
+        for node in scheduler.body
+        if isinstance(node, ast.FunctionDef) and node.name == "schedule"
+    )
+
+
+class TestBalanceMambaSource(unittest.TestCase):
+    def test_mamba_block_aligned_split_uses_upstream_interface(self):
+        """Guard the waiting-path call against upstream signature drift."""
+        branches = [
+            node
+            for node in ast.walk(_schedule_tree())
+            if isinstance(node, ast.If)
+            and "need_mamba_block_aligned_split" in ast.unparse(node.test)
+            and "load_kv_async" in ast.unparse(node.test)
+        ]
+
+        self.assertEqual(len(branches), 1)
+        calls = [
+            node
+            for node in ast.walk(branches[0])
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_mamba_block_aligned_split"
+        ]
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            [ast.unparse(arg) for arg in calls[0].args],
+            [
+                "request",
+                "num_new_tokens",
+                "num_new_local_computed_tokens",
+                "num_external_computed_tokens",
+            ],
+        )
+
+    def test_hybrid_connector_clears_shared_prefix_boundary(self):
+        """The per-group lookup cannot provide a shared-prefix junction."""
+        branches = [
+            node
+            for node in ast.walk(_schedule_tree())
+            if isinstance(node, ast.If)
+            and "has_mamba_layers" in ast.unparse(node.test)
+            and "HybridKVCacheCoordinator" in ast.unparse(node.test)
+        ]
+
+        self.assertEqual(len(branches), 1)
+        resets = [
+            node
+            for node in ast.walk(branches[0])
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and ast.unparse(node.targets[0]) == "request.shared_prefix_boundary"
+            and isinstance(node.value, ast.Constant)
+            and node.value.value == 0
+        ]
+        self.assertEqual(len(resets), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -440,7 +440,6 @@ class BalanceScheduler(Scheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
-                num_uncached_common_prefix_tokens = 0
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
@@ -468,6 +467,9 @@ class BalanceScheduler(Scheduler):
                         # the last block) is transferred unconditionally by
                         # _apply_prefix_caching in nixl/worker.py.
                         num_new_local_computed_tokens = max(per_group_hits)
+                        # The per-group lookup does not detect an uncached shared
+                        # prefix, so there is no junction to pin in this path.
+                        request.shared_prefix_boundary = 0
                         if self.kv_cache_manager.log_stats:
                             assert self.kv_cache_manager.prefix_cache_stats is not None
                             self.kv_cache_manager.prefix_cache_stats.record(
@@ -478,14 +480,6 @@ class BalanceScheduler(Scheduler):
                     else:
                         new_computed_blocks, num_new_local_computed_tokens = self.kv_cache_manager.get_computed_blocks(
                             request
-                        )
-
-                    # In case of hybrid models, obtain hint for Marconi-style APC logic
-                    if self.has_mamba_layers:
-                        num_uncached_common_prefix_tokens = getattr(
-                            self.kv_cache_manager.coordinator,
-                            "num_uncached_common_prefix_tokens",
-                            0,
                         )
 
                     # Get externally-cached tokens if using a KVConnector.
@@ -594,7 +588,6 @@ class BalanceScheduler(Scheduler):
                         num_new_tokens,
                         num_new_local_computed_tokens,
                         num_external_computed_tokens,
-                        num_uncached_common_prefix_tokens,
                     )
                     if num_new_tokens == 0:
                         break


### PR DESCRIPTION
### What this PR does / why we need it?

This is an independent follow-up to #13235/#13275 for the remaining Mamba waiting-path adaptation. It does not include or replace the `get_computed_blocks()` tuple-unpacking change from #13275.

Upstream vLLM PR [#47782](https://github.com/vllm-project/vllm/pull/47782) changed Mamba shared-prefix handling:

- `_mamba_block_aligned_split()` now reads `request.shared_prefix_boundary` and no longer accepts `num_uncached_common_prefix_tokens`.
- The Hybrid+KVConnector per-group lookup path explicitly resets `request.shared_prefix_boundary` to `0`, because that lookup cannot detect an uncached shared-prefix junction.

The copied `BalanceScheduler.schedule()` body still used the removed fifth argument. When `self.need_mamba_block_aligned_split and not load_kv_async` is reached, this can raise a `TypeError`. It also missed the boundary reset on the special Hybrid+Connector path.

This PR:

- removes the obsolete `num_uncached_common_prefix_tokens` plumbing and fifth call argument;
- resets `request.shared_prefix_boundary = 0` after the per-group cache lookup, matching upstream;
- adds two source-level regression UTs that guard the four-argument call and the special-path reset.

The source-level tests are intentionally independent of NPU/PyTorch runtime so this copied-interface regression is caught in CPU-only checks. A three-way merge check against #13275 showed no conflict markers.

### Does this PR introduce _any_ user-facing change?

No API change. It prevents balance scheduling from failing on the Mamba block-aligned waiting path and preserves the upstream shared-prefix behavior.

### How was this patch tested?

- `python tests/ut/patch/platform/test_balance_mamba_source.py -v` — 2 tests passed
- `python -m compileall -q vllm_ascend/patch/platform/patch_balance_schedule.py tests/ut/patch/platform/test_balance_mamba_source.py`
- `python -m ruff check vllm_ascend/patch/platform/patch_balance_schedule.py tests/ut/patch/platform/test_balance_mamba_source.py`
- `git diff --check`

The repository-wide Pytest entry point could not be collected locally because this Windows environment does not have `torch` installed; it fails while importing `tests/ut/conftest.py` before reaching the new tests.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
