### PR TITLE
[BugFix][Misc] Restore prefiller active token accounting without extra RPC

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -621,7 +621,16 @@
     - CMakeLists.txt
   tests:
     - tests/ut/
+
 # Single File
+- name: load_balance_proxy_server_example
+  optional: true
+  cpu_only: true
+  source_file_dependencies:
+    - examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+  tests:
+    - tests/ut/examples/test_load_balance_proxy_server_example.py
+
 - name: dependency_documentation
   optional: true
   cpu_only: true

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -381,15 +381,11 @@ class SharedProxyScheduler:
         self,
         role: ServerRole,
         load: float,
-        *,
-        active_tokens: bool = False,
-        kv_cache: bool = False,
     ) -> dict[str, Any]:
         key = self._pop_valid(role)
         entry = self._pool(role).servers[key]
-        if active_tokens:
-            entry.active_tokens += load
-        if kv_cache:
+        entry.active_tokens += load
+        if role is ServerRole.PREFILL:
             entry.active_kv_cache += load
         self._push_heap(role, key)
         return {"key": key, "host": entry.host, "port": entry.port}
@@ -407,26 +403,41 @@ class SharedProxyScheduler:
             return
         entry = self._pool(role).servers[key]
         if active_tokens:
-            entry.active_tokens -= load
+            entry.active_tokens = max(0.0, entry.active_tokens - load)
         if kv_cache:
             entry.active_kv_cache = max(0.0, entry.active_kv_cache - load)
         self._push_heap(role, key)
 
     def begin_request(self, load: float) -> dict[str, Any]:
-        """Pick a prefiller, reserve KV pressure, and count this as an active request."""
+        """Pick a prefiller, reserve token/KV pressure, and count this as an active request."""
         with self._lock:
-            picked = self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
+            picked = self._pick_server(ServerRole.PREFILL, load)
             self.request_num += 1
             return picked
 
-    def reserve_prefill_kv(self, load: float) -> dict[str, Any]:
-        """Pick a prefiller for recompute without bumping the active request count."""
+    def reserve_prefill(self, load: float) -> dict[str, Any]:
+        """Pick a prefiller for recompute and reserve its token/KV pressure."""
         with self._lock:
-            return self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
+            return self._pick_server(ServerRole.PREFILL, load)
 
-    def pick_decoder(self, load: float) -> dict[str, Any]:
+    def finish_prefill_and_pick_decoder(
+        self,
+        prefiller_key: str,
+        prefiller_load: float,
+        decoder_load: float,
+    ) -> dict[str, Any]:
+        """Atomically move load accounting from prefill compute to decode."""
         with self._lock:
-            return self._pick_server(ServerRole.DECODE, load, active_tokens=True)
+            decoder = self._pick_server(ServerRole.DECODE, decoder_load)
+            self._release_load(ServerRole.PREFILL, prefiller_key, prefiller_load, active_tokens=True)
+            return decoder
+
+    def abort_prefill(self, key: str, load: float, is_initial_request: bool) -> None:
+        """Release all pressure reserved before decoder selection."""
+        with self._lock:
+            self._release_load(ServerRole.PREFILL, key, load, active_tokens=True, kv_cache=True)
+            if is_initial_request:
+                self.request_num = max(0, self.request_num - 1)
 
     def release_prefill_kv(self, key: str, load: float) -> None:
         with self._lock:
@@ -904,20 +915,26 @@ async def _abort_prefill_selection(
     *,
     is_initial_request: bool,
 ) -> None:
-    if is_initial_request:
-        await runtime.schedule("finish_request", prefiller_key, prefiller_score, None, 0.0, release_prefill_kv=True)
-    else:
-        await runtime.schedule("release_prefill_kv", prefiller_key, prefiller_score)
+    await asyncio.shield(
+        runtime.schedule(
+            "abort_prefill",
+            prefiller_key,
+            prefiller_score,
+            is_initial_request=is_initial_request,
+        )
+    )
 
 
 async def _finish_instance(runtime: WorkerRuntime, info: InstanceInfo, *, release_prefill_kv: bool) -> None:
