### PR TITLE
[Feature][Attention][Kernel] Add TriangleMix sparse prefill on Ascend

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -78,6 +78,16 @@
   tests:
     - tests/e2e/pull_request/two_card/test_gemma4.py
 
+- name: attention_trianglemix
+  optional: false
+  base: attention_common
+  source_file_dependencies:
+    - vllm_ascend/attention/trianglemix.py
+    - csrc/attention/triangle_paged_sparse_attention
+  tests:
+    - tests/ut/attention/a2/test_trianglemix.py
+    - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
+
 - name: attention_fa3
   optional: false
   base: attention_common
@@ -824,6 +834,7 @@ estimated_times:
   tests/ut/attention/a2/test_sfa_cp_precision.py: 160
   tests/ut/attention/a2/test_sfa_v1.py: 30
   tests/ut/attention/a2/test_sfa_v1_precision.py: 100
+  tests/ut/attention/a2/test_trianglemix.py: 30
   tests/ut/compilation/a2/test_acl_graph.py: 40
   tests/ut/device_allocator/a2/test_find_loaded_library.py: 40
   tests/ut/eplb/core/a2/test_eplb_utils.py: 30

--- a/csrc/attention/sparse_attention_score/op_kernel/attn_infra/epilogue/block/block_epilogue_online_softmax.hpp
+++ b/csrc/attention/sparse_attention_score/op_kernel/attn_infra/epilogue/block/block_epilogue_online_softmax.hpp
@@ -21,6 +21,13 @@
 
 namespace NpuArch::Epilogue::Block {
 
+struct ProceduralBoundaryMaskParams {
+    uint32_t mode;
+    uint32_t queryBegin;
+    uint32_t keyBegin;
+    uint32_t windowTokens;
+};
+
 template <
     class OutputType_,
     class InputType_,
@@ -124,6 +131,155 @@ public:
         } else {
             AscendC::SetVectorMask<int8_t>(0x0, mask);
         }
+    }
+
+    __aicore__ inline
+    void SetNegativeInfinityRangeUb(
+        const AscendC::LocalTensor<float> &rowBuffer,
+        uint32_t begin,
+        uint32_t end)
+    {
+        if (begin >= end) {
+            return;
+        }
+        constexpr uint32_t FLOAT_ELEMENTS_PER_DATA_BLOCK =
+            BLOCK_SIZE_IN_BYTE / sizeof(float);
+        constexpr float NEGATIVE_INFINITY = -3.402823466e+38F;
+
+        const uint32_t firstBlockBegin =
+            begin / FLOAT_ELEMENTS_PER_DATA_BLOCK *
+            FLOAT_ELEMENTS_PER_DATA_BLOCK;
+        const uint32_t lastBlockBegin =
+            (end - 1U) / FLOAT_ELEMENTS_PER_DATA_BLOCK *
+            FLOAT_ELEMENTS_PER_DATA_BLOCK;
+
+        if (firstBlockBegin == lastBlockBegin) {
+            if (begin == firstBlockBegin &&
+                end == firstBlockBegin + FLOAT_ELEMENTS_PER_DATA_BLOCK) {
+                AscendC::Duplicate(
+                    rowBuffer[firstBlockBegin],
+                    NEGATIVE_INFINITY,
+                    FLOAT_ELEMENTS_PER_DATA_BLOCK);
+                return;
+            }
+            const uint32_t firstLane = begin - firstBlockBegin;
+            const uint32_t laneCount = end - begin;
+            const uint64_t laneBits =
+                ((1ULL << laneCount) - 1ULL) << firstLane;
+            uint64_t rangeMask[2] = {laneBits, 0ULL};
+            AscendC::Duplicate<float>(
+                rowBuffer[firstBlockBegin],
+                NEGATIVE_INFINITY,
+                rangeMask,
+                1,
+                1,
+                0);
+            return;
+        }
+
+        uint32_t alignedMiddleBegin = begin;
+        const uint32_t firstLane = begin - firstBlockBegin;
+        if (firstLane != 0U) {
+            const uint32_t laneCount =
+                FLOAT_ELEMENTS_PER_DATA_BLOCK - firstLane;
+            const uint64_t laneBits =
+                ((1ULL << laneCount) - 1ULL) << firstLane;
+            uint64_t rangeMask[2] = {laneBits, 0ULL};
+            AscendC::Duplicate<float>(
+                rowBuffer[firstBlockBegin],
+                NEGATIVE_INFINITY,
+                rangeMask,
+                1,
+                1,
+                0);
+            alignedMiddleBegin =
+                firstBlockBegin + FLOAT_ELEMENTS_PER_DATA_BLOCK;
+        }
+
+        uint32_t alignedMiddleEnd = end;
+        const uint32_t lastLaneCount = end - lastBlockBegin;
+        if (lastLaneCount != FLOAT_ELEMENTS_PER_DATA_BLOCK) {
+            alignedMiddleEnd = lastBlockBegin;
+        }
+
+        if (alignedMiddleBegin < alignedMiddleEnd) {
+            AscendC::Duplicate(
+                rowBuffer[alignedMiddleBegin],
+                NEGATIVE_INFINITY,
+                alignedMiddleEnd - alignedMiddleBegin);
+        }
+
+        if (lastLaneCount != FLOAT_ELEMENTS_PER_DATA_BLOCK) {
+            const uint64_t laneBits =
+                (1ULL << lastLaneCount) - 1ULL;
+            uint64_t rangeMask[2] = {laneBits, 0ULL};
+            AscendC::Duplicate<float>(
+                rowBuffer[lastBlockBegin],
+                NEGATIVE_INFINITY,
+                rangeMask,
+                1,
+                1,
+                0);
+        }
+    }
+
+    __aicore__ inline
+    void ApplyProceduralBoundaryMaskUb(
+        uint32_t sUbOffset,
+        uint32_t rowOffsetThisSubBlock,
+        uint32_t rowOffsetCurLoop,
+        uint32_t rowNumCurLoop,
+        uint32_t columnNum,
+        uint32_t columnNumRound,
+        uint32_t qSBlockSize,
+        const ProceduralBoundaryMaskParams &params)
+    {
+        if (params.mode == 0U) {
+            return;
+        }
+
+        for (uint32_t localRow = 0U;
+             localRow < rowNumCurLoop;
+             ++localRow) {
+            const uint32_t globalRow =
+                rowOffsetThisSubBlock + rowOffsetCurLoop + localRow;
+            const uint32_t tokenInTile = globalRow % qSBlockSize;
+            const uint32_t queryPosition =
+                params.queryBegin + tokenInTile;
+            const uint32_t lower =
+                params.mode == 2U &&
+                        queryPosition > params.windowTokens
+                    ? queryPosition - params.windowTokens
+                    : 0U;
+            const uint32_t upper = queryPosition + 1U;
+            uint32_t validBegin =
+                lower > params.keyBegin
+                    ? lower - params.keyBegin
+                    : 0U;
+            validBegin = Min(validBegin, columnNum);
+            uint32_t validEnd =
+                upper > params.keyBegin
+                    ? upper - params.keyBegin
+                    : 0U;
+            validEnd = Min(validEnd, columnNum);
+
+            const AscendC::LocalTensor<float> rowBuffer =
+                lsUbTensor[
+                    sUbOffset + localRow * columnNumRound];
+            if (validBegin >= validEnd) {
+                SetNegativeInfinityRangeUb(
+                    rowBuffer, 0U, columnNumRound);
+            } else {
+                SetNegativeInfinityRangeUb(
+                    rowBuffer, 0U, validBegin);
+                SetNegativeInfinityRangeUb(
+                    rowBuffer, validEnd, columnNumRound);
+            }
+        }
+        AscendC::SetVectorMask<int8_t>(
+            static_cast<uint64_t>(-1),
+            static_cast<uint64_t>(-1));
+        AscendC::PipeBarrier<PIPE_V>();
     }
 
     __aicore__ inline
