### PR TITLE
[BugFix] Sync recompute scheduler with vLLM v0.26

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
-import inspect
-import textwrap
 from collections import defaultdict
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -113,21 +110,6 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
             client_index=request.client_index,
         )
     ]
-
-
-def test_schedule_uses_current_mamba_split_contract():
-    source = textwrap.dedent(inspect.getsource(RecomputeScheduler.schedule))
-    tree = ast.parse(source)
-    calls = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "_mamba_block_aligned_split"
-    ]
-
-    assert calls
-    assert max(len(call.args) for call in calls) == 4
 
 
 def test_failed_remote_kv_load_rezeroes_unwritten_blocks():

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -9,7 +9,6 @@ from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
 
 from vllm.sampling_params import SamplingParams
-from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.engine import EngineCoreOutput, FinishReason
 from vllm.v1.request import Request, RequestStatus
 
@@ -148,50 +147,3 @@ def test_failed_remote_kv_load_rezeroes_unwritten_blocks():
 
     scheduler.kv_cache_manager.cache_blocks.assert_called_once_with(request, 32)
     scheduler.kv_cache_manager.record_blocks_for_zeroing.assert_called_once_with(request.request_id, 32)
-
-
-def test_schedule_forwards_cow_copies_and_filters_async_loaded_blocks():
-    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
-    scheduler.current_step = 0
-    scheduler.max_num_scheduled_tokens = 1
-    scheduler.max_num_encoder_input_tokens = 0
-    scheduler.num_spec_tokens = 0
-    scheduler.prefill_capacity_bound = False
-    scheduler._pause_state = PauseState.PAUSED_ALL
-    scheduler.running = []
-    scheduler.waiting = []
-    scheduler.skipped_waiting = []
-    scheduler.lora_config = None
-    scheduler.max_num_running_reqs = 1
-    scheduler.kv_cache_config = SimpleNamespace(kv_cache_groups=[])
-    scheduler.use_v2_model_runner = False
-    scheduler.prev_step_scheduled_req_ids = set()
-    scheduler._make_cached_request_data = MagicMock(return_value=[])
-    scheduler.dynamic_sd_lookup = None
-    scheduler.reset_preempted_req_ids = set()
-    scheduler.finished_req_ids = set()
-    scheduler.encoder_cache_manager = MagicMock()
-    scheduler.encoder_cache_manager.get_freed_mm_hashes.return_value = []
-    scheduler.needs_kv_cache_zeroing = True
-    scheduler._skip_zero_block_ids = {11}
-    scheduler.sched_step_seq = 4
-    scheduler.defer_block_free = False
-    scheduler.connector = None
-    scheduler.ec_connector = None
-    scheduler._update_after_schedule = MagicMock()
-    scheduler._free_cow_retained_blocks = MagicMock()
-
-    block_copy = SimpleNamespace(src_block_id=1, dst_block_id=2)
-    retained_blocks = [SimpleNamespace(block_id=1), SimpleNamespace(block_id=2)]
-    scheduler.kv_cache_manager = MagicMock()
-    scheduler.kv_cache_manager.take_kv_cache_block_copies.return_value = (
-        [block_copy],
-        retained_blocks,
-    )
-    scheduler.kv_cache_manager.take_new_block_ids.return_value = [10, 11, 12]
-
-    output = scheduler.schedule()
-
-    assert output.kv_cache_block_copies == [block_copy]
-    assert output.new_block_ids_to_zero == [10, 12]
-    scheduler._free_cow_retained_blocks.assert_called_once_with(retained_blocks, 5)

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -110,22 +110,3 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
             client_index=request.client_index,
         )
     ]
-
-
-def test_failed_remote_kv_load_rezeroes_unwritten_blocks():
-    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
-    scheduler.connector = MagicMock()
-    scheduler.needs_kv_cache_zeroing = True
-    scheduler.kv_cache_manager = MagicMock()
-    scheduler.failed_recving_kv_req_ids = {"request"}
-    scheduler.finished_recving_kv_req_ids = {"request"}
-    request = SimpleNamespace(
-        request_id="request",
-        num_computed_tokens=32,
-        num_tokens=64,
-    )
-
-    scheduler._update_waiting_for_remote_kv(request)
-
-    scheduler.kv_cache_manager.cache_blocks.assert_called_once_with(request, 32)
-    scheduler.kv_cache_manager.record_blocks_for_zeroing.assert_called_once_with(request.request_id, 32)

--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
+import inspect
+import textwrap
 from collections import defaultdict
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
 
 from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.engine import EngineCoreOutput, FinishReason
 from vllm.v1.request import Request, RequestStatus
 
@@ -110,3 +114,84 @@ def test_finish_recomputed_request_uses_normal_abort_cleanup():
             client_index=request.client_index,
         )
     ]