-    await runtime.schedule(
-        "finish_request",
-        info.prefiller_key,
-        info.prefiller_score,
-        info.decoder_key,
-        info.decoder_score,
-        release_prefill_kv,
+    await asyncio.shield(
+        runtime.schedule(
+            "finish_request",
+            info.prefiller_key,
+            info.prefiller_score,
+            info.decoder_key,
+            info.decoder_score,
+            release_prefill_kv,
+        )
     )
 
 
@@ -933,38 +950,42 @@ async def assign_instances(
     prefiller_score = calculate_prefill_score(request_length)
     decoder_score = calculate_decode_score(request_length)
     request_id = next_req_id()
-    pick_prefill = "begin_request" if is_initial_request else "reserve_prefill_kv"
+    pick_prefill = "begin_request" if is_initial_request else "reserve_prefill"
     prefiller = await runtime.schedule(pick_prefill, prefiller_score)
     prefiller_key = prefiller["key"]
 
     try:
+        prefiller_client = await runtime.get_client(ServerRole.PREFILL, prefiller_key)
         response = await send_request_to_service(
-            await runtime.get_client(ServerRole.PREFILL, prefiller_key),
+            prefiller_client,
             api,
             req_data,
             request_id,
             max_retries=args.max_retries,
             base_delay=args.retry_delay,
         )
-    except Exception:
-        await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
+        response_json = response.json()
+        kv_transfer_params = response_json.get("kv_transfer_params", {})
+        if kv_transfer_params:
+            req_data["kv_transfer_params"] = kv_transfer_params
+        prefiller_cached_tokens = extract_cached_tokens(response_json)
+
+        decoder = await runtime.schedule(
+            "finish_prefill_and_pick_decoder",
+            prefiller_key,
+            prefiller_score,
+            decoder_score,
+        )
+    except (asyncio.CancelledError, Exception):
+        await _abort_prefill_selection(
+            runtime,
+            prefiller_key,
+            prefiller_score,
+            is_initial_request=is_initial_request,
+        )
         raise
 
-    response_json = response.json()
-    kv_transfer_params = response_json.get("kv_transfer_params", {})
-    if kv_transfer_params:
-        req_data["kv_transfer_params"] = kv_transfer_params
-    prefiller_cached_tokens = extract_cached_tokens(response_json)
-
-    try:
-        decoder = await runtime.schedule("pick_decoder", decoder_score)
-    except Exception:
-        await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
-        raise
-
-    prefiller_client = await runtime.get_client(ServerRole.PREFILL, prefiller_key)
-    decoder_client = await runtime.get_client(ServerRole.DECODE, decoder["key"])
-    logger.debug("Using %s %s", prefiller_client.base_url, decoder_client.base_url)
+    logger.debug("Using %s %s", prefiller_client.base_url, build_base_url(decoder["host"], decoder["port"]))
     return InstanceInfo(
         request_id=request_id,
         prefiller_key=prefiller_key,

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -439,6 +439,21 @@ class SharedProxyScheduler:
             if is_initial_request:
                 self.request_num = max(0, self.request_num - 1)
 
+    def abort_assignment(
+        self,
+        prefiller_key: str,
+        prefiller_load: float,
+        decoder_key: str,
+        decoder_load: float,
+        is_initial_request: bool,
+    ) -> None:
+        """Release load reserved by a completed prefill-to-decode assignment."""
+        with self._lock:
+            self._release_load(ServerRole.PREFILL, prefiller_key, prefiller_load, kv_cache=True)
+            self._release_load(ServerRole.DECODE, decoder_key, decoder_load, active_tokens=True)
+            if is_initial_request:
+                self.request_num = max(0, self.request_num - 1)
+
     def release_prefill_kv(self, key: str, load: float) -> None:
         with self._lock:
             self._release_load(ServerRole.PREFILL, key, load, kv_cache=True)
@@ -925,6 +940,27 @@ async def _abort_prefill_selection(
     )
 
 
+async def _abort_assignment(
+    runtime: WorkerRuntime,
+    prefiller_key: str,
+    prefiller_score: float,
+    decoder_key: str,
+    decoder_score: float,
+    *,
+    is_initial_request: bool,
+) -> None:
+    await asyncio.shield(
+        runtime.schedule(
+            "abort_assignment",
+            prefiller_key,
+            prefiller_score,
+            decoder_key,
+            decoder_score,
+            is_initial_request=is_initial_request,
+        )
+    )
+
+
 async def _finish_instance(runtime: WorkerRuntime, info: InstanceInfo, *, release_prefill_kv: bool) -> None:
     await asyncio.shield(
         runtime.schedule(
@@ -953,6 +989,7 @@ async def assign_instances(
     pick_prefill = "begin_request" if is_initial_request else "reserve_prefill"
     prefiller = await runtime.schedule(pick_prefill, prefiller_score)
     prefiller_key = prefiller["key"]
+    decoder = None
 
     try:
         prefiller_client = await runtime.get_client(ServerRole.PREFILL, prefiller_key)
@@ -976,16 +1013,27 @@ async def assign_instances(
             prefiller_score,
             decoder_score,
         )
+        decoder_client = await runtime.get_client(ServerRole.DECODE, decoder["key"])
     except (asyncio.CancelledError, Exception):
-        await _abort_prefill_selection(
-            runtime,
-            prefiller_key,
-            prefiller_score,
-            is_initial_request=is_initial_request,
-        )
+        if decoder is None:
+            await _abort_prefill_selection(
+                runtime,
+                prefiller_key,
+                prefiller_score,
+                is_initial_request=is_initial_request,
+            )
+        else:
+            await _abort_assignment(
+                runtime,
+                prefiller_key,
+                prefiller_score,
+                decoder["key"],
+                decoder_score,
+                is_initial_request=is_initial_request,
+            )
         raise
 
-    logger.debug("Using %s %s", prefiller_client.base_url, build_base_url(decoder["host"], decoder["port"]))
+    logger.debug("Using %s %s", prefiller_client.base_url, decoder_client.base_url)
     return InstanceInfo(
         request_id=request_id,
         prefiller_key=prefiller_key,

--- a/tests/ut/examples/test_load_balance_proxy_server_example.py
+++ b/tests/ut/examples/test_load_balance_proxy_server_example.py
@@ -1,0 +1,272 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROXY_PATH = REPO_ROOT / "examples" / "disaggregated_prefill_v1" / "load_balance_proxy_server_example.py"
+MODULE_NAME = "vllm_ascend_load_balance_proxy_server_example"
+MISSING_MODULE = object()
+
+
+@pytest.fixture(scope="module")
+def proxy_module():
+    previous_policy = asyncio.get_event_loop_policy()
+    previous_uvloop = sys.modules.pop("uvloop", MISSING_MODULE)
+    try:
+        sys.modules.pop(MODULE_NAME, None)
+        spec = importlib.util.spec_from_file_location(MODULE_NAME, PROXY_PATH)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[MODULE_NAME] = module
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        asyncio.set_event_loop_policy(previous_policy)
+        sys.modules.pop(MODULE_NAME, None)
+        sys.modules.pop("uvloop", None)
+        if previous_uvloop is not MISSING_MODULE:
+            sys.modules["uvloop"] = previous_uvloop
+
+
+class RecordingRuntime:
+    def __init__(self, scheduler: Any):
+        self.scheduler = scheduler
+        self.scheduled_methods: list[str] = []
+
+    async def schedule(self, method: str, /, *args, **kwargs):
+        self.scheduled_methods.append(method)
+        return getattr(self.scheduler, method)(*args, **kwargs)
+
+    async def get_client(self, _role, _key):
+        return SimpleNamespace(base_url="http://prefiller/v1")
+
+
+class FakeResponse:
+    def json(self) -> dict:
+        return {}
+
+
+class InvalidJsonResponse:
+    def json(self) -> dict:
+        raise ValueError("invalid JSON")
+
+
+def test_import_tolerates_missing_uvloop(monkeypatch):
+    module_name = f"{MODULE_NAME}_without_uvloop"
+    previous_policy = asyncio.get_event_loop_policy()
+    monkeypatch.setitem(sys.modules, "uvloop", None)
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, PROXY_PATH)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    finally:
+        asyncio.set_event_loop_policy(previous_policy)
+        sys.modules.pop(module_name, None)
+
+
+def test_finish_prefill_and_pick_decoder_transfers_active_pressure(proxy_module):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+
+    prefiller = scheduler.begin_request(10.0)
+    prefiller_entry = scheduler.prefillers[prefiller["key"]]
+    assert (prefiller_entry.active_tokens, prefiller_entry.active_kv_cache) == (10.0, 10.0)
+    assert scheduler.request_num == 1
+
+    decoder = scheduler.finish_prefill_and_pick_decoder(prefiller["key"], 10.0, 25.0)
+
+    assert (prefiller_entry.active_tokens, prefiller_entry.active_kv_cache) == (0.0, 10.0)
+    assert scheduler.decoders[decoder["key"]].active_tokens == 25.0
+    assert scheduler.request_num == 1
+
+
+def test_repeated_release_does_not_make_active_tokens_negative(proxy_module):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+
+    prefiller = scheduler.begin_request(10.0)
+    decoder = scheduler.finish_prefill_and_pick_decoder(prefiller["key"], 10.0, 25.0)
+    scheduler.release_decoder(decoder["key"], 25.0)
+    scheduler.release_decoder(decoder["key"], 25.0)
+    scheduler.abort_prefill(prefiller["key"], 10.0, is_initial_request=True)
+    scheduler.abort_prefill(prefiller["key"], 10.0, is_initial_request=True)
+
+    assert scheduler.prefillers[prefiller["key"]].active_tokens == 0.0
+    assert scheduler.decoders[decoder["key"]].active_tokens == 0.0
+    assert scheduler.request_num == 0
+
+
+def test_prefill_routing_distinguishes_compute_from_kv_pressure(proxy_module):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100), ("127.0.0.1", 8101)],
+        [("127.0.0.1", 8200)],
+    )
+
+    busy_prefiller = scheduler.begin_request(10.0)
+    kv_only_prefiller = scheduler.reserve_prefill(10.0)
+    decoder = scheduler.finish_prefill_and_pick_decoder(kv_only_prefiller["key"], 10.0, 1.0)
+    scheduler.release_decoder(decoder["key"], 1.0)
+
+    next_prefiller = scheduler.reserve_prefill(10.0)
+
+    assert next_prefiller["key"] == kv_only_prefiller["key"]
+    assert next_prefiller["key"] != busy_prefiller["key"]
+
+
+def test_assign_instances_does_not_add_a_success_path_scheduler_rpc(proxy_module, monkeypatch):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+    runtime = RecordingRuntime(scheduler)
+
+    async def send_success(*_args, **_kwargs):
+        return FakeResponse()
+
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_success)
+
+    info = asyncio.run(proxy_module.assign_instances("/completions", {}, 100, is_initial_request=True))
+
+    assert runtime.scheduled_methods == ["begin_request", "finish_prefill_and_pick_decoder"]
+    assert scheduler.prefillers[info.prefiller_key].active_tokens == 0.0
+    assert scheduler.prefillers[info.prefiller_key].active_kv_cache > 0.0
+    assert scheduler.decoders[info.decoder_key].active_tokens == 100.0
+
+
+def test_assign_instances_releases_prefill_pressure_when_prefill_fails(proxy_module, monkeypatch):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+    runtime = RecordingRuntime(scheduler)
+
+    async def send_failed(*_args, **_kwargs):
+        raise RuntimeError("prefill failed")
+
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_failed)
+
+    with pytest.raises(RuntimeError, match="prefill failed"):
+        asyncio.run(proxy_module.assign_instances("/completions", {}, 100, is_initial_request=True))
+
+    prefiller = next(iter(scheduler.prefillers.values()))
+    assert (prefiller.active_tokens, prefiller.active_kv_cache) == (0.0, 0.0)
+    assert scheduler.request_num == 0
+    assert runtime.scheduled_methods == ["begin_request", "abort_prefill"]
+
+
+def test_assign_instances_releases_prefill_pressure_when_response_json_is_invalid(proxy_module, monkeypatch):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+    runtime = RecordingRuntime(scheduler)
+
+    async def send_invalid_json(*_args, **_kwargs):
+        return InvalidJsonResponse()
+
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_invalid_json)
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        asyncio.run(proxy_module.assign_instances("/completions", {}, 100, is_initial_request=True))
+
+    prefiller = next(iter(scheduler.prefillers.values()))
+    assert (prefiller.active_tokens, prefiller.active_kv_cache) == (0.0, 0.0)
+    assert scheduler.request_num == 0
+    assert runtime.scheduled_methods == ["begin_request", "abort_prefill"]
+
+
+def test_assign_instances_releases_prefill_pressure_when_no_decoder_exists(proxy_module, monkeypatch):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [],
+    )
+    runtime = RecordingRuntime(scheduler)
+
+    async def send_success(*_args, **_kwargs):
+        return FakeResponse()
+
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_success)
+
+    with pytest.raises(RuntimeError, match="No available decode servers"):
+        asyncio.run(proxy_module.assign_instances("/completions", {}, 100, is_initial_request=True))
+
+    prefiller = next(iter(scheduler.prefillers.values()))
+    assert (prefiller.active_tokens, prefiller.active_kv_cache) == (0.0, 0.0)
+    assert scheduler.request_num == 0
+    assert runtime.scheduled_methods == [
+        "begin_request",
+        "finish_prefill_and_pick_decoder",
+        "abort_prefill",
+    ]
+
+
+@pytest.mark.parametrize("is_initial_request", [True, False])
+def test_assign_instances_releases_prefill_pressure_when_cancelled(
+    proxy_module,
+    monkeypatch,
+    is_initial_request,
+):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+    runtime = RecordingRuntime(scheduler)
+
+    async def send_cancelled(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            proxy_module.assign_instances(
+                "/completions",
+                {},
+                100,
+                is_initial_request=is_initial_request,
+            )
+        )
+
+    prefiller = next(iter(scheduler.prefillers.values()))
+    assert (prefiller.active_tokens, prefiller.active_kv_cache) == (0.0, 0.0)
+    assert scheduler.request_num == 0
+    expected_pick = "begin_request" if is_initial_request else "reserve_prefill"
+    assert runtime.scheduled_methods == [expected_pick, "abort_prefill"]