@@ -919,6 +1075,30 @@ public:
         uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
         uint32_t qSBlockSize, uint32_t qNBlockSize, uint32_t curStackTileMod, Arch::CrossCoreFlag softmaxFlag)
     {
+        const ProceduralBoundaryMaskParams noProceduralMask{
+            0U, 0U, 0U, 0U};
+        operator()(
+            gOutput,
+            gInput,
+            layoutOutput,
+            layoutInput,
+            actualBlockShape,
+            isFirstStackTile,
+            isLastNoMaskStackTile,
+            qSBlockSize,
+            qNBlockSize,
+            curStackTileMod,
+            softmaxFlag,
+            noProceduralMask);
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<ElementInput> gInput,
+        const LayoutOutput &layoutOutput, const LayoutInput &layoutInput, GemmCoord actualBlockShape,
+        uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
+        uint32_t qSBlockSize, uint32_t qNBlockSize, uint32_t curStackTileMod, Arch::CrossCoreFlag softmaxFlag,
+        const ProceduralBoundaryMaskParams &proceduralMask)
+    {
         uint32_t rowNum = actualBlockShape.m();
         uint32_t columnNum = actualBlockShape.n();
         uint32_t columnNumRound = RoundUp(columnNum, BLOCK_SIZE);
@@ -973,6 +1153,15 @@ public:
                 auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
                 ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                ApplyProceduralBoundaryMaskUb(
+                    (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                    rowOffsetThisSubBlock,
+                    rowOffsetCurLoop,
+                    rowNumCurLoop,
+                    columnNum,
+                    columnNumRound,
+                    qSBlockSize,
+                    proceduralMask);
                 SubCoreCompute<false>(
                     gOutputCurLoop,
                     layoutOutputCurLoop,

--- a/csrc/attention/triangle_paged_sparse_attention/op_host/CMakeLists.txt
+++ b/csrc/attention/triangle_paged_sparse_attention/op_host/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 TriangleMix contributors.
+# This file is licensed under CANN Open Software License Agreement
+# Version 2.0. See LICENSE in the repository root.
+
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    set(triangle_paged_sparse_attention_depends
+        attention/sparse_attention_score
+        CACHE INTERNAL "Dependencies for triangle_paged_sparse_attention"
+    )
+    target_sources(op_host_aclnn PRIVATE
+        triangle_paged_sparse_attention_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME TrianglePagedSparseAttention
+    OPTIONS
+        --cce-auto-sync=off
+        -Wno-deprecated-declarations
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(
+        OPTYPE triangle_paged_sparse_attention
+        ACLNNTYPE aclnn
+    )
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../op_kernel
+    )
+endif()

--- a/csrc/attention/triangle_paged_sparse_attention/op_host/triangle_paged_sparse_attention_def.cpp
+++ b/csrc/attention/triangle_paged_sparse_attention/op_host/triangle_paged_sparse_attention_def.cpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is free software, you can redistribute it and/or modify it
+ * under the terms and conditions of CANN Open Software License Agreement
+ * Version 2.0 (the "License"). Please refer to the License for details.
+ * You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+ * KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ge {
+static graphStatus InferShape(gert::InferShapeContext* context)
+{
+    const gert::Shape* queryShape = context->GetInputShape(0);
+    gert::Shape* outputShape = context->GetOutputShape(0);
+    *outputShape = *queryShape;
+    return GRAPH_SUCCESS;
+}
+
+static graphStatus InferDataType(gert::InferDataTypeContext* context)
+{
+    context->SetOutputDataType(0, context->GetInputDataType(0));
+    return GRAPH_SUCCESS;
+}
+}  // namespace ge
+
+namespace ops {
+class TrianglePagedSparseAttention : public OpDef {
+public:
+    explicit TrianglePagedSparseAttention(const char* name) : OpDef(name)
+    {
+        this->Input("query")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("key_cache")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("value_cache")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Input("block_table")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Output("attention_out")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16})
+            .Format({ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND});
+        this->Attr("query_start").Int();
+        this->Attr("seq_len").Int();
+        this->Attr("prompt_len").Int();
+        this->Attr("scale").Float();
+        this->Attr("q_tile").AttrType(OPTIONAL).Int(32);
+        this->Attr("page_size").AttrType(OPTIONAL).Int(128);
+        this->Attr("sink_tokens").AttrType(OPTIONAL).Int(8);
+        this->Attr("local_window").AttrType(OPTIONAL).Int(512);
+        this->Attr("dense_tail").AttrType(OPTIONAL).Int(128);
+
+        this->SetInferShape(ge::InferShape)
+            .SetInferDataType(ge::InferDataType);
+        this->AICore().AddConfig("ascend910b");
+    }
+};
+
+OP_ADD(TrianglePagedSparseAttention);
+}  // namespace ops

--- a/csrc/attention/triangle_paged_sparse_attention/op_host/triangle_paged_sparse_attention_tiling.cpp
+++ b/csrc/attention/triangle_paged_sparse_attention/op_host/triangle_paged_sparse_attention_tiling.cpp
@@ -1,0 +1,350 @@
+/**
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is free software, you can redistribute it and/or modify it
+ * under the terms of CANN Open Software License Agreement Version 2.0.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+ * KIND. See LICENSE in the repository root for the full license text.
+ */
+
+#include "../op_kernel/triangle_paged_sparse_attention_tiling.h"
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <cstdint>
+#include <initializer_list>
+#include <limits>
+
+#include "register/op_def_registry.h"
+#include "tiling/platform/platform_ascendc.h"
+
+#ifndef OP_LOGE
+#define OP_LOGE(nodeName, ...)                    \
+    do {                                          \
+        (void)(nodeName);                         \
+        std::fprintf(stderr, "[TPSA] ");          \
+        std::fprintf(stderr, __VA_ARGS__);        \
+        std::fprintf(stderr, "\n");               \
+    } while (0)
+#endif
+
+namespace {
+
+constexpr uint32_t kTilingMagic = 0x54505341U;  // "TPSA"
+constexpr uint32_t kAbiVersion = 2;
+constexpr uint32_t kFastImplementation = 2;
+constexpr int64_t kQueryHeads = 32;
+constexpr int64_t kKvHeads = 8;
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kPageSize = 128;
+constexpr int64_t kQueryTile = 32;
+constexpr int64_t kKvTile = 512;
+constexpr int64_t kSinkTokens = 8;
+constexpr int64_t kLocalWindow = 512;
+constexpr int64_t kDenseTail = 128;
+constexpr uint32_t kGroupSize =
+    static_cast<uint32_t>(kQueryHeads / kKvHeads);
+constexpr uint32_t kCubeRows =
+    static_cast<uint32_t>(kQueryTile) * kGroupSize;
+constexpr uint32_t kScoreBytes =
+    kCubeRows * static_cast<uint32_t>(kKvTile) * sizeof(float);
+constexpr uint32_t kProbabilityBytes =
+    kCubeRows * static_cast<uint32_t>(kKvTile) * sizeof(uint16_t);
+constexpr uint32_t kOutputTmpBytes =
+    kCubeRows * static_cast<uint32_t>(kHeadDim) * sizeof(float);
+constexpr uint32_t kOutputUpdateBytes = kOutputTmpBytes;
+constexpr uint32_t kLseScratchBytes = kCubeRows * sizeof(float);
+constexpr uint32_t kWorkspaceAlignment = 512;
+
+constexpr uint32_t AlignUpU32(uint32_t value, uint32_t alignment)
+{
+    return (value + alignment - 1U) / alignment * alignment;
+}
+
+constexpr uint32_t kScoreOffsetBytes = 0;
+constexpr uint32_t kProbabilityOffsetBytes =
+    kScoreOffsetBytes + kScoreBytes;
+constexpr uint32_t kOutputTmpOffsetBytes =
+    kProbabilityOffsetBytes + kProbabilityBytes;
+constexpr uint32_t kOutputUpdateOffsetBytes =
+    kOutputTmpOffsetBytes + kOutputTmpBytes;
+constexpr uint32_t kLseScratchOffsetBytes =
+    kOutputUpdateOffsetBytes + kOutputUpdateBytes;
+constexpr uint32_t kWorkspacePerCoreBytes = AlignUpU32(
+    kLseScratchOffsetBytes + kLseScratchBytes,
+    kWorkspaceAlignment);
+
+enum InputIndex : size_t {
+    kQuery = 0,
+    kKeyCache = 1,
+    kValueCache = 2,
+    kBlockTable = 3,
+};
+
+bool HasShape(
+    const gert::StorageShape* storageShape,
+    std::initializer_list<int64_t> expectedTail)
+{
+    if (storageShape == nullptr) {
+        return false;
+    }
+    const gert::Shape& shape = storageShape->GetStorageShape();
+    if (shape.GetDimNum() != expectedTail.size()) {
+        return false;
+    }
+    size_t index = 0;
+    for (int64_t expected : expectedTail) {
+        if (expected >= 0 && shape.GetDim(index) != expected) {
+            return false;
+        }
+        ++index;
+    }
+    return true;
+}
+
+bool SameShape(
+    const gert::StorageShape* lhsStorage,
+    const gert::StorageShape* rhsStorage)
+{
+    if (lhsStorage == nullptr || rhsStorage == nullptr) {
+        return false;
+    }
+    const gert::Shape& lhs = lhsStorage->GetStorageShape();
+    const gert::Shape& rhs = rhsStorage->GetStorageShape();
+    if (lhs.GetDimNum() != rhs.GetDimNum()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.GetDimNum(); ++i) {
+        if (lhs.GetDim(i) != rhs.GetDim(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+namespace optiling {
+
+struct TrianglePagedSparseAttentionCompileInfo {};
+
+ge::graphStatus TilingFunc(gert::TilingContext* context)
+{
+    if (context == nullptr) {
+        return ge::GRAPH_FAILED;
+    }
+
+    const auto* queryShape = context->GetInputShape(kQuery);
+    const auto* keyShape = context->GetInputShape(kKeyCache);
+    const auto* valueShape = context->GetInputShape(kValueCache);
+    const auto* blockTableShape = context->GetInputShape(kBlockTable);
+
+    if (!HasShape(queryShape, {-1, kQueryHeads, kHeadDim})) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "query must be [Tq, 32, 128] BF16 (BSND without batch)");
+        return ge::GRAPH_FAILED;
+    }
+    if (!HasShape(
+            keyShape, {-1, kPageSize, kKvHeads, kHeadDim})) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "key_cache must be [num_pages, 128, 8, 128] BF16");
+        return ge::GRAPH_FAILED;
+    }
+    if (!SameShape(keyShape, valueShape)) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "value_cache shape must exactly match key_cache");
+        return ge::GRAPH_FAILED;
+    }
+    if (!HasShape(blockTableShape, {1, -1})) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "block_table must be batch-one [1, max_pages] INT32");
+        return ge::GRAPH_FAILED;
+    }
+
+    if (context->GetInputDesc(kQuery)->GetDataType() != ge::DT_BF16 ||
+        context->GetInputDesc(kKeyCache)->GetDataType() != ge::DT_BF16 ||
+        context->GetInputDesc(kValueCache)->GetDataType() != ge::DT_BF16 ||
+        context->GetInputDesc(kBlockTable)->GetDataType() != ge::DT_INT32) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "fixed fast path requires BF16 Q/K/V and INT32 block_table");
+        return ge::GRAPH_FAILED;
+    }
+
+    const auto* attrs = context->GetAttrs();
+    if (attrs == nullptr) {
+        OP_LOGE(context->GetNodeName(), "attributes are required");
+        return ge::GRAPH_FAILED;
+    }
+    const int64_t* queryStartPtr = attrs->GetInt(0);
+    const int64_t* seqLenPtr = attrs->GetInt(1);
+    const int64_t* promptLenPtr = attrs->GetInt(2);
+    const float* scalePtr = attrs->GetFloat(3);
+    const int64_t* queryTilePtr = attrs->GetInt(4);
+    const int64_t* pageSizePtr = attrs->GetInt(5);
+    const int64_t* sinkTokensPtr = attrs->GetInt(6);
+    const int64_t* localWindowPtr = attrs->GetInt(7);
+    const int64_t* denseTailPtr = attrs->GetInt(8);
+    if (queryStartPtr == nullptr || seqLenPtr == nullptr ||
+        promptLenPtr == nullptr || scalePtr == nullptr ||
+        queryTilePtr == nullptr || pageSizePtr == nullptr ||
+        sinkTokensPtr == nullptr || localWindowPtr == nullptr ||
+        denseTailPtr == nullptr) {
+        OP_LOGE(context->GetNodeName(), "failed to read required attributes");
+        return ge::GRAPH_FAILED;
+    }
+
+    if (*queryTilePtr != kQueryTile || *pageSizePtr != kPageSize ||
+        *sinkTokensPtr != kSinkTokens ||
+        *localWindowPtr != kLocalWindow || *denseTailPtr != kDenseTail) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "only q_tile=32, page_size=128, sink=8, window=512, "
+            "dense_tail=128 is compiled");
+        return ge::GRAPH_FAILED;
+    }
+    if (*queryStartPtr < 0 || *seqLenPtr <= 0 ||
+        *promptLenPtr < *seqLenPtr || !std::isfinite(*scalePtr) ||
+        *scalePtr <= 0.0F) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "invalid query_start/seq_len/prompt_len/scale attributes");
+        return ge::GRAPH_FAILED;
+    }
+
+    const gert::Shape& query = queryShape->GetStorageShape();
+    const gert::Shape& key = keyShape->GetStorageShape();
+    const gert::Shape& blockTable = blockTableShape->GetStorageShape();
+    const int64_t queryTokens = query.GetDim(0);
+    const int64_t physicalPages = key.GetDim(0);
+    const int64_t blockTableCapacity = blockTable.GetDim(1);
+    const int64_t requiredPages =
+        (*seqLenPtr + kPageSize - 1) / kPageSize;
+
+    if (queryTokens <= 0 ||
+        *queryStartPtr + queryTokens != *seqLenPtr) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "batch-one prefill requires query_start + Tq == seq_len");
+        return ge::GRAPH_FAILED;
+    }
+    if (physicalPages <= 0 || blockTableCapacity < requiredPages) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "block_table lacks logical pages required by seq_len");
+        return ge::GRAPH_FAILED;
+    }
+    if (*promptLenPtr > std::numeric_limits<uint32_t>::max()) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "first kernel ABI supports prompt lengths up to UINT32_MAX");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto* tiling =
+        context->GetTilingData<TrianglePagedSparseAttentionTilingData>();
+    if (tiling == nullptr) {
+        OP_LOGE(context->GetNodeName(), "tiling buffer is unavailable");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto* platformInfo = context->GetPlatformInfo();
+    if (platformInfo == nullptr) {
+        OP_LOGE(context->GetNodeName(), "platform info is unavailable");
+        return ge::GRAPH_FAILED;
+    }
+    const platform_ascendc::PlatformAscendC platform(platformInfo);
+    const uint32_t aicCores = platform.GetCoreNumAic();
+    if (aicCores == 0) {
+        OP_LOGE(context->GetNodeName(), "Ascend platform reports zero AICs");
+        return ge::GRAPH_FAILED;
+    }
+
+    const uint32_t queryTileCount =
+        (static_cast<uint32_t>(queryTokens) +
+         static_cast<uint32_t>(kQueryTile) - 1U) /
+        static_cast<uint32_t>(kQueryTile);
+    const uint32_t taskCount =
+        queryTileCount * static_cast<uint32_t>(kKvHeads);
+    const uint32_t blockDim = std::min(aicCores, taskCount);
+    const uint32_t sparseBegin =
+        static_cast<uint32_t>(kSinkTokens + kLocalWindow + 1);
+    const uint32_t sparseEnd = static_cast<uint32_t>(
+        std::max<int64_t>(0, *promptLenPtr - kDenseTail));
+
+    tiling->magic = kTilingMagic;
+    tiling->abiVersion = kAbiVersion;
+    tiling->implementationStatus = kFastImplementation;
+    tiling->blockDim = blockDim;
+    tiling->queryTokens = static_cast<uint32_t>(queryTokens);
+    tiling->queryStart = static_cast<uint32_t>(*queryStartPtr);
+    tiling->seqLen = static_cast<uint32_t>(*seqLenPtr);
+    tiling->promptLen = static_cast<uint32_t>(*promptLenPtr);
+    tiling->queryHeads = static_cast<uint32_t>(kQueryHeads);
+    tiling->kvHeads = static_cast<uint32_t>(kKvHeads);
+    tiling->headDim = static_cast<uint32_t>(kHeadDim);
+    tiling->pageSize = static_cast<uint32_t>(kPageSize);
+    tiling->physicalPageCount = static_cast<uint32_t>(physicalPages);
+    tiling->blockTablePageCapacity =
+        static_cast<uint32_t>(blockTableCapacity);
+    tiling->queryTile = static_cast<uint32_t>(kQueryTile);
+    tiling->taskCount = taskCount;
+    tiling->sinkTokens = static_cast<uint32_t>(kSinkTokens);
+    tiling->localWindow = static_cast<uint32_t>(kLocalWindow);
+    tiling->denseTail = static_cast<uint32_t>(kDenseTail);
+    tiling->sparseBegin = sparseBegin;
+    tiling->sparseEnd = sparseEnd;
+    tiling->reserved0 = 0;
+    tiling->reserved1 = 0;
+    tiling->reserved2 = 0;
+    tiling->scale = *scalePtr;
+    tiling->kvTile = static_cast<uint32_t>(kKvTile);
+    tiling->groupSize = kGroupSize;
+    tiling->queryTileCount = queryTileCount;
+    tiling->activeAicCores = blockDim;
+    tiling->workspacePerCoreBytes = kWorkspacePerCoreBytes;
+    tiling->scoreOffsetBytes = kScoreOffsetBytes;
+    tiling->probabilityOffsetBytes = kProbabilityOffsetBytes;
+    tiling->outputTmpOffsetBytes = kOutputTmpOffsetBytes;
+    tiling->outputUpdateOffsetBytes = kOutputUpdateOffsetBytes;
+    tiling->lseScratchOffsetBytes = kLseScratchOffsetBytes;
+    tiling->workspaceBytes = blockDim * kWorkspacePerCoreBytes;
+    tiling->pipelineStages = 1;
+
+    context->SetBlockDim(blockDim);
+    // The non-templated build emits one dynamic MIX kernel with tiling key 0.
+    context->SetTilingKey(0);
+    size_t* workspaceSizes = context->GetWorkspaceSizes(1);
+    const size_t libApiWorkspaceBytes =
+        static_cast<size_t>(platform.GetLibApiWorkSpaceSize());
+    const size_t userWorkspaceBytes =
+        static_cast<size_t>(tiling->workspaceBytes);
+    if (libApiWorkspaceBytes >
+        std::numeric_limits<size_t>::max() - userWorkspaceBytes) {
+        OP_LOGE(
+            context->GetNodeName(),
+            "system and user workspace byte count overflows size_t");
+        return ge::GRAPH_FAILED;
+    }
+    workspaceSizes[0] = libApiWorkspaceBytes + userWorkspaceBytes;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepareForTrianglePagedSparseAttention(
+    gert::TilingParseContext* context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(TrianglePagedSparseAttention)
+    .Tiling(TilingFunc)
+    .TilingParse<TrianglePagedSparseAttentionCompileInfo>(
+        TilingPrepareForTrianglePagedSparseAttention);
+
+}  // namespace optiling

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/CMakeLists.txt
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/CMakeLists.txt
@@ -1,0 +1,28 @@
+# ----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ----------------------------------------------------------------------------------------------------------
+
+if ("${CMAKE_BUILD_TYPE}x" STREQUAL "Debugx")
+    npu_op_kernel_options(ascendc_kernels ALL OPTIONS -g -O0)
+else()
+    npu_op_kernel_options(ascendc_kernels ALL OPTIONS -O3)
+endif()
+
+npu_op_kernel_sources(ascendc_kernels
+    KERNEL_DIR ./
+)
+
+npu_op_kernel_library(ascendc_kernels
+    SRC_BASE ${CMAKE_CURRENT_SOURCE_DIR}/
+    TILING_LIBRARY cust_optiling
+)
+
+npu_op_package_add(${package_name}
+    LIBRARY ascendc_kernels
+)

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/fia_paged_kv_address.h
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/fia_paged_kv_address.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is licensed under CANN Open Software License Agreement
+ * Version 2.0. See LICENSE in the repository root.
+ *
+ * Paged BSND address mapping extracted from the CANN 9.0.1
+ * FusedInferAttentionScore QK/PV loaders:
+ *
+ *   fused_infer_attention_score/attn_infra/gemm/block/block_mmad_qk.hpp
+ *   fused_infer_attention_score/attn_infra/gemm/block/block_mmad_pv.hpp
+ *
+ * Source revision: ops-transformer v9.0.1,
+ * 8038339a99bae113a7ae07f4547306d6d15bbddf.
+ *
+ * This file establishes the exact logical-page -> physical-page address
+ * contract used by the fused Cube/Vector path.
+ */
+#ifndef TRIANGLE_PAGED_ATTENTION_FIA_PAGED_KV_ADDRESS_H
+#define TRIANGLE_PAGED_ATTENTION_FIA_PAGED_KV_ADDRESS_H
+
+#include "kernel_operator.h"
+
+namespace TrianglePaged {
+
+struct PagedKvLocation {
+    uint32_t logicalPage;
+    uint32_t physicalPage;
+    uint32_t offsetInPage;
+    uint32_t elementOffset;
+};
+
+/*
+ * Cache layout is BSND:
+ *   [physical_page, page_size, kv_head, head_dim].
+ *
+ * Batch is fixed to one in the first production fast path, so blockTable is
+ * the first and only row of [1, max_pages].
+ */
+__aicore__ inline PagedKvLocation ResolvePagedBsndLocation(
+    AscendC::GlobalTensor<int32_t>& blockTable,
+    uint32_t logicalToken,
+    uint32_t kvHead,
+    uint32_t pageSize,
+    uint32_t kvHeads,
+    uint32_t headDim)
+{
+    PagedKvLocation location{};
+    location.logicalPage = logicalToken / pageSize;
+    location.offsetInPage = logicalToken % pageSize;
+    location.physicalPage =
+        static_cast<uint32_t>(blockTable.GetValue(location.logicalPage));
+    location.elementOffset =
+        (((location.physicalPage * pageSize + location.offsetInPage) *
+          kvHeads + kvHead) * headDim);
+    return location;
+}
+
+}  // namespace TrianglePaged
+
+#endif  // TRIANGLE_PAGED_ATTENTION_FIA_PAGED_KV_ADDRESS_H

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_block_mmad.h
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_block_mmad.h
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is licensed under CANN Open Software License Agreement
+ * Version 2.0. See LICENSE in the repository root.
+ */
+#ifndef TRIANGLE_PAGED_ATTENTION_BLOCK_MMAD_H
+#define TRIANGLE_PAGED_ATTENTION_BLOCK_MMAD_H
+
+/*
+ * The Cube loops below are deliberately derived from the CANN 9.0.1
+ * BlockSparseAttention QK/PV blocks, while the GM->L1 address generation is
+ * taken from FIA PageAttention.  The important difference from both upstream
+ * implementations is the input contract:
+ *
+ *   - an absolute contiguous logical-token interval is supplied directly;
+ *   - every page fragment is resolved through block_table;
+ *   - no packed GM K/V, full mask, or selectIdx array is materialized.
+ *
+ * The Cube and online-softmax primitives are shared with the in-tree
+ * SparseAttentionScore operator.  TrianglePagedSparseAttention only
+ * specializes paged K/V address generation and the static Triangle schedule.
+ *
+ * Cache layout is fixed BSND:
+ *   [physical_page, 128, 8, 128].
+ */
+
+#include "../../sparse_attention_score/op_kernel/arch22/kernel_utils.hpp"
+
+namespace TrianglePaged {
+
+template <class BaseMmad>
+class DirectPagedQkMmad : public BaseMmad {
+public:
+    using ArchTag = typename BaseMmad::ArchTag;
+    using L1TileShape = typename BaseMmad::L1TileShape;
+    using L0TileShape = typename BaseMmad::L0TileShape;
+    using ElementA = typename BaseMmad::ElementA;
+    using ElementB = typename BaseMmad::ElementB;
+    using ElementC = typename BaseMmad::ElementC;
+    using LayoutA = typename BaseMmad::LayoutA;
+    using LayoutB = typename BaseMmad::LayoutB;
+    using LayoutC = typename BaseMmad::LayoutC;
+    using LayoutAInL1 = typename BaseMmad::LayoutAInL1;
+    using LayoutBInL1 = typename BaseMmad::LayoutBInL1;
+    using LayoutAInL0 = typename BaseMmad::LayoutAInL0;
+    using LayoutBInL0 = typename BaseMmad::LayoutBInL0;
+    using LayoutCInL0 = typename BaseMmad::LayoutCInL0;
+    using L1AAlignHelper = typename BaseMmad::L1AAlignHelper;
+
+    __aicore__ inline explicit DirectPagedQkMmad(
+        NpuArch::Arch::Resource<ArchTag>& resource,
+        uint32_t l1Offset = 0)
+        : BaseMmad(resource, l1Offset)
+    {
+    }
+
+    __aicore__ inline void operator()(
+        AscendC::GlobalTensor<ElementA> gQ,
+        AscendC::GlobalTensor<ElementB> gK,
+        AscendC::GlobalTensor<ElementC> gS,
+        AscendC::GlobalTensor<int32_t> gBlockTable,
+        LayoutA layoutQ,
+        LayoutB layoutK,
+        LayoutC layoutS,
+        NpuArch::GemmCoord shape,
+        uint32_t absoluteTokenStart,
+        uint32_t pageSize,
+        uint32_t strideKv)
+    {
+        const uint32_t rows = shape.m();
+        const uint32_t tokenCount = shape.n();
+        const uint32_t embed = shape.k();
+        const uint32_t rowsRound =
+            RoundUp<L1AAlignHelper::M_ALIGNED>(rows);
+        LayoutAInL1 qL1Layout =
+            LayoutAInL1::template MakeLayout<ElementA>(rows, embed);
+        const uint32_t nLoops =
+            CeilDiv<L1TileShape::N>(tokenCount);
+
+        for (uint32_t nLoop = 0; nLoop < nLoops; ++nLoop) {
+            const uint32_t nActual =
+                nLoop + 1U < nLoops
+                    ? L1TileShape::N
+                    : tokenCount - nLoop * L1TileShape::N;
+            LayoutBInL1 kL1Layout =
+                LayoutBInL1::template MakeLayout<ElementB>(
+                    embed, nActual);
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(
+                this->l1KvPingPongFlag);
+
+            uint32_t copied = 0;
+            while (copied < nActual) {
+                const uint32_t logicalToken =
+                    absoluteTokenStart + nLoop * L1TileShape::N + copied;
+                const uint32_t logicalPage = logicalToken / pageSize;
+                const uint32_t pageOffset = logicalToken % pageSize;
+                const uint32_t physicalPage = static_cast<uint32_t>(
+                    gBlockTable.GetValue(logicalPage));
+                const uint32_t fragment =
+                    AscendC::Std::min(
+                        nActual - copied, pageSize - pageOffset);
+                const uint64_t physicalElementOffset =
+                    static_cast<uint64_t>(
+                        physicalPage * pageSize + pageOffset) *
+                    strideKv;
+
+                auto sourceLayout =
+                    layoutK.GetTileLayout(
+                        NpuArch::MakeCoord(embed, fragment));
+                NpuArch::MatrixCoord destinationCoord{0, copied};
+                auto destination =
+                    this->l1BTensor[this->l1KvPingPongFlag]
+                        [kL1Layout.GetOffset(destinationCoord)];
+                this->copyGmToL1B(
+                    destination,
+                    gK[physicalElementOffset],
+                    kL1Layout,
+                    sourceLayout);
+                copied += fragment;
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(
+                this->l1KvPingPongFlag);
+
+            const uint32_t mLoops =
+                CeilDiv<L0TileShape::M>(rows);
+            const uint32_t kLoops =
+                CeilDiv<L0TileShape::K>(embed);
+            for (uint32_t mLoop = 0; mLoop < mLoops; ++mLoop) {
+                const uint32_t mActual =
+                    mLoop + 1U < mLoops
+                        ? L0TileShape::M
+                        : rows - mLoop * L0TileShape::M;
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(
+                    this->l0CPingPongFlag);
+                for (uint32_t kLoop = 0; kLoop < kLoops; ++kLoop) {
+                    const uint32_t kActual =
+                        kLoop + 1U < kLoops
+                            ? L0TileShape::K
+                            : embed - kLoop * L0TileShape::K;
+                    LayoutAInL0 qL0Layout =
+                        LayoutAInL0::template MakeLayout<ElementA>(
+                            mActual, kActual);
+                    NpuArch::MatrixCoord qCoord{
+                        mLoop * L0TileShape::M,
+                        kLoop * L0TileShape::K};
+                    auto qL1 =
+                        this->l1ATensor[qL1Layout.GetOffset(qCoord)];
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag);
+                    this->copyL1ToL0A(
+                        this->l0ATensor[this->l0ABPingPongFlag],
+                        qL1,
+                        qL0Layout,
+                        qL1Layout);
+
+                    LayoutBInL0 kL0Layout =
+                        LayoutBInL0::template MakeLayout<ElementB>(
+                            kActual, nActual);
+                    NpuArch::MatrixCoord kCoord{
+                        kLoop * L0TileShape::K, 0};
+                    auto kL1 =
+                        this->l1BTensor[this->l1KvPingPongFlag]
+                            [kL1Layout.GetOffset(kCoord)];
+                    if (mLoop == 0U && kLoop == 0U) {
+                        AscendC::WaitFlag<
+                            AscendC::HardEvent::MTE2_MTE1>(
+                            this->l1KvPingPongFlag);
+                    }
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag + 2U);
+                    this->copyL1ToL0B(
+                        this->l0BTensor[this->l0ABPingPongFlag],
+                        kL1,
+                        kL0Layout,
+                        kL1Layout);
+                    if (mLoop + 1U == mLoops &&
+                        kLoop + 1U == kLoops) {
+                        AscendC::SetFlag<
+                            AscendC::HardEvent::MTE1_MTE2>(
+                            this->l1KvPingPongFlag);
+                    }
+
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(
+                        EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(
+                        EVENT_ID0);
+                    this->tileMmad(
+                        this->l0CTensor[this->l0CPingPongFlag],
+                        this->l0ATensor[this->l0ABPingPongFlag],
+                        this->l0BTensor[this->l0ABPingPongFlag],
+                        rowsRound,
+                        nActual,
+                        kActual,
+                        kLoop == 0U);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag + 2U);
+                    this->l0ABPingPongFlag =
+                        1U - this->l0ABPingPongFlag;
+                }
+
+                AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                NpuArch::MatrixCoord sCoord{
+                    mLoop * L0TileShape::M,
+                    nLoop * L1TileShape::N};
+                auto sTileLayout =
+                    layoutS.GetTileLayout(
+                        NpuArch::MakeCoord(mActual, nActual));
+                auto cLayout =
+                    LayoutCInL0::MakeLayoutInL0C(
+                        NpuArch::MakeCoord(mActual, nActual));
+                this->copyL0CToGm(
+                    gS[layoutS.GetOffset(sCoord)],
+                    this->l0CTensor[this->l0CPingPongFlag],
+                    sTileLayout,
+                    cLayout);
+                AscendC::SetFlag<AscendC::HardEvent::FIX_M>(
+                    this->l0CPingPongFlag);
+                this->l0CPingPongFlag =
+                    1U - this->l0CPingPongFlag;
+            }
+            this->l1KvPingPongFlag =
+                1U - this->l1KvPingPongFlag;
+        }
+    }
+};
+
+template <class BaseMmad>
+class DirectPagedPvMmad : public BaseMmad {
+public:
+    using ArchTag = typename BaseMmad::ArchTag;
+    using L1TileShape = typename BaseMmad::L1TileShape;
+    using L0TileShape = typename BaseMmad::L0TileShape;
+    using ElementA = typename BaseMmad::ElementA;
+    using ElementB = typename BaseMmad::ElementB;
+    using ElementC = typename BaseMmad::ElementC;
+    using LayoutA = typename BaseMmad::LayoutA;
+    using LayoutB = typename BaseMmad::LayoutB;
+    using LayoutC = typename BaseMmad::LayoutC;
+    using LayoutAInL1 = typename BaseMmad::LayoutAInL1;
+    using LayoutBInL1 = typename BaseMmad::LayoutBInL1;
+    using LayoutAInL0 = typename BaseMmad::LayoutAInL0;
+    using LayoutBInL0 = typename BaseMmad::LayoutBInL0;
+    using LayoutCInL0 = typename BaseMmad::LayoutCInL0;
+    using L1AAlignHelper = typename BaseMmad::L1AAlignHelper;
+
+    __aicore__ inline explicit DirectPagedPvMmad(
+        NpuArch::Arch::Resource<ArchTag>& resource,
+        uint32_t l1Offset = 0)
+        : BaseMmad(resource, l1Offset)
+    {
+    }
+
+    __aicore__ inline void operator()(
+        AscendC::GlobalTensor<ElementA> gP,
+        AscendC::GlobalTensor<ElementB> gV,
+        AscendC::GlobalTensor<ElementC> gOTmp,
+        AscendC::GlobalTensor<int32_t> gBlockTable,
+        LayoutA layoutP,
+        LayoutB layoutV,
+        LayoutC layoutOTmp,
+        NpuArch::GemmCoord shape,
+        uint32_t absoluteTokenStart,
+        uint32_t pageSize,
+        uint32_t strideKv,
+        NpuArch::Arch::CrossCoreFlag softmaxReady)
+    {
+        const uint32_t rows = shape.m();
+        const uint32_t embed = shape.n();
+        const uint32_t tokenCount = shape.k();
+        LayoutBInL1 vL1Layout =
+            LayoutBInL1::template MakeLayout<ElementB>(
+                tokenCount, embed);
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+        uint32_t copied = 0;
+        while (copied < tokenCount) {
+            const uint32_t logicalToken =
+                absoluteTokenStart + copied;
+            const uint32_t logicalPage = logicalToken / pageSize;
+            const uint32_t pageOffset = logicalToken % pageSize;
+            const uint32_t physicalPage = static_cast<uint32_t>(
+                gBlockTable.GetValue(logicalPage));
+            const uint32_t fragment =
+                AscendC::Std::min(
+                    tokenCount - copied, pageSize - pageOffset);
+            const uint64_t physicalElementOffset =
+                static_cast<uint64_t>(
+                    physicalPage * pageSize + pageOffset) *
+                strideKv;
+            auto sourceLayout =
+                layoutV.GetTileLayout(
+                    NpuArch::MakeCoord(fragment, embed));
+            NpuArch::MatrixCoord destinationCoord{copied, 0};
+            auto destination =
+                this->l1BTensor[
+                    vL1Layout.GetOffset(destinationCoord)];
+            this->copyGmToL1B(
+                destination,
+                gV[physicalElementOffset],
+                vL1Layout,
+                sourceLayout);
+            copied += fragment;
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID0);
+        NpuArch::Arch::CrossCoreWaitFlag(softmaxReady);
+
+        const uint32_t mLoops =
+            CeilDiv<L1TileShape::M>(rows);
+        const uint32_t kLoops =
+            CeilDiv<L1TileShape::K>(tokenCount);
+        for (uint32_t mLoop = 0; mLoop < mLoops; ++mLoop) {
+            const uint32_t mActual =
+                mLoop + 1U < mLoops
+                    ? L1TileShape::M
+                    : rows - mLoop * L1TileShape::M;
+            const uint32_t mRound =
+                RoundUp<L1AAlignHelper::M_ALIGNED>(mActual);
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(
+                this->l0CPingPongFlag);
+
+            for (uint32_t kLoop = 0; kLoop < kLoops; ++kLoop) {
+                const uint32_t kActual =
+                    kLoop + 1U < kLoops
+                        ? L1TileShape::K
+                        : tokenCount - kLoop * L1TileShape::K;
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(
+                    this->l1PPingPongFlag);
+                NpuArch::MatrixCoord pCoord{
+                    mLoop * L1TileShape::M,
+                    kLoop * L1TileShape::K};
+                auto pGm = gP[layoutP.GetOffset(pCoord)];
+                auto pTileLayout =
+                    layoutP.GetTileLayout(
+                        NpuArch::MakeCoord(mActual, kActual));
+                LayoutAInL1 pL1Layout =
+                    LayoutAInL1::template MakeLayout<ElementA>(
+                        mActual, kActual);
+                this->copyGmToL1A(
+                    this->l1ATensor[this->l1PPingPongFlag],
+                    pGm,
+                    pL1Layout,
+                    pTileLayout);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(
+                    this->l1PPingPongFlag);
+
+                const uint32_t kL0Loops =
+                    CeilDiv<L0TileShape::K>(kActual);
+                for (uint32_t kL0Loop = 0;
+                     kL0Loop < kL0Loops;
+                     ++kL0Loop) {
+                    const uint32_t kL0Actual =
+                        kL0Loop + 1U < kL0Loops
+                            ? L0TileShape::K
+                            : kActual - kL0Loop * L0TileShape::K;
+                    LayoutAInL0 pL0Layout =
+                        LayoutAInL0::template MakeLayout<ElementA>(
+                            mActual, kL0Actual);
+                    NpuArch::MatrixCoord pL1Coord{
+                        0, kL0Loop * L0TileShape::K};
+                    auto pL1 =
+                        this->l1ATensor[this->l1PPingPongFlag]
+                            [pL1Layout.GetOffset(pL1Coord)];
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag);
+                    if (kL0Loop == 0U) {
+                        AscendC::WaitFlag<
+                            AscendC::HardEvent::MTE2_MTE1>(
+                            this->l1PPingPongFlag);
+                    }
+                    this->copyL1ToL0A(
+                        this->l0ATensor[this->l0ABPingPongFlag],
+                        pL1,
+                        pL0Layout,
+                        pL1Layout);
+                    if (kL0Loop + 1U == kL0Loops) {
+                        AscendC::SetFlag<
+                            AscendC::HardEvent::MTE1_MTE2>(
+                            this->l1PPingPongFlag);
+                    }
+
+                    LayoutBInL0 vL0Layout =
+                        LayoutBInL0::template MakeLayout<ElementB>(
+                            kL0Actual, embed);
+                    NpuArch::MatrixCoord vL1Coord{
+                        kLoop * L1TileShape::K +
+                            kL0Loop * L0TileShape::K,
+                        0};
+                    auto vL1 =
+                        this->l1BTensor[
+                            vL1Layout.GetOffset(vL1Coord)];
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag + 2U);
+                    this->copyL1ToL0B(
+                        this->l0BTensor[this->l0ABPingPongFlag],
+                        vL1,
+                        vL0Layout,
+                        vL1Layout);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(
+                        EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(
+                        EVENT_ID0);
+                    this->tileMmad(
+                        this->l0CTensor[this->l0CPingPongFlag],
+                        this->l0ATensor[this->l0ABPingPongFlag],
+                        this->l0BTensor[this->l0ABPingPongFlag],
+                        mRound,
+                        embed,
+                        kL0Actual,
+                        kLoop == 0U && kL0Loop == 0U);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(
+                        this->l0ABPingPongFlag + 2U);
+                    this->l0ABPingPongFlag =
+                        1U - this->l0ABPingPongFlag;
+                }
+                this->l1PPingPongFlag =
+                    1U - this->l1PPingPongFlag;
+            }
+
+            AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+            NpuArch::MatrixCoord oCoord{
+                mLoop * L0TileShape::M, 0};
+            auto oTileLayout =
+                layoutOTmp.GetTileLayout(
+                    NpuArch::MakeCoord(mActual, embed));
+            auto cLayout =
+                LayoutCInL0::MakeLayoutInL0C(
+                    NpuArch::MakeCoord(mActual, embed));
+            this->copyL0CToGm(
+                gOTmp[layoutOTmp.GetOffset(oCoord)],
+                this->l0CTensor[this->l0CPingPongFlag],
+                oTileLayout,
+                cLayout);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(
+                this->l0CPingPongFlag);
+            this->l0CPingPongFlag =
+                1U - this->l0CPingPongFlag;
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+    }
+};
+
+}  // namespace TrianglePaged
+
+#endif  // TRIANGLE_PAGED_ATTENTION_BLOCK_MMAD_H

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_fia_fast_path.h
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_fia_fast_path.h
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is licensed under CANN Open Software License Agreement
+ * Version 2.0. See LICENSE in the repository root.
+ */
+#ifndef TRIANGLE_PAGED_ATTENTION_FIA_FAST_PATH_H
+#define TRIANGLE_PAGED_ATTENTION_FIA_FAST_PATH_H
+
+#include "triangle_paged_block_mmad.h"
+#include "triangle_paged_sparse_attention_tiling.h"
+#include "triangle_schedule.h"
+
+namespace TrianglePaged {
+
+using namespace AscendC;
+using namespace NpuArch;
+
+constexpr uint32_t kFastImplementation = 2;
+constexpr uint32_t kKvTile = 512;
+constexpr uint32_t kCubeInnerKvTile = 128;
+constexpr uint32_t kGroupSize = kQueryHeads / kKvHeads;
+constexpr uint32_t kCubeRows = kQueryTile * kGroupSize;
+constexpr uint32_t kWorkspaceAlignment = 512;
+
+enum class IntervalKind : uint32_t {
+    kSink = 0,
+    kLocal = 1,
+    kDense = 2,
+};
+
+__aicore__ inline uint32_t IntervalTileCount(KvInterval interval)
+{
+    const uint32_t length = interval.end - interval.begin;
+    return (length + kKvTile - 1U) / kKvTile;
+}
+
+__aicore__ inline bool NeedsBoundaryMask(
+    IntervalKind kind,
+    uint32_t keyBegin,
+    uint32_t keyEnd,
+    uint32_t qBegin,
+    uint32_t qEnd,
+    uint32_t windowTokens)
+{
+    if (kind == IntervalKind::kSink) {
+        return false;
+    }
+    if (keyEnd > qBegin + 1U) {
+        return true;
+    }
+    if (kind == IntervalKind::kLocal) {
+        const uint32_t latestLower =
+            qEnd - 1U > windowTokens
+                ? qEnd - 1U - windowTokens
+                : 0U;
+        return keyBegin < latestLower;
+    }
+    return false;
+}
+
+class TrianglePagedFiaFastPath {
+private:
+    using ArchTag = NpuArch::Arch::AtlasA2;
+    using Element = bfloat16_t;
+    using LayoutQ = NpuArch::layout::RowMajor;
+    using LayoutK = NpuArch::layout::ColumnMajor;
+    using LayoutV = NpuArch::layout::RowMajor;
+    using LayoutS = NpuArch::layout::RowMajor;
+    using LayoutP = NpuArch::layout::RowMajor;
+    using LayoutO = NpuArch::layout::RowMajor;
+    using LayoutOTmp = NpuArch::layout::RowMajor;
+    using LayoutUpdate = NpuArch::layout::RowMajor;
+    using LayoutLse = NpuArch::layout::RowMajor;
+    using LayoutMask = NpuArch::layout::RowMajor;
+
+    using QType = NpuArch::Gemm::GemmType<Element, LayoutQ>;
+    using KType = NpuArch::Gemm::GemmType<Element, LayoutK>;
+    using VType = NpuArch::Gemm::GemmType<Element, LayoutV>;
+    using SType = NpuArch::Gemm::GemmType<float, LayoutS>;
+    using PType = NpuArch::Gemm::GemmType<Element, LayoutP>;
+    using OType = NpuArch::Gemm::GemmType<Element, LayoutO>;
+    using OTmpType = NpuArch::Gemm::GemmType<float, LayoutOTmp>;
+    using UpdateType = NpuArch::Gemm::GemmType<float, LayoutUpdate>;
+    using LseType = NpuArch::Gemm::GemmType<float, LayoutLse>;
+    using MaskType = NpuArch::Gemm::GemmType<int8_t, LayoutMask>;
+
+    using QkL1Shape =
+        NpuArch::GemmShape<
+            kCubeRows, kCubeInnerKvTile, kHeadDim>;
+    using QkL0Shape =
+        NpuArch::GemmShape<
+            kCubeRows, kCubeInnerKvTile, kHeadDim>;
+    using QkPolicy =
+        NpuArch::Gemm::MmadAtlasA2SFAIQK<false, false>;
+    using QkBase = NpuArch::Gemm::Block::BlockMmad<
+        QkPolicy, QkL1Shape, QkL0Shape, QType, KType, SType>;
+    using QkMmad = DirectPagedQkMmad<QkBase>;
+
+    // The outer KV tile is 512, but Atlas A2 L0 ping-pong stages can hold
+    // only 128 BF16 K/N elements for this M=128 geometry.  Keep Cube tiles
+    // at 128: QK naturally emits four score sub-tiles, and PV accumulates four
+    // K=128 MMADs into one output tile.
+    using PvL1Shape =
+        NpuArch::GemmShape<kCubeRows, kHeadDim, kKvTile>;
+    using PvL0Shape =
+        NpuArch::GemmShape<
+            kCubeRows, kHeadDim, kCubeInnerKvTile>;
+    using PvPolicy =
+        NpuArch::Gemm::MmadAtlasA2SFAIPV<false, false>;
+    using PvBase = NpuArch::Gemm::Block::BlockMmad<
+        PvPolicy, PvL1Shape, PvL0Shape, PType, VType, OTmpType>;
+    using PvMmad = DirectPagedPvMmad<PvBase>;
+
+    static constexpr uint32_t kQkL1Bytes =
+        QkBase::L1A_SIZE + QkBase::L1B_SIZE * QkBase::STAGES;
+    static constexpr uint32_t kPvL1Bytes =
+        PvBase::L1A_SIZE * PvBase::STAGES + PvBase::L1B_SIZE;
+    static_assert(
+        kQkL1Bytes + kPvL1Bytes <= ArchTag::L1_SIZE,
+        "QK and PV L1 allocations exceed Atlas A2 L1");
+
+    static constexpr uint32_t kQkL0ARequired =
+        QkL0Shape::M * QkL0Shape::K * sizeof(Element);
+    static constexpr uint32_t kQkL0BRequired =
+        QkL0Shape::N * QkL0Shape::K * sizeof(Element);
+    static constexpr uint32_t kQkL0CRequired =
+        QkL0Shape::M * QkL0Shape::N * sizeof(float);
+    static constexpr uint32_t kPvL0ARequired =
+        PvL0Shape::M * PvL0Shape::K * sizeof(Element);
+    static constexpr uint32_t kPvL0BRequired =
+        PvL0Shape::N * PvL0Shape::K * sizeof(Element);
+    static constexpr uint32_t kPvL0CRequired =
+        PvL0Shape::M * PvL0Shape::N * sizeof(float);
+    static_assert(
+        kQkL0ARequired <= QkBase::L0A_PINGPONG_BUF_SIZE &&
+            kQkL0BRequired <= QkBase::L0B_PINGPONG_BUF_SIZE &&
+            kQkL0CRequired <= QkBase::L0C_PINGPONG_BUF_SIZE,
+        "QK L0 tile exceeds an Atlas A2 ping-pong stage");
+    static_assert(
+        kPvL0ARequired <= PvBase::L0A_PINGPONG_BUF_SIZE &&
+            kPvL0BRequired <= PvBase::L0B_PINGPONG_BUF_SIZE &&
+            kPvL0CRequired <= PvBase::L0C_PINGPONG_BUF_SIZE,
+        "PV L0 tile exceeds an Atlas A2 ping-pong stage");
+
+    using SoftmaxPolicy =
+        NpuArch::Epilogue::EpilogueAtlasA2OnlineSoftmax<
+            NpuArch::Epilogue::LseMode::NONE, float>;
+    using OnlineSoftmax =
+        NpuArch::Epilogue::Block::BlockEpilogue<
+            SoftmaxPolicy, PType, SType, MaskType>;
+    using RescalePolicy =
+        NpuArch::Epilogue::EpilogueAtlasA2RescaleO<
+            NpuArch::Epilogue::LseMode::NONE, float>;
+    using RescaleOutput =
+        NpuArch::Epilogue::Block::BlockEpilogue<
+            RescalePolicy, OType, OTmpType, UpdateType, LseType>;
+
+public:
+    __aicore__ inline void Init(
+        GM_ADDR query,
+        GM_ADDR keyCache,
+        GM_ADDR valueCache,
+        GM_ADDR blockTable,
+        GM_ADDR attentionOut,
+        GM_ADDR workspace,
+        const TrianglePagedSparseAttentionTilingData& tiling)
+    {
+        tiling_ = tiling;
+        const uint64_t queryElements =
+            static_cast<uint64_t>(tiling_.queryTokens) *
+            kQueryHeads * kHeadDim;
+        const uint64_t cacheElements =
+            static_cast<uint64_t>(tiling_.physicalPageCount) *
+            kPageSize * kKvHeads * kHeadDim;
+        query_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ Element*>(query), queryElements);
+        key_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ Element*>(keyCache), cacheElements);
+        value_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ Element*>(valueCache), cacheElements);
+        blockTable_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ int32_t*>(blockTable),
+            tiling_.blockTablePageCapacity);
+        output_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ Element*>(attentionOut),
+            queryElements);
+
+#ifdef __DAV_C220_VEC__
+        coreIndex_ = GetBlockIdx() / GetSubBlockNum();
+#else
+        coreIndex_ = GetBlockIdx();
+#endif
+        __gm__ uint8_t* coreWorkspace =
+            reinterpret_cast<__gm__ uint8_t*>(workspace) +
+            static_cast<uint64_t>(coreIndex_) *
+                tiling_.workspacePerCoreBytes;
+        score_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ float*>(
+                coreWorkspace + tiling_.scoreOffsetBytes));
+        probability_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ Element*>(
+                coreWorkspace + tiling_.probabilityOffsetBytes));
+        outputTmp_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ float*>(
+                coreWorkspace + tiling_.outputTmpOffsetBytes));
+        outputUpdate_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ float*>(
+                coreWorkspace + tiling_.outputUpdateOffsetBytes));
+        lseScratch_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ float*>(
+                coreWorkspace + tiling_.lseScratchOffsetBytes));
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (tiling_.implementationStatus != kFastImplementation ||
+            tiling_.abiVersion != 2U ||
+            tiling_.queryTile != kQueryTile ||
+            tiling_.kvTile != kKvTile ||
+            tiling_.groupSize != kGroupSize) {
+            return;
+        }
+
+#ifdef __DAV_C220_CUBE__
+        InitCubeEvents();
+        QkMmad qk(resource_);
+        PvMmad pv(resource_, kQkL1Bytes);
+#endif
+#ifdef __DAV_C220_VEC__
+        InitVectorEvents();
+        OnlineSoftmax onlineSoftmax(resource_, tiling_.scale);
+        RescaleOutput rescaleOutput(resource_);
+#endif
+
+        NpuArch::Arch::CrossCoreFlag qkReady(1);
+        NpuArch::Arch::CrossCoreFlag softmaxReady(2);
+        NpuArch::Arch::CrossCoreFlag pvReady(3);
+
+        for (uint32_t task = coreIndex_;
+             task < tiling_.taskCount;
+             task += tiling_.activeAicCores) {
+            const uint32_t queryTileIndex = task / kKvHeads;
+            const uint32_t kvHead = task % kKvHeads;
+            const uint32_t queryRow =
+                queryTileIndex * kQueryTile;
+            const uint32_t queryTileTokens =
+                MinU32(kQueryTile, tiling_.queryTokens - queryRow);
+            const uint32_t queryTileBegin =
+                tiling_.queryStart + queryRow;
+            const uint32_t queryTileEnd =
+                queryTileBegin + queryTileTokens;
+            const uint64_t kvHeadOffset =
+                static_cast<uint64_t>(kvHead) * kHeadDim;
+
+            const QuerySpanSchedule querySpans = SplitQueryTile(
+                queryTileBegin,
+                queryTileEnd,
+                tiling_.sparseBegin,
+                tiling_.sparseEnd);
+            for (uint32_t spanIndex = 0;
+                 spanIndex < querySpans.count;
+                 ++spanIndex) {
+                const QuerySpan querySpan =
+                    querySpans.span[spanIndex];
+                const uint32_t spanQueryRow =
+                    queryRow + querySpan.begin - queryTileBegin;
+                const uint32_t queryTokens =
+                    querySpan.end - querySpan.begin;
+                const uint32_t qBegin = querySpan.begin;
+                const uint32_t qEnd = querySpan.end;
+                const uint32_t rows = queryTokens * kGroupSize;
+                const uint64_t queryOffset =
+                    (static_cast<uint64_t>(spanQueryRow) *
+                         kQueryHeads +
+                     kvHead * kGroupSize) *
+                    kHeadDim;
+
+            const TileSchedule schedule = BuildTileSchedule(
+                qBegin,
+                qEnd,
+                tiling_.seqLen,
+                tiling_.sparseBegin,
+                tiling_.sparseEnd,
+                tiling_.sinkTokens,
+                tiling_.localWindow);
+            uint32_t totalTiles = 0;
+            for (uint32_t interval = 0;
+                 interval < schedule.count;
+                 ++interval) {
+                totalTiles +=
+                    IntervalTileCount(schedule.interval[interval]);
+            }
+            if (totalTiles == 0U) {
+                continue;
+            }
+
+#ifdef __DAV_C220_CUBE__
+            LayoutQ layoutQ(rows, kHeadDim);
+            uint32_t groupHeads = kGroupSize;
+            qk.loadQGM(
+                query_[queryOffset],
+                layoutQ,
+                rows,
+                groupHeads,
+                static_cast<uint64_t>(kQueryHeads * kHeadDim));
+#endif
+
+            uint32_t tileOrdinal = 0;
+            for (uint32_t intervalIndex = 0;
+                 intervalIndex < schedule.count;
+                 ++intervalIndex) {
+                const KvInterval interval =
+                    schedule.interval[intervalIndex];
+                const IntervalKind kind =
+                    querySpan.sparse == 0U
+                        ? IntervalKind::kDense
+                        : (interval.begin == 0U &&
+                                   interval.end <= tiling_.sinkTokens
+                               ? IntervalKind::kSink
+                               : IntervalKind::kLocal);
+                const uint32_t tiles =
+                    IntervalTileCount(interval);
+                for (uint32_t tile = 0; tile < tiles; ++tile) {
+                    const uint32_t keyBegin =
+                        interval.begin + tile * kKvTile;
+                    const uint32_t keyCount =
+                        MinU32(kKvTile, interval.end - keyBegin);
+                    const uint32_t keyEnd = keyBegin + keyCount;
+                    const bool first = tileOrdinal == 0U;
+                    const bool last =
+                        tileOrdinal + 1U == totalTiles;
+                    const bool boundaryMask = NeedsBoundaryMask(
+                        kind,
+                        keyBegin,
+                        keyEnd,
+                        qBegin,
+                        qEnd,
+                        tiling_.localWindow);
+
+                    LayoutS layoutS(rows, keyCount, kKvTile);
+                    NpuArch::GemmCoord qkShape{
+                        rows, keyCount, kHeadDim};
+#ifdef __DAV_C220_CUBE__
+                    LayoutK layoutK(
+                        kKvHeads * kHeadDim, kKvTile);
+                    qk(
+                        query_[queryOffset],
+                        key_[kvHeadOffset],
+                        score_,
+                        blockTable_,
+                        layoutQ,
+                        layoutK,
+                        layoutS,
+                        qkShape,
+                        keyBegin,
+                        kPageSize,
+                        kKvHeads * kHeadDim);
+                    NpuArch::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(
+                        qkReady);
+#endif
+#ifdef __DAV_C220_VEC__
+                    NpuArch::Arch::CrossCoreWaitFlag(qkReady);
+                    const uint32_t proceduralMaskMode =
+                        !boundaryMask
+                            ? 0U
+                            : (kind == IntervalKind::kLocal ? 2U : 1U);
+                    const NpuArch::Epilogue::Block::
+                        ProceduralBoundaryMaskParams proceduralMask{
+                            proceduralMaskMode,
+                            qBegin,
+                            keyBegin,
+                            tiling_.localWindow};
+                    LayoutP layoutP(rows, keyCount, kKvTile);
+                    onlineSoftmax(
+                        probability_,
+                        score_,
+                        layoutP,
+                        layoutS,
+                        qkShape,
+                        first,
+                        0,
+                        queryTokens,
+                        kGroupSize,
+                        0,
+                        softmaxReady,
+                        proceduralMask);
+#endif
+
+                    NpuArch::GemmCoord pvShape{
+                        rows, kHeadDim, keyCount};
+                    LayoutOTmp layoutOTmp(
+                        rows, kHeadDim, kHeadDim);
+#ifdef __DAV_C220_CUBE__
+                    LayoutP layoutP(rows, keyCount, kKvTile);
+                    LayoutV layoutV(kKvTile, kKvHeads * kHeadDim);
+                    pv(
+                        probability_,
+                        value_[kvHeadOffset],
+                        outputTmp_,
+                        blockTable_,
+                        layoutP,
+                        layoutV,
+                        layoutOTmp,
+                        pvShape,
+                        keyBegin,
+                        kPageSize,
+                        kKvHeads * kHeadDim,
+                        softmaxReady);
+                    NpuArch::Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(
+                        pvReady);
+#endif
+#ifdef __DAV_C220_VEC__
+                    LayoutO layoutO(
+                        tiling_.queryTokens,
+                        kQueryHeads * kHeadDim);
+                    LayoutUpdate layoutUpdate(
+                        rows, kHeadDim, kHeadDim);
+                    LayoutLse layoutLse(
+                        tiling_.queryTokens, kQueryHeads);
+                    NpuArch::Arch::CrossCoreWaitFlag(pvReady);
+                    rescaleOutput(
+                        output_[queryOffset],
+                        outputTmp_,
+                        outputUpdate_,
+                        lseScratch_,
+                        layoutO,
+                        layoutOTmp,
+                        layoutUpdate,
+                        layoutLse,
+                        pvShape,
+                        queryTokens,
+                        kGroupSize,
+                        first,
+                        last,
+                        0);
+#endif
+                    ++tileOrdinal;
+                }
+            }
+        }
+        }
+        FinalizeEvents();
+    }
+
+private:
+    __aicore__ inline void InitCubeEvents()
+    {
+#ifdef __DAV_C220_CUBE__
+        for (uint32_t event = 0; event < 8U; ++event) {
+            SetFlag<HardEvent::M_MTE1>(event);
+            SetFlag<HardEvent::MTE1_MTE2>(event);
+        }
+        SetFlag<HardEvent::FIX_M>(EVENT_ID0);
+        SetFlag<HardEvent::FIX_M>(EVENT_ID1);
+#endif
+    }
+
+    __aicore__ inline void InitVectorEvents()
+    {
+#ifdef __DAV_C220_VEC__
+        SetFlag<HardEvent::MTE3_V>(EVENT_ID0);
+        SetFlag<HardEvent::MTE3_V>(EVENT_ID1);
+        SetFlag<HardEvent::MTE3_V>(EVENT_ID2);
+        SetFlag<HardEvent::MTE3_V>(EVENT_ID4);
+        SetFlag<HardEvent::MTE3_MTE2>(EVENT_ID2);
+        SetFlag<HardEvent::MTE3_MTE2>(EVENT_ID3);
+        SetFlag<HardEvent::MTE3_MTE2>(EVENT_ID4);
+        SetFlag<HardEvent::MTE3_MTE2>(EVENT_ID5);
+        SetFlag<HardEvent::MTE3_MTE2>(EVENT_ID6);
+        SetFlag<HardEvent::V_MTE2>(EVENT_ID0);
+        SetFlag<HardEvent::V_MTE2>(EVENT_ID1);
+        SetFlag<HardEvent::V_MTE2>(EVENT_ID2);
+        SetFlag<HardEvent::V_MTE2>(EVENT_ID3);
+#endif
+    }
+
+    /*
+     * Event tokens are resources, not just ordering annotations.  Drain the
+     * same tokens initialized above before the MIX kernel returns; in
+     * particular MTE3_MTE2(EVENT_ID6) is produced only after the final
+     * rescale CopyOToGm has completed.
+     */
+    __aicore__ inline void FinalizeEvents()
+    {
+#ifdef __DAV_C220_CUBE__
+        for (uint32_t event = 0; event < 8U; ++event) {
+            WaitFlag<HardEvent::M_MTE1>(event);
+        }
+        WaitFlag<HardEvent::FIX_M>(EVENT_ID0);
+        WaitFlag<HardEvent::FIX_M>(EVENT_ID1);
+        for (uint32_t event = 0; event < 8U; ++event) {
+            WaitFlag<HardEvent::MTE1_MTE2>(event);
+        }
+#endif
+#ifdef __DAV_C220_VEC__
+        WaitFlag<HardEvent::MTE3_MTE2>(EVENT_ID2);
+        WaitFlag<HardEvent::MTE3_MTE2>(EVENT_ID3);
+        WaitFlag<HardEvent::MTE3_MTE2>(EVENT_ID4);
+        WaitFlag<HardEvent::MTE3_MTE2>(EVENT_ID5);
+        WaitFlag<HardEvent::MTE3_MTE2>(EVENT_ID6);
+
+        WaitFlag<HardEvent::MTE3_V>(EVENT_ID0);
+        WaitFlag<HardEvent::MTE3_V>(EVENT_ID1);
+        WaitFlag<HardEvent::MTE3_V>(EVENT_ID2);
+        WaitFlag<HardEvent::MTE3_V>(EVENT_ID4);
+        WaitFlag<HardEvent::V_MTE2>(EVENT_ID0);
+        WaitFlag<HardEvent::V_MTE2>(EVENT_ID1);
+        WaitFlag<HardEvent::V_MTE2>(EVENT_ID2);
+        WaitFlag<HardEvent::V_MTE2>(EVENT_ID3);
+#endif
+        PipeBarrier<PIPE_ALL>();
+    }
+
+    TrianglePagedSparseAttentionTilingData tiling_{};
+    uint32_t coreIndex_{0};
+    NpuArch::Arch::Resource<ArchTag> resource_;
+
+    GlobalTensor<Element> query_;
+    GlobalTensor<Element> key_;
+    GlobalTensor<Element> value_;
+    GlobalTensor<int32_t> blockTable_;
+    GlobalTensor<Element> output_;
+    GlobalTensor<float> score_;
+    GlobalTensor<Element> probability_;
+    GlobalTensor<float> outputTmp_;
+    GlobalTensor<float> outputUpdate_;
+    GlobalTensor<float> lseScratch_;
+};
+
+}  // namespace TrianglePaged
+
+#endif  // TRIANGLE_PAGED_ATTENTION_FIA_FAST_PATH_H

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_sparse_attention.cpp
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_sparse_attention.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is licensed under CANN Open Software License Agreement
+ * Version 2.0. See LICENSE in the repository root.
+ */
+#include "kernel_operator.h"
+
+#include "fia_paged_kv_address.h"
+#include "triangle_paged_fia_fast_path.h"
+#include "triangle_schedule.h"
+#include "triangle_paged_sparse_attention_tiling.h"
+
+namespace TrianglePaged {
+
+using namespace AscendC;
+
+/*
+ * This is a deliberately bounded numerical reference kernel.  Its purpose is
+ * to establish the paged-KV and Triangle softmax correctness contract before
+ * the hot path is replaced by the FIA Cube/Vector pipeline.
+ *
+ * It is a real attention implementation: skipped Middle tokens are never read
+ * for QK or PV, and sink/local logits share one softmax normalization domain.
+ * It is not a performance claim: the dot-product and scalar reductions use
+ * LocalTensor::GetValue().
+ */
+#ifdef TRIANGLE_ENABLE_AIV_REFERENCE
+constexpr uint32_t kReferenceImplementation = 1;
+constexpr uint32_t kReferenceMaxSequenceLength = 2048;
+
+struct RowSchedule {
+    KvInterval interval[2];
+    uint32_t count;
+    uint32_t keyCount;
+};
+
+__aicore__ inline uint32_t MaxU32(uint32_t a, uint32_t b)
+{
+    return a > b ? a : b;
+}
+
+__aicore__ inline RowSchedule BuildRowSchedule(
+    uint32_t queryPosition,
+    const TrianglePagedSparseAttentionTilingData& tiling)
+{
+    RowSchedule result{};
+    const uint32_t causalEnd = MinU32(queryPosition + 1, tiling.seqLen);
+    const bool sparse =
+        queryPosition >= tiling.sparseBegin &&
+        queryPosition < tiling.sparseEnd;
+
+    if (!sparse) {
+        result.interval[0] = {0, causalEnd};
+        result.count = causalEnd == 0 ? 0 : 1;
+        result.keyCount = causalEnd;
+        return result;
+    }
+
+    const uint32_t sinkEnd = MinU32(tiling.sinkTokens, causalEnd);
+    const uint32_t localBeginRaw =
+        queryPosition > tiling.localWindow
+            ? queryPosition - tiling.localWindow
+            : 0;
+
+    // Merge overlap so a sink token is normalized and accumulated only once.
+    if (localBeginRaw <= sinkEnd) {
+        result.interval[0] = {0, causalEnd};
+        result.count = causalEnd == 0 ? 0 : 1;
+        result.keyCount = causalEnd;
+        return result;
+    }
+
+    result.interval[0] = {0, sinkEnd};
+    result.interval[1] = {localBeginRaw, causalEnd};
+    result.count = (sinkEnd == 0 ? 0 : 1) +
+                   (localBeginRaw < causalEnd ? 1 : 0);
+    result.keyCount =
+        sinkEnd + (causalEnd > localBeginRaw
+                       ? causalEnd - localBeginRaw
+                       : 0);
+    if (sinkEnd == 0 && localBeginRaw < causalEnd) {
+        result.interval[0] = result.interval[1];
+    }
+    return result;
+}
+
+class TrianglePagedSparseAttentionReference {
+public:
+    __aicore__ inline void Init(
+        GM_ADDR query,
+        GM_ADDR keyCache,
+        GM_ADDR valueCache,
+        GM_ADDR blockTable,
+        GM_ADDR attentionOut,
+        const TrianglePagedSparseAttentionTilingData& tilingData,
+        TPipe* pipe)
+    {
+        pipe_ = pipe;
+        tilingData_ = tilingData;
+
+        const uint64_t queryElements =
+            static_cast<uint64_t>(tilingData_.queryTokens) *
+            tilingData_.queryHeads * tilingData_.headDim;
+        const uint64_t cacheElements =
+            static_cast<uint64_t>(tilingData_.physicalPageCount) *
+            tilingData_.pageSize * tilingData_.kvHeads * tilingData_.headDim;
+
+        query_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ bfloat16_t*>(query), queryElements);
+        keyCache_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ bfloat16_t*>(keyCache), cacheElements);
+        valueCache_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ bfloat16_t*>(valueCache), cacheElements);
+        blockTable_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ int32_t*>(blockTable),
+            tilingData_.blockTablePageCapacity);
+        output_.SetGlobalBuffer(
+            reinterpret_cast<__gm__ bfloat16_t*>(attentionOut),
+            queryElements);
+
+        pipe_->InitBuffer(
+            queryInQueue_, 1, kHeadDim * sizeof(bfloat16_t));
+        pipe_->InitBuffer(
+            keyInQueue_, 1, kHeadDim * sizeof(bfloat16_t));
+        pipe_->InitBuffer(
+            valueInQueue_, 1, kHeadDim * sizeof(bfloat16_t));
+        pipe_->InitBuffer(
+            outputQueue_, 1, kHeadDim * sizeof(bfloat16_t));
+
+        pipe_->InitBuffer(queryFloatBuffer_, kHeadDim * sizeof(float));
+        pipe_->InitBuffer(kvFloatBuffer_, kHeadDim * sizeof(float));
+        pipe_->InitBuffer(productBuffer_, kHeadDim * sizeof(float));
+        pipe_->InitBuffer(outputFloatBuffer_, kHeadDim * sizeof(float));
+        pipe_->InitBuffer(
+            scoreBuffer_,
+            kReferenceMaxSequenceLength * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (tilingData_.implementationStatus != kReferenceImplementation ||
+            tilingData_.seqLen > kReferenceMaxSequenceLength) {
+            return;
+        }
+
+        const uint32_t core = GetBlockIdx();
+        for (uint32_t task = core; task < tilingData_.taskCount;
+             task += tilingData_.blockDim) {
+            ProcessTask(task);
+        }
+    }
+
+private:
+    __aicore__ inline float ComputeScore(
+        const LocalTensor<float>& queryFloat,
+        uint32_t logicalToken,
+        uint32_t kvHead)
+    {
+        const PagedKvLocation location = ResolvePagedBsndLocation(
+            blockTable_,
+            logicalToken,
+            kvHead,
+            tilingData_.pageSize,
+            tilingData_.kvHeads,
+            tilingData_.headDim);
+
+        LocalTensor<bfloat16_t> key =
+            keyInQueue_.AllocTensor<bfloat16_t>();
+        DataCopy(key, keyCache_[location.elementOffset], kHeadDim);
+        keyInQueue_.EnQue<bfloat16_t>(key);
+        key = keyInQueue_.DeQue<bfloat16_t>();
+
+        LocalTensor<float> kvFloat = kvFloatBuffer_.Get<float>();
+        LocalTensor<float> product = productBuffer_.Get<float>();
+        Cast(kvFloat, key, RoundMode::CAST_NONE, kHeadDim);
+        PipeBarrier<PIPE_V>();
+        Mul(product, queryFloat, kvFloat, kHeadDim);
+        PipeBarrier<PIPE_V>();
+
+        float score = 0.0F;
+        for (uint32_t d = 0; d < kHeadDim; ++d) {
+            score += product.GetValue(d);
+        }
+        keyInQueue_.FreeTensor(key);
+        return score * tilingData_.scale;
+    }
+
+    __aicore__ inline void AccumulateValue(
+        LocalTensor<float>& outputFloat,
+        uint32_t logicalToken,
+        uint32_t kvHead,
+        float weight)
+    {
+        const PagedKvLocation location = ResolvePagedBsndLocation(
+            blockTable_,
+            logicalToken,
+            kvHead,
+            tilingData_.pageSize,
+            tilingData_.kvHeads,
+            tilingData_.headDim);
+
+        LocalTensor<bfloat16_t> value =
+            valueInQueue_.AllocTensor<bfloat16_t>();
+        DataCopy(value, valueCache_[location.elementOffset], kHeadDim);
+        valueInQueue_.EnQue<bfloat16_t>(value);
+        value = valueInQueue_.DeQue<bfloat16_t>();
+
+        LocalTensor<float> kvFloat = kvFloatBuffer_.Get<float>();
+        Cast(kvFloat, value, RoundMode::CAST_NONE, kHeadDim);
+        PipeBarrier<PIPE_V>();
+        Muls(kvFloat, kvFloat, weight, kHeadDim);
+        PipeBarrier<PIPE_V>();
+        Add(outputFloat, outputFloat, kvFloat, kHeadDim);
+        PipeBarrier<PIPE_V>();
+        valueInQueue_.FreeTensor(value);
+    }
+
+    __aicore__ inline void ProcessTask(uint32_t task)
+    {
+        const uint32_t queryRow = task / tilingData_.queryHeads;
+        const uint32_t queryHead = task % tilingData_.queryHeads;
+        const uint32_t kvHead =
+            queryHead / (tilingData_.queryHeads / tilingData_.kvHeads);
+        const uint32_t queryPosition = tilingData_.queryStart + queryRow;
+        const uint64_t queryOffset =
+            (static_cast<uint64_t>(queryRow) * tilingData_.queryHeads +
+             queryHead) *
+            tilingData_.headDim;
+
+        const RowSchedule schedule =
+            BuildRowSchedule(queryPosition, tilingData_);
+        if (schedule.count == 0 || schedule.keyCount == 0 ||
+            schedule.keyCount > kReferenceMaxSequenceLength) {
+            return;
+        }
+
+        LocalTensor<bfloat16_t> query =
+            queryInQueue_.AllocTensor<bfloat16_t>();
+        DataCopy(query, query_[queryOffset], kHeadDim);
+        queryInQueue_.EnQue<bfloat16_t>(query);
+        query = queryInQueue_.DeQue<bfloat16_t>();
+
+        LocalTensor<float> queryFloat = queryFloatBuffer_.Get<float>();
+        LocalTensor<float> scores = scoreBuffer_.Get<float>();
+        Cast(queryFloat, query, RoundMode::CAST_NONE, kHeadDim);
+        PipeBarrier<PIPE_V>();
+
+        uint32_t scoreIndex = 0;
+        float rowMax = -3.402823466e+38F;
+        for (uint32_t intervalIndex = 0;
+             intervalIndex < schedule.count;
+             ++intervalIndex) {
+            const KvInterval interval = schedule.interval[intervalIndex];
+            for (uint32_t token = interval.begin; token < interval.end;
+                 ++token) {
+                const float score =
+                    ComputeScore(queryFloat, token, kvHead);
+                scores.SetValue(scoreIndex, score);
+                rowMax = score > rowMax ? score : rowMax;
+                ++scoreIndex;
+            }
+        }
+        queryInQueue_.FreeTensor(query);
+
+        Adds(scores, scores, -rowMax, scoreIndex);
+        PipeBarrier<PIPE_V>();
+        Exp(scores, scores, scoreIndex);
+        PipeBarrier<PIPE_V>();
+
+        float rowSum = 0.0F;
+        for (uint32_t i = 0; i < scoreIndex; ++i) {
+            rowSum += scores.GetValue(i);
+        }
+        Muls(scores, scores, 1.0F / rowSum, scoreIndex);
+        PipeBarrier<PIPE_V>();
+
+        LocalTensor<float> outputFloat =
+            outputFloatBuffer_.Get<float>();
+        Duplicate(outputFloat, 0.0F, kHeadDim);
+        PipeBarrier<PIPE_V>();
+
+        scoreIndex = 0;
+        for (uint32_t intervalIndex = 0;
+             intervalIndex < schedule.count;
+             ++intervalIndex) {
+            const KvInterval interval = schedule.interval[intervalIndex];
+            for (uint32_t token = interval.begin; token < interval.end;
+                 ++token) {
+                AccumulateValue(
+                    outputFloat,
+                    token,
+                    kvHead,
+                    scores.GetValue(scoreIndex));
+                ++scoreIndex;
+            }
+        }
+
+        LocalTensor<bfloat16_t> output =
+            outputQueue_.AllocTensor<bfloat16_t>();
+        Cast(output, outputFloat, RoundMode::CAST_RINT, kHeadDim);
+        outputQueue_.EnQue<bfloat16_t>(output);
+        output = outputQueue_.DeQue<bfloat16_t>();
+        DataCopy(output_[queryOffset], output, kHeadDim);
+        outputQueue_.FreeTensor(output);
+    }
+
+    TPipe* pipe_{nullptr};
+    TrianglePagedSparseAttentionTilingData tilingData_{};
+
+    GlobalTensor<bfloat16_t> query_;
+    GlobalTensor<bfloat16_t> keyCache_;
+    GlobalTensor<bfloat16_t> valueCache_;
+    GlobalTensor<int32_t> blockTable_;
+    GlobalTensor<bfloat16_t> output_;
+
+    TQue<QuePosition::VECIN, 1> queryInQueue_;
+    TQue<QuePosition::VECIN, 1> keyInQueue_;
+    TQue<QuePosition::VECIN, 1> valueInQueue_;
+    TQue<QuePosition::VECOUT, 1> outputQueue_;
+
+    TBuf<TPosition::VECCALC> queryFloatBuffer_;
+    TBuf<TPosition::VECCALC> kvFloatBuffer_;
+    TBuf<TPosition::VECCALC> productBuffer_;
+    TBuf<TPosition::VECCALC> outputFloatBuffer_;
+    TBuf<TPosition::VECCALC> scoreBuffer_;
+};
+#endif  // TRIANGLE_ENABLE_AIV_REFERENCE
+
+}  // namespace TrianglePaged
+
+extern "C" __global__ __aicore__ void triangle_paged_sparse_attention(
+    GM_ADDR query,
+    GM_ADDR key_cache,
+    GM_ADDR value_cache,
+    GM_ADDR block_table,
+    GM_ADDR attention_out,
+    GM_ADDR workspace,
+    GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    REGISTER_TILING_DEFAULT(TrianglePagedSparseAttentionTilingData);
+    GET_TILING_DATA(tilingData, tiling);
+    __gm__ uint8_t *userWorkspace = AscendC::GetUserWorkspace(workspace);
+
+    TrianglePaged::TrianglePagedFiaFastPath kernel;
+    kernel.Init(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        attention_out,
+        userWorkspace,
+        tilingData);
+    kernel.Process();
+}

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_sparse_attention_tiling.h
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_paged_sparse_attention_tiling.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is licensed under CANN Open Software License Agreement
+ * Version 2.0. See LICENSE in the repository root.
+ */
+#ifndef TRIANGLE_PAGED_SPARSE_ATTENTION_TILING_H
+#define TRIANGLE_PAGED_SPARSE_ATTENTION_TILING_H
+
+#include <cstdint>
+
+/*
+ * ABI shared by the host tiler and the AscendC kernel.
+ *
+ * implementationStatus values:
+ *   0: build-only skeleton (must not dispatch);
+ *   1: bounded AIV numerical reference kernel;
+ *   2: direct-paged production Cube/Vector pipeline.
+ *
+ * ABI v2 appends the production task geometry and a byte-addressed workspace
+ * layout.  The v1 prefix is intentionally stable so the numerical oracle can
+ * remain in the same binary while the long-prefill path is brought up.
+ */
+struct TrianglePagedSparseAttentionTilingData {
+    uint32_t magic;
+    uint32_t abiVersion;
+    uint32_t implementationStatus;
+    uint32_t blockDim;
+
+    uint32_t queryTokens;
+    uint32_t queryStart;
+    uint32_t seqLen;
+    uint32_t promptLen;
+
+    uint32_t queryHeads;
+    uint32_t kvHeads;
+    uint32_t headDim;
+    uint32_t pageSize;
+
+    uint32_t physicalPageCount;
+    uint32_t blockTablePageCapacity;
+    uint32_t queryTile;
+    uint32_t taskCount;
+
+    uint32_t sinkTokens;
+    uint32_t localWindow;
+    uint32_t denseTail;
+    uint32_t sparseBegin;
+
+    uint32_t sparseEnd;
+    uint32_t reserved0;
+    uint32_t reserved1;
+    uint32_t reserved2;
+
+    float scale;
+
+    // ABI v2: one task is (query_tile, kv_head).  Four GQA query heads
+    // belonging to one KV head are folded into Cube M:
+    //   M = queryTile(32) * groupSize(4) = 128.
+    uint32_t kvTile;
+    uint32_t groupSize;
+    uint32_t queryTileCount;
+    uint32_t activeAicCores;
+
+    // Per-AIC workspace.  Every offset and stride is in bytes; no packed K/V,
+    // block mask, or selected-index array exists in this ABI.
+    uint32_t workspacePerCoreBytes;
+    uint32_t scoreOffsetBytes;
+    uint32_t probabilityOffsetBytes;
+    uint32_t outputTmpOffsetBytes;
+
+    uint32_t outputUpdateOffsetBytes;
+    uint32_t lseScratchOffsetBytes;
+    uint32_t workspaceBytes;
+    uint32_t pipelineStages;
+};
+
+#endif  // TRIANGLE_PAGED_SPARSE_ATTENTION_TILING_H

