### PR TITLE
[BugFix][MiniMax M3] Fix repeated-output drift in sparse attention

### DIFF
--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_triton.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_triton.py
@@ -1019,13 +1019,15 @@ def _gqa_sparse_fwd_kernel(
             safe_page = tl.maximum(page, 0)
             pos = c + off_n
             pos_mask = (pos < seq_len) & valid_page
+            tail_or_invalid = (~valid_page) | (c + BLOCK_SIZE_K > seq_len)
+            load_pos_mask = pos_mask | (~tail_or_invalid)
             k = tl.load(
                 k_cache_ptr
                 + safe_page * stride_k_blk
                 + off_n[None, :] * stride_k_pos
                 + pid_kh * stride_k_h
                 + off_d[:, None] * stride_k_d,
-                mask=d_mask[:, None],
+                mask=d_mask[:, None] & load_pos_mask[None, :],
                 other=0.0,
             )
             if USE_FP8:
@@ -1049,7 +1051,7 @@ def _gqa_sparse_fwd_kernel(
                 + off_n[:, None] * stride_v_pos
                 + pid_kh * stride_v_h
                 + off_d[None, :] * stride_v_d,
-                mask=d_mask[None, :],
+                mask=load_pos_mask[:, None] & d_mask[None, :],
                 other=0.0,
             )
             if USE_FP8:
@@ -1221,13 +1223,15 @@ def _gqa_sparse_decode_kernel(
         safe_page = tl.maximum(page, 0)
         pos = c + off_n
         pos_mask = (pos < kv_len) & valid_page
+        tail_or_invalid = (~valid_page) | (c + BLOCK_SIZE_K > kv_len)
+        load_pos_mask = pos_mask | (~tail_or_invalid)
         k = tl.load(
             k_cache_ptr
             + safe_page * stride_k_blk
             + off_n[None, :] * stride_k_pos
             + pid_kh * stride_k_h
             + off_d[:, None] * stride_k_d,
-            mask=d_mask[:, None],
+            mask=d_mask[:, None] & load_pos_mask[None, :],
             other=0.0,
         )
         if USE_FP8:
@@ -1247,7 +1251,7 @@ def _gqa_sparse_decode_kernel(
             + off_n[:, None] * stride_v_pos
             + pid_kh * stride_v_h
             + off_d[None, :] * stride_v_d,
-            mask=d_mask[None, :],
+            mask=load_pos_mask[:, None] & d_mask[None, :],
             other=0.0,
         )
         if USE_FP8:
@@ -1612,9 +1616,16 @@ def minimax_m3_index_decode(
 
     global_max_block_count = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
     if block_count is None:
-        max_block_count = global_max_block_count
+        max_block_count = min(global_max_block_count, int(block_table.shape[-1]))
     else:
-        max_block_count = max(0, min(block_count, global_max_block_count - block_offset))
+        max_block_count = max(
+            0,
+            min(
+                block_count,
+                global_max_block_count - block_offset,
+                int(block_table.shape[-1]),
+            ),
+        )
     score_block_stride = round_up(
         max_block_count,
         SCORE_BLOCK_STRIDE_ALIGNMENT,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes repeated-output drift in the MiniMax M3 Triton sparse attention implementation.

- Masks K/V loads for invalid pages and partially valid tail blocks in both prefill and decode kernels, preventing invalid cache data from affecting attention results.
- Limits the decode index block count to the actual block table width.
- Preserves the existing tensor-parallel block sharding constraints when calculating the effective block count.

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax M3 sparse attention produces stable and repeatable outputs for requests containing tail blocks or invalid sparse-attention selections.

There are no API, configuration, or interface changes.

### How was this patch tested?
Not involved
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
