### PR TITLE
[Feature][LoRA] 1.Support W8A8 dynamic multi-LoRA inference for MoE models; 2. support shared expert + lora;3. Gereneral quant MOE FrameWork for Lora inference 

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,2 +1,248 @@
-def test_lora_placeholder():
-    pass
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from vllm.lora.layers.base import BaseLayerWithLoRA
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
+
+from vllm_ascend.lora.fused_moe import (
+    AscendFusedMoEWithLoRA,
+    _moe_lora_projection_enabled,
+    _recover_moe_lora_routing,
+    is_moe_lora_active,
+    moe_lora_apply_w2,
+    moe_lora_apply_w13,
+)
+from vllm_ascend.lora.punica_npu import (
+    PunicaWrapperNPU,
+    _moe_lora_bmm_expand_slice_op,
+)
+
+
+def test_moe_wrapper_preserves_shared_expert_module_path() -> None:
+    shared_experts = torch.nn.Linear(2, 2)
+    base_layer = SimpleNamespace(
+        use_ep=False,
+        dynamic_eplb=False,
+        _shared_experts=shared_experts,
+        multistream_overlap_gate=False,
+        local_num_experts=4,
+        moe_config=SimpleNamespace(is_act_and_mul=True),
+    )
+
+    with (
+        patch(
+            "vllm_ascend.lora.fused_moe._get_lora_device",
+            return_value=torch.device("cpu"),
+        ),
+        patch(
+            "vllm_ascend.lora.fused_moe.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm_ascend.lora.fused_moe.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm_ascend.lora.fused_moe.envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2",
+            0,
+        ),
+    ):
+        wrapper = AscendFusedMoEWithLoRA(base_layer)
+
+    assert wrapper._shared_experts is shared_experts
+    assert wrapper.base_layer._shared_experts is shared_experts
+    assert wrapper.n_slices == 12
+
+
+@pytest.mark.parametrize("shared_experts", [None, object()])
+def test_shared_experts_select_compatible_expand_slice(shared_experts) -> None:
+    base_layer = SimpleNamespace(
+        _shared_experts=shared_experts,
+        set_lora_context=Mock(),
+    )
+    wrapper = SimpleNamespace(
+        base_layer=base_layer,
+        _build_lora_context=Mock(return_value="context"),
+    )
+    punica_wrapper = Mock()
+
+    with patch.object(BaseLayerWithLoRA, "set_mapping"):
+        AscendFusedMoEWithLoRA.set_mapping(wrapper, punica_wrapper)
+
+    if shared_experts is None:
+        punica_wrapper.enable_compatible_lora_bmm_expand_slice.assert_not_called()
+    else:
+        punica_wrapper.enable_compatible_lora_bmm_expand_slice.assert_called_once()
+    base_layer.set_lora_context.assert_called_once_with("context")
+
+
+@pytest.mark.parametrize(
+    ("force_compatible_path", "rank", "slice_size", "expect_bmm"),
+    [
+        (False, 4, 8, False),
+        (False, 16, 8, True),
+        (True, 4, 8, True),
+    ],
+)
+def test_expand_slice_selects_compatible_path(
+    force_compatible_path,
+    rank,
+    slice_size,
+    expect_bmm,
+) -> None:
+    wrapper = SimpleNamespace(
+        _force_lora_bmm_expand_slice=force_compatible_path,
+    )
+
+    selected = PunicaWrapperNPU._requires_bmm_expand_slice(
+        wrapper,
+        torch.empty(2, rank),
+        slice_size,
+    )
+
+    assert selected is expect_bmm
+
+
+@pytest.mark.parametrize("add_inputs", [True, False])
+def test_bmm_expand_slice_masks_base_tokens(add_inputs) -> None:
+    x = torch.tensor([[1.0, 2.0], [4.0, 5.0], [2.0, 3.0]])
+    weights = torch.tensor(
+        [
+            [[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]],
+            [[[2.0, 0.0], [0.0, 2.0], [1.0, -1.0]]],
+        ]
+    )
+    indices = torch.tensor([0, -1, 1])
+    y = torch.full((3, 5), 7.0)
+    original = y.clone()
+
+    _moe_lora_bmm_expand_slice_op(
+        y,
+        x,
+        weights,
+        indices,
+        1,
+        3,
+        add_inputs,
+    )
+
+    delta = torch.tensor([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0], [4.0, 6.0, -1.0]])
+    expected_slice = original[:, 1:4] + delta if add_inputs else delta
+    torch.testing.assert_close(y[:, 1:4], expected_slice)
+    torch.testing.assert_close(y[:, :1], original[:, :1])
+    torch.testing.assert_close(y[:, 4:], original[:, 4:])
+
+
+@pytest.mark.parametrize(
+    ("lora_b", "w13_num_slices", "expected"),
+    [
+        ([torch.zeros(2, 3)] * 3, 2, (False, False)),
+        (
+            [torch.ones(2, 3), torch.zeros(2, 3), torch.zeros(2, 3)],
+            2,
+            (True, False),
+        ),
+        (
+            [torch.zeros(2, 3), torch.ones(2, 3), torch.zeros(2, 3)],
+            2,
+            (False, True),
+        ),
+        (
+            [torch.zeros(2, 3), torch.zeros(2, 3), torch.ones(2, 3)],
+            2,
+            (True, False),
+        ),
+        ([torch.ones(2, 3), torch.zeros(2, 3)], 1, (True, False)),
+    ],
+)
+def test_moe_lora_projection_enabled(
+    lora_b,
+    w13_num_slices,
+    expected,
+) -> None:
+    assert _moe_lora_projection_enabled(lora_b, w13_num_slices) == expected
+
+
+def test_moe_lora_apply_uses_projection_masks() -> None:
+    punica_wrapper = Mock()
+    punica_wrapper.token_lora_indices = torch.tensor([0])
+    context = SimpleNamespace(
+        top_k=1,
+        punica_wrapper=punica_wrapper,
+        w13_lora_a_stacked="w13_a",
+        w13_lora_b_stacked="w13_b",
+        w2_lora_a_stacked="w2_a",
+        w2_lora_b_stacked="w2_b",
+        adapter_enabled="all_enabled",
+        w13_adapter_enabled="w13_enabled",
+        w2_adapter_enabled="w2_enabled",
+    )
+
+    routing = moe_lora_apply_w13(
+        context,
+        gate_up_out="gate_up_out",
+        hidden_states="hidden_states",
+        expanded_row_idx=torch.tensor([0]),
+        topk_ids=torch.tensor([[0]]),
+    )
+    moe_lora_apply_w2(
+        context,
+        down_out="down_out",
+        silu_out="silu_out",
+        lora_routing=routing,
+    )
+
+    assert punica_wrapper.add_lora_fused_moe.call_count == 2
+    calls = punica_wrapper.add_lora_fused_moe.call_args_list
+    assert calls[0].kwargs["adapter_enabled"] == "w13_enabled"
+    assert calls[1].kwargs["adapter_enabled"] == "w2_enabled"
+
+
+def test_allgather_routing_preserves_multi_adapter_and_base_mapping() -> None:
+    context = SimpleNamespace(
+        top_k=2,
+        punica_wrapper=SimpleNamespace(
+            token_lora_indices=torch.tensor([0, -1, 1]),
+        ),
+    )
+    topk_ids = torch.tensor([[1, 0], [0, 1], [1, 1]])
+    # Original flat rows [0..5] land at these expert-sorted positions.
+    expanded_row_idx = torch.tensor([2, 0, 1, 3, 4, 5])
+
+    expert_ids, lora_slots = _recover_moe_lora_routing(
+        context,
+        expanded_row_idx,
+        topk_ids,
+    )
+
+    assert torch.equal(expert_ids, torch.tensor([0, 0, 1, 1, 1, 1]))
+    assert torch.equal(lora_slots, torch.tensor([0, -1, 0, -1, 1, 1]))
+
+
+def test_moe_lora_active_follows_batch_metadata() -> None:
+    assert not is_moe_lora_active(None)
+    assert not is_moe_lora_active(SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=True)))
+    assert is_moe_lora_active(SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False)))
+
+
+@pytest.mark.parametrize(
+    ("index_mapping", "expected_no_lora"),
+    [
+        ((0, 0), True),
+        ((0, 1), False),
+        ((2, 0), False),
+    ],
+)
+def test_decode_metadata_refreshes_no_lora(
+    index_mapping,
+    expected_no_lora,
+) -> None:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    mapping = SimpleNamespace(index_mapping=index_mapping)
+
+    with patch.object(PunicaWrapperBase, "update_metadata"):
+        wrapper.update_metadata(mapping, [], 2, 100)
+
+    assert wrapper.no_lora is expected_no_lora

--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -486,6 +486,81 @@ def test_allgather_token_dispatch_mxfp4_keeps_prequantized_scale():
     assert output.dynamic_scale is returned_scale
 
 
+@pytest.mark.parametrize(
+    ("no_lora", "expected_quant_mode", "expect_dynamic_scale"),
+    [
+        (False, -1, False),
+        (True, 1, True),
+    ],
+)
+def test_allgather_w8a8_lora_controls_dispatch_quantization(
+    no_lora,
+    expected_quant_mode,
+    expect_dynamic_scale,
+):
+    dispatcher = TokenDispatcherWithAllGather(
+        top_k=1,
+        num_experts=2,
+        num_local_experts=2,
+    )
+    dispatcher.set_lora_context(MagicMock(punica_wrapper=MagicMock(no_lora=no_lora)))
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    returned_scale = torch.randn(2)
+    token_dispatch_input = build_token_dispatch_input_fixture(
+        hidden_states=hidden_states,
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.tensor([[0], [1]], dtype=torch.int32),
+        quant_type=QuantType.W8A8,
+    )
+    init_routing_output = (
+        hidden_states,
+        torch.tensor([0, 1], dtype=torch.int32),
+        torch.tensor([1, 1], dtype=torch.int32),
+        returned_scale,
+    )
+
+    with patch(
+        "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+        return_value=init_routing_output,
+    ) as mock_init_routing:
+        output = dispatcher.token_dispatch(token_dispatch_input)
+
+    assert mock_init_routing.call_args.kwargs["quant_mode"] == expected_quant_mode
+    assert (output.dynamic_scale is not None) == expect_dynamic_scale
+
+
+def test_allgather_bf16_lora_keeps_unquantized_dispatch_path():
+    dispatcher = TokenDispatcherWithAllGather(
+        top_k=1,
+        num_experts=2,
+        num_local_experts=2,
+    )
+    dispatcher.set_lora_context(MagicMock(punica_wrapper=MagicMock(no_lora=False)))
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    token_dispatch_input = build_token_dispatch_input_fixture(
+        hidden_states=hidden_states,
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.tensor([[0], [1]], dtype=torch.int32),
+        quant_type=QuantType.NONE,
+    )
+    init_routing_output = (
+        hidden_states,
+        torch.tensor([0, 1], dtype=torch.int32),
+        torch.tensor([1, 1], dtype=torch.int32),
+        None,
+    )
+
+    with patch(
+        "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+        return_value=init_routing_output,
+    ) as mock_init_routing:
+        output = dispatcher.token_dispatch(token_dispatch_input)
+
+    assert mock_init_routing.call_args.kwargs["quant_mode"] == -1
+    assert output.hidden_states is hidden_states
+    assert output.dynamic_scale is None
+
+
 class TestTokenDispatcherWithAllGather(TestBase):
     def setUp(self):
         # Mock dependencies

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -15,6 +15,7 @@
 import ast
 import inspect
 import textwrap
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import TypedDict
 from unittest.mock import MagicMock, patch
@@ -916,6 +917,164 @@ class TestAscendFusedMoESharedExperts:
 
         torch.testing.assert_close(part1_out, gate_up)
         torch.testing.assert_close(part2_out, F.sigmoid(gate_out) * down_out)