--- a/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_schedule.h
+++ b/csrc/attention/triangle_paged_sparse_attention/op_kernel/triangle_schedule.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ * This program is licensed under CANN Open Software License Agreement
+ * Version 2.0. See LICENSE in the repository root.
+ *
+ * Fixed TriangleMix schedule shared with the earlier 910B compile probe.
+ *
+ * This helper enumerates only logical KV intervals.  It does not pack K/V and
+ * it does not permit the skipped middle region to enter QK or PV.
+ */
+#ifndef TRIANGLE_PAGED_ATTENTION_SCHEDULE_H
+#define TRIANGLE_PAGED_ATTENTION_SCHEDULE_H
+
+#include "kernel_operator.h"
+
+namespace TrianglePaged {
+
+constexpr uint32_t kQueryHeads = 32;
+constexpr uint32_t kKvHeads = 8;
+constexpr uint32_t kHeadDim = 128;
+constexpr uint32_t kPageSize = 128;
+constexpr uint32_t kSinkTokens = 8;
+constexpr uint32_t kWindowTokens = 512;
+constexpr uint32_t kDenseTailTokens = 128;
+constexpr uint32_t kQueryTile = 32;
+
+struct KvInterval {
+    uint32_t begin;
+    uint32_t end;  // Exclusive absolute logical token index.
+};
+
+struct TileSchedule {
+    KvInterval interval[2];
+    uint32_t count;
+    uint32_t dense;
+};
+
+/*
+ * A q-tile can straddle either TriangleMix boundary.  Scheduling the whole
+ * tile as dense in that case is semantically wrong: sparse rows would submit
+ * the skipped middle keys to Cube.  Split the tile into homogeneous spans so
+ * each span can run an independent online-softmax reduction.
+ */
+struct QuerySpan {
+    uint32_t begin;  // Inclusive absolute query position.
+    uint32_t end;    // Exclusive absolute query position.
+    uint32_t sparse;
+};
+
+struct QuerySpanSchedule {
+    QuerySpan span[3];
+    uint32_t count;
+};
+
+__aicore__ inline uint32_t MinU32(uint32_t a, uint32_t b)
+{
+    return a < b ? a : b;
+}
+
+__aicore__ inline uint32_t MaxU32(uint32_t a, uint32_t b)
+{
+    return a > b ? a : b;
+}
+
+__aicore__ inline void AppendQuerySpan(
+    QuerySpanSchedule& result,
+    uint32_t begin,
+    uint32_t end,
+    uint32_t sparse)
+{
+    if (begin >= end || result.count >= 3U) {
+        return;
+    }
+    result.span[result.count] = {begin, end, sparse};
+    ++result.count;
+}
+
+__aicore__ inline QuerySpanSchedule SplitQueryTile(
+    uint32_t qBegin,
+    uint32_t qEnd,
+    uint32_t sparseBegin,
+    uint32_t sparseEnd)
+{
+    QuerySpanSchedule result{};
+    if (qBegin >= qEnd) {
+        return result;
+    }
+    if (sparseBegin >= sparseEnd) {
+        AppendQuerySpan(result, qBegin, qEnd, 0U);
+        return result;
+    }
+
+    const uint32_t densePrefixEnd = MinU32(qEnd, sparseBegin);
+    AppendQuerySpan(result, qBegin, densePrefixEnd, 0U);
+
+    const uint32_t sparseSpanBegin = MaxU32(qBegin, sparseBegin);
+    const uint32_t sparseSpanEnd = MinU32(qEnd, sparseEnd);
+    AppendQuerySpan(result, sparseSpanBegin, sparseSpanEnd, 1U);
+
+    const uint32_t denseTailBegin = MaxU32(qBegin, sparseEnd);
+    AppendQuerySpan(result, denseTailBegin, qEnd, 0U);
+    return result;
+}
+
+__aicore__ inline TileSchedule BuildTileSchedule(
+    uint32_t qBegin,
+    uint32_t qEnd,
+    uint32_t kvLength,
+    uint32_t sparseBegin,
+    uint32_t sparseEnd,
+    uint32_t sinkTokens = kSinkTokens,
+    uint32_t windowTokens = kWindowTokens)
+{
+    TileSchedule result{};
+    qEnd = MinU32(qEnd, kvLength);
+
+    const bool fullySparse = qBegin >= sparseBegin && qEnd <= sparseEnd;
+    if (!fullySparse) {
+        result.interval[0] = {0, qEnd};
+        result.count = qEnd == 0 ? 0 : 1;
+        result.dense = 1;
+        return result;
+    }
+
+    const uint32_t sinkEnd = MinU32(sinkTokens, kvLength);
+    const uint32_t localBeginRaw =
+        qBegin > windowTokens ? qBegin - windowTokens : 0;
+    const uint32_t localBegin = MinU32(localBeginRaw, qEnd);
+
+    // Merge overlapping ranges so sink logits are never counted twice.
+    if (localBegin <= sinkEnd) {
+        result.interval[0] = {0, qEnd};
+        result.count = qEnd == 0 ? 0 : 1;
+        result.dense = 0;
+        return result;
+    }
+
+    result.interval[0] = {0, sinkEnd};
+    result.interval[1] = {localBegin, qEnd};
+    result.count = (sinkEnd == 0 ? 0 : 1) + (localBegin < qEnd ? 1 : 0);
+    if (sinkEnd == 0 && localBegin < qEnd) {
+        result.interval[0] = result.interval[1];
+    }
+    result.dense = 0;
+    return result;
+}
+
+}  // namespace TrianglePaged
+
+#endif  // TRIANGLE_PAGED_ATTENTION_SCHEDULE_H

