### PR TITLE
[v0.25.1rc][BugFix][Frontend] Support DeepSeek V4 0731 reasoning effort

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.tokenizers import deepseek_v4
+from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
 
 class FakeTokenizer:
@@ -64,7 +65,7 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
     cases = [
         ("none", "chat", None),
         ("minimal", "thinking", "high"),
-        ("low", "thinking", "high"),
+        ("low", "thinking", None),
         ("medium", "thinking", "high"),
         ("high", "thinking", "high"),
         ("xhigh", "thinking", "max"),
@@ -80,3 +81,44 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
         )
         assert captured_kwargs[-1]["thinking_mode"] == expected_mode
         assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_prefix"),
+    [
+        ("low", "<\uff5cbegin\u2581of\u2581sentence\uff5c><\uff5cUser\uff5c>hi"),
+        (
+            "high",
+            "<\uff5cbegin\u2581of\u2581sentence\uff5c>Reasoning Effort: Absolute maximum with no shortcuts permitted.",
+        ),
+        (
+            "max",
+            "<\uff5cbegin\u2581of\u2581sentence\uff5c>Reasoning Effort: "
+            "Beyond maximum \u2014 exhaustive, relentless, and uncompromising.",
+        ),
+    ],
+)
+def test_deepseek_v4_renders_0731_reasoning_effort_prompts(
+    reasoning_effort,
+    expected_prefix,
+):
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        enable_thinking=True,
+        reasoning_effort=reasoning_effort,
+    )
+
+    assert prompt.startswith(expected_prefix)
+    assert prompt.endswith("<\uff5cAssistant\uff5c><think>")
+
+
+def test_deepseek_v4_rejects_invalid_renderer_reasoning_effort():
+    with pytest.raises(ValueError, match="Invalid reasoning effort: unexpected"):
+        deepseek_v4_encoding.render_message(
+            0,
+            [{"role": "user", "content": "hi"}],
+            thinking_mode="thinking",
+            reasoning_effort="unexpected",
+        )

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -67,7 +67,25 @@
 #       Remove this patch if upstream exposes a platform allocator capability hook
 #       for sleep mode validation.
 #
-# ** 3. File: platform/patch_distributed.py**
+# ** 3. File: platform/patch_deepseek_v4_thinking.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tokenizers.deepseek_v4.get_deepseek_v4_tokenizer`
+#      `vllm.tokenizers.deepseek_v4_encoding.render_message`
+#    Why:
+#       DeepSeek-V4-Flash-0731 defines three reasoning effort levels: low has
+#       no prompt prefix, high uses the original "Absolute maximum" prefix,
+#       and max uses the new "Beyond maximum" prefix. The supported vLLM
+#       Python tokenizer predates this 0731 prompt mapping.
+#    How:
+#       Monkey-patch the tokenizer wrapper to preserve low as the default
+#       no-prefix mode, and wrap render_message to prepend the official 0731
+#       high or max prompt before the first message in thinking mode.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/50580
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #50580.
+#
+# ** 4. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.distributed.all_reduce`, `torch.distributed.broadcast`
 #    Why:
@@ -79,7 +97,7 @@
 #    Future Plan:
 #       Find a better way to support tensor alignment for 310p without this patch.
 #
-# ** 4. File: platform/patch_dp_device_ids.py**
+# ** 5. File: platform/patch_dp_device_ids.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.dp_utils.get_physical_gpu_ids_for_local_dp_rank`
 #    Why:
@@ -103,7 +121,7 @@
 #       handles a pre-sharded visible-devices env var, or vLLM-Ascend stops
 #       relying on application-level device slicing for DP.
 #
-# ** 5. File: platform/patch_fused_moe.py**
+# ** 6. File: platform/patch_fused_moe.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.layers.fused_moe.FusedMoE`
 #    Why:
@@ -122,7 +140,7 @@
 #       Remove this patch once upstream exposes a backend dispatch / plugin hook
 #       for selecting the MoE runner implementation.
 #
-# ** 6. File: platform/patch_kv_cache_coordinator.py**
+# ** 7. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.HybridKVCacheCoordinator.find_longest_cache_hit_per_group`
 #    Why:
@@ -146,7 +164,7 @@
 #       Remove this patch when vLLM PR #42524 and #44243 is included in the supported
 #       upstream vLLM version.
 #