+
+    def test_quantized_shared_experts_use_dense_wrappers_for_lora(
+        self,
+        monkeypatch,
+    ):
+        layer = AscendFusedMoE.__new__(AscendFusedMoE)
+        nn.Module.__init__(layer)
+        gate_up_proj = MagicMock()
+        gate_up_proj.weight_scale = object()
+        gate_up_proj.side_effect = lambda value: (value * 2.0 + 1.0, None)
+        down_proj = MagicMock()
+        down_proj.weight_scale = object()
+        down_proj.side_effect = lambda value: (value * 2.0 + 1.0, None)
+        layer._shared_experts = SimpleNamespace(
+            gate_up_proj=gate_up_proj,
+            act_fn=nn.Identity(),
+            down_proj=down_proj,
+            expert_gate=None,
+        )
+        layer._ascend_moe_lora_context = SimpleNamespace(
+            punica_wrapper=SimpleNamespace(no_lora=False),
+        )
+        layer.quant_type = QuantType.W8A8
+        layer.multistream_overlap_shared_expert = False
+        hidden_states = torch.randn(2, 4)
+        current_stream = MagicMock()
+
+        monkeypatch.setattr(
+            fused_moe_legacy_module.torch.npu,
+            "current_stream",
+            lambda: current_stream,
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module,
+            "shared_experts_calculation_stream",
+            MagicMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module,
+            "npu_stream_switch",
+            lambda *args, **kwargs: nullcontext(),
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module.torch_npu,
+            "npu_quant_matmul",
+            MagicMock(side_effect=AssertionError("must use dense wrappers")),
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module,
+            "_EXTRA_CTX",
+            SimpleNamespace(moe_comm_type=MoECommType.ALLGATHER),
+        )
+
+        output = layer._forward_shared_experts(
+            hidden_states,
+            fused_moe_module.FusedMoEEvents(
+                before_routed_experts=MagicMock(),
+            ),
+        )
+
+        expected = (hidden_states * 2.0 + 1.0) * 2.0 + 1.0
+        torch.testing.assert_close(output, expected)
+
+    def test_base_batch_keeps_raw_quant_shared_path_after_lora_wrapping(
+        self,
+        monkeypatch,
+    ):
+        layer = AscendFusedMoE.__new__(AscendFusedMoE)
+        nn.Module.__init__(layer)
+        gate_weight = object()
+        gate_scale = object()
+        gate_scale_fp32 = object()
+        down_weight = object()
+        down_scale = object()
+        gate_base = SimpleNamespace(
+            weight=gate_weight,
+            weight_scale=gate_scale,
+            weight_scale_fp32=gate_scale_fp32,
+        )
+        down_base = SimpleNamespace(
+            weight=down_weight,
+            weight_scale=down_scale,
+        )
+        gate_wrapper = MagicMock(base_layer=gate_base)
+        down_wrapper = MagicMock(base_layer=down_base)
+        layer._shared_experts = SimpleNamespace(
+            gate_up_proj=gate_wrapper,
+            act_fn=nn.Identity(),
+            down_proj=down_wrapper,
+            expert_gate=None,
+        )
+        layer._ascend_moe_lora_context = SimpleNamespace(
+            punica_wrapper=SimpleNamespace(no_lora=True),
+        )
+        layer.quant_type = QuantType.W8A8
+        layer.multistream_overlap_shared_expert = False
+        hidden_states = torch.randn(2, 4)
+        quantized_input = torch.ones(2, 4, dtype=torch.int8)
+        input_scale = torch.ones(2)
+        gate_out = torch.ones(2, 8, dtype=torch.int32)
+        quantized_activation = torch.ones(2, 4, dtype=torch.int8)
+        activation_scale = torch.ones(2)
+        expected = torch.randn(2, 4)
+        current_stream = MagicMock()
+        quant_matmul = MagicMock(side_effect=[gate_out, expected])
+
+        monkeypatch.setattr(
+            fused_moe_legacy_module.torch.npu,
+            "current_stream",
+            lambda: current_stream,
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module,
+            "shared_experts_calculation_stream",
+            MagicMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module,
+            "npu_stream_switch",
+            lambda *args, **kwargs: nullcontext(),
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module.torch_npu,
+            "npu_dynamic_quant",
+            MagicMock(return_value=(quantized_input, input_scale)),
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module.torch_npu,
+            "npu_quant_matmul",
+            quant_matmul,
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module.torch.ops._C_ascend,
+            "npu_dequant_swiglu_quant",
+            MagicMock(return_value=(quantized_activation, activation_scale)),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            fused_moe_legacy_module,
+            "_EXTRA_CTX",
+            SimpleNamespace(moe_comm_type=MoECommType.ALLGATHER),
+        )
+
+        output = layer._forward_shared_experts(
+            hidden_states,
+            fused_moe_module.FusedMoEEvents(
+                before_routed_experts=MagicMock(),
+            ),
+        )
+
+        assert output is expected
+        gate_wrapper.assert_not_called()
+        down_wrapper.assert_not_called()
+        assert quant_matmul.call_count == 2
+        assert quant_matmul.call_args_list[0].args[1] is gate_weight
+        assert quant_matmul.call_args_list[0].args[2] is gate_scale
+        assert quant_matmul.call_args_list[1].args[1] is down_weight
+        assert quant_matmul.call_args_list[1].args[2] is down_scale
 
     @pytest.mark.parametrize("has_shared_experts", [False, True])
     def test_shared_forward_impl_routes_shared_output(self, monkeypatch, has_shared_experts):

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -223,6 +223,7 @@ class TestMoECommMethod(TestBase):
         w2 = torch.randn(16, 8).contiguous()
         topk_weights = dispatch_topk_weights
         topk_ids = torch.tensor([[0, 1], [1, 2], [2, 0], [1, 1]])
+        lora_context = MagicMock()
 
         # Make sure tensors are contiguous and have correct strides
         hidden_states = hidden_states.contiguous()
@@ -248,6 +249,7 @@ class TestMoECommMethod(TestBase):
                 need_trans=False,
                 dynamic_eplb=False,
                 quant=MoEQuantParams(),
+                lora_context=lora_context,
             )
         )
 
@@ -256,6 +258,7 @@ class TestMoECommMethod(TestBase):
 
         # Verify token_dispatch was called
         mock_td_instance.token_dispatch.assert_called_once()
+        mock_td_instance.set_lora_context.assert_called_once_with(lora_context)
 
         # Verify unified_apply_mlp was called
         mock_unified_apply_mlp.assert_called_once()

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -9,7 +9,10 @@ from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.lora.quant_moe import apply_quant_moe_lora
+from vllm_ascend.lora.quant_moe import (
+    apply_quant_moe_lora,
+    configure_quant_moe_lora_dispatch,
+)
 from vllm_ascend.ops.fused_moe.moe_mlp import (
     cumsum_group_list,
     unified_apply_mlp,
@@ -331,6 +334,25 @@ class TestQuantMoELoRA(unittest.TestCase):
 
         with self.assertRaisesRegex(NotImplementedError, "no implementation registered"):
             apply_quant_moe_lora(mlp_compute_input=mlp_compute_input)
+
+    def test_dynamic_int8_backend_owns_dispatch_validation(self):
+        hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
+
+        with_quant = configure_quant_moe_lora_dispatch(
+            quant_type=QuantType.W8A8,
+            hidden_states=hidden_states,
+            dynamic_scale=None,
+            with_quant=True,
+        )
+
+        self.assertFalse(with_quant)
+        with self.assertRaisesRegex(NotImplementedError, "Dynamic INT8"):
+            configure_quant_moe_lora_dispatch(
+                quant_type=QuantType.W8A8,
+                hidden_states=torch.ones(2, 8, dtype=torch.int8),
+                dynamic_scale=torch.ones(2),
+                with_quant=True,
+            )
 
     def test_injects_lora_at_bf16_boundaries(self):
         hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -1,4 +1,5 @@
 import unittest
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
@@ -8,11 +9,11 @@ from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.lora.quant_moe import apply_quant_moe_lora
 from vllm_ascend.ops.fused_moe.moe_mlp import (
     cumsum_group_list,
     unified_apply_mlp,
     unquant_apply_mlp,
-    w8a8_dynamic_lora_apply_mlp,
 )
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
@@ -24,6 +25,7 @@ from vllm_ascend.quantization.quant_type import QuantType
 
 MXFP4_TEST_DTYPE = getattr(torch, "float4_e2m1fn_x2", torch.float16)
 MOE_MLP = "vllm_ascend.ops.fused_moe.moe_mlp"
+QUANT_MOE_LORA = "vllm_ascend.lora.quant_moe"
 
 
 class TestCumsumGroupList(unittest.TestCase):
@@ -258,7 +260,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         mock_unquant.assert_not_called()
 
 
-class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
+class TestQuantMoELoRA(unittest.TestCase):
     @staticmethod
     def _compute_input(
         *,
@@ -290,13 +292,13 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
             ),
         )
 
-    def test_active_w8a8_lora_uses_dedicated_path(self):
+    def test_active_quant_lora_uses_extensible_dispatcher(self):
         expected = torch.randn(2, 8)
         mlp_compute_input = self._compute_input()
 
         with (
             patch(
-                f"{MOE_MLP}.w8a8_dynamic_lora_apply_mlp",
+                f"{QUANT_MOE_LORA}.apply_quant_moe_lora",
                 return_value=expected,
             ) as mock_lora,
             patch(f"{MOE_MLP}.quant_apply_mlp") as mock_quant,
@@ -316,7 +318,7 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
 
         with (
             patch(f"{MOE_MLP}.quant_apply_mlp", return_value=expected) as mock_quant,
-            patch(f"{MOE_MLP}.w8a8_dynamic_lora_apply_mlp") as mock_lora,
+            patch(f"{QUANT_MOE_LORA}.apply_quant_moe_lora") as mock_lora,
         ):
             output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
 
@@ -324,11 +326,11 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
         mock_quant.assert_called_once()
         mock_lora.assert_not_called()
 
-    def test_active_non_w8a8_lora_is_rejected(self):
+    def test_unregistered_quant_type_is_rejected(self):
         mlp_compute_input = self._compute_input(quant_type=QuantType.W4A8)
 
-        with self.assertRaisesRegex(NotImplementedError, "only W8A8_DYNAMIC"):
-            unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+        with self.assertRaisesRegex(NotImplementedError, "no implementation registered"):
+            apply_quant_moe_lora(mlp_compute_input=mlp_compute_input)
 
     def test_injects_lora_at_bf16_boundaries(self):
         hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
@@ -347,8 +349,23 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
         stream = MagicMock(name="npu_stream")
         stream.record_event.return_value = event
 
+        mlp_compute_input = replace(
+            self._compute_input(),
+            hidden_states=hidden_states,
+            group_list=torch.tensor([1, 1]),
+            weights=MoEWeights(
+                w1=[torch.ones(1, 4, 6, dtype=torch.int8)],
+                w1_scale=[torch.ones(1, 6)],
+                w2=[torch.ones(1, 3, 4, dtype=torch.int8)],
+                w2_scale=[torch.ones(1, 4, dtype=torch.bfloat16)],
+            ),
+            lora_context=lora_context,
+            expanded_row_idx=expanded_row_idx,
+            topk_ids=topk_ids,
+        )
+
         with (
-            patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx,
+            patch(f"{QUANT_MOE_LORA}._EXTRA_CTX") as mock_ctx,
             patch("torch.npu.current_stream", return_value=stream),
             patch.object(
                 DeviceOperator,
@@ -359,12 +376,12 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
                 ],
             ) as mock_quant,
             patch(
-                f"{MOE_MLP}.torch_npu.npu_grouped_matmul",
+                f"{QUANT_MOE_LORA}.torch_npu.npu_grouped_matmul",
                 return_value=[gate_up_out],
                 create=True,
             ) as mock_gmm1,
             patch(
-                f"{MOE_MLP}.torch_npu.npu_swiglu",
+                f"{QUANT_MOE_LORA}.torch_npu.npu_swiglu",
                 return_value=activated,
                 create=True,
             ),
@@ -374,27 +391,14 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
                 return_value=down_out,
             ) as mock_gmm2,
             patch(
-                "vllm_ascend.lora.fused_moe.moe_lora_apply_w13",
+                f"{QUANT_MOE_LORA}.moe_lora_apply_w13",
                 return_value=routing,
             ) as mock_w13,
