### PR TITLE
support swiglu_dynamic_mx_quant_fusion_pass

### DIFF
--- a/tests/e2e/pull_request/one_card/compile/test_swiglu_dynamic_mx_quant_fusion.py
+++ b/tests/e2e/pull_request/one_card/compile/test_swiglu_dynamic_mx_quant_fusion.py
@@ -1,0 +1,318 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import torch
+import torch.nn as nn
+import torch_npu
+import vllm.config
+from vllm.compilation.passes.fx_utils import OpOverload
+from vllm.config import ModelConfig, VllmConfig
+from vllm.distributed import ensure_model_parallel_initialized, init_distributed_environment
+from vllm.utils.system_utils import update_environment_variables
+
+import vllm_ascend.ops.register_custom_ops  # noqa
+from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.compilation.passes.swiglu_dynamic_mx_quant_fusion_pass import (
+    SwiGluDynamicMXQuantFusionPass,
+)
+
+from .backend import TestBackend
+
+# Cache backend to avoid duplicate pattern registration
+_backend_cache = None
+
+
+def get_or_create_backend(vllm_config):
+    """Get or create backend with fusion passes (cached to avoid duplicate pattern registration)."""
+    global _backend_cache
+    if _backend_cache is None:
+        _backend_cache = TestBackend(
+            custom_passes=[SwiGluDynamicMXQuantFusionPass(vllm_config=vllm_config)]
+        )
+    return _backend_cache
+
+
+class TestSwiGluDynamicMXQuantModel(nn.Module):
+    """
+    A minimal test model that simulates the pattern:
+        SwiGlu → DynamicMXQuant
+    """
+
+    def __init__(self, hidden_size: int, dtype: torch.dtype, device="npu"):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+
+    def forward(self, x):
+        """
+        Forward pass:
+          1. Perform SwiGlu activation (input is split in half: gate and up)
+          2. Dynamic MX quantization
+        Returns both quantized output and scale.
+        """
+        # SwiGlu splits input into gate and up, applies SiLU to gate, then multiplies
+        swiglu_out = torch.ops.npu.npu_swiglu(x)
+
+        # Dynamic MX quantization
+        quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch.float8_e4m3fn)
+
+        return quantized_output[0], quantized_output[1]
+
+    def ops_in_model_before(self) -> list[OpOverload]:
+        """Return the list of expected operators BEFORE fusion."""
+        return [torch.ops.npu.npu_swiglu.default, torch.ops.npu.npu_dynamic_mx_quant.default]
+
+    def ops_in_model_after(self) -> list[OpOverload]:
+        """Return the list of expected operators AFTER successful fusion."""
+        return [torch.ops.npu.npu_swiglu_mx_quant.default]
+
+
+class TestSwiGluDynamicMXQuantSPModel(nn.Module):
+    """
+    A test model that simulates the pattern:
+        SwiGlu → maybe_allgather → DynamicMXQuant
+    """
+
+    def __init__(self, hidden_size: int, dtype: torch.dtype, device="npu"):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+
+    def forward(self, x):
+        """
+        Forward pass:
+          1. Perform SwiGlu activation
+          2. Maybe all_gather (sequence parallelism)
+          3. Dynamic MX quantization
+        Returns both quantized output and scale.
+        """
+        # SwiGlu splits input into gate and up, applies SiLU to gate, then multiplies
+        swiglu_out = torch.ops.npu.npu_swiglu(x)
+
+        # Maybe all_gather for sequence parallelism
+        swiglu_out = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(swiglu_out, True)
+
+        # Dynamic MX quantization
+        quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch.float8_e4m3fn)
+
+        return quantized_output[0], quantized_output[1]
+
+    def ops_in_model_before(self) -> list[OpOverload]:
+        """Return the list of expected operators BEFORE fusion."""
+        return [
+            torch.ops.npu.npu_swiglu.default,
+            torch.ops.vllm.maybe_all_gather_and_maybe_unpad.default,
+            torch.ops.npu.npu_dynamic_mx_quant.default,
+        ]
+
+    def ops_in_model_after(self) -> list[OpOverload]:
+        """Return the list of expected operators AFTER successful fusion."""
+        return [
+            torch.ops.npu.npu_swiglu_mx_quant.default,
+            torch.ops.vllm.maybe_all_gather_and_maybe_unpad.default,
+        ]
+
+
+class TestSwiGluDynamicMXQuantFloat4Model(nn.Module):
+    """
+    A test model that simulates the pattern:
+        SwiGlu → DynamicMXQuant with float4_e2m1fn_x2
+    """
+
+    def __init__(self, hidden_size: int, dtype: torch.dtype, device="npu"):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+
+    def forward(self, x):
+        """
+        Forward pass:
+          1. Perform SwiGlu activation (input is split in half: gate and up)
+          2. Dynamic MX quantization with float4
+        Returns both quantized output and scale.
+        """
+        # SwiGlu splits input into gate and up, applies SiLU to gate, then multiplies
+        swiglu_out = torch.ops.npu.npu_swiglu(x)
+
+        # Dynamic MX quantization with float4
+        quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch_npu.float4_e2m1fn_x2)
+
+        return quantized_output[0], quantized_output[1]
+
+    def ops_in_model_before(self) -> list[OpOverload]:
+        """Return the list of expected operators BEFORE fusion."""
+        return [torch.ops.npu.npu_swiglu.default, torch.ops.npu.npu_dynamic_mx_quant.default]
+
+    def ops_in_model_after(self) -> list[OpOverload]:
+        """Return the list of expected operators AFTER successful fusion."""
+        return [torch.ops.npu.npu_swiglu_mx_quant.default]
+
+
+class TestSwiGluDynamicMXQuantSPFloat4Model(nn.Module):
+    """
+    A test model that simulates the pattern:
+        SwiGlu → maybe_allgather → DynamicMXQuant with float4_e2m1fn_x2
+    """
+
+    def __init__(self, hidden_size: int, dtype: torch.dtype, device="npu"):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+
+    def forward(self, x):
+        """
+        Forward pass:
+          1. Perform SwiGlu activation
+          2. Maybe all_gather (sequence parallelism)
+          3. Dynamic MX quantization with float4
+        Returns both quantized output and scale.
+        """
+        # SwiGlu splits input into gate and up, applies SiLU to gate, then multiplies
+        swiglu_out = torch.ops.npu.npu_swiglu(x)
+
+        # Maybe all_gather for sequence parallelism
+        swiglu_out = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(swiglu_out, True)
+
+        # Dynamic MX quantization with float4
+        quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch_npu.float4_e2m1fn_x2)
+
+        return quantized_output[0], quantized_output[1]
+
+    def ops_in_model_before(self) -> list[OpOverload]:
+        """Return the list of expected operators BEFORE fusion."""
+        return [
+            torch.ops.npu.npu_swiglu.default,
+            torch.ops.vllm.maybe_all_gather_and_maybe_unpad.default,
+            torch.ops.npu.npu_dynamic_mx_quant.default,
+        ]
+
+    def ops_in_model_after(self) -> list[OpOverload]:
+        """Return the list of expected operators AFTER successful fusion."""
+        return [
+            torch.ops.npu.npu_swiglu_mx_quant.default,
+            torch.ops.vllm.maybe_all_gather_and_maybe_unpad.default,
+        ]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [128])  # Input size is 2*hidden_size for gate+up
+@pytest.mark.parametrize("num_tokens", [257])
+@pytest.mark.parametrize("sp_enable", [False, True])
+def test_swiglu_dynamic_mx_quant_fusion(
+    dtype: torch.dtype,
+    hidden_size: int,
+    num_tokens: int,
+    sp_enable: bool,
+):
+    """
+    End-to-end test for SwiGlu+DynamicMXQuant fusion with float8.
+    Compares: Operator presence/absence before and after graph transformation
+    """
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(1)
+
+    vllm_config = VllmConfig(model_config=ModelConfig(dtype=dtype))
+
+    with vllm.config.set_current_vllm_config(vllm_config):
+        update_environment_variables(
+            {
+                "RANK": "0",
+                "LOCAL_RANK": "0",
+                "WORLD_SIZE": "1",
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": "12345",
+            }
+        )
+        init_distributed_environment()
+        ensure_model_parallel_initialized(1, 1)
+
+    with vllm.config.set_current_vllm_config(vllm_config), set_ascend_forward_context(None, vllm_config):
+        backend = get_or_create_backend(vllm_config)
+
+        if sp_enable:
+            model = TestSwiGluDynamicMXQuantSPModel(hidden_size, dtype, device="npu")
+        else:
+            model = TestSwiGluDynamicMXQuantModel(hidden_size, dtype, device="npu")
+        model = model.to("npu")
+
+        # Input is 2*hidden_size for gate and up projections
+        x = torch.rand(num_tokens, hidden_size * 2, device="npu", dtype=dtype, requires_grad=False)
+
+        result_unfused = model(x)
+        print("Unfused result:", [t.shape for t in result_unfused])
+        model_fused = torch.compile(model, backend=backend)
+        result_fused = model_fused(x)
+        print("Fused result:", [t.shape for t in result_fused])
+
+        print("=== Checking operator fusion ===")
+        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=not sp_enable)
+        backend.check_after_ops(model.ops_in_model_after())
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [128])  # Input size is 2*hidden_size for gate+up
+@pytest.mark.parametrize("num_tokens", [257])
+@pytest.mark.parametrize("sp_enable", [False, True])
+def test_swiglu_dynamic_mx_quant_fusion_float4(
+    dtype: torch.dtype,
+    hidden_size: int,
+    num_tokens: int,
+    sp_enable: bool,
+):
+    """
+    End-to-end test for SwiGlu+DynamicMXQuant fusion with float4_e2m1fn_x2.
+    Compares: Operator presence/absence before and after graph transformation
+    """
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(1)
+
+    vllm_config = VllmConfig(model_config=ModelConfig(dtype=dtype))
+
+    with vllm.config.set_current_vllm_config(vllm_config):
+        update_environment_variables(
+            {
+                "RANK": "0",
+                "LOCAL_RANK": "0",
+                "WORLD_SIZE": "1",
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": "12345",
+            }
+        )
+        init_distributed_environment()
+        ensure_model_parallel_initialized(1, 1)
+
+    with vllm.config.set_current_vllm_config(vllm_config), set_ascend_forward_context(None, vllm_config):
+        backend = get_or_create_backend(vllm_config)
+
+        if sp_enable:
+            model = TestSwiGluDynamicMXQuantSPFloat4Model(hidden_size, dtype, device="npu")
+        else:
+            model = TestSwiGluDynamicMXQuantFloat4Model(hidden_size, dtype, device="npu")
+        model = model.to("npu")
+
+        # Input is 2*hidden_size for gate and up projections
+        x = torch.rand(num_tokens, hidden_size * 2, device="npu", dtype=dtype, requires_grad=False)
+
+        result_unfused = model(x)
+        print("Unfused result:", [t.shape for t in result_unfused])
+        model_fused = torch.compile(model, backend=backend)
+        result_fused = model_fused(x)
+        print("Fused result:", [t.shape for t in result_fused])
+
+        print("=== Checking operator fusion ===")
+        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=not sp_enable)
+        backend.check_after_ops(model.ops_in_model_after())

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -61,6 +61,11 @@ class GraphFusionPassManager:
 
             self.passes.append(QKNormRopeFusionPass(config))
 
