### PR TITLE
[CI] Add options for releases/v0.25.1rc and releases/0.26.0rc

### DIFF
--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -30,6 +30,8 @@ on:
         type: choice
         options:
           - main
+          - releases/v0.26.0rc
+          - releases/v0.25.1rc
           - releases/v0.24.0rc
           - releases/v0.23.0
           - releases/v0.22.1rc

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -41,6 +41,8 @@ on:
         type: choice
         options:
           - main
+          - releases/v0.26.0rc
+          - releases/v0.25.1rc
           - releases/v0.24.0rc
           - releases/v0.23.0
           - releases/v0.22.1rc


### PR DESCRIPTION
### What this PR does / why we need it?

Add options for releases/v0.25.1rc and releases/0.26.0rc

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