+
+
+def test_schedule_uses_current_mamba_split_contract():
+    source = textwrap.dedent(inspect.getsource(RecomputeScheduler.schedule))
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_mamba_block_aligned_split"
+    ]
+
+    assert calls
+    assert max(len(call.args) for call in calls) == 4
+
+
+def test_failed_remote_kv_load_rezeroes_unwritten_blocks():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    scheduler.connector = MagicMock()
+    scheduler.needs_kv_cache_zeroing = True
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.failed_recving_kv_req_ids = {"request"}
+    scheduler.finished_recving_kv_req_ids = {"request"}
+    request = SimpleNamespace(
+        request_id="request",
+        num_computed_tokens=32,
+        num_tokens=64,
+    )
+
+    scheduler._update_waiting_for_remote_kv(request)
+
+    scheduler.kv_cache_manager.cache_blocks.assert_called_once_with(request, 32)
+    scheduler.kv_cache_manager.record_blocks_for_zeroing.assert_called_once_with(request.request_id, 32)
+
+
+def test_schedule_forwards_cow_copies_and_filters_async_loaded_blocks():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    scheduler.current_step = 0
+    scheduler.max_num_scheduled_tokens = 1
+    scheduler.max_num_encoder_input_tokens = 0
+    scheduler.num_spec_tokens = 0
+    scheduler.prefill_capacity_bound = False
+    scheduler._pause_state = PauseState.PAUSED_ALL
+    scheduler.running = []
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+    scheduler.lora_config = None
+    scheduler.max_num_running_reqs = 1
+    scheduler.kv_cache_config = SimpleNamespace(kv_cache_groups=[])
+    scheduler.use_v2_model_runner = False
+    scheduler.prev_step_scheduled_req_ids = set()
+    scheduler._make_cached_request_data = MagicMock(return_value=[])
+    scheduler.dynamic_sd_lookup = None
+    scheduler.reset_preempted_req_ids = set()
+    scheduler.finished_req_ids = set()
+    scheduler.encoder_cache_manager = MagicMock()
+    scheduler.encoder_cache_manager.get_freed_mm_hashes.return_value = []
+    scheduler.needs_kv_cache_zeroing = True
+    scheduler._skip_zero_block_ids = {11}
+    scheduler.sched_step_seq = 4
+    scheduler.defer_block_free = False
+    scheduler.connector = None
+    scheduler.ec_connector = None
+    scheduler._update_after_schedule = MagicMock()
+    scheduler._free_cow_retained_blocks = MagicMock()
+
+    block_copy = SimpleNamespace(src_block_id=1, dst_block_id=2)
+    retained_blocks = [SimpleNamespace(block_id=1), SimpleNamespace(block_id=2)]
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.kv_cache_manager.take_kv_cache_block_copies.return_value = (
+        [block_copy],
+        retained_blocks,
+    )
+    scheduler.kv_cache_manager.take_new_block_ids.return_value = [10, 11, 12]
+
+    output = scheduler.schedule()
+
+    assert output.kv_cache_block_copies == [block_copy]
+    assert output.new_block_ids_to_zero == [10, 12]
+    scheduler._free_cow_retained_blocks.assert_called_once_with(retained_blocks, 5)

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import time
 from collections import defaultdict
 from dataclasses import dataclass, fields
-from typing import cast
 
 from vllm.config import SchedulerConfig, VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
@@ -112,6 +111,8 @@ class RecomputeScheduler(Scheduler):
         if request.request_id in self.failed_recving_kv_req_ids:
             if request.num_computed_tokens:
                 self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
+                if self.needs_kv_cache_zeroing:
+                    self.kv_cache_manager.record_blocks_for_zeroing(request.request_id, request.num_computed_tokens)
             else:
                 self.kv_cache_manager.free(request)
             self.failed_recving_kv_req_ids.remove(request.request_id)
@@ -480,7 +481,6 @@ class RecomputeScheduler(Scheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
-                num_uncached_common_prefix_tokens = 0
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
@@ -511,6 +511,9 @@ class RecomputeScheduler(Scheduler):
                         # the last block) is transferred unconditionally by
                         # _apply_prefix_caching in nixl/worker.py.
                         num_new_local_computed_tokens = max(per_group_hits)
+                        # The per-group lookup does not detect an uncached shared
+                        # prefix, so there is no junction to pin in this path.
+                        request.shared_prefix_boundary = 0
                         if self.kv_cache_manager.log_stats:
                             assert self.kv_cache_manager.prefix_cache_stats is not None
                             self.kv_cache_manager.prefix_cache_stats.record(
@@ -519,21 +522,11 @@ class RecomputeScheduler(Scheduler):
                                 preempted=request.num_preemptions > 0,
                             )
                     else:
-                        computed_result = self.kv_cache_manager.get_computed_blocks(request)
                         (
                             new_computed_blocks,
                             num_new_local_computed_tokens,
                             request.shared_prefix_boundary,
-                        ) = cast(tuple[KVCacheBlocks, int, int], computed_result)
-
-                    # In case of hybrid models, obtain a hint for the
-                    # Marconi-style APC admission logic.
-                    if self.has_mamba_layers:
-                        num_uncached_common_prefix_tokens = getattr(
-                            self.kv_cache_manager.coordinator,
-                            "num_uncached_common_prefix_tokens",
-                            0,
-                        )
+                        ) = self.kv_cache_manager.get_computed_blocks(request)
 
                     # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
