### PR TITLE
[Refactor][FusedMoE] Split shared expert executor

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,7 @@ from vllm_ascend._310p.fused_moe.fused_moe import (
 )
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
+from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts
 
 
 def _build_runner() -> AscendMoERunner310:
@@ -50,6 +52,7 @@ def test_runner_310_installs_specialized_comm():
     moe_config = MagicMock()
     runner.moe_config = moe_config
     routed_experts = SimpleNamespace(quant_config=None, quant_method=None)
+    runner.ascend_shared_experts = SimpleNamespace(multistream_overlap=True)
     comm_method = object()
 
     with (
@@ -66,7 +69,7 @@ def test_runner_310_installs_specialized_comm():
         )
 
         assert routed_experts.quant_method is None
-        assert runner.multistream_overlap_shared_expert is False
+        assert runner.ascend_shared_experts.multistream_overlap is False
         assert fused_moe_310_module._MoECommMethods[MoECommType.ALLGATHER] is comm_method
         parent_init.assert_called_once()
 
@@ -107,16 +110,17 @@ class _Gate(nn.Module):
 
 @pytest.mark.parametrize("with_gate", [False, True])
 def test_shared_experts_part2_310_applies_optional_gate(with_gate):
-    runner = _build_runner()
-    runner._shared_experts = SimpleNamespace(
+    shared_experts_layer = SimpleNamespace(
         act_fn=nn.Identity(),
         down_proj=_Projection(),
         expert_gate=_Gate() if with_gate else None,
     )
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.layer = shared_experts_layer
     hidden_states = torch.randn(3, 4)
     shared_gate_up = torch.randn(3, 4)
 
-    output = runner._shared_experts_part2(hidden_states, shared_gate_up)
+    output = shared_experts.part2(hidden_states, shared_gate_up)
 
     expected = shared_gate_up * 2.0 + 1.0
     if with_gate:
@@ -125,13 +129,13 @@ def test_shared_experts_part2_310_applies_optional_gate(with_gate):
 
 
 @pytest.mark.parametrize("has_shared_experts", [False, True])
-def test_shared_forward_impl_310_returns_current_runner_contract(monkeypatch, has_shared_experts):
+def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_shared_experts):
     runner = _build_runner()
-    runner._shared_experts = object() if has_shared_experts else None
     hidden_states = torch.randn(2, 4)
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
+    ascend_shared_experts = SimpleNamespace(forward=MagicMock(return_value=shared_out))
     routed_result = SimpleNamespace(
         routed_out=routed_out,
         before_dispatch_evt=None,
@@ -139,24 +143,30 @@ def test_shared_forward_impl_310_returns_current_runner_contract(monkeypatch, ha
         before_combine_evt=None,
         swiglu_limit=0.0,
     )
-    runner.routed_experts = SimpleNamespace(no_shared_forward_impl=MagicMock(return_value=routed_result))
-    runner._forward_shared_experts = MagicMock(return_value=shared_out)
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=routed_result if has_shared_experts else routed_out)
+    )
+    runner.ascend_shared_experts = ascend_shared_experts if has_shared_experts else None
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
     current_stream = MagicMock()
 
     monkeypatch.setattr(AscendMoERunner310, "is_internal_router", property(lambda _: False))
     monkeypatch.setattr(fused_moe_310_module.torch.npu, "current_stream", lambda: current_stream)
 
-    result = runner.shared_forward_impl(hidden_states, router_logits)
+    result = runner._forward_impl(hidden_states, router_logits, shared_experts_input=None)
 
-    runner.routed_experts.no_shared_forward_impl.assert_called_once_with(
-        hidden_states=hidden_states,
-        router_logits=router_logits,
-        return_with_event=True,
-    )
     if has_shared_experts:
+        runner.routed_experts.forward_impl.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
         assert result[0] is shared_out
         assert result[1] is routed_out
-        runner._forward_shared_experts.assert_called_once()
+        ascend_shared_experts.forward.assert_called_once()
     else:
+        runner.routed_experts.forward_impl.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
         assert result is routed_out
-        runner._forward_shared_experts.assert_not_called()
+        ascend_shared_experts.forward.assert_not_called()

--- a/tests/ut/ops/a3_2/test_select_experts.py
+++ b/tests/ut/ops/a3_2/test_select_experts.py
@@ -87,6 +87,11 @@ def setup_vllm_config_mock(mocker: MockerFixture):
 @pytest.fixture
 def mock_dist_env(mocker: MockerFixture):
     mock_moe_comm_method = MagicMock()
