### PR TITLE
[Doc][Misc] Relocate max-model-len and max-num-seqs notice to deployment section

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -529,6 +529,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script(A3)
 
    :::::{tab-set}
@@ -1294,9 +1297,6 @@ After several minutes, you can get the performance evaluation result.
 |Long Context (64K)|Server-D Node|32|1|32|132K|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
-
-**Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -418,6 +418,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
    :::::{tab-set}

--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -457,6 +457,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
    :::::{tab-set}
@@ -1047,9 +1050,6 @@ After about several minutes, you can get the performance evaluation result.
 | Long Context (128K, high concurrency >4) |Server / Single Machine|16|8|2|128K|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
-
-**Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -293,6 +293,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
    :::::{tab-set}
@@ -859,9 +862,6 @@ After about several minutes, you can get the performance evaluation result.
 |Multimodal (1080P)|Server-D Node|16|1|16|17k|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
-
-**Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
 ### 9.2 Tuning Guidelines
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR relocates the notice regarding `max-model-len` and `max-num-seqs` configuration from the Performance Tuning section (Chapter 9) to the Multi-Node PD Separation Deployment parameter descriptions section (Chapter 5.3) for DeepSeek-V3.1, Kimi-K2.5, and Kimi-K2.6 model tutorials. This makes the documentation more coherent as these parameters are defined in the table immediately preceding the notice.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation changes only, verified visually.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