--- a/csrc/attention/triangle_paged_sparse_attention/triangle_paged_sparse_attention_torch_adpt.h
+++ b/csrc/attention/triangle_paged_sparse_attention/triangle_paged_sparse_attention_torch_adpt.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 TriangleMix contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+#ifndef TRIANGLE_PAGED_SPARSE_ATTENTION_TORCH_ADPT_H
+#define TRIANGLE_PAGED_SPARSE_ATTENTION_TORCH_ADPT_H
+
+#include <ATen/MemoryOverlap.h>
+#include <c10/core/DeviceGuard.h>
+
+namespace vllm_ascend {
+
+at::Tensor& npu_triangle_paged_sparse_attention(
+    const at::Tensor& query,
+    const at::Tensor& key_cache,
+    const at::Tensor& value_cache,
+    const at::Tensor& block_table,
+    int64_t query_start,
+    int64_t seq_len,
+    int64_t prompt_len,
+    double scale,
+    at::Tensor& output)
+{
+    TORCH_CHECK(query.is_privateuseone(), "query must be an NPU tensor");
+    TORCH_CHECK(
+        key_cache.is_privateuseone() && value_cache.is_privateuseone() &&
+            block_table.is_privateuseone() && output.is_privateuseone(),
+        "key_cache, value_cache, block_table, and output must be NPU tensors");
+    TORCH_CHECK(
+        query.scalar_type() == at::ScalarType::BFloat16 &&
+            key_cache.scalar_type() == at::ScalarType::BFloat16 &&
+            value_cache.scalar_type() == at::ScalarType::BFloat16 &&
+            output.scalar_type() == at::ScalarType::BFloat16,
+        "TriangleMix query, KV cache, and output must be BF16");
+    TORCH_CHECK(
+        block_table.scalar_type() == at::ScalarType::Int,
+        "TriangleMix block_table must be INT32");
+    TORCH_CHECK(
+        query.device() == key_cache.device() &&
+            query.device() == value_cache.device() &&
+            query.device() == block_table.device() &&
+            query.device() == output.device(),
+        "TriangleMix tensors must be on the same NPU device");
+    TORCH_CHECK(
+        query.is_contiguous() && key_cache.is_contiguous() &&
+            value_cache.is_contiguous() && block_table.is_contiguous() &&
+            output.is_contiguous(),
+        "TriangleMix tensors must be contiguous");
+    TORCH_CHECK(
+        query.dim() == 3 && query.size(1) == 32 && query.size(2) == 128,
+        "TriangleMix query must be [Tq, 32, 128]");
+    TORCH_CHECK(
+        key_cache.dim() == 4 && key_cache.size(1) == 128 &&
+            key_cache.size(2) == 8 && key_cache.size(3) == 128,
+        "TriangleMix key_cache must be [pages, 128, 8, 128]");
+    TORCH_CHECK(
+        value_cache.sizes() == key_cache.sizes(),
+        "TriangleMix value_cache must match key_cache");
+    TORCH_CHECK(
+        block_table.dim() == 2 && block_table.size(0) == 1,
+        "TriangleMix block_table must be [1, max_pages]");
+    TORCH_CHECK(
+        output.sizes() == query.sizes(),
+        "TriangleMix output must match query");
+    TORCH_CHECK(
+        query_start >= 0 && seq_len > 0 &&
+            query_start + query.size(0) == seq_len &&
+            prompt_len >= seq_len,
+        "invalid TriangleMix sequence coordinates");
+    at::assert_no_internal_overlap(output);
+    at::assert_no_overlap(output, query);
+    at::assert_no_overlap(output, key_cache);
+    at::assert_no_overlap(output, value_cache);
+    at::assert_no_overlap(output, block_table);
+    c10::OptionalDeviceGuard device_guard(query.device());
+
+    constexpr int64_t query_tile = 32;
+    constexpr int64_t page_size = 128;
+    constexpr int64_t sink_tokens = 8;
+    constexpr int64_t local_window = 512;
+    constexpr int64_t dense_tail = 128;
+    EXEC_NPU_CMD(
+        aclnnTrianglePagedSparseAttention,
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        query_start,
+        seq_len,
+        prompt_len,
+        scale,
+        query_tile,
+        page_size,
+        sink_tokens,
+        local_window,
+        dense_tail,
+        output);
+    return output;
+}
+
+}  // namespace vllm_ascend
+
+#endif  // TRIANGLE_PAGED_SPARSE_ATTENTION_TORCH_ADPT_H

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -130,6 +130,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "store_kv_block"
         "store_kv_block_metadata"
         "sparse_attention_score"
