### PR TITLE
[releases/v0.26.0rc][CI] drop vllm main test for releases/v0.26.0rc

### DIFF
--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -201,7 +201,6 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.e2e-test.outputs.main_commit }}
           - ${{ needs.e2e-test.outputs.release_tag }}
     needs: [e2e-test, ensure-csrc-cache]
     if: ${{ needs.e2e-test.outputs.has_tests == 'true' }}

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -337,7 +337,6 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
           - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
@@ -363,7 +362,6 @@ jobs:
     strategy:
       matrix:
         vllm_version:
-          - ${{ needs.pre-commit.outputs.main_commit }}
           - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests_upstream.yaml
     with:


### PR DESCRIPTION
### What this PR does / why we need it?

drop vllm main test for releases/v0.26.0rc

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
