### PR TITLE
[BugFix] Return prompt_logprobs via proxy merge in disaggregated PD setup

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -162,6 +162,10 @@ class InstanceInfo:
     decoder_host: str
     decoder_port: int
     prefiller_cached_tokens: int | None = None
+    # prompt-side fields produced by prefiller (decoder can't, proxy merges them)
+    prompt_logprobs: Any = None
+    prompt_token_ids: Any = None
+    prompt_text: Any = None
 
 
 TAINT_PRIORITY = 1e15
@@ -955,6 +959,10 @@ async def assign_instances(
     if kv_transfer_params:
         req_data["kv_transfer_params"] = kv_transfer_params
     prefiller_cached_tokens = extract_cached_tokens(response_json)
+    # harvest prompt-side fields from prefiller (has h, local prefill fills tensor)
+    _p_pl = response_json.get("prompt_logprobs")
+    _p_pti = response_json.get("prompt_token_ids")
+    _p_pt = response_json.get("prompt_text")
 
     try:
         decoder = await runtime.schedule("pick_decoder", decoder_score)
@@ -974,6 +982,9 @@ async def assign_instances(
         decoder_host=decoder["host"],
         decoder_port=decoder["port"],
         prefiller_cached_tokens=prefiller_cached_tokens,
+        prompt_logprobs=_p_pl,
+        prompt_token_ids=_p_pti,
+        prompt_text=_p_pt,
     )
 
 
@@ -1009,6 +1020,34 @@ async def handle_completions_impl(api: str, request: Request):
         else:
             origin_prompt = ""
         origin_max_tokens = req_data.get("max_tokens", 16)
+
+        # prompt_logprobs must be non-streaming (vllm rejects stream+prompt_logprobs).
+        # Strip it before sending to decoder, then merge prefiller's value back.
+        if req_data.get("prompt_logprobs") is not None and not stream_flag:
+            decode_req = req_data.copy()
+            decode_req.pop("prompt_logprobs", None)
+            decode_req.pop("echo", None)
+            decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+            headers = auth_headers(instance_info.request_id)
+            try:
+                d_resp = await decoder_client.post(api, json=decode_req, headers=headers)
+                d_resp.raise_for_status()
+                d_json = d_resp.json()
+                choice = (d_json.get("choices") or [{}])[0]
+                if choice.get("stop_reason") == "recomputed":
+                    # rare: decoder requests recompute; merge not supported, skip
+                    logger.warning("prompt_logprobs + recomputed retry: merge skipped for %s", instance_info.request_id)
+                else:
+                    if instance_info.prompt_logprobs is not None:
+                        d_json["prompt_logprobs"] = instance_info.prompt_logprobs
+                    if instance_info.prompt_token_ids is not None:
+                        d_json["prompt_token_ids"] = instance_info.prompt_token_ids
+                    if instance_info.prompt_text is not None:
+                        d_json["prompt_text"] = instance_info.prompt_text
+                return JSONResponse(d_json)
+            finally:
+                await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+                request_released = True
 
         async def generate_stream():
             nonlocal instance_info


### PR DESCRIPTION
In the PD-disaggregated setup, a request with prompt_logprobs crashes the decoder (root cause in vllm core, vllm-project/vllm#50792, fix PR vllm-project/vllm#180296). The decoder (kv_consumer) cannot produce prompt_logprobs (it only gets K/V, not hidden states); the prefiller can. Harvest prompt_logprobs/prompt_token_ids/prompt_text from the prefiller response, strip prompt_logprobs/echo before forwarding to the decoder, and merge them back into the decoder's non-streaming response.

Closes #13363

### What this PR does / why we need it?

In the PD-disaggregated setup, a request with `prompt_logprobs` crashes the decoder (vllm core root cause: vllm-project/vllm#50792, fix PR vllm-project/vllm#180296). The decoder (kv_consumer) cannot produce `prompt_logprobs` — it only gets K/V, not hidden states; the prefiller can. This PR makes the disagg proxy harvest `prompt_logprobs`/`prompt_token_ids`/`prompt_text` from the prefiller, strip `prompt_logprobs`/`echo` before forwarding to the decoder, and merge them back into the decoder's non-streaming response. The decoder never receives `prompt_logprobs`, so it never hits the crashing path, while the client gets real values.

Changes are in `examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py`:
- `InstanceInfo`: add the three prompt-side fields.
- `assign_instances`: harvest them from the prefiller response (also on reassignment).
- `handle_completions_impl`: non-streaming `prompt_logprobs` path — strip, POST to decoder, merge prefiller's values back. (vllm rejects `stream=True` + `prompt_logprobs>0`, so only non-streaming needs handling.)

### Does this PR introduce _any_ user-facing change?

Yes, but only for the example proxy: non-streaming `prompt_logprobs` requests through the disagg proxy now return real `prompt_logprobs` (from the prefiller) instead of crashing the decoder. No change to the vllm engine or API.

### How was this patch tested?

Manual reproduction on a PD-disaggregated setup (1 prefiller + 1 decoder + this proxy), `prompt_logprobs=1` non-streaming:

| Setup | `prompt_logprobs` | Before | After |
|---|---|---|---|
| PD disagg (P+D) | yes | `OverflowError`, decoder crash | no crash, real `prompt_logprobs` returned |
| PD disagg (P+D) | no | no crash | no crash (unchanged) |

After the fix, the response carries real prompt logprobs sourced from the prefiller and the decoder no longer crashes. No unit test added — this path needs a multi-engine PD setup with an external KV connector, not covered by the single-engine test harness.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
