### PR TITLE
[v0.24.0][DOC]Modify the scope of scenarios supported by CP

### DIFF
--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -15,12 +15,14 @@ To learn more about the theory and implementation details of context parallel, p
 
 ## Supported Scenarios
 
-Currently context parallel can be used together with most other features, supported features are as follows:
+CP(Context Parallel) supports eager and graph execution, prefix caching, chunked prefill, speculative decoding, P/D disaggregation, and MLAPO on the model and hardware combinations documented by vLLM Ascend. The following table shows whether each feature can be combined with DCP across devices and attention backends:
 
-|         | Eager | Graph | Prefix <br> Cache | Chunked <br> Prefill | SpecDecode <br> (MTP) | PD <br> disaggregation | MLAPO |
-| ------- | ----- | ----- | ------ | ------ | ----- | ----- | ----- |
-| **PCP** | ✅    | ✅     | ✅      | ✅       | ✅      | ✅ | ✅|
-| **DCP** | ✅    | ✅     | ✅      | ✅       | ✅      | ✅ | ✅ |
+| Device | Attention Backend | Chunked Prefill + CP | Prefix Caching + CP | Graph Mode + CP | P/D Disaggregation + CP | MLAPO + CP | Speculative Decoding + CP |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Ascend A2/A3 | MLA/GQA | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported (MLA)<br>— Not applicable (GQA) | 🟢 P/D disaggregation<br>🔴 PD-mixed deployment |
+| Ascend A2/A3 | SFA | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported |
+| Ascend 950 | MLA/GQA | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental (MLA)<br>— Not applicable (GQA) | 🔵 P/D disaggregation<br>🔴 PD-mixed deployment |
+| Ascend 950 | SFA | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported |
 
 ## How to use Context Parallel
 

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -24,6 +24,11 @@ CP(Context Parallel) supports eager and graph execution, prefix caching, chunked
 | Ascend 950 | MLA/GQA | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental (MLA)<br>— Not applicable (GQA) | 🔵 P/D disaggregation<br>🔴 PD-mixed deployment |
 | Ascend 950 | SFA | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported |
 
+- 🟢 **Supported**: Combining the feature with DCP is supported.
+- 🔵 **Experimental**: Combining the feature with DCP is experimentally supported; interfaces and functionality may change.
+- 🔴 **Not supported**: Combining the feature with DCP is not supported.
+- **Not applicable**: The feature does not apply to this attention backend.
+
 ## How to use Context Parallel
 
 You can enable `PCP` and `DCP` by `prefill_context_parallel_size` and `decode_context_parallel_size`, refer to the following example:


### PR DESCRIPTION
### What this PR does / why we need it?
Modify the scope of scenarios supported by CP.
In scenario 950, SFA does not support the overlay of CP, while MLA and GQA are experimentally supported.

### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350

pick-from:https://github.com/vllm-project/vllm-ascend/pull/13302