-# ** 7. File: platform/patch_kv_cache_utils.py**
+# ** 8. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
 #      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
@@ -165,7 +183,7 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
-# ** 8. File: platform/patch_mamba_config.py**
+# ** 9. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -177,7 +195,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM merges the PR.
 #
-# ** 9. File: platform/patch_mamba_config_310.py**
+# ** 10. File: platform/patch_mamba_config_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -194,7 +212,7 @@
 #    Future Plan:
 #       Remove this patch once upstream supports 310P-aligned mamba block sizing.
 #
-# ** 10. File: platform/patch_mamba_manager.py**
+# ** 11. File: platform/patch_mamba_manager.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.single_type_kv_cache_manager.MambaManager`
 #    Why:
@@ -214,7 +232,7 @@
 #          hybrid prefix cache lookup for DCP.
 #       2. Remove this patch once upstream accept 46892 pr or fixed the bug by other pr.
 #
-# ** 11. File: platform/patch_minimax_m2_config.py**
+# ** 12. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.ModelConfig._verify_quantization`
 #    Why:
@@ -275,7 +293,7 @@
 #       Drop the alias once upstream registry includes it or the checkpoint
 #       standardizes architecture strings.
 #
-# ** 12. File: platform/patch_mla_prefill_backend.py**
+# ** 13. File: platform/patch_mla_prefill_backend.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.attention.backends.mla.common.get_mla_prefill_backend`
 #    Why:
@@ -297,7 +315,7 @@
 #       platform/device hook so Ascend can be selected (or skipped) without
 #       monkey-patching.
 #
-# ** 13. File: platform/patch_multiproc_executor.py**
+# ** 14. File: platform/patch_multiproc_executor.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.executor.multiproc_executor.MultiprocExecutor`
 #    Why:
@@ -310,7 +328,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM fix the issue.
 #
-# ** 14. File: platform/patch_pp_mtp.py**
+# ** 15. File: platform/patch_pp_mtp.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.outputs.ModelRunnerOutput`
 #    Why:
@@ -400,7 +418,7 @@
 #       supports local drafter models with PP > 1, or moves the PP validation to a
 #       separate hook that can be overridden per-model-type.
 #
-# ** 15. File: platform/patch_profiling_chunk.py**
+# ** 16. File: platform/patch_profiling_chunk.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCore.__init__`
 #   2. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
@@ -428,7 +446,7 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 16. File: platform/patch_speculative_config.py**
+# ** 17. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -451,7 +469,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 17. File: platform/patch_structured_output.py**
+# ** 18. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -473,7 +491,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 18. File: platform/patch_swa_inflight_free.py**
+# ** 19. File: platform/patch_swa_inflight_free.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.KVCacheCoordinator.remove_skipped_blocks`
 #      `vllm.v1.core.sched.scheduler.Scheduler.__init__`
@@ -513,7 +531,7 @@
 #       Remove this patch once the supported upstream vLLM revision for v0.25.1
 #       maintenance includes PR #47728.
 #
-# ** 19. File: platform/patch_torch_accelerator.py**
+# ** 20. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -533,7 +551,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 20. File: platform/patch_tool_choice_none_content.py**
+# ** 21. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -549,7 +567,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 21. File: platform/patch_use_v2_model_runner.py**
+# ** 22. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:
@@ -574,7 +592,7 @@
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
 #
