### PR TITLE
[BugFix][v0.23.0][KV Pool] Guard batch_get_key_info before memcache backend init

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -138,11 +138,19 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_is_exist(keys)
 
-    def batch_get_key_info(self, keys: list[str]):
+    def batch_get_key_info(self, keys: list[str]) -> list[Any]:
+        if self._lazy_init and not self._store_initialized:
+            logger.debug(
+                "MemcacheBackend.batch_get_key_info called before store initialization; "
+                "returning empty list for %d keys.",
+                len(keys),
+            )
+            return []
         assert self.store is not None
         return self.store.batch_get_key_info(keys)
 
     def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+        self.ensure_initialized()
         assert self.store is not None
         return self.store.batch_alloc(keys, sizes)
 


### PR DESCRIPTION
fix(kv_pool): guard batch_get_key_info before memcache backend init

When the MemcacheBackend store is not yet initialized (lazy_init mode),
batch_get_key_info hit `assert self.store is not None` and crashed the
scheduler/worker. Return an empty list instead, matching the list[KeyInfo]
return contract; callers treat an empty result as zero cache hits.

Also call ensure_initialized() in batch_alloc so allocation triggers lazy
init, and annotate the return type as list[Any].

Signed-off-by: tyy0829 <1455207791@qq.com>

---
Scope: limited to `memcache_backend.py`.
- `batch_get_key_info`: return `[]` when the store is not initialized (lazy_init) instead of asserting, so the scheduler/worker no longer crash before the store is up. Matches the `list[KeyInfo]` return contract.
- `batch_alloc`: call `ensure_initialized()` so allocation triggers lazy init.
- Annotate return type as `list[Any]`.
Rebased on the latest `releases/v0.23.0`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
