### PR TITLE
[MTP][BugFix] Preserve MoE weight loaders during online updates

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -132,6 +132,10 @@ def test_process_weights_after_loading_uses_version_specific_layout(
 ):
     method = _build_unquantized_method()
     layer = _build_weight_layer()
+    w13_loader = MagicMock()
+    w2_loader = MagicMock()
+    layer.w13_weight.weight_loader = w13_loader
+    layer.w2_weight.weight_loader = w2_loader
     original_w13 = layer.w13_weight.detach().clone()
     original_w2 = layer.w2_weight.detach().clone()
     ascend_config = SimpleNamespace(enable_fused_mc2=False)
@@ -152,6 +156,8 @@ def test_process_weights_after_loading_uses_version_specific_layout(
     torch.testing.assert_close(layer.w2_weight, original_w2.transpose(1, 2))
     assert layer.w13_weight.is_contiguous() is True
     assert layer.w2_weight.is_contiguous() is True
+    assert layer.w13_weight.weight_loader is w13_loader
+    assert layer.w2_weight.weight_loader is w2_loader
 
 
 @pytest.mark.parametrize("moe_comm_type", [MoECommType.ALLGATHER, MoECommType.FUSED_MC2])

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -248,6 +249,102 @@ class TestNPUWorker(TestBase):
 
             mock_allocator.wake_up.assert_called_once_with(tags=["test_tag"])
             worker.sleep_wakeup_manager.wakeup.assert_called_once_with(["test_tag"])
+
+    @staticmethod
+    def _make_unquantized_moe_model():
+        model = torch.nn.Module()
+        model.mlp = torch.nn.Module()
+        model.mlp.experts = torch.nn.Module()
+        model.mlp.experts.routed_experts = torch.nn.Module()
+        routed_experts = model.mlp.experts.routed_experts
+        routed_experts.w13_weight = torch.nn.Parameter(torch.empty(2, 4, 6))
+        routed_experts.w2_weight = torch.nn.Parameter(torch.empty(2, 3, 4))
+        routed_experts.w13_weight.weight_loader = MagicMock()
+        routed_experts.w2_weight.weight_loader = MagicMock()
+        return model
+
+    @patch("vllm_ascend.worker.worker.CaMemAllocator")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_wake_up_prepares_target_and_mtp_drafter_weights(self, mock_get_config, mock_allocator_class):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        target_model = self._make_unquantized_moe_model()
+        draft_model = self._make_unquantized_moe_model()
+        storage_ptrs = [
+            (
+                model.mlp.experts.routed_experts.w13_weight.untyped_storage().data_ptr(),
+                model.mlp.experts.routed_experts.w2_weight.untyped_storage().data_ptr(),
+            )
+            for model in (target_model, draft_model)
+        ]
+        weight_loaders = [
+            (
+                model.mlp.experts.routed_experts.w13_weight.weight_loader,
+                model.mlp.experts.routed_experts.w2_weight.weight_loader,
+            )
+            for model in (target_model, draft_model)
+        ]
+        mock_get_config.return_value = SimpleNamespace(weight_nz_mode=0, enable_sleep_mode_extra_cleanup=False)
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+        worker.model_runner = SimpleNamespace(
+            model=target_model,
+            drafter=SimpleNamespace(model=draft_model),
+            post_kv_cache_wake_up=MagicMock(),
+        )
+        worker.vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(hf_text_config=SimpleNamespace(hidden_size=4)),
+            quant_config=None,
+            speculative_config=SimpleNamespace(method="mtp"),
+        )
+        worker._sleep_saved_buffers = {}
+
+        worker.wake_up(tags=["weights"])
+
+        for model, (w13_storage_ptr, w2_storage_ptr), (w13_loader, w2_loader) in zip(
+            (target_model, draft_model), storage_ptrs, weight_loaders
+        ):
+            routed_experts = model.mlp.experts.routed_experts
+            self.assertEqual(routed_experts.w13_weight.shape, (2, 6, 4))
+            self.assertEqual(routed_experts.w2_weight.shape, (2, 4, 3))
+            self.assertEqual(routed_experts.w13_weight.untyped_storage().data_ptr(), w13_storage_ptr)
+            self.assertEqual(routed_experts.w2_weight.untyped_storage().data_ptr(), w2_storage_ptr)
+            self.assertIs(routed_experts.w13_weight.weight_loader, w13_loader)
+            self.assertIs(routed_experts.w2_weight.weight_loader, w2_loader)
+        mock_allocator_class.get_instance.return_value.wake_up.assert_called_once_with(tags=["weights"])
+
+    @patch("vllm_ascend.worker.worker.CaMemAllocator")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_wake_up_does_not_prepare_non_mtp_drafter(self, mock_get_config, mock_allocator_class):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        target_model = self._make_unquantized_moe_model()
+        draft_model = self._make_unquantized_moe_model()
+        mock_get_config.return_value = SimpleNamespace(weight_nz_mode=0, enable_sleep_mode_extra_cleanup=False)
+
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+        worker.model_runner = SimpleNamespace(
+            model=target_model,
+            drafter=SimpleNamespace(model=draft_model),
+            post_kv_cache_wake_up=MagicMock(),
+        )
+        worker.vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(hf_text_config=SimpleNamespace(hidden_size=4)),
+            quant_config=None,
+            speculative_config=SimpleNamespace(method="eagle3"),
+        )
+        worker._sleep_saved_buffers = {}
+
+        worker.wake_up(tags=["weights"])
+
+        target_experts = target_model.mlp.experts.routed_experts
+        draft_experts = draft_model.mlp.experts.routed_experts
+        self.assertEqual(target_experts.w13_weight.shape, (2, 6, 4))
+        self.assertEqual(target_experts.w2_weight.shape, (2, 4, 3))
+        self.assertEqual(draft_experts.w13_weight.shape, (2, 4, 6))
+        self.assertEqual(draft_experts.w2_weight.shape, (2, 3, 4))
 
     @patch("vllm_ascend.worker.worker.current_platform")
     @patch("vllm_ascend.worker.worker.MemorySnapshot")

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -27,6 +27,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
+from vllm.model_executor.utils import replace_parameter
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -74,11 +75,12 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
     def process_weights_after_loading(self, layer):
         super(UnquantizedFusedMoEMethod, self).process_weights_after_loading(layer)
 