+    mock_eplb_config = MagicMock(dynamic_eplb=False, expert_map_path=None)
+    mock_ascend_config = MagicMock(
+        enable_multistream_moe=False,
+        eplb_config=mock_eplb_config,
+    )
 
     def mock_prepare(hidden_states, router_logits, **kwargs):
         return MoEPrepareOutput(
@@ -129,12 +134,12 @@ def mock_dist_env(mocker: MockerFixture):
         patch("vllm.model_executor.layers.fused_moe.layer.get_dp_group", return_value=mock_dp_and_tp_group(mocker)),
         patch("vllm.model_executor.layers.fused_moe.config.get_dp_group", return_value=mock_dp_and_tp_group(mocker)),
         patch(
-            "vllm_ascend.ops.fused_moe.fused_moe.get_ascend_config",
-            return_value=MagicMock(enable_multistream_moe=False, expert_map_path=None),
+            "vllm_ascend.patch.platform.patch_fused_moe.get_ascend_config",
+            return_value=mock_ascend_config,
         ),
         patch(
             "vllm_ascend.ops.fused_moe.routed_experts.get_ascend_config",
-            return_value=MagicMock(enable_multistream_moe=False, expert_map_path=None),
+            return_value=mock_ascend_config,
         ),
         patch(
             "vllm_ascend.ops.fused_moe.routed_experts.init_eplb_config",
@@ -159,13 +164,14 @@ def mock_moe_env(mocker: MockerFixture):
         patch(
             "torch_npu.npu_moe_init_routing",
             return_value=(torch.randn(8, 2), torch.randint(0, 8, (8, 2)), torch.tensor([0, 1, 2, 4, 6, 2, 7, 1])),
+            create=True,
         ),
-        patch("torch_npu.npu_moe_compute_expert_tokens", return_value=(torch.randn(8, 2))),
-        patch("torch_npu.npu_moe_distribute_dispatch", return_value=(torch.randn(16, 2))),
-        patch("torch_npu.npu_moe_distribute_combine", return_value=(torch.randn(16, 2))),
-        patch("torch_npu.npu_grouped_matmul", return_value=([torch.randn(16, 2)])),
-        patch("torch_npu.npu_swiglu", return_value=(torch.randn(16, 2))),
-        patch("torch_npu.npu_moe_finalize_routing", return_value=(torch.randn(16, 2))),
+        patch("torch_npu.npu_moe_compute_expert_tokens", return_value=(torch.randn(8, 2)), create=True),
+        patch("torch_npu.npu_moe_distribute_dispatch", return_value=(torch.randn(16, 2)), create=True),
+        patch("torch_npu.npu_moe_distribute_combine", return_value=(torch.randn(16, 2)), create=True),
+        patch("torch_npu.npu_grouped_matmul", return_value=([torch.randn(16, 2)]), create=True),
+        patch("torch_npu.npu_swiglu", return_value=(torch.randn(16, 2)), create=True),
+        patch("torch_npu.npu_moe_finalize_routing", return_value=(torch.randn(16, 2)), create=True),
     ):
         if hasattr(torch_npu, "npu_moe_distribute_dispatch_v2"):
             with (

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -13,9 +14,11 @@ from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 from vllm_ascend.ops.fused_moe.routed_experts import (
     AscendRoutedExperts,
     AscendUnquantizedFusedMoEMethod,
+    FusedMoEResult,
     make_eplb_placement_config,
     use_multistage_eplb_load,
 )
+from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts
 from vllm_ascend.quantization.quant_type import QuantType
 
 
@@ -229,7 +232,8 @@ def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_ena
     assert runner._maybe_reduce_shared_expert_output(shared_output) is shared_output
 
 
-def test_routed_experts_no_shared_forward_impl_runs_current_flow(monkeypatch):
+@pytest.mark.parametrize("return_with_event", [False, True])
+def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_event):
     routed_experts = AscendRoutedExperts.__new__(AscendRoutedExperts)
     hidden_states = torch.randn(2, 4)
     prepared_hidden_states = torch.randn(2, 4)
@@ -267,6 +271,7 @@ def test_routed_experts_no_shared_forward_impl_runs_current_flow(monkeypatch):
     routed_experts.log2phy = None
     routed_experts.global_redundant_expert_num = 0
     routed_experts.dynamic_eplb = False
+    routed_experts.return_with_event = return_with_event
     moe_comm_method = MagicMock()
     moe_comm_method.prepare.return_value = SimpleNamespace(
         hidden_states=prepared_hidden_states,
@@ -288,12 +293,16 @@ def test_routed_experts_no_shared_forward_impl_runs_current_flow(monkeypatch):
     )
     monkeypatch.setattr(routed_experts_module, "get_forward_context", lambda: SimpleNamespace(all_moe_layers=None))
 
-    result = routed_experts.no_shared_forward_impl(
+    result = routed_experts.forward_impl(
         hidden_states=hidden_states,
         router_logits=router_logits,
     )
 
-    assert result is finalized
+    if return_with_event:
+        assert isinstance(result, FusedMoEResult)
+        assert result.routed_out is finalized
+    else:
+        assert result is finalized
     moe_comm_method.prepare.assert_called_once_with(
         hidden_states=hidden_states,
         router_logits=router_logits,
@@ -325,17 +334,17 @@ class _Gate(nn.Module):
 
 @pytest.mark.parametrize("with_gate", [False, True])
 def test_shared_experts_part2_applies_optional_gate(with_gate):
-    runner = AscendMoERunner.__new__(AscendMoERunner)
-    nn.Module.__init__(runner)
-    runner._shared_experts = SimpleNamespace(
+    shared_experts_layer = SimpleNamespace(
         act_fn=nn.Identity(),
         down_proj=_Projection(),
         expert_gate=_Gate() if with_gate else None,
     )
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.layer = shared_experts_layer
     hidden_states = torch.randn(3, 4)
     shared_gate_up = torch.randn(3, 4)
 
-    output = runner._shared_experts_part2(hidden_states, shared_gate_up)
+    output = shared_experts.part2(hidden_states, shared_gate_up)
 
     expected = shared_gate_up * 2.0 + 1.0
     if with_gate:
@@ -344,14 +353,14 @@ def test_shared_experts_part2_applies_optional_gate(with_gate):
 
 
 @pytest.mark.parametrize("has_shared_experts", [False, True])
-def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_experts):
+def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_experts):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
-    runner._shared_experts = object() if has_shared_experts else None
     hidden_states = torch.randn(2, 4)
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
+    ascend_shared_experts = SimpleNamespace(forward=MagicMock(return_value=shared_out))
     routed_result = SimpleNamespace(
         routed_out=routed_out,
         before_dispatch_evt=None,
@@ -359,24 +368,30 @@ def test_shared_forward_impl_returns_current_runner_contract(monkeypatch, has_sh
         before_combine_evt=None,
         swiglu_limit=0.0,
     )
-    runner.routed_experts = SimpleNamespace(no_shared_forward_impl=MagicMock(return_value=routed_result))
-    runner._forward_shared_experts = MagicMock(return_value=shared_out)
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=routed_result if has_shared_experts else routed_out)
+    )
+    runner.ascend_shared_experts = ascend_shared_experts if has_shared_experts else None
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
     current_stream = MagicMock()
 
     monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: False))
     monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
 