-            patch("vllm_ascend.lora.fused_moe.moe_lora_apply_w2") as mock_w2,
+            patch(f"{QUANT_MOE_LORA}.moe_lora_apply_w2") as mock_w2,
         ):
             mock_ctx.moe_comm_type = MoECommType.ALLGATHER
-            output, output_event = w8a8_dynamic_lora_apply_mlp(
-                hidden_states=hidden_states,
-                w1=[torch.ones(1, 4, 6, dtype=torch.int8)],
-                w1_scale=[torch.ones(1, 6)],
-                w2=[torch.ones(1, 3, 4, dtype=torch.int8)],
-                w2_scale=[torch.ones(1, 4, dtype=torch.bfloat16)],
-                group_list=torch.tensor([1, 1]),
-                group_list_type=1,
-                activation="silu",
-                swiglu_limit=0.0,
-                lora_context=lora_context,
-                expanded_row_idx=expanded_row_idx,
-                topk_ids=topk_ids,
-                dynamic_scale=None,
-                dynamic_eplb=False,
+            output, output_event = apply_quant_moe_lora(
+                mlp_compute_input=mlp_compute_input,
             )
 
         self.assertIs(output, down_out)
@@ -430,43 +434,31 @@ class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
         )
 
     def test_rejects_unsupported_execution_modes(self):
-        kwargs = {
-            "hidden_states": torch.randn(1, 4, dtype=torch.bfloat16),
-            "w1": [torch.ones(1, 4, 8, dtype=torch.int8)],
-            "w1_scale": [torch.ones(1, 8)],
-            "w2": [torch.ones(1, 4, 4, dtype=torch.int8)],
-            "w2_scale": [torch.ones(1, 4)],
-            "group_list": torch.tensor([1]),
-            "group_list_type": 1,
-            "activation": "silu",
-            "swiglu_limit": 0.0,
-            "lora_context": SimpleNamespace(),
-            "expanded_row_idx": torch.tensor([0]),
-            "topk_ids": torch.tensor([[0]]),
-            "dynamic_scale": None,
-            "dynamic_eplb": False,
-        }
+        mlp_compute_input = self._compute_input()
 
-        with patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx:
+        with patch(f"{QUANT_MOE_LORA}._EXTRA_CTX") as mock_ctx:
             mock_ctx.moe_comm_type = MoECommType.FUSED_MC2
             with self.assertRaisesRegex(NotImplementedError, "FusedMC2"):
-                w8a8_dynamic_lora_apply_mlp(**kwargs)
+                apply_quant_moe_lora(mlp_compute_input=mlp_compute_input)
 
             mock_ctx.moe_comm_type = MoECommType.ALLGATHER
             with self.assertRaisesRegex(NotImplementedError, "dynamic EPLB"):
-                w8a8_dynamic_lora_apply_mlp(**(kwargs | {"dynamic_eplb": True}))
+                apply_quant_moe_lora(
+                    mlp_compute_input=replace(
+                        mlp_compute_input,
+                        dynamic_eplb=True,
+                    )
+                )
 
             with self.assertRaisesRegex(
                 AssertionError,
                 "Dispatch-side quantization",
             ):
