### PR TITLE
[BugFix][Sampler] Fix inf in Qwen30b RL sampling by recording stream for q releases/v0.21.0rc

### DIFF
--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -39,6 +39,7 @@ def random_sample(
             for i, generator in generators.items():
                 q[i].exponential_(generator=generator)
     torch.npu.current_stream().wait_stream(global_stream())
+    q.record_stream(torch.npu.current_stream())
     return probs.div_(q).argmax(dim=-1).view(-1)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an `inf` sampling issue observed in Qwen3 30B RL workloads on Ascend.

In `random_sample()`, tensor `q` is allocated on `global_stream()` but consumed on `torch.npu.current_stream()` via `probs.div_(q)`. The code only establishes an execution dependency (`wait_stream`), but does not declare the storage lifetime of `q` on the consumer stream.

Without `q.record_stream(torch.npu.current_stream())`, the caching allocator may reclaim and reuse `q`'s buffer on the sampling stream before the queued division on the current stream has read it. On Ascend, `exponential_()` is a multi-kernel in-place sequence (`uniform_ -> neg_ -> add_(1) -> masked_fill_ -> log_ -> mul_(-1)`), so the next decode step's negative intermediate state can overwrite the old `q` address while the previous consumer is still reading it.

For Qwen3 30B RL (vocab size 151936 vs. tokenizer length 151669), the masked tail of 267 ids has exactly zero probability. With a corrupted `q`, `0 / negative_q = -0` wins `argmax` and selects the first masked OOV id (`151669`), whose raw logprob is `-inf`. The OOV token then enters the autoregressive context and corrupts all subsequent outputs.

Adding `q.record_stream(torch.npu.current_stream())` declares that `q` must remain alive on the consumer stream, preventing the allocator from recycling the buffer too early.

Reproduction with the real `exponential_()` intermediate-state race:
- Before fix: 64/64 rows selected the masked OOV id `151669` with raw logprob `-inf`
- After fix: 0/64 rows invalid, sampled ids stay legal

Note: the same fix is being submitted against all supported release branches (`releases/v0.13.0` -> `main`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Reproduced the allocator-reuse race with real `exponential_()` intermediate states (`uniform_ -> neg_`): 64/64 sampled rows selected the masked OOV id `151669` with raw logprob `-inf` before the fix; after the fix 0/64 rows are invalid and sampled ids stay legal.
- Verified natural address reuse of `q` across consecutive decode steps is eliminated with `record_stream`.
- Existing sampler unit tests pass.
- NPU hardware verification pending on the original RL environment (`bsz=256, decode>=10k, TP=4, n=8`).
- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