-    result = runner.shared_forward_impl(hidden_states, router_logits)
+    result = runner._forward_impl(hidden_states, router_logits, shared_experts_input=None)
 
-    runner.routed_experts.no_shared_forward_impl.assert_called_once_with(
-        hidden_states=hidden_states,
-        router_logits=router_logits,
-        return_with_event=True,
-    )
     if has_shared_experts:
+        runner.routed_experts.forward_impl.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
         assert result[0] is shared_out
         assert result[1] is routed_out
-        runner._forward_shared_experts.assert_called_once()
+        ascend_shared_experts.forward.assert_called_once()
     else:
+        runner.routed_experts.forward_impl.assert_called_once_with(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
         assert result is routed_out
-        runner._forward_shared_experts.assert_not_called()
+        ascend_shared_experts.forward.assert_not_called()

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -160,5 +160,7 @@ class AscendMoERunner310(AscendMoERunner):
             routed_scaling_factor=routed_scaling_factor,
         )
 
-        self.multistream_overlap_shared_expert = False
+        ascend_shared_experts = getattr(self, "ascend_shared_experts", None)
+        if ascend_shared_experts is not None:
+            ascend_shared_experts.multistream_overlap = False
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl310(self.moe_config)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -14,58 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from dataclasses import dataclass, field
-from functools import wraps
-
 import torch
 import torch.nn.functional as F
-import torch_npu
-from vllm.distributed import get_dp_group, get_ep_group, get_tp_group, tensor_model_parallel_all_reduce
-from vllm.logger import logger
+from vllm.distributed import get_dp_group, get_ep_group, get_tp_group
 from vllm.model_executor.layers.fused_moe.layer import (
     FusedMoE,  # noqa: F401
     MoERunner,
 )
 