-                w8a8_dynamic_lora_apply_mlp(
-                    **(
-                        kwargs
-                        | {
-                            "hidden_states": torch.ones(1, 4, dtype=torch.int8),
-                            "dynamic_scale": torch.ones(1),
-                        }
+                apply_quant_moe_lora(
+                    mlp_compute_input=replace(
+                        mlp_compute_input,
+                        hidden_states=torch.ones(2, 8, dtype=torch.int8),
+                        dynamic_scale=torch.ones(2),
                     )
                 )
 

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -1,11 +1,19 @@
 import unittest
+from types import SimpleNamespace
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
-from vllm_ascend.ops.fused_moe.moe_mlp import cumsum_group_list, unified_apply_mlp, unquant_apply_mlp
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.fused_moe.moe_mlp import (
+    cumsum_group_list,
+    unified_apply_mlp,
+    unquant_apply_mlp,
+    w8a8_dynamic_lora_apply_mlp,
+)
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
     MoEQuantParams,
@@ -15,6 +23,7 @@ from vllm_ascend.ops.fused_moe.moe_stage_params import MoEMxfpParams
 from vllm_ascend.quantization.quant_type import QuantType
 
 MXFP4_TEST_DTYPE = getattr(torch, "float4_e2m1fn_x2", torch.float16)
+MOE_MLP = "vllm_ascend.ops.fused_moe.moe_mlp"
 
 
 class TestCumsumGroupList(unittest.TestCase):
@@ -247,6 +256,219 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertEqual(quant_kwargs["activation"], MoEActivation.SWIGLUSTEP)
         self.assertEqual(quant_kwargs["swiglu_limit"], 5.0)
         mock_unquant.assert_not_called()
+
+
+class TestW8A8DynamicLoraApplyMlp(unittest.TestCase):
+    @staticmethod
+    def _compute_input(
+        *,
+        quant_type=QuantType.W8A8,
+        no_lora=False,
+        dynamic_scale=None,
+    ):
+        return MoEMlpComputeInput(
+            hidden_states=torch.randn(2, 8, dtype=torch.bfloat16),
+            group_list=torch.tensor([2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=dynamic_scale,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones(1, 8, 16, dtype=torch.int8)],
+                w2=[torch.ones(1, 8, 8, dtype=torch.int8)],
+                w1_scale=[torch.ones(1, 16)],
+                w2_scale=[torch.ones(1, 8)],
+            ),
+            quant=MoEQuantParams(quant_type=quant_type),
+            fusion=True,
+            activation="silu",
+            need_trans=False,
+            dynamic_eplb=False,
+            expanded_row_idx=torch.tensor([0, 1], dtype=torch.int32),
+            topk_ids=torch.tensor([[0], [0]], dtype=torch.int32),
+            lora_context=SimpleNamespace(
+                punica_wrapper=SimpleNamespace(no_lora=no_lora),
+            ),
+        )
+
+    def test_active_w8a8_lora_uses_dedicated_path(self):
+        expected = torch.randn(2, 8)
+        mlp_compute_input = self._compute_input()
+
+        with (
+            patch(
+                f"{MOE_MLP}.w8a8_dynamic_lora_apply_mlp",
+                return_value=expected,
+            ) as mock_lora,
+            patch(f"{MOE_MLP}.quant_apply_mlp") as mock_quant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        mock_lora.assert_called_once()
+        mock_quant.assert_not_called()
+
+    def test_base_only_w8a8_keeps_existing_path(self):
+        expected = torch.randn(2, 8)
+        mlp_compute_input = self._compute_input(
+            no_lora=True,
+            dynamic_scale=torch.randn(2),
+        )
+
+        with (
+            patch(f"{MOE_MLP}.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch(f"{MOE_MLP}.w8a8_dynamic_lora_apply_mlp") as mock_lora,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        mock_quant.assert_called_once()
+        mock_lora.assert_not_called()
+
+    def test_active_non_w8a8_lora_is_rejected(self):
+        mlp_compute_input = self._compute_input(quant_type=QuantType.W4A8)
+
+        with self.assertRaisesRegex(NotImplementedError, "only W8A8_DYNAMIC"):
+            unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+    def test_injects_lora_at_bf16_boundaries(self):
+        hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+        quantized_input = torch.ones(2, 4, dtype=torch.int8)
+        input_scale = torch.ones(2, dtype=torch.float32)
+        gate_up_out = torch.randn(2, 6, dtype=torch.bfloat16)
+        activated = torch.randn(2, 3, dtype=torch.bfloat16)
+        quantized_activated = torch.ones(2, 3, dtype=torch.int8)
+        activated_scale = torch.ones(2, dtype=torch.float32)
+        down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+        lora_context = SimpleNamespace()
+        routing = (torch.tensor([0, 1]), torch.tensor([0, 1]))
+        expanded_row_idx = torch.tensor([0, 1], dtype=torch.int32)
+        topk_ids = torch.tensor([[0], [1]], dtype=torch.int32)
+        event = MagicMock(name="before_gmm2_evt")
+        stream = MagicMock(name="npu_stream")
+        stream.record_event.return_value = event
+
+        with (
+            patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx,
+            patch("torch.npu.current_stream", return_value=stream),
+            patch.object(
+                DeviceOperator,
+                "npu_dynamic_quant",
+                side_effect=[
+                    (quantized_input, input_scale),
+                    (quantized_activated, activated_scale),
+                ],
+            ) as mock_quant,
+            patch(
+                f"{MOE_MLP}.torch_npu.npu_grouped_matmul",
+                return_value=[gate_up_out],
+                create=True,
+            ) as mock_gmm1,
+            patch(
+                f"{MOE_MLP}.torch_npu.npu_swiglu",
+                return_value=activated,
+                create=True,
+            ),
+            patch.object(
+                DeviceOperator,
+                "npu_grouped_matmul_gmm2",
+                return_value=down_out,
+            ) as mock_gmm2,
+            patch(
+                "vllm_ascend.lora.fused_moe.moe_lora_apply_w13",
+                return_value=routing,
+            ) as mock_w13,
+            patch("vllm_ascend.lora.fused_moe.moe_lora_apply_w2") as mock_w2,
+        ):
+            mock_ctx.moe_comm_type = MoECommType.ALLGATHER
+            output, output_event = w8a8_dynamic_lora_apply_mlp(
+                hidden_states=hidden_states,
+                w1=[torch.ones(1, 4, 6, dtype=torch.int8)],
+                w1_scale=[torch.ones(1, 6)],
+                w2=[torch.ones(1, 3, 4, dtype=torch.int8)],
+                w2_scale=[torch.ones(1, 4, dtype=torch.bfloat16)],
+                group_list=torch.tensor([1, 1]),
+                group_list_type=1,
+                activation="silu",
+                swiglu_limit=0.0,
+                lora_context=lora_context,
+                expanded_row_idx=expanded_row_idx,
+                topk_ids=topk_ids,
+                dynamic_scale=None,
+                dynamic_eplb=False,
+            )
+
+        self.assertIs(output, down_out)
+        self.assertIs(output_event, event)
+        self.assertEqual(mock_quant.call_count, 2)
+        self.assertIs(
+            mock_quant.call_args_list[0].kwargs["hidden_states"],
+            hidden_states,
+        )
+        self.assertIs(
+            mock_quant.call_args_list[1].kwargs["hidden_states"],
+            activated,
+        )
+        self.assertIs(mock_gmm1.call_args.kwargs["x"][0], quantized_input)
+        self.assertIs(
+            mock_gmm2.call_args.kwargs["hidden_states"],
+            quantized_activated,
+        )
+        mock_w13.assert_called_once()
+        self.assertIs(mock_w13.call_args.args[0], lora_context)
+        self.assertIs(mock_w13.call_args.kwargs["gate_up_out"], gate_up_out)
+        self.assertIs(mock_w13.call_args.kwargs["hidden_states"], hidden_states)
+        self.assertIs(
+            mock_w13.call_args.kwargs["expanded_row_idx"],
+            expanded_row_idx,
+        )
+        self.assertIs(mock_w13.call_args.kwargs["topk_ids"], topk_ids)
+        mock_w2.assert_called_once_with(
+            lora_context,
+            down_out=down_out,
+            silu_out=activated,
+            lora_routing=routing,
+        )
+
+    def test_rejects_unsupported_execution_modes(self):
+        kwargs = {
+            "hidden_states": torch.randn(1, 4, dtype=torch.bfloat16),
+            "w1": [torch.ones(1, 4, 8, dtype=torch.int8)],
+            "w1_scale": [torch.ones(1, 8)],
+            "w2": [torch.ones(1, 4, 4, dtype=torch.int8)],
+            "w2_scale": [torch.ones(1, 4)],
+            "group_list": torch.tensor([1]),
+            "group_list_type": 1,
+            "activation": "silu",
+            "swiglu_limit": 0.0,
+            "lora_context": SimpleNamespace(),
+            "expanded_row_idx": torch.tensor([0]),
+            "topk_ids": torch.tensor([[0]]),
+            "dynamic_scale": None,
+            "dynamic_eplb": False,
+        }
+
+        with patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx:
+            mock_ctx.moe_comm_type = MoECommType.FUSED_MC2
+            with self.assertRaisesRegex(NotImplementedError, "FusedMC2"):
+                w8a8_dynamic_lora_apply_mlp(**kwargs)
+
+            mock_ctx.moe_comm_type = MoECommType.ALLGATHER
+            with self.assertRaisesRegex(NotImplementedError, "dynamic EPLB"):
+                w8a8_dynamic_lora_apply_mlp(**(kwargs | {"dynamic_eplb": True}))
+
+            with self.assertRaisesRegex(
+                AssertionError,
+                "Dispatch-side quantization",
+            ):
+                w8a8_dynamic_lora_apply_mlp(
+                    **(
+                        kwargs
+                        | {
+                            "hidden_states": torch.ones(1, 4, dtype=torch.int8),
+                            "dynamic_scale": torch.ones(1),
+                        }
+                    )
+                )
 
 
 if __name__ == "__main__":

--- a/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import torch
@@ -13,6 +14,9 @@ from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.quantization.methods.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod,
     AscendW8A8DynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8_pdmix import (
+    AscendW8A8PDMixFusedMoeMethod,
 )
 
 
@@ -129,6 +133,19 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertEqual(param_dict["w2_weight_scale"].dtype, torch.bfloat16)
         self.assertEqual(param_dict["w2_weight_offset"].shape, (self.num_experts, self.hidden_size, 1))
 
+    def test_lora_rejects_derived_w8a8_schemes(self):
+        method = object.__new__(AscendW8A8PDMixFusedMoeMethod)
+        layer = SimpleNamespace(_ascend_moe_lora_context=object())
+
+        with self.assertRaisesRegex(NotImplementedError, "only the W8A8_DYNAMIC"):
+            method.apply(
+                layer=layer,
+                x=torch.empty(1, self.hidden_size),
+                router_logits=torch.empty(1, self.num_experts),
+                top_k=1,
+                renormalize=True,
+            )
+
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.select_experts")
     def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_select_experts, mock_extra_ctx):
@@ -150,6 +167,8 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         layer.w13_weight_scale_fp32 = torch.ones(self.num_experts, 2 * self.intermediate_size, dtype=torch.float32)
         layer.w2_weight_scale = torch.ones(self.num_experts, hidden_size, dtype=torch.float32)
         layer.swiglu_limit = 1000000
+        lora_context = object()
+        layer._ascend_moe_lora_context = lora_context
 
         x = torch.randn(tokens, hidden_size, dtype=torch.float32)
         router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
@@ -186,6 +205,7 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertIs(fused_experts_input.routing.pertoken_scale, pertoken_scale)
         self.assertIs(fused_experts_input.topk_weights, topk_weights)
         self.assertIs(fused_experts_input.topk_ids, topk_ids)
+        self.assertIs(fused_experts_input.lora_context, lora_context)
 
     @patch("torch_npu.npu_format_cast")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -17,25 +17,15 @@
 
 Design (see plan in conversation history):
 
-  - Inherits weight allocation / set_lora / slice helpers from upstream
-    FusedMoEWithLoRA. Only the injection mechanism differs: upstream wraps
-    Triton modular kernel internals (`TritonExperts.activation` / `moe_sum`),
-    which do not exist on Ascend. We instead wrap the per-layer
-    `quant_method.apply` and, inside it, temporarily swap the active
-    `MoECommMethod._apply_mlp` so the LoRA delta is added on permuted
-    activations between the grouped GMMs.
+  - Inherits weight allocation / set_lora / TP slicing from vLLM 0.23.0's
+    FusedMoEWithLoRA. Ascend publishes one context on the base MoE layer and
+    threads it explicitly through dispatch and MLP inputs; LoRA deltas are
+    injected at the BF16 boundaries between the grouped matmuls.
 
-  - Per-layer ownership is critical: `_MoECommMethods` is a module-level
-    singleton shared by all 48 MoE layers. If we wrapped `_apply_mlp` at
-    init time, layer N+1 would compose on top of layer N's wrapper and
-    every forward would stack all layers' LoRA deltas. We bracket the swap
-    inside `apply_wrapper` so only the active layer is in effect.
-
-  - v1 deliberately limits scope to: unquant + AllGather + TP-only +
-    no shared experts + no FusedMC2 + no dynamic EPLB. These are the exact
-    conditions under which `Qwen3-30B-A3B-Thinking-2507` runs cleanly with
-    TP=4 EP=1 on 4×64GB. Other paths assert early so users get a clear
-    error rather than silently wrong outputs.
+  - Quantized v1 deliberately limits scope to W8A8_DYNAMIC + AllGather +
+    TP-only + no FusedMC2 + no dynamic EPLB. Shared experts stay on their
+    dense LoRA wrappers while routed experts use this MoE path. Other
+    combinations fail early rather than silently producing wrong outputs.
 """
 
 from __future__ import annotations
@@ -47,6 +37,7 @@ from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.logger import logger
 from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
 from vllm.lora.layers.utils import _get_lora_device
@@ -54,12 +45,38 @@ from vllm.lora.layers.utils import _get_lora_device
 import vllm_ascend.envs as envs_ascend
 
 
+def _moe_lora_projection_enabled(
+    lora_b: list[torch.Tensor],
+    w13_num_slices: int,
+) -> tuple[bool, bool]:
+    """Return whether routed w13 and w2 contain a non-zero LoRA B."""
+    if len(lora_b) == 2:
+        w13_lora_b, w2_lora_b = lora_b
+        return (
+            bool(torch.count_nonzero(w13_lora_b).item()),
+            bool(torch.count_nonzero(w2_lora_b).item()),
+        )
+
+    if len(lora_b) != 3:
+        raise ValueError(f"Expected 2 or 3 routed-expert LoRA B tensors, got {len(lora_b)}")
+
+    w1_lora_b, w2_lora_b, w3_lora_b = lora_b
+    w13_enabled = bool(torch.count_nonzero(w1_lora_b).item())
+    if w13_num_slices == 2:
+        w13_enabled = w13_enabled or bool(torch.count_nonzero(w3_lora_b).item())
+    return w13_enabled, bool(torch.count_nonzero(w2_lora_b).item())
+
+
+def is_moe_lora_active(lora_context) -> bool:
+    """Return whether the current batch contains at least one LoRA token."""
+    return lora_context is not None and not lora_context.punica_wrapper.no_lora
+
+
 def _assert_ascend_moe_lora_supported(base_layer: nn.Module) -> None:
     if getattr(base_layer, "use_ep", False):
         raise AssertionError(
             "Ascend MoE LoRA v1 does not support expert parallelism. "
-            "Launch with `--enable-expert-parallel=false` and use TP only "
-            "(e.g. TP=4 for Qwen3-30B-A3B on 4x64GB)."
+            "Launch with `--enable-expert-parallel=false` and use TP only."
         )
     if getattr(base_layer, "dynamic_eplb", False):
         raise AssertionError(
@@ -73,11 +90,10 @@ def _assert_ascend_moe_lora_supported(base_layer: nn.Module) -> None:
             "Set VLLM_ASCEND_ENABLE_FUSED_MC2=0."
         )
     if getattr(base_layer, "_shared_experts", None) is not None:
-        raise AssertionError(
-            "Ascend MoE LoRA v1 does not wrap the shared_experts path "
-            "(it runs outside quant_method.apply). The target model "
-            "Qwen3-30B-A3B-Thinking-2507 has no shared experts; models "
-            "like DeepSeek-V3 are not yet supported."
+        logger.warning_once(
+            "Ascend MoE LoRA: shared_experts detected. Routed-expert LoRA "
+            "uses the MoE path; shared-expert LoRA uses dense wrappers with "
+            "the compatible NPU expand-slice implementation."
         )
     if getattr(base_layer, "multistream_overlap_gate", False):
         raise AssertionError(
@@ -127,7 +143,11 @@ def moe_lora_apply_w13(lora_context, *, gate_up_out, hidden_states, expanded_row
         lora_a_stacked=lora_context.w13_lora_a_stacked,
         lora_b_stacked=lora_context.w13_lora_b_stacked,
         expert_ids=expert_per_row,
-        adapter_enabled=lora_context.adapter_enabled,
+        adapter_enabled=getattr(
+            lora_context,
+            "w13_adapter_enabled",
+            lora_context.adapter_enabled,
+        ),
         token_lora_mapping=lora_per_row,
     )
     return routing
@@ -146,7 +166,11 @@ def moe_lora_apply_w2(lora_context, *, down_out, silu_out, lora_routing):
         lora_a_stacked=lora_context.w2_lora_a_stacked,
         lora_b_stacked=lora_context.w2_lora_b_stacked,
         expert_ids=expert_per_row,
-        adapter_enabled=lora_context.adapter_enabled,
+        adapter_enabled=getattr(
+            lora_context,
+            "w2_adapter_enabled",
+            lora_context.adapter_enabled,
+        ),
         token_lora_mapping=lora_per_row,
     )
 
@@ -174,8 +198,59 @@ class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
         self.tp_rank = get_tensor_model_parallel_rank()
         self.device = _get_lora_device(base_layer)
         self._enable_aux_cuda_stream = envs.VLLM_LORA_ENABLE_DUAL_STREAM
+        # vLLM 0.23.0's _build_lora_context reads these attributes. Ascend
+        # does not use the CUDA auxiliary-stream implementation.
+        self._lora_stream = None
+        self._events = None
         self.moe_config = base_layer.moe_config
         self._w13_slices = 2 if base_layer.moe_config.is_act_and_mul else 1
+        # FusedMoEWithLoRA.__init__ normally creates this field, but Ascend
+        # intentionally skips that GPU-kernel constructor. The v0.23 model
+        # manager uses it when constructing dummy/warmup MoE adapters.
+        self.n_slices = base_layer.local_num_experts * (self._w13_slices + 1)
+        # Keep the original module path visible after the FusedMoE layer is
+        # replaced by this wrapper. vLLM's model manager continues walking
+        # ``<moe>._shared_experts.*`` and wraps those dense projections in
+        # place; both references point to the same shared-expert module.
+        shared_experts = getattr(base_layer, "_shared_experts", None)
+        if shared_experts is not None:
+            self._shared_experts = shared_experts
+
+    def create_lora_weights(
+        self,
+        max_loras,
+        lora_config,
+        model_config=None,
+    ) -> None:
+        super().create_lora_weights(max_loras, lora_config, model_config)
+        self.w13_adapter_enabled = torch.zeros_like(self.adapter_enabled)
+        self.w2_adapter_enabled = torch.zeros_like(self.adapter_enabled)
+
+    def reset_lora(self, index: int) -> None:
+        super().reset_lora(index)
+        self.w13_adapter_enabled[index] = 0
+        self.w2_adapter_enabled[index] = 0
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+    ) -> None:
+        assert isinstance(lora_b, list)
+        w13_enabled, w2_enabled = _moe_lora_projection_enabled(
+            lora_b,
+            self._w13_slices,
+        )
+        super().set_lora(index, lora_a, lora_b)
+        self.w13_adapter_enabled[index] = int(w13_enabled)
+        self.w2_adapter_enabled[index] = int(w2_enabled)
+
+    def _build_lora_context(self):
+        lora_context = super()._build_lora_context()
+        lora_context.w13_adapter_enabled = self.w13_adapter_enabled
+        lora_context.w2_adapter_enabled = self.w2_adapter_enabled
+        return lora_context
 
     # ------------------------------------------------------------------
     # Mapping
@@ -187,13 +262,14 @@ class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
         # deliberately skip in __init__. We instead build the per-layer
         # MoELoRAContext (now that punica_wrapper is available) and publish it
         # on the module that ``AscendUnquantizedFusedMoEMethod.apply`` reads via
-        # ``getattr(layer, "_ascend_moe_lora_context", None)`` -- the base layer
-        # itself on 0.23.0, but ``base_layer.routed_experts`` on main (there the
-        # runner *is* the layer and it calls apply with ``layer=routed_experts``).
+        # ``getattr(layer, "_ascend_moe_lora_context", None)`` on v0.23.0's
+        # FusedMoE layer.
         # The context holds stable references (the in-place-updated LoRA stacks,
         # adapter_enabled and the punica wrapper), so building it once here is
         # sufficient.
         BaseLayerWithLoRA.set_mapping(self, punica_wrapper)
+        if getattr(self.base_layer, "_shared_experts", None) is not None:
+            punica_wrapper.enable_compatible_lora_bmm_expand_slice()
         self.base_layer.set_lora_context(self._build_lora_context())
 
 

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -33,11 +33,7 @@ def _moe_lora_bmm_expand_slice_op(
         return
 
     delta = torch.bmm(gathered, x_active.unsqueeze(-1)).squeeze(-1)
-    delta = torch.where(
-        (indices >= 0).unsqueeze(-1),
-        delta,
-        torch.zeros_like(delta),
-    )
+    delta.masked_fill_((indices < 0).unsqueeze(-1), 0.0)
 
     y_slice = y.narrow(1, y_offset, y_slice_size)
     y_slice = y_slice[: delta.shape[0]]

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -9,6 +9,57 @@ from vllm_ascend.lora.utils import refresh_all_lora_classes
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
+@torch.library.custom_op(
+    "vllm_ascend::moe_lora_bmm_expand_slice",
+    mutates_args={"y"},
+)
+def _moe_lora_bmm_expand_slice_op(
+    y: torch.Tensor,
+    x: torch.Tensor,
+    w_t_all: torch.Tensor,
+    indices: torch.Tensor,
+    y_offset: int,
+    y_slice_size: int,
+    add_inputs: bool,
+) -> None:
+    rows = x.shape[0]
+    indices = indices[:rows]
+    safe_indices = indices.clamp(min=0).to(torch.long)
+    gathered = w_t_all[safe_indices, 0].to(y.dtype)
+    active_rank = gathered.shape[-1]
+    x_active = x[..., :active_rank].to(y.dtype).contiguous()
+
+    if x_active.shape[0] == 0 or gathered.shape[1] == 0:
+        return
+
+    delta = torch.bmm(gathered, x_active.unsqueeze(-1)).squeeze(-1)
+    delta = torch.where(
+        (indices >= 0).unsqueeze(-1),
+        delta,
+        torch.zeros_like(delta),
+    )
+
+    y_slice = y.narrow(1, y_offset, y_slice_size)
+    y_slice = y_slice[: delta.shape[0]]
+    if add_inputs:
+        y_slice.add_(delta)
+    else:
+        y_slice.copy_(delta)
+
+
+@_moe_lora_bmm_expand_slice_op.register_fake
+def _moe_lora_bmm_expand_slice_fake(
+    y: torch.Tensor,
+    x: torch.Tensor,
+    w_t_all: torch.Tensor,
+    indices: torch.Tensor,
+    y_offset: int,
+    y_slice_size: int,
+    add_inputs: bool,
+) -> None:
+    return None
+
+
 # The platforms that are compatible with the PyTorch-native implementation can
 # inherit this class
 class PunicaWrapperNPU(PunicaWrapperBase):
@@ -48,6 +99,38 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand = sgmv_expand
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
+        self._force_lora_bmm_expand_slice = False
+
+    def enable_compatible_lora_bmm_expand_slice(self) -> None:
+        """Enable the dense LoRA expand path used by shared experts."""
+        self._force_lora_bmm_expand_slice = True
+
+    def update_metadata(
+        self,
+        mapping,
+        lora_index_to_id,
+        max_loras,
+        vocab_size,
+        **kwargs,
+    ) -> None:
+        super().update_metadata(
+            mapping,
+            lora_index_to_id,
+            max_loras,
+            vocab_size,
+            **kwargs,
+        )
+        # PunicaWrapperBase only refreshes no_lora for prefill metadata.
+        # Keep it batch-accurate for decode so base-only batches retain the
+        # original fused W8A8 MoE path.
+        self.no_lora = not any(lora_id > 0 for lora_id in mapping.index_mapping)
+
+    def _requires_bmm_expand_slice(
+        self,
+        x: torch.Tensor,
+        y_slice_size: int,
+    ) -> bool:
+        return self._force_lora_bmm_expand_slice or x.shape[-1] > y_slice_size
 
     def _shrink_prefill(
         self,
@@ -115,6 +198,16 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         # No LoRA request, so return directly
         if self.no_lora:
             return
+        if self._requires_bmm_expand_slice(x, y_slice_size):
+            self._bmm_expand_slice(
+                y,
+                x,
+                w_t_all,
+                y_offset,
+                y_slice_size,
+                add_inputs,
+            )
+            return
         self.sgmv_expand_slice(
             x,
             w_t_all,
@@ -134,10 +227,39 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         y_slice_size: int,
         add_inputs: bool,
     ):
+        if self._requires_bmm_expand_slice(x, y_slice_size):
+            self._bmm_expand_slice(
+                y,
+                x,
+                w_t_all,
+                y_offset,
+                y_slice_size,
+                add_inputs,
+            )
+            return
         self.bgmv_expand_slice(
             x,
             w_t_all,
             y,
+            self._get_token_lora_indices(x),
+            y_offset,
+            y_slice_size,
+            add_inputs,
+        )
+
+    def _bmm_expand_slice(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        y_offset: int,
+        y_slice_size: int,
+        add_inputs: bool,
+    ) -> None:
+        _moe_lora_bmm_expand_slice_op(
+            y,
+            x,
+            w_t_all,
             self._get_token_lora_indices(x),
             y_offset,
             y_slice_size,

--- a/vllm_ascend/lora/quant_moe.py
+++ b/vllm_ascend/lora/quant_moe.py
@@ -36,12 +36,14 @@ from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.quantization.quant_type import QuantType
 
 QuantMoELoRAApply = Callable[[MoEMlpComputeInput], tuple[torch.Tensor, torch.npu.Event | None]]
+QuantMoELoRADispatchValidator = Callable[[torch.Tensor, torch.Tensor | None], None]
 
 
 @dataclass(frozen=True)
 class QuantMoELoRAImpl:
     apply: QuantMoELoRAApply
     requires_unquantized_dispatch: bool
+    validate_dispatch_input: QuantMoELoRADispatchValidator | None
 
 
 _QUANT_MOE_LORA_IMPLS: dict[QuantType, QuantMoELoRAImpl] = {}
@@ -51,6 +53,7 @@ def register_quant_moe_lora_impl(
     quant_type: QuantType,
     *,
     requires_unquantized_dispatch: bool = True,
+    validate_dispatch_input: QuantMoELoRADispatchValidator | None = None,
 ):
     """Register the LoRA execution implementation for a quantized MoE type."""
 
@@ -60,6 +63,7 @@ def register_quant_moe_lora_impl(
         _QUANT_MOE_LORA_IMPLS[quant_type] = QuantMoELoRAImpl(
             apply=apply,
             requires_unquantized_dispatch=requires_unquantized_dispatch,
+            validate_dispatch_input=validate_dispatch_input,
         )
         return apply
 
@@ -76,9 +80,24 @@ def apply_quant_moe_lora(
     return impl.apply(mlp_compute_input)
 
 
-def quant_moe_lora_requires_unquantized_dispatch(quant_type: QuantType) -> bool:
-    """Return the dispatch policy declared by a quantized MoE LoRA impl."""
-    return _get_quant_moe_lora_impl(quant_type).requires_unquantized_dispatch
+def configure_quant_moe_lora_dispatch(
+    *,
+    quant_type: QuantType,
+    hidden_states: torch.Tensor,
+    dynamic_scale: torch.Tensor | None,
+    with_quant: bool,
+) -> bool:
+    """Apply a registered implementation's policy to MoE dispatch.
+
+    The generic token dispatcher deliberately does not interpret activation
+    dtypes or scales. Those details belong to the quantization implementation.
+    """
+    impl = _get_quant_moe_lora_impl(quant_type)
+    if impl.validate_dispatch_input is not None:
+        impl.validate_dispatch_input(hidden_states, dynamic_scale)
+    if impl.requires_unquantized_dispatch:
+        return False
+    return with_quant
 
 
 def _get_quant_moe_lora_impl(quant_type: QuantType) -> QuantMoELoRAImpl:
@@ -117,7 +136,18 @@ def _apply_moe_activation(
     return torch_npu.npu_swiglu(gate_up_out)
 
 
-@register_quant_moe_lora_impl(QuantType.W8A8)
+def _validate_dynamic_int8_dispatch(
+    hidden_states: torch.Tensor,
+    dynamic_scale: torch.Tensor | None,
+) -> None:
+    if dynamic_scale is not None or hidden_states.dtype == torch.int8:
+        raise NotImplementedError("Dynamic INT8 MoE LoRA requires unquantized activations before AllGather dispatch.")
+
+
+@register_quant_moe_lora_impl(
+    QuantType.W8A8,
+    validate_dispatch_input=_validate_dynamic_int8_dispatch,
+)
 def _apply_dynamic_int8_moe_lora(
     mlp_compute_input: MoEMlpComputeInput,
 ) -> tuple[torch.Tensor, torch.npu.Event | None]:
@@ -221,6 +251,6 @@ def _apply_dynamic_int8_moe_lora(
 
 __all__ = [
     "apply_quant_moe_lora",
-    "quant_moe_lora_requires_unquantized_dispatch",
+    "configure_quant_moe_lora_dispatch",
     "register_quant_moe_lora_impl",
 ]

--- a/vllm_ascend/lora/quant_moe.py
+++ b/vllm_ascend/lora/quant_moe.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extensible quantized MoE LoRA execution.
+
+The public entry point is intentionally independent of a concrete quantization
+scheme. Each supported scheme registers an implementation keyed by
+``QuantType``. Implementations preserve floating-point activation boundaries
+for LoRA while retaining the quantized base expert matmuls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+import torch_npu
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.lora.fused_moe import moe_lora_apply_w2, moe_lora_apply_w13
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
+from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
+from vllm_ascend.quantization.quant_type import QuantType
+
+QuantMoELoRAApply = Callable[[MoEMlpComputeInput], tuple[torch.Tensor, torch.npu.Event | None]]
+
+
+@dataclass(frozen=True)
+class QuantMoELoRAImpl:
+    apply: QuantMoELoRAApply
+    requires_unquantized_dispatch: bool
+
+
+_QUANT_MOE_LORA_IMPLS: dict[QuantType, QuantMoELoRAImpl] = {}
+
+
+def register_quant_moe_lora_impl(
+    quant_type: QuantType,
+    *,
+    requires_unquantized_dispatch: bool = True,
+):
+    """Register the LoRA execution implementation for a quantized MoE type."""
+
+    def decorator(apply: QuantMoELoRAApply) -> QuantMoELoRAApply:
+        if quant_type in _QUANT_MOE_LORA_IMPLS:
+            raise ValueError(f"Quantized MoE LoRA implementation already registered for {quant_type}.")
+        _QUANT_MOE_LORA_IMPLS[quant_type] = QuantMoELoRAImpl(
+            apply=apply,
+            requires_unquantized_dispatch=requires_unquantized_dispatch,
+        )
+        return apply
+
+    return decorator
+
+
+def apply_quant_moe_lora(
+    *,
+    mlp_compute_input: MoEMlpComputeInput,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Dispatch a quantized MoE LoRA request to its quant implementation."""
+    quant_type = mlp_compute_input.quant.quant_type
+    impl = _get_quant_moe_lora_impl(quant_type)
+    return impl.apply(mlp_compute_input)
+
+
+def quant_moe_lora_requires_unquantized_dispatch(quant_type: QuantType) -> bool:
+    """Return the dispatch policy declared by a quantized MoE LoRA impl."""
+    return _get_quant_moe_lora_impl(quant_type).requires_unquantized_dispatch
+
+
+def _get_quant_moe_lora_impl(quant_type: QuantType) -> QuantMoELoRAImpl:
+    impl = _QUANT_MOE_LORA_IMPLS.get(quant_type)
+    if impl is None:
+        supported = ", ".join(item.name for item in _QUANT_MOE_LORA_IMPLS)
+        raise NotImplementedError(
+            "Ascend quantized MoE LoRA has no implementation registered for "
+            f"{quant_type.name}. Registered quant types: {supported or 'none'}."
+        )
+    return impl
+
+
+def _apply_moe_activation(
+    gate_up_out: torch.Tensor,
+    activation: str | None,
+    swiglu_limit: float,
+) -> torch.Tensor:
+    if activation == MoEActivation.SWIGLUOAI:
+        return AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out)
+    if activation == MoEActivation.SWIGLUSTEP:
+        return AscendSwigluStepAndMul.swiglustep_forward(
+            gate_up_out,
+            limit=swiglu_limit or 7.0,
+        )
+    if activation in (MoEActivation.GELU, MoEActivation.GELU_TANH):
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
+        return torch.nn.functional.gelu(gate, approximate=approximate) * up
+
+    if swiglu_limit > 0:
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        gate = gate.clamp(max=swiglu_limit)
+        up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+        gate_up_out = torch.cat((gate, up), dim=-1)
+    return torch_npu.npu_swiglu(gate_up_out)
+
+
+@register_quant_moe_lora_impl(QuantType.W8A8)
+def _apply_dynamic_int8_moe_lora(
+    mlp_compute_input: MoEMlpComputeInput,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Dynamic INT8 base experts with floating-point LoRA boundaries."""
+    if _EXTRA_CTX.moe_comm_type != MoECommType.ALLGATHER:
+        raise NotImplementedError(
+            "Ascend quantized MoE LoRA currently supports only the "
+            "AllGather TP path; EP, AlltoAll, MC2, and FusedMC2 are unsupported."
+        )
+    if mlp_compute_input.dynamic_eplb:
+        raise NotImplementedError("Ascend quantized MoE LoRA does not support dynamic EPLB.")
+
+    hidden_states = mlp_compute_input.hidden_states
+    if mlp_compute_input.dynamic_scale is not None or hidden_states.dtype == torch.int8:
+        raise AssertionError(
+            "Quantized MoE LoRA requires BF16/FP16 routed activations. "
+            "Dispatch-side quantization must be disabled for LoRA batches."
+        )
+    if mlp_compute_input.expanded_row_idx is None or mlp_compute_input.topk_ids is None:
+        raise AssertionError("Quantized MoE LoRA requires AllGather routing metadata (expanded_row_idx and topk_ids).")
+
+    weights = mlp_compute_input.weights
+    if weights.w1_scale_bias is not None or weights.w2_scale_bias is not None:
+        raise NotImplementedError("Quantized MoE LoRA does not support fused scale-bias.")
+    if weights.w1_offset is not None or weights.w2_offset is not None:
+        raise NotImplementedError("Quantized MoE LoRA does not support antiquant offsets.")
+    if weights.w1_scale is None or weights.w2_scale is None:
+        raise AssertionError("Quantized MoE LoRA requires w1 and w2 weight scales.")
+
+    w1_list = weights.w1 if isinstance(weights.w1, list) else [weights.w1]
+    w2_list = weights.w2 if isinstance(weights.w2, list) else [weights.w2]
+    w1_scale_list = weights.w1_scale if isinstance(weights.w1_scale, list) else [weights.w1_scale]
+    w2_scale_list = weights.w2_scale if isinstance(weights.w2_scale, list) else [weights.w2_scale]
+    if not all(len(values) == 1 for values in (w1_list, w2_list, w1_scale_list, w2_scale_list)):
+        raise NotImplementedError("Quantized MoE LoRA does not support per-expert tensor lists used by dynamic EPLB.")
+
+    input_dtype = hidden_states.dtype
+    quantized_input, input_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states=hidden_states,
+        dynamic_scale=None,
+        act_quant_type=torch.int8,
+        use_mxfp_quant=False,
+    )
+    gate_up_out = torch_npu.npu_grouped_matmul(
+        x=[quantized_input],
+        weight=w1_list,
+        scale=[w1_scale_list[0].to(w2_scale_list[0].dtype)],
+        per_token_scale=[input_scale],
+        split_item=2,
+        group_type=0,
+        group_list=mlp_compute_input.group_list,
+        group_list_type=mlp_compute_input.group_list_type,
+        output_dtype=input_dtype,
+    )[0]
+    lora_routing = moe_lora_apply_w13(
+        mlp_compute_input.lora_context,
+        gate_up_out=gate_up_out,
+        hidden_states=hidden_states,
+        expanded_row_idx=mlp_compute_input.expanded_row_idx,
+        topk_ids=mlp_compute_input.topk_ids,
+    )
+
+    activated = _apply_moe_activation(
+        gate_up_out,
+        mlp_compute_input.activation,
+        mlp_compute_input.swiglu_limit,
+    )
+    quantized_activated, activated_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states=activated,
+        dynamic_scale=None,
+        act_quant_type=torch.int8,
+        use_mxfp_quant=False,
+    )
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    down_out = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states=quantized_activated,
+        weight=w2_list,
+        weight_scale=w2_scale_list,
+        per_token_scale=activated_scale,
+        group_list=mlp_compute_input.group_list,
+        group_list_type=mlp_compute_input.group_list_type,
+        input_dtype=input_dtype,
+        act_quant_type=torch.int8,
+        weight_quant_type=None,
+        scale_type=None,
+        per_token_scale_type=None,
+        use_bf16=input_dtype == torch.bfloat16,
+        use_mxfp_quant=False,
+        bias=None,
+        fallback_output_dtype=w2_scale_list[0].dtype,
+        mxfp_quant_dtype=None,
+    )
+    moe_lora_apply_w2(
+        mlp_compute_input.lora_context,
+        down_out=down_out,
+        silu_out=activated,
+        lora_routing=lora_routing,
+    )
+    return down_out, before_gmm2_evt
+
+
+__all__ = [
+    "apply_quant_moe_lora",
+    "quant_moe_lora_requires_unquantized_dispatch",
+    "register_quant_moe_lora_impl",
+]

--- a/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe_0_23_0.py
@@ -23,6 +23,7 @@ vllm_ascend.ops.fused_moe.fused_moe only.
 
 from __future__ import annotations
 
+from vllm_ascend.lora.fused_moe import is_moe_lora_active
 from vllm_ascend.ops.fused_moe.fused_moe import (
     _EXTRA_CTX,
     AllGatherCommImpl,
@@ -566,10 +567,18 @@ class AscendFusedMoE(FusedMoE):
 
         with npu_stream_switch(shared_experts_calculation_stream(), enabled=self.multistream_overlap_shared_expert):
             # Only used for int quantization
-            has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
-                self._shared_experts.down_proj, "weight_scale"
+            gate_up_proj = self._shared_experts.gate_up_proj
+            down_proj = self._shared_experts.down_proj
+            # Dense LoRA wrappers keep quantized base weights/scales on their
+            # ``base_layer``. Unwrap only for the base-only raw quant path;
+            # active LoRA batches continue through the wrappers below.
+            quantized_gate_up_proj = getattr(gate_up_proj, "base_layer", gate_up_proj)
+            quantized_down_proj = getattr(down_proj, "base_layer", down_proj)
+            has_quantized_shared = hasattr(quantized_gate_up_proj, "weight_scale") and hasattr(
+                quantized_down_proj, "weight_scale"
             )
-            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+            shared_lora_active = is_moe_lora_active(getattr(self, "_ascend_moe_lora_context", None))
+            if has_quantized_shared and not shared_lora_active and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -579,8 +588,8 @@ class AscendFusedMoE(FusedMoE):
                 maybe_wait_event(fused_moe_evts.after_routed_experts)
                 hidden_states = torch_npu.npu_quant_matmul(
                     quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
+                    quantized_gate_up_proj.weight,
+                    quantized_gate_up_proj.weight_scale,
                     pertoken_scale=None,
                     bias=None,
                     output_dtype=torch.int32,
@@ -595,7 +604,7 @@ class AscendFusedMoE(FusedMoE):
                     group_index.fill_(hidden_states.shape[0])
                 quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                     x=hidden_states,
-                    weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
+                    weight_scale=quantized_gate_up_proj.weight_scale_fp32,
                     activation_scale=pertoken_scale,
                     bias=None,
                     quant_scale=None,
@@ -611,13 +620,13 @@ class AscendFusedMoE(FusedMoE):
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = torch_npu.npu_quant_matmul(
                     quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
+                    quantized_down_proj.weight,
+                    quantized_down_proj.weight_scale,
                     pertoken_scale=swiglu_out_scale,
                     bias=None,
                     output_dtype=original_dtype,
                 )
-            elif has_quantized_shared and self.quant_type == QuantType.W4A8MXFP:
+            elif has_quantized_shared and not shared_lora_active and self.quant_type == QuantType.W4A8MXFP:
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -627,7 +636,7 @@ class AscendFusedMoE(FusedMoE):
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
-                hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
+                hidden_states = quantized_gate_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
@@ -641,7 +650,7 @@ class AscendFusedMoE(FusedMoE):
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
+                shared_out = quantized_down_proj((quantized_x, swiglu_out_scale))[0]
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -93,6 +93,11 @@ class MoECommMethod(ABC):
         self.token_dispatcher = self._get_token_dispatcher()
         self.prepare_finalize = self._get_prepare_finalize()
         self.use_fusion_ops = set_gmmswigluquant_method()
+        self.lora_context = None
+
+    def set_lora_context(self, lora_context) -> None:
+        self.lora_context = lora_context
+        self.token_dispatcher.set_lora_context(lora_context)
 
     def prepare(
         self,
@@ -140,6 +145,12 @@ class MoECommMethod(ABC):
         routed_topk_ids = fused_experts_input.topk_ids
         if fused_experts_input.routing.log2phy is not None:
             routed_topk_ids = fused_experts_input.routing.log2phy[routed_topk_ids]
+
+        # The v0.23.0 runner stores LoRA state on the FusedMoE layer and
+        # passes it through MoEFusedExpertsInput. Refresh the long-lived
+        # dispatcher for every call so W8A8 routing keeps BF16 activations
+        # only for batches that actually contain LoRA tokens.
+        self.set_lora_context(fused_experts_input.lora_context)
 
         token_dispatch_input = build_token_dispatch_input(
             fused_experts_input=fused_experts_input,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -361,136 +361,6 @@ def quant_apply_mlp(
     return hidden_states, before_gmm2_evt
 
 
-def w8a8_dynamic_lora_apply_mlp(
-    hidden_states: torch.Tensor,
-    w1: list[torch.Tensor] | torch.Tensor,
-    w1_scale: list[torch.Tensor] | torch.Tensor,
-    w2: list[torch.Tensor] | torch.Tensor,
-    w2_scale: list[torch.Tensor] | torch.Tensor,
-    group_list: torch.Tensor,
-    *,
-    group_list_type: int,
-    activation: str | None,
-    swiglu_limit: float,
-    lora_context,
-    expanded_row_idx: torch.Tensor | None,
-    topk_ids: torch.Tensor | None,
-    dynamic_scale: torch.Tensor | None,
-    dynamic_eplb: bool,
-) -> tuple[torch.Tensor, torch.npu.Event | None]:
-    """Run W8A8_DYNAMIC experts with BF16 LoRA injection boundaries."""
-    if _EXTRA_CTX.moe_comm_type != MoECommType.ALLGATHER:
-        raise NotImplementedError(
-            "Ascend W8A8_DYNAMIC MoE LoRA currently supports only the "
-            "AllGather TP path; EP, AlltoAll, MC2, and FusedMC2 are unsupported."
-        )
-    if dynamic_eplb:
-        raise NotImplementedError("Ascend W8A8_DYNAMIC MoE LoRA does not support dynamic EPLB.")
-    if dynamic_scale is not None or hidden_states.dtype == torch.int8:
-        raise AssertionError(
-            "W8A8_DYNAMIC MoE LoRA requires BF16/FP16 routed activations. "
-            "Dispatch-side quantization must be disabled for LoRA batches."
-        )
-    if expanded_row_idx is None or topk_ids is None:
-        raise AssertionError(
-            "W8A8_DYNAMIC MoE LoRA requires AllGather routing metadata (expanded_row_idx and topk_ids)."
-        )
-
-    w1_list = w1 if isinstance(w1, list) else [w1]
-    w2_list = w2 if isinstance(w2, list) else [w2]
-    w1_scale_list = w1_scale if isinstance(w1_scale, list) else [w1_scale]
-    w2_scale_list = w2_scale if isinstance(w2_scale, list) else [w2_scale]
-    if not all(len(values) == 1 for values in (w1_list, w2_list, w1_scale_list, w2_scale_list)):
-        raise NotImplementedError(
-            "W8A8_DYNAMIC MoE LoRA does not support per-expert tensor lists used by dynamic EPLB."
-        )
-
-    from vllm_ascend.lora.fused_moe import (
-        moe_lora_apply_w2,
-        moe_lora_apply_w13,
-    )
-
-    input_dtype = hidden_states.dtype
-    lora_w13_input = hidden_states
-    quantized_input, input_scale = DeviceOperator.npu_dynamic_quant(
-        hidden_states=hidden_states,
-        dynamic_scale=None,
-        act_quant_type=torch.int8,
-        use_mxfp_quant=False,
-    )
-
-    gate_up_out = torch_npu.npu_grouped_matmul(
-        x=[quantized_input],
-        weight=w1_list,
-        scale=[w1_scale_list[0].to(w2_scale_list[0].dtype)],
-        per_token_scale=[input_scale],
-        split_item=2,
-        group_type=0,
-        group_list=group_list,
-        group_list_type=group_list_type,
-        output_dtype=input_dtype,
-    )[0]
-    lora_routing = moe_lora_apply_w13(
-        lora_context,
-        gate_up_out=gate_up_out,
-        hidden_states=lora_w13_input,
-        expanded_row_idx=expanded_row_idx,
-        topk_ids=topk_ids,
-    )
-
-    if activation == MoEActivation.SWIGLUOAI:
-        activated = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out)
-    elif activation == MoEActivation.SWIGLUSTEP:
-        activated = AscendSwigluStepAndMul.swiglustep_forward(
-            gate_up_out,
-            limit=swiglu_limit or 7.0,
-        )
-    elif activation in (MoEActivation.GELU, MoEActivation.GELU_TANH):
-        gate, up = gate_up_out.chunk(2, dim=-1)
-        approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
-        activated = torch.nn.functional.gelu(gate, approximate=approximate) * up
-    else:
-        if swiglu_limit > 0:
-            gate, up = gate_up_out.chunk(2, dim=-1)
-            gate = gate.clamp(max=swiglu_limit)
-            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
-            gate_up_out = torch.cat((gate, up), dim=-1)
-        activated = torch_npu.npu_swiglu(gate_up_out)
-
-    quantized_activated, activated_scale = DeviceOperator.npu_dynamic_quant(
-        hidden_states=activated,
-        dynamic_scale=None,
-        act_quant_type=torch.int8,
-        use_mxfp_quant=False,
-    )
-    before_gmm2_evt = torch.npu.current_stream().record_event()
-    down_out = DeviceOperator.npu_grouped_matmul_gmm2(
-        hidden_states=quantized_activated,
-        weight=w2_list,
-        weight_scale=w2_scale_list,
-        per_token_scale=activated_scale,
-        group_list=group_list,
-        group_list_type=group_list_type,
-        input_dtype=input_dtype,
-        act_quant_type=torch.int8,
-        weight_quant_type=None,
-        scale_type=None,
-        per_token_scale_type=None,
-        use_bf16=input_dtype == torch.bfloat16,
-        use_mxfp_quant=False,
-        bias=None,
-        fallback_output_dtype=w2_scale_list[0].dtype,
-        mxfp_quant_dtype=None,
-    )
-    moe_lora_apply_w2(
-        lora_context,
-        down_out=down_out,
-        silu_out=activated,
-        lora_routing=lora_routing,
-    )
-    return down_out, before_gmm2_evt
-
-
 def unquant_apply_mlp(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -635,29 +505,9 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     from vllm_ascend.lora.fused_moe import is_moe_lora_active
 
     if is_moe_lora_active(mlp_compute_input.lora_context):
-        if mlp_compute_input.quant.quant_type != QuantType.W8A8:
-            raise NotImplementedError("Ascend quantized MoE LoRA currently supports only W8A8_DYNAMIC.")
-        if w1_scale_bias is not None or w2_scale_bias is not None:
-            raise NotImplementedError("W8A8_DYNAMIC MoE LoRA does not support fused scale-bias.")
-        if w1_offset is not None or w2_offset is not None:
-            raise NotImplementedError("W8A8_DYNAMIC MoE LoRA does not support antiquant offsets.")
-        assert w1_scale is not None and w2_scale is not None
-        return w8a8_dynamic_lora_apply_mlp(
-            hidden_states=hidden_states,
-            w1=w1,
-            w1_scale=w1_scale,
-            w2=w2,
-            w2_scale=w2_scale,
-            group_list=group_list,
-            group_list_type=group_list_type,
-            activation=activation,
-            swiglu_limit=swiglu_limit,
-            lora_context=mlp_compute_input.lora_context,
-            expanded_row_idx=mlp_compute_input.expanded_row_idx,
-            topk_ids=mlp_compute_input.topk_ids,
-            dynamic_scale=dynamic_scale,
-            dynamic_eplb=dynamic_eplb,
-        )
+        from vllm_ascend.lora.quant_moe import apply_quant_moe_lora
+
+        return apply_quant_moe_lora(mlp_compute_input=mlp_compute_input)
 
     assert w1_scale is not None and w2_scale is not None
     act_quant_type = torch.int8 if mlp_compute_input.quant.is_int_quant else torch.float8_e4m3fn

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -361,6 +361,136 @@ def quant_apply_mlp(
     return hidden_states, before_gmm2_evt
 
 
+def w8a8_dynamic_lora_apply_mlp(
+    hidden_states: torch.Tensor,
+    w1: list[torch.Tensor] | torch.Tensor,
+    w1_scale: list[torch.Tensor] | torch.Tensor,
+    w2: list[torch.Tensor] | torch.Tensor,
+    w2_scale: list[torch.Tensor] | torch.Tensor,
+    group_list: torch.Tensor,
+    *,
+    group_list_type: int,
+    activation: str | None,
+    swiglu_limit: float,
+    lora_context,
+    expanded_row_idx: torch.Tensor | None,
+    topk_ids: torch.Tensor | None,
+    dynamic_scale: torch.Tensor | None,
+    dynamic_eplb: bool,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Run W8A8_DYNAMIC experts with BF16 LoRA injection boundaries."""
+    if _EXTRA_CTX.moe_comm_type != MoECommType.ALLGATHER:
+        raise NotImplementedError(
+            "Ascend W8A8_DYNAMIC MoE LoRA currently supports only the "
+            "AllGather TP path; EP, AlltoAll, MC2, and FusedMC2 are unsupported."
+        )
+    if dynamic_eplb:
+        raise NotImplementedError("Ascend W8A8_DYNAMIC MoE LoRA does not support dynamic EPLB.")
+    if dynamic_scale is not None or hidden_states.dtype == torch.int8:
+        raise AssertionError(
+            "W8A8_DYNAMIC MoE LoRA requires BF16/FP16 routed activations. "
+            "Dispatch-side quantization must be disabled for LoRA batches."
+        )
+    if expanded_row_idx is None or topk_ids is None:
+        raise AssertionError(
+            "W8A8_DYNAMIC MoE LoRA requires AllGather routing metadata (expanded_row_idx and topk_ids)."
+        )
+
+    w1_list = w1 if isinstance(w1, list) else [w1]
+    w2_list = w2 if isinstance(w2, list) else [w2]
+    w1_scale_list = w1_scale if isinstance(w1_scale, list) else [w1_scale]
+    w2_scale_list = w2_scale if isinstance(w2_scale, list) else [w2_scale]
+    if not all(len(values) == 1 for values in (w1_list, w2_list, w1_scale_list, w2_scale_list)):
+        raise NotImplementedError(
+            "W8A8_DYNAMIC MoE LoRA does not support per-expert tensor lists used by dynamic EPLB."
+        )
+
+    from vllm_ascend.lora.fused_moe import (
+        moe_lora_apply_w2,
+        moe_lora_apply_w13,
+    )
+
+    input_dtype = hidden_states.dtype
+    lora_w13_input = hidden_states
+    quantized_input, input_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states=hidden_states,
+        dynamic_scale=None,
+        act_quant_type=torch.int8,
+        use_mxfp_quant=False,
+    )
+
+    gate_up_out = torch_npu.npu_grouped_matmul(
+        x=[quantized_input],
+        weight=w1_list,
+        scale=[w1_scale_list[0].to(w2_scale_list[0].dtype)],
+        per_token_scale=[input_scale],
+        split_item=2,
+        group_type=0,
+        group_list=group_list,
+        group_list_type=group_list_type,
+        output_dtype=input_dtype,
+    )[0]
+    lora_routing = moe_lora_apply_w13(
+        lora_context,
+        gate_up_out=gate_up_out,
+        hidden_states=lora_w13_input,
+        expanded_row_idx=expanded_row_idx,
+        topk_ids=topk_ids,
+    )
+
+    if activation == MoEActivation.SWIGLUOAI:
+        activated = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out)
+    elif activation == MoEActivation.SWIGLUSTEP:
+        activated = AscendSwigluStepAndMul.swiglustep_forward(
+            gate_up_out,
+            limit=swiglu_limit or 7.0,
+        )
+    elif activation in (MoEActivation.GELU, MoEActivation.GELU_TANH):
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
+        activated = torch.nn.functional.gelu(gate, approximate=approximate) * up
+    else:
+        if swiglu_limit > 0:
+            gate, up = gate_up_out.chunk(2, dim=-1)
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+            gate_up_out = torch.cat((gate, up), dim=-1)
+        activated = torch_npu.npu_swiglu(gate_up_out)
+
+    quantized_activated, activated_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states=activated,
+        dynamic_scale=None,
+        act_quant_type=torch.int8,
+        use_mxfp_quant=False,
+    )
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    down_out = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states=quantized_activated,
+        weight=w2_list,
+        weight_scale=w2_scale_list,
+        per_token_scale=activated_scale,
+        group_list=group_list,
+        group_list_type=group_list_type,
+        input_dtype=input_dtype,
+        act_quant_type=torch.int8,
+        weight_quant_type=None,
+        scale_type=None,
+        per_token_scale_type=None,
+        use_bf16=input_dtype == torch.bfloat16,
+        use_mxfp_quant=False,
+        bias=None,
+        fallback_output_dtype=w2_scale_list[0].dtype,
+        mxfp_quant_dtype=None,
+    )
+    moe_lora_apply_w2(
+        lora_context,
+        down_out=down_out,
+        silu_out=activated,
+        lora_routing=lora_routing,
+    )
+    return down_out, before_gmm2_evt
+
+
 def unquant_apply_mlp(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -500,6 +630,33 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
             lora_context=mlp_compute_input.lora_context,
             expanded_row_idx=mlp_compute_input.expanded_row_idx,
             topk_ids=mlp_compute_input.topk_ids,
+        )
+
+    from vllm_ascend.lora.fused_moe import is_moe_lora_active
+
+    if is_moe_lora_active(mlp_compute_input.lora_context):
+        if mlp_compute_input.quant.quant_type != QuantType.W8A8:
+            raise NotImplementedError("Ascend quantized MoE LoRA currently supports only W8A8_DYNAMIC.")
+        if w1_scale_bias is not None or w2_scale_bias is not None:
+            raise NotImplementedError("W8A8_DYNAMIC MoE LoRA does not support fused scale-bias.")
+        if w1_offset is not None or w2_offset is not None:
+            raise NotImplementedError("W8A8_DYNAMIC MoE LoRA does not support antiquant offsets.")
+        assert w1_scale is not None and w2_scale is not None
+        return w8a8_dynamic_lora_apply_mlp(
+            hidden_states=hidden_states,
+            w1=w1,
+            w1_scale=w1_scale,
+            w2=w2,
+            w2_scale=w2_scale,
+            group_list=group_list,
+            group_list_type=group_list_type,
+            activation=activation,
+            swiglu_limit=swiglu_limit,
+            lora_context=mlp_compute_input.lora_context,
+            expanded_row_idx=mlp_compute_input.expanded_row_idx,
+            topk_ids=mlp_compute_input.topk_ids,
+            dynamic_scale=dynamic_scale,
+            dynamic_eplb=dynamic_eplb,
         )
 
     assert w1_scale is not None and w2_scale is not None

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -33,6 +33,7 @@ from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import is_moe_lora_active
+from vllm_ascend.lora.quant_moe import quant_moe_lora_requires_unquantized_dispatch
 from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all, gather_from_sequence_parallel_region
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
@@ -366,17 +367,17 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         with_quant = token_dispatch_input.quant.dispatch_with_quant and quant_type != QuantType.W8A8FP8
         with_quant = with_quant and not unquantized_mxfp4_dispatch
         lora_active = is_moe_lora_active(self.lora_context)