+        "triangle_paged_sparse_attention"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -46,6 +46,7 @@
 #include "attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
 #include "attention/sparse_attention_score/sparse_attention_score_torch_adpt.h"
+#include "attention/triangle_paged_sparse_attention/triangle_paged_sparse_attention_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
 #include "attention/store_kv_block_metadata/store_kv_block_metadata_torch_adpt.cpp"
 #include <c10/core/Device.h>
@@ -2239,6 +2240,18 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                           bool return_softmax_lse=False) -> (Tensor attention_out, Tensor softmax_max, Tensor softmax_sum)"
     );
     ops.impl("npu_sparse_flash_attention", torch::kPrivateUse1, &vllm_ascend::npu_sparse_flash_attention);
+
+    ops.def(
+        "npu_triangle_paged_sparse_attention("
+        "Tensor query, Tensor key_cache, Tensor value_cache, "
+        "Tensor block_table, int query_start, int seq_len, "
+        "int prompt_len, float scale, Tensor(a!) out) -> Tensor(a!)"
+    );
+    ops.impl(
+        "npu_triangle_paged_sparse_attention",
+        torch::kPrivateUse1,
+        &vllm_ascend::npu_triangle_paged_sparse_attention
+    );
 
     ops.def(
         "npu_kv_quant_sparse_flash_attention(Tensor query, Tensor key, Tensor value,"

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -93,6 +93,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. Can also be configured via the `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable during the migration period. |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature depends on FlashComm1. Please ensure that FlashComm1 is enabled before enabling this feature.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
+| `trianglemix`                       | dict | `{}`    | Experimental TriangleMix sparse-prefill path for selected dense-attention layers. Disabled by default and falls back to FIA for unsupported requests. |
 | `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. |
 
@@ -169,6 +170,34 @@ The legacy top-level `enable_balance_scheduling`, `recompute_scheduler_enable`, 
 | `enable_entropy_verify` | bool  | `False` | Whether to enable entropy verify mode. Entropy verify adjusts the acceptance threshold based on the entropy of the target distribution — higher entropy (uncertain) tokens get a lower threshold (easier to accept), while lower entropy (confident) tokens get a stricter threshold. |
 | `posterior_threshold`   | float | `0.95`  | Upper bound for the entropy-adjusted acceptance threshold. Must be in (0, 1]. The effective threshold is `min(exp(-entropy * posterior_alpha), posterior_threshold)`. |
 | `posterior_alpha`       | float | `0.4`   | Scaling factor for entropy in the threshold computation. Must be >= 0. Higher values make the threshold more sensitive to entropy — high-entropy tokens become much easier to accept, improving performance but reducing precision. |
+
+**trianglemix**
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enabled` | bool | `False` | Enable TriangleMix for the selected layers. |
+| `layers` | str or list | `""` | Layer indices or inclusive ranges, for example `"5,7,10,15-35"`. |
+| `strict` | bool | `False` | Raise on a custom-operator launch error instead of falling back to official FIA. |
+| `min_sparse_rows` | int | `128` | Minimum sparse-middle query rows required to use the custom path. |
+| `min_saved_qk` | int | `913152` | Minimum estimated skipped Q-K products required to use the custom path. |
+| `split_min_sparse_rows` | int | `192` | Minimum sparse rows when the query chunk also contains a dense prefix or tail. |
+| `split_min_saved_qk` | int | `1299264` | Minimum skipped Q-K products for a mixed dense/sparse query chunk. |
+| `stats_log_interval` | int | `0` | Emit per-layer hit/fallback counters every N calls; `0` disables periodic logging. |
+
+TriangleMix is a prefill-only path. Decode, graph capture, batch sizes greater
+than one, unsupported model geometry, and unsupported parallel configurations
+continue to use FIA. For example:
+
+```python
+{
+    "trianglemix": {
+        "enabled": True,
+        "layers": "5,7,10,15-35",
+        "strict": False,
+        "stats_log_interval": 100,
+    }
+}
+```
 
 **scheduler_config.short_request_first_config**
 

--- a/tests/ut/attention/a2/test_trianglemix.py
+++ b/tests/ut/attention/a2/test_trianglemix.py
@@ -1,0 +1,227 @@
+#
+# Copyright (c) 2026 TriangleMix contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+"""Unit tests for TriangleMix configuration and scheduler-step routing."""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm_ascend.attention.trianglemix import (
+    TriangleMixConfig,
+    TriangleMixFallbackReason,
+    TriangleMixRequestPlan,
+    build_trianglemix_plan,
+    parse_layer_indices,
+    run_trianglemix,
+    trianglemix_dispatch_reason,
+)
+
+
+def test_parse_layer_indices() -> None:
+    assert parse_layer_indices("5,7,10,15-17") == frozenset({5, 7, 10, 15, 16, 17})
+
+
+@pytest.mark.parametrize("value", ["-1", "7-5", "x"])
+def test_parse_layer_indices_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        parse_layer_indices(value)
+
+
+def test_config_is_opt_in_and_requires_layers() -> None:
+    assert not TriangleMixConfig.from_mapping({}).enabled
+    with pytest.raises(ValueError, match="requires at least one"):
+        TriangleMixConfig.from_mapping({"enabled": True})
+
+
+def test_additional_config_controls_selected_layers() -> None:
+    config = TriangleMixConfig.from_mapping(
+        {"enabled": False, "layers": "3"},
+    )
+    assert not config.enabled
+    assert config.layer_indices == frozenset({3})
+
+
+def test_long_single_prefill_uses_direct_path() -> None:
+    config = TriangleMixConfig.from_mapping(
+        {
+            "enabled": True,
+            "layers": "5",
+            "min_sparse_rows": 1,
+            "min_saved_qk": 1,
+        }
+    )
+    plan = build_trianglemix_plan(
+        state_name="ChunkedPrefill",
+        cumulative_query_ends=[2048],
+        seq_lens=[8320],
+        prompt_lens=[8320],
+        num_decodes=0,
+        num_prefills=1,
+        config=config,
+    )
+    assert plan.direct
+    assert plan.query_start == 6272
+    assert plan.sparse_end == 8192
+    assert plan.saved_qk > 0
+
+
+def test_prompt_length_controls_dense_tail_across_chunks() -> None:
+    config = TriangleMixConfig.from_mapping(
+        {
+            "enabled": True,
+            "layers": "5",
+            "min_sparse_rows": 0,
+            "min_saved_qk": 0,
+        }
+    )
+    plan = build_trianglemix_plan(
+        state_name="ChunkedPrefill",
+        cumulative_query_ends=[2048],
+        seq_lens=[4096],
+        prompt_lens=[8320],
+        num_decodes=0,
+        num_prefills=1,
+        config=config,
+    )
+    assert plan.sparse_end == 4096
+    assert plan.prompt_len == 8320
+
+
+@pytest.mark.parametrize(
+    ("state", "query_ends", "seq_lens", "prompt_lens", "decodes", "prefills", "reason"),
+    [
+        (
+            "DecodeOnly",
+            [1],
+            [8321],
+            [8320],
+            1,
+            0,
+            TriangleMixFallbackReason.STATE_UNSUPPORTED,
+        ),
+        (
+            "ChunkedPrefill",
+            [1024, 2048],
+            [1024, 1024],
+            [1024, 1024],
+            0,
+            2,
+            TriangleMixFallbackReason.BATCH_UNSUPPORTED,
+        ),
+        (
+            "ChunkedPrefill",
+            None,
+            None,
+            None,
+            0,
+            0,
+            TriangleMixFallbackReason.MISSING_METADATA,
+        ),
+    ],
+)
+def test_unsupported_requests_fall_back(
+    state,
+    query_ends,
+    seq_lens,
+    prompt_lens,
+    decodes,
+    prefills,
+    reason,
+) -> None:
+    config = TriangleMixConfig.from_mapping({"enabled": True, "layers": "5"})
+    plan = build_trianglemix_plan(
+        state_name=state,
+        cumulative_query_ends=query_ends,
+        seq_lens=seq_lens,
+        prompt_lens=prompt_lens,
+        num_decodes=decodes,
+        num_prefills=prefills,
+        config=config,
+    )
+    assert not plan.direct
+    assert plan.reason is reason
+
+
+def _direct_plan(query_len: int = 2048) -> TriangleMixRequestPlan:
+    return TriangleMixRequestPlan(
+        query_len=query_len,
+        seq_len=8320,
+        prompt_len=8320,
+        query_start=8320 - query_len,
+        sparse_start=8320 - query_len,
+        sparse_end=8192,
+        saved_qk=1_500_000,
+        reason=TriangleMixFallbackReason.NONE,
+    )
+
+
+def test_runtime_contract_rejects_unsupported_geometry() -> None:
+    config = TriangleMixConfig.from_mapping({"enabled": True, "layers": "5"})
+    query = torch.empty(2048, 16, 128, dtype=torch.bfloat16)
+    output = torch.empty_like(query)
+    key_cache = torch.empty(65, 128, 8, 128, dtype=torch.bfloat16)
+    value_cache = torch.empty_like(key_cache)
+    block_table = torch.arange(65, dtype=torch.int32).view(1, -1)
+
+    reason = trianglemix_dispatch_reason(
+        config=config,
+        plan=_direct_plan(),
+        layer_name="model.layers.5.self_attn.attn",
+        query=query,
+        output=output,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table=block_table,
+        causal=True,
+        capturing=False,
+        tensor_parallel_size=1,
+        context_parallel_enabled=False,
+        sliding_window=None,
+        sinks=None,
+        alibi_slopes=None,
+        enable_c8_quant=False,
+    )
+
+    assert reason is TriangleMixFallbackReason.QUERY_UNSUPPORTED
+
+
+def test_run_trianglemix_uses_native_out_operator() -> None:
+    query = torch.empty(2048, 32, 128, dtype=torch.bfloat16)
+    output = torch.empty_like(query)
+    key_cache = torch.empty(65, 128, 8, 128, dtype=torch.bfloat16)
+    value_cache = torch.empty_like(key_cache)
+    block_table = torch.arange(65, dtype=torch.int32).view(1, -1)
+
+    with patch.object(
+        torch.ops._C_ascend,
+        "npu_triangle_paged_sparse_attention",
+        create=True,
+        return_value=output,
+    ) as op:
+        result = run_trianglemix(
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            block_table=block_table,
+            plan=_direct_plan(),
+            scale=0.0883883476,
+            output=output,
+        )
+
+    assert result is output
+    args = op.call_args.args
+    assert args[0] is query
+    assert args[1] is key_cache
+    assert args[2] is value_cache
+    assert args[3] is block_table
+    assert args[4:7] == (6272, 8320, 8320)
+    assert args[8].data_ptr() == output.data_ptr()
+    assert args[8].shape == query.shape

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -50,6 +50,11 @@ class AscendConfig:
         self.eplb_config = EplbConfig(eplb_config)
 
         from vllm_ascend import envs as ascend_envs
+        from vllm_ascend.attention.trianglemix import TriangleMixConfig
+
+        self.trianglemix = TriangleMixConfig.from_mapping(
+            additional_config.get("trianglemix", {}),
+        )
 
         self.scheduler_config = SchedulerConfig(
             additional_config,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -24,6 +24,7 @@ import torch_npu
 import vllm.envs as envs_vllm
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (  # type: ignore
     AttentionBackend,
@@ -40,8 +41,17 @@ from vllm.v1.attention.backends.registry import (  # type: ignore
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import AttentionSpec, CrossAttentionSpec
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
+from vllm_ascend.attention.trianglemix import (
+    TriangleMixFallbackReason,
+    TriangleMixRequestPlan,
+    TriangleMixRuntimeStats,
+    build_trianglemix_plan,
+    timed_trianglemix_launch,
+    trianglemix_dispatch_reason,
+)
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     PagedAttentionGraphParam,
@@ -199,6 +209,9 @@ class AscendMetadata:
     model_runner_type: str = ""
     # prefill reshape_and_cache event
     reshape_cache_event: torch.npu.Event = None
+    # Immutable per-step sparse-prefill routing metadata. It is built once
+    # and reused by all selected layers in this scheduler step.
+    trianglemix_plan: TriangleMixRequestPlan | None = None
 
 
 class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
@@ -373,6 +386,21 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             num_decodes=num_decodes,
             num_prefills=num_prefills,
         )
+        trianglemix_config = get_ascend_config().trianglemix
+        trianglemix_plan = None
+        if trianglemix_config.enabled:
+            prompt_lens = None
+            if common_attn_metadata.num_prompt_tokens_cpu is not None:
+                prompt_lens = common_attn_metadata.num_prompt_tokens_cpu[:num_reqs].tolist()
+            trianglemix_plan = build_trianglemix_plan(
+                state_name=getattr(attn_state, "name", str(attn_state)),
+                cumulative_query_ends=actual_seq_lengths_q,
+                seq_lens=seq_lens_list,
+                prompt_lens=prompt_lens,
+                num_decodes=num_decodes,
+                num_prefills=num_prefills,
+                config=trianglemix_config,
+            )
         attn_metadata = self.metadata_cls(
             num_actual_tokens=num_actual_tokens,
             num_decode_tokens=num_decode_tokens,
@@ -390,6 +418,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             num_decodes=num_decodes,
             causal=common_attn_metadata.causal,
             model_runner_type=self.model_config.runner_type,
+            trianglemix_plan=trianglemix_plan,
             **backend_metadata,
         )
         return attn_metadata
@@ -465,6 +494,79 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # attn_metadata during graph replay. Record the captured layer name only
         # for that path.
         self._layer_name: str | None = None
+        self.trianglemix_config = get_ascend_config().trianglemix
+        self.trianglemix_stats = TriangleMixRuntimeStats(self.trianglemix_config)
+
+    def _try_trianglemix(
+        self,
+        query: torch.Tensor,
+        attn_metadata: AscendMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor | None:
+        layer_name = self._layer_name or ""
+        reason = trianglemix_dispatch_reason(
+            config=self.trianglemix_config,
+            plan=attn_metadata.trianglemix_plan,
+            layer_name=layer_name,
+            query=query,
+            output=output,
+            key_cache=self.key_cache,
+            value_cache=self.value_cache,
+            block_table=attn_metadata.block_tables,
+            causal=attn_metadata.causal,
+            capturing=bool(_EXTRA_CTX.capturing),
+            tensor_parallel_size=(self.vllm_config.parallel_config.tensor_parallel_size),
+            context_parallel_enabled=(
+                self.vllm_config.parallel_config.prefill_context_parallel_size > 1
+                or self.vllm_config.parallel_config.decode_context_parallel_size > 1
+            ),
+            sliding_window=self.sliding_window,
+            sinks=self.sinks,
+            alibi_slopes=self.alibi_slopes,
+            enable_c8_quant=self.enable_c8_quant,
+        )
+        plan = attn_metadata.trianglemix_plan
+        if reason is not TriangleMixFallbackReason.NONE:
+            # Calls on disabled/unselected layers are normal dense execution,
+            # not sparse-path fallback events.
+            if reason not in (
+                TriangleMixFallbackReason.DISABLED,
+                TriangleMixFallbackReason.LAYER_NOT_SELECTED,
+            ):
+                self.trianglemix_stats.record(layer_name=layer_name, reason=reason)
+            return None
+
+        assert plan is not None
+        assert self.key_cache is not None and self.value_cache is not None
+        try:
+            result, enqueue_ns = timed_trianglemix_launch(
+                query=query,
+                key_cache=self.key_cache,
+                value_cache=self.value_cache,
+                block_table=attn_metadata.block_tables,
+                plan=plan,
+                scale=self.scale,
+                output=output,
+            )
+        except Exception:
+            self.trianglemix_stats.record(
+                layer_name=layer_name,
+                reason=TriangleMixFallbackReason.OPERATOR_ERROR,
+            )
+            if self.trianglemix_config.strict:
+                raise
+            logger.exception(
+                "TriangleMix launch failed at layer %s; using official FIA",
+                layer_name,
+            )
+            return None
+        self.trianglemix_stats.record(
+            layer_name=layer_name,
+            reason=TriangleMixFallbackReason.NONE,
+            saved_qk=plan.saved_qk,
+            enqueue_ns=enqueue_ns,
+        )
+        return result
 
     def _graph_metadata_layer_name(self, layer: AttentionLayer | None = None) -> str | None:
         layer_name = layer.layer_name if layer is not None else self._layer_name
@@ -1278,6 +1380,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         output: torch.Tensor,
         kv_cache=None,
     ):
+        trianglemix_output = self._try_trianglemix(query, attn_metadata, output)
+        if trianglemix_output is not None:
+            return trianglemix_output
         # we inherit ForwardContext in model runner v2, when enable model
         # runner v2, there is not capturing attribute in forward_context,
         # just use getattr to avoid attribute error.
@@ -1629,8 +1734,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
-        if self._use_layer_aware_fia_graph_replay:
-            self._layer_name = layer.layer_name
+        self._layer_name = layer.layer_name
 
         if output_scale is not None or output_block_scale is not None:
             raise NotImplementedError("fused output quantization is not yet supported for AscendAttentionBackendImpl")

--- a/vllm_ascend/attention/trianglemix.py
+++ b/vllm_ascend/attention/trianglemix.py
@@ -1,0 +1,387 @@
+#
+# Copyright (c) 2026 TriangleMix contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Optional TriangleMix sparse-prefill routing for the Ascend backend."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import regex as re
+import torch
+from vllm.logger import logger
+
+TRIANGLE_QUERY_HEADS = 32
+TRIANGLE_KV_HEADS = 8
+TRIANGLE_HEAD_SIZE = 128
+TRIANGLE_CACHE_BLOCK_SIZE = 128
+TRIANGLE_SINK_TOKENS = 8
+TRIANGLE_LOCAL_WINDOW = 512
+TRIANGLE_DENSE_TAIL = 128
+
+_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+_PREFILL_STATES = frozenset({"PrefillNoCache", "PrefillCacheHit", "ChunkedPrefill"})
+
+
+class TriangleMixFallbackReason(str, Enum):
+    NONE = "none"
+    DISABLED = "disabled"
+    LAYER_NOT_SELECTED = "layer_not_selected"
+    STATE_UNSUPPORTED = "state_unsupported"
+    MIXED_DECODE = "mixed_decode"
+    BATCH_UNSUPPORTED = "batch_unsupported"
+    MISSING_METADATA = "missing_metadata"
+    INVALID_LENGTHS = "invalid_lengths"
+    NO_SPARSE_MIDDLE = "no_sparse_middle"
+    BELOW_MIN_SPARSE_ROWS = "below_min_sparse_rows"
+    BELOW_MIN_SAVED_QK = "below_min_saved_qk"
+    GEOMETRY_UNSUPPORTED = "geometry_unsupported"
+    GRAPH_CAPTURE = "graph_capture"
+    CONTEXT_PARALLEL = "context_parallel"
+    TENSOR_PARALLEL = "tensor_parallel"
+    NON_CAUSAL = "non_causal"
+    MODEL_UNSUPPORTED = "model_unsupported"
+    QUERY_UNSUPPORTED = "query_unsupported"
+    KV_CACHE_UNSUPPORTED = "kv_cache_unsupported"
+    BLOCK_TABLE_UNSUPPORTED = "block_table_unsupported"
+    OPERATOR_UNAVAILABLE = "operator_unavailable"
+    OPERATOR_ERROR = "operator_error"
+
+
+def parse_layer_indices(value: object) -> frozenset[int]:
+    if isinstance(value, (list, tuple, set, frozenset)):
+        value = ",".join(str(item) for item in value)
+    text = str(value or "").strip()
+    if not text:
+        return frozenset()
+    indices: set[int] = set()
+    for item in text.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "-" in item:
+            start_text, end_text = item.split("-", 1)
+            start, end = int(start_text), int(end_text)
+            if start < 0 or end < start:
+                raise ValueError(f"Invalid TriangleMix layer range: {item!r}")
+            indices.update(range(start, end + 1))
+        else:
+            index = int(item)
+            if index < 0:
+                raise ValueError(f"Invalid TriangleMix layer index: {item!r}")
+            indices.add(index)
+    return frozenset(indices)
+
+
+def _as_bool(value: object, *, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError(f"{name} must be a boolean, got {value!r}")
+
+
+@dataclass(frozen=True)
+class TriangleMixConfig:
+    enabled: bool = False
+    layer_indices: frozenset[int] = frozenset()
+    strict: bool = False
+    min_sparse_rows: int = 128
+    min_saved_qk: int = 913_152
+    split_min_sparse_rows: int = 192
+    split_min_saved_qk: int = 1_299_264
+    stats_log_interval: int = 0
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: object,
+    ) -> TriangleMixConfig:
+        section: Mapping[str, Any] = value if isinstance(value, Mapping) else {}
+        config = cls(
+            enabled=_as_bool(section.get("enabled", False), name="trianglemix.enabled"),
+            layer_indices=parse_layer_indices(section.get("layers", "")),
+            strict=_as_bool(section.get("strict", False), name="trianglemix.strict"),
+            min_sparse_rows=int(section.get("min_sparse_rows", 128)),
+            min_saved_qk=int(section.get("min_saved_qk", 913_152)),
+            split_min_sparse_rows=int(section.get("split_min_sparse_rows", 192)),
+            split_min_saved_qk=int(section.get("split_min_saved_qk", 1_299_264)),
+            stats_log_interval=int(section.get("stats_log_interval", 0)),
+        )
+        if (
+            config.min_sparse_rows < 0
+            or config.min_saved_qk < 0
+            or config.split_min_sparse_rows < 0
+            or config.split_min_saved_qk < 0
+            or config.stats_log_interval < 0
+        ):
+            raise ValueError("TriangleMix thresholds must be non-negative")
+        if config.enabled and not config.layer_indices:
+            raise ValueError("trianglemix.enabled requires at least one selected layer")
+        return config
+
+    def uses_layer(self, layer_name: str) -> bool:
+        match = _LAYER_INDEX_RE.search(layer_name)
+        return self.enabled and match is not None and int(match.group(1)) in self.layer_indices
+
+
+@dataclass(frozen=True)
+class TriangleMixRequestPlan:
+    query_len: int
+    seq_len: int
+    prompt_len: int
+    query_start: int
+    sparse_start: int
+    sparse_end: int
+    saved_qk: int
+    reason: TriangleMixFallbackReason
+
+    @property
+    def direct(self) -> bool:
+        return self.reason is TriangleMixFallbackReason.NONE
+
+
+def _saved_qk(sparse_start: int, sparse_end: int) -> int:
+    if sparse_end <= sparse_start:
+        return 0
+    rows = sparse_end - sparse_start
+    return rows * (sparse_start + sparse_end - 1041) // 2
+
+
+def build_trianglemix_plan(
+    *,
+    state_name: str,
+    cumulative_query_ends: Sequence[int] | None,
+    seq_lens: Sequence[int] | None,
+    prompt_lens: Sequence[int] | None,
+    num_decodes: int,
+    num_prefills: int,
+    config: TriangleMixConfig,
+) -> TriangleMixRequestPlan:
+    query_ends = tuple(int(value) for value in cumulative_query_ends or ())
+    sequences = tuple(int(value) for value in seq_lens or ())
+    prompts = tuple(int(value) for value in prompt_lens or ())
+    if state_name not in _PREFILL_STATES:
+        reason = TriangleMixFallbackReason.STATE_UNSUPPORTED
+    elif num_decodes:
+        reason = TriangleMixFallbackReason.MIXED_DECODE
+    elif len(sequences) != 1 or len(query_ends) != 1 or len(prompts) != 1 or num_prefills != 1:
+        reason = (
+            TriangleMixFallbackReason.BATCH_UNSUPPORTED if sequences else TriangleMixFallbackReason.MISSING_METADATA
+        )
+    else:
+        reason = TriangleMixFallbackReason.NONE
+
+    query_len = query_ends[0] if len(query_ends) == 1 else 0
+    seq_len = sequences[0] if len(sequences) == 1 else 0
+    prompt_len = prompts[0] if len(prompts) == 1 else 0
+    if reason is TriangleMixFallbackReason.NONE and (query_len <= 0 or seq_len < query_len or prompt_len < seq_len):
+        reason = TriangleMixFallbackReason.INVALID_LENGTHS
+
+    query_start = max(0, seq_len - query_len)
+    sparse_start = max(query_start, TRIANGLE_SINK_TOKENS + TRIANGLE_LOCAL_WINDOW + 1)
+    sparse_end = min(seq_len, max(0, prompt_len - TRIANGLE_DENSE_TAIL))
+    saved_qk = _saved_qk(sparse_start, sparse_end)
+    if reason is TriangleMixFallbackReason.NONE:
+        if sparse_end <= sparse_start:
+            reason = TriangleMixFallbackReason.NO_SPARSE_MIDDLE
+        elif sparse_end - sparse_start < config.min_sparse_rows:
+            reason = TriangleMixFallbackReason.BELOW_MIN_SPARSE_ROWS
+        elif saved_qk < config.min_saved_qk:
+            reason = TriangleMixFallbackReason.BELOW_MIN_SAVED_QK
+        elif (
+            sparse_start > query_start or sparse_end < seq_len
+        ) and sparse_end - sparse_start < config.split_min_sparse_rows:
+            reason = TriangleMixFallbackReason.BELOW_MIN_SPARSE_ROWS
+        elif (sparse_start > query_start or sparse_end < seq_len) and saved_qk < config.split_min_saved_qk:
+            reason = TriangleMixFallbackReason.BELOW_MIN_SAVED_QK
+    return TriangleMixRequestPlan(
+        query_len=query_len,
+        seq_len=seq_len,
+        prompt_len=prompt_len,
+        query_start=query_start,
+        sparse_start=sparse_start,
+        sparse_end=sparse_end,
+        saved_qk=saved_qk,
+        reason=reason,
+    )
+
+
+def trianglemix_dispatch_reason(
+    *,
+    config: TriangleMixConfig,
+    plan: TriangleMixRequestPlan | None,
+    layer_name: str,
+    query: torch.Tensor,
+    output: torch.Tensor,
+    key_cache: torch.Tensor | None,
+    value_cache: torch.Tensor | None,
+    block_table: torch.Tensor | None,
+    causal: bool,
+    capturing: bool,
+    tensor_parallel_size: int,
+    context_parallel_enabled: bool,
+    sliding_window: int | None,
+    sinks: torch.Tensor | None,
+    alibi_slopes: torch.Tensor | None,
+    enable_c8_quant: bool,
+) -> TriangleMixFallbackReason:
+    if not config.enabled:
+        return TriangleMixFallbackReason.DISABLED
+    if not config.uses_layer(layer_name):
+        return TriangleMixFallbackReason.LAYER_NOT_SELECTED
+    if plan is None:
+        return TriangleMixFallbackReason.MISSING_METADATA
+    if capturing:
+        return TriangleMixFallbackReason.GRAPH_CAPTURE
+    if not plan.direct:
+        return plan.reason
+    if tensor_parallel_size != 1:
+        return TriangleMixFallbackReason.TENSOR_PARALLEL
+    if context_parallel_enabled:
+        return TriangleMixFallbackReason.CONTEXT_PARALLEL
+    if not causal:
+        return TriangleMixFallbackReason.NON_CAUSAL
+    if sliding_window is not None or sinks is not None or alibi_slopes is not None or enable_c8_quant:
+        return TriangleMixFallbackReason.MODEL_UNSUPPORTED
+    if (
+        query.ndim != 3
+        or tuple(query.shape)
+        != (
+            plan.query_len,
+            TRIANGLE_QUERY_HEADS,
+            TRIANGLE_HEAD_SIZE,
+        )
+        or query.dtype != torch.bfloat16
+        or not query.is_contiguous()
+        or output.dtype != torch.bfloat16
+        or output.shape[0] < plan.query_len
+        or not output.is_contiguous()
+    ):
+        return TriangleMixFallbackReason.QUERY_UNSUPPORTED
+    expected_cache_tail = (
+        TRIANGLE_CACHE_BLOCK_SIZE,
+        TRIANGLE_KV_HEADS,
+        TRIANGLE_HEAD_SIZE,
+    )
+    if (
+        key_cache is None
+        or value_cache is None
+        or key_cache.ndim != 4
+        or tuple(key_cache.shape[1:]) != expected_cache_tail
+        or value_cache.shape != key_cache.shape
+        or key_cache.dtype != torch.bfloat16
+        or value_cache.dtype != torch.bfloat16
+        or not key_cache.is_contiguous()
+        or not value_cache.is_contiguous()
+    ):
+        return TriangleMixFallbackReason.KV_CACHE_UNSUPPORTED
+    required_pages = (plan.seq_len + TRIANGLE_CACHE_BLOCK_SIZE - 1) // TRIANGLE_CACHE_BLOCK_SIZE
+    if (
+        block_table is None
+        or block_table.ndim != 2
+        or block_table.shape[0] != 1
+        or block_table.shape[1] < required_pages
+        or block_table.dtype != torch.int32
+        or not block_table.is_contiguous()
+    ):
+        return TriangleMixFallbackReason.BLOCK_TABLE_UNSUPPORTED
+    if any(tensor.device != query.device for tensor in (key_cache, value_cache, block_table, output)):
+        return TriangleMixFallbackReason.KV_CACHE_UNSUPPORTED
+    try:
+        _ = torch.ops._C_ascend.npu_triangle_paged_sparse_attention
+    except AttributeError:
+        return TriangleMixFallbackReason.OPERATOR_UNAVAILABLE
+    return TriangleMixFallbackReason.NONE
+
+
+def run_trianglemix(
+    *,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    plan: TriangleMixRequestPlan,
+    scale: float,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    output_view = output[: plan.query_len].view_as(query)
+    torch.ops._C_ascend.npu_triangle_paged_sparse_attention(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        plan.query_start,
+        plan.seq_len,
+        plan.prompt_len,
+        scale,
+        output_view,
+    )
+    return output
+
+
+@dataclass
+class TriangleMixRuntimeStats:
+    """Per-backend counters; no request data is retained."""
+
+    config: TriangleMixConfig
+    counters: Counter[str] = field(default_factory=Counter)
+
+    def record(
+        self,
+        *,
+        layer_name: str,
+        reason: TriangleMixFallbackReason,
+        saved_qk: int = 0,
+        enqueue_ns: int = 0,
+    ) -> None:
+        self.counters["calls"] += 1
+        if reason is TriangleMixFallbackReason.NONE:
+            self.counters["hits"] += 1
+            self.counters["estimated_saved_qk"] += saved_qk
+            self.counters["host_enqueue_ns"] += enqueue_ns
+        else:
+            self.counters["fallbacks"] += 1
+            self.counters[f"fallback:{reason.value}"] += 1
+        interval = self.config.stats_log_interval
+        if interval and self.counters["calls"] % interval == 0:
+            logger.info(
+                "TriangleMix stats layer=%s calls=%d hits=%d fallbacks=%d "
+                "reason=%s estimated_saved_qk=%d host_enqueue_ns=%d",
+                layer_name,
+                self.counters["calls"],
+                self.counters["hits"],
+                self.counters["fallbacks"],
+                reason.value,
+                self.counters["estimated_saved_qk"],
+                self.counters["host_enqueue_ns"],
+            )
+
+
+def timed_trianglemix_launch(**kwargs: Any) -> tuple[torch.Tensor, int]:
+    started = time.perf_counter_ns()
+    result = run_trianglemix(**kwargs)
+    return result, time.perf_counter_ns() - started

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -213,6 +213,10 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
     # E.g., tensor([100, 200, 50]) means req0 has 100 tokens already computed.
     num_computed_tokens_cpu: torch.Tensor = None
 
+    # CPU tensor of the immutable final prompt length per request. Sparse
+    # prefill policies must not infer this value from the current chunk.
+    num_prompt_tokens_cpu: torch.Tensor = None
+
     # Number of decode tokens per request, used for speculative decoding.
     # E.g., 1 for normal decoding, >1 for speculative decoding.
     decode_token_per_req: int = 1
@@ -254,6 +258,7 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
             seq_lens=self.seq_lens[:num_actual_reqs],
             seq_lens_cpu=_slice_reqs(self.seq_lens_cpu),
             num_computed_tokens_cpu=_slice_reqs(self.num_computed_tokens_cpu),
+            num_prompt_tokens_cpu=_slice_reqs(self.num_prompt_tokens_cpu),
             num_reqs=num_actual_reqs,
             num_actual_tokens=num_actual_tokens,
             max_query_len=self.max_query_len,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2888,6 +2888,7 @@ class NPUModelRunner(GPUModelRunner):
             # TODO
             # num_computed_tokens_cpu=self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs_padded],
             num_computed_tokens_cpu=num_computed_tokens_cpu,
+            num_prompt_tokens_cpu=num_prompt_tokens_cpu,
             num_reqs=num_reqs_padded,
             num_actual_tokens=num_tokens,
             max_query_len=max_query_len,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds an opt-in TriangleMix sparse-prefill path for Ascend NPU. TriangleMix uses a static sink + local-window + dense-tail attention pattern, which is different from the dynamic top-k block-sparse path used by `SparseAttentionScore`.

The implementation:

- reads paged KV directly without gather/reorder copies;
- performs sparse scheduling, QK, online softmax, and PV in one AscendC launch;
- caches request metadata and records hit/fallback counters;
- routes short or unsupported requests to the existing FIA implementation;
- keeps decode on the existing official attention path.

It is enabled through `additional_config.trianglemix`; the default behavior is unchanged.

TriangleMix paper: https://arxiv.org/abs/2507.21526

Fixes #13246

### Does this PR introduce _any_ user-facing change?

Yes. It adds the optional `additional_config.trianglemix` configuration block. TriangleMix is disabled by default, so existing users see no behavior change.

Example:

```json
{
  "trianglemix": {
    "enabled": true,
    "layers": "5,7,10,15-35",
    "strict": false,
    "stats_log_interval": 100
  }
}
```

### How was this patch tested?

Environment: Ascend 910B3, CANN 9.0.1, PyTorch 2.10.0, torch-npu 2.10.0.post2, vLLM 0.26.0.

- Built the TriangleMix CANN package and the latest vLLM-Ascend Torch binding successfully.
- Unit tests: `tests/ut/attention/a2/test_trianglemix.py` — 13/13 passed.
- NPU operator correctness matrix — 20/20 passed.
- 8192-token comparison against dense attention: max absolute error `3.2582e-4`, mean absolute error `4.1136e-5`, relative L2 error `2.3324e-3`.
- Qwen3-8B end-to-end test with a 2048-token prompt: all 36 prefill layers used TriangleMix; decode used the existing official path; dense and sparse runs produced identical token IDs for the tested continuation.
- Re-applied the patch cleanly to upstream `main` at `8f3fd59a203c3b35f29b6a77f459c9a78da7d5c0`; `git diff --check` and Python syntax checks passed.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
