### PR TITLE
[Feature] Enable msprobe to dump specified requests data

### DIFF
--- a/docs/source/developer_guide/performance_and_debug/msprobe_guide.md
+++ b/docs/source/developer_guide/performance_and_debug/msprobe_guide.md
@@ -290,6 +290,7 @@ Use `msprobe graph_visualize` to build or compare graphs, then open the generate
 - `RuntimeError: Please enforce eager mode`: Restart vLLM and add the `--enforce-eager` flag.
 - No dump files: Confirm that the JSON path is correct and every node has write permission. In distributed scenarios set `keep_all_ranks` so that every rank writes its own dump.
 - Dumps are too large: Start with a `statistics` task to locate abnormal tensors, then narrow the scope with `scope`/`list`/`tensor_list`, `filters`, `token_range`, etc.
+- `TypeError: PrecisionDebugger.start() got an unexpected keyword argument 'scheduled_tokens'`: Please Upgrade `msprobe` to v26.2.0 or later.
 
 ---
 

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -748,6 +748,16 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.debugger.step.assert_not_called()
         self.assertTrue(runner._debugger_started)
 
+    def test_start_dump_data_forwards_kwargs_to_debugger_start(self):
+        debugger = MagicMock(spec=["start", "step"])
+        runner = self._build_runner(debugger)
+        runner._debugger_started = False
+
+        runner._start_dump_data(scheduled_tokens={"req-0": 42})
+
+        debugger.start.assert_called_once_with(runner.model, scheduled_tokens={"req-0": 42})
+        self.assertTrue(runner._debugger_started)
+
     @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
@@ -824,7 +834,7 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "sentinel"):
             runner.execute_model(scheduler_output)
 
-        runner._start_dump_data.assert_called_once_with()
+        runner._start_dump_data.assert_called_once_with(scheduled_tokens={"req0": 1})
 
 
 class TestCorrectOptimisticSeqLensCpu(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1868,7 +1868,7 @@ class NPUModelRunner(GPUModelRunner):
                 )
 
                 if has_ec_transfer() and not get_ec_transfer().is_consumer:
-                    self._start_dump_data()
+                    self._start_dump_data(scheduled_tokens = scheduler_output.num_scheduled_tokens)
                     with self.maybe_get_ec_connector_output(
                         scheduler_output,
                         encoder_cache=self.encoder_cache,
@@ -1908,7 +1908,7 @@ class NPUModelRunner(GPUModelRunner):
                     if not has_kv_transfer_group():
                         return EMPTY_MODEL_RUNNER_OUTPUT
                     return self.kv_connector_no_forward(scheduler_output, self.vllm_config)
-                self._start_dump_data()
+                self._start_dump_data(scheduled_tokens = scheduler_output.num_scheduled_tokens)
                 num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
                 max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
                 (
@@ -3653,10 +3653,10 @@ class NPUModelRunner(GPUModelRunner):
             load_model_total_time,
         )
 
-    def _start_dump_data(self) -> None:
+    def _start_dump_data(self, **kwargs) -> None:
         if self.debugger is None or self._debugger_started:
             return
-        self.debugger.start(self.model)
+        self.debugger.start(self.model, **kwargs)
         self._debugger_started = True
 
     def _finalize_dump_data(self, **kwargs) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enables msprobe to dump specified requests data, it updates _start_dump_data in model_runner_v1.py to accept keyword arguments (**kwargs) and passes scheduled_tokens from scheduler_output when starting the debugger.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
tests were added in this PR.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
