### PR TITLE
[Cherry-pick][releases/v0.26.0rc][BugFix][Scheduler] Adapt BalanceScheduler get_computed_blocks (from #13275)

### DIFF
--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -476,9 +476,11 @@ class BalanceScheduler(Scheduler):
                                 preempted=request.num_preemptions > 0,
                             )
                     else:
-                        new_computed_blocks, num_new_local_computed_tokens = self.kv_cache_manager.get_computed_blocks(
-                            request
-                        )
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            request.shared_prefix_boundary,
+                        ) = self.kv_cache_manager.get_computed_blocks(request)
 
                     # In case of hybrid models, obtain hint for Marconi-style APC logic
                     if self.has_mamba_layers:


### PR DESCRIPTION
Cherry-pick of PR #13275 onto `releases/v0.26.0rc`.

Original PR: https://github.com/vllm-project/vllm-ascend/pull/13275  
Original effective commit: `ad1414bc7b33cfb6e99e2266b25c4bfca369bee3`  
Original author: @zhao-stack

The source PR contains a production fix followed by an added-then-removed UT pair. This backport cherry-picks the effective production commit only, so its final diff matches #13275 without carrying two net-zero commits.

---

### What this PR does / why we need it?

The copied `BalanceScheduler.schedule()` implementation on `releases/v0.26.0rc` still expects two values from `KVCacheManager.get_computed_blocks()`.

The vLLM version pinned by this branch returns:

```python
(computed_blocks, num_computed_tokens, shared_prefix_boundary)
```

When balance scheduling reaches this path, the two-value unpack can fail with `ValueError: too many values to unpack (expected 2)`.

This backport updates the copied scheduler to unpack the third value into `request.shared_prefix_boundary`, matching upstream vLLM and PR #13275.

### Does this PR introduce _any_ user-facing change?

No. It prevents a runtime failure when balance scheduling is enabled.

### How was this patch tested?

Passed locally:

- source AST contract check: exactly one `get_computed_blocks()` call is unpacked into the expected three targets;
- `python -m ruff format --check vllm_ascend/patch/platform/patch_balance_schedule.py`;
- `python -m ruff check vllm_ascend/patch/platform/patch_balance_schedule.py`;
- `python -m compileall -q vllm_ascend/patch/platform/patch_balance_schedule.py`;
- `git diff --check origin/releases/v0.26.0rc..HEAD`.

The existing `test_patch_balance_schedule.py` could not be collected in this Windows environment because `tests/ut/conftest.py` imports `torch`, which is not installed locally. CI verification is still required.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