-from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.moe_comm_method import setup_moe_comm_method
-from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import (
-    npu_stream_switch,
-    shared_expert_dp_enabled,
-    shared_experts_calculation_stream,
-)
-
-
-def get_compressed_expert_map(expert_map: torch.Tensor) -> str:
-    global_indices = torch.where(expert_map != -1)[0]
-    local_indices = expert_map[global_indices]
-    return ", ".join(
-        f"{local_index.item()}->{global_index.item()}"
-        for local_index, global_index in zip(local_indices, global_indices)
-    )
-
-
-@dataclass
-class FusedMoEEvents:
-    before_routed_experts: torch.npu.Event
-    after_routed_experts: torch.npu.Event | None = field(default=None)
-    before_dispatch: torch.npu.Event | None = field(default=None)
-    before_gmm2: torch.npu.Event | None = field(default=None)
-    before_combine: torch.npu.Event | None = field(default=None)
-    swiglu_limit: float = 0.0
-    swiglu_alpha: float = 1.0
-    swiglu_beta: float = 0.0
-
-
-def mock_false():
-    return False
-
-
-def mock_true():
-    return True
+from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts, FusedMoEEvents
 
 
 class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
@@ -109,75 +69,17 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
-        ascend_config = get_ascend_config()
-        self._shared_experts = shared_experts
-
-        self.multistream_overlap_shared_expert = (
-            ascend_config.multistream_overlap_shared_expert and shared_experts is not None
-        )
+        self.ascend_shared_experts = None
+        if shared_experts is not None:
+            routed_experts.return_with_event = True
+            self.ascend_shared_experts = AscendSharedExperts(
+                shared_experts,
+                self.moe_config,
+                self.quant_type,
+                self._quant_method,
+            )
 
         setup_moe_comm_method(self.moe_config)
-        if self.multistream_overlap_shared_expert:
-            # Wrap the quant_method's process_weights_after_loading to validate that
-            # splitting shared expert computation (gate_up projection + activation,
-            # then down projection) yields identical results to integrated
-            # computation after weight loading.
-            original_process_weights = self._quant_method.process_weights_after_loading
-
-            @wraps(original_process_weights)
-            def wrapped_process_weights(*args, **kwargs):
-                result = original_process_weights(*args, **kwargs)
-                self._validate_shared_expert_consistency()
-                return result
-
-            self._quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
-
-    def _validate_shared_expert_consistency(self):
-        """Validate that split shared expert computation matches integrated computation."""
-        test_input = (
-            torch.rand(10, self.hidden_size, device="npu", dtype=self.moe_config.in_dtype) * 2 - 1
-        )  # Random input for testing, scoped to [-1, 1]
-
-        assert self._shared_experts is not None
-        integrated_out = self._shared_experts(test_input)
-        part1_out = self._shared_experts_part1(test_input)
-        split_out = self._shared_experts_part2(test_input, part1_out)
-
-        if not torch.allclose(integrated_out, split_out):
-            diff = (integrated_out - split_out).abs()
-            logger.error(
-                "[fused_moe/layer] Shared expert split computation validation failed."
-                " The split-path computation does not match the integrated-path result."
-                " max_abs_diff=%s, integrated_sum=%s, integrated_norm=%s,"
-                " split_sum=%s, split_norm=%s, hidden_size=%s, dtype=%s.",
-                diff.max().item(),
-                integrated_out.sum().item(),
-                integrated_out.norm().item(),
-                split_out.sum().item(),
-                split_out.norm().item(),
-                self.hidden_size,
-                self.moe_config.in_dtype,
-            )
-            raise ValueError("FusedMoE shared experts split computation does not match the integrated computation.")
-        logger.info_once(
-            "[fused_moe/layer] Shared expert split computation validation passed."
-            " Integrated and split-path results are consistent."
-        )
-
-    def _shared_experts_part1(self, hidden_states: torch.Tensor):
-        shared_gate_up, _ = self._shared_experts.gate_up_proj(hidden_states)  # type: ignore
-        return shared_gate_up
-
-    def _shared_experts_part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
-        shared_act = self._shared_experts.act_fn(shared_gate_up)  # type: ignore
-        shared_out, _ = self._shared_experts.down_proj(shared_act)  # type: ignore
-
-        # Qwen3-Next specific gating mechanism
-        assert self._shared_experts is not None
-        if hasattr(self._shared_experts, "expert_gate") and self._shared_experts.expert_gate is not None:
-            gate_out, _ = self._shared_experts.expert_gate(hidden_states)  # type: ignore
-            shared_out = F.sigmoid(gate_out) * shared_out
-        return shared_out
 
     @property
     def is_internal_router(self) -> bool:
