### PR TITLE
[v0.23.0][Misc] Add AscendStore PP save diagnostics

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -371,51 +371,12 @@ class ChunkedTokenDatabase:
         if block_id is None:
             block_idx = start // group_block_size
             if block_idx >= len(block_ids):
-                group_metadata = self.metadata[kv_cache_group_id]
-                logger.warning(
-                    "KVSIZE_BLOCK_ID_MISSING pp=%d group=%d cache_role=%s "
-                    "start=%d end=%d group_block_size=%d block_idx=%d block_ids=%s",
-                    group_metadata.pp_rank,
-                    kv_cache_group_id,
-                    cache_role,
-                    start,
-                    end,
-                    group_block_size,
-                    block_idx,
-                    block_ids,
-                )
                 return addr_list, size_list, 0
             block_id = block_ids[block_idx]
         group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
-        group_metadata = self.metadata[kv_cache_group_id]
         length = len(group_block_len)
         if length == 0:
-            logger.warning(
-                "KVSIZE_EMPTY_BUFFERS pp=%d group=%d cache_role=%s start=%d end=%d "
-                "block_id=%d group_block_size=%d addrs=%s block_lens=%s block_strides=%s",
-                group_metadata.pp_rank,
-                kv_cache_group_id,
-                cache_role,
-                start,
-                end,
-                block_id,
-                group_block_size,
-                group_addrs,
-                group_block_len,
-                group_block_stride,
-            )
             return addr_list, size_list, block_id
-        if len(group_addrs) != length or (group_block_stride and len(group_block_stride) != length):
-            logger.warning(
-                "KVSIZE_METADATA_MISMATCH pp=%d group=%d cache_role=%s "
-                "addr_count=%d block_len_count=%d block_stride_count=%d",
-                group_metadata.pp_rank,
-                kv_cache_group_id,
-                cache_role,
-                len(group_addrs),
-                length,
-                len(group_block_stride) if group_block_stride else 0,
-            )
         for index, base_addr in enumerate(group_addrs):
             block_len = group_block_len[index % length]
             block_stride = group_block_stride[index % length] if group_block_stride else block_len
@@ -423,29 +384,6 @@ class ChunkedTokenDatabase:
             size = int(block_len / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
-            if size <= 0:
-                logger.warning(
-                    "KVSIZE_ZERO pp=%d group=%d cache_role=%s buffer_index=%d "
-                    "start=%d end=%d token_span=%d block_id=%d group_block_size=%d "
-                    "base_addr=%d addr=%d block_len=%d block_stride=%d "
-                    "size_numerator=%d size=%d",
-                    group_metadata.pp_rank,
-                    kv_cache_group_id,
-                    cache_role,
-                    index,
-                    start,
-                    end,
-                    end - start,
-                    block_id,
-                    group_block_size,
-                    base_addr,
-                    addr,
-                    block_len,
-                    block_stride,
-                    block_len * (end - start),
-                    size,
-                )
-
         return addr_list, size_list, block_id
 
     def prepare_block_info(self, start: int, end: int, block_ids: list[int]) -> tuple[int, list[int]]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -371,12 +371,51 @@ class ChunkedTokenDatabase:
         if block_id is None:
             block_idx = start // group_block_size
             if block_idx >= len(block_ids):
+                group_metadata = self.metadata[kv_cache_group_id]
+                logger.warning(
+                    "KVSIZE_BLOCK_ID_MISSING pp=%d group=%d cache_role=%s "
+                    "start=%d end=%d group_block_size=%d block_idx=%d block_ids=%s",
+                    group_metadata.pp_rank,
+                    kv_cache_group_id,
+                    cache_role,
+                    start,
+                    end,
+                    group_block_size,
+                    block_idx,
+                    block_ids,
+                )
                 return addr_list, size_list, 0
             block_id = block_ids[block_idx]
         group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
+        group_metadata = self.metadata[kv_cache_group_id]
         length = len(group_block_len)
         if length == 0:
+            logger.warning(
+                "KVSIZE_EMPTY_BUFFERS pp=%d group=%d cache_role=%s start=%d end=%d "
+                "block_id=%d group_block_size=%d addrs=%s block_lens=%s block_strides=%s",
+                group_metadata.pp_rank,
+                kv_cache_group_id,
+                cache_role,
+                start,
+                end,
+                block_id,
+                group_block_size,
+                group_addrs,
+                group_block_len,
+                group_block_stride,
+            )
             return addr_list, size_list, block_id
+        if len(group_addrs) != length or (group_block_stride and len(group_block_stride) != length):
+            logger.warning(
+                "KVSIZE_METADATA_MISMATCH pp=%d group=%d cache_role=%s "
+                "addr_count=%d block_len_count=%d block_stride_count=%d",
+                group_metadata.pp_rank,
+                kv_cache_group_id,
+                cache_role,
+                len(group_addrs),
+                length,
+                len(group_block_stride) if group_block_stride else 0,
+            )
         for index, base_addr in enumerate(group_addrs):
             block_len = group_block_len[index % length]
             block_stride = group_block_stride[index % length] if group_block_stride else block_len
@@ -384,6 +423,29 @@ class ChunkedTokenDatabase:
             size = int(block_len / group_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
+            if size <= 0:
+                logger.warning(
+                    "KVSIZE_ZERO pp=%d group=%d cache_role=%s buffer_index=%d "
+                    "start=%d end=%d token_span=%d block_id=%d group_block_size=%d "
+                    "base_addr=%d addr=%d block_len=%d block_stride=%d "
+                    "size_numerator=%d size=%d",
+                    group_metadata.pp_rank,
+                    kv_cache_group_id,
+                    cache_role,
+                    index,
+                    start,
+                    end,
+                    end - start,
+                    block_id,
+                    group_block_size,
+                    base_addr,
+                    addr,
+                    block_len,
+                    block_stride,
+                    block_len * (end - start),
+                    size,
+                )
+
         return addr_list, size_list, block_id
 
     def prepare_block_info(self, start: int, end: int, block_ids: list[int]) -> tuple[int, list[int]]:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -760,22 +760,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
             keys = [keys[index] for index in missing_indices]
             key_block_ids = [key_block_ids[index] for index in missing_indices]
 
-            logger.debug(
-                "Storing KV cache for %d out of %d blocks for request %s in group %d",
-                len(keys),
-                token_len // group_block_size,
-                req_id,
-                group_id,
-            )
-            logger.debug(
-                "KV pool put request=%s group=%d token_len=%d keys=%d sample_keys=%s",
-                req_id,
-                group_id,
-                token_len,
-                len(keys),
-                keys[:3],
-            )
-
             addrs = []
             sizes = []
             stored_events: list[BlockStored] = []
@@ -826,6 +810,41 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         )
                         stored_events.append(stored_event)
                         logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)