+        # Keep expert-aware loaders attached for later online weight updates.
         w13_data = self._maybe_pad_weight(layer.w13_weight.data).transpose(1, 2).contiguous()
-        layer.w13_weight = torch.nn.Parameter(w13_data, requires_grad=False)
+        replace_parameter(layer, "w13_weight", w13_data)
 
         w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
-        layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
+        replace_parameter(layer, "w2_weight", w2_data)
 
         # TODO: Current dispatch_ffn_combine/mega_moe fusion operator ONLY supports NZ format.
         # Therefore, we must cast weights to NZ when fusion is enabled.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -41,6 +41,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorHandsha
 from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
+from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
@@ -247,23 +248,36 @@ class NPUWorker(WorkerBase):
         hidden_size = self.vllm_config.model_config.hf_text_config.hidden_size
         model = self.model_runner.model
         if self.vllm_config.quant_config is None and (tags is None or "weights" in tags):
-            for name, param in model.named_parameters():
-                if "w2_weight" in name and param.shape[2] == hidden_size:
-                    parts = name.split(".")
-                    param_name = parts[-1]
-                    parent_module = model.get_submodule(".".join(parts[:-1]))
+            weight_models = [model]
+            speculative_config = self.vllm_config.speculative_config
+            if speculative_config is not None and speculative_config.method == "mtp":
+                drafter = getattr(self.model_runner, "drafter", None)
+                draft_model = getattr(drafter, "model", None)
+                if draft_model is not None and draft_model is not model:
+                    weight_models.append(draft_model)
 