@@ -654,7 +647,6 @@ class RecomputeScheduler(Scheduler):
                         num_new_tokens,
                         num_new_local_computed_tokens,
                         num_external_computed_tokens,
-                        num_uncached_common_prefix_tokens,
                     )
                     if num_new_tokens == 0:
                         break
@@ -739,6 +731,14 @@ class RecomputeScheduler(Scheduler):
                     # only the successfully loaded tokens.
                     request.num_computed_tokens = num_computed_tokens
                     self._inflight_prefills.add(request)
+                    if self.needs_kv_cache_zeroing:
+                        self._skip_zero_block_ids.update(
+                            self.kv_cache_manager.get_zeroing_block_ids_in_range(
+                                request.request_id,
+                                num_new_local_computed_tokens,
+                                num_computed_tokens,
+                            )
+                        )
                     continue
 
                 self.running.append(request)
@@ -839,10 +839,10 @@ class RecomputeScheduler(Scheduler):
             self.prev_step_scheduled_req_ids.clear()
             self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
-        # Drain new attention block ids every step so the manager-side list
-        # does not grow unbounded; only kv-cache zeroing consumes them.
-        new_attn_block_ids = self.kv_cache_manager.take_new_block_ids()
-        new_block_ids_to_zero = (new_attn_block_ids or None) if self.needs_kv_cache_zeroing else None
+        kv_cache_block_copies, cow_retained_blocks = self.kv_cache_manager.take_kv_cache_block_copies()
+        if kv_cache_block_copies:
+            self._free_cow_retained_blocks(cow_retained_blocks, self.sched_step_seq + 1)
+        pending_kv_cache_block_copies = kv_cache_block_copies or None
 
         # Dynamic speculative decoding: compute optimal K.
         num_spec_tokens_to_schedule = self.num_spec_tokens
@@ -864,7 +864,8 @@ class RecomputeScheduler(Scheduler):
             # the previous and the current steps.
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
-            new_block_ids_to_zero=new_block_ids_to_zero,
+            new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
+            kv_cache_block_copies=pending_kv_cache_block_copies,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             preempted_reqs=preempted_req_data,
             recomputed_reqs=recomputed_reqs,
@@ -1044,6 +1045,7 @@ class RecomputeScheduler(Scheduler):
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
+            ec_transfer_params = None
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
 
@@ -1112,7 +1114,7 @@ class RecomputeScheduler(Scheduler):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
-                    kv_transfer_params = self._free_request(request)
+                    kv_transfer_params, ec_transfer_params = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -1142,6 +1144,7 @@ class RecomputeScheduler(Scheduler):
                         events=request.take_events(),
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,


### PR DESCRIPTION
### What this PR does / why we need it?

The v0.26 main2main update partially adapted the copied `RecomputeScheduler`: it updated `get_computed_blocks()` to return `shared_prefix_boundary`, but retained the v0.25 `_mamba_block_aligned_split()` call contract. Hybrid Mamba/KDA models consequently fail with a positional-argument `TypeError` when recompute scheduling is enabled.

This PR synchronizes the remaining vLLM v0.26 scheduler contracts:

- use `Request.shared_prefix_boundary` and remove the deleted Mamba split argument;
- skip zeroing blocks populated by asynchronous KV loads and re-zero unwritten blocks after load failure;
- forward hybrid partial-prefix copy-on-write block copies and retain their endpoints until the execution fence;
- propagate both KV and encoder-cache transfer parameters returned by `_free_request()`.

No open PR was found covering these v0.26 `RecomputeScheduler` compatibility gaps.

### Does this PR introduce _any_ user-facing change?

Yes. Recompute scheduling can run against vLLM v0.26 without the stale Mamba split call and preserves the v0.26 hybrid-cache and transfer behavior.

### How was this patch tested?

Static checks completed locally:

```bash
git diff --check
uvx ruff check vllm_ascend/core/recompute_scheduler.py
uvx ruff format --check vllm_ascend/core/recompute_scheduler.py
```

All checks passed. The reported Kimi K3 deployment was also able to start after applying the patch. Further forced-recompute accuracy validation is still required on an Ascend environment.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
