### PR TITLE
[Performance][Ops] Fuse Kimi KDA RMSNorm and sigmoid gate

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -834,6 +834,7 @@ estimated_times:
   tests/ut/ops/a2/test_gdn_layerwise_kv.py: 30
   tests/ut/ops/a2/test_token_dispatcher.py: 30
   tests/ut/ops/a3_2/test_activation.py: 50
+  tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py: 20
   tests/ut/ops/a3_2/test_select_experts.py: 20
   tests/ut/quantization/methods/a2/test_w4a16.py: 30
   tests/ut/quantization/methods/a2/test_w4a4_flatquant.py: 40

--- a/tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py
+++ b/tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.ops.triton.kda.fused_norm_gate import apply_kda_rms_norm_sigmoid_gate
+
+
+@pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_kimi_kda_fused_rms_norm_sigmoid_gate(dtype: torch.dtype):
+    torch.manual_seed(20260801)
+    tokens, heads, head_dim = 37, 4, 128
+    eps = 1e-6
+    core_attn_out = torch.randn(
+        1,
+        tokens,
+        heads,
+        head_dim,
+        dtype=dtype,
+        device="npu",
+    )
+    output_gate = torch.randn(
+        tokens,
+        heads,
+        head_dim,
+        dtype=dtype,
+        device="npu",
+    )
+    weight = torch.randn(head_dim, dtype=dtype, device="npu")
+
+    actual = apply_kda_rms_norm_sigmoid_gate(
+        core_attn_out,
+        output_gate,
+        weight,
+        eps,
+    )
+
+    x_float = core_attn_out.float()
+    variance = x_float.square().mean(dim=-1, keepdim=True)
+    expected = x_float * torch.rsqrt(variance + eps)
+    expected = expected * weight.float()
+    expected = expected * output_gate.float().sigmoid().unsqueeze(0)
+    expected = expected.to(dtype)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -171,6 +171,32 @@ def test_zero_padded_spec_output_supports_multiple_real_and_dummy_rows():
     assert masked.device == output.device
 
 
+def test_output_norm_gate_uses_kda_fused_triton_kernel():
+    attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
+    nn.Module.__init__(attention)
+    attention.o_norm = SimpleNamespace(
+        weight=nn.Parameter(torch.randn(3)),
+        eps=1e-6,
+    )
+    core_attn_out = torch.randn(1, 4, 2, 3)
+    output_gate = torch.randn(4, 2, 3)
+    expected = torch.randn_like(core_attn_out)
+
+    with patch(
+        "vllm_ascend.ops.kimi_kda.apply_kda_rms_norm_sigmoid_gate",
+        return_value=expected,
+    ) as fused_norm_gate:
+        actual = attention._apply_output_norm_gate(core_attn_out, output_gate)
+
+    assert actual is expected
+    fused_norm_gate.assert_called_once_with(
+        core_attn_out,
+        output_gate,
+        attention.o_norm.weight,
+        attention.o_norm.eps,
+    )
+
+
 def test_conv_post_load_processing_packs_kernel_layout_in_place():
     attention = _make_conv_pack_attention()
     convs = (attention.q_conv1d, attention.k_conv1d, attention.v_conv1d)

--- a/typos.toml
+++ b/typos.toml
@@ -43,6 +43,7 @@ depthwise_seperable_CNN = "depthwise_seperable_CNN"
 
 [default.extend-words]
 mata = "mata"
+tbe = "tbe"
 iy = "iy"
 tendencias = "tendencias"
 PARD = "PARD"

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -47,6 +47,7 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+from vllm_ascend.ops.triton.kda.fused_norm_gate import apply_kda_rms_norm_sigmoid_gate
 from vllm_ascend.ops.triton.kda.kda import fused_kda_gate
 from vllm_ascend.utils import is_vl_model, parse_layer_idx
 
@@ -258,9 +259,21 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             core_attn_out,
             self.prefix,
         )