--- a/tests/ut/examples/test_load_balance_proxy_server_example.py
+++ b/tests/ut/examples/test_load_balance_proxy_server_example.py
@@ -27,13 +27,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PROXY_PATH = REPO_ROOT / "examples" / "disaggregated_prefill_v1" / "load_balance_proxy_server_example.py"
 MODULE_NAME = "vllm_ascend_load_balance_proxy_server_example"
-MISSING_MODULE = object()
 
 
 @pytest.fixture(scope="module")
 def proxy_module():
     previous_policy = asyncio.get_event_loop_policy()
-    previous_uvloop = sys.modules.pop("uvloop", MISSING_MODULE)
+    previous_uvloop = sys.modules.pop("uvloop", None)
     try:
         sys.modules.pop(MODULE_NAME, None)
         spec = importlib.util.spec_from_file_location(MODULE_NAME, PROXY_PATH)
@@ -46,7 +45,7 @@ def proxy_module():
         asyncio.set_event_loop_policy(previous_policy)
         sys.modules.pop(MODULE_NAME, None)
         sys.modules.pop("uvloop", None)
-        if previous_uvloop is not MISSING_MODULE:
+        if previous_uvloop is not None:
             sys.modules["uvloop"] = previous_uvloop
 
 
@@ -233,6 +232,114 @@ def test_assign_instances_releases_prefill_pressure_when_no_decoder_exists(proxy
         "begin_request",
         "finish_prefill_and_pick_decoder",
         "abort_prefill",
+    ]
+
+
+@pytest.mark.parametrize("is_initial_request", [True, False])
+def test_assign_instances_releases_assignment_when_decoder_client_fails(
+    proxy_module,
+    monkeypatch,
+    is_initial_request,
+):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+    runtime = RecordingRuntime(scheduler)
+    if not is_initial_request:
+        scheduler.request_num = 1
+
+    async def send_success(*_args, **_kwargs):
+        return FakeResponse()
+
+    async def get_client(role, _key):
+        if role is proxy_module.ServerRole.DECODE:
+            raise RuntimeError("decoder client unavailable")
+        return SimpleNamespace(base_url="http://prefiller/v1")
+
+    monkeypatch.setattr(runtime, "get_client", get_client)
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_success)
+
+    with pytest.raises(RuntimeError, match="decoder client unavailable"):
+        asyncio.run(
+            proxy_module.assign_instances(
+                "/completions",
+                {},
+                100,
+                is_initial_request=is_initial_request,
+            )
+        )
+
+    prefiller = next(iter(scheduler.prefillers.values()))
+    decoder = next(iter(scheduler.decoders.values()))
+    assert (prefiller.active_tokens, prefiller.active_kv_cache) == (0.0, 0.0)
+    assert decoder.active_tokens == 0.0
+    assert scheduler.request_num == (0 if is_initial_request else 1)
+    expected_pick = "begin_request" if is_initial_request else "reserve_prefill"
+    assert runtime.scheduled_methods == [
+        expected_pick,
+        "finish_prefill_and_pick_decoder",
+        "abort_assignment",
+    ]
+
+
+@pytest.mark.parametrize("is_initial_request", [True, False])
+def test_assign_instances_releases_assignment_when_decoder_client_lookup_is_cancelled(
+    proxy_module,
+    monkeypatch,
+    is_initial_request,
+):
+    scheduler = proxy_module.SharedProxyScheduler(
+        [("127.0.0.1", 8100)],
+        [("127.0.0.1", 8200)],
+    )
+    runtime = RecordingRuntime(scheduler)
+    if not is_initial_request:
+        scheduler.request_num = 1
+    decoder_client_requested = asyncio.Event()
+
+    async def send_success(*_args, **_kwargs):
+        return FakeResponse()
+
+    async def get_client(role, _key):
+        if role is proxy_module.ServerRole.DECODE:
+            decoder_client_requested.set()
+            await asyncio.Future()
+        return SimpleNamespace(base_url="http://prefiller/v1")
+
+    monkeypatch.setattr(runtime, "get_client", get_client)
+    monkeypatch.setattr(proxy_module, "runtime", runtime)
+    monkeypatch.setattr(proxy_module, "global_args", SimpleNamespace(max_retries=1, retry_delay=0.0))
+    monkeypatch.setattr(proxy_module, "send_request_to_service", send_success)
+
+    async def cancel_assignment():
+        task = asyncio.create_task(
+            proxy_module.assign_instances(
+                "/completions",
+                {},
+                100,
+                is_initial_request=is_initial_request,
+            )
+        )
+        await decoder_client_requested.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(cancel_assignment())
+
+    prefiller = next(iter(scheduler.prefillers.values()))
+    decoder = next(iter(scheduler.decoders.values()))
+    assert (prefiller.active_tokens, prefiller.active_kv_cache) == (0.0, 0.0)
+    assert decoder.active_tokens == 0.0
+    assert scheduler.request_num == (0 if is_initial_request else 1)
+    expected_pick = "begin_request" if is_initial_request else "reserve_prefill"
+    assert runtime.scheduled_methods == [
+        expected_pick,
+        "finish_prefill_and_pick_decoder",
+        "abort_assignment",
     ]
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR restores prefiller `active_tokens` accounting in the disaggregated prefill load-balance proxy.