@@ -193,7 +95,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     @property
     def _fused_output_is_reduced(self) -> bool:
         # For MC2/ALLTOALL/FUSED_MC2 comm types, finalize() already includes
-        # TP all-reduce for the routed output, and _forward_shared_experts
+        # TP all-reduce for the routed output, and AscendSharedExperts.forward
         # handles it for the shared output. Signal this to the upstream
         # MoERunner.forward() so _maybe_reduce_final_output does not apply a
         # second TP all-reduce (which would double-count the contributions).
@@ -217,7 +119,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         self,
         shared_output: torch.Tensor | None,
     ) -> torch.Tensor | None:
-        # _forward_shared_experts already handles shared expert TP all-reduce
+        # AscendSharedExperts.forward already handles shared expert TP all-reduce
         # for MC2/ALLTOALL/FUSED_MC2. For AllGather the reduction is done
         # via _maybe_reduce_final_output on the combined (shared + routed)
         # output. Skip any additional reduction here.
@@ -234,159 +136,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     def set_lora_context(self, lora_context):
         self.routed_experts._ascend_moe_lora_context = lora_context
 
-    def _forward_shared_experts(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
-        if self._shared_experts is None:
-            return None
-
-        def maybe_wait_event(evt: torch.npu.Event | None):
-            if evt is not None:
-                torch.npu.current_stream().wait_event(evt)
-
-        with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
-            # Only used for int quantization
-            has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
-                self._shared_experts.down_proj, "weight_scale"
-            )
-            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
-                original_dtype = hidden_states.dtype
-                # Execute dynamic quant concurrently with MoE gate.
-                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-                quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-                # Execute the gate projection and activation concurrently with the
-                # dispatch communication.
-                maybe_wait_event(fused_moe_evts.after_routed_experts)
-                hidden_states = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
-                    pertoken_scale=None,
-                    bias=None,
-                    output_dtype=torch.int32,
-                )
-                # Execute activation concurrently with gmm2.
-
-                maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
-                    x=hidden_states,
-                    weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
-                    activation_scale=pertoken_scale,
-                    bias=None,
-                    quant_scale=None,
-                    quant_offset=None,
-                    group_index=None,
-                    activate_left=True,
-                    quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=fused_moe_evts.swiglu_limit,
-                    glu_alpha=fused_moe_evts.swiglu_alpha,
-                    glu_bias=fused_moe_evts.swiglu_beta,
-                )
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
-                    pertoken_scale=swiglu_out_scale,
-                    bias=None,
-                    output_dtype=original_dtype,
-                )
-            elif has_quantized_shared and self.quant_type == QuantType.W4A8MXFP:
-                original_dtype = hidden_states.dtype
-                # Execute dynamic quant concurrently with MoE gate.
-                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-                quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
-                    hidden_states, dst_type=torch.float8_e4m3fn
-                )
-                # Execute the gate projection and activation concurrently with the
-                # dispatch communication.
-                maybe_wait_event(fused_moe_evts.before_dispatch)
-                hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
-                # Execute activation concurrently with gmm2.
-                maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
-                    hidden_states,
-                    topk_weight=None,
-                    group_index=None,
-                    dst_type=torch.float8_e4m3fn,
-                    quant_mode=2,
-                    clamp_value=fused_moe_evts.swiglu_limit,
-                )
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
-            else:
-                # Ensure the shared experts wait for hidden_states to be ready.
-                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
-                # Execute the gate projection and activation concurrently with the
-                # dispatch communication.
-                maybe_wait_event(fused_moe_evts.before_dispatch)
-                part1_out = self._shared_experts_part1(hidden_states)
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = self._shared_experts_part2(hidden_states, part1_out)
-
-        # Make sure the default stream waits for the shared experts stream to
-        # finish.
-        if self.multistream_overlap_shared_expert:
-            torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
-
-        # NOTE: This is exactly the opposite of
-        # `maybe_all_reduce_tensor_model_parallel`
-        moe_comm_type = _EXTRA_CTX.moe_comm_type
-        if (
-            moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
-            and not shared_expert_dp_enabled()
-        ):
-            shared_out = tensor_model_parallel_all_reduce(shared_out)
-        return shared_out
-
-    def shared_forward_impl(  # type: ignore[override]
-        self, hidden_states: torch.Tensor, router_logits: torch.Tensor
-    ):
-        if self.is_internal_router:
-            gate = self.gate
-            assert gate is not None
-            # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
-            # increase with extra hidden states. We also assume that all gate
-            # linear is unquantized so that we the weight is pre-casted in
-            # process_weights_after_loading of AscendUnquantizedLinearMethod.
-            hidden_states_fp32 = hidden_states.float()
-            before_routed_experts = torch.npu.current_stream().record_event()
-            router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
-            after_routed_experts = torch.npu.current_stream().record_event()
-        else:
-            before_routed_experts = torch.npu.current_stream().record_event()
-            after_routed_experts = None
-
-        fused_moe_results = self.routed_experts.no_shared_forward_impl(
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-            return_with_event=True,
-        )
-        routed_out = fused_moe_results.routed_out
-
-        if self._shared_experts is None:
-            return routed_out
-
-        shared_out = self._forward_shared_experts(
-            hidden_states,
-            FusedMoEEvents(
-                after_routed_experts=after_routed_experts,
-                before_routed_experts=before_routed_experts,
-                before_dispatch=fused_moe_results.before_dispatch_evt,
-                before_gmm2=fused_moe_results.before_gmm2_evt,
-                before_combine=fused_moe_results.before_combine_evt,
-                swiglu_limit=fused_moe_results.swiglu_limit,
-                swiglu_alpha=getattr(fused_moe_results, "swiglu_alpha", 1.0),
-                swiglu_beta=getattr(fused_moe_results, "swiglu_beta", 0.0),
-            ),
-        )
-        return shared_out, routed_out
-
     def _forward_impl(
         self,
         hidden_states: torch.Tensor,
@@ -395,10 +144,43 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         with self._sequence_parallel_context():
-            if self.shared_experts is None:
-                return self.routed_experts.no_shared_forward_impl(
+            if self.ascend_shared_experts is None:
+                return self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
                 )
+            if self.is_internal_router:
+                gate = self.gate
+                assert gate is not None
+                # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
+                # increase with extra hidden states. We also assume that all gate
+                # linear is unquantized so that we the weight is pre-casted in
+                # process_weights_after_loading of AscendUnquantizedLinearMethod.
+                hidden_states_fp32 = hidden_states.float()
+                before_routed_experts = torch.npu.current_stream().record_event()
+                router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
+                after_routed_experts = torch.npu.current_stream().record_event()
             else:
-                return self.shared_forward_impl(hidden_states, router_logits)
+                before_routed_experts = torch.npu.current_stream().record_event()
+                after_routed_experts = None
+
+            fused_moe_results = self.routed_experts.forward_impl(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
+            routed_out = fused_moe_results.routed_out
+
+            shared_out = self.ascend_shared_experts.forward(
+                hidden_states,
+                FusedMoEEvents(
+                    after_routed_experts=after_routed_experts,
+                    before_routed_experts=before_routed_experts,
+                    before_dispatch=fused_moe_results.before_dispatch_evt,
+                    before_gmm2=fused_moe_results.before_gmm2_evt,
+                    before_combine=fused_moe_results.before_combine_evt,
+                    swiglu_limit=fused_moe_results.swiglu_limit,
+                    swiglu_alpha=getattr(fused_moe_results, "swiglu_alpha", 1.0),
+                    swiglu_beta=getattr(fused_moe_results, "swiglu_beta", 0.0),
+                ),
+            )
+            return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -277,6 +277,7 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         self.log2phy = None
         self.global_redundant_expert_num = 0
         self.init_eplb(n_shared_experts)
+        self.return_with_event = False
 
         vllm_config = get_current_vllm_config()
 
@@ -406,12 +407,11 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             quant_type = getattr(method, "quant_type", QuantType.NONE)
         return quant_type
 
-    def no_shared_forward_impl(
+    def forward_impl(
         self,
         *,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
-        return_with_event: bool = False,
     ):
         forward_context = get_forward_context()
         # When static kernels are enabled, the forward pass runs twice
@@ -496,7 +496,7 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         if lora_context is not None:
             sync_lora_context(self.quant_method, None)
 
-        if return_with_event:
+        if self.return_with_event:
             return FusedMoEResult(
                 routed_out=routed_out,
                 before_dispatch_evt=fused_experts_results.before_dispatch_evt,

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -1,0 +1,236 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from dataclasses import dataclass, field
+from functools import wraps
+
+import torch
+import torch.nn.functional as F
+import torch_npu
+from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.logger import logger
+from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
+
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import (
+    npu_stream_switch,
+    shared_expert_dp_enabled,
+    shared_experts_calculation_stream,
+)
+
+
+@dataclass
+class FusedMoEEvents:
+    before_routed_experts: torch.npu.Event
+    after_routed_experts: torch.npu.Event | None = field(default=None)
+    before_dispatch: torch.npu.Event | None = field(default=None)
+    before_gmm2: torch.npu.Event | None = field(default=None)
+    before_combine: torch.npu.Event | None = field(default=None)
+    swiglu_limit: float = 0.0
+    swiglu_alpha: float = 1.0
+    swiglu_beta: float = 0.0
+
+
+class AscendSharedExperts:
+    """Ascend-owned shared expert executor.
+
+    Keep the original shared expert module registered on ``AscendMoERunner``
+    for checkpoint compatibility while moving split/overlap execution details
+    out of the runner.
+    """
+
+    def __init__(
+        self,
+        layer: torch.nn.Module,
+        moe_config,
+        quant_type: QuantType,
+        quant_method: FusedMoEMethodBase,
+    ):
+        self.layer = layer
+        self.hidden_size = moe_config.hidden_dim
+        self.in_dtype = moe_config.in_dtype
+        self.quant_type = quant_type
+        ascend_config = get_ascend_config()
+        self.multistream_overlap = ascend_config.multistream_overlap_shared_expert
+
+        if self.multistream_overlap:
+            # Wrap the quant_method's process_weights_after_loading to validate that
+            # splitting shared expert computation (gate_up projection + activation,
+            # then down projection) yields identical results to integrated
+            # computation after weight loading.
+            original_process_weights = quant_method.process_weights_after_loading
+
+            @wraps(original_process_weights)
+            def wrapped_process_weights(*args, **kwargs):
+                result = original_process_weights(*args, **kwargs)
+                self.validate_consistency()
+                return result
+
+            quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
+
+    def validate_consistency(self):
+        """Validate that split shared expert computation matches integrated computation."""
+        test_input = (
+            torch.rand(10, self.hidden_size, device="npu", dtype=self.in_dtype) * 2 - 1
+        )  # Random input for testing, scoped to [-1, 1]
+
+        integrated_out = self.layer(test_input)
+        part1_out = self.part1(test_input)
+        split_out = self.part2(test_input, part1_out)
+
+        if not torch.allclose(integrated_out, split_out):
+            diff = (integrated_out - split_out).abs()
+            logger.error(
+                "[fused_moe/layer] Shared expert split computation validation failed."
+                " The split-path computation does not match the integrated-path result."
+                " max_abs_diff=%s, integrated_sum=%s, integrated_norm=%s,"
+                " split_sum=%s, split_norm=%s, hidden_size=%s, dtype=%s.",
+                diff.max().item(),
+                integrated_out.sum().item(),
+                integrated_out.norm().item(),
+                split_out.sum().item(),
+                split_out.norm().item(),
+                self.hidden_size,
+                self.in_dtype,
+            )
+            raise ValueError("FusedMoE shared experts split computation does not match the integrated computation.")
+        logger.info_once(
+            "[fused_moe/layer] Shared expert split computation validation passed."
+            " Integrated and split-path results are consistent."
+        )
+
+    def part1(self, hidden_states: torch.Tensor):
+        shared_gate_up, _ = self.layer.gate_up_proj(hidden_states)  # type: ignore
+        return shared_gate_up
+
+    def part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
+        shared_act = self.layer.act_fn(shared_gate_up)  # type: ignore
+        shared_out, _ = self.layer.down_proj(shared_act)  # type: ignore
+
+        # Qwen3-Next specific gating mechanism
+        if hasattr(self.layer, "expert_gate") and self.layer.expert_gate is not None:
+            gate_out, _ = self.layer.expert_gate(hidden_states)  # type: ignore
+            shared_out = F.sigmoid(gate_out) * shared_out
+        return shared_out
+
+    def forward(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
+        def maybe_wait_event(evt: torch.npu.Event | None):
+            if evt is not None:
+                torch.npu.current_stream().wait_event(evt)
+
+        with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap):
+            # Only used for int quantization
+            has_quantized_shared = hasattr(self.layer.gate_up_proj, "weight_scale") and hasattr(
+                self.layer.down_proj, "weight_scale"
+            )
+            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+                original_dtype = hidden_states.dtype
+                # Execute dynamic quant concurrently with MoE gate.
+                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+                quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
+                # Execute the gate projection and activation concurrently with the
+                # dispatch communication.
+                maybe_wait_event(fused_moe_evts.after_routed_experts)
+                hidden_states = torch_npu.npu_quant_matmul(
+                    quantized_x,
+                    self.layer.gate_up_proj.weight,
+                    self.layer.gate_up_proj.weight_scale,
+                    pertoken_scale=None,
+                    bias=None,
+                    output_dtype=torch.int32,
+                )
+                # Execute activation concurrently with gmm2.
+
+                maybe_wait_event(fused_moe_evts.before_gmm2)
+                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+                    x=hidden_states,
+                    weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
+                    activation_scale=pertoken_scale,
+                    bias=None,
+                    quant_scale=None,
+                    quant_offset=None,
+                    group_index=None,
+                    activate_left=True,
+                    quant_mode=1,
+                    swiglu_mode=1,
+                    clamp_limit=fused_moe_evts.swiglu_limit,
+                    glu_alpha=fused_moe_evts.swiglu_alpha,
+                    glu_bias=fused_moe_evts.swiglu_beta,
+                )
+                # Execute the down projection concurrently with the combine
+                # communication.
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out = torch_npu.npu_quant_matmul(
+                    quantized_x,
+                    self.layer.down_proj.weight,
+                    self.layer.down_proj.weight_scale,
+                    pertoken_scale=swiglu_out_scale,
+                    bias=None,
+                    output_dtype=original_dtype,
+                )
+            elif has_quantized_shared and self.quant_type == QuantType.W4A8MXFP:
+                original_dtype = hidden_states.dtype
+                # Execute dynamic quant concurrently with MoE gate.
+                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+                quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(
+                    hidden_states, dst_type=torch.float8_e4m3fn
+                )
+                # Execute the gate projection and activation concurrently with the
+                # dispatch communication.
+                maybe_wait_event(fused_moe_evts.before_dispatch)
+                hidden_states = self.layer.gate_up_proj((quantized_x, pertoken_scale))[0]
+                # Execute activation concurrently with gmm2.
+                maybe_wait_event(fused_moe_evts.before_gmm2)
+                quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
+                    hidden_states,
+                    topk_weight=None,
+                    group_index=None,
+                    dst_type=torch.float8_e4m3fn,
+                    quant_mode=2,
+                    clamp_value=fused_moe_evts.swiglu_limit,
+                )
+                # Execute the down projection concurrently with the combine
+                # communication.
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out = self.layer.down_proj((quantized_x, swiglu_out_scale))[0]
+            else:
+                # Ensure the shared experts wait for hidden_states to be ready.
+                torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
+                # Execute the gate projection and activation concurrently with the
+                # dispatch communication.
+                maybe_wait_event(fused_moe_evts.before_dispatch)
+                part1_out = self.part1(hidden_states)
+                # Execute the down projection concurrently with the combine
+                # communication.
+                maybe_wait_event(fused_moe_evts.before_combine)
+                shared_out = self.part2(hidden_states, part1_out)
+
+        # Make sure the default stream waits for the shared experts stream to
+        # finish.
+        if self.multistream_overlap:
+            torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
+
+        # NOTE: This is exactly the opposite of
+        # `maybe_all_reduce_tensor_model_parallel`
+        moe_comm_type = _EXTRA_CTX.moe_comm_type
+        if (
+            moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
+            and not shared_expert_dp_enabled()
+        ):
+            shared_out = tensor_model_parallel_all_reduce(shared_out)
+        return shared_out


### PR DESCRIPTION
### What this PR does / why we need it?

Come from https://github.com/vllm-project/vllm-ascend/issues/13220

Move Ascend shared expert split and overlap execution out of the MoE runner into a dedicated shared expert executor.

This keeps the routed expert execution path focused on routed experts and keeps shared expert projection, activation, overlap scheduling, consistency validation, and shared-output reduction in AscendSharedExperts. Routed expert event results are still requested only when shared experts are present.

### Does this PR introduce _any_ user-facing change?

No. This is an internal refactor and should preserve fused MoE behavior.

### How was this patch tested?

- git diff --check
- python -m py_compile vllm_ascend/ops/fused_moe/fused_moe.py vllm_ascend/ops/fused_moe/routed_experts.py vllm_ascend/ops/fused_moe/shared_experts.py vllm_ascend/_310p/fused_moe/fused_moe.py
- python -m pytest -q tests/ut/ops/test_fused_moe.py tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
