### PR TITLE
[BugFix][v0.25.1][KV Pool] Guard batch_get_key_info before memcache backend init

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -134,11 +134,19 @@ class MemcacheBackend(Backend):
         assert self.store is not None
         return self.store.batch_is_exist(keys)
 
-    def batch_get_key_info(self, keys: list[str]):
+    def batch_get_key_info(self, keys: list[str]) -> list[Any]:
+        if self._lazy_init and not self._store_initialized:
+            logger.debug(
+                "MemcacheBackend.batch_get_key_info called before store initialization; "
+                "returning empty list for %d keys.",
+                len(keys),
+            )
+            return []
         assert self.store is not None
         return self.store.batch_get_key_info(keys)
 
     def batch_alloc(self, keys: list[str], sizes: list[int]) -> list[int]:
+        self.ensure_initialized()
         assert self.store is not None
         return self.store.batch_alloc(keys, sizes)
 


### PR DESCRIPTION
fix(kv_pool): guard batch_get_key_info before memcache backend init

When the MemcacheBackend store is not yet initialized (lazy_init mode),
batch_get_key_info hit `assert self.store is not None` and crashed the
scheduler/worker. Return an empty list instead, matching the list[KeyInfo]
return contract; callers treat an empty result as zero cache hits.

Also call ensure_initialized() in batch_alloc so allocation triggers lazy
init, and annotate the return type as list[Any].

(cherry picked from commit 476b7fb6be099265db821a9339afe30f99e8b941)
Signed-off-by: tyy0829 <1455207791@qq.com>

---
Cherry-pick of #13307, rebased on `releases/v0.25.1rc`.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