-# ** 22. File: platform/patch_weight_transfer_engine.py**
+# ** 23. File: platform/patch_weight_transfer_engine.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["nccl"]`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -17,6 +17,7 @@
 import os
 
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
+from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
+
+REASONING_EFFORT_PROMPTS = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively "
+        "decompose the problem to resolve the root cause, rigorously "
+        "stress-testing your logic against all potential paths, edge cases, "
+        "and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting "
+        "every intermediate step, considered alternative, and rejected "
+        "hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum \u2014 exhaustive, relentless, and "
+        "uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely "
+        "nothing to chance: exhaustively decompose the problem into its most "
+        "fundamental components, trace every causal chain to its root, and "
+        "resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the "
+        "solution from multiple angles and are certain that no assumption "
+        "remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
+
+_original_render_message = deepseek_v4_encoding.render_message
+_original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
+
+
+def _patched_render_message(
+    index: int,
+    messages: list[dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: str | None = None,
+) -> str:
+    reasoning_effort = reasoning_effort or "low"
+    if reasoning_effort not in REASONING_EFFORT_PROMPTS:
+        raise ValueError(
+            f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+        )
+
+    prompt = _original_render_message(
+        index,
+        messages,
+        thinking_mode,
+        drop_thinking,
+        reasoning_effort="high",
+    )
+    if index == 0 and thinking_mode == "thinking":
+        return REASONING_EFFORT_PROMPTS[reasoning_effort] + prompt
+    return prompt
+
+
+def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
+    dsv4_tokenizer = _original_get_deepseek_v4_tokenizer(tokenizer)
+    tokenizer_cls = type(dsv4_tokenizer)
+    original_apply_chat_template = tokenizer_cls.apply_chat_template
+
+    def apply_chat_template(
+        self,
+        messages: list[ChatCompletionMessageParam],
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs,
+    ) -> str | list[int]:
+        if kwargs.get("reasoning_effort") == "low":
+            kwargs = dict(kwargs)
+            kwargs["reasoning_effort"] = None
+        return original_apply_chat_template(
+            self,
+            messages,
+            tools=tools,
+            **kwargs,
+        )
+
+    tokenizer_cls.apply_chat_template = apply_chat_template
+    return dsv4_tokenizer
+
+
+if not hasattr(deepseek_v4_encoding, "REASONING_EFFORT_PROMPTS"):
+    deepseek_v4_encoding.REASONING_EFFORT_PROMPTS = REASONING_EFFORT_PROMPTS
+    deepseek_v4_encoding.render_message = _patched_render_message
+    deepseek_v4.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer


### PR DESCRIPTION
### What this PR does / why we need it?

This is the v0.25.1 release backport of #13313.

DeepSeek-V4-Flash-0731 defines three thinking levels with distinct prompt behavior:

- `low`: no reasoning-effort prefix
- `high`: the existing `Reasoning Effort: Absolute maximum` prefix
- `max`: the new `Reasoning Effort: Beyond maximum` prefix

The vLLM v0.25.1 tokenizer maps `low` to the old high prompt and maps both `max` and `xhigh` to the old max renderer, whose prompt is now the 0731 high prompt. vLLM Ascend does not include the upstream Rust frontend, so this PR applies the same narrow Python-only monkey patch as #13313 to the active DeepSeek V4 tokenizer and renderer path.

The patch keeps the existing OpenAI compatibility aliases (`minimal`/`medium` map to `high`, and `xhigh` maps to `max`) and becomes a no-op once the supported vLLM includes the Python support from https://github.com/vllm-project/vllm/pull/50580.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-V4-Flash-0731 requests using `reasoning_effort=low`, `high`, or `max` now render the checkpoint's official prompt for that level on the v0.25.1 release stack.

### How was this patch tested?

- Verified imports resolve to the dedicated vLLM `v0.25.1` checkout at commit `752a3a504485790a2e8491cacbb35c137339ad34` and this `releases/v0.25.1rc` worktree.
- `python -m pytest -q tests/ut/patch/platform/test_deepseek_v4_thinking.py`
  - Result: `7 passed`
- `bash format.sh ci`
  - Result: all configured checks passed, including ruff, codespell, typos, markdownlint, gitleaks, and repository-local checks.
  - The release branch tracks `.github/workflows/scripts/gitleaks.sh` as non-executable, so the check temporarily used an executable mode plus the official `gitleaks v8.30.1 linux_arm64` binary; no unrelated mode change is included.
- Loaded the tokenizer from `/models/DeepSeek-V4-Flash-0731` and compared complete rendered prompts with the checkpoint's `encoding/encoding_dsv4.py`:
  - `low`: exact match, SHA-256 prefix `d02a7a950b48a4b2`
  - `high`: exact match, SHA-256 prefix `d04fe9cf686e5b67`
  - `max`: exact match, SHA-256 prefix `146ff5986b6faf8e`
- Repeated tokenizer factory calls on vLLM v0.25.1 return distinct dynamic subclasses, confirming the wrapper does not accumulate on one class.

https://github.com/vllm-project/vllm/commit/752a3a504485790a2e8491cacbb35c137339ad34

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
