### PR TITLE
[v0.25.1rc][BugFix] Fix compressed prefix-cache hit length accounting

### DIFF
--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -31,7 +31,10 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
 )
 
-from vllm_ascend.core.single_type_kv_cache_manager import get_manager_for_kv_cache_spec
+from vllm_ascend.core.single_type_kv_cache_manager import (
+    CompressAttentionManager,
+    get_manager_for_kv_cache_spec,
+)
 from vllm_ascend.utils import vllm_version_is
 
 USE_MULTI_GROUPS_KV_CACHE = True
@@ -365,9 +368,17 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 )
                 if vllm_version_is("0.25.1"):
                     hit_blocks = hit_result
-                    # Compressed attention stores one physical block for
-                    # spec.block_size * compress_ratio logical tokens.
-                    _new_hit_length = len(hit_blocks[0]) * effective_block_size
+                    # Preserve the v0.25.1 DCP block span, then convert
+                    # compressed physical blocks to logical scheduler tokens.
+                    block_size = spec.block_size
+                    if self.dcp_world_size > 1:
+                        block_size *= self.dcp_world_size
+                    compress_ratio = (
+                        max(getattr(spec, "compress_ratio", 1) or 1, 1)
+                        if issubclass(manager_cls, CompressAttentionManager)
+                        else 1
+                    )
+                    _new_hit_length = len(hit_blocks[0]) * block_size * compress_ratio
                 else:
                     hit_blocks, _new_hit_length = hit_result
                 if use_eagle:
@@ -446,7 +457,15 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             )
             if vllm_version_is("0.25.1"):
                 hit_blocks = hit_result
-                group_hit_length = len(hit_blocks[0]) * self._get_effective_block_size(spec)
+                block_size = spec.block_size
+                if self.dcp_world_size > 1:
+                    block_size *= self.dcp_world_size
+                compress_ratio = (
+                    max(getattr(spec, "compress_ratio", 1) or 1, 1)
+                    if issubclass(manager_cls, CompressAttentionManager)
+                    else 1
+                )
+                group_hit_length = len(hit_blocks[0]) * block_size * compress_ratio
             else:
                 hit_blocks, group_hit_length = hit_result
             for group_id, blocks in zip(group_ids, hit_blocks, strict=True):

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -365,12 +365,9 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                 )
                 if vllm_version_is("0.25.1"):
                     hit_blocks = hit_result
-                    # hit_blocks[0] holds physical blocks; effective_block_size
-                    # includes compress_ratio and over-counts for compressed specs.
-                    block_size = spec.block_size
-                    if self.dcp_world_size > 1:
-                        block_size *= self.dcp_world_size
-                    _new_hit_length = len(hit_blocks[0]) * block_size
+                    # Compressed attention stores one physical block for
+                    # spec.block_size * compress_ratio logical tokens.
+                    _new_hit_length = len(hit_blocks[0]) * effective_block_size
                 else:
                     hit_blocks, _new_hit_length = hit_result
                 if use_eagle:
@@ -449,12 +446,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             )
             if vllm_version_is("0.25.1"):
                 hit_blocks = hit_result
-                # hit_blocks[0] holds physical blocks; _get_effective_block_size
-                # includes compress_ratio and over-counts for compressed specs.
-                block_size = spec.block_size
-                if self.dcp_world_size > 1:
-                    block_size *= self.dcp_world_size
-                group_hit_length = len(hit_blocks[0]) * block_size
+                group_hit_length = len(hit_blocks[0]) * self._get_effective_block_size(spec)
             else:
                 hit_blocks, group_hit_length = hit_result
             for group_id, blocks in zip(group_ids, hit_blocks, strict=True):


### PR DESCRIPTION
## What this PR does

Fixes compressed prefix-cache **hit-length** reconstruction in the vLLM 0.25.1 compatibility path on `releases/v0.25.1rc`, which omitted `compress_ratio` and **under-reported** the reusable prefix length — causing the final prefix-cache hit length to collapse to zero for DeepSeek-V4's hybrid KV-cache configuration.

For vLLM 0.25.1, `SingleTypeKVCacheManager.find_longest_cache_hit()` returns matched physical cache blocks without their logical hit length. `AscendHybridKVCacheCoordinator` reconstructs the reusable scheduler-token count from `hit_blocks[0]`. The affected v0.25.1 branch reconstructed it as:

```python
block_size = spec.block_size
if self.dcp_world_size > 1:
    block_size *= self.dcp_world_size
_new_hit_length = len(hit_blocks[0]) * block_size
```

For compressed attention, one physical block represents `spec.block_size * dcp_world_size * compress_ratio` logical tokens. Omitting `compress_ratio` under-reported the reusable length, and the hybrid-group minimum/alignment then reduced it to zero — so already-matched compressed KV blocks were not reused.

This PR uses the existing effective-block-size helpers in both v0.25.1 reconstruction sites:

