### PR TITLE
[v0.24.0rc][Doc][Misc] Backport Kimi-K2-Thinking tuning docs to v0.24.0rc

### DIFF
--- a/docs/source/tutorials/models/Kimi-K2-Thinking.md
+++ b/docs/source/tutorials/models/Kimi-K2-Thinking.md
@@ -188,20 +188,27 @@ Run the following script to start the vLLM server:
 
 **Parameter and Environment Variable Descriptions:**
 
-- `HCCL_BUFFSIZE=1024`: configures the HCCL buffer size.
-- `TASK_QUEUE_ENABLE=1`: enables task queue scheduling.
-- `OMP_PROC_BIND=false`: avoids overly strict OpenMP CPU binding.
-- `HCCL_OP_EXPANSION_MODE=AIV`: enables the AIV communication path.
-- `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True`: reduces NPU memory fragmentation.
-- `SERVER_PORT`: sets the service port. The generated script maps `DEFAULT_PORT` to `8000`.
-- `--tensor-parallel-size 16`: uses 16-way tensor parallelism on the A3 node.
-- `--max-model-len 8192`: sets the maximum model context length.
-- `--max-num-batched-tokens 8192`: sets the maximum number of batched tokens.
-- `--max-num-seqs 12`: sets the maximum number of concurrent sequences.
-- `--gpu-memory-utilization 0.9`: controls the memory ratio used by vLLM.
-- `--trust-remote-code`: allows loading model-specific remote code.
-- `--enable-expert-parallel`: enables expert parallelism for MoE layers.
-- `--no-enable-prefix-caching`: disables prefix caching for a stable baseline.
+The following table covers the generated `model`, all `envs`, and all `server_cmd` entries. Parameters are categorized by review priority: version-sensitive parameters, performance parameters, and Kimi-K2-Thinking-specific parameters.
+
+| Parameter | Validated Value | Category | Description and Tuning Guidance |
+| --- | --- | --- | --- |
+| `moonshotai/Kimi-K2-Thinking` | model path | Model-specific | Specifies the model weight path passed to `vllm serve`. Because `--served-model-name` is not set in the script, API requests must use `moonshotai/Kimi-K2-Thinking` as the model name unless you add an explicit served-model-name override; see the FAQ in Chapter 10. |
+| `HCCL_BUFFSIZE` | `1024` | Performance | Configures the HCCL communication buffer used by distributed NPU communication. This document validates `1024`; other values need separate throughput, TTFT, TPOT, and HCCL stability validation. |
+| `TASK_QUEUE_ENABLE` | `1` | Version-sensitive / Performance | Enables task queue scheduling on Ascend. This document validates `1`; other values or version changes need startup and first-request validation. |
+| `OMP_PROC_BIND` | `false` | Performance | Avoids overly strict OpenMP CPU binding. This document validates `false`; other values need separate CPU affinity, NPU health, and HCCL stability validation. |
+| `HCCL_OP_EXPANSION_MODE` | `AIV` | Performance | Enables the AIV communication path. This document validates `AIV`; other values need separate throughput and latency validation. |
+| `PYTORCH_NPU_ALLOC_CONF` | `expandable_segments:True` | Memory / Performance | Reduces NPU memory fragmentation. This document validates `expandable_segments:True`; other allocator settings need separate startup, memory, and runtime stability validation. |
+| `SERVER_PORT` and `--port` | `8000` | Service | Sets the OpenAI-compatible service port. The documentation generator maps `DEFAULT_PORT` in the YAML to `8000`; update the curl examples if you change this value. |
+| `--tensor-parallel-size` | `16` | Model-specific / Performance | Uses all 16 NPUs on one Atlas 800 A3 node. This document validates `tp16`; other topologies need separate memory, accuracy, and communication validation. |
+| `--max-model-len` | `8192` | Performance | Sets the maximum input plus output tokens for one request and determines KV cache reservation. This document validates `8192`; larger values need separate NPU memory, accuracy, and performance validation. Keep it close to the real maximum input and output length for your workload. |
+| `--max-num-batched-tokens` | `8192` | Performance | Limits tokens processed in one scheduler step. This document validates `8192`; other values need separate memory, TTFT, TPOT, and throughput validation. |
+| `--max-num-seqs` | `12` | Performance | Limits active sequences scheduled at the same time. This document validates `12`; higher values need separate tail-latency and throughput validation. The reference sweep in Chapter 8 shows concurrency 16 causes severe TTFT growth; validate tail latency before raising it in production. |
+| `--gpu-memory-utilization` | `0.9` | Memory / Performance | Controls the fraction of NPU HBM used by vLLM for KV cache planning. This document validates `0.9`; other values need separate startup, OOM, and runtime stability validation. |
+| `--trust-remote-code` | enabled | Model-specific | Required because the model package contains model-specific configuration, modeling, tokenizer, and chat-template files. Disable it only after replacing the remote-code dependency with a validated native implementation. |
+| `--enable-expert-parallel` | enabled | Model-specific / Performance | Enables expert parallelism for Kimi-K2-Thinking MoE layers so experts can be distributed across NPUs. This document validates it as enabled; disabling it is not validated in this tutorial. |
+| `--no-enable-prefix-caching` | enabled | Performance | Disables prefix caching for the validated baseline and random-prompt benchmarks. Prefix caching is not validated in this tutorial. |
+
+**Common Issues Tip:** For common environment, installation, and general parameter issues during deployment, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html). If the service runs under high concurrency, verify NPU health and HCCL status before increasing the request rate.
 
 **Service Verification:**
 