-        if lora_active and quant_type == QuantType.W8A8:
-            if dynamic_scale is not None or hidden_states.dtype == torch.int8:
-                raise NotImplementedError(
-                    "Ascend W8A8_DYNAMIC MoE LoRA v1 is TP-only and requires "
-                    "unquantized activations before AllGather dispatch."
-                )
-            # The LoRA A projection needs the expert-sorted BF16/FP16 input.
-            # Quantize inside the MLP after routing instead.
-            with_quant = False
-        elif lora_active and token_dispatch_input.quant.is_quant:
-            raise NotImplementedError("Ascend quantized MoE LoRA currently supports only W8A8_DYNAMIC.")
+        if lora_active and token_dispatch_input.quant.is_quant:
+            requires_unquantized_dispatch = quant_moe_lora_requires_unquantized_dispatch(quant_type)
+            if requires_unquantized_dispatch:
+                if dynamic_scale is not None or hidden_states.dtype == torch.int8:
+                    raise NotImplementedError(
+                        "This Ascend quantized MoE LoRA implementation requires "
+                        "unquantized activations before AllGather dispatch."
+                    )
+                # The LoRA A projection needs the expert-sorted floating-point
+                # input. Quantize inside the registered MLP implementation.
+                with_quant = False
         is_mxfp = token_dispatch_input.quant.is_mxfp
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -33,7 +33,7 @@ from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import is_moe_lora_active
-from vllm_ascend.lora.quant_moe import quant_moe_lora_requires_unquantized_dispatch
+from vllm_ascend.lora.quant_moe import configure_quant_moe_lora_dispatch
 from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all, gather_from_sequence_parallel_region
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
@@ -368,16 +368,12 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         with_quant = with_quant and not unquantized_mxfp4_dispatch
         lora_active = is_moe_lora_active(self.lora_context)
         if lora_active and token_dispatch_input.quant.is_quant:
