### PR TITLE
[CI] add support for daily nightly e2e

### DIFF
--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -49,6 +49,8 @@ jobs:
       aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
       command: ${{ steps.resolve.outputs.command }}
       build_type: ${{ steps.resolve.outputs.build_type }}
+      cann_version: ${{ steps.resolve.outputs.cann_version }}
+      cann_date: ${{ steps.resolve.outputs.cann_date }}
     steps:
       - name: Install system dependencies
         run: |
@@ -133,6 +135,8 @@ jobs:
           AOP_ENABLED="false"
           IS_A3_560T="false"
           BUILD_TYPE="release"
+          CANN_VERSION="2026.07.29"
+          CANN_DATE="20260729"
           NEXT_IS_BRANCH=0
           for WORD in $ALL_ARGS; do
             if [ "$NEXT_IS_BRANCH" = "1" ]; then
@@ -149,6 +153,16 @@ jobs:
             elif [ "$NEXT_IS_BUILD_TYPE" = "1" ]; then
               BUILD_TYPE="$WORD"
               NEXT_IS_BUILD_TYPE=0
+            elif [ "$WORD" = "--cann-version" ]; then
+              NEXT_IS_CANN_VERSION=1
+            elif [ "$NEXT_IS_CANN_VERSION" = "1" ]; then
+              CANN_VERSION="$WORD"
+              NEXT_IS_CANN_VERSION=0
+            elif [ "$WORD" = "--cann-date" ]; then
+              NEXT_IS_CANN_DATE=1
+            elif [ "$NEXT_IS_CANN_DATE" = "1" ]; then
+              CANN_DATE="$WORD"
+              NEXT_IS_CANN_DATE=0
             else
               if [ -z "$TEST_CASES" ]; then
                 TEST_CASES="$WORD"
@@ -171,6 +185,8 @@ jobs:
             echo "branch=$BRANCH"
             echo "aop_enabled=$AOP_ENABLED"
             echo "build_type=$BUILD_TYPE"
+            echo "cann_version=$CANN_VERSION"
+            echo "cann_date=$CANN_DATE"
           } >> "$GITHUB_OUTPUT"
 
           PR_SHA=$(gh api "$PR_URL" --jq '.head.sha')
@@ -247,12 +263,14 @@ jobs:
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
-            -f build_type='${{ needs.authorize.outputs.build_type }}'
+            -f build_type='${{ needs.authorize.outputs.build_type }}' \
+            -f cann_version='${{ needs.authorize.outputs.cann_version }}' \
+            -f cann_date='${{ needs.authorize.outputs.cann_date }}'
           sleep 8
           A2_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a2.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
           echo "a2_run_id=$A2_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Dispatched Nightly-A2 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}'"
+          echo "Dispatched Nightly-A2 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}', cann_version='${{ needs.authorize.outputs.cann_version }}', cann_date='${{ needs.authorize.outputs.cann_date }}'"
 
   dispatch-a3:
     name: Trigger Nightly-A3
@@ -289,12 +307,14 @@ jobs:
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
-            -f build_type='${{ needs.authorize.outputs.build_type }}'
+            -f build_type='${{ needs.authorize.outputs.build_type }}' \
+            -f cann_version='${{ needs.authorize.outputs.cann_version }}' \
+            -f cann_date='${{ needs.authorize.outputs.cann_date }}'
           sleep 8
           A3_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
           echo "a3_run_id=$A3_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Dispatched Nightly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}'"
+          echo "Dispatched Nightly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}', cann_version='${{ needs.authorize.outputs.cann_version }}', cann_date='${{ needs.authorize.outputs.cann_date }}'"
 
   dispatch-a3-560t:
     name: Trigger Nightly-A3-560T
@@ -331,12 +351,14 @@ jobs:
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
-            -f build_type='${{ needs.authorize.outputs.build_type }}'
+            -f build_type='${{ needs.authorize.outputs.build_type }}' \
+            -f cann_version='${{ needs.authorize.outputs.cann_version }}' \
+            -f cann_date='${{ needs.authorize.outputs.cann_date }}'
           sleep 8
           A3_560T_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3_560t.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
           echo "a3_560t_run_id=$A3_560T_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Dispatched Nightly-A3-560T with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}'"
+          echo "Dispatched Nightly-A3-560T with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}', cann_version='${{ needs.authorize.outputs.cann_version }}', cann_date='${{ needs.authorize.outputs.cann_date }}'"
 
   dispatch-weekly-a2:
     name: Trigger Weekly-A2

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -48,6 +48,7 @@ jobs:
       vllm_ascend_ref: ${{ steps.resolve.outputs.vllm_ascend_ref }}
       aop_enabled: ${{ steps.resolve.outputs.aop_enabled }}
       command: ${{ steps.resolve.outputs.command }}