@@ -341,21 +348,9 @@ Reference results for 1024 input tokens and 1024 output tokens are:
 
 | Scenario | Deployment Mode | Total NPUs | Weight Version | Key Considerations |
 |----------|----------------|------------|----------------|---------------------|
-| Long Context | Single-node | 16 (A3) | bfloat16 | Keep `--max-model-len` close to the real maximum input and output length; reduce `--max-num-seqs` first when memory pressure is high. |
-| Low Latency | Single-node | 16 (A3) | bfloat16 | Reduce `--max-num-seqs` and `--max-num-batched-tokens` to reduce queueing delay. |
-| High Throughput | Single-node | 16 (A3) | bfloat16 | Increase `--max-num-seqs` gradually and benchmark with a request rate close to the real workload. |
-
-#### Table 2: Detailed Recommendations
-
-- **Long context:** use `tp16`, keep `--max-model-len` close to the real maximum input and output length, and reduce `--max-num-seqs` first when memory pressure is high.
-- **Low latency:** reduce `--max-num-seqs` and `--max-num-batched-tokens` to reduce queueing delay.
-- **High throughput:** increase `--max-num-seqs` gradually and benchmark with a request rate close to the real workload. For long-context throughput tests, evaluate `--decode-context-parallel-size` as an optional tuning knob.
-- For 1024 input tokens and 1024 output tokens in the reference concurrency sweep, `--max-concurrency 8` had the best output throughput. Higher concurrency increased TTFT significantly, so validate tail latency before using it in production.
-
-> **Note:**
->
-> - `--max-model-len` and `--max-num-seqs` need to be set according to the actual usage scenario.
-> - If the service runs under high concurrency, verify NPU health and HCCL status before increasing request rate.
+| Long Context | Single-node | 16 (A3) | bfloat16 | Keep `--max-model-len` close to the real maximum input and output length, and reduce `--max-num-seqs` first when memory pressure is high. The validated scope of this single-node baseline covers up to 2K input / 2K output in Chapter 8. |
+| Low Latency | Single-node | 16 (A3) | bfloat16 | Reduce `--max-num-seqs` and `--max-num-batched-tokens` from the validated baseline (`12` and `8192`) to reduce queueing delay. In the Chapter 8 concurrency sweep, concurrency 1-4 kept mean TTFT below 1s; validate TTFT, TPOT, and tail latency against the target latency SLO. |
+| High Throughput | Single-node | 16 (A3) | bfloat16 | Increase `--max-num-seqs` gradually and benchmark with a request rate close to the real workload. In the 1K/1K concurrency sweep in Chapter 8, concurrency 8 gave the best output throughput; validate tail latency before using higher concurrency in production. |
 
 ### 9.2 Tuning Guidelines
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR backports the `Kimi-K2-Thinking` deployment and tuning documentation to the `releases/v0.24.0rc` branch (backport of #12991).

Specifically, it:
1. Clarifies the review scope for deployment scripts in Chapter 5.
2. Explains key parameters using requested criteria (version-sensitive, performance, and model-specific).
3. Adds performance recommendation tables in Chapter 9 (Scenario Overview and Detailed Node Configuration).
4. Moves parameter notes from Chapter 9 to Chapter 5.

### Does this PR introduce _any_ user-facing change?

Yes, this is a documentation-only update for the Kimi-K2-Thinking tutorial on `releases/v0.24.0rc`.

### How was this patch tested?

Tested by running:
- `git diff --check -- docs/source/tutorials/models/Kimi-K2-Thinking.md`

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
