### PR TITLE
[CI] Change default main2main model from dsv4-pro to dsv4-flash

### DIFF
--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -25,6 +25,10 @@ on:
         description: 'Target vLLM commit hash (default: latest vLLM main HEAD)'
         required: false
         default: ''
+      model:
+        description: 'opencode model name (default: deepseek/deepseek-v4-flash)'
+        required: false
+        default: 'deepseek/deepseek-v4-flash'
 
 permissions:
   contents: write
@@ -38,7 +42,7 @@ defaults:
 
 env:
   UPSTREAM_REPO: vllm-project/vllm-ascend
-  MAIN2MAIN_MODEL: deepseek/deepseek-v4-pro
+  MAIN2MAIN_MODEL: ${{ github.event_name == 'workflow_dispatch' && inputs.model || 'deepseek/deepseek-v4-flash' }}
   
 
 jobs:


### PR DESCRIPTION
### What this PR does / why we need it?
Change default main2main model from dsv4-pro to dsv4-flash for better performance.
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