After the shared-scheduler refactor, prefiller selection reserved only `active_kv_cache`. As a result, `active_tokens` remained zero and the prefiller score effectively degraded from:

```text
active_tokens + active_kv_cache * 0.3
```

to KV-only pressure. A prefiller that was still computing could therefore receive the same priority as one that had completed prefill and was only holding KV cache.

The prior change effectively favored lower Manager RPC overhead over accurate short-lived prefill accounting. This PR takes the position that routing correctness should not be weakened for that optimization, especially because the accounting can be restored without increasing the successful-path RPC count: prefiller token release is folded into decoder selection, keeping the hot-path RPC count unchanged.

The fix:

- Reserves both active-token and KV-cache pressure when selecting a prefiller for initial requests and recompute.
- Combines prefiller token release with decoder selection in one locked scheduler operation and one Manager RPC.
- Atomically cleans up active tokens, KV cache, and the active request count.
- Handles cancellation together with ordinary failures and shields both abort and final cleanup so interrupted requests cannot leak scheduler pressure.
- Clamps active-token releases at zero to prevent duplicate or ambiguous Manager RPC cleanup from creating permanent negative load.

The normal selection-path RPC count is unchanged:

| Path | Before | After |
|---|---|---|
| Initial request | `begin_request` + `pick_decoder` | `begin_request` + `finish_prefill_and_pick_decoder` |
| Recompute | `reserve_prefill_kv` + `pick_decoder` | `reserve_prefill` + `finish_prefill_and_pick_decoder` |