+        if self.ascend_compilation_config.get("fuse_swiglu_dynamic_mx_quant", True):
+            from .passes.swiglu_dynamic_mx_quant_fusion_pass import SwiGluDynamicMXQuantFusionPass
+
+            self.passes.append(SwiGluDynamicMXQuantFusionPass(config))
+
         if self.ascend_compilation_config.get("fuse_muls_add", True) and not is_310p():
             from .passes.muls_add_pass import MulsAddFusionPass
 

--- a/vllm_ascend/compilation/passes/swiglu_dynamic_mx_quant_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/swiglu_dynamic_mx_quant_fusion_pass.py
@@ -1,0 +1,316 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+import torch_npu
+from torch._inductor.pattern_matcher import PatternMatcherPass, PatternPrettyPrinter
+from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config.compilation import Range
+from vllm.logger import logger
+
+from vllm_ascend.compilation.passes.base_pattern import BasePattern
+
+
+class SwiGluDynamicMXQuantPattern(BasePattern):
+    """
+    Pattern for fusing SwiGlu and DynamicMXQuant operations.
+
+    Matches the pattern:
+        swiglu_out = torch_npu.npu_swiglu(x)
+        quantized_out, scale = torch_npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch.float8_e4m3fn)
+
+    Replaces with:
+        quantized_out, scale = torch_npu.npu_swiglu_mx_quant(x, dst_type=torch.float8_e4m3fn)
+    """
+
+    def __init__(self, vllm_config: VllmConfig):
+        super().__init__(vllm_config, eps=1e-6)  # eps not used for SwiGlu
+
+    def get_inputs(self):
+        """
+        Generate example inputs for the SwiGluDynamicMXQuant fusion pattern.
+        """
+        x = torch.randn(2, 64 * 2, device="npu", dtype=self.dtype)  # SwiGlu splits input in half
+        return [x]
+
+    def get_pattern(self):
+        """
+        Pattern function that matches SwiGlu followed by DynamicMXQuant.
+        """
+        def pattern(x: torch.Tensor):
+            """
+            Pattern for SwiGluDynamicMXQuant fusion.
+            """
+            swiglu_out = torch.ops.npu.npu_swiglu(x)
+            quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch.float8_e4m3fn)
+            return quantized_output[0], quantized_output[1]
+
+        return pattern
+
+    def get_replacement(self):
+        """
+        Replacement function using the fused npu_swiglu_mx_quant operator.
+        """
+        def replacement(x: torch.Tensor):
+            """
+            Replacement for the SwiGluDynamicMXQuant fusion.
+            """
+            output = torch.ops.npu.npu_swiglu_mx_quant(x, activation_left=True, dst_type=torch.float8_e4m3fn)
+            return output[0], output[1]
+
+        return replacement
+
+
+class SwiGluDynamicMXQuantSPPattern(BasePattern):
+    """
+    Pattern for fusing SwiGlu and DynamicMXQuant operations with sequence parallelism.
+
+    Matches the pattern:
+        swiglu_out = torch_npu.npu_swiglu(x)
+        swiglu_out = maybe_all_gather_and_maybe_unpad(swiglu_out, True)
+        quantized_out, scale = torch_npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch.float8_e4m3fn)
+
+    Replaces with:
+        quantized_out, scale = torch_npu.npu_swiglu_mx_quant(x, dst_type=torch.float8_e4m3fn)
+        quantized_out = maybe_all_gather_and_maybe_unpad(quantized_out, True)
+        scale = maybe_all_gather_and_maybe_unpad(scale, True)
+    """
+
+    def __init__(self, vllm_config: VllmConfig):
+        super().__init__(vllm_config, eps=1e-6)  # eps not used for SwiGlu
+
+    def get_inputs(self):
+        """
+        Generate example inputs for the SwiGluDynamicMXQuant fusion pattern with SP.
+        """
+        x = torch.randn(2, 64 * 2, device="npu", dtype=self.dtype)  # SwiGlu splits input in half
+        return [x]
+
+    def get_pattern(self):
+        """
+        Pattern function that matches SwiGlu followed by all_gather and DynamicMXQuant.
+        """
+        def pattern(x: torch.Tensor):
+            """
+            Pattern for SwiGluDynamicMXQuant fusion with sequence parallelism.
+            """
+            swiglu_out = torch.ops.npu.npu_swiglu(x)
+            swiglu_out = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(swiglu_out, True)
+            quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch.float8_e4m3fn)
+            return quantized_output[0], quantized_output[1]
+
+        return pattern
+
+    def get_replacement(self):
+        """
+        Replacement function using the fused npu_swiglu_mx_quant operator with SP.
+        """
+        def replacement(x: torch.Tensor):
+            """
+            Replacement for the SwiGluDynamicMXQuant fusion with sequence parallelism.
+            """
+            output = torch.ops.npu.npu_swiglu_mx_quant(x, dst_type=torch.float8_e4m3fn)
+            quantized_output = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(output[0], True)
+            mxscale = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(output[1], True)
+            return quantized_output, mxscale
+
+        return replacement
+
+
+class SwiGluDynamicMXQuantFloat4Pattern(BasePattern):
+    """
+    Pattern for fusing SwiGlu and DynamicMXQuant operations with float4_e2m1fn_x2 dtype.
+
+    Matches the pattern:
+        swiglu_out = torch_npu.npu_swiglu(x)
+        quantized_out, scale = torch_npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch_npu.float4_e2m1fn_x2)
+
+    Replaces with:
+        quantized_out, scale = torch_npu.npu_swiglu_mx_quant(x, dst_type=torch_npu.float4_e2m1fn_x2)
+    """
+
+    def __init__(self, vllm_config: VllmConfig):
+        super().__init__(vllm_config, eps=1e-6)  # eps not used for SwiGlu
+
+    def get_inputs(self):
+        """
+        Generate example inputs for the SwiGluDynamicMXQuant fusion pattern.
+        """
+        x = torch.randn(2, 64 * 2, device="npu", dtype=self.dtype)  # SwiGlu splits input in half
+        return [x]
+
+    def get_pattern(self):
+        """
+        Pattern function that matches SwiGlu followed by DynamicMXQuant with float4.
+        """
+        def pattern(x: torch.Tensor):
+            """
+            Pattern for SwiGluDynamicMXQuant fusion with float4_e2m1fn_x2.
+            """
+            swiglu_out = torch.ops.npu.npu_swiglu(x)
+            quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch_npu.float4_e2m1fn_x2)
+            return quantized_output[0], quantized_output[1]
+
+        return pattern
+
+    def get_replacement(self):
+        """
+        Replacement function using the fused npu_swiglu_mx_quant operator with float4.
+        """
+        def replacement(x: torch.Tensor):
+            """
+            Replacement for the SwiGluDynamicMXQuant fusion with float4_e2m1fn_x2.
+            """
+            output = torch.ops.npu.npu_swiglu_mx_quant(x, dst_type=torch_npu.float4_e2m1fn_x2)
+            return output[0], output[1]
+
+        return replacement
+
+
+class SwiGluDynamicMXQuantSPFloat4Pattern(BasePattern):
+    """
+    Pattern for fusing SwiGlu and DynamicMXQuant operations with sequence parallelism and float4_e2m1fn_x2 dtype.
+
+    Matches the pattern:
+        swiglu_out = torch_npu.npu_swiglu(x)
+        swiglu_out = maybe_all_gather_and_maybe_unpad(swiglu_out, True)
+        quantized_out, scale = torch_npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch_npu.float4_e2m1fn_x2)
+
+    Replaces with:
+        quantized_out, scale = torch_npu.npu_swiglu_mx_quant(x, dst_type=torch_npu.float4_e2m1fn_x2)
+        quantized_out = maybe_all_gather_and_maybe_unpad(quantized_out, True)
+        scale = maybe_all_gather_and_maybe_unpad(scale, True)
+    """
+
+    def __init__(self, vllm_config: VllmConfig):
+        super().__init__(vllm_config, eps=1e-6)  # eps not used for SwiGlu
+
+    def get_inputs(self):
+        """
+        Generate example inputs for the SwiGluDynamicMXQuant fusion pattern with SP.
+        """
+        x = torch.randn(2, 64 * 2, device="npu", dtype=self.dtype)  # SwiGlu splits input in half
+        return [x]
+
+    def get_pattern(self):
+        """
+        Pattern function that matches SwiGlu followed by all_gather and DynamicMXQuant with float4.
+        """
+        def pattern(x: torch.Tensor):
+            """
+            Pattern for SwiGluDynamicMXQuant fusion with sequence parallelism and float4_e2m1fn_x2.
+            """
+            swiglu_out = torch.ops.npu.npu_swiglu(x)
+            swiglu_out = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(swiglu_out, True)
+            quantized_output = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=torch_npu.float4_e2m1fn_x2)
+            return quantized_output[0], quantized_output[1]
+
+        return pattern
+
+    def get_replacement(self):
+        """
+        Replacement function using the fused npu_swiglu_mx_quant operator with SP and float4.
+        """
+        def replacement(x: torch.Tensor):
+            """
+            Replacement for the SwiGluDynamicMXQuant fusion with sequence parallelism and float4_e2m1fn_x2.
+            """
+            output = torch.ops.npu.npu_swiglu_mx_quant(x, dst_type=torch_npu.float4_e2m1fn_x2)
+            quantized_output = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(output[0], True)
+            mxscale = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(output[1], True)
+            return quantized_output, mxscale
+
+        return replacement
+
+
+class SwiGluDynamicMXQuantFusionPass(VllmInductorPass):
+    """
+    A pass for fusing SwiGlu and DynamicMXQuant operations on Ascend.
+
+    This pass optimizes models like Qwen3-8B and Qwen3-32B that use the
+    SwiGlu activation function followed by MX quantization.
+    """
+
+    def __init__(self, vllm_config: VllmConfig):
+        super().__init__(vllm_config)
+        self.pattern_match_passes: PatternMatcherPass = PatternMatcherPass(
+            pass_name="swiglu_dynamic_mx_quant_fusion_pass"
+        )
+
+        dtype = vllm_config.model_config.dtype
+        if dtype not in (torch.bfloat16, torch.float16):
+            logger.debug("SwiGlu DynamicMXQuant fusion not enabled: unsupported dtype %s", dtype)
+            return
+
+        # Check if the required npu_swiglu_mx_quant operator is available with float8
+        try:
+            # Test if the operator exists with float8
+            test_tensor = torch.empty(1, 2, device="npu", dtype=dtype)
+            _ = torch.ops.npu.npu_swiglu_mx_quant(test_tensor, dst_type=torch.float8_e4m3fn)
+            float8_available = True
+        except (AttributeError, RuntimeError) as e:
+            logger.debug(
+                "SwiGlu DynamicMXQuant fusion (float8) not enabled: npu_swiglu_mx_quant operator unavailable: %s", e
+            )
+            float8_available = False
+
+        # Check if the required npu_swiglu_mx_quant operator is available with float4
+        try:
+            # Test if the operator exists with float4
+            test_tensor = torch.empty(1, 2, device="npu", dtype=dtype)
+            _ = torch.ops.npu.npu_swiglu_mx_quant(test_tensor, dst_type=torch_npu.float4_e2m1fn_x2)
+            float4_available = True
+        except (AttributeError, RuntimeError) as e:
+            logger.debug(
+                "SwiGlu DynamicMXQuant fusion (float4) not enabled: npu_swiglu_mx_quant operator unavailable: %s", e
+            )
+            float4_available = False
+
+        if not float8_available and not float4_available:
+            return
+
+        # Register the float8 patterns
+        if float8_available:
+            SwiGluDynamicMXQuantPattern(vllm_config).register(self.pattern_match_passes)
+            SwiGluDynamicMXQuantSPPattern(vllm_config).register(self.pattern_match_passes)
+            logger.debug("SwiGlu DynamicMXQuant float8 fusion patterns registered")
+
+        # Register the float4 patterns
+        if float4_available:
+            SwiGluDynamicMXQuantFloat4Pattern(vllm_config).register(self.pattern_match_passes)
+            SwiGluDynamicMXQuantSPFloat4Pattern(vllm_config).register(self.pattern_match_passes)
+            logger.debug("SwiGlu DynamicMXQuant float4 fusion patterns registered")
+
+    def __call__(self, graph: torch.fx.Graph):
+        self.begin()
+        self.matched_count = self.pattern_match_passes.apply(graph)
+        logger.debug("Fused %s SwiGlu DynamicMXQuant patterns", self.matched_count)
+        logger.debug("Patterns registered for replacement:")
+        pattern_idx = 0
+        for pattern_entry in self.pattern_match_passes.patterns.values():
+            for p in pattern_entry:
+                p_str = PatternPrettyPrinter.run(p.pattern)
+                logger.debug("Pattern %d: %s", pattern_idx, p_str)
+                pattern_idx += 1
+        self.end_and_log()
+
+    def is_applicable_for_range(self, compile_range: Range) -> bool:
+        """
+        Check if the pass is applicable for the current configuration.
+        """
+        return True