+      build_type: ${{ steps.resolve.outputs.build_type }}
     steps:
       - name: Install system dependencies
         run: |
@@ -131,6 +132,7 @@ jobs:
           TEST_CASES=""
           AOP_ENABLED="false"
           IS_A3_560T="false"
+          BUILD_TYPE="release"
           NEXT_IS_BRANCH=0
           for WORD in $ALL_ARGS; do
             if [ "$NEXT_IS_BRANCH" = "1" ]; then
@@ -142,6 +144,11 @@ jobs:
               AOP_ENABLED="true"
             elif [ "$WORD" = "--a3-560t" ]; then
               IS_A3_560T="true"
+            elif [ "$WORD" = "--build-type" ]; then
+              NEXT_IS_BUILD_TYPE=1
+            elif [ "$NEXT_IS_BUILD_TYPE" = "1" ]; then
+              BUILD_TYPE="$WORD"
+              NEXT_IS_BUILD_TYPE=0
             else
               if [ -z "$TEST_CASES" ]; then
                 TEST_CASES="$WORD"
@@ -163,6 +170,7 @@ jobs:
             echo "test_cases=$TEST_CASES"
             echo "branch=$BRANCH"
             echo "aop_enabled=$AOP_ENABLED"
+            echo "build_type=$BUILD_TYPE"
           } >> "$GITHUB_OUTPUT"
 
           PR_SHA=$(gh api "$PR_URL" --jq '.head.sha')
@@ -238,12 +246,13 @@ jobs:
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f build_type='${{ needs.authorize.outputs.build_type }}'
           sleep 8
           A2_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a2.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
           echo "a2_run_id=$A2_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Dispatched Nightly-A2 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+          echo "Dispatched Nightly-A2 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}'"
 
   dispatch-a3:
     name: Trigger Nightly-A3
@@ -279,12 +288,13 @@ jobs:
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f build_type='${{ needs.authorize.outputs.build_type }}'
           sleep 8
           A3_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
           echo "a3_run_id=$A3_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Dispatched Nightly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+          echo "Dispatched Nightly-A3 with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}'"
 
   dispatch-a3-560t:
     name: Trigger Nightly-A3-560T
@@ -320,12 +330,13 @@ jobs:
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
-            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}'
+            -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
+            -f build_type='${{ needs.authorize.outputs.build_type }}'
           sleep 8
           A3_560T_RUN_ID=$(gh api "repos/$REPO/actions/workflows/schedule_nightly_test_a3_560t.yaml/runs?per_page=1" \
             --jq '.workflow_runs[0].id')
           echo "a3_560t_run_id=$A3_560T_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Dispatched Nightly-A3-560T with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}'"
+          echo "Dispatched Nightly-A3-560T with test_cases='${{ needs.authorize.outputs.test_cases }}', branch='${{ needs.authorize.outputs.branch }}', build_type='${{ needs.authorize.outputs.build_type }}'"
 
   dispatch-weekly-a2:
     name: Trigger Weekly-A2

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -52,6 +52,14 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type for nightly image: "release" or "daily". Daily uses daily base image from quay.io/atlas_inference/vllm-ascend'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
 
 permissions:
   contents: read
@@ -121,6 +129,7 @@ jobs:
       vllm_ascend_branches: ${{ steps.export.outputs.vllm_ascend_branches }}
       single_node: ${{ steps.set-matrix.outputs.single_node }}
       multi_node: ${{ steps.set-matrix.outputs.multi_node }}
+      build_type: ${{ steps.export.outputs.build_type }}
     steps:
       - id: export
         run: |
@@ -130,6 +139,7 @@ jobs:
             input_branch="${{ inputs.vllm_ascend_branch }}"
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
+            echo "build_type=${{ inputs.build_type }}"
           } >> $GITHUB_OUTPUT
 
       - name: Checkout repository
@@ -171,10 +181,14 @@ jobs:
     with:
       target: a2
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node
@@ -193,7 +207,18 @@ jobs:
     with:
       soc_version: a2
       runner: linux-amd64-cpu-8-hk
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
+          )
+        }
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       request_id: ${{ inputs.request_id || '' }}
@@ -250,7 +275,18 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
+          )
+        }
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
@@ -326,7 +362,18 @@ jobs:
       runner: ${{ matrix.test_config.os }}
       model_list: ${{ toJson(matrix.test_config.model_list) }}
       model_filter: ${{ needs.parse-trigger.outputs.filter }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
+          )
+        }
       is_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (
@@ -356,7 +403,18 @@ jobs:
       runner: ${{ matrix.test_config.os }}
       model_list: ${{ toJson(matrix.test_config.model_list) }}
       model_filter: ${{ needs.parse-trigger.outputs.filter }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a2'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
+          )
+        }
       is_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' &&

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -60,6 +60,16 @@ on:
         options:
           - release
           - daily