An invalid prefill response body now releases the reserved prefiller load and updates initial-request accounting instead of leaking both.

Decoder client validation now happens when streaming starts. If a selected decoder key is unexpectedly missing from a worker's client map, the failure can therefore occur after the streaming response has been created, changing that rare failure from an HTTP 500 to an empty HTTP 200 stream.

### Does this PR introduce _any_ user-facing change?

Yes. The disaggregated prefill load-balance proxy now includes active prefill compute pressure when selecting a prefiller. This improves routing under concurrent load. There are no API, CLI, or configuration changes.

### How was this patch tested?

Added regression tests covering:

- Prefiller active-token and KV-cache counter lifecycles.
- Compute-aware prefiller routing.
- Unchanged scheduler/Manager RPC count on the successful path.
- Atomic cleanup when prefill fails or no decoder is available.
- Cleanup of initial-request and recompute reservations after cancellation.
- Repeated cleanup without negative active-token counters.
- Invalid prefill JSON responses without leaked scheduler reservations.

Run with:

```bash
pytest -q -p no:cacheprovider \
  --confcutdir=tests/ut/examples \
  tests/ut/examples/test_load_balance_proxy_server_example.py
```

Result:

```text
10 passed
```

The change affects the prefiller priority used by the multi-node PD nightly and
weekly examples and should also be covered by PD system performance validation.
````

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