```python
_new_hit_length = len(hit_blocks[0]) * effective_block_size
group_hit_length = len(hit_blocks[0]) * self._get_effective_block_size(spec)
```

## Root cause and regression point

The v0.23 path already reconstructed hit length with `effective_block_size` (compress_ratio included). The regression was introduced by commit `9c03b2a4` ([CI] Main2main: upgrade vLLM commit to 0717, #12502, 2026-07-24): the vLLM 0.25.1 compatibility branch for the changed cache-manager return contract switched both reconstruction sites from `effective_block_size` to a manually derived `spec.block_size * dcp_world_size`, dropping `compress_ratio`. Hence the issue appears only on the v0.25.1 path, not v0.23.

## DCP scope

The bug does **not** depend on DCP being enabled:

- DCP disabled: `dcp_world_size=1`, but `compress_ratio` was still omitted.
- DCP enabled: `_get_effective_block_size()` preserves `dcp_world_size` **and** includes `compress_ratio`.
- DCP is neither removed nor applied twice by this fix.

Example with `block_size=32`, `compress_ratio=128`:

| DCP config | Old length / physical block | Correct length / physical block |
|---|---:|---:|
| DCP disabled (`dcp_world_size=1`) | 32 | 4096 |
| DCP2 | 64 | 8192 |
| DCP4 | 128 | 16384 |

The `CompressAttentionManager` already uses the same source-of-truth formula (`block_size * dcp_world_size * compress_ratio`) when looking up compressed cache blocks; the fixed Coordinator now matches it.

## Impact on non-compressed models

`_get_effective_block_size()` only multiplies by a compression ratio when the KV-cache spec exposes `compress_ratio`. Non-Mamba specs without it (e.g. GLM5.2 Full Attention / non-compressed MLA) retain the previous `spec.block_size * dcp_world_size` behavior — unchanged. Mamba prefix caching has its own effective-block-size semantics in the existing helper and the per-group transfer path skips Mamba groups; this PR does not modify that.

## Why 4K / 8K / 64K / 128K all reported zero

C128 group, `block_size=32`, DCP disabled — one physical block = 4096 logical tokens, old path computed:

| Logical prefix | Physical C128 blocks | Old reported length | 4096-aligned result |
|---:|---:|---:|---:|
| 4K | 1 | 32 | 0 |
| 8K | 2 | 64 | 0 |
| 64K | 16 | 512 | 0 |
| 128K | 32 | 1024 | 0 |

Physical cache blocks and prefix hashes existed; the Coordinator just converted the matched block count to the wrong logical-token unit, and hybrid-group alignment collapsed the reusable length to zero.

## Why target releases/v0.25.1rc

The affected branch is guarded by `vllm_version_is("0.25.1")`. Newer vLLM manager contracts return both matched blocks and their logical hit length, so they do not use these two reconstruction sites.

## User-facing change

No API / model-weight / quantization / serving-config change. The fix corrects prefix-cache accounting and lets already-matched compressed KV blocks be reused by the scheduler. Models without compressed KV-cache specs keep existing behavior.

## How was this patch tested?

Environment: DeepSeek-V4-Flash-0731 W8A8C16, vLLM-Ascend `releases/v0.25.1rc`, Atlas 800I A2, P/D disaggregated serving, prefix cache on Prefill nodes.

Before the fix (P nodes DP8/TP1, `dcp_world_size=1`, vLLM DCP disabled):

| Workload | Prefix-cache hit rate |
|---|---:|
| 8K smoke test | 0.00% |
| 64K test | 0.00% |

After the fix:

| Workload | Requests / concurrency | Hit rate | Failed |
|---|---:|---:|---:|
| 64K -> 1K, low latency | 64 / 16 | 93.74% | 0 |
| 128K -> 1K, low latency | 192 / 48 | 93.75% | 0 |
| 64K -> 1K, high throughput | 1600 / 400 | 93.74% | 0 |
| 128K -> 1K, high throughput | 1024 / 256 | 89.78% - 89.84% | 0 |

The online MooncakeHybridConnector configuration requires context-parallel world size 1, so these E2E results validate the non-DCP path. The DCP formula is verified against `CompressAttentionManager`; an explicit `compress_ratio > 1` + `dcp_world_size > 1` regression UT is recommended before merge.

Additional checks: `git diff --check`, Python syntax compile, identical fixed-file SHA256 across active Prefill nodes, GitHub pre-commit + DCO.

## Related

- Fix branch: https://github.com/Liuchenbing-2026/vllm-ascend/tree/v0.25.1rc_fix_prefix_cache
- Regression commit: https://github.com/vllm-project/vllm-ascend/commit/9c03b2a46b808ae19c27354e0b0e700694960a8c

Co-authored-by: wangzhao-11a <73340653+wangzhao-11a@users.noreply.github.com>

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
