### PR TITLE
[Misc][v0.23.0] Fix translation extraction for tables nested in tabs

### DIFF
--- a/.github/workflows/schedule_doc_translate.yaml
+++ b/.github/workflows/schedule_doc_translate.yaml
@@ -89,7 +89,11 @@ jobs:
           fi
           make clean && make html
           sphinx-build -b gettext source _build/gettext
-          sphinx-intl update -p _build/gettext -l zh_CN
+
+          sphinx-intl update \
+            -p _build/gettext \
+            -d source/locale \
+            -l zh_CN
 
       - name: Detect PO files to translate
         id: detect
@@ -135,7 +139,10 @@ jobs:
           python .github/workflows/scripts/po_translate.py \
             --files "${{ steps.detect.outputs.files }}" \
             --validate-only
-          make -C docs intl SPHINXOPTS="-W --keep-going"
+          # The Sphinx extension checks every table nested in tabs across the
+          # entire documentation tree after gettext catalogs are applied.
+          make -C docs intl \
+            SPHINXOPTS="-W --keep-going -D validate_tab_table_translations=1"
 
       - name: Process translated files
         if: steps.detect.outputs.has_changes == 'true'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "myst_parser",
     "sphinxarg.ext",
     "sphinx_design",
+    "tools.docs_i18n.sphinx_extension",
     "sphinx_togglebutton",
     "sphinx_substitution_extensions",
     "tools.docs_codegen.sphinx_extension",

--- a/tools/docs_i18n/__init__.py
+++ b/tools/docs_i18n/__init__.py
@@ -1,0 +1,1 @@
+"""Sphinx helpers for documentation localization."""

--- a/tools/docs_i18n/sphinx_extension.py
+++ b/tools/docs_i18n/sphinx_extension.py
@@ -1,0 +1,71 @@
+from docutils import nodes
+from sphinx.errors import SphinxError
+from sphinx.transforms import SphinxTransform
+
+
+def _is_inside_tab_content(node: nodes.Node) -> bool:
+    """Return whether a node is inside a sphinx-design tab content node."""
+    parent = node.parent
+    while parent is not None:
+        if isinstance(parent, nodes.Element) and parent.get("design_component") == "tab-content":
+            return True
+        parent = parent.parent
+    return False
+
+
+class RestoreTabTableCellSource(SphinxTransform):
+    """Restore source metadata for tables nested in sphinx-design tabs."""
+
+    # Run before Sphinx's PreserveTranslatableMessages (10) and Locale (20)
+    # transforms so both gettext extraction and localized HTML see the cells.
+    default_priority = 5
+
+    def apply(self, **kwargs) -> None:
+        for table in self.document.findall(nodes.table):
+            if not _is_inside_tab_content(table):
+                continue
+
+            source = table.source or self.document.get("source")
+            line = table.line or 0
+            for paragraph in table.findall(nodes.paragraph):
+                if not paragraph.source:
+                    paragraph.source = source
+                if paragraph.line is None:
+                    paragraph.line = line
+
+
+class ValidateTabTableCellTranslations(SphinxTransform):
+    """Fail a localized build when a table in a tab was not translated."""
+
+    # Run after Sphinx's Locale transform (20), which sets the ``translated``
+    # attribute after applying the message catalog to each translatable node.
+    default_priority = 30
+
+    def apply(self, **kwargs) -> None:
+        if not self.config.validate_tab_table_translations:
+            return
+
+        untranslated = []
+        for table in self.document.findall(nodes.table):
+            if not _is_inside_tab_content(table):
+                continue
+
+            for paragraph in table.findall(nodes.paragraph):
+                # Complex tables may contain structural paragraphs without
+                # visible text. Sphinx does not extract or translate them.
+                if paragraph.astext().strip() and not paragraph.get("translated", False):
+                    untranslated.append(f"{paragraph.source}:{paragraph.line}: {paragraph.astext()!r}")
+
+        if untranslated:
+            details = "\n".join(f"- {item}" for item in untranslated)
+            raise SphinxError("localized table cells nested in tabs were not translated:\n" + details)
+
+
+def setup(app):
+    app.add_config_value("validate_tab_table_translations", False, "env")
+    app.add_transform(RestoreTabTableCellSource)
+    app.add_transform(ValidateTabTableCellTranslations)
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes gettext extraction and localized HTML rendering for Markdown tables nested inside `sphinx-design` tabs.

Table-cell paragraph nodes inside tabs may lose their source metadata during parsing. As a result, Sphinx does not treat these nodes as translatable, so their content is missing from PO files and remains untranslated in the generated Chinese documentation.

This PR:

- Adds a Sphinx extension that restores source metadata for table cells nested inside tabs.
- Applies the fix globally to all affected tables across the documentation tree, rather than targeting specific pages or messages.
- Adds strict validation to ensure every non-empty table cell inside tabs has been translated during the localized HTML build.
- Configures `sphinx-intl update` with the explicit locale directory.
- Preserves incremental translation behavior: when `force=false`, only changed or newly generated PO files are translated.
- Makes the workflow fail if any affected table content is not extracted, translated, or applied during rendering.

Regular tables continue to use Sphinx's native gettext behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Tables nested inside tabs are now correctly translated and rendered in the Chinese documentation.

### How was this patch tested?

- https://github.com/vllm-project/vllm-ascend/pull/13411

It can be translated correctly:
<img width="978" height="457" alt="image" src="https://github.com/user-attachments/assets/81de8297-da5b-4b27-b4d6-e742a79ae894" />


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