+      cann_version:
+        description: 'CANN version embedded in the daily image tag (e.g. 2026.07.29). Only effective when build_type=daily and build-image is skipped.'
+        required: false
+        default: '2026.07.29'
+        type: string
+      cann_date:
+        description: 'Date suffix (YYYYMMDD, e.g. 20260729) of the published daily image to pull. Only effective when build_type=daily and build-image is skipped.'
+        required: false
+        default: '20260729'
+        type: string
 
 permissions:
   contents: read
@@ -130,6 +140,8 @@ jobs:
       single_node: ${{ steps.set-matrix.outputs.single_node }}
       multi_node: ${{ steps.set-matrix.outputs.multi_node }}
       build_type: ${{ steps.export.outputs.build_type }}
+      cann_version: ${{ steps.export.outputs.cann_version }}
+      cann_date: ${{ steps.export.outputs.cann_date }}
     steps:
       - id: export
         run: |
@@ -140,6 +152,8 @@ jobs:
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
             echo "build_type=${{ inputs.build_type }}"
+            echo "cann_version=${{ inputs.cann_version }}"
+            echo "cann_date=${{ inputs.cann_date }}"
           } >> $GITHUB_OUTPUT
 
       - name: Checkout repository
@@ -182,6 +196,7 @@ jobs:
       target: a2
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -214,7 +229,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
           )
@@ -282,7 +297,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
           )
@@ -369,7 +384,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
           )
@@ -410,7 +425,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a2-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a2', matrix.vllm_ascend_branch)
           )

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -53,6 +53,14 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type for nightly image: "release" or "daily". Daily uses daily base image from quay.io/atlas_inference/vllm-ascend'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
 
 permissions:
   contents: read
@@ -121,6 +129,7 @@ jobs:
       double_node: ${{ steps.set-matrix.outputs.double_node }}
       single_node: ${{ steps.set-matrix.outputs.single_node }}
       multi_card: ${{ steps.set-matrix.outputs.multi_card }}
+      build_type: ${{ steps.export.outputs.build_type }}
     steps:
       - id: export
         run: |
@@ -129,6 +138,7 @@ jobs:
             input_branch="${{ inputs.vllm_ascend_branch }}"
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
+            echo "build_type=${{ inputs.build_type }}"
           } >> $GITHUB_OUTPUT
 
       - name: Checkout repository
@@ -170,10 +180,14 @@ jobs:
     with:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node
@@ -192,7 +206,18 @@ jobs:
     with:
       soc_version: a3
       runner: linux-aarch64-a3-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       replicas: 1
@@ -231,7 +256,18 @@ jobs:
     with:
       soc_version: a3
       runner: linux-aarch64-a3-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       replicas: 1
@@ -269,7 +305,18 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       should_run: >-
@@ -298,7 +345,18 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -61,6 +61,16 @@ on:
         options:
           - release
           - daily
+      cann_version:
+        description: 'CANN version embedded in the daily image tag (e.g. 2026.07.29). Only effective when build_type=daily and build-image is skipped.'
+        required: false
+        default: '2026.07.29'
+        type: string
+      cann_date:
+        description: 'Date suffix (YYYYMMDD, e.g. 20260729) of the published daily image to pull. Only effective when build_type=daily and build-image is skipped.'
+        required: false
+        default: '20260729'
+        type: string
 
 permissions:
   contents: read
@@ -130,6 +140,8 @@ jobs:
       single_node: ${{ steps.set-matrix.outputs.single_node }}
       multi_card: ${{ steps.set-matrix.outputs.multi_card }}
       build_type: ${{ steps.export.outputs.build_type }}
+      cann_version: ${{ steps.export.outputs.cann_version }}
+      cann_date: ${{ steps.export.outputs.cann_date }}
     steps:
       - id: export
         run: |
@@ -139,6 +151,8 @@ jobs:
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
             echo "build_type=${{ inputs.build_type }}"
+            echo "cann_version=${{ inputs.cann_version }}"
+            echo "cann_date=${{ inputs.cann_date }}"
           } >> $GITHUB_OUTPUT
 
       - name: Checkout repository
@@ -181,6 +195,7 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -213,7 +228,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )
@@ -263,7 +278,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )
@@ -312,7 +327,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )
@@ -352,7 +367,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -53,6 +53,14 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type for nightly image: "release" or "daily". Daily uses daily base image from quay.io/atlas_inference/vllm-ascend'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
 
 permissions:
   contents: read
@@ -122,6 +130,7 @@ jobs:
       double_node: ${{ steps.set-matrix.outputs.double_node }}
       single_node: ${{ steps.set-matrix.outputs.single_node }}
       multi_card: ${{ steps.set-matrix.outputs.multi_card }}