+
+            invalid_indices = [
+                index for index, key_sizes in enumerate(sizes) if not key_sizes or any(size <= 0 for size in key_sizes)
+            ]
+            sample_indices = invalid_indices[:3] if invalid_indices else list(range(min(3, len(keys))))
+            key_samples = [
+                {
+                    "key": keys[index],
+                    "start": starts[index],
+                    "end": ends[index],
+                    "block_id": key_block_ids[index],
+                    "size_count": len(sizes[index]),
+                    "min_size": min(sizes[index]) if sizes[index] else None,
+                }
+                for index in sample_indices
+            ]
+            flat_sizes = [size for key_sizes in sizes for size in key_sizes]
+            group_metadata = self.token_database.metadata[group_id]
+            logger.warning(
+                "KVPOOL_PUT request=%s pp=%d tp=%d group=%d token_len=%d "
+                "group_block_size=%d keys=%d size_count=%d min_size=%s "
+                "max_size=%s invalid_keys=%d key_samples=%s",
+                req_id,
+                group_metadata.pp_rank,
+                self.tp_rank,
+                group_id,
+                token_len,
+                group_block_size,
+                len(keys),
+                len(flat_sizes),
+                min(flat_sizes) if flat_sizes else None,
+                max(flat_sizes) if flat_sizes else None,
+                len(invalid_indices),
+                key_samples,
+            )
 
             if self.kv_role == "kv_consumer":
                 keys, addrs, sizes = self._decode_adaptor_prefill_pp(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -128,6 +128,21 @@ class KVPoolWorker:
         self.dcp_rank = get_decode_context_model_parallel_rank() if self.dcp_size > 1 else 0
         self.model_name = model_config.model.split("/")[-1]
 
+        logger.warning(
+            "KVPOOL_RANK global_rank=%d local_rank=%d tp_rank=%d tp_size=%d "
+            "pp_rank=%d pp_size=%d pcp_rank=%d pcp_size=%d dcp_rank=%d dcp_size=%d",
+            parallel_config.rank,
+            self.local_rank,
+            self.tp_rank,
+            self.tp_size,
+            self.pp_rank,
+            self.pp_size,
+            self.pcp_rank,
+            self.pcp_size,
+            self.dcp_rank,
+            self.dcp_size,
+        )
+
     def _init_kv_transfer_config(self, vllm_config, extra_config, use_layerwise, kv_cache_config) -> None:
         self._extra_config = extra_config
         self.use_layerwise = use_layerwise
@@ -611,18 +626,52 @@ class KVPoolWorker:
         group_block_lens: list[int] = []
         group_block_strides: list[int] = []
         physical_layers = set()
+        hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
         for layer_name in layer_names:
             phys = self._extract_physical_layer_index(layer_name)
-            if phys >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
+            if phys >= hidden_layers:
+                logger.warning(
+                    "KVREG_LAYER_SKIPPED pp=%d tp=%d group=%d layer=%s "
+                    "physical_layer=%d hidden_layers=%d local_layers=%d",
+                    self.pp_rank,
+                    self.tp_rank,
+                    group_id,
+                    layer_name,
+                    phys,
+                    hidden_layers,
+                    self.num_layers,
+                )
                 continue
             physical_layers.add(phys)
             cache_or_caches = self.kv_caches[layer_name]
-            for cache in self._as_cache_tuple(cache_or_caches):
+            for cache_index, cache in enumerate(self._as_cache_tuple(cache_or_caches)):
                 base_addr = cache.data_ptr()
-                block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+                block_len, block_stride, region_len, block_size_scale = self._get_cache_block_metadata(cache)
                 group_addrs.append(base_addr)
                 group_block_lens.append(block_len)
                 group_block_strides.append(block_stride)
+                logger.warning(
+                    "KVREG_CACHE pp=%d tp=%d group=%d layer=%s physical_layer=%d "
+                    "cache_index=%d shape=%s stride=%s dtype=%s element_size=%s "
+                    "base_addr=%s num_blocks=%s block_size_scale=%s "
+                    "block_len=%s block_stride=%s region_len=%s",
+                    self.pp_rank,
+                    self.tp_rank,
+                    group_id,
+                    layer_name,
+                    phys,
+                    cache_index,
+                    tuple(cache.shape),
+                    tuple(cache.stride()),
+                    cache.dtype,
+                    cache.element_size(),
+                    base_addr,
+                    self.num_blocks,
+                    block_size_scale,
+                    block_len,
+                    block_stride,
+                    region_len,
+                )
         self.group_kv_caches_base_addr[group_id] = group_addrs
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides
@@ -709,6 +758,17 @@ class KVPoolWorker:
                 self._infer_cache_group_metadata(group_id, group_spec.layer_names)
         else:
             self._infer_cache_group_metadata(0, list(kv_caches.keys()))
+
+        logger.warning(
+            "KVREG_SUMMARY pp=%d tp=%d hf_layers=%s expected_local_layers=%d "
+            "actual_group_layers=%s group_addr_counts=%s",
+            self.pp_rank,
+            self.tp_rank,
+            getattr(self.hf_config, "num_hidden_layers", None),
+            self.num_layers,
+            self.group_num_layers,
+            {group_id: len(addrs) for group_id, addrs in self.group_kv_caches_base_addr.items()},
+        )
 
         # group_num_layers is computed from the actual kv_caches dict which
         # includes ALL attention layers (main + MTP). For single-group models,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -626,52 +626,18 @@ class KVPoolWorker:
         group_block_lens: list[int] = []
         group_block_strides: list[int] = []
         physical_layers = set()
-        hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
         for layer_name in layer_names:
             phys = self._extract_physical_layer_index(layer_name)
-            if phys >= hidden_layers:
-                logger.warning(
-                    "KVREG_LAYER_SKIPPED pp=%d tp=%d group=%d layer=%s "
-                    "physical_layer=%d hidden_layers=%d local_layers=%d",
-                    self.pp_rank,
-                    self.tp_rank,
-                    group_id,
-                    layer_name,
-                    phys,
-                    hidden_layers,
-                    self.num_layers,
-                )
+            if phys >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
                 continue
             physical_layers.add(phys)
             cache_or_caches = self.kv_caches[layer_name]
-            for cache_index, cache in enumerate(self._as_cache_tuple(cache_or_caches)):
+            for cache in self._as_cache_tuple(cache_or_caches):
                 base_addr = cache.data_ptr()
-                block_len, block_stride, region_len, block_size_scale = self._get_cache_block_metadata(cache)
+                block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
                 group_addrs.append(base_addr)
                 group_block_lens.append(block_len)
                 group_block_strides.append(block_stride)
-                logger.warning(
-                    "KVREG_CACHE pp=%d tp=%d group=%d layer=%s physical_layer=%d "
-                    "cache_index=%d shape=%s stride=%s dtype=%s element_size=%s "
-                    "base_addr=%s num_blocks=%s block_size_scale=%s "
-                    "block_len=%s block_stride=%s region_len=%s",
-                    self.pp_rank,
-                    self.tp_rank,
-                    group_id,
-                    layer_name,
-                    phys,
-                    cache_index,
-                    tuple(cache.shape),
-                    tuple(cache.stride()),
-                    cache.dtype,
-                    cache.element_size(),
-                    base_addr,
-                    self.num_blocks,
-                    block_size_scale,
-                    block_len,
-                    block_stride,
-                    region_len,
-                )
         self.group_kv_caches_base_addr[group_id] = group_addrs
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides


### PR DESCRIPTION
### What this PR does / why we need it?

Adds targeted AscendStore diagnostics for a GLM-5.1 `memcache + use_layerwise=false + PP4` issue where PP ranks 2 and 3 pass zero sizes to `batch_put_from_layers`.

The diagnostics:
- log global/local/TP/PP/PCP/DCP rank mapping once per worker
- log a compact KV cache registration summary once per worker
- consolidate non-layerwise puts into one log per request and cache group, including size counts, min/max size, invalid-key count, and at most three key-level samples

This is a diagnostic-only draft and does not change KV save behavior.

### Does this PR introduce _any_ user-facing change?

No functional change. It adds temporary warning-level diagnostics.

### How was this patch tested?

- Relevant pre-commit hooks passed, including ruff, formatting, codespell, and repository policy checks.
- Python syntax compilation passed for the changed modules.
- The targeted AscendStore unit test could not run in the local macOS environment because the workspace vLLM checkout is a dev/incompatible revision and Ascend runtime extensions are unavailable. NPU validation is required.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