-        core_attn_out = self.o_norm(core_attn_out, output_gate)
+        core_attn_out = self._apply_output_norm_gate(core_attn_out, output_gate)
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
+
+    def _apply_output_norm_gate(
+        self,
+        core_attn_out: torch.Tensor,
+        output_gate: torch.Tensor,
+    ) -> torch.Tensor:
+        return apply_kda_rms_norm_sigmoid_gate(
+            core_attn_out,
+            output_gate,
+            self.o_norm.weight,
+            self.o_norm.eps,
+        )
 
     @staticmethod
     def _run_causal_conv1d(

--- a/vllm_ascend/ops/triton/kda/ascend_ub_utils.py
+++ b/vllm_ascend/ops/triton/kda/ascend_ub_utils.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code adapted from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""Minimal Ascend launch helpers used by the FLA fused norm-gate kernel.
+
+The block-size calculations are the single-dimension and row-tile cases from
+FLA's ``ascend_ub_manager.py``. Keeping the focused subset here avoids a
+runtime dependency on the private ``fla.modules.backends`` package.
+"""
+
+import warnings
+from functools import cache
+
+import torch
+from vllm.triton_utils import triton
+
+ASCEND_MAX_GRID_DIM = 65535
+_FALLBACK_UB_CAPACITY_BITS = 65536 * 8
+
+
+@cache
+def _get_ub_capacity_bits() -> int:
+    if hasattr(torch, "npu"):
+        try:
+            if torch.npu.is_available():
+                from tbe.common.platform import (  # type: ignore[import-not-found]
+                    get_soc_spec,
+                    set_current_compile_soc_info,
+                )
+
+                device = torch.npu
+                set_current_compile_soc_info(device.get_device_name(device.current_device()))
+                ub_size_bytes = get_soc_spec("UB_SIZE")
+                if ub_size_bytes is not None and ub_size_bytes > 0:
+                    return int(ub_size_bytes) * 8
+        except Exception as error:
+            warnings.warn(
+                f"Failed to detect Ascend UB capacity; using the conservative 64-KiB fallback: {error}",
+                stacklevel=3,
+            )
+            return _FALLBACK_UB_CAPACITY_BITS
+
+    return _FALLBACK_UB_CAPACITY_BITS
+
+
+def get_multiprocessor_count(device_index: int = 0) -> int:
+    """Return the number of NPU vector cores used to cap the launch grid."""
+    try:
+        properties = triton.runtime.driver.active.utils.get_device_properties(device_index)
+        return properties["multiprocessor_count"]
+    except Exception:
+        try:
+            target = triton.runtime.driver.active.get_current_target()
+            if target.backend == "npu":
+                properties = triton.runtime.driver.active.utils.get_device_properties(device_index)
+                return properties["num_vectorcore"]
+        except Exception:
+            pass
+        return 1
+
+
+def _largest_power_of_two_at_most(value: int) -> int:
+    value = max(1, value)
+    return triton.next_power_of_2(value + 1) // 2
+
+
+def _ub_safe_block(
+    desired: int,
+    fixed_size: int,
+    memory_multiplier: float,
+    safety_margin: float,
+) -> int:
+    safe_capacity_bits = int(_get_ub_capacity_bits() * safety_margin)
+    bytes_per_element = 4
+    max_block = int(safe_capacity_bits // (memory_multiplier * max(1, fixed_size) * bytes_per_element * 8))
+    return min(desired, _largest_power_of_two_at_most(max_block))
+
+
+def compute_ub_block_size(
+    dim_size: int,
+    memory_multiplier: float,
+    *,
+    safety_margin: float = 0.9,
+    fallback: int = 2048,
+    min_block: int = 1,
+    max_block: int | None = None,
+    desired: int | None = None,
+) -> int:
+    """Compute the FLA UB-safe block size for one tilable dimension."""
+    if desired is None:
+        desired = triton.next_power_of_2(dim_size)
+    try:
+        block = _ub_safe_block(desired, 1, memory_multiplier, safety_margin)
+    except Exception:
+        block = min(desired, fallback)
+    block = max(min_block, block)
+    if max_block is not None:
+        block = min(block, max_block)
+    return block
+
+
+def compute_row_tile_block_size(
+    row_dim: int,
+    fixed_dim: int,
+    memory_multiplier: float,
+    *,
+    tiling_row: bool = True,
+    safety_margin: float = 0.85,
+    fallback: int = 16,
+    min_block: int = 1,
+    max_block: int | None = None,
+) -> int:
+    """Compute the FLA UB-safe tile along one axis of a two-dimensional tile."""
+    tiled_dim = row_dim if tiling_row else fixed_dim
+    fixed_size = fixed_dim if tiling_row else row_dim
+    desired = triton.next_power_of_2(tiled_dim)
+    try:
+        block = _ub_safe_block(desired, fixed_size, memory_multiplier, safety_margin)
+    except Exception:
+        block = min(desired, fallback)
+    block = max(min_block, block)
+    if max_block is not None:
+        block = min(block, max_block)
+    return block

--- a/vllm_ascend/ops/triton/kda/fused_norm_gate.py
+++ b/vllm_ascend/ops/triton/kda/fused_norm_gate.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+"""Fused RMSNorm and output-gate kernel for Kimi KDA on Ascend.
+
+The forward kernel is synced from flash-linear-attention commit 31d15f7554,
+file ``fla/modules/backends/triton_ascend/fused_norm_gate.py``.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .ascend_ub_utils import (
+    ASCEND_MAX_GRID_DIM,
+    compute_row_tile_block_size,
+    compute_ub_block_size,
+    get_multiprocessor_count,
+)
+
+_BD_MEM_MULT = 6.0
+_FWD_MEM_MULT = 3.0
+_UB_SAFETY_MARGIN = 0.85
+_FALLBACK_MAX_BD = 65536 // 4
+_MAX_BT = 128
+_LARGE_BD = 2048
+_LARGE_BD_FWD_MEM_MULT = 4.0
+
+_ACTIVATION_SWISH = 0
+_ACTIVATION_SIGMOID = 1
+
+
+def _activation_id(activation: str) -> int:
+    if activation in ("swish", "silu"):
+        return _ACTIVATION_SWISH
+    if activation == "sigmoid":
+        return _ACTIVATION_SIGMOID
+    raise ValueError(f"Unsupported activation: {activation}")
+
+
+def _fwd_memory_multiplier(block_dim: int) -> float:
+    if block_dim >= _LARGE_BD:
+        return max(_FWD_MEM_MULT, _LARGE_BD_FWD_MEM_MULT)
+    return _FWD_MEM_MULT
+
+
+def _get_layer_norm_gated_tiles(feature_dim: int) -> tuple[int, int]:
+    block_dim = compute_ub_block_size(
+        feature_dim,
+        _BD_MEM_MULT,
+        safety_margin=_UB_SAFETY_MARGIN,
+        fallback=_FALLBACK_MAX_BD,
+        desired=triton.next_power_of_2(feature_dim),
+    )
+    if feature_dim > block_dim:
+        raise RuntimeError(
+            f"LayerNormGated feature dim {feature_dim} exceeds "
+            f"UB-safe block size {block_dim}. Column-tiled kernels are "
+            "not yet implemented for this size."
+        )
+    block_rows = compute_row_tile_block_size(
+        1 << 20,
+        block_dim,
+        _fwd_memory_multiplier(block_dim),
+        tiling_row=True,
+        safety_margin=_UB_SAFETY_MARGIN,
+        fallback=16,
+        min_block=1,
+        max_block=_MAX_BT,
+    )
+    return block_dim, block_rows
+
+
+def _launch_config(
+    num_rows: int,
+    feature_dim: int,
+    device_index: int,
+) -> tuple[int, int, int]:
+    block_dim, block_rows = _get_layer_norm_gated_tiles(feature_dim)
+    num_tiles = triton.cdiv(num_rows, block_rows)
+    num_streams = max(
+        1,
+        min(
+            get_multiprocessor_count(device_index),
+            num_tiles,
+            ASCEND_MAX_GRID_DIM,
+        ),
+    )
+    return block_dim, block_rows, num_streams
+
+
+@triton.jit(do_not_specialize=["T"])
+def layer_norm_gated_fwd_kernel(
+    x,
+    g,
+    y,
+    w,
+    b,
+    residual,
+    residual_out,
+    mean,
+    rstd,
+    eps,
+    T,
+    NS,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    BT: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    """Grid-stride forward: each program owns a BT-row tile stream."""
+    stream_index = tl.program_id(0)
+    columns = tl.arange(0, BD)
+    column_mask = columns < D
+
+    if HAS_WEIGHT:
+        block_weight = tl.load(w + columns, mask=column_mask).to(tl.float32)
+    if HAS_BIAS:
+        block_bias = tl.load(b + columns, mask=column_mask).to(tl.float32)
+
+    num_tiles = tl.cdiv(T, BT)
+    for tile_index in range(stream_index, num_tiles, NS):
+        rows = tile_index * BT + tl.arange(0, BT)
+        row_mask = rows < T
+        mask = row_mask[:, None] & column_mask[None, :]
+        row_offsets = rows[:, None] * D + columns[None, :]
+
+        block_x = tl.load(x + row_offsets, mask=mask, other=0.0).to(tl.float32)
+        if HAS_RESIDUAL:
+            block_x += tl.load(residual + row_offsets, mask=mask, other=0.0).to(tl.float32)
+        if STORE_RESIDUAL_OUT:
+            tl.store(
+                residual_out + row_offsets,
+                block_x.to(residual_out.dtype.element_ty),
+                mask=mask,
+            )
+
+        if not IS_RMS_NORM:
+            block_mean = tl.sum(block_x, axis=1) / D
+            tl.store(mean + rows, block_mean, mask=row_mask)
+            block_xbar = tl.where(mask, block_x - block_mean[:, None], 0.0)
+            block_var = tl.sum(block_xbar * block_xbar, axis=1) / D
+        else:
+            block_xbar = tl.where(mask, block_x, 0.0)
+            block_var = tl.sum(block_xbar * block_xbar, axis=1) / D
+        block_rstd = 1 / tl.sqrt(block_var + eps)
+        tl.store(rstd + rows, block_rstd, mask=row_mask)
+
+        block_x_hat = (
+            (block_x - block_mean[:, None]) * block_rstd[:, None] if not IS_RMS_NORM else block_x * block_rstd[:, None]
+        )
+        block_y = block_x_hat * block_weight[None, :] if HAS_WEIGHT else block_x_hat
+        if HAS_BIAS:
+            block_y = block_y + block_bias[None, :]
+
+        block_gate = tl.load(g + row_offsets, mask=mask, other=0.0).to(tl.float32)
+        if ACTIVATION == 0:
+            block_y = block_y * block_gate * tl.sigmoid(block_gate)
+        else:
+            block_y = block_y * tl.sigmoid(block_gate)
+
+        tl.store(y + row_offsets, block_y.to(y.dtype.element_ty), mask=mask)
+
+
+def layer_norm_gated_fwd_npu(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    residual: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    residual_dtype: torch.dtype | None = None,
+    is_rms_norm: bool = False,
+):
+    if residual is not None:
+        residual_dtype = residual.dtype
+    num_rows, feature_dim = x.shape
+    if g.shape != (num_rows, feature_dim):
+        raise ValueError(f"gate shape must be {(num_rows, feature_dim)}, got {tuple(g.shape)}")
+    if residual is not None and residual.shape != (num_rows, feature_dim):
+        raise ValueError(f"residual shape must be {(num_rows, feature_dim)}, got {tuple(residual.shape)}")
+    if weight is not None and weight.shape != (feature_dim,):
+        raise ValueError(f"weight shape must be {(feature_dim,)}, got {tuple(weight.shape)}")
+    if bias is not None and bias.shape != (feature_dim,):
+        raise ValueError(f"bias shape must be {(feature_dim,)}, got {tuple(bias.shape)}")
+
+    output = torch.empty_like(x, dtype=x.dtype if out_dtype is None else out_dtype)
+    if residual is not None or (residual_dtype is not None and residual_dtype != x.dtype):
+        residual_output = torch.empty(
+            num_rows,
+            feature_dim,
+            device=x.device,
+            dtype=residual_dtype,
+        )
+    else:
+        residual_output = None
+    mean = torch.empty((num_rows,), dtype=torch.float, device=x.device) if not is_rms_norm else None
+    rstd = torch.empty((num_rows,), dtype=torch.float, device=x.device)
+
+    block_dim, block_rows, num_streams = _launch_config(
+        num_rows,
+        feature_dim,
+        x.device.index,
+    )
+    activation_id = _activation_id(activation)
+    layer_norm_gated_fwd_kernel[(num_streams,)](
+        x=x,
+        g=g,
+        y=output,
+        w=weight,
+        b=bias,
+        residual=residual,
+        residual_out=residual_output,
+        mean=mean,
+        rstd=rstd,
+        eps=eps,
+        T=num_rows,
+        NS=num_streams,
+        D=feature_dim,
+        BD=block_dim,
+        BT=block_rows,
+        ACTIVATION=activation_id,
+        IS_RMS_NORM=is_rms_norm,
+        STORE_RESIDUAL_OUT=residual_output is not None,
+        HAS_RESIDUAL=residual is not None,
+        HAS_WEIGHT=weight is not None,
+        HAS_BIAS=bias is not None,
+    )
+    return output, mean, rstd, residual_output if residual_output is not None else x
+
+
+def _kda_rms_norm_sigmoid_gate_impl(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Apply Kimi's per-head RMSNorm and sigmoid output gate."""
+    if x.shape[-1] != gate.shape[-1]:
+        raise ValueError(f"KDA output and gate head dimensions differ: {x.shape[-1]} != {gate.shape[-1]}")
+    if x.numel() != gate.numel():
+        raise ValueError(f"KDA output and gate element counts differ: {x.numel()} != {gate.numel()}")
+
+    output_shape = x.shape
+    feature_dim = output_shape[-1]
+    x_2d = x.contiguous().reshape(-1, feature_dim)
+    gate_2d = gate.contiguous().reshape(-1, feature_dim)
+    output, _, _, _ = layer_norm_gated_fwd_npu(
+        x=x_2d,
+        g=gate_2d,
+        weight=weight.contiguous(),
+        bias=None,
+        activation="sigmoid",
+        eps=eps,
+        is_rms_norm=True,
+    )
+    return output.reshape(output_shape)
+
+
+def _kda_rms_norm_sigmoid_gate_fake(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    del gate, weight, eps
+    return torch.empty_like(x)
+
+
+direct_register_custom_op(
+    op_name="kda_rms_norm_sigmoid_gate",
+    op_func=_kda_rms_norm_sigmoid_gate_impl,
+    fake_impl=_kda_rms_norm_sigmoid_gate_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+
+def apply_kda_rms_norm_sigmoid_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Call the KDA-specific opaque op backed by the FLA Ascend kernel."""
+    return torch.ops.vllm.kda_rms_norm_sigmoid_gate(x, gate, weight, eps)


### PR DESCRIPTION
### What this PR does / why we need it?

- Adds an Ascend Triton fused RMSNorm and sigmoid output-gate kernel for Kimi KDA, adapted from flash-linear-attention commit 31d15f7554.
- Routes only AscendKimiGatedDeltaNetAttention output normalization and gating through a KDA-specific opaque custom op.
- Keeps the global RMSNormGated implementation and other model execution paths unchanged.
- Adds CPU delegation coverage and an A3 FP16/BF16 numerical test.

This PR is based directly on releases/v0.26.0rc after #12950 and is independent of the open C8 work in #13225.

### Does this PR introduce _any_ user-facing change?

Yes. Kimi-K3 KDA layers use the fused Ascend RMSNorm and sigmoid-gate inference path.

### How was this patch tested?

- git diff --check
- Python compileall for all changed Python and test files
- Added tests/ut/ops/test_kimi_kda.py coverage for KDA fused-op delegation
- Added tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py for FP16/BF16 NPU numerical comparison
- Actual pytest execution was not available on the local macOS environment because torch, torch_npu, Triton Ascend, and NPU hardware are unavailable; the new tests are routed to CPU and A3 PR CI.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