-                    w2_data = param.transpose(1, 2)
-                    w2_data = torch.nn.Parameter(w2_data, requires_grad=False)
-                    setattr(parent_module, param_name, w2_data)
-                elif "w13_weight" in name and param.shape[1] == hidden_size:
-                    parts = name.split(".")
-                    param_name = parts[-1]
-                    parent_module = model.get_submodule(".".join(parts[:-1]))
+            # Unquantized Ascend MoE stores weights in an execution layout
+            # after loading. Restore the loadable layout for every model that
+            # receives online updates. The MTP drafter is a separate model and
+            # must follow the same wake-up preparation as the target.
+            for weight_model in weight_models:
+                for name, param in weight_model.named_parameters():
+                    if "w2_weight" in name and param.shape[2] == hidden_size:
+                        parts = name.split(".")
+                        param_name = parts[-1]
+                        parent_module = weight_model.get_submodule(".".join(parts[:-1]))
 
-                    w13_data = param.transpose(1, 2)
-                    w13_data = torch.nn.Parameter(w13_data, requires_grad=False)
-                    setattr(parent_module, param_name, w13_data)
+                        # Preserve weight_loader for subsequent online updates.
+                        w2_data = param.transpose(1, 2)
+                        replace_parameter(parent_module, param_name, w2_data)
+                    elif "w13_weight" in name and param.shape[1] == hidden_size:
+                        parts = name.split(".")
+                        param_name = parts[-1]
+                        parent_module = weight_model.get_submodule(".".join(parts[:-1]))
+
+                        # Preserve weight_loader for subsequent online updates.
+                        w13_data = param.transpose(1, 2)
+                        replace_parameter(parent_module, param_name, w13_data)
 
         # Restore the buffers after level 2 sleep
         if len(self._sleep_saved_buffers):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR prevents existing `weight_loader` metadata from being dropped when unquantized Ascend MoE weights change layout during online RL weight updates with MTP.

The target model and the MTP drafter receive actor weights through `model.load_weights()`. After loading, Ascend converts `w13_weight` and `w2_weight` from the loadable layout to the execution layout. The previous implementation registered raw `torch.nn.Parameter` objects during this conversion, which dropped the existing expert-aware `weight_loader`.

In addition, `NPUWorker.wake_up()` restored the loadable layout only for the target model, while the MTP drafter is a separate model that receives the same online updates.

This change:

- uses vLLM's public `replace_parameter()` helper when converting unquantized MoE weights in both layout directions, preserving an existing `weight_loader`;
- prepares both the target model and the MTP drafter during `wake_up()` when `speculative_config.method == "mtp"`;
- keeps non-MTP drafter behavior unchanged;
- adds unit coverage for loader preservation, target/drafter wake-up handling, and non-MTP isolation.

The change does not add model code, environment variables, global state, or a framework-side patch.

### Does this PR introduce any user-facing change?

Yes. In MTP mode, `NPUWorker.wake_up()` now applies the existing unquantized MoE layout preparation to both the target and the MTP drafter.

There is no API or configuration change, and non-MTP speculative methods keep their existing behavior.

### How was this patch tested?

Unit coverage is included for:

- preserving `w13_weight` and `w2_weight` layout, contiguity, and `weight_loader` after `process_weights_after_loading()`;
- preparing both target and MTP drafter weights in `NPUWorker.wake_up()`;
- confirming that non-MTP drafters are not included in the new behavior.

Manual integration validation was performed with:

- Ascend NPU;
- Qwen3.5-35B-A3B;
- MTP speculative decoding enabled;
- repeated online actor-to-rollout weight updates;
- graph rollout modes.

Both modes completed multiple training iterations without `weight_loader` errors. Draft acceptance and reward remained normal.
<img width="871" height="497" alt="image" src="https://github.com/user-attachments/assets/581cb666-8b3c-47fd-a028-b75f897517fb" />


Additional checks:

```bash
git diff --check
python -m py_compile \
  tests/ut/ops/test_fused_moe.py \
  tests/ut/worker/a2/test_worker_v1.py \
  vllm_ascend/ops/fused_moe/routed_experts.py \
  vllm_ascend/worker/worker.py
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