+      build_type: ${{ steps.export.outputs.build_type }}
     steps:
       - id: export
         run: |
@@ -130,6 +139,7 @@ jobs:
             input_branch="${{ inputs.vllm_ascend_branch }}"
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
+            echo "build_type=${{ inputs.build_type }}"
           } >> $GITHUB_OUTPUT
 
       - name: Checkout repository
@@ -171,10 +181,14 @@ jobs:
     with:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node
@@ -193,7 +207,18 @@ jobs:
     with:
       soc_version: a3-560t
       runner: linux-aarch64-a3-0-cn12-001
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       replicas: 1
@@ -233,7 +258,18 @@ jobs:
     with:
       soc_version: a3-560t
       runner: linux-aarch64-a3-0-cn12-001
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       ascend_log_prefix: ${{ needs.setup-vars.outputs.ascend_log_prefix }}/${{ matrix.vllm_ascend_branch }}
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       replicas: 1
@@ -288,7 +324,18 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node_560t.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
       should_run: >-
@@ -317,7 +364,18 @@ jobs:
     uses: ./.github/workflows/_e2e_nightly_single_node_560t.yaml
     with:
       runner: ${{ matrix.test_config.os }}
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-${{ matrix.vllm_ascend_branch }}-a3'
+      image: >-
+        ${
+          needs.build-image.result == 'success' &&
+          format('{0}:{1}', needs.build-image.outputs.swr_registry, needs.build-image.outputs.full_tag)
+          ||
+          (
+            needs.setup-vars.outputs.build_type == 'daily' &&
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            ||
+            format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
+          )
+        }
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -61,6 +61,16 @@ on:
         options:
           - release
           - daily
+      cann_version:
+        description: 'CANN version embedded in the daily image tag (e.g. 2026.07.29). Only effective when build_type=daily and build-image is skipped.'
+        required: false
+        default: '2026.07.29'
+        type: string
+      cann_date:
+        description: 'Date suffix (YYYYMMDD, e.g. 20260729) of the published daily image to pull. Only effective when build_type=daily and build-image is skipped.'
+        required: false
+        default: '20260729'
+        type: string
 
 permissions:
   contents: read
@@ -131,6 +141,8 @@ jobs:
       single_node: ${{ steps.set-matrix.outputs.single_node }}
       multi_card: ${{ steps.set-matrix.outputs.multi_card }}
       build_type: ${{ steps.export.outputs.build_type }}
+      cann_version: ${{ steps.export.outputs.cann_version }}
+      cann_date: ${{ steps.export.outputs.cann_date }}
     steps:
       - id: export
         run: |
@@ -140,6 +152,8 @@ jobs:
             normalized=$(echo "$input_branch" | tr '/' '-')
             echo "vllm_ascend_branches=[\"${normalized}\"]"
             echo "build_type=${{ inputs.build_type }}"
+            echo "cann_version=${{ inputs.cann_version }}"
+            echo "cann_date=${{ inputs.cann_date }}"
           } >> $GITHUB_OUTPUT
 
       - name: Checkout repository
@@ -182,6 +196,7 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -214,7 +229,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )
@@ -265,7 +280,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )
@@ -331,7 +346,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )
@@ -371,7 +386,7 @@ jobs:
           ||
           (
             needs.setup-vars.outputs.build_type == 'daily' &&
-            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, '2026.07.29', '20260729')
+            format('swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{0}-a3-cann{1}-{2}', matrix.vllm_ascend_branch, needs.setup-vars.outputs.cann_version, needs.setup-vars.outputs.cann_date)
             ||
             format('swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-{0}-a3', matrix.vllm_ascend_branch)
           )


### PR DESCRIPTION
### What this PR does / why we need it?

Introduces a new build_type input (release | daily, default release) to schedule_nightly_test_a2.yaml, schedule_nightly_test_a3.yaml, and schedule_nightly_test_a3_560t.yaml. When set to daily, tests run against the daily image published at swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend:daily-{branch}-{soc}-cann{cann_version}-{date} (which bundles daily-built deps such as torch_npu, memcache, memfabric and triton-ascend).
- Extends the /nightly slash-command dispatcher (pr_nightly_command.yml) to accept a --build-type <release|daily> flag and forward build_type to the dispatched A2/A3/A3-560T runs.
- Propagates build_type from setup-vars into the build-image job and passes the corresponding daily secrets (HW_USERNAME_DAILY, HW_TOKEN_DAILY, QUAY_DAILY_PASSWORD) so image build/push can target the daily repositories.
- Reworks the test image selection into a 3-tier fallback:
1. If the build-image job succeeded → use its freshly built swr_registry:full_tag;
2. Else if build_type == daily → use the prebuilt daily image;
3. Otherwise → fall back to the existing nightly-ci-{branch}-{soc} image.

### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
