### PR TITLE
[Doc][Misc] Relocate max-model-len notice to parameter descriptions in model tutorials

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -413,6 +413,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
     === "Node 0(Prefill)"
@@ -953,9 +956,6 @@ After several minutes, you can get the performance evaluation result.
 |Long Context (64K)|Server-D Node|16|4|8|132K|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
-
-**Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -394,6 +394,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
 === "Node 0(Prefill)"

--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -441,6 +441,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
     === "Node 0(Prefill)"
@@ -1028,9 +1031,6 @@ After about several minutes, you can get the performance evaluation result.
 |Long Context (128K, high concurrency >4)|Server / Single Machine|16|8|2|128K|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
-
-**Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
 ### 9.2 Tuning Guidelines
 

--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -284,6 +284,9 @@ Parameter descriptions:
 |`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
 |`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
+**Notice:**
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario.
+
 1. `run_dp_template.sh` script
 
 === "Node 0(Prefill)"
@@ -854,9 +857,6 @@ After about several minutes, you can get the performance evaluation result.
 |Multimodal (1080P)|Server-D Node|16|1|16|17k|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
-
-**Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
 ### 9.2 Tuning Guidelines
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR relocates the notice regarding `max-model-len` and `max-num-seqs` from the performance tuning section to the multi-node PD separation deployment parameter descriptions across several model tutorials (DeepSeek-V3.1, DeepSeek-V3.2, Kimi-K2.5, and Kimi-K2.6). This ensures that users are prompted to configure these parameters during deployment setup rather than later during tuning.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation changes only, no functional code changes.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
