### PR TITLE
[310P][Performance] Support Qwen3 dflash/dspark for Ascend 310P

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -52,6 +52,12 @@
   optional: false
   source_file_dependencies:
     - vllm_ascend/_310p
+    # The 310P parallel-drafting route is reached through these shared files, so
+    # a change to them must run the 310P suites too; vllm_ascend/_310p alone
+    # would leave the DFlash/DSpark path untested on this device.
+    - vllm_ascend/spec_decode/dflash_proposer.py
+    - vllm_ascend/spec_decode/dspark_proposer.py
+    - vllm_ascend/patch/worker/patch_qwen3_dflash.py
   tests:
     - tests/ut/_310p
     - tests/e2e/pull_request/one_card/_310p

--- a/tests/e2e/pull_request/four_card/_310p/test_parallel_draft_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_parallel_draft_310p.py
@@ -1,0 +1,126 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DFlash / DSpark parallel drafting on Atlas 300I (310P), TP=4, drafter eager.
+
+Mirrors the A2 tests (one_card/spec_decode/test_dflash.py, test_dspark.py):
+same checkpoints, prompt, chat template, max_tokens, acceptance helper and
+per-position tolerance. Acceptance moves more with prompt formatting than with
+anything this port changes, so comparing against BASELINES only means something
+if those match. Only what 310P forces differs -- fp16 (the custom FIA kernel is
+fp16-only), block_size 128 (the only KV page size its block selection covers),
+enforce_eager (the drafter cannot be captured; see parallel_draft_attention),
+and TP=4, which shards heads without changing the numerics.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# 310P adaptation lives on Model Runner V1.
+os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+from transformers import AutoTokenizer  # noqa: E402
+from vllm import SamplingParams  # noqa: E402
+from vllm.v1.metrics.reader import Counter, Vector  # noqa: E402
+
+from tests.e2e.conftest import VllmRunner  # noqa: E402
+from tests.e2e.pull_request.one_card.spec_decode.utils import (  # noqa: E402
+    BASELINES,
+    DFLASH,
+    DSPARK,
+    calculate_acceptance_per_pos,
+)
+
+# (method, num_speculative_tokens), matching the A2 tests' parametrisation.
+CASES = [("dspark", DSPARK, 7), ("dflash", DFLASH, 8)]
+
+# The A2 tolerance, applied one-sided: upstream uses abs(a - b) < 0.1, which
+# also fails when acceptance improves, and a port gate only cares about the
+# downside.
+TOLERANCE = 0.1
+
+
+def _resolve(name, env):
+    """Allow a pre-fetched local copy so four TP ranks do not race to download."""
+    return os.environ.get(env, name)
+
+
+@pytest.mark.parametrize(("method", "registry", "num_speculative_tokens"), CASES)
+def test_parallel_draft_acceptance(method, registry, num_speculative_tokens):
+    main_model = _resolve(registry[method]["main"], "QWEN3_8B_PATH")
+    spec_model = _resolve(registry[method]["spec"], f"{method.upper()}_SPEC_PATH")
+    for path in (main_model, spec_model):
+        if path.startswith("/") and not os.path.isdir(path):
+            pytest.skip(f"model path not found: {path}")
+
+    tokenizer = AutoTokenizer.from_pretrained(main_model, trust_remote_code=True)
+    prompts = [
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Hello, your name is"}],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+    ]
+    sampling_params = SamplingParams(temperature=0, ignore_eos=False, max_tokens=256)
+
+    with VllmRunner(
+        main_model,
+        max_model_len=4096,
+        dtype="float16",
+        tensor_parallel_size=4,
+        block_size=128,
+        enforce_eager=True,
+        distributed_executor_backend="mp",
+        enable_prefix_caching=False,
+        disable_log_stats=False,
+        max_num_seqs=256,
+        gpu_memory_utilization=0.8,
+        speculative_config={
+            "method": method,
+            "model": spec_model,
+            "num_speculative_tokens": num_speculative_tokens,
+            "draft_tensor_parallel_size": 4,
+        },
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        print(f"Generated: {output.outputs[0].text!r}")
+
+    num_drafts = sum(m.value for m in metrics if m.name == "vllm:spec_decode_num_drafts")
+    acceptance = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
+    golden = BASELINES[method]
+    print(f"{method}: num_drafts={num_drafts} acceptance_per_pos={acceptance} golden={golden}")
+
+    # num_drafts is the denominator of every rate above and this prompt hits EOS
+    # well inside max_tokens, so it is small -- BASELINES is itself quantised to
+    # fifths. Assert it rather than leave it invisible: a change that stopped
+    # generation after one step would pass or fail for an unrelated reason.
+    assert num_drafts >= 5, f"only {num_drafts} draft steps; the rates are too coarse to compare"
+
+    # Every position, not just position 0: the 310P-specific machinery (context
+    # KV precompute, per-layer drafting RoPE, query slot mapping, non-causal FIA
+    # over the query block) shows up as a decaying tail while position 0 -- the
+    # target's own bonus token -- still looks healthy.
+    low = [i for i, (a, b) in enumerate(zip(acceptance, golden)) if a < b - TOLERANCE]
+    assert not low, (
+        f"{method} acceptance below the A2 baseline at positions {low}: "
+        f"got {[round(a, 4) for a in acceptance]}, golden {golden}, tolerance {TOLERANCE}"
+    )

--- a/tests/ut/_310p/attention/test_attention_v1_310.py
+++ b/tests/ut/_310p/attention/test_attention_v1_310.py
@@ -115,6 +115,133 @@ class TestAscendAttentionBackendImpl310(TestBase):
         self.assertIs(kwargs["out"], output)
         self.assertIs(result, output)
 
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu._npu_flash_attention")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_forward_prefill_310_coerces_device_seq_lens_to_host(
+        self, mock_get_forward_context, mock_npu_flash_attention, mock_npu_reshape_and_cache
+    ):
+        """Parallel drafting (DFlash/DSpark) makes the builder hand out a device
+        seq_lens tensor for the A2/A3 FIA path. 310P's prefill feeds seq_len to
+        ATB's SelfAttention encoder, which reads it from host memory and segfaults
+        on a device tensor. The prefill path must coerce it to host."""
+        from types import SimpleNamespace
+
+        query = torch.randn(10, 8, 64)
+        key = torch.randn(10, 8, 64)
+        value = torch.randn(10, 8, 64)
+        output = torch.empty_like(query)
+
+        host_seq_lens = torch.tensor([10])
+        device_seq_lens = MagicMock()
+        device_seq_lens.device = SimpleNamespace(type="npu")
+        device_seq_lens.cpu.return_value = host_seq_lens
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.attn_mask = torch.randn(1, 1, 10, 10)
+        metadata.seq_lens = device_seq_lens
+        metadata.actual_seq_lengths_q = [10]
+        metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
+        metadata.num_actual_tokens = 10
+        metadata.slot_mapping = torch.zeros(10, dtype=torch.long)
+
+        self.impl.support_compressed_mask = False
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        mock_npu_flash_attention.return_value = torch.ones(10, 8, 64)
+
+        self.impl.forward_impl(query, key, value, None, metadata, output)
+
+        device_seq_lens.cpu.assert_called_once()
+        _, kwargs = mock_npu_flash_attention.call_args
+        self.assertIs(kwargs["seq_len"], host_seq_lens, "ATB received a device seq_len; it needs host")
+
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu._npu_flash_attention_v3", create=True)
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_forward_prefill_310_v3_also_gets_host_seq_lens(
+        self, mock_get_forward_context, mock_flash_attention_v3, mock_npu_reshape_and_cache
+    ):
+        """Same coercion on the compressed-mask path.
+
+        With a torch_npu/ATB build that supports compressed masks, prefill
+        dispatches to _npu_flash_attention_v3 instead. Every other 310P attention
+        test pins support_compressed_mask to False, so that operator had no
+        coverage at all -- yet it is what production runs once the runtime is
+        upgraded. Host seq_len is the established contract for both: without
+        speculation the builder always handed these ops a CPU tensor.
+        """
+        from types import SimpleNamespace
+
+        query = torch.randn(10, 8, 64)
+        key = torch.randn(10, 8, 64)
+        value = torch.randn(10, 8, 64)
+        output = torch.empty_like(query)
+
+        host_seq_lens = torch.tensor([10])
+        device_seq_lens = MagicMock()
+        device_seq_lens.device = SimpleNamespace(type="npu")
+        device_seq_lens.cpu.return_value = host_seq_lens
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillNoCache
+        metadata.attn_mask = torch.randn(1, 1, 10, 10)
+        metadata.seq_lens = device_seq_lens
+        metadata.actual_seq_lengths_q = [10]
+        metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
+        metadata.num_actual_tokens = 10
+        metadata.slot_mapping = torch.zeros(10, dtype=torch.long)
+
+        self.impl.support_compressed_mask = True
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        mock_flash_attention_v3.return_value = torch.ones(10, 8, 64)
+
+        self.impl.forward_impl(query, key, value, None, metadata, output)
+
+        mock_flash_attention_v3.assert_called_once()
+        _, kwargs = mock_flash_attention_v3.call_args
+        self.assertIs(kwargs["seq_len"], host_seq_lens, "v3 received a device seq_len; it needs host")
+
+    @patch("torch_npu._npu_reshape_and_cache")
+    @patch("torch_npu._npu_paged_attention_splitfuse_v2", create=True)
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    def test_splitfuse_v2_uses_the_fixed_compressed_mask(
+        self, mock_get_forward_context, mock_splitfuse_v2, mock_npu_reshape_and_cache
+    ):
+        """The compressed splitfuse path is what makes graph capture possible.
+
+        The legacy get_splitfuse_mask builds its mask from .to("cpu") + .tolist()
+        of live metadata -- a device sync that cannot be captured. The compressed
+        variant uses a cached fixed 2048x2048 mask instead, with no sync, which is
+        why FULL_DECODE_ONLY becomes viable. Pin that it is actually used.
+        """
+        query = torch.randn(4, 8 * 64)
+        output = torch.empty_like(query)
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.ChunkedPrefill
+        metadata.causal = True
+        metadata.seq_lens = torch.tensor([4])
+        metadata.query_lens_cpu = torch.tensor([4], dtype=torch.int32)
+        metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
+        metadata.num_actual_tokens = 4
+        metadata.slot_mapping = torch.zeros(4, dtype=torch.long)
+
+        self.impl.support_compressed_mask = True
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+
+        with patch(
+            "vllm_ascend._310p.attention.attention_mask.AttentionMaskBuilder310.get_splitfuse_mask"
+        ) as legacy_mask:
+            self.impl.forward_impl(query, None, None, None, metadata, output)
+
+        mock_splitfuse_v2.assert_called_once()
+        legacy_mask.assert_not_called()
+        _, kwargs = mock_splitfuse_v2.call_args
+        # Fixed square mask, not one derived per step from live metadata.
+        self.assertEqual(kwargs["mask"].shape[0], kwargs["mask"].shape[1])
+        self.assertIs(kwargs["seq_len"], metadata.query_lens_cpu)
+
     @patch("torch_npu.npu_format_cast", return_value=torch.randn((1, 128, 16, 16), dtype=torch.float16))
     @patch("torch_npu._npu_reshape_and_cache")
     @patch("torch_npu._npu_paged_attention_splitfuse")

--- a/tests/ut/_310p/attention/test_parallel_draft_attention_310p.py
+++ b/tests/ut/_310p/attention/test_parallel_draft_attention_310p.py
@@ -1,0 +1,543 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch as mock_patch
+
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend._310p.attention import parallel_draft_attention as fia_mod
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+
+FIA_MOD = "vllm_ascend._310p.attention.parallel_draft_attention"
+
+NUM_HEADS = 16
+NUM_KV_HEADS = 4
+HEAD_DIM = 128
+BLOCK_SIZE = 128
+NUM_BLOCKS = 8
+BATCH = 3
+DFLASH_Q = 9  # K + 1
+KV_LENS = [200, 133, 65]
+
+
+def make_vllm_config(*, method="dflash", num_spec=8, arch="DFlashDraftModel", eager=True, tp=2, **hf):
+    """`hf` sets extra hf_config fields the scope validator reads.
+
+    Absent ones fall back to getattr defaults, which is what the real
+    Qwen3DSpark checkpoint looks like -- it carries none of the DFlash
+    diffusion/attention keys.
+    """
+    return SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method=method,
+            num_speculative_tokens=num_spec,
+            draft_model_config=SimpleNamespace(hf_config=SimpleNamespace(architectures=[arch], **hf)),
+        ),
+        model_config=SimpleNamespace(enforce_eager=eager),
+        parallel_config=SimpleNamespace(tensor_parallel_size=tp),
+    )
+
+
+def make_cache(*, dtype=torch.float16, block_size=BLOCK_SIZE, num_kv_heads=NUM_KV_HEADS):
+    shape = (NUM_BLOCKS, num_kv_heads * HEAD_DIM // 16, block_size, 16)
+    return torch.zeros(shape, dtype=dtype)
+
+
+def make_impl(*, vllm_config=None, num_heads=NUM_HEADS, num_kv_heads=NUM_KV_HEADS, head_size=HEAD_DIM, cache=None):
+    key_cache = cache if cache is not None else make_cache()
+    return SimpleNamespace(
+        vllm_config=vllm_config if vllm_config is not None else make_vllm_config(),
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        scale=HEAD_DIM**-0.5,
+        key_cache=key_cache,
+        value_cache=key_cache.clone(),
+        _fia_scope_validated=False,
+    )
+
+
+def make_metadata(*, q_lens=None, kv_lens=None, block_cols=4, block_dtype=torch.int32):
+    q_lens = q_lens if q_lens is not None else [DFLASH_Q] * BATCH
+    kv_lens = kv_lens if kv_lens is not None else list(KV_LENS)
+    md = SimpleNamespace(
+        num_actual_tokens=sum(q_lens),
+        seq_lens_list=kv_lens,
+        block_tables=torch.zeros(len(kv_lens), block_cols, dtype=block_dtype),
+        # Deliberately wrong: the base builder overwrites this field with
+        # cumulative endpoints, and the adapter must not read it.
+        actual_seq_lengths_q=list(torch.tensor(q_lens).cumsum(0).tolist()),
+        causal=False,
+        attn_mask=torch.ones(2048, 2048),  # must be ignored
+    )
+    md.query_lens_cpu = torch.tensor(q_lens, dtype=torch.int32)
+    return md
+
+
+class _FakeFia:
+    """Stands in for custom_fused_infer_attention_v310.
+
+    The real op is only registered in a 310P-targeted build, so CI hosts never
+    have it. Records the positional tensors alongside the kwargs so the call
+    contract can be asserted on either. Like the real op it allocates its own
+    output rather than writing into a caller buffer.
+    """
+
+    def __init__(self, out_builder=None):
+        self.calls = []
+        self._out_builder = out_builder
+
+    def __call__(self, query, key, value, **kwargs):
+        self.calls.append(dict(kwargs, query=query, key=key, value=value))
+        if self._out_builder is not None:
+            return self._out_builder(self.calls[-1])
+        return torch.zeros_like(query)
+
+
+def run_forward(impl=None, md=None, fia=None, num_tokens=None):
+    impl = impl if impl is not None else make_impl()
+    md = md if md is not None else make_metadata()
+    fia = fia if fia is not None else _FakeFia()
+    n = num_tokens if num_tokens is not None else md.num_actual_tokens
+    # Width follows the impl so head-layout cases reshape cleanly and fail on the
+    # scope check rather than on the reshape itself.
+    width = impl.num_heads * impl.head_size
+    query = torch.zeros(n, width, dtype=torch.float16)
+    output = torch.zeros(n, width, dtype=torch.float16)
+    with (
+        mock_patch(f"{FIA_MOD}._fia_op", return_value=fia),
+        mock_patch(f"{FIA_MOD}.torch_npu.get_npu_format", return_value=ACL_FORMAT_FRACTAL_NZ),
+    ):
+        result = fia_mod.forward_parallel_draft_fia(impl, query, md, output)
+    return result, fia, output
+
+
+class TestFiaCallContract(TestBase):
+    def test_mask_is_none_regardless_of_metadata(self):
+        _, fia, _ = run_forward()
+        self.assertIsNone(fia.calls[0]["attn_mask"])
+
+    def test_layout_flags(self):
+        _, fia, _ = run_forward()
+        kwargs = fia.calls[0]
+        self.assertEqual(kwargs["input_layout"], "TND")
+        self.assertEqual(kwargs["block_size"], BLOCK_SIZE)
+        # The wrapper takes no inner_precise; passing one is a TypeError.
+        self.assertNotIn("inner_precise", kwargs)
+
+    def test_every_wrapper_argument_is_passed_explicitly(self):
+        """Nothing may fall back to a wrapper default.
+
+        The defaults are upstream's to change -- input_layout's already moved
+        from "BSH" to "BSND" -- and a silent move there changes our numerics with
+        no test failing anywhere.
+        """
+        import inspect
+
+        from vllm_ascend._310p.ops.custom_fused_infer_attention import (
+            custom_fused_infer_attention_v310,
+        )
+
+        accepted = set(inspect.signature(custom_fused_infer_attention_v310).parameters)
+        _, fia, _ = run_forward()
+        # query/key/value go positionally; the fake records them by name.
+        self.assertEqual(accepted, set(fia.calls[0]))
+
+    def test_q_lens_are_raw_not_cumulative(self):
+        md = make_metadata()
+        _, fia, _ = run_forward(md=md)
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_q"], [DFLASH_Q] * BATCH)
+        self.assertNotEqual(
+            fia.calls[0]["actual_seq_lengths_q"],
+            md.actual_seq_lengths_q,
+            "adapter used the cumulative endpoints from the base metadata",
+        )
+
+    def test_kv_lens_are_passed_through(self):
+        _, fia, _ = run_forward()
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_kv"], KV_LENS)
+
+    def test_caches_are_passed_by_reference(self):
+        """The caches go through untouched: no wrapping, no copy, no reformat."""
+        impl = make_impl()
+        _, fia, _ = run_forward(impl=impl)
+        self.assertIs(fia.calls[0]["key"], impl.key_cache)
+        self.assertIs(fia.calls[0]["value"], impl.value_cache)
+
+    def test_head_counts_and_scale(self):
+        _, fia, _ = run_forward()
+        kwargs = fia.calls[0]
+        self.assertEqual(kwargs["num_heads"], NUM_HEADS)
+        self.assertEqual(kwargs["num_key_value_heads"], NUM_KV_HEADS)
+        self.assertAlmostEqual(kwargs["scale_value"], HEAD_DIM**-0.5)
+
+    def test_query_is_reshaped_to_tnd(self):
+        _, fia, _ = run_forward()
+        self.assertEqual(tuple(fia.calls[0]["query"].shape), (BATCH * DFLASH_Q, NUM_HEADS, HEAD_DIM))
+
+    def test_result_is_copied_into_the_caller_buffer(self):
+        marker = 0.5
+
+        def build_out(kwargs):
+            return torch.full_like(kwargs["query"], marker)
+
+        result, _, output = run_forward(fia=_FakeFia(build_out))
+        self.assertTrue(bool((output[: BATCH * DFLASH_Q] == marker).all()))
+        self.assertIs(result, output, "adapter must return the caller's output buffer")
+
+    def test_dspark_expects_k_queries_not_k_plus_one(self):
+        impl = make_impl(vllm_config=make_vllm_config(method="dspark", num_spec=7, arch="Qwen3DSparkModel"))
+        md = make_metadata(q_lens=[7] * BATCH)
+        _, fia, _ = run_forward(impl=impl, md=md)
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_q"], [7] * BATCH)
+
+
+class TestFiaDynamicGuards(TestBase):
+    def test_missing_raw_q_lens_is_refused(self):
+        md = make_metadata()
+        del md.query_lens_cpu
+        with self.assertRaisesRegex(RuntimeError, "query_lens_cpu is missing"):
+            run_forward(md=md)
+
+    def test_wrong_q_len_for_method_is_refused(self):
+        # DFlash must query K + 1 = 9; 8 would silently drop the anchor.
+        md = make_metadata(q_lens=[8] * BATCH)
+        with self.assertRaisesRegex(RuntimeError, "expects every request to query 9"):
+            run_forward(md=md)
+
+    def test_cumulative_q_lens_are_refused(self):
+        md = make_metadata()
+        md.query_lens_cpu = torch.tensor([9, 18, 27], dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "expects every request to query 9"):
+            run_forward(md=md)
+
+    def test_token_count_disagreement_is_refused(self):
+        md = make_metadata()
+        md.num_actual_tokens = BATCH * DFLASH_Q - 1
+        with self.assertRaisesRegex(RuntimeError, "must all agree"):
+            run_forward(md=md)
+
+    def test_batch_size_disagreement_is_refused(self):
+        md = make_metadata(kv_lens=[200, 133])
+        with self.assertRaisesRegex(RuntimeError, "batch size disagreement"):
+            run_forward(md=md)
+
+    def test_non_int32_block_table_is_refused(self):
+        md = make_metadata(block_dtype=torch.int64)
+        with self.assertRaisesRegex(RuntimeError, "rank-2 int32"):
+            run_forward(md=md)
+
+    def test_kv_len_exceeding_block_table_capacity_is_refused(self):
+        # 2 columns x 128 = 256 addressable, but one request needs 300.
+        md = make_metadata(kv_lens=[300, 133, 65], block_cols=2)
+        with self.assertRaisesRegex(RuntimeError, "exceeds what its block table can address"):
+            run_forward(md=md)
+
+    def test_q_len_greater_than_kv_len_is_refused(self):
+        md = make_metadata(kv_lens=[200, 133, 5])
+        with self.assertRaisesRegex(RuntimeError, r"need 0 < q_len\(9\) <= kv_len\(5\)"):
+            run_forward(md=md)
+
+
+class TestFiaScopeValidation(TestBase):
+    def _expect_refusal(self, pattern, **impl_kwargs):
+        with self.assertRaisesRegex(RuntimeError, pattern):
+            run_forward(impl=make_impl(**impl_kwargs))
+
+    def test_unsupported_method_is_refused(self):
+        # Refused by the adapter's own early check, before the scope validator: it
+        # has to resolve queries-per-request from the method first. Reaching here
+        # at all means routing let something through, hence the wording.
+        self._expect_refusal("reached with unsupported method", vllm_config=make_vllm_config(method="eagle3"))
+
+    def test_scope_validator_refuses_unsupported_method_on_its_own(self):
+        """The validator is the documented scope lock, so its method branch is
+        covered directly -- the adapter's early check shadows it in the forward
+        path, which would otherwise leave it untested."""
+        cache = make_cache()
+        with self.assertRaisesRegex(RuntimeError, "only covers"):
+            fia_mod.validate_fia_scope(
+                vllm_config=make_vllm_config(method="eagle3"),
+                query=torch.zeros(1, NUM_HEADS, HEAD_DIM, dtype=torch.float16),
+                key_cache=cache,
+                value_cache=cache.clone(),
+                num_heads=NUM_HEADS,
+                num_kv_heads=NUM_KV_HEADS,
+                head_size=HEAD_DIM,
+            )
+
+    def test_unexpected_k_is_refused(self):
+        self._expect_refusal("must be >= 1", vllm_config=make_vllm_config(num_spec=0))
+
+    def test_unsupported_architecture_is_refused(self):
+        self._expect_refusal("outside this scope", vllm_config=make_vllm_config(arch="LlamaForCausalLM"))
+
+    def test_target_in_graph_mode_is_allowed(self):
+        """model_config.enforce_eager describes the engine, not this route.
+
+        "Target in ACLGraph, drafter eager" is the configuration we want, so an
+        engine-wide eager requirement here would reject it for a constraint that
+        only applies to this op. What must not happen is captured separately, in
+        TestFiaCaptureGuard.
+        """
+        _, fia, _ = run_forward(impl=make_impl(vllm_config=make_vllm_config(eager=False)))
+        self.assertEqual(len(fia.calls), 1)
+
+    def test_tp4_layout_is_allowed(self):
+        """TP only shards heads; the per-rank layout is what is checked. Qwen3-8B
+        at TP=4 is 8 query / 2 KV heads, which satisfies the structural rules, so
+        it must run rather than be refused."""
+        impl = make_impl(
+            vllm_config=make_vllm_config(tp=4),
+            num_heads=8,
+            num_kv_heads=2,
+            cache=make_cache(num_kv_heads=2),
+        )
+        _, fia, _ = run_forward(impl=impl)
+        self.assertEqual(len(fia.calls), 1)
+        self.assertEqual(fia.calls[0]["num_heads"], 8)
+        self.assertEqual(fia.calls[0]["num_key_value_heads"], 2)
+
+    def test_too_many_per_rank_heads_is_refused(self):
+        """Qwen3-8B is 32 query heads, so TP=1 lands outside the envelope the
+        operator's own test covers (1..16). Refuse rather than run untested."""
+        self._expect_refusal(
+            "exceeds the 16 this scope covers",
+            num_heads=32,
+            num_kv_heads=8,
+            cache=make_cache(num_kv_heads=8),
+        )
+
+    def test_illegal_gqa_is_refused(self):
+        # 17 query heads do not divide evenly by 4 KV heads.
+        self._expect_refusal("invalid GQA layout", num_heads=17)
+
+    def test_non_16_aligned_kv_is_refused(self):
+        # Any num_kv_heads * 128 is 16-aligned, so break it with a small head_dim:
+        # 1 KV head * 8 = 8 is not a multiple of 16.
+        self._expect_refusal(
+            "must be a multiple of 16",
+            num_heads=4,
+            num_kv_heads=1,
+            head_size=8,
+            cache=make_cache(num_kv_heads=1),
+        )
+
+    def test_bf16_is_refused(self):
+        self._expect_refusal("only supports float16", cache=make_cache(dtype=torch.bfloat16))
+
+    def test_wrong_cache_block_size_is_refused(self):
+        self._expect_refusal("this scope only covers 128", cache=make_cache(block_size=64))
+
+    def test_non_nz_cache_format_is_refused(self):
+        impl = make_impl()
+        md = make_metadata()
+        query = torch.zeros(md.num_actual_tokens, NUM_HEADS * HEAD_DIM, dtype=torch.float16)
+        output = torch.zeros_like(query)
+        with (
+            mock_patch(f"{FIA_MOD}._fia_op", return_value=_FakeFia()),
+            mock_patch(f"{FIA_MOD}.torch_npu.get_npu_format", return_value=2),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "expected ACL_FORMAT_FRACTAL_NZ"):
+                fia_mod.forward_parallel_draft_fia(impl, query, md, output)
+
+    def test_scope_is_validated_once_then_cached(self):
+        impl = make_impl()
+        fia = _FakeFia()
+        with mock_patch(f"{FIA_MOD}.validate_fia_scope") as validator:
+            with (
+                mock_patch(f"{FIA_MOD}._fia_op", return_value=fia),
+                mock_patch(f"{FIA_MOD}.torch_npu.get_npu_format", return_value=ACL_FORMAT_FRACTAL_NZ),
+            ):
+                for _ in range(3):
+                    md = make_metadata()
+                    query = torch.zeros(md.num_actual_tokens, NUM_HEADS * HEAD_DIM, dtype=torch.float16)
+                    fia_mod.forward_parallel_draft_fia(impl, query, md, torch.zeros_like(query))
+        self.assertEqual(validator.call_count, 1, "startup invariants must not be re-checked per step")
+        self.assertEqual(len(fia.calls), 3)
+
+
+class TestFiaOpResolution(TestBase):
+    def test_missing_op_fails_loud_without_fallback(self):
+        # A wheel built for a non-310P SOC imports fine but carries no such
+        # symbol. That must stop the run, not silently reroute to the causal
+        # split-fuse kernel.
+        # Swap the whole namespace for an empty one rather than patching the
+        # attribute: torch.ops._C_ascend resolves lazily, so the attribute may
+        # legitimately not exist yet and patch.object would fail on setup.
+        with mock_patch.object(torch.ops, "_C_ascend", SimpleNamespace()):
+            with self.assertRaisesRegex(RuntimeError, "no fallback"):
+                fia_mod._fia_op()
+
+
+class TestFiaReturnHandling(TestBase):
+    def test_mismatched_return_shape_is_refused(self):
+        def bad_shape(call):
+            q = call["query"]
+            # Same element count, wrong layout -- numel alone would accept this.
+            return torch.zeros(q.shape[0], q.shape[2], q.shape[1], dtype=q.dtype)
+
+        with self.assertRaisesRegex(RuntimeError, "expected the query shape"):
+            run_forward(fia=_FakeFia(bad_shape))
+
+    def test_mismatched_return_dtype_is_refused(self):
+        with self.assertRaisesRegex(RuntimeError, "expected the query shape"):
+            run_forward(fia=_FakeFia(lambda call: torch.zeros_like(call["query"], dtype=torch.float32)))
+
+
+class TestFiaNonCausalScopeLocks(TestBase):
+    """This route sends attn_mask=None, which the kernel maps to NO_MASK.
+
+    That is only correct for a drafter whose attention is full and non-causal.
+    A causal or sliding-window checkpoint would still run and return plausible
+    numbers, so each of these has to be refused at startup rather than found
+    later as an accuracy loss.
+
+    The public z-lab/Qwen3-8B-DFlash-b16 checkpoint satisfies all of them:
+    use_sliding_window False, sliding_window None, five full_attention layers.
+    """
+
+    def _refuse(self, pattern, **hf):
+        with self.assertRaisesRegex(RuntimeError, pattern):
+            run_forward(impl=make_impl(vllm_config=make_vllm_config(**hf)))
+
+    def test_sliding_window_layer_is_refused(self):
+        self._refuse(
+            "other than full_attention",
+            layer_types=["full_attention", "sliding_attention"],
+        )
+
+    def test_use_sliding_window_flag_is_refused(self):
+        self._refuse("sliding-window attention", use_sliding_window=True)
+
+    def test_sliding_window_size_is_refused(self):
+        self._refuse("sliding-window attention", sliding_window=4096)
+
+    def test_causal_dflash_config_is_refused(self):
+        self._refuse("causal attention", dflash_config=SimpleNamespace(causal=True))
+
+    def test_all_full_attention_is_accepted(self):
+        # The real checkpoint's layer_types; must not be caught by the above.
+        _, fia, _ = run_forward(
+            impl=make_impl(vllm_config=make_vllm_config(layer_types=["full_attention"] * 5))
+        )
+        self.assertEqual(len(fia.calls), 1)
+
+
+class TestFiaSpeculativeTokenScope(TestBase):
+    """K is not a fixed list: the kernel tiles the query dimension, so the only
+    real ceiling is the draft checkpoint's own diffusion block."""
+
+    def test_k15_is_accepted_for_dflash(self):
+        """The public checkpoint's recommended K: block_size 16, so q = 16."""
+        impl = make_impl(vllm_config=make_vllm_config(num_spec=15, block_size=16))
+        _, fia, _ = run_forward(impl=impl, md=make_metadata(q_lens=[16] * BATCH))
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_q"], [16] * BATCH)
+
+    def test_k8_is_accepted_for_dflash(self):
+        """Smaller than the block allows is legitimate -- the Ascend MRV1 DFlash
+        tests use K=8 against the same block-16 checkpoint."""
+        impl = make_impl(vllm_config=make_vllm_config(num_spec=8, block_size=16))
+        _, fia, _ = run_forward(impl=impl, md=make_metadata(q_lens=[9] * BATCH))
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_q"], [9] * BATCH)
+
+    def test_dflash_loses_one_row_to_the_anchor(self):
+        """K=16 on a block-16 checkpoint needs 17 rows; DSpark's K=16 would fit."""
+        impl = make_impl(vllm_config=make_vllm_config(num_spec=16, block_size=16))
+        with self.assertRaisesRegex(RuntimeError, "diffusion block holds"):
+            run_forward(impl=impl, md=make_metadata(q_lens=[17] * BATCH))
+
+    def test_dspark_uses_the_whole_block(self):
+        impl = make_impl(
+            vllm_config=make_vllm_config(
+                method="dspark", num_spec=7, arch="Qwen3DSparkModel", block_size=7
+            )
+        )
+        _, fia, _ = run_forward(impl=impl, md=make_metadata(q_lens=[7] * BATCH))
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_q"], [7] * BATCH)
+
+    def test_dspark_beyond_its_block_is_refused(self):
+        impl = make_impl(
+            vllm_config=make_vllm_config(
+                method="dspark", num_spec=8, arch="Qwen3DSparkModel", block_size=7
+            )
+        )
+        with self.assertRaisesRegex(RuntimeError, "diffusion block holds"):
+            run_forward(impl=impl, md=make_metadata(q_lens=[8] * BATCH))
+
+    def test_q_beyond_one_kernel_tile_is_allowed(self):
+        """seqStepQ is 32 at head_dim <= 128 and the host splits into
+        ceil(q / seqStepQ) blocks, so a query longer than one tile is tiled, not
+        rejected. Guards against reintroducing a ceiling the kernel never had."""
+        impl = make_impl(vllm_config=make_vllm_config(num_spec=39, block_size=40))
+        _, fia, _ = run_forward(impl=impl, md=make_metadata(q_lens=[40] * BATCH, block_cols=8))
+        self.assertEqual(fia.calls[0]["actual_seq_lengths_q"], [40] * BATCH)
+
+    def test_scope_is_checked_before_query_length(self):
+        """An out-of-scope configuration must be reported as such.
+
+        The q-len check assumes the configuration is in scope, so when it ran
+        first an out-of-scope K surfaced as a wrong q-len and blamed the metadata
+        for carrying cumulative endpoints.
+        """
+        impl = make_impl(vllm_config=make_vllm_config(num_spec=16, block_size=16))
+        with self.assertRaisesRegex(RuntimeError, "diffusion block holds"):
+            run_forward(impl=impl, md=make_metadata(q_lens=[9] * BATCH))
+
+
+class TestFiaCaptureGuard(TestBase):
+    """This op must never end up inside an ACLGraph capture.
+
+    Its actual_seq_lengths_q / _kv are host SymInt[] read at dispatch, so a
+    captured graph would freeze one step's lengths and replay them for every
+    later step -- plausible numbers, silently wrong. The guard fires at the
+    moment it would happen rather than inferring from configuration, so the
+    supported split (target captured, drafter eager) stays legal.
+    """
+
+    def _run_with_ctx(self, *, available, capturing):
+        ctx = SimpleNamespace(capturing=capturing)
+        with (
+            mock_patch(f"{FIA_MOD}.is_forward_context_available", return_value=available),
+            mock_patch(f"{FIA_MOD}._EXTRA_CTX", ctx),
+        ):
+            return run_forward()
+
+    def test_capture_is_refused(self):
+        with self.assertRaisesRegex(RuntimeError, "during ACLGraph capture"):
+            self._run_with_ctx(available=True, capturing=True)
+
+    def test_replay_is_allowed(self):
+        """Replay sets capturing False; only capture is the problem."""
+        _, fia, _ = self._run_with_ctx(available=True, capturing=False)
+        self.assertEqual(len(fia.calls), 1)
+
+    def test_extra_ctx_is_not_read_without_a_forward_context(self):
+        """Reading _EXTRA_CTX with no forward context raises "Forward context is
+        not set", so the availability check has to short-circuit. Locked with an
+        object that detonates on any attribute access."""
+
+        class _Detonator:
+            def __getattr__(self, name):
+                raise AssertionError(f"_EXTRA_CTX.{name} read without a forward context")
+
+        with (
+            mock_patch(f"{FIA_MOD}.is_forward_context_available", return_value=False),
+            mock_patch(f"{FIA_MOD}._EXTRA_CTX", _Detonator()),
+        ):
+            _, fia, _ = run_forward()
+        self.assertEqual(len(fia.calls), 1)

--- a/tests/ut/_310p/attention/test_parallel_draft_routing_310p.py
+++ b/tests/ut/_310p/attention/test_parallel_draft_routing_310p.py
@@ -1,0 +1,153 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import patch as mock_patch
+
+from tests.ut.base import TestBase
+from vllm_ascend._310p.attention.attention_v1 import AscendAttentionBackendImpl310
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+
+ATTN_MOD = "vllm_ascend._310p.attention.attention_v1"
+
+CAUSAL_STATES = [
+    AscendAttentionState.PrefillNoCache,
+    AscendAttentionState.DecodeOnly,
+    AscendAttentionState.ChunkedPrefill,
+    AscendAttentionState.PrefillCacheHit,
+    AscendAttentionState.SpecDecoding,
+]
+
+
+def make_impl(method="dflash"):
+    impl = AscendAttentionBackendImpl310.__new__(AscendAttentionBackendImpl310)
+    impl.vllm_config = SimpleNamespace(
+        speculative_config=(SimpleNamespace(method=method) if method is not None else None)
+    )
+    impl._fia_scope_validated = False
+    return impl
+
+
+def make_metadata(state, causal):
+    return SimpleNamespace(attn_state=state, causal=causal)
+
+
+@contextlib.contextmanager
+def routed(is_draft_model):
+    """Patch the three seams forward_impl dispatches on, and record which fired."""
+    calls = {}
+
+    def record(name):
+        def fn(*args, **kwargs):
+            calls[name] = calls.get(name, 0) + 1
+            return name
+
+        return fn
+
+    with (
+        mock_patch(f"{ATTN_MOD}._EXTRA_CTX", SimpleNamespace(is_draft_model=is_draft_model)),
+        mock_patch(f"{ATTN_MOD}.forward_parallel_draft_fia", record("fia")),
+        mock_patch.object(AscendAttentionBackendImpl310, "forward_prefill_310", record("prefill")),
+        mock_patch.object(AscendAttentionBackendImpl310, "forward_paged_attention", record("paged")),
+        mock_patch.object(AscendAttentionBackendImpl310, "forward_chunked_prefill_310", record("splitfuse")),
+    ):
+        yield calls
+
+
+def call(impl, md):
+    return impl.forward_impl(None, None, None, None, md, None)
+
+
+class TestParallelDraftRouting(TestBase):
+    def test_dflash_draft_non_causal_chunked_prefill_goes_to_adn(self):
+        with routed(is_draft_model=True) as calls:
+            result = call(make_impl("dflash"), make_metadata(AscendAttentionState.ChunkedPrefill, causal=False))
+        self.assertEqual(result, "fia")
+        self.assertEqual(calls, {"fia": 1})
+
+    def test_dspark_draft_non_causal_chunked_prefill_goes_to_adn(self):
+        with routed(is_draft_model=True) as calls:
+            result = call(make_impl("dspark"), make_metadata(AscendAttentionState.ChunkedPrefill, causal=False))
+        self.assertEqual(result, "fia")
+        self.assertEqual(calls, {"fia": 1})
+
+    def test_causal_paths_are_unchanged(self):
+        """Every causal state must keep its existing 310P route, custom FIA untouched."""
+        expected = {
+            AscendAttentionState.PrefillNoCache: "prefill",
+            AscendAttentionState.DecodeOnly: "paged",
+            AscendAttentionState.ChunkedPrefill: "splitfuse",
+            AscendAttentionState.PrefillCacheHit: "splitfuse",
+            AscendAttentionState.SpecDecoding: "splitfuse",
+        }
+        for state in CAUSAL_STATES:
+            for is_draft in (False, True):
+                with routed(is_draft_model=is_draft) as calls:
+                    result = call(make_impl("dflash"), make_metadata(state, causal=True))
+                self.assertEqual(result, expected[state], f"{state} (draft={is_draft}) took the wrong route")
+                self.assertNotIn("fia", calls, f"{state} reached custom FIA despite being causal")
+
+    def test_non_draft_non_causal_fails_loud(self):
+        """Target attention must never silently fall through to the causal kernel."""
+        with routed(is_draft_model=False) as calls:
+            with self.assertRaisesRegex(NotImplementedError, "no non-causal attention path"):
+                call(make_impl("dflash"), make_metadata(AscendAttentionState.ChunkedPrefill, causal=False))
+        self.assertEqual(calls, {})
+
+    def test_unsupported_method_non_causal_fails_loud(self):
+        with routed(is_draft_model=True) as calls:
+            with self.assertRaisesRegex(NotImplementedError, "no non-causal attention path"):
+                call(make_impl("eagle3"), make_metadata(AscendAttentionState.ChunkedPrefill, causal=False))
+        self.assertEqual(calls, {})
+
+    def test_no_speculative_config_non_causal_fails_loud(self):
+        with routed(is_draft_model=True) as calls:
+            with self.assertRaisesRegex(NotImplementedError, "no non-causal attention path"):
+                call(make_impl(method=None), make_metadata(AscendAttentionState.ChunkedPrefill, causal=False))
+        self.assertEqual(calls, {})
+
+    def test_causal_paths_do_not_need_a_forward_context(self):
+        """Causal routing must not consult _EXTRA_CTX.
+
+        Reading it requires an active forward context. Adding that requirement to
+        the causal path would break callers that never needed one -- as it did
+        break test_forward_mtp_310, which mocks out the split-fuse method and so
+        establishes no context.
+        """
+
+        class Exploding:
+            def __getattr__(self, name):
+                raise AssertionError(f"causal path read _EXTRA_CTX.{name}")
+
+        for state in CAUSAL_STATES:
+            with (
+                mock_patch(f"{ATTN_MOD}._EXTRA_CTX", Exploding()),
+                mock_patch(f"{ATTN_MOD}.forward_parallel_draft_fia"),
+                mock_patch.object(AscendAttentionBackendImpl310, "forward_prefill_310", lambda *a: "prefill"),
+                mock_patch.object(AscendAttentionBackendImpl310, "forward_paged_attention", lambda *a: "paged"),
+                mock_patch.object(
+                    AscendAttentionBackendImpl310, "forward_chunked_prefill_310", lambda *a: "splitfuse"
+                ),
+            ):
+                call(make_impl("dflash"), make_metadata(state, causal=True))
+
+    def test_draft_non_causal_in_other_states_fails_loud(self):
+        """Only ChunkedPrefill is validated; other non-causal states must refuse."""
+        for state in (AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding):
+            with routed(is_draft_model=True) as calls:
+                with self.assertRaisesRegex(NotImplementedError, "no non-causal attention path"):
+                    call(make_impl("dflash"), make_metadata(state, causal=False))
+            self.assertEqual(calls, {}, f"{state} should not have been routed anywhere")

--- a/tests/ut/_310p/spec_decode/test_parallel_drafting_inputs_310p.py
+++ b/tests/ut/_310p/spec_decode/test_parallel_drafting_inputs_310p.py
@@ -1,0 +1,852 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from unittest.mock import patch as mock_patch
+
+import numpy as np
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend._310p.spec_decode.parallel_drafting_inputs import expand_parallel_drafting_inputs
+
+MASK_ID = 151666
+BLOCK_SIZE = 128
+GUARD = -99  # sentinel written past the used region to catch overruns
+
+# Profile-run fixture sizes. These must differ so a fix that only covers the
+# context forward is distinguishable from one that covers both.
+NUM_REQS = 2
+CONTEXT_TOKENS = 12
+
+
+def _flag_now():
+    from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
+
+    return AscendRotaryEmbedding310._is_drafting_update_enabled
+
+
+def _set_flag(state):
+    from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
+
+    AscendRotaryEmbedding310.set_rope_position_flag_310p(state)
+
+
+@contextlib.contextmanager
+def _null_context(*args, **kwargs):
+    yield
+
+# `_expand_drafting_inputs` is defined in dflash_proposer, so every name it looks
+# up -- is_310p, the Triton launcher -- resolves from that module even when the
+# caller is a DSpark proposer. Patching dspark_proposer.* would silently miss.
+DFLASH_MOD = "vllm_ascend.spec_decode.dflash_proposer"
+HELPER_MOD = "vllm_ascend._310p.spec_decode.parallel_drafting_inputs"
+
+
+def reference_expand(
+    *,
+    next_token_ids,
+    target_positions,
+    context_slot_mapping,
+    out_input_ids,
+    out_context_positions,
+    out_query_positions,
+    out_context_slot_mapping,
+    out_query_slot_mapping,
+    out_token_indices,
+    block_table,
+    query_start_loc,
+    seq_lens,
+    num_rejected_tokens,
+    parallel_drafting_token_id,
+    block_size,
+    num_query_per_req,
+    num_speculative_tokens,
+    total_input_tokens,
+    batch_size,
+    sample_from_anchor,
+):
+    """Line-by-line transcription of
+    ops/triton/spec_decode/utils.py::copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid.
+
+    This is the golden, not a second implementation. Do not vectorize it: its whole
+    value is that a mismatch points at one specific line of the original kernel.
+    """
+    for req_idx in range(batch_size):
+        ctx_start = int(query_start_loc[req_idx])
+        ctx_end = int(query_start_loc[req_idx + 1])
+
+        for j in range(ctx_start, ctx_end):
+            out_context_positions[j] = int(target_positions[j])
+            out_context_slot_mapping[j] = int(context_slot_mapping[j])
+
+        num_rejected = int(num_rejected_tokens[req_idx]) if num_rejected_tokens is not None else 0
+        valid_ctx_end = ctx_end - num_rejected
+        effective_seq_len = int(seq_lens[req_idx]) - num_rejected
+        last_pos = int(target_positions[valid_ctx_end - 1])
+
+        for q_idx in range(num_query_per_req):
+            out_idx = req_idx * num_query_per_req + q_idx
+            out_query_positions[out_idx] = last_pos + 1 + q_idx
+
+            cache_pos = effective_seq_len + q_idx
+            block_id = int(block_table[req_idx, cache_pos // block_size])
+            out_query_slot_mapping[out_idx] = block_id * block_size + cache_pos % block_size
+
+            if q_idx == 0:
+                out_input_ids[out_idx] = int(next_token_ids[req_idx])
+            else:
+                out_input_ids[out_idx] = parallel_drafting_token_id
+
+            if sample_from_anchor:
+                out_token_indices[req_idx * num_speculative_tokens + q_idx] = out_idx
+            elif q_idx > 0:
+                out_token_indices[req_idx * num_speculative_tokens + q_idx - 1] = out_idx
+
+
+def make_case(*, ctx_lens, seq_lens, rejected, num_query_per_req, num_spec):
+    """Build one input set.
+
+    ctx_lens is this round's scheduled segment per request; seq_lens is the total KV
+    length per request. They are NOT the same thing -- conflating them is the easiest
+    way to write a test that passes against a broken helper. Positions are absolute:
+    a request whose total KV is 257 and which scheduled 4 tokens this round carries
+    positions [253, 254, 255, 256].
+    """
+    batch_size = len(ctx_lens)
+    assert len(seq_lens) == batch_size
+    for n_ctx, n_seq in zip(ctx_lens, seq_lens):
+        assert n_seq >= n_ctx, "total KV length cannot be shorter than this round's segment"
+    total = sum(ctx_lens)
+
+    qsl = torch.zeros(batch_size + 1, dtype=torch.int32)
+    qsl[1:] = torch.tensor(ctx_lens, dtype=torch.int32).cumsum(0)
+
+    positions = torch.cat(
+        [torch.arange(n_seq - n_ctx, n_seq, dtype=torch.int32) for n_ctx, n_seq in zip(ctx_lens, seq_lens)]
+    )
+    ctx_slots = torch.arange(total, dtype=torch.int32) * 3 + 7
+
+    max_blocks = (max(seq_lens) + num_query_per_req) // BLOCK_SIZE + 2
+    # Descending, non-contiguous physical page ids, shifted past the logical index
+    # range so no entry can equal its own column.
+    #
+    # That invariant is what makes these fixtures discriminating: a query slot is
+    # physical * block_size + offset while the raw cache position is
+    # logical * block_size + offset, with the same offset. So physical != logical
+    # is exactly the condition under which a slot differs from the position, and a
+    # helper that ignored the block table entirely would be caught.
+    #
+    # The plain reversal used before had a fixed point at the middle column for odd
+    # max_blocks (arange(3).flip(0) == [2, 1, 0], so column 1 maps to page 1). With
+    # seq_lens=[129] the whole query block landed on that column and every slot
+    # equalled its cache position.
+    block_table = (
+        torch.arange(batch_size * max_blocks, dtype=torch.int32).flip(0).reshape(batch_size, max_blocks) + max_blocks
+    )
+    assert bool(
+        (block_table != torch.arange(max_blocks, dtype=torch.int32)).all()
+    ), "block table maps some logical page to the same physical page; slots would be degenerate"
+
+    return dict(
+        next_token_ids=torch.arange(batch_size, dtype=torch.int32) + 1000,
+        target_positions=positions,
+        context_slot_mapping=ctx_slots,
+        block_table=block_table,
+        query_start_loc=qsl,
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int32),
+        num_rejected_tokens=(torch.tensor(rejected, dtype=torch.int32) if rejected is not None else None),
+        parallel_drafting_token_id=MASK_ID,
+        block_size=BLOCK_SIZE,
+        num_query_per_req=num_query_per_req,
+        num_speculative_tokens=num_spec,
+        total_input_tokens=total,
+        batch_size=batch_size,
+    )
+
+
+def run_both(case, sample_from_anchor):
+    b, q, k = case["batch_size"], case["num_query_per_req"], case["num_speculative_tokens"]
+    total = case["total_input_tokens"]
+    slack = 8  # extra room so an overrun lands on GUARD instead of out of bounds
+
+    def fresh():
+        return dict(
+            out_input_ids=torch.full((b * q + slack,), GUARD, dtype=torch.int32),
+            out_context_positions=torch.full((total + slack,), GUARD, dtype=torch.int32),
+            out_query_positions=torch.full((b * q + slack,), GUARD, dtype=torch.int32),
+            out_context_slot_mapping=torch.full((total + slack,), GUARD, dtype=torch.int32),
+            out_query_slot_mapping=torch.full((b * q + slack,), GUARD, dtype=torch.int32),
+            out_token_indices=torch.full((b * k + slack,), GUARD, dtype=torch.int32),
+        )
+
+    got, want = fresh(), fresh()
+    expand_parallel_drafting_inputs(**case, **got, sample_from_anchor=sample_from_anchor)
+    reference_expand(**case, **want, sample_from_anchor=sample_from_anchor)
+    return got, want, slack
+
+
+class TestExpandParallelDraftingInputs(TestBase):
+    def _assert_matches(self, case, sample_from_anchor):
+        got, want, slack = run_both(case, sample_from_anchor)
+        for name in want:
+            torch.testing.assert_close(got[name], want[name], msg=f"{name} mismatch")
+            tail = got[name][-slack:]
+            self.assertTrue(
+                bool((tail == GUARD).all()),
+                f"{name}: helper wrote past its used region (tail={tail.tolist()})",
+            )
+
+    def test_dflash_single_request(self):
+        self._assert_matches(
+            make_case(ctx_lens=[4], seq_lens=[257], rejected=None, num_query_per_req=9, num_spec=8),
+            sample_from_anchor=False,
+        )
+
+    def test_dspark_single_request(self):
+        self._assert_matches(
+            make_case(ctx_lens=[4], seq_lens=[257], rejected=None, num_query_per_req=7, num_spec=7),
+            sample_from_anchor=True,
+        )
+
+    def test_ragged_segment_with_distinct_seq_lens(self):
+        self._assert_matches(
+            make_case(ctx_lens=[1, 4, 2], seq_lens=[257, 134, 66], rejected=None, num_query_per_req=9, num_spec=8),
+            sample_from_anchor=False,
+        )
+
+    def test_rejected_tail_excluded_from_query_but_kept_in_context(self):
+        # Every request keeps at least one valid context token after rejection.
+        self._assert_matches(
+            make_case(ctx_lens=[1, 4, 2], seq_lens=[257, 134, 66], rejected=[0, 3, 1], num_query_per_req=9, num_spec=8),
+            sample_from_anchor=False,
+        )
+        self._assert_matches(
+            make_case(ctx_lens=[1, 4, 2], seq_lens=[257, 134, 66], rejected=[0, 3, 1], num_query_per_req=7, num_spec=7),
+            sample_from_anchor=True,
+        )
+
+    def test_query_slots_cross_page_boundary(self):
+        # effective_seq_len lands at 127/128/129 so the K+1 query slots straddle a
+        # kernel page and must follow the block table into a new physical page.
+        for seq_len in (127, 128, 129):
+            self._assert_matches(
+                make_case(ctx_lens=[2], seq_lens=[seq_len], rejected=None, num_query_per_req=9, num_spec=8),
+                sample_from_anchor=False,
+            )
+
+    def test_context_buffer_untouched_beyond_scheduled_segment(self):
+        case = make_case(ctx_lens=[1, 4, 2], seq_lens=[257, 134, 66], rejected=None, num_query_per_req=9, num_spec=8)
+        got, _, _ = run_both(case, sample_from_anchor=False)
+        total = case["total_input_tokens"]
+        self.assertTrue(bool((got["out_context_positions"][total:] == GUARD).all()))
+        self.assertTrue(bool((got["out_context_slot_mapping"][total:] == GUARD).all()))
+
+    def test_query_slots_never_equal_raw_cache_positions(self):
+        """The block table must be load-bearing for every shape the suite uses.
+
+        This is implied by the no-fixed-point invariant asserted in make_case, but
+        checking the end result across all shapes keeps the two from drifting apart
+        if the fixture construction is ever changed.
+        """
+        shapes = [
+            dict(ctx_lens=[2], seq_lens=[127], rejected=None, num_query_per_req=9, num_spec=8),
+            dict(ctx_lens=[2], seq_lens=[128], rejected=None, num_query_per_req=9, num_spec=8),
+            dict(ctx_lens=[2], seq_lens=[129], rejected=None, num_query_per_req=9, num_spec=8),
+            dict(ctx_lens=[4], seq_lens=[257], rejected=None, num_query_per_req=7, num_spec=7),
+            dict(ctx_lens=[1, 4, 2], seq_lens=[257, 134, 66], rejected=[0, 3, 1], num_query_per_req=9, num_spec=8),
+        ]
+        for shape in shapes:
+            case = make_case(**shape)
+            _, want, _ = run_both(case, sample_from_anchor=False)
+            b, q = case["batch_size"], case["num_query_per_req"]
+            rejected = shape["rejected"] or [0] * b
+            for req in range(b):
+                effective_seq_len = shape["seq_lens"][req] - rejected[req]
+                slots = want["out_query_slot_mapping"][req * q : (req + 1) * q]
+                raw = torch.arange(effective_seq_len, effective_seq_len + q, dtype=torch.int32)
+                self.assertFalse(
+                    bool(torch.equal(slots, raw)),
+                    f"{shape}: request {req} slots equal raw cache positions, "
+                    f"so the block table is not exercised",
+                )
+
+
+class _ExplodingLauncher:
+    """Stand-in for the Triton kernel: subscripting it (kernel[grid]) raises.
+
+    Used in both directions -- the 310P path must never reach it, and the Triton
+    path must always reach it.
+    """
+
+    def __getitem__(self, _grid):
+        raise AssertionError("Triton kernel was launched")
+
+
+def make_dflash_proposer(*, num_spec=8, selected_block_size=BLOCK_SIZE, kernel_block_size=BLOCK_SIZE, candidates=None):
+    """Build an AscendDflashProposer without running __init__.
+
+    Only the attributes set_inputs_first_pass actually touches are stubbed.
+    """
+    from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+    p = AscendDflashProposer.__new__(AscendDflashProposer)
+    p.num_speculative_tokens = num_spec
+    p.device = torch.device("cpu")
+    p.parallel_drafting_token_id = MASK_ID
+    p.kernel_block_size = kernel_block_size
+    p.kv_cache_gid = 0
+    p.input_ids = torch.zeros(64, dtype=torch.int32)
+    p.positions = torch.zeros(64, dtype=torch.int32)
+    p._context_positions_buffer = torch.zeros(64, dtype=torch.int32)
+    p._context_slot_mapping_buffers = torch.zeros(64, dtype=torch.int32)
+    p._slot_mapping_buffer = torch.zeros(64, dtype=torch.int32)
+    p._dflash_hidden_states = torch.zeros(64, 8)
+    p.arange_dflash = torch.arange(65, dtype=torch.int32)
+    p.token_arange_np = np.arange(65, dtype=np.int32)
+    p.runner = SimpleNamespace(
+        input_batch=SimpleNamespace(block_table={0: SimpleNamespace(block_size=selected_block_size)}),
+        kernel_block_sizes={0: list(candidates if candidates is not None else [128, 64])},
+    )
+    return p
+
+
+def make_dflash_cad(ctx_lens, seq_lens):
+    batch_size = len(ctx_lens)
+    total = sum(ctx_lens)
+    qsl = torch.zeros(batch_size + 1, dtype=torch.int32)
+    qsl[1:] = torch.tensor(ctx_lens, dtype=torch.int32).cumsum(0)
+    return SimpleNamespace(
+        num_reqs=batch_size,
+        slot_mapping=torch.arange(total, dtype=torch.int32) * 3 + 7,
+        block_table_tensor=torch.arange(batch_size * 6, dtype=torch.int32).flip(0).reshape(batch_size, 6) + 6,
+        query_start_loc=qsl,
+        query_start_loc_cpu=qsl.clone(),
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int32),
+        max_seq_len=max(seq_lens),
+        num_actual_tokens=total,
+        max_query_len=0,
+        causal=True,
+        attn_mask=object(),
+        attn_state=None,
+        actual_seq_lengths_q=[],
+        decode_token_per_req=0,
+    )
+
+
+class TestDflashDispatch(TestBase):
+    CTX_LENS = [2, 4]
+    SEQ_LENS = [257, 134]
+
+    def _call(self, proposer, cad):
+        total = sum(self.CTX_LENS)
+        return proposer.set_inputs_first_pass(
+            target_token_ids=torch.zeros(total, dtype=torch.int32),
+            next_token_ids=torch.tensor([11, 22], dtype=torch.int32),
+            target_positions=torch.cat(
+                [
+                    torch.arange(n_seq - n_ctx, n_seq, dtype=torch.int32)
+                    for n_ctx, n_seq in zip(self.CTX_LENS, self.SEQ_LENS)
+                ]
+            ),
+            target_hidden_states=torch.zeros(total, 8),
+            token_indices_to_sample=None,
+            cad=cad,
+            num_rejected_tokens_gpu=None,
+        )
+
+    def test_310p_uses_helper_and_never_launches_triton(self):
+        seen = {}
+
+        def spy(**kwargs):
+            seen.update(kwargs)
+
+        proposer = make_dflash_proposer()
+        cad = make_dflash_cad(self.CTX_LENS, self.SEQ_LENS)
+        with (
+            mock_patch(f"{DFLASH_MOD}.is_310p", return_value=True),
+            mock_patch(f"{HELPER_MOD}.expand_parallel_drafting_inputs", spy),
+            mock_patch(f"{DFLASH_MOD}.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+                       _ExplodingLauncher()),
+        ):
+            self._call(proposer, cad)
+
+        self.assertEqual(seen["num_query_per_req"], 9)
+        self.assertEqual(seen["num_speculative_tokens"], 8)
+        self.assertIs(seen["sample_from_anchor"], False)
+        self.assertEqual(seen["block_size"], BLOCK_SIZE)
+        self.assertEqual(seen["batch_size"], 2)
+        self.assertEqual(seen["total_input_tokens"], sum(self.CTX_LENS))
+        self.assertIsNone(seen["num_rejected_tokens"])
+        # Buffer identity: catches wiring the helper to the wrong destination,
+        # which a value comparison would not.
+        self.assertIs(seen["out_input_ids"], proposer.input_ids)
+        self.assertIs(seen["out_query_positions"], proposer.positions)
+        self.assertIs(seen["out_context_positions"], proposer._context_positions_buffer)
+        self.assertIs(seen["out_context_slot_mapping"], proposer._context_slot_mapping_buffers)
+        self.assertIs(seen["out_query_slot_mapping"], proposer._slot_mapping_buffer)
+        self.assertIs(seen["block_table"], cad.block_table_tensor)
+
+    def test_non_310p_still_launches_triton(self):
+        proposer = make_dflash_proposer()
+        cad = make_dflash_cad(self.CTX_LENS, self.SEQ_LENS)
+
+        def must_not_run(_proposer):
+            raise AssertionError("resolve_310p_block_size ran on the non-310P path")
+
+        with (
+            mock_patch(f"{DFLASH_MOD}.is_310p", return_value=False),
+            mock_patch(f"{HELPER_MOD}.resolve_310p_block_size", must_not_run),
+            mock_patch(f"{DFLASH_MOD}.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+                       _ExplodingLauncher()),
+        ):
+            with self.assertRaisesRegex(AssertionError, "Triton kernel was launched"):
+                self._call(proposer, cad)
+
+    def test_310p_slot_mapping_matches_the_verified_helper(self):
+        """End-to-end through the real helper, not a spy: proves the wiring works."""
+        proposer = make_dflash_proposer()
+        cad = make_dflash_cad(self.CTX_LENS, self.SEQ_LENS)
+        with (
+            mock_patch(f"{DFLASH_MOD}.is_310p", return_value=True),
+            mock_patch(f"{DFLASH_MOD}.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+                       _ExplodingLauncher()),
+        ):
+            num_query_total, _, _, _ = self._call(proposer, cad)
+
+        want = torch.zeros(64, dtype=torch.int32)
+        for req, seq_len in enumerate(self.SEQ_LENS):
+            for q_idx in range(9):
+                cache_pos = seq_len + q_idx
+                physical = int(cad.block_table_tensor[req, cache_pos // BLOCK_SIZE])
+                want[req * 9 + q_idx] = physical * BLOCK_SIZE + cache_pos % BLOCK_SIZE
+        torch.testing.assert_close(proposer._slot_mapping_buffer[:num_query_total], want[:num_query_total])
+
+    def test_310p_metadata_is_switched_to_non_causal_parallel_draft(self):
+        proposer = make_dflash_proposer()
+        cad = make_dflash_cad(self.CTX_LENS, self.SEQ_LENS)
+        with (
+            mock_patch(f"{DFLASH_MOD}.is_310p", return_value=True),
+            mock_patch(f"{DFLASH_MOD}.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+                       _ExplodingLauncher()),
+        ):
+            num_query_total, token_indices, out_cad, _ = self._call(proposer, cad)
+
+        from vllm_ascend.attention.attention_v1 import AscendAttentionState
+
+        self.assertEqual(num_query_total, 2 * 9)
+        self.assertEqual(token_indices.shape[0], 2 * 8)
+        self.assertEqual(out_cad.num_actual_tokens, 2 * 9)
+        self.assertEqual(out_cad.max_query_len, 9)
+        self.assertIs(out_cad.causal, False)
+        self.assertIsNone(out_cad.attn_mask)
+        self.assertEqual(out_cad.attn_state, AscendAttentionState.ChunkedPrefill)
+        self.assertEqual(out_cad.actual_seq_lengths_q, [9, 9])
+        # seq_lens must become effective history + this round's query block.
+        torch.testing.assert_close(out_cad.seq_lens, torch.tensor([257 + 9, 134 + 9], dtype=torch.int32))
+
+
+class TestResolve310pBlockSize(TestBase):
+    def _resolve(self, **kwargs):
+        from vllm_ascend._310p.spec_decode.parallel_drafting_inputs import resolve_310p_block_size
+
+        return resolve_310p_block_size(make_dflash_proposer(**kwargs))
+
+    def test_accepts_the_supported_configuration(self):
+        self.assertEqual(self._resolve(), BLOCK_SIZE)
+
+    def test_rejects_a_selected_size_outside_scope(self):
+        with self.assertRaisesRegex(RuntimeError, "only covers kernel block size 128"):
+            self._resolve(selected_block_size=64)
+
+    def test_rejects_drafter_disagreeing_with_the_block_table(self):
+        with self.assertRaisesRegex(RuntimeError, "kernel_block_size is 64"):
+            self._resolve(kernel_block_size=64)
+
+    def test_rejects_a_candidate_list_without_the_supported_size(self):
+        with self.assertRaisesRegex(RuntimeError, "not in the runner's candidate list"):
+            self._resolve(candidates=[64])
+
+
+def make_dspark_proposer(*, num_spec=7, num_groups=1, kv_spec_block_size=BLOCK_SIZE):
+    """Build an AscendDSparkProposer without running __init__.
+
+    DSpark drives the expansion per KV cache group, so it needs the per-group
+    buffers on top of what DFlash uses.
+    """
+    from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+
+    p = AscendDSparkProposer.__new__(AscendDSparkProposer)
+    p.num_speculative_tokens = num_spec
+    # Anchor-first layout: the only one 310P covers, so q == K rather than 1 + K.
+    p.sample_from_anchor = True
+    p.num_query_per_req = num_spec
+    p.device = torch.device("cpu")
+    p.parallel_drafting_token_id = MASK_ID
+    p.kernel_block_size = BLOCK_SIZE
+    p.kv_cache_gid = 0
+    p.input_ids = torch.zeros(64, dtype=torch.int32)
+    p.positions = torch.zeros(64, dtype=torch.int32)
+    p._context_positions_buffer = torch.zeros(64, dtype=torch.int32)
+    p._dflash_hidden_states = torch.zeros(64, 8)
+    p._dspark_seed_buffer = torch.zeros(64, dtype=torch.int64)
+    p.arange_dflash = torch.arange(65, dtype=torch.int32)
+    p.token_arange_np = np.arange(65, dtype=np.int32)
+    p.runner = SimpleNamespace(
+        input_batch=SimpleNamespace(block_table={0: SimpleNamespace(block_size=BLOCK_SIZE)}),
+        kernel_block_sizes={0: [128, 64]},
+    )
+
+    gids = list(range(num_groups))
+    p.draft_attn_groups = [
+        SimpleNamespace(kv_cache_group_id=gid, kv_cache_spec=SimpleNamespace(block_size=kv_spec_block_size))
+        for gid in gids
+    ]
+    # Stub the source, not the derived dict: set_inputs_first_pass rebuilds
+    # _per_group_block_table_buffers from _per_group_block_tables on every call,
+    # so anything written to the former is discarded before it is read.
+    p._per_group_block_tables = {
+        gid: torch.arange(2 * 6, dtype=torch.int32).flip(0).reshape(2, 6) + 6 for gid in gids
+    }
+    p._per_group_block_table_buffers = {}
+    p._per_group_slot_mappings = {gid: torch.arange(64, dtype=torch.int32) * 3 + 7 for gid in gids}
+    p._per_group_context_slot_mapping_buffers = {gid: torch.zeros(64, dtype=torch.int32) for gid in gids}
+    p._per_group_query_slot_mapping_buffers = {gid: torch.zeros(64, dtype=torch.int32) for gid in gids}
+    p._layer_group_idx = gids
+    return p
+
+
+class TestDSparkDispatch(TestBase):
+    CTX_LENS = [2, 4]
+    SEQ_LENS = [257, 134]
+    Q_PER_REQ = 7  # DSpark queries K positions, not K + 1
+
+    def _call(self, proposer, cad):
+        total = sum(self.CTX_LENS)
+        return proposer.set_inputs_first_pass(
+            target_token_ids=torch.zeros(total, dtype=torch.int32),
+            next_token_ids=torch.tensor([11, 22], dtype=torch.int32),
+            target_positions=torch.cat(
+                [
+                    torch.arange(n_seq - n_ctx, n_seq, dtype=torch.int32)
+                    for n_ctx, n_seq in zip(self.CTX_LENS, self.SEQ_LENS)
+                ]
+            ),
+            target_hidden_states=torch.zeros(total, 8),
+            token_indices_to_sample=None,
+            cad=cad,
+            num_rejected_tokens_gpu=None,
+        )
+
+    def _run_310p(self, proposer, spy=None):
+        """Drive set_inputs_first_pass as if on 310P.
+
+        `is_310p` is patched in both modules: dspark_proposer reads it for the
+        single-group scope guard, dflash_proposer for the dispatch itself.
+        With spy=None the real helper runs, so the wiring is exercised end to end.
+        """
+        cad = make_dflash_cad(self.CTX_LENS, self.SEQ_LENS)
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock_patch(f"{DFLASH_MOD}.is_310p", return_value=True))
+            stack.enter_context(
+                mock_patch("vllm_ascend.spec_decode.dspark_proposer.is_310p", return_value=True)
+            )
+            stack.enter_context(
+                mock_patch(
+                    f"{DFLASH_MOD}.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+                    _ExplodingLauncher(),
+                )
+            )
+            if spy is not None:
+                stack.enter_context(mock_patch(f"{HELPER_MOD}.expand_parallel_drafting_inputs", spy))
+            return self._call(proposer, cad), cad
+
+    def test_single_group_calls_helper_once_with_dspark_semantics(self):
+        calls = []
+
+        def spy(**kwargs):
+            calls.append(kwargs)
+
+        proposer = make_dspark_proposer()
+        self._run_310p(proposer, spy=spy)
+
+        self.assertEqual(len(calls), 1, "Qwen3-8B DSpark must drive exactly one draft KV group")
+        seen = calls[0]
+        # DSpark queries K positions and samples from the anchor; DFlash does K + 1
+        # and skips it. Getting these wrong does not raise, it only degrades
+        # acceptance, so assert them explicitly.
+        self.assertEqual(seen["num_query_per_req"], 7)
+        self.assertEqual(seen["num_speculative_tokens"], 7)
+        self.assertIs(seen["sample_from_anchor"], True)
+        # 310P substitutes the pinned kernel block size for the caller's allocation
+        # block size, so this is 128 (the cache block), not 7 (the algorithm block).
+        self.assertEqual(seen["block_size"], BLOCK_SIZE)
+        # Per-group buffers, not the DFlash flat ones.
+        self.assertIs(seen["out_context_slot_mapping"], proposer._per_group_context_slot_mapping_buffers[0])
+        self.assertIs(seen["out_query_slot_mapping"], proposer._per_group_query_slot_mapping_buffers[0])
+        self.assertIs(seen["context_slot_mapping"], proposer._per_group_slot_mappings[0])
+        self.assertIs(seen["block_table"], proposer._per_group_block_tables[0])
+
+    def test_multi_group_is_refused_on_310p(self):
+        proposer = make_dspark_proposer(num_groups=2)
+        with self.assertRaisesRegex(RuntimeError, "single draft KV cache group"):
+            self._run_310p(proposer, spy=lambda **kw: None)
+
+    def test_metadata_matches_dspark_layout(self):
+        proposer = make_dspark_proposer()
+        (result, _) = self._run_310p(proposer)
+        num_query_total, token_indices, out_cad, _ = result
+
+        from vllm_ascend.attention.attention_v1 import AscendAttentionState
+
+        self.assertEqual(num_query_total, 2 * self.Q_PER_REQ)
+        self.assertEqual(token_indices.shape[0], 2 * self.Q_PER_REQ)
+        self.assertEqual(out_cad.num_actual_tokens, 2 * self.Q_PER_REQ)
+        self.assertEqual(out_cad.num_input_tokens, 2 * self.Q_PER_REQ)
+        self.assertEqual(out_cad.max_query_len, self.Q_PER_REQ)
+        # positions is handed over whole, not sliced to num_query_total: the
+        # attention backend slices it to num_input_tokens, which is DP-padded and
+        # can exceed the local query count. A pre-slice here reads out of bounds
+        # under multi-DP, so assert identity rather than length.
+        self.assertIs(out_cad.positions, proposer.positions)
+        self.assertGreaterEqual(out_cad.positions.shape[0], num_query_total)
+        self.assertIs(out_cad.causal, False)
+        self.assertIsNone(out_cad.attn_mask)
+        self.assertEqual(out_cad.attn_state, AscendAttentionState.ChunkedPrefill)
+        self.assertEqual(out_cad.actual_seq_lengths_q, [self.Q_PER_REQ] * 2)
+        torch.testing.assert_close(
+            out_cad.seq_lens,
+            torch.tensor([257 + self.Q_PER_REQ, 134 + self.Q_PER_REQ], dtype=torch.int32),
+        )
+        # slot_mapping must come from the primary group's query buffer.
+        expected = proposer._per_group_query_slot_mapping_buffers[0][: 2 * self.Q_PER_REQ]
+        self.assertEqual(out_cad.slot_mapping.data_ptr(), expected.data_ptr())
+
+    def test_slot_mapping_matches_the_verified_helper(self):
+        """Runs the real helper end to end, so the per-group wiring is checked."""
+        proposer = make_dspark_proposer()
+        (result, _) = self._run_310p(proposer)
+        num_query_total = result[0]
+
+        block_table = proposer._per_group_block_tables[0]
+        want = torch.zeros(64, dtype=torch.int32)
+        for req, seq_len in enumerate(self.SEQ_LENS):
+            for q_idx in range(self.Q_PER_REQ):
+                cache_pos = seq_len + q_idx
+                physical = int(block_table[req, cache_pos // BLOCK_SIZE])
+                want[req * self.Q_PER_REQ + q_idx] = physical * BLOCK_SIZE + cache_pos % BLOCK_SIZE
+        torch.testing.assert_close(
+            proposer._per_group_query_slot_mapping_buffers[0][:num_query_total],
+            want[:num_query_total],
+        )
+
+    def test_non_310p_still_launches_triton(self):
+        proposer = make_dspark_proposer()
+        cad = make_dflash_cad(self.CTX_LENS, self.SEQ_LENS)
+        with (
+            mock_patch(f"{DFLASH_MOD}.is_310p", return_value=False),
+            mock_patch("vllm_ascend.spec_decode.dspark_proposer.is_310p", return_value=False),
+            mock_patch(f"{DFLASH_MOD}.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
+                       _ExplodingLauncher()),
+        ):
+            with self.assertRaisesRegex(AssertionError, "Triton kernel was launched"):
+                self._call(proposer, cad)
+
+
+class TestProfileRopeFlagCoverage(TestBase):
+    """dummy_run(is_profile=True) must keep the 310P drafting RoPE flag on for both
+    the context KV precompute and the query forward that follows it.
+
+    The flag is what makes each rotary call refresh the global cos/sin slice with
+    its own positions. Covering only the first forward leaves the query forward
+    reading the context slice, which produces wrong numbers rather than an error.
+    """
+
+    def _fake_model(self, seen):
+        class FakeModel:
+            def precompute_and_store_context_kv(_self, states, positions):
+                seen.append(("context", _flag_now(), int(positions.shape[0])))
+
+            def __call__(_self, *, input_ids, positions, inputs_embeds):
+                seen.append(("query", _flag_now(), int(positions.shape[0])))
+
+        return FakeModel()
+
+    def _make_proposer(self, cls, seen, num_spec):
+        p = cls.__new__(cls)
+        p.model = self._fake_model(seen)
+        p.num_speculative_tokens = num_spec
+        # Only DSpark reads this attribute; DFlash derives 1 + K locally. The
+        # anchor-first value is the one 310P covers.
+        p.sample_from_anchor = True
+        p.num_query_per_req = num_spec
+        p.max_query_tokens = 64
+        p.use_cuda_graph = False
+        p.vllm_config = SimpleNamespace()
+        p.input_ids = torch.zeros(64, dtype=torch.int32)
+        p.hidden_states = torch.zeros(64, 8)
+        p.token_indices_to_sample = torch.zeros(64, dtype=torch.int32)
+        p._context_positions_buffer = torch.arange(64, dtype=torch.int32)
+        p._slot_mapping_buffer = torch.zeros(64, dtype=torch.int32)
+        p._dflash_hidden_states = torch.zeros(64, 8)
+        p.arange_dflash = torch.arange(65, dtype=torch.int32)
+        p.token_arange_np = np.arange(65, dtype=np.int32)
+        p.attn_layer_names = []
+        p.draft_attn_groups = []
+        p.kv_cache_gid = 0
+        p._get_positions = lambda n: torch.arange(n, dtype=torch.int32)
+        p._pad_draft_buffers = lambda *a, **kw: None
+        p.runner = MagicMock()
+        p.runner._sync_metadata_across_dp.return_value = (CONTEXT_TOKENS, None, None)
+        p.runner.attn_groups = []
+        return p
+
+    def _run_profile(self, cls, num_spec, caller_module):
+        import importlib
+
+        seen = []
+        proposer = self._make_proposer(cls, seen, num_spec)
+        module = importlib.import_module(caller_module)
+
+        # set_ascend_forward_context / get_forward_context are imported directly
+        # into each proposer module, so they must be patched where dummy_run reads
+        # them; patching llm_base_proposer.* would not be seen. dspark_proposer
+        # does not import get_forward_context at all, so patch it only where it
+        # exists rather than creating an attribute that production code lacks.
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock_patch(f"{DFLASH_MOD}.is_310p", return_value=True))
+            stack.enter_context(mock_patch(f"{caller_module}.set_ascend_forward_context", _null_context))
+            if hasattr(module, "get_forward_context"):
+                stack.enter_context(mock_patch(f"{caller_module}.get_forward_context", MagicMock()))
+            proposer.dummy_run(num_tokens=CONTEXT_TOKENS, num_reqs=NUM_REQS, is_profile=True)
+        return seen
+
+    def _assert_both_forwards_covered(self, seen):
+        self.assertEqual([kind for kind, _, _ in seen], ["context", "query"])
+        for kind, flag, _ in seen:
+            self.assertTrue(flag, f"{kind} forward ran with the drafting RoPE flag off")
+        ctx_len, q_len = seen[0][2], seen[1][2]
+        self.assertNotEqual(
+            ctx_len,
+            q_len,
+            "context and query lengths coincide, so this cannot tell a half fix "
+            "(flag on for only the first forward) from a full one",
+        )
+
+    def test_dflash_profile_covers_context_and_query(self):
+        from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+        self._assert_both_forwards_covered(
+            self._run_profile(AscendDflashProposer, 8, "vllm_ascend.spec_decode.dflash_proposer")
+        )
+
+    def test_dspark_profile_covers_context_and_query(self):
+        from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+
+        self._assert_both_forwards_covered(
+            self._run_profile(AscendDSparkProposer, 7, "vllm_ascend.spec_decode.dspark_proposer")
+        )
+
+    def test_flag_is_restored_after_the_profile_branch(self):
+        from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+        _set_flag(False)
+        self._run_profile(AscendDflashProposer, 8, "vllm_ascend.spec_decode.dflash_proposer")
+        self.assertFalse(_flag_now(), "flag leaked out of the profile branch")
+
+    def test_flag_is_restored_even_when_the_forward_raises(self):
+        from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+        proposer = AscendDflashProposer.__new__(AscendDflashProposer)
+        # Forcing is_310p matters: without it the context manager yields without
+        # touching the flag and the restore assertion below passes vacuously.
+        with mock_patch(f"{DFLASH_MOD}.is_310p", return_value=True):
+            _set_flag(False)
+            with self.assertRaises(ValueError):
+                with proposer._profile_rope_context():
+                    self.assertTrue(_flag_now(), "flag was never set, so the check below is vacuous")
+                    raise ValueError("boom")
+        self.assertFalse(_flag_now())
+
+    def test_non_310p_leaves_the_flag_untouched(self):
+        from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+
+        proposer = AscendDflashProposer.__new__(AscendDflashProposer)
+        _set_flag(False)
+        with mock_patch(f"{DFLASH_MOD}.is_310p", return_value=False):
+            with proposer._profile_rope_context():
+                self.assertFalse(_flag_now(), "non-310P must not enable the 310P drafting flag")
+        self.assertFalse(_flag_now())
+
+
+class TestBonusAnchorRefusedOn310p(TestBase):
+    """310P covers only the anchor-first DSpark layout.
+
+    With ``dspark_bonus_anchor=True`` a request queries 1 + K positions instead
+    of K. The 310P expansion fallback and the FIA route both assume q == K, and
+    the mismatch does not raise anywhere -- it shifts every slot and token index
+    by one and silently returns wrong tokens. So construction must refuse it.
+    """
+
+    NUM_SPEC = 7
+    MAX_BATCH = 4
+
+    def _init_proposer(self, *, bonus_anchor, on_310p):
+        from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+
+        hf_config = SimpleNamespace(dspark_bonus_anchor=True) if bonus_anchor else SimpleNamespace()
+        draft_model_config = SimpleNamespace(hf_config=hf_config, get_hidden_size=lambda: 8)
+        vllm_config = SimpleNamespace(
+            speculative_config=SimpleNamespace(
+                draft_sample_method="greedy",
+                draft_model_config=draft_model_config,
+            )
+        )
+
+        def parent_init(proposer, cfg, device, runner=None):
+            del runner
+            proposer.draft_model_config = cfg.speculative_config.draft_model_config
+            proposer.num_speculative_tokens = self.NUM_SPEC
+            proposer.max_batch_size = self.MAX_BATCH
+            proposer.max_num_tokens = 64
+            proposer.dtype = torch.float32
+            proposer.device = device
+            proposer.hidden_size = 8
+            proposer.hidden_states = torch.empty(0)
+            proposer._dflash_hidden_states = torch.empty(0)
+
+        with (
+            mock_patch.object(AscendDSparkProposer.__base__, "__init__", parent_init),
+            mock_patch("vllm_ascend.spec_decode.dspark_proposer.is_310p", return_value=on_310p),
+        ):
+            return AscendDSparkProposer(vllm_config, torch.device("cpu"))
+
+    def test_bonus_anchor_is_refused_on_310p(self):
+        with self.assertRaisesRegex(NotImplementedError, "dspark_bonus_anchor"):
+            self._init_proposer(bonus_anchor=True, on_310p=True)
+
+    def test_bonus_anchor_is_allowed_off_310p(self):
+        """The guard is device-scoped: other devices keep upstream's layout."""
+        proposer = self._init_proposer(bonus_anchor=True, on_310p=False)
+        self.assertFalse(proposer.sample_from_anchor)
+        self.assertEqual(proposer.num_query_per_req, 1 + self.NUM_SPEC)
+
+    def test_anchor_first_is_accepted_on_310p(self):
+        """The guard is layout-scoped: it must not reject the supported case."""
+        proposer = self._init_proposer(bonus_anchor=False, on_310p=True)
+        self.assertTrue(proposer.sample_from_anchor)
+        self.assertEqual(proposer.num_query_per_req, self.NUM_SPEC)

--- a/tests/ut/_310p/test_qwen3_context_rope_310p.py
+++ b/tests/ut/_310p/test_qwen3_context_rope_310p.py
@@ -1,0 +1,152 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch as mock_patch
+
+import torch
+
+from tests.ut.base import TestBase
+from vllm_ascend.patch.worker.patch_qwen3_dflash import apply_context_rope
+
+PATCH_MOD = "vllm_ascend.patch.worker.patch_qwen3_dflash"
+
+NUM_LAYERS = 5  # both target checkpoints have num_hidden_layers == 5
+NUM_CTX = 6
+NUM_KV_HEADS = 4
+HEAD_DIM = 8
+KV_SIZE = NUM_KV_HEADS * HEAD_DIM
+
+
+class OutOfPlaceRope:
+    """310P-style rotary: returns new tensors and never writes through its input.
+
+    Marks its output so a caller that drops the return value is caught.
+    """
+
+    def __init__(self, layer_idx):
+        self.layer_idx = layer_idx
+        self.calls = []
+
+    def __call__(self, positions, query, key):
+        self.calls.append(int(positions.shape[0]))
+        return torch.full_like(query, float(self.layer_idx + 1)), torch.empty_like(key)
+
+
+class InPlaceRope:
+    """A2/A3-style rotary: writes through its input and returns that same storage."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, positions, query, key):
+        self.calls.append(int(positions.shape[0]))
+        query.mul_(-1.0)
+        return query, key
+
+
+def make_layers(rope_factory):
+    return [SimpleNamespace(self_attn=SimpleNamespace(rotary_emb=rope_factory(i))) for i in range(NUM_LAYERS)]
+
+
+def make_k_normed():
+    # Distinct per-layer values so a layer mix-up is visible.
+    base = torch.arange(NUM_LAYERS * NUM_CTX * KV_SIZE, dtype=torch.float32)
+    return base.reshape(NUM_LAYERS, NUM_CTX, NUM_KV_HEADS, HEAD_DIM).clone()
+
+
+def run(layers, all_k_normed, positions=None):
+    return apply_context_rope(
+        layers=layers,
+        all_k_normed=all_k_normed,
+        context_positions=(positions if positions is not None else torch.arange(NUM_CTX, dtype=torch.int32)),
+        num_layers=NUM_LAYERS,
+        num_ctx=NUM_CTX,
+        kv_size=KV_SIZE,
+    )
+
+
+class TestApplyContextRope310P(TestBase):
+    def test_rotates_one_layer_at_a_time(self):
+        """Each layer gets num_ctx positions, never L * num_ctx.
+
+        The fused form overflows the 310P global cos/sin buffer, which is sized
+        max_num_batched_tokens, for any realistic context with 5 layers.
+        """
+        layers = make_layers(OutOfPlaceRope)
+        with mock_patch(f"{PATCH_MOD}.is_310p", return_value=True):
+            run(layers, make_k_normed())
+
+        for i, layer in enumerate(layers):
+            self.assertEqual(
+                layer.self_attn.rotary_emb.calls,
+                [NUM_CTX],
+                f"layer {i} was not rotated exactly once with num_ctx positions",
+            )
+
+    def test_uses_the_rotated_result_not_the_input(self):
+        """310P rotary is out of place, so dropping the return value would feed
+        unrotated K into the cache -- wrong numbers, no error."""
+        layers = make_layers(OutOfPlaceRope)
+        with mock_patch(f"{PATCH_MOD}.is_310p", return_value=True):
+            out = run(layers, make_k_normed())
+
+        self.assertEqual(tuple(out.shape), (NUM_LAYERS * NUM_CTX, KV_SIZE))
+        per_layer = out.view(NUM_LAYERS, NUM_CTX, KV_SIZE)
+        for i in range(NUM_LAYERS):
+            # Each stub returns its own marker value; seeing it proves that
+            # layer's result was kept and landed in that layer's slice.
+            self.assertTrue(
+                bool((per_layer[i] == float(i + 1)).all()),
+                f"layer {i} slice does not hold that layer's rotated output",
+            )
+
+    def test_does_not_pass_repeated_positions(self):
+        positions = torch.arange(NUM_CTX, dtype=torch.int32)
+        layers = make_layers(OutOfPlaceRope)
+        with mock_patch(f"{PATCH_MOD}.is_310p", return_value=True):
+            run(layers, make_k_normed(), positions=positions)
+
+        for layer in layers:
+            self.assertNotEqual(
+                layer.self_attn.rotary_emb.calls,
+                [NUM_LAYERS * NUM_CTX],
+                "positions were repeated across layers; that is the fused form",
+            )
+
+    def test_non_310p_keeps_the_single_fused_call(self):
+        layers = make_layers(lambda _i: InPlaceRope())
+        with mock_patch(f"{PATCH_MOD}.is_310p", return_value=False):
+            out = run(layers, make_k_normed())
+
+        self.assertEqual(
+            layers[0].self_attn.rotary_emb.calls,
+            [NUM_LAYERS * NUM_CTX],
+            "non-310P must keep rotating all layers in one fused call",
+        )
+        for layer in layers[1:]:
+            self.assertEqual(layer.self_attn.rotary_emb.calls, [], "only layer 0 drives the fused call")
+        self.assertEqual(tuple(out.shape), (NUM_LAYERS * NUM_CTX, KV_SIZE))
+
+    def test_non_310p_result_reflects_the_rotation(self):
+        """In-place rotary returns its input storage, so taking the return value
+        is a no-op there -- but it must still carry the rotation."""
+        k_normed = make_k_normed()
+        expected = k_normed.view(NUM_LAYERS * NUM_CTX, KV_SIZE).clone() * -1.0
+        layers = make_layers(lambda _i: InPlaceRope())
+        with mock_patch(f"{PATCH_MOD}.is_310p", return_value=False):
+            out = run(layers, k_normed)
+
+        torch.testing.assert_close(out, expected)

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -81,7 +81,14 @@ class _DSparkProposerTestBase:
             proposer.hidden_states = torch.empty(0)
             proposer._dflash_hidden_states = torch.empty(0)
 
-        with patch.object(AscendDSparkProposer.__base__, "__init__", mock_parent_init):
+        # These cases cover device-independent configuration, so pin is_310p
+        # off: on a 310P-built install it is true, and the proposer refuses the
+        # bonus-anchor layout there (that refusal has its own coverage in
+        # tests/ut/_310p/spec_decode/).
+        with (
+            patch.object(AscendDSparkProposer.__base__, "__init__", mock_parent_init),
+            patch("vllm_ascend.spec_decode.dspark_proposer.is_310p", return_value=False),
+        ):
             proposer = AscendDSparkProposer(vllm_config, device)
 
         num_query_total = num_reqs * proposer.num_query_per_req
@@ -197,10 +204,10 @@ class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
     @pytest.mark.parametrize("dp_padding", MULTI_DP_PADDING_SIZES)
     def test_positions_not_pre_sliced(self, monkeypatch, dp_padding):
         """``cad.positions`` must be the full buffer, not ``[:num_query_total]``."""
-        monkeypatch.setattr(
-            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
-            MagicMock(),
-        )
+        # Stub the dispatch entry point rather than the Triton launcher behind it:
+        # `_expand_drafting_inputs` picks a backend from `is_310p()`, so patching one
+        # backend leaves the test taking the other one on that device.
+        monkeypatch.setattr(AscendDSparkProposer, "_expand_drafting_inputs", MagicMock())
         num_reqs, block_size, max_num_tokens = 4, 5, 256
         num_query_total = num_reqs * block_size
         num_input_tokens = num_query_total + dp_padding
@@ -217,10 +224,10 @@ class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
     def test_positions_full_and_padded_for_dsa(self, monkeypatch, dp_padding):
         """After set_inputs_first_pass + _pad_draft_buffers, positions[:num_input]
         is full-length and zero-padded in the DP region."""
-        monkeypatch.setattr(
-            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid",
-            MagicMock(),
-        )
+        # Stub the dispatch entry point rather than the Triton launcher behind it:
+        # `_expand_drafting_inputs` picks a backend from `is_310p()`, so patching one
+        # backend leaves the test taking the other one on that device.
+        monkeypatch.setattr(AscendDSparkProposer, "_expand_drafting_inputs", MagicMock())
         num_reqs, block_size, max_num_tokens = 4, 5, 256
         num_query_total = num_reqs * block_size
         num_input_tokens = num_query_total + dp_padding

--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -24,6 +24,10 @@ from vllm.v1.attention.backends.registry import (  # type: ignore
     register_backend,
 )
 
+from vllm_ascend._310p.attention.parallel_draft_attention import (
+    FIA_SUPPORTED_METHODS,
+    forward_parallel_draft_fia,
+)
 from vllm_ascend._310p.attention.attention_mask import (
     AttentionMaskBuilder310,
     is_compressed_mask_supported,
@@ -32,6 +36,7 @@ from vllm_ascend._310p.attention.metadata_builder import (
     AscendAttentionMetadataBuilder310,
     get_query_lens_cpu,
 )
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_v1 import (
     AscendAttentionBackend,
     AscendAttentionBackendImpl,
@@ -108,6 +113,10 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.support_compressed_mask = is_compressed_mask_supported()
+        # Set once by the custom FIA adapter after its first successful scope check.
+        # Everything that check covers is a startup invariant, so it runs once per
+        # impl and still raises before any wrong output can be produced.
+        self._fia_scope_validated = False
 
     def _flash_attention(
         self,
@@ -219,8 +228,18 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         Returns:
             The output tensor after flash attention.
         """
-        real_tokens = int(attn_metadata.seq_lens.sum().item())
+        # ATB's SelfAttention encoder reads seq_len from host memory. In non-spec
+        # runs the builder hands out a CPU tensor, so this held implicitly; but
+        # parallel drafting (DFlash/DSpark) makes the builder return a device
+        # tensor for the A2/A3 FIA path (attention_v1.py: parallel_drafting
+        # branch), and passing that straight through segfaults ATB with
+        # "tensor.hostData is null". Coerce to host here -- the mirror of
+        # forward_paged_attention, which coerces seq_lens to device for the paged
+        # op. Each path pins seq_lens to what its own operator needs.
         seq_len = attn_metadata.seq_lens
+        if seq_len.device.type != "cpu":
+            seq_len = seq_len.cpu()
+        real_tokens = int(seq_len.sum().item())
         aligned_tokens = int(query.shape[0])
         delta = aligned_tokens - real_tokens
 
@@ -252,8 +271,6 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         # Host qLens filled in AscendAttentionMetadataBuilder310.build(); eager fallback only.
         qlens = get_query_lens_cpu(attn_metadata)
         if qlens is None:
-            from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-
             if _EXTRA_CTX.capturing:
                 raise RuntimeError(
                     "310P splitfuse requires attn_metadata.query_lens_cpu during graph capture; "
@@ -327,6 +344,35 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
             NotImplementedError: If the attention state is not supported on 310P.
         """
         state = attn_metadata.attn_state
+
+        # Everything below this block is causal. Test `causal` first because it is
+        # local and false for almost every call: that keeps the causal path free of
+        # the forward-context lookup _EXTRA_CTX needs, which it never required
+        # before, and skips that lookup per layer per step.
+        if not attn_metadata.causal:
+            # DFlash/DSpark parallel drafting is the only non-causal path that
+            # reaches forward_impl; pooling's non-causal case returns earlier in
+            # forward(). self.vllm_config is bound in
+            # AscendAttentionBackendImpl.__init__ via get_current_vllm_config().
+            spec_config = self.vllm_config.speculative_config
+            is_parallel_draft_adn = (
+                _EXTRA_CTX.is_draft_model
+                and spec_config is not None
+                and spec_config.method in FIA_SUPPORTED_METHODS
+                and state == AscendAttentionState.ChunkedPrefill
+            )
+            if is_parallel_draft_adn:
+                return forward_parallel_draft_fia(self, query, attn_metadata, output)
+            # Falling through would hand a non-causal request to the split-fuse
+            # kernel, which returns a plausible but wrong result instead of
+            # failing, so refuse here.
+            raise NotImplementedError(
+                f"310P has no non-causal attention path for attn_state={state}, "
+                f"is_draft_model={_EXTRA_CTX.is_draft_model}, "
+                f"method={getattr(spec_config, 'method', None)}. Only DFlash/DSpark draft "
+                f"ChunkedPrefill is routed to custom FIA in this scope."
+            )
+
         # Condition for PrefillNoCache: No previous tokens have been processed yet
         if state == AscendAttentionState.PrefillNoCache:
             output = self.forward_prefill_310(query, key, value, attn_metadata, output)

--- a/vllm_ascend/_310p/attention/parallel_draft_attention.py
+++ b/vllm_ascend/_310p/attention/parallel_draft_attention.py
@@ -1,0 +1,331 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import torch
+import torch_npu
+from vllm.forward_context import is_forward_context_available
+
+from vllm_ascend._310p.attention.metadata_builder import get_query_lens_cpu
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+
+# Scope of this route. TP is not pinned: it only shards heads across ranks and
+# does not change the numerics, so what matters is the per-rank layout, checked
+# structurally below.
+FIA_BLOCK_SIZE = 128  # the only KV page size the kernel's block selection covers
+# headDim <= 256 and headDim * blockSize <= 16384 are the operator's own tiling
+# limits; the head count is not a kernel limit but the envelope its unit test
+# covers (1..16 heads, MHA and GQA), so it is where this scope stops.
+FIA_MAX_HEAD_DIM = 256
+FIA_MAX_HEAD_DIM_X_BLOCK = 16384  # with block=128 this caps head_dim at 128
+FIA_MAX_NUM_HEADS = 16
+FIA_SUPPORTED_METHODS = {"dflash", "dspark"}
+# config.json architecture strings (the vLLM registry keys), not model class
+# names -- matching against the class names never fires.
+FIA_SUPPORTED_ARCHITECTURES = {"DFlashDraftModel", "Qwen3DSparkModel"}
+
+def expected_queries_per_request(method, num_speculative_tokens):
+    """Queries each request issues per draft step.
+
+    DFlash prepends an anchor to the K mask tokens, DSpark does not.
+    """
+    return num_speculative_tokens + 1 if method == "dflash" else num_speculative_tokens
+
+
+def _fia_op():
+    """Resolve the custom FIA op wrapper.
+
+    The kernel is built only for the ascend310 SOC branch, so a wheel produced
+    for another target imports fine and simply does not carry the symbol. Going
+    through the operator's own wrapper rather than torch.ops keeps the argument
+    marshalling in one place and picks up @allow_in_graph.
+    """
+    if not hasattr(torch.ops._C_ascend, "npu_custom_fused_infer_attention_v310"):
+        raise RuntimeError(
+            "310P parallel draft attention needs "
+            "torch.ops._C_ascend.npu_custom_fused_infer_attention_v310, which is not "
+            "registered. Rebuild with SOC_VERSION=ascend310p1. There is no fallback: "
+            "the causal split-fuse kernel would return plausible but wrong numbers."
+        )
+    from vllm_ascend._310p.ops.custom_fused_infer_attention import (
+        custom_fused_infer_attention_v310,
+    )
+
+    return custom_fused_infer_attention_v310
+
+
+def validate_fia_scope(*, vllm_config, query, key_cache, value_cache, num_heads, num_kv_heads, head_size):
+    """Check every startup invariant once, before the first custom FIA call."""
+    spec_config = vllm_config.speculative_config
+    method = getattr(spec_config, "method", None)
+    if spec_config is None or method not in FIA_SUPPORTED_METHODS:
+        raise RuntimeError(
+            f"custom FIA draft attention only covers {sorted(FIA_SUPPORTED_METHODS)}, got {method}"
+        )
+    num_spec = spec_config.num_speculative_tokens
+    if num_spec < 1:
+        raise RuntimeError(f"num_speculative_tokens must be >= 1, got {num_spec}")
+
+    hf_config = spec_config.draft_model_config.hf_config
+    architectures = getattr(hf_config, "architectures", None) or []
+    arch = architectures[0] if architectures else None
+    if arch not in FIA_SUPPORTED_ARCHITECTURES:
+        raise RuntimeError(
+            f"draft architecture {arch} is outside this scope "
+            f"({sorted(FIA_SUPPORTED_ARCHITECTURES)})"
+        )
+
+    # This route passes attn_mask=None, which the kernel maps to NO_MASK: every
+    # query row sees the whole [0, kv_len) range. That is only correct for a
+    # drafter whose layers are all full non-causal attention. A causal or
+    # sliding-window checkpoint would still run and return plausible numbers, so
+    # refuse it here rather than discover it as an accuracy loss.
+    layer_types = getattr(hf_config, "layer_types", None)
+    if layer_types is not None and any(t != "full_attention" for t in layer_types):
+        raise RuntimeError(
+            f"this route sends attn_mask=None (non-causal); draft layer_types "
+            f"{sorted(set(layer_types))} include something other than full_attention"
+        )
+    if getattr(hf_config, "use_sliding_window", False) or getattr(hf_config, "sliding_window", None):
+        raise RuntimeError(
+            "this route sends attn_mask=None (non-causal); the draft checkpoint "
+            "requests sliding-window attention, which it cannot express"
+        )
+    if getattr(getattr(hf_config, "dflash_config", None), "causal", False):
+        raise RuntimeError("this route sends attn_mask=None; the draft checkpoint asks for causal attention")
+
+    # A draft step's query rows must fit in one diffusion block. DFlash spends
+    # one row on the anchor and DSpark does not, so this caps DFlash at
+    # block_size - 1 speculative tokens and DSpark at block_size. Unrelated to
+    # the CLI --block-size, which is the KV page size (FIA_BLOCK_SIZE).
+    diffusion_block = getattr(hf_config, "block_size", None)
+    if diffusion_block:
+        q = expected_queries_per_request(method, num_spec)
+        if q > diffusion_block:
+            raise RuntimeError(
+                f"num_speculative_tokens={num_spec} needs {q} query rows per request, "
+                f"more than the checkpoint's diffusion block holds ({diffusion_block}). "
+                f"The ceiling is {diffusion_block - 1 if method == 'dflash' else diffusion_block} "
+                f"for {method}."
+            )
+
+    # No engine-wide eager check here: "target in ACLGraph, drafter eager" is a
+    # supported configuration, and enforce_eager describes the engine rather than
+    # this route. What must not happen is checked per call below.
+
+    # Per-rank head layout, constrained structurally rather than by a fixed count.
+    # TP is not checked: it only shards these heads across ranks and does not
+    # change the numerics, so any TP whose resulting layout satisfies the rules
+    # below is fine (e.g. Qwen3-8B is 32Q/8KV -> 16/4 at TP=2, 8/2 at TP=4).
+    if not 0 < head_size <= FIA_MAX_HEAD_DIM:
+        raise RuntimeError(f"custom FIA requires 0 < head_dim <= {FIA_MAX_HEAD_DIM}, got {head_size}")
+    if head_size * FIA_BLOCK_SIZE > FIA_MAX_HEAD_DIM_X_BLOCK:
+        # With the fixed 128-token block this caps head_dim at 128.
+        raise RuntimeError(
+            f"head_dim * block_size = {head_size * FIA_BLOCK_SIZE} exceeds the kernel's "
+            f"{FIA_MAX_HEAD_DIM_X_BLOCK}"
+        )
+    if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+        raise RuntimeError(f"invalid GQA layout: {num_heads} query heads / {num_kv_heads} KV heads")
+    if num_heads > FIA_MAX_NUM_HEADS:
+        # Qwen3-8B is 32 query heads, so TP=1 lands outside the covered envelope
+        # while TP=2 (16) and TP=4 (8) are inside it.
+        raise RuntimeError(
+            f"per-rank query heads {num_heads} exceeds the {FIA_MAX_NUM_HEADS} this scope "
+            f"covers; raise the tensor-parallel size so each rank holds fewer heads"
+        )
+    if (num_kv_heads * head_size) % 16 != 0:
+        raise RuntimeError(
+            f"NZ alignment: num_kv_heads * head_dim = {num_kv_heads * head_size} must be a "
+            f"multiple of 16"
+        )
+
+    for name, tensor in (("query", query), ("key_cache", key_cache), ("value_cache", value_cache)):
+        if tensor.dtype != torch.float16:
+            raise RuntimeError(
+                f"custom FIA on 310P only supports float16 in this scope, but {name} is "
+                f"{tensor.dtype}. Start the engine with dtype=float16."
+            )
+
+    if key_cache.ndim != 4 or value_cache.ndim != 4:
+        raise RuntimeError(f"custom FIA needs rank-4 NZ K/V caches, got {key_cache.ndim}/{value_cache.ndim}")
+    if key_cache.shape != value_cache.shape:
+        raise RuntimeError(f"K/V cache shapes differ: {key_cache.shape} vs {value_cache.shape}")
+    if key_cache.device != value_cache.device:
+        raise RuntimeError(f"K/V caches are on different devices: {key_cache.device} vs {value_cache.device}")
+
+    for name, cache in (("key_cache", key_cache), ("value_cache", value_cache)):
+        fmt = int(torch_npu.get_npu_format(cache))
+        if fmt != ACL_FORMAT_FRACTAL_NZ:
+            raise RuntimeError(
+                f"{name} is in acl format {fmt}, expected ACL_FORMAT_FRACTAL_NZ "
+                f"({ACL_FORMAT_FRACTAL_NZ}); the kernel reads the NZ layout directly"
+            )
+
+    if key_cache.shape[-1] != 16:
+        raise RuntimeError(f"NZ cache last dim must be 16, got {key_cache.shape[-1]}")
+    # Compared against the scope constant, not against a value derived from the
+    # cache itself -- the latter would be tautological.
+    if key_cache.shape[-2] != FIA_BLOCK_SIZE:
+        raise RuntimeError(
+            f"cache physical block size is {key_cache.shape[-2]}, this scope only covers "
+            f"{FIA_BLOCK_SIZE}"
+        )
+    expected_dim1 = num_kv_heads * head_size // 16
+    if key_cache.shape[1] != expected_dim1:
+        raise RuntimeError(
+            f"NZ cache dim1 is {key_cache.shape[1]}, expected num_kv_heads*head_size/16 = {expected_dim1}"
+        )
+
+
+def forward_parallel_draft_fia(self, query, attn_metadata, output):
+    """Non-causal parallel-draft attention via the in-tree custom FIA op.
+
+    ``attn_mask=None`` is what makes the kernel non-causal: its host tiling maps an empty
+    mask to NO_MASK and the kernel neither loads nor applies one, so every query row
+    sees the full ``[0, actual_seq_lengths_kv[b])`` range -- context plus this
+    round's entire query block. Never pass the 310P compressed split-fuse mask here,
+    and never synthesize an all-zero causal mask to imitate it.
+    """
+    fia_op = _fia_op()
+
+    num_tokens = int(attn_metadata.num_actual_tokens)
+    query_slice = query[:num_tokens]
+    output_slice = output[:num_tokens]
+
+    # Raw per-request q-lens come from the 310P builder, which diffed the CPU
+    # endpoints outside the forward. The tensor is host/pinned, so .tolist() costs
+    # no device sync. Never rebuild these from the base metadata's
+    # actual_seq_lengths_q (cumulative endpoints) or from max_query_len.
+    raw_q_lens = get_query_lens_cpu(attn_metadata)
+    if raw_q_lens is None:
+        raise RuntimeError(
+            "310P parallel draft attention needs raw per-request query lengths on "
+            "attn_metadata, but query_lens_cpu is missing. It is set by "
+            "AscendAttentionMetadataBuilder310.build() for ChunkedPrefill/SpecDecoding; "
+            "check that the draft metadata went through that builder."
+        )
+    q_lens = raw_q_lens.tolist()
+    kv_lens = attn_metadata.seq_lens_list
+
+    # actual_seq_lengths_q / _kv are host SymInt[] read at dispatch, so capturing
+    # this op would freeze one step's lengths into the graph and replay them for
+    # every later step -- plausible numbers, silently wrong. The availability
+    # check must short-circuit: reading _EXTRA_CTX with no forward context raises
+    # "Forward context is not set".
+    if is_forward_context_available() and _EXTRA_CTX.capturing:
+        raise RuntimeError(
+            "310P parallel draft attention was reached during ACLGraph capture. "
+            "This op reads host sequence lengths at dispatch and cannot be captured; "
+            "the drafter must stay eager. Capturing the target model is supported."
+        )
+
+    method = getattr(self.vllm_config.speculative_config, "method", None)
+    if method not in FIA_SUPPORTED_METHODS:
+        raise RuntimeError(f"custom FIA draft attention reached with unsupported method {method}")
+
+    # Scope first, shapes second. The q-len check below assumes the configuration
+    # is in scope, so if K is out of scope it reports a wrong q-len and blames the
+    # metadata -- which is what an out-of-scope K=15 DFlash run used to hit,
+    # pointing at cumulative endpoints instead of at the K it was launched with.
+    if not self._fia_scope_validated:
+        validate_fia_scope(
+            vllm_config=self.vllm_config,
+            query=query_slice.reshape(num_tokens, self.num_heads, self.head_size),
+            key_cache=self.key_cache,
+            value_cache=self.value_cache,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_size,
+        )
+        self._fia_scope_validated = True
+
+    expected_q = expected_queries_per_request(
+        method, self.vllm_config.speculative_config.num_speculative_tokens
+    )
+    if any(q != expected_q for q in q_lens):
+        raise RuntimeError(
+            f"{method} expects every request to query {expected_q} positions, got {q_lens}. "
+            f"A cumulative-endpoint tensor was most likely passed instead of raw "
+            f"per-request lengths."
+        )
+    if sum(q_lens) != num_tokens or query_slice.shape[0] != num_tokens:
+        raise RuntimeError(
+            f"sum(q_lens)={sum(q_lens)}, num_actual_tokens={num_tokens}, query rows="
+            f"{query_slice.shape[0]} must all agree"
+        )
+
+    block_table = attn_metadata.block_tables[: len(q_lens)]
+    if len(kv_lens) != len(q_lens) or block_table.shape[0] != len(q_lens):
+        raise RuntimeError(
+            f"batch size disagreement: {len(q_lens)} q-lens, {len(kv_lens)} kv-lens, "
+            f"{block_table.shape[0]} block-table rows"
+        )
+    if block_table.ndim != 2 or block_table.dtype != torch.int32:
+        raise RuntimeError(
+            f"block table must be a rank-2 int32 tensor, got ndim={block_table.ndim} "
+            f"dtype={block_table.dtype}"
+        )
+
+    # Fixed by scope rather than read back from the cache; validate_fia_scope
+    # checks the cache's physical block size against this same constant.
+    capacity = block_table.shape[1] * FIA_BLOCK_SIZE
+    for b, (q_len, kv_len) in enumerate(zip(q_lens, kv_lens)):
+        if not 0 < q_len <= kv_len:
+            raise RuntimeError(f"request {b}: need 0 < q_len({q_len}) <= kv_len({kv_len})")
+        if kv_len > capacity:
+            raise RuntimeError(
+                f"request {b}: kv_len {kv_len} exceeds what its block table can address "
+                f"({block_table.shape[1]} pages x {FIA_BLOCK_SIZE})"
+            )
+
+    key_cache = self.key_cache
+    value_cache = self.value_cache
+    query_tnd = query_slice.reshape(num_tokens, self.num_heads, self.head_size)
+
+    # The op allocates its own output and has no `out=` overload, so this path
+    # eats one copy. Do not add an `_out` variant locally to avoid it: the ABI is
+    # owned by the shared op, and forking it here is how the two drift.
+    fia_out = fia_op(
+        query_tnd,
+        key_cache,
+        value_cache,
+        attn_mask=None,
+        actual_seq_lengths_q=q_lens,
+        actual_seq_lengths_kv=kv_lens,
+        block_table=block_table,
+        num_heads=self.num_heads,
+        num_key_value_heads=self.num_kv_heads,
+        block_size=FIA_BLOCK_SIZE,
+        input_layout="TND",
+        scale_value=self.scale,
+        # inner_precise is not a wrapper argument: it pins it to 2 internally.
+        # Every other value is passed explicitly rather than left to a default,
+        # so a change to the wrapper's defaults cannot move our numerics silently
+        # -- input_layout's default already went from "BSH" to "BSND".
+    )
+
+    # The op's contract is "output has the same shape as query". Check that rather
+    # than numel against the possibly flat output slice: a numel match would also
+    # accept a transposed or mis-headed result.
+    if tuple(fia_out.shape) != tuple(query_tnd.shape) or fia_out.dtype != query_tnd.dtype:
+        raise RuntimeError(
+            f"custom FIA returned {tuple(fia_out.shape)}/{fia_out.dtype}, expected the "
+            f"query shape {tuple(query_tnd.shape)}/{query_tnd.dtype}"
+        )
+
+    output_slice.copy_(fia_out.reshape(output_slice.shape))
+    return output

--- a/vllm_ascend/_310p/spec_decode/parallel_drafting_inputs.py
+++ b/vllm_ascend/_310p/spec_decode/parallel_drafting_inputs.py
@@ -1,0 +1,138 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import torch
+
+# The only kernel/allocation block size this scope supports. Owned by the
+# attention adapter because it is the kernel's constraint; imported rather than
+# redeclared so the two cannot drift. Everything that claims to be "the block
+# size" is checked against it rather than against each other: cross-checking
+# three sources only proves they agree, not that they equal the value the custom
+# FIA kernel was validated at.
+from vllm_ascend._310p.attention.parallel_draft_attention import FIA_BLOCK_SIZE
+
+
+def resolve_310p_block_size(proposer) -> int:
+    """Read the selected kernel block size and pin it to FIA_BLOCK_SIZE.
+
+    310P only. Never call this on the Triton path: that path must keep using its
+    own source (proposer.kernel_block_size for DFlash, the group's
+    kv_cache_spec.block_size for DSpark) so A2/A3 behaviour is unchanged.
+
+    Runs once per draft step rather than per layer, so the handful of attribute
+    reads here are not worth caching.
+    """
+    gid = proposer.kv_cache_gid
+    selected = proposer.runner.input_batch.block_table[gid].block_size
+    if selected != FIA_BLOCK_SIZE:
+        raise RuntimeError(
+            f"this scope only covers kernel block size {FIA_BLOCK_SIZE}, but KV cache "
+            f"group {gid} selected {selected}; re-scope before changing anything"
+        )
+    if proposer.kernel_block_size != FIA_BLOCK_SIZE:
+        raise RuntimeError(
+            f"proposer.kernel_block_size is {proposer.kernel_block_size}, expected "
+            f"{FIA_BLOCK_SIZE}; the drafter and the block table disagree about the "
+            f"kernel block size, which would corrupt slot mapping"
+        )
+    # runner.kernel_block_sizes[gid] is a *candidate list* (typically [128, 64]),
+    # never a scalar, so check membership rather than equality.
+    candidates = proposer.runner.kernel_block_sizes[gid]
+    if FIA_BLOCK_SIZE not in candidates:
+        raise RuntimeError(
+            f"{FIA_BLOCK_SIZE} is not in the runner's candidate list {candidates} for "
+            f"KV cache group {gid}"
+        )
+    return FIA_BLOCK_SIZE
+
+
+def expand_parallel_drafting_inputs(
+    *,
+    next_token_ids: torch.Tensor,
+    target_positions: torch.Tensor,
+    context_slot_mapping: torch.Tensor,
+    out_input_ids: torch.Tensor,
+    out_context_positions: torch.Tensor,
+    out_query_positions: torch.Tensor,
+    out_context_slot_mapping: torch.Tensor,
+    out_query_slot_mapping: torch.Tensor,
+    out_token_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_rejected_tokens: torch.Tensor | None,
+    parallel_drafting_token_id: int,
+    block_size: int,
+    num_query_per_req: int,
+    num_speculative_tokens: int,
+    total_input_tokens: int,
+    batch_size: int,
+    sample_from_anchor: bool = False,
+) -> None:
+    """Triton-free DFlash/DSpark input expansion for 310P.
+
+    Field-for-field equivalent of ``copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid``
+    in ``vllm_ascend/ops/triton/spec_decode/utils.py``. Writes in place into the
+    caller's persistent buffers and returns nothing.
+
+    ``sample_from_anchor`` selects DSpark's sampling layout (take ``num_speculative_tokens``
+    positions starting at the anchor) instead of DFlash's (skip the anchor, take the
+    next ``num_speculative_tokens``).
+
+    No ``.cpu()`` / ``.item()`` / ``.tolist()`` anywhere: every value stays on device
+    so this adds no synchronization to the draft step.
+    """
+    device = target_positions.device
+    b, q, k = batch_size, num_query_per_req, num_speculative_tokens
+
+    # The scheduled context is copied verbatim over the whole ragged range. The
+    # rejected tail deliberately stays in place: it is excluded downstream by the
+    # shortened seq_lens, and the new query slots overwrite those cache positions.
+    # Assumes query_start_loc[batch_size] == total_input_tokens, which every caller
+    # guarantees; checking it here would cost a D2H on the draft hot path.
+    out_context_positions[:total_input_tokens] = target_positions[:total_input_tokens]
+    out_context_slot_mapping[:total_input_tokens] = context_slot_mapping[:total_input_tokens]
+
+    ctx_end = query_start_loc[1 : b + 1].to(torch.int64)
+    if num_rejected_tokens is None:
+        num_rejected = torch.zeros(b, dtype=torch.int64, device=device)
+    else:
+        num_rejected = num_rejected_tokens[:b].to(torch.int64)
+
+    # Absolute position of the last still-valid context token per request.
+    last_pos = target_positions[ctx_end - num_rejected - 1].to(torch.int64)
+    # Total KV length after dropping the rejected tail: where this round's query
+    # block starts in the cache. Derived from seq_lens (total KV), not from the
+    # scheduled segment length.
+    effective_seq_len = seq_lens[:b].to(torch.int64) - num_rejected
+
+    q_arange = torch.arange(q, dtype=torch.int64, device=device)
+    out_query_positions[: b * q] = (last_pos[:, None] + 1 + q_arange).flatten()
+
+    # int64 throughout so `block_id * block_size` cannot overflow before it is
+    # narrowed back into the int32 destination buffer.
+    cache_pos = effective_seq_len[:, None] + q_arange
+    block_id = block_table[:b].gather(1, cache_pos // block_size).to(torch.int64)
+    out_query_slot_mapping[: b * q] = (block_id * block_size + cache_pos % block_size).flatten()
+
+    ids = out_input_ids[: b * q].view(b, q)
+    ids.fill_(parallel_drafting_token_id)
+    ids[:, 0] = next_token_ids[:b]
+
+    anchor_offset = 0 if sample_from_anchor else 1
+    req_base = torch.arange(b, dtype=torch.int64, device=device)[:, None] * q
+    k_arange = torch.arange(k, dtype=torch.int64, device=device)
+    out_token_indices[: b * k] = (req_base + k_arange + anchor_offset).flatten()

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -29,9 +29,6 @@ from vllm_ascend.device.mxfp_compat import (
     QUANT_DTYPES,
     SCALE_DTYPES,
 )
-from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
-from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
-from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -39,6 +36,9 @@ DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
 
 if HAS_TRITON:
+    from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
+    from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
+    from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
     triton_q_rms = None  # type: ignore

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -32,9 +32,14 @@ import vllm_ascend.patch.worker.patch_mamba_utils  # noqa
 import vllm_ascend.patch.worker.patch_qwen3_next_mtp  # noqa
 import vllm_ascend.patch.worker.patch_step3p5  # noqa
 
+# DFlash's context KV precompute is device-neutral and needed on 310P too; its
+# RoPE branches internally. DSpark inherits the same model-side implementation,
+# so it needs no patch of its own (its mask token is handled by the platform
+# patch patch_speculative_config).
+import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
+
 if not is_310p():
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
-    import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa
 else:
     import vllm_ascend.patch.worker.patch_idex_310  # noqa

--- a/vllm_ascend/patch/worker/patch_qwen3_dflash.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_dflash.py
@@ -5,6 +5,38 @@ from vllm.model_executor.models.qwen3_dflash import (
     DFlashQwen3Model,
 )
 
+from vllm_ascend.utils import is_310p
+
+
+def apply_context_rope(*, layers, all_k_normed, context_positions, num_layers, num_ctx, kv_size):
+    """Rotate the fused context K and return it as [num_layers * num_ctx, kv_size].
+
+    The return value must be used on every device. On A2/A3 the rotary op reshapes
+    with .contiguous() and mutates that storage, so the result aliases the input
+    and taking it is a no-op; on 310P npu_apply_rotary_pos_emb allocates new
+    tensors, so ignoring the result silently feeds unrotated K into the cache.
+
+    310P additionally rotates one layer at a time. The fused [L * num_ctx] form
+    cannot be used there because the drafting-time rotary path fills a module
+    global cos/sin buffer sized max_num_batched_tokens, which L * num_ctx
+    overflows for any realistic context with a multi-layer drafter.
+    """
+    if not is_310p():
+        all_k_flat = all_k_normed.view(num_layers * num_ctx, kv_size)
+        positions_repeated = context_positions.repeat(num_layers)
+        rotated, _ = layers[0].self_attn.rotary_emb(positions_repeated, all_k_flat, all_k_flat.clone())
+        return rotated
+
+    per_layer = all_k_normed.view(num_layers, num_ctx, kv_size)
+    for i in range(num_layers):
+        layer_k = per_layer[i]
+        # Each layer gets its own rotary module rather than layers[0]'s. They are
+        # required to agree (_build_fused_kv_buffers asserts it), so this matches
+        # the fused path while not depending on that assertion holding.
+        rotated, _ = layers[i].self_attn.rotary_emb(context_positions, layer_k, layer_k.clone())
+        per_layer[i] = rotated
+    return all_k_normed.view(num_layers * num_ctx, kv_size)
+
 
 def precompute_and_store_context_kv(
     self,
@@ -37,13 +69,16 @@ def precompute_and_store_context_kv(
         k_norm_layer = self.layers[i].self_attn.k_norm
         all_k_normed[i] = k_norm_layer(all_k[i])
 
-    # --- Fused RoPE across all layers ---
-    # View as [L * num_ctx, kv] so RoPE sees one big batch (no copy).
-    # In-place RoPE: pass K as the "query" arg with key=None.
-    all_k_flat = all_k_normed.view(L * num_ctx, kv)
-    positions_repeated = context_positions.repeat(L)
-    tmpv = all_k_flat.clone()
-    self.layers[0].self_attn.rotary_emb(positions_repeated, all_k_flat, tmpv)
+    # --- Context RoPE (fused across layers off 310P, per layer on it) ---
+    # K is passed in the "query" argument slot with a throwaway tensor as "key".
+    all_k_flat = apply_context_rope(
+        layers=self.layers,
+        all_k_normed=all_k_normed,
+        context_positions=context_positions,
+        num_layers=L,
+        num_ctx=num_ctx,
+        kv_size=kv,
+    )
 
     if context_slot_mapping is None:
         return

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Any
 
 import torch
@@ -8,8 +9,13 @@ from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+# Safe to import at module scope even where Triton is absent (310P CI uninstalls
+# it): vllm.triton_utils substitutes a placeholder whose `jit` is a no-op
+# decorator, so the kernel object exists and only fails if actually launched --
+# which the dispatch in _expand_drafting_inputs never does on 310P.
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.utils import is_310p
 
 
 class AscendDflashProposer(AscendEagleProposer):
@@ -60,6 +66,128 @@ class AscendDflashProposer(AscendEagleProposer):
 
         self.parallel_drafting_hidden_state_tensor = None
 
+    @contextmanager
+    def _profile_rope_context(self):
+        """Keep the 310P drafting RoPE flag on for the whole profile branch.
+
+        dummy_run(is_profile=True) calls precompute_and_store_context_kv and then
+        model(...) directly, bypassing _run_merged_draft, which is what normally
+        turns this flag on. Without it neither forward refreshes the global cos/sin
+        slice, so both silently reuse whatever the target's dummy run left behind
+        -- and the two need different positions anyway (context_positions vs query
+        positions, different lengths).
+
+        Shared with AscendDSparkProposer, which inherits it.
+        """
+        if not is_310p():
+            yield
+            return
+
+        from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
+
+        AscendRotaryEmbedding310.set_rope_position_flag_310p(True)
+        try:
+            yield
+        finally:
+            AscendRotaryEmbedding310.set_rope_position_flag_310p(False)
+
+    def _expand_drafting_inputs(
+        self,
+        *,
+        next_token_ids,
+        target_positions,
+        context_slot_mapping,
+        out_input_ids,
+        out_context_positions,
+        out_query_positions,
+        out_context_slot_mapping,
+        out_query_slot_mapping,
+        out_token_indices,
+        block_table,
+        query_start_loc,
+        seq_lens,
+        num_rejected_tokens,
+        parallel_drafting_token_id,
+        block_size,
+        num_query_per_req,
+        num_speculative_tokens,
+        total_input_tokens,
+        batch_size,
+        sample_from_anchor,
+    ) -> None:
+        """Expand DFlash/DSpark drafting inputs.
+
+        310P has no Triton and uses the vectorized PyTorch equivalent; every other
+        device keeps the original kernel launch. Both write in place into the same
+        persistent buffers.
+
+        Shared with AscendDSparkProposer, which inherits this method. Note that the
+        names looked up inside it always resolve from *this* module, whichever
+        subclass is calling.
+        """
+        if is_310p():
+            from vllm_ascend._310p.spec_decode.parallel_drafting_inputs import (
+                expand_parallel_drafting_inputs,
+                resolve_310p_block_size,
+            )
+
+            # 310P reads the selected BlockTable size and pins it to FIA_BLOCK_SIZE.
+            # The caller's `block_size` is deliberately ignored here and left intact
+            # for the Triton path below, so A2/A3 keeps its exact current source.
+            expand_parallel_drafting_inputs(
+                next_token_ids=next_token_ids,
+                target_positions=target_positions,
+                context_slot_mapping=context_slot_mapping,
+                out_input_ids=out_input_ids,
+                out_context_positions=out_context_positions,
+                out_query_positions=out_query_positions,
+                out_context_slot_mapping=out_context_slot_mapping,
+                out_query_slot_mapping=out_query_slot_mapping,
+                out_token_indices=out_token_indices,
+                block_table=block_table,
+                query_start_loc=query_start_loc,
+                seq_lens=seq_lens,
+                num_rejected_tokens=num_rejected_tokens,
+                parallel_drafting_token_id=parallel_drafting_token_id,
+                block_size=resolve_310p_block_size(self),
+                num_query_per_req=num_query_per_req,
+                num_speculative_tokens=num_speculative_tokens,
+                total_input_tokens=total_input_tokens,
+                batch_size=batch_size,
+                sample_from_anchor=sample_from_anchor,
+            )
+            return
+
+        copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
+            # Inputs
+            next_token_ids_ptr=next_token_ids,
+            target_positions_ptr=target_positions,
+            context_slot_mapping_ptr=context_slot_mapping,
+            # Outputs
+            out_input_ids_ptr=out_input_ids,
+            out_context_positions_ptr=out_context_positions,
+            out_query_positions_ptr=out_query_positions,
+            out_context_slot_mapping_ptr=out_context_slot_mapping,
+            out_query_slot_mapping_ptr=out_query_slot_mapping,
+            out_token_indices_ptr=out_token_indices,
+            # Block table
+            block_table_ptr=block_table,
+            block_table_stride=block_table.stride(0),
+            # Metadata
+            query_start_loc_ptr=query_start_loc,
+            seq_lens_ptr=seq_lens,
+            num_rejected_tokens_ptr=(num_rejected_tokens if num_rejected_tokens is not None else 0),
+            # Scalars
+            parallel_drafting_token_id=parallel_drafting_token_id,
+            block_size=block_size,
+            num_query_per_req=num_query_per_req,
+            num_speculative_tokens=num_speculative_tokens,
+            total_input_tokens=total_input_tokens,
+            batch_size=batch_size,
+            HAS_NUM_REJECTED=num_rejected_tokens is not None,
+            SAMPLE_FROM_ANCHOR=sample_from_anchor,
+        )
+
     def set_inputs_first_pass(
         self,
         target_token_ids: torch.Tensor,
@@ -92,33 +220,29 @@ class AscendDflashProposer(AscendEagleProposer):
 
         has_num_rejected = num_rejected_tokens_gpu is not None
 
-        copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
-            # Inputs
-            next_token_ids_ptr=next_token_ids,
-            target_positions_ptr=target_positions,
-            context_slot_mapping_ptr=cad.slot_mapping,
-            # Outputs
-            out_input_ids_ptr=self.input_ids,
-            out_context_positions_ptr=self._context_positions_buffer,
-            out_query_positions_ptr=self.positions,
-            out_context_slot_mapping_ptr=self._context_slot_mapping_buffers,
-            out_query_slot_mapping_ptr=self._slot_mapping_buffer,
-            out_token_indices_ptr=token_indices_to_sample,
-            # Block table
-            block_table_ptr=cad.block_table_tensor,
-            block_table_stride=cad.block_table_tensor.stride(0),
-            # Metadata
-            query_start_loc_ptr=cad.query_start_loc,
-            seq_lens_ptr=cad.seq_lens,
-            num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
-            # Scalars
+        self._expand_drafting_inputs(
+            next_token_ids=next_token_ids,
+            target_positions=target_positions,
+            context_slot_mapping=cad.slot_mapping,
+            out_input_ids=self.input_ids,
+            out_context_positions=self._context_positions_buffer,
+            out_query_positions=self.positions,
+            out_context_slot_mapping=self._context_slot_mapping_buffers,
+            out_query_slot_mapping=self._slot_mapping_buffer,
+            out_token_indices=token_indices_to_sample,
+            block_table=cad.block_table_tensor,
+            query_start_loc=cad.query_start_loc,
+            seq_lens=cad.seq_lens,
+            num_rejected_tokens=(num_rejected_tokens_gpu if has_num_rejected else None),
+            # Unchanged from before: the dispatch swaps in the selected BlockTable
+            # size on 310P only, so the Triton path keeps this exact source.
             parallel_drafting_token_id=self.parallel_drafting_token_id,
             block_size=self.kernel_block_size,
             num_query_per_req=num_query_per_req,
             num_speculative_tokens=self.num_speculative_tokens,
             total_input_tokens=num_context,
             batch_size=batch_size,
-            HAS_NUM_REJECTED=has_num_rejected,
+            sample_from_anchor=False,
         )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
@@ -227,12 +351,16 @@ class AscendDflashProposer(AscendEagleProposer):
             draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             if is_profile:
-                self.model.precompute_and_store_context_kv(context_states, context_positions)
-                self.model(
-                    input_ids=self.input_ids[:num_query_total],
-                    positions=self._get_positions(num_query_total),
-                    inputs_embeds=None,
-                )
+                # Both forwards must run with the 310P drafting RoPE flag on: they
+                # use different positions (context vs query, different lengths) and
+                # neither refreshes the global cos/sin slice on its own here.
+                with self._profile_rope_context():
+                    self.model.precompute_and_store_context_kv(context_states, context_positions)
+                    self.model(
+                        input_ids=self.input_ids[:num_query_total],
+                        positions=self._get_positions(num_query_total),
+                        inputs_embeds=None,
+                    )
 
             else:
                 self._dflash_num_context = num_input_tokens

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -12,8 +12,8 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.utils import is_310p
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -42,6 +42,16 @@ class AscendDSparkProposer(AscendDflashProposer):
             self.num_query_per_req = self.num_speculative_tokens
         else:
             self.num_query_per_req = 1 + self.num_speculative_tokens
+        if is_310p() and not self.sample_from_anchor:
+            # The 310P draft attention route pins the query block to K, and the
+            # expansion fallback below is only validated for the anchor-first
+            # layout. A bonus-anchor checkpoint would silently shift every slot
+            # and token index by one instead of failing, so refuse up front.
+            raise NotImplementedError(
+                "DSpark with dspark_bonus_anchor=True is not supported on 310P; "
+                "only the anchor-first layout (num_query_per_req == "
+                "num_speculative_tokens) is validated on this device."
+            )
 
         blk = 1 + self.num_speculative_tokens
         self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
@@ -231,40 +241,49 @@ class AscendDSparkProposer(AscendDflashProposer):
         # per kv-cache-group to fill positions / input_ids / query slot_mapping
         # / token_indices.
         draft_attn_groups = getattr(self, "draft_attn_groups", [])
+        if is_310p():
+            # Qwen3-8B DSpark has 5 identical attention layers, which vLLM merges
+            # into a single KV cache group. The per-group machinery here exists for
+            # DeepSeek-V4 DSpark; 310P has only been validated for the single-group
+            # case, so refuse rather than silently expanding just one of several.
+            active_gids = [
+                g.kv_cache_group_id
+                for g in draft_attn_groups
+                if self._per_group_block_table_buffers.get(g.kv_cache_group_id) is not None
+            ]
+            if len(active_gids) != 1:
+                raise NotImplementedError(
+                    f"310P DSpark drafting only covers a single draft KV cache group, got "
+                    f"{active_gids}. Multi-group DSpark (DeepSeek-V4) is out of scope."
+                )
+
         for attn_group in draft_attn_groups:
             gid = attn_group.kv_cache_group_id
             gid_block_table = self._per_group_block_table_buffers.get(gid)
             if gid_block_table is None:
                 continue
             kv_block_size = int(attn_group.kv_cache_spec.block_size)
-            copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
-                # Inputs
-                next_token_ids_ptr=next_token_ids,
-                target_positions_ptr=target_positions,
-                context_slot_mapping_ptr=self._per_group_slot_mappings[gid],
-                # Outputs
-                out_input_ids_ptr=self.input_ids,
-                out_context_positions_ptr=self._context_positions_buffer,
-                out_query_positions_ptr=self.positions,
-                out_context_slot_mapping_ptr=self._per_group_context_slot_mapping_buffers[gid],
-                out_query_slot_mapping_ptr=self._per_group_query_slot_mapping_buffers[gid],
-                out_token_indices_ptr=token_indices_to_sample,
-                # Block table
-                block_table_ptr=gid_block_table,
-                block_table_stride=gid_block_table.stride(0),
-                # Metadata
-                query_start_loc_ptr=cad.query_start_loc,
-                seq_lens_ptr=cad.seq_lens,
-                num_rejected_tokens_ptr=num_rejected_tokens_gpu,
-                # Scalars
+            self._expand_drafting_inputs(
+                next_token_ids=next_token_ids,
+                target_positions=target_positions,
+                context_slot_mapping=self._per_group_slot_mappings[gid],
+                out_input_ids=self.input_ids,
+                out_context_positions=self._context_positions_buffer,
+                out_query_positions=self.positions,
+                out_context_slot_mapping=self._per_group_context_slot_mapping_buffers[gid],
+                out_query_slot_mapping=self._per_group_query_slot_mapping_buffers[gid],
+                out_token_indices=token_indices_to_sample,
+                block_table=gid_block_table,
+                query_start_loc=cad.query_start_loc,
+                seq_lens=cad.seq_lens,
+                num_rejected_tokens=(num_rejected_tokens_gpu if has_num_rejected else None),
                 parallel_drafting_token_id=self.parallel_drafting_token_id,
                 block_size=kv_block_size,
                 num_query_per_req=self.num_query_per_req,
                 num_speculative_tokens=self.num_speculative_tokens,
                 total_input_tokens=self._dflash_num_context,
                 batch_size=batch_size,
-                HAS_NUM_REJECTED=has_num_rejected,
-                SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                sample_from_anchor=self.sample_from_anchor,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
@@ -341,12 +360,16 @@ class AscendDSparkProposer(AscendDflashProposer):
             draft_attn_metadatas=[],
         ):
             if is_profile:
-                self.model.precompute_and_store_context_kv(context_states, context_positions)
-                self.model(
-                    input_ids=self.input_ids[:num_query_total],
-                    positions=self._get_positions(num_query_total),
-                    inputs_embeds=None,
-                )
+                # Both forwards must run with the 310P drafting RoPE flag on: they
+                # use different positions (context vs query, different lengths) and
+                # neither refreshes the global cos/sin slice on its own here.
+                with self._profile_rope_context():
+                    self.model.precompute_and_store_context_kv(context_states, context_positions)
+                    self.model(
+                        input_ids=self.input_ids[:num_query_total],
+                        positions=self._get_positions(num_query_total),
+                        inputs_embeds=None,
+                    )
 
             else:
                 self._dflash_num_context = num_input_tokens


### PR DESCRIPTION
### What this PR does / why we need it?
Add DFlash and DSpark parallel drafting support for Atlas 300I (310P) on model_runner_v1. Both methods draft a whole block per step, which 310P could not serve before for two independent reasons: the existing split-fuse attention path is causal, and the input-expansion kernel is Triton-only (#10665).

This PR adds the non-causal attention route, a Triton-free input expansion, and the 310P context-RoPE handling. A2/A3 keep their existing code path — every device-specific branch is behind `is_310p()`.

**Depends on #13087**, which adds the operator. No `csrc` changes here

#### Performance Test
Test from gsm8k dataset, num_speculative_tokens=7,
temperature=0 and without topk/topp, output_len=2048.
Atlas 300I, TP=4, fp16, drafter eager.

| Model | Spec Method | Acc Length | Acc Rate per Position | 
|---|---|---|---|
| Qwen3-8B | DFlash | 4.88 | [0.87, 0.74, 0.62, 0.52, 0.44, 0.38, 0.32] | 
| Qwen3-8B | DSpark | 6.58 | [0.95, 0.90, 0.84, 0.79, 0.75, 0.70, 0.65] |

### Does this PR introduce _any_ user-facing change?
DFlash and DSpark become available on 310P. No change on other devices.

### How was this patch tested?

```
--dtype float16 --tensor-parallel-size 4 --block-size 128
--speculative-config '{"num_speculative_tokens": K, "method": "dspark", "model": "drafter_path", "enforce_eager": "true"}'
```

Support EAGER, or FULL_DECODE_ONLY for the target with the drafter kept eager:

```
--compilation-config '{"cudagraph_capture_sizes":[bs * (K+1)],"cudagraph_mode":"FULL_DECODE_ONLY"}'
```

Note 310P supports FULL_DECODE_ONLY rather than PIECEWISE, and only the target is captured — hence a single capture size, not the `[bs*K, bs*(K+1)]` pair the A2 PIECEWISE configuration needs. Verified at `bs=1`, `cudagraph_capture_sizes=[8]`.

**Unit tests** — 125 cases on the CPU runner, under the existing `310p` test group, which now also triggers on the shared proposer and patch paths. The Triton-free expansion is compared field by field against a line-by-line transcription of the kernel it replaces, over ragged batches, rejected tails, page boundaries and both sampling layouts.

**E2E** — `four_card/_310p/test_parallel_draft_310p.py`, parametrised over both methods, mirroring `one_card/spec_decode/test_dflash.py` and `test_dspark.py` so the acceptance comparison against `BASELINES` is like-for-like.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