### PR DESCRIPTION
  ```markdown
     ### What this PR does / why we need it?

     This PR introduces a new graph fusion pass `SwiGluDynamicMXQuantFusionPass` for the Ascend backend.

     It fuses the pattern:
     ```python
     swiglu_out = torch.ops.npu.npu_swiglu(x)
     quantized_out, scale = torch.ops.npu.npu_dynamic_mx_quant(swiglu_out, dst_type=...)
   ```

   into a single fused operator:

   ```python
     quantized_out, scale = torch.ops.npu.npu_swiglu_mx_quant(x, ...)
   ```

   Key changes:
   • Added vllm_ascend/compilation/passes/swiglu_dynamic_mx_quant_fusion_pass.py implementing the fusion pass.
   • Registered the pass in vllm_ascend/compilation/graph_fusion_pass_manager.py under the config key fuse_swiglu_dynamic_mx_quant (enabled by default).
   • Supports both torch.float8_e4m3fn and torch_npu.float4_e2m1fn_x2 quantization dtypes.
   • Supports both standalone and sequence-parallelism variants (with maybe_all_gather_and_maybe_unpad).
   • Added E2E test tests/e2e/pull_request/one_card/compile/test_swiglu_dynamic_mx_quant_fusion.py covering float8/float4 with and without sequence parallelism.

   This fusion reduces memory movement and improves performance for models that use SwiGlu activation followed by MX quantization (e.g., Qwen3 series).

   Does this PR introduce any user-facing change?

   No direct user-facing API change. The fusion is applied automatically during graph compilation when fuse_swiglu_dynamic_mx_quant is enabled (default: True) and the underlying npu_swiglu_mx_quant operator is available.

   Users may observe improved inference performance and reduced memory bandwidth usage for supported models. If the fused operator is unavailable, the pass falls back to the original unfused operators silently.

   How was this patch tested?

   • Added new E2E test: tests/e2e/pull_request/one_card/compile/test_swiglu_dynamic_mx_quant_fusion.py
   • The test validates operator presence before and after fusion for the following cases:
       • test_swiglu_dynamic_mx_quant_fusion: float8 (torch.float8_e4m3fn) with sp_enable=False/True
       • test_swiglu_dynamic_mx_quant_fusion_float4: float4 (torch_npu.float4_e2m1fn_x2) with sp_enable=False/True
   • CI should pass with the new test.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
