### PR TITLE
[Bug Fix][SpecDecode]Fix MTP hang with oproj tensor parallel

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -663,8 +663,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 self.query_start_loc_group[draft_index][num_reqs + 1 :].fill_(0)
                 common_attn_metadata.query_start_loc = self.query_start_loc_group[draft_index][: num_reqs + 1]
                 if self.pcp_size * self.dcp_size > 1 and draft_index > 0:
-                    assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
-                    common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:num_reqs]
+                    if self.block_table_tensor_clone is not None:
+                        common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:num_reqs]
+                    else:
+                        common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor.clone()
                 if not self.use_compress or draft_index == 0:
                     attn_metadata_eagle = builder.build_for_graph_capture(
                         common_attn_metadata,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -54,7 +54,7 @@ from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
-from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.utils import enable_sp, lmhead_tp_enable, oproj_tp_enable, shared_expert_dp_enabled
 
 
 @contextmanager
@@ -578,6 +578,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
+        build_dummy_draft_metadata = (
+            (aclgraph_runtime_mode == CUDAGraphMode.FULL or (self.method == "mtp" and oproj_tp_enable()))
+            and len(self.runner.attn_groups) > 0
+        )
+
         # init block table tensor clone is only available after profile run and is only used for graph mode
         if (
             self.pcp_size * self.dcp_size > 1
@@ -595,7 +600,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 pin_memory=self.runner.pin_memory,
             )
 
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
+        if build_dummy_draft_metadata:
             num_computed_tokens_cpu = self.runner.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
 
             # num_reqs is already the padded version


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a hang/AICore timeout issue when running MTP speculative decoding with `oproj_tensor_parallel_size` enabled on vLLM Ascend D nodes.

In the failing configuration, D nodes can have mixed real and idle DP ranks during speculative decoding:

- Ranks with real requests execute the MTP `propose` path.
- Idle ranks execute the MTP `dummy_run` path.

Before this change, the dummy draft path only built multi-step draft attention metadata when `aclgraph_runtime_mode == FULL`. For GLM MTP speculative decoding, the draft model runs in eager mode, so the dummy path skipped draft metadata construction. As a result, real ranks and dummy ranks executed inconsistent draft attention paths when `oproj_tensor_parallel_size` enabled DSA `o_proj` OTP collectives.

This mismatch could make asynchronous NPU work fail and later surface as a hang or AICore timeout at the next target ACLGraph pre-sync.

This PR updates the dummy draft metadata condition so that MTP with `oproj_tensor_parallel_size` also builds draft metadata, even when the draft model runs in eager mode. This keeps real `propose` and idle `dummy_run` ranks aligned for speculative draft execution.

The fix is intentionally minimal:

- Import `oproj_tp_enable`.
- Build dummy draft metadata when `self.method == "mtp" and oproj_tp_enable()`.
- Preserve existing FULL graph behavior.
- Do not disable or ignore `oproj_tensor_parallel_size`.

### Does this PR introduce _any_ user-facing change?

Yes. This PR fixes the behavior of MTP speculative decoding with `oproj_tensor_parallel_size` enabled on Ascend D nodes.

Users can now run MTP speculative decoding together with `oproj_tensor_parallel_size` without the D node hanging in the verified GLM MTP P/D deployment.

No API, CLI option, or configuration format is changed.

### How was this patch tested?

Validated manually in a vLLM + vLLM Ascend P/D separated deployment with GLM MTP speculative decoding.

Tested scenarios:

1. D node configured with:

```bash
--speculative-config '{"num_speculative_tokens":5, "method":"deepseek_mtp", "enforce_eager":true}'
```

and `oproj_tensor_parallel_size=16`.

Result: request completed successfully; no hang or AICore timeout.

2. D node configured with:

```bash
--speculative-config '{"num_speculative_tokens":5, "method":"deepseek_mtp", "enforce_eager":true}'
```

without `oproj_tensor_parallel_size`.

Result: request completed successfully; no regression.

Additional local checks:

```bash
python -m py_compile vllm_ascend/spec_decode/llm_base_proposer.py
git diff --check -- vllm_ascend/spec_decode/llm_base_proposer.py
```

Both checks passed.

No unit test was added because the failure depends on multi-rank Ascend NPU execution with P/D separation, MTP speculative decoding, and OTP collectives. The issue could not be reproduced in the local unit test environment without the required distributed NPU setup.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