-            requires_unquantized_dispatch = quant_moe_lora_requires_unquantized_dispatch(quant_type)
-            if requires_unquantized_dispatch:
-                if dynamic_scale is not None or hidden_states.dtype == torch.int8:
-                    raise NotImplementedError(
-                        "This Ascend quantized MoE LoRA implementation requires "
-                        "unquantized activations before AllGather dispatch."
-                    )
-                # The LoRA A projection needs the expert-sorted floating-point
-                # input. Quantize inside the registered MLP implementation.
-                with_quant = False
+            with_quant = configure_quant_moe_lora_dispatch(
+                quant_type=quant_type,
+                hidden_states=hidden_states,
+                dynamic_scale=dynamic_scale,
+                with_quant=with_quant,
+            )
         is_mxfp = token_dispatch_input.quant.is_mxfp
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -32,6 +32,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.lora.fused_moe import is_moe_lora_active
 from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all, gather_from_sequence_parallel_region
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
@@ -68,6 +69,10 @@ class MoETokenDispatcher(ABC, Generic[TMoECombineMetadata]):
         """
         self.top_k = kwargs.get("top_k", 0)
         self.num_experts = kwargs.get("num_experts", 0)
+        self.lora_context = None
+
+    def set_lora_context(self, lora_context) -> None:
+        self.lora_context = lora_context
 
     @property
     def ep_group(self):
@@ -354,13 +359,25 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
     ):
         quant_type = token_dispatch_input.quant.quant_type
         dynamic_scale = token_dispatch_input.routing.pertoken_scale
+        hidden_states = token_dispatch_input.hidden_states
         unquantized_mxfp4_dispatch = quant_type == QuantType.MXFP4 and dynamic_scale is None
         # Without prepare-stage scales, MXFP4 stays unquantized in dispatch and
         # is quantized again inside the MLP path.
         with_quant = token_dispatch_input.quant.dispatch_with_quant and quant_type != QuantType.W8A8FP8
         with_quant = with_quant and not unquantized_mxfp4_dispatch
+        lora_active = is_moe_lora_active(self.lora_context)
+        if lora_active and quant_type == QuantType.W8A8:
+            if dynamic_scale is not None or hidden_states.dtype == torch.int8:
+                raise NotImplementedError(
+                    "Ascend W8A8_DYNAMIC MoE LoRA v1 is TP-only and requires "
+                    "unquantized activations before AllGather dispatch."
+                )
+            # The LoRA A projection needs the expert-sorted BF16/FP16 input.
+            # Quantize inside the MLP after routing instead.
+            with_quant = False
+        elif lora_active and token_dispatch_input.quant.is_quant:
+            raise NotImplementedError("Ascend quantized MoE LoRA currently supports only W8A8_DYNAMIC.")
         is_mxfp = token_dispatch_input.quant.is_mxfp
-        hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
         expert_map = token_dispatch_input.routing.expert_map

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -237,6 +237,11 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        lora_context = getattr(layer, "_ascend_moe_lora_context", None)
+        if lora_context is not None and type(self) is not AscendW8A8DynamicFusedMoEMethod:
+            raise NotImplementedError(
+                "Ascend quantized MoE LoRA v1 supports only the W8A8_DYNAMIC scheme, not derived W8A8FP8/PDMix schemes."
+            )
         zero_expert_num = getattr(layer, "zero_expert_num", 0)
         zero_expert_type = getattr(layer, "zero_expert_type", None)
         n_shared_experts = getattr(layer, "n_shared_experts", 0)
@@ -344,6 +349,9 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
                 swiglu_limit=layer.swiglu_limit,
+                # Per-layer state is installed by AscendFusedMoEWithLoRA.
+                # None keeps the base-only W8A8 path unchanged.
+                lora_context=lora_context,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:


### PR DESCRIPTION
## Motivation

This PR adds Ascend support for multi-LoRA inference on MoE models with a
W8A8_DYNAMIC quantized base model.

The main target is DeepSeek V4 Flash-style models containing routed experts and
shared experts. LoRA computation must preserve floating-point activation
boundaries while the base expert GMMs remain quantized.

## Verification
Here I verified this pr from deepseekv4 flash w8a8-int8, and the lora is trainied by mindspeed.
Since mindspeed does not support transfering dsv4flash lora checkpoint  from megatron to peft, so I solve this by my self https://github.com/SkychenLee/LoraAdapterTransformer/blob/main/README.md , you  can  directly use the scritpt to transfer the lora adapter for dsv4 flash or you can use the skill I provided to transfer any model's lora adapters from any code agent.
Here are the command for **start up** of the model
```
#!/usr/bin/bash
export OMP_PROC_BIND=false
export OMP_NUM_THREADS=10
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True

export TASK_QUEUE_ENABLE=1
export HCCL_OP_EXPANSION_MODE="AIV"
export HCCL_BUFFSIZE=512

sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl kernel.sched_migration_cost_ns=50000
 
vllm serve "your deep seek v4 flash moel path" \
  --safetensors-load-strategy 'prefetch' \
  --max-model-len 10240 \
  --max-num-batched-tokens 10240 \
  --served-model-name ds \
  --gpu-memory-utilization 0.9 \
  --max-num-seqs 32 \
  --data-parallel-size 1 \
  --tensor-parallel-size 8 \
  --quantization ascend \
  --port 7000 \
  --block-size 128 \
  --enable-chunked-prefill \
  --no-enable-prefix-caching \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --async-scheduling \
  --enable-lora \
  --lora-modules lora1="your lora adapter path"\
  --max-lora-rank 16 
```
## Changes

### Routed expert LoRA

- Add Ascend-native routed expert LoRA execution for vLLM v0.23.0.
- Propagate the per-layer LoRA context through MoE dispatch and MLP execution.
- Recover the `(expert_id, LoRA slot)` mapping after expert routing to support:
  - multiple adapters in one batch;
  - base and LoRA requests mixed in one batch;
  - different adapters selected by different tokens.
- Apply:
  - `w13` LoRA after GMM1 and before activation;
  - `w2` LoRA after GMM2;
  - base tokens with zero LoRA delta.
- Add separate `w13` and `w2` adapter enable masks so adapters containing only
  part of the MoE projections do not execute unintended deltas.

### Quantized MoE LoRA

- Add an extensible quantized MoE LoRA implementation registry keyed by
  `QuantType`.
- Keep the public execution and dispatch interfaces independent of W8A8.
- Let each quantization implementation define:
  - whether dispatch-side activation quantization must be disabled;
  - how dispatch inputs should be validated;
  - how the quantized expert MLP should be executed.
- Register the first implementation for W8A8_DYNAMIC:
  1. preserve the routed BF16/FP16 input;
  2. dynamically quantize input for INT8 GMM1;
  3. inject BF16 `w13` LoRA;
  4. run SwiGLU/activation;
  5. dynamically quantize activation for INT8 GMM2;
  6. inject BF16 `w2` LoRA.
- Keep the existing fused W8A8 path unchanged for base-only batches.
- Refresh `no_lora` metadata during decode so base-only decode batches do not
  unnecessarily enter the LoRA path.
- Fail explicitly for quantization schemes without a registered MoE LoRA
  implementation.

### Shared expert LoRA

- Preserve the `_shared_experts` module hierarchy so shared-expert adapter
  weights can be discovered and loaded by the vLLM LoRA model manager.
- Execute shared experts through the existing dense LoRA wrappers when LoRA is
  active.
- Unwrap dense LoRA wrappers only for the optimized base-only quantized shared
  expert path.
- Add a gather+BMM expand-slice fallback for shared-expert dense LoRA B
  projections that are incompatible with the existing NPU expand-slice shape
  restrictions.
- Automatically enable the compatible expand-slice path when shared experts
  are present; no new user-facing option is introduced.

## Supported scope

The initial quantized implementation supports:

- W8A8_DYNAMIC base experts;
- AllGather communication;
- tensor parallelism without expert parallelism;
- statically loaded multiple adapters;
- mixed base and multi-adapter requests in the same batch;
- routed experts, shared experts, and existing attention LoRA paths.

The following combinations are not supported by this initial implementation
and fail explicitly:

- expert parallelism and All-to-All;
- MC2/FusedMC2;
- dynamic EPLB;
- derived W8A8FP8 and PDMix MoE schemes;
- multistream-overlap gate execution.

Other quantization formats can be added through the new quantized MoE LoRA
registry without changing the generic token dispatcher or MoE MLP entry.

## Tests

Unit tests were added for:

- LoRA-active and base-only dispatch quantization behavior;
- single-adapter, multi-adapter, and base/adapter token routing;
- routed expert mapping after token sorting;
- BF16 LoRA injection around the two quantized GMM operations;
- two dynamic activation quantization calls;
- independent `w13` and `w2` adapter enable masks;
- shared-expert discovery and dense LoRA execution;
- gather+BMM expand-slice fallback;
- TP LoRA weight slicing;
- unsupported execution modes and unregistered quantization formats.

Static validation completed:

- Python compilation checks;
- Ruff lint and formatting checks;
- Git whitespace checks.

## Compatibility

- No new CLI arguments or request fields are introduced.
- The existing PEFT adapter format is unchanged.
- BF16 MoE LoRA continues to use the existing unquantized execution path.
- Base-only W8A8 batches retain the original fused quantized path.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
