### PR TITLE
[BugFix][MoE] Fix W8A8 scale handling for dynamic EPLB

### DIFF
--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -505,75 +505,6 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
             )
         self.assertEqual(m.gmm.call_args.kwargs["scale"][0].dtype, torch.bfloat16)
 
-    def test_w8a8_dynamic_eplb_passes_all_w1_scales_to_gmm1(self):
-        scale0 = torch.arange(8, dtype=torch.float32)
-        scale1 = torch.arange(8, 16, dtype=torch.float32)
-        with _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m:
-            kwargs = self._common_w8a8_kwargs(
-                activation=MoEActivation.GELU_TANH,
-                w2_scale_dtype=torch.bfloat16,
-            )
-            kwargs.update(
-                {
-                    "w1": [torch.randn(8, 4), torch.randn(8, 4)],
-                    "w1_scale": [scale0, scale1],
-                    "w2": [torch.randn(4, 4), torch.randn(4, 4)],
-                    "w2_scale": [
-                        torch.randn(4, dtype=torch.bfloat16),
-                        torch.randn(4, dtype=torch.bfloat16),
-                    ],
-                    "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                    "dynamic_eplb": True,
-                }
-            )
-            quant_apply_mlp(**kwargs)
-
-        scales = m.gmm.call_args.kwargs["scale"]
-        self.assertEqual(len(scales), 2)
-        self.assertEqual(scales[0].dtype, torch.bfloat16)
-        self.assertEqual(scales[1].dtype, torch.bfloat16)
-        torch.testing.assert_close(scales[0], scale0.bfloat16())
-        torch.testing.assert_close(scales[1], scale1.bfloat16())
-
-    def test_w8a8_dynamic_eplb_rejects_gmm1_weight_scale_count_mismatch(self):
-        with (
-            _mock_w8a8_gelu_compute(torch.zeros(1, 8)),
-            self.assertRaisesRegex(
-                ValueError,
-                "npu_grouped_matmul: expected one scale per physical expert, but got weights=2 and scales=1.",
-            ),
-        ):
-            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
-            kwargs.update(
-                {
-                    "w1": [torch.randn(8, 4), torch.randn(8, 4)],
-                    "w1_scale": [torch.randn(8)],
-                    "w2": [torch.randn(4, 4), torch.randn(4, 4)],
-                    "w2_scale": [torch.randn(4), torch.randn(4)],
-                    "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                    "dynamic_eplb": True,
-                }
-            )
-            quant_apply_mlp(**kwargs)
-
-    def test_w8a8_dynamic_eplb_rejects_empty_gmm1_scale_list(self):
-        with (
-            _mock_w8a8_gelu_compute(torch.zeros(1, 8)),
-            self.assertRaisesRegex(ValueError, "npu_grouped_matmul: expert scale list must not be empty."),
-        ):
-            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
-            kwargs.update(
-                {
-                    "w1": [torch.randn(8, 4)],
-                    "w1_scale": [],
-                    "w2": [torch.randn(4, 4)],
-                    "w2_scale": [torch.randn(4)],
-                    "group_list": torch.tensor([1], dtype=torch.int64),
-                    "dynamic_eplb": True,
-                }
-            )
-            quant_apply_mlp(**kwargs)
-
     def test_alltoall_dynamic_eplb_swigluoai_passes_all_w1_scales_to_gmm1(self):
         self._ctx_mock.moe_comm_type = MoECommType.ALLTOALL
         scale0 = torch.arange(8, dtype=torch.float32)
@@ -727,100 +658,6 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
         torch.testing.assert_close(packed_scale, weight_scale.float())
         self.assertIs(out, expected)
 
-    def test_mc2_dynamic_eplb_swigluoai_rejects_mismatched_scale_shapes(self):
-        self._ctx_mock.moe_comm_type = MoECommType.MC2
-        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
-        kwargs.update(
-            {
-                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
-                "w1_scale": [
-                    torch.arange(8, dtype=torch.bfloat16),
-                    torch.arange(8, dtype=torch.bfloat16).view(1, 8),
-                ],
-                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
-                "w2_scale": [torch.randn(4), torch.randn(4)],
-                "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                "dynamic_eplb": True,
-            }
-        )
-
-        with (
-            _patch_npu_stream()[0],
-            patch("torch_npu.npu_grouped_matmul", return_value=[torch.zeros(1, 8, dtype=torch.int32)], create=True),
-            patch(f"{MOE_MLP}.dispose_tensor"),
-            self.assertRaisesRegex(
-                ValueError,
-                r"npu_dequant_swiglu_quant: all physical expert scales must have the same shape",
-            ),
-        ):
-            quant_apply_mlp(**kwargs)
-
-    def test_mc2_dynamic_eplb_swigluoai_rejects_weight_scale_count_mismatch(self):
-        self._ctx_mock.moe_comm_type = MoECommType.MC2
-        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
-        kwargs.update(
-            {
-                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
-                "w1_scale": [torch.arange(8, dtype=torch.bfloat16)],
-                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
-                "w2_scale": [torch.randn(4), torch.randn(4)],
-                "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                "dynamic_eplb": True,
-            }
-        )
-
-        with (
-            _patch_npu_stream()[0],
-            patch("torch_npu.npu_grouped_matmul", return_value=[torch.zeros(1, 8, dtype=torch.int32)], create=True),
-            patch(f"{MOE_MLP}.dispose_tensor"),
-            self.assertRaisesRegex(
-                ValueError,
-                "npu_dequant_swiglu_quant: expected one scale per physical expert, but got weights=2 and scales=1.",
-            ),
-        ):
-            quant_apply_mlp(**kwargs)
-
-    def test_mc2_swiglustep_dynamic_eplb_passes_all_w1_scales_to_gmm1(self):
-        self._ctx_mock.moe_comm_type = MoECommType.MC2
-        scale0 = torch.arange(8, dtype=torch.float32)
-        scale1 = torch.arange(8, 16, dtype=torch.float32)
-        expected = torch.zeros(1, 4, dtype=torch.float32)
-        kwargs = self._common_w8a8_kwargs(
-            activation=MoEActivation.SWIGLUSTEP,
-            w2_scale_dtype=torch.bfloat16,
-        )
-        kwargs.update(
-            {
-                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
-                "w1_scale": [scale0, scale1],
-                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
-                "w2_scale": [
-                    torch.randn(4, dtype=torch.bfloat16),
-                    torch.randn(4, dtype=torch.bfloat16),
-                ],
-                "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                "dynamic_eplb": True,
-            }
-        )
-
-        with (
-            _patch_npu_stream()[0],
-            patch("torch_npu.npu_grouped_matmul", return_value=[torch.zeros(1, 8)], create=True) as mock_gmm,
-            patch(f"{MOE_MLP}.AscendSwigluStepAndMul.swiglustep_forward", return_value=torch.zeros(1, 4)),
-            patch.object(DeviceOperator, "npu_dynamic_quant", return_value=(torch.zeros(1, 4), torch.ones(1))),
-            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected),
-            patch(f"{MOE_MLP}.dispose_tensor"),
-        ):
-            out, _ = quant_apply_mlp(**kwargs)
-
-        scales = mock_gmm.call_args.kwargs["scale"]
-        self.assertEqual(len(scales), 2)
-        self.assertEqual(scales[0].dtype, torch.bfloat16)
-        self.assertEqual(scales[1].dtype, torch.bfloat16)
-        torch.testing.assert_close(scales[0], scale0.bfloat16())
-        torch.testing.assert_close(scales[1], scale1.bfloat16())
-        self.assertIs(out, expected)
-
 
 class TestQuantApplyMlpNoGeluImpact(_GeluPathBase):
     """Non-GELU activations must NOT enter the GELU path (no regression)."""
@@ -831,7 +668,6 @@ class TestQuantApplyMlpNoGeluImpact(_GeluPathBase):
             patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx,
             patch(f"{MOE_MLP}.HAS_TRITON", False),
             patch("torch_npu.npu_swiglu", return_value=torch.zeros(1, 4), create=True) as mock_swiglu,
-            patch(f"{MOE_MLP}.AscendSwigluStepAndMul.swiglustep_forward", return_value=torch.zeros(1, 4)),
             patch("torch.nn.functional.gelu") as mock_gelu,
         ):
             mock_ctx.moe_comm_type = -1  # not MoECommType.MC2

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -505,6 +505,111 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
             )
         self.assertEqual(m.gmm.call_args.kwargs["scale"][0].dtype, torch.bfloat16)
 
+    def test_w8a8_dynamic_eplb_passes_all_w1_scales_to_gmm1(self):
+        scale0 = torch.arange(8, dtype=torch.float32)
+        scale1 = torch.arange(8, 16, dtype=torch.float32)
+        with _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m:
+            kwargs = self._common_w8a8_kwargs(
+                activation=MoEActivation.GELU_TANH,
+                w2_scale_dtype=torch.bfloat16,
+            )
+            kwargs.update(
+                {
+                    "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                    "w1_scale": [scale0, scale1],
+                    "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                    "w2_scale": [
+                        torch.randn(4, dtype=torch.bfloat16),
+                        torch.randn(4, dtype=torch.bfloat16),
+                    ],
+                    "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                    "dynamic_eplb": True,
+                }
+            )
+            quant_apply_mlp(**kwargs)
+
+        scales = m.gmm.call_args.kwargs["scale"]
+        self.assertEqual(len(scales), 2)
+        self.assertEqual(scales[0].dtype, torch.bfloat16)
+        self.assertEqual(scales[1].dtype, torch.bfloat16)
+        torch.testing.assert_close(scales[0], scale0.bfloat16())
+        torch.testing.assert_close(scales[1], scale1.bfloat16())
+
+    def test_w8a8_dynamic_eplb_rejects_gmm1_weight_scale_count_mismatch(self):
+        with (
+            _mock_w8a8_gelu_compute(torch.zeros(1, 8)),
+            self.assertRaisesRegex(
+                ValueError,
+                "npu_grouped_matmul: expected one scale per physical expert, but got weights=2 and scales=1.",
+            ),
+        ):
+            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
+            kwargs.update(
+                {
+                    "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                    "w1_scale": [torch.randn(8)],
+                    "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                    "w2_scale": [torch.randn(4), torch.randn(4)],
+                    "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                    "dynamic_eplb": True,
+                }
+            )
+            quant_apply_mlp(**kwargs)
+
+    def test_w8a8_dynamic_eplb_rejects_empty_gmm1_scale_list(self):
+        with (
+            _mock_w8a8_gelu_compute(torch.zeros(1, 8)),
+            self.assertRaisesRegex(ValueError, "npu_grouped_matmul: expert scale list must not be empty."),
+        ):
+            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
+            kwargs.update(
+                {
+                    "w1": [torch.randn(8, 4)],
+                    "w1_scale": [],
+                    "w2": [torch.randn(4, 4)],
+                    "w2_scale": [torch.randn(4)],
+                    "group_list": torch.tensor([1], dtype=torch.int64),
+                    "dynamic_eplb": True,
+                }
+            )
+            quant_apply_mlp(**kwargs)
+
+    def test_alltoall_dynamic_eplb_swigluoai_passes_all_w1_scales_to_gmm1(self):
+        self._ctx_mock.moe_comm_type = MoECommType.ALLTOALL
+        scale0 = torch.arange(8, dtype=torch.float32)
+        scale1 = torch.arange(8, 16, dtype=torch.float32)
+        with (
+            _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m,
+            patch("torch_npu.npu_clipped_swiglu", return_value=torch.zeros(1, 4), create=True),
+            patch.object(DeviceOperator, "npu_dynamic_quant", return_value=(torch.zeros(1, 4), torch.ones(1))),
+        ):
+            kwargs = self._common_w8a8_kwargs(
+                activation="swigluoai_uninterleave",
+                w2_scale_dtype=torch.bfloat16,
+            )
+            kwargs.update(
+                {
+                    "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                    "w1_scale": [scale0, scale1],
+                    "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                    "w2_scale": [
+                        torch.randn(4, dtype=torch.bfloat16),
+                        torch.randn(4, dtype=torch.bfloat16),
+                    ],
+                    "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                    "dynamic_eplb": True,
+                }
+            )
+            quant_apply_mlp(**kwargs)
+
+        gmm1_kwargs = m.gmm.call_args.kwargs
+        self.assertEqual(len(gmm1_kwargs["weight"]), 2)
+        self.assertEqual(len(gmm1_kwargs["scale"]), 2)
+        self.assertEqual(gmm1_kwargs["scale"][0].dtype, torch.bfloat16)
+        self.assertEqual(gmm1_kwargs["scale"][1].dtype, torch.bfloat16)
+        torch.testing.assert_close(gmm1_kwargs["scale"][0], scale0.bfloat16())
+        torch.testing.assert_close(gmm1_kwargs["scale"][1], scale1.bfloat16())
+
     def test_gelu_path_does_not_call_swiglu_op(self):
         """GELU path must use torch.gelu, never the SwiGLU NPU op."""
         with _mock_w8a8_gelu_compute(torch.zeros(1, 8)), patch("torch_npu.npu_swiglu", create=True) as mock_swiglu:
@@ -546,6 +651,176 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
         # Non-fused dequant GMM1 IS used instead.
         self.assertIn("scale", m.gmm.call_args.kwargs)
 
+    def test_mc2_dynamic_eplb_swigluoai_stacks_w1_scale(self):
+        self._ctx_mock.moe_comm_type = MoECommType.MC2
+        gate_up_out = torch.zeros(1, 8, dtype=torch.int32)
+        expected = torch.zeros(1, 4, dtype=torch.float32)
+        scale0 = torch.arange(8, dtype=torch.bfloat16)
+        scale1 = torch.arange(8, 16, dtype=torch.bfloat16)
+
+        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
+        kwargs.update(
+            {
+                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                "w1_scale": [scale0, scale1],
+                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                "w2_scale": [torch.randn(4), torch.randn(4)],
+                "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                "dynamic_eplb": True,
+            }
+        )
+
+        with (
+            _patch_npu_stream()[0],
+            patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True),
+            patch(
+                "torch.ops._C_ascend.npu_dequant_swiglu_quant",
+                return_value=(torch.zeros(1, 4, dtype=torch.int8), torch.ones(1)),
+                create=True,
+            ) as mock_dequant_swiglu,
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected),
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            out, _ = quant_apply_mlp(**kwargs)
+
+        weight_scale = mock_dequant_swiglu.call_args.kwargs["weight_scale"]
+        self.assertEqual(weight_scale.shape, torch.Size([2, 8]))
+        self.assertEqual(weight_scale.dtype, torch.float32)
+        torch.testing.assert_close(weight_scale[0], scale0.float())
+        torch.testing.assert_close(weight_scale[1], scale1.float())
+        self.assertIs(out, expected)
+
+    def test_mc2_swigluoai_preserves_single_list_w1_scale_shape(self):
+        self._ctx_mock.moe_comm_type = MoECommType.MC2
+        gate_up_out = torch.zeros(1, 8, dtype=torch.int32)
+        expected = torch.zeros(1, 4, dtype=torch.float32)
+        weight_scale = torch.arange(12, dtype=torch.bfloat16).view(3, 4)
+
+        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
+        kwargs.update(
+            {
+                "w1": [torch.randn(8, 4)],
+                "w1_scale": [weight_scale],
+                "w2": [torch.randn(4, 4)],
+                "w2_scale": [torch.randn(4)],
+                "group_list": torch.tensor([1], dtype=torch.int64),
+                "dynamic_eplb": False,
+            }
+        )
+
+        with (
+            _patch_npu_stream()[0],
+            patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True),
+            patch(
+                "torch.ops._C_ascend.npu_dequant_swiglu_quant",
+                return_value=(torch.zeros(1, 4, dtype=torch.int8), torch.ones(1)),
+                create=True,
+            ) as mock_dequant_swiglu,
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected),
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            out, _ = quant_apply_mlp(**kwargs)
+
+        packed_scale = mock_dequant_swiglu.call_args.kwargs["weight_scale"]
+        self.assertEqual(packed_scale.shape, torch.Size([3, 4]))
+        self.assertEqual(packed_scale.dtype, torch.float32)
+        torch.testing.assert_close(packed_scale, weight_scale.float())
+        self.assertIs(out, expected)
+
+    def test_mc2_dynamic_eplb_swigluoai_rejects_mismatched_scale_shapes(self):
+        self._ctx_mock.moe_comm_type = MoECommType.MC2
+        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
+        kwargs.update(
+            {
+                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                "w1_scale": [
+                    torch.arange(8, dtype=torch.bfloat16),
+                    torch.arange(8, dtype=torch.bfloat16).view(1, 8),
+                ],
+                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                "w2_scale": [torch.randn(4), torch.randn(4)],
+                "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                "dynamic_eplb": True,
+            }
+        )
+
+        with (
+            _patch_npu_stream()[0],
+            patch("torch_npu.npu_grouped_matmul", return_value=[torch.zeros(1, 8, dtype=torch.int32)], create=True),
+            patch(f"{MOE_MLP}.dispose_tensor"),
+            self.assertRaisesRegex(
+                ValueError,
+                r"npu_dequant_swiglu_quant: all physical expert scales must have the same shape",
+            ),
+        ):
+            quant_apply_mlp(**kwargs)
+
+    def test_mc2_dynamic_eplb_swigluoai_rejects_weight_scale_count_mismatch(self):
+        self._ctx_mock.moe_comm_type = MoECommType.MC2
+        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
+        kwargs.update(
+            {
+                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                "w1_scale": [torch.arange(8, dtype=torch.bfloat16)],
+                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                "w2_scale": [torch.randn(4), torch.randn(4)],
+                "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                "dynamic_eplb": True,
+            }
+        )
+
+        with (
+            _patch_npu_stream()[0],
+            patch("torch_npu.npu_grouped_matmul", return_value=[torch.zeros(1, 8, dtype=torch.int32)], create=True),
+            patch(f"{MOE_MLP}.dispose_tensor"),
+            self.assertRaisesRegex(
+                ValueError,
+                "npu_dequant_swiglu_quant: expected one scale per physical expert, but got weights=2 and scales=1.",
+            ),
+        ):
+            quant_apply_mlp(**kwargs)
+
+    def test_mc2_swiglustep_dynamic_eplb_passes_all_w1_scales_to_gmm1(self):
+        self._ctx_mock.moe_comm_type = MoECommType.MC2
+        scale0 = torch.arange(8, dtype=torch.float32)
+        scale1 = torch.arange(8, 16, dtype=torch.float32)
+        expected = torch.zeros(1, 4, dtype=torch.float32)
+        kwargs = self._common_w8a8_kwargs(
+            activation=MoEActivation.SWIGLUSTEP,
+            w2_scale_dtype=torch.bfloat16,
+        )
+        kwargs.update(
+            {
+                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                "w1_scale": [scale0, scale1],
+                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                "w2_scale": [
+                    torch.randn(4, dtype=torch.bfloat16),
+                    torch.randn(4, dtype=torch.bfloat16),
+                ],
+                "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                "dynamic_eplb": True,
+            }
+        )
+
+        with (
+            _patch_npu_stream()[0],
+            patch("torch_npu.npu_grouped_matmul", return_value=[torch.zeros(1, 8)], create=True) as mock_gmm,
+            patch(f"{MOE_MLP}.AscendSwigluStepAndMul.swiglustep_forward", return_value=torch.zeros(1, 4)),
+            patch.object(DeviceOperator, "npu_dynamic_quant", return_value=(torch.zeros(1, 4), torch.ones(1))),
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected),
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            out, _ = quant_apply_mlp(**kwargs)
+
+        scales = mock_gmm.call_args.kwargs["scale"]
+        self.assertEqual(len(scales), 2)
+        self.assertEqual(scales[0].dtype, torch.bfloat16)
+        self.assertEqual(scales[1].dtype, torch.bfloat16)
+        torch.testing.assert_close(scales[0], scale0.bfloat16())
+        torch.testing.assert_close(scales[1], scale1.bfloat16())
+        self.assertIs(out, expected)
+
 
 class TestQuantApplyMlpNoGeluImpact(_GeluPathBase):
     """Non-GELU activations must NOT enter the GELU path (no regression)."""
@@ -556,6 +831,7 @@ class TestQuantApplyMlpNoGeluImpact(_GeluPathBase):
             patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx,
             patch(f"{MOE_MLP}.HAS_TRITON", False),
             patch("torch_npu.npu_swiglu", return_value=torch.zeros(1, 4), create=True) as mock_swiglu,
+            patch(f"{MOE_MLP}.AscendSwigluStepAndMul.swiglustep_forward", return_value=torch.zeros(1, 4)),
             patch("torch.nn.functional.gelu") as mock_gelu,
         ):
             mock_ctx.moe_comm_type = -1  # not MoECommType.MC2

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -96,6 +96,68 @@ def _require_single_tensor_for_swiglu_quant(
     return tensor_or_list
 
 
+def _as_tensor_list(tensor_or_list: list[torch.Tensor] | torch.Tensor) -> list[torch.Tensor]:
+    return tensor_or_list if isinstance(tensor_or_list, list) else [tensor_or_list]
+
+
+def _validate_expert_tensor_lists(*, weights: list[torch.Tensor], scales: list[torch.Tensor], op_name: str) -> None:
+    if not weights:
+        raise ValueError(f"{op_name}: expert weight list must not be empty.")
+    if not scales:
+        raise ValueError(f"{op_name}: expert scale list must not be empty.")
+    if len(weights) != len(scales):
+        raise ValueError(
+            f"{op_name}: expected one scale per physical expert, "
+            f"but got weights={len(weights)} and scales={len(scales)}."
+        )
+
+
+def _prepare_dequant_swiglu_weight_scale(
+    w1: list[torch.Tensor] | torch.Tensor, w1_scale: list[torch.Tensor] | torch.Tensor
+) -> torch.Tensor:
+    if not isinstance(w1, list) and not isinstance(w1_scale, list):
+        weight_scale = w1_scale
+    else:
+        weights = _as_tensor_list(w1)
+        scales = _as_tensor_list(w1_scale)
+        _validate_expert_tensor_lists(weights=weights, scales=scales, op_name="npu_dequant_swiglu_quant")
+
+        if len(scales) == 1:
+            weight_scale = scales[0]
+        else:
+            scale_shape = scales[0].shape
+            for index, scale in enumerate(scales):
+                if scale.dim() not in (1, 2):
+                    raise ValueError(
+                        "npu_dequant_swiglu_quant: physical expert scales must be 1D or 2D, "
+                        f"but scale[{index}] has shape {tuple(scale.shape)}."
+                    )
+                if scale.shape != scale_shape:
+                    raise ValueError(
+                        "npu_dequant_swiglu_quant: all physical expert scales must have the same shape, "
+                        f"but scale[0] has shape {tuple(scale_shape)} "
+                        f"and scale[{index}] has shape {tuple(scale.shape)}."
+                    )
+
+            weight_scale = torch.stack([scale.reshape(-1) for scale in scales], dim=0)
+    if weight_scale.dtype != torch.float32:
+        weight_scale = weight_scale.to(torch.float32)
+    if weight_scale.dim() == 1:
+        weight_scale = weight_scale.reshape(1, -1)
+    return weight_scale
+
+
+def _prepare_grouped_matmul_scales(
+    weight: list[torch.Tensor] | torch.Tensor,
+    weight_scale: list[torch.Tensor] | torch.Tensor,
+    output_dtype: torch.dtype,
+) -> list[torch.Tensor]:
+    weights = _as_tensor_list(weight)
+    scales = _as_tensor_list(weight_scale)
+    _validate_expert_tensor_lists(weights=weights, scales=scales, op_name="npu_grouped_matmul")
+    return [scale.to(output_dtype) if scale.dtype != output_dtype else scale for scale in scales]
+
+
 def quant_apply_mlp(
     hidden_states: torch.Tensor,
     w1: list[torch.Tensor] | torch.Tensor,
@@ -205,7 +267,7 @@ def quant_apply_mlp(
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],
-                "scale": [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale],
+                "scale": _prepare_grouped_matmul_scales(w1, w1_scale, _output_dtype),
                 "bias": None,
                 "per_token_scale": [pertoken_scale],
                 "split_item": 2,
@@ -226,8 +288,6 @@ def quant_apply_mlp(
                 hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
             )
         else:
-            if w1_scale[0].dtype != torch.float32:
-                w1_scale[0] = w1_scale[0].to(torch.float32)
             # gmm1: gate_up_proj
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
@@ -243,7 +303,7 @@ def quant_apply_mlp(
             # act_fn: swiglu
             dequant_swiglu_kwargs = {
                 "x": hidden_states,
-                "weight_scale": w1_scale[0],
+                "weight_scale": _prepare_dequant_swiglu_weight_scale(w1, w1_scale),
                 "activation_scale": pertoken_scale,
                 "bias": None,
                 "quant_scale": None,
@@ -390,7 +450,7 @@ def quant_apply_mlp(
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],
-                "scale": [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale],
+                "scale": _prepare_grouped_matmul_scales(w1, w1_scale, _output_dtype),
                 "bias": bias1,
                 "per_token_scale": [pertoken_scale],
                 "split_item": 2,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -96,8 +96,13 @@ def _require_single_tensor_for_swiglu_quant(
     return tensor_or_list
 
 
-def _prepare_dequant_swiglu_weight_scale(w1_scale: list[torch.Tensor] | torch.Tensor) -> torch.Tensor:
-    if isinstance(w1_scale, list):
+def _prepare_dequant_swiglu_weight_scale(
+    w1_scale: list[torch.Tensor] | torch.Tensor,
+    is_swigluoai_uninterleave: bool,
+) -> torch.Tensor:
+    if not is_swigluoai_uninterleave:
+        weight_scale = w1_scale[0]
+    elif isinstance(w1_scale, list):
         if len(w1_scale) == 1:
             weight_scale = w1_scale[0]
         else:
@@ -106,7 +111,7 @@ def _prepare_dequant_swiglu_weight_scale(w1_scale: list[torch.Tensor] | torch.Te
         weight_scale = w1_scale
     if weight_scale.dtype != torch.float32:
         weight_scale = weight_scale.to(torch.float32)
-    if weight_scale.dim() == 1:
+    if is_swigluoai_uninterleave and weight_scale.dim() == 1:
         weight_scale = weight_scale.reshape(1, -1)
     return weight_scale
 
@@ -248,8 +253,6 @@ def quant_apply_mlp(
                 hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
             )
         else:
-            if not is_swigluoai_uninterleave and w1_scale[0].dtype != torch.float32:
-                w1_scale[0] = w1_scale[0].to(torch.float32)
             # gmm1: gate_up_proj
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
@@ -265,9 +268,7 @@ def quant_apply_mlp(
             # act_fn: swiglu
             dequant_swiglu_kwargs = {
                 "x": hidden_states,
-                "weight_scale": (
-                    _prepare_dequant_swiglu_weight_scale(w1_scale) if is_swigluoai_uninterleave else w1_scale[0]
-                ),
+                "weight_scale": _prepare_dequant_swiglu_weight_scale(w1_scale, is_swigluoai_uninterleave),
                 "activation_scale": pertoken_scale,
                 "bias": None,
                 "quant_scale": None,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -96,50 +96,14 @@ def _require_single_tensor_for_swiglu_quant(
     return tensor_or_list
 
 
-def _as_tensor_list(tensor_or_list: list[torch.Tensor] | torch.Tensor) -> list[torch.Tensor]:
-    return tensor_or_list if isinstance(tensor_or_list, list) else [tensor_or_list]
-
-
-def _validate_expert_tensor_lists(*, weights: list[torch.Tensor], scales: list[torch.Tensor], op_name: str) -> None:
-    if not weights:
-        raise ValueError(f"{op_name}: expert weight list must not be empty.")
-    if not scales:
-        raise ValueError(f"{op_name}: expert scale list must not be empty.")
-    if len(weights) != len(scales):
-        raise ValueError(
-            f"{op_name}: expected one scale per physical expert, "
-            f"but got weights={len(weights)} and scales={len(scales)}."
-        )
-
-
-def _prepare_dequant_swiglu_weight_scale(
-    w1: list[torch.Tensor] | torch.Tensor, w1_scale: list[torch.Tensor] | torch.Tensor
-) -> torch.Tensor:
-    if not isinstance(w1, list) and not isinstance(w1_scale, list):
-        weight_scale = w1_scale
-    else:
-        weights = _as_tensor_list(w1)
-        scales = _as_tensor_list(w1_scale)
-        _validate_expert_tensor_lists(weights=weights, scales=scales, op_name="npu_dequant_swiglu_quant")
-
-        if len(scales) == 1:
-            weight_scale = scales[0]
+def _prepare_dequant_swiglu_weight_scale(w1_scale: list[torch.Tensor] | torch.Tensor) -> torch.Tensor:
+    if isinstance(w1_scale, list):
+        if len(w1_scale) == 1:
+            weight_scale = w1_scale[0]
         else:
-            scale_shape = scales[0].shape
-            for index, scale in enumerate(scales):
-                if scale.dim() not in (1, 2):
-                    raise ValueError(
-                        "npu_dequant_swiglu_quant: physical expert scales must be 1D or 2D, "
-                        f"but scale[{index}] has shape {tuple(scale.shape)}."
-                    )
-                if scale.shape != scale_shape:
-                    raise ValueError(
-                        "npu_dequant_swiglu_quant: all physical expert scales must have the same shape, "
-                        f"but scale[0] has shape {tuple(scale_shape)} "
-                        f"and scale[{index}] has shape {tuple(scale.shape)}."
-                    )
-
-            weight_scale = torch.stack([scale.reshape(-1) for scale in scales], dim=0)
+            weight_scale = torch.stack([scale.reshape(-1) for scale in w1_scale], dim=0)
+    else:
+        weight_scale = w1_scale
     if weight_scale.dtype != torch.float32:
         weight_scale = weight_scale.to(torch.float32)
     if weight_scale.dim() == 1:
@@ -147,14 +111,10 @@ def _prepare_dequant_swiglu_weight_scale(
     return weight_scale
 
 
-def _prepare_grouped_matmul_scales(
-    weight: list[torch.Tensor] | torch.Tensor,
-    weight_scale: list[torch.Tensor] | torch.Tensor,
-    output_dtype: torch.dtype,
+def _prepare_swigluoai_grouped_matmul_scales(
+    weight_scale: list[torch.Tensor] | torch.Tensor, output_dtype: torch.dtype
 ) -> list[torch.Tensor]:
-    weights = _as_tensor_list(weight)
-    scales = _as_tensor_list(weight_scale)
-    _validate_expert_tensor_lists(weights=weights, scales=scales, op_name="npu_grouped_matmul")
+    scales = weight_scale if isinstance(weight_scale, list) else [weight_scale]
     return [scale.to(output_dtype) if scale.dtype != output_dtype else scale for scale in scales]
 
 
@@ -267,7 +227,7 @@ def quant_apply_mlp(
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],
-                "scale": _prepare_grouped_matmul_scales(w1, w1_scale, _output_dtype),
+                "scale": [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale],
                 "bias": None,
                 "per_token_scale": [pertoken_scale],
                 "split_item": 2,
@@ -288,6 +248,8 @@ def quant_apply_mlp(
                 hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
             )
         else:
+            if not is_swigluoai_uninterleave and w1_scale[0].dtype != torch.float32:
+                w1_scale[0] = w1_scale[0].to(torch.float32)
             # gmm1: gate_up_proj
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[hidden_states],
@@ -303,7 +265,9 @@ def quant_apply_mlp(
             # act_fn: swiglu
             dequant_swiglu_kwargs = {
                 "x": hidden_states,
-                "weight_scale": _prepare_dequant_swiglu_weight_scale(w1, w1_scale),
+                "weight_scale": (
+                    _prepare_dequant_swiglu_weight_scale(w1_scale) if is_swigluoai_uninterleave else w1_scale[0]
+                ),
                 "activation_scale": pertoken_scale,
                 "bias": None,
                 "quant_scale": None,
@@ -447,10 +411,13 @@ def quant_apply_mlp(
                 dispose_tensor(quantized_hidden_states)
         else:
             # gmm1: gate_up_proj
+            scale = [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale]
+            if is_swigluoai_uninterleave:
+                scale = _prepare_swigluoai_grouped_matmul_scales(w1_scale, _output_dtype)
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],
-                "scale": _prepare_grouped_matmul_scales(w1, w1_scale, _output_dtype),
+                "scale": scale,
                 "bias": bias1,
                 "per_token_scale": [pertoken_scale],
                 "split_item": 2,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes W8A8 MoE scale handling for the `swigluoai_uninterleave` path when dynamic EPLB provides list-form local physical expert weights and scales.

With dynamic EPLB enabled, a MoE layer may receive one weight tensor and one scale tensor per local physical expert. However, some MoE MLP paths previously passed all local expert weights while only using the first `w1_scale`. This made the weight and scale inputs inconsistent and could cause NPU operator shape errors.

This PR updates the scale preparation logic for the `swigluoai_uninterleave` path to:

* pass all local physical expert scales to grouped matmul in the All-to-All path
* stack multi-expert scales into the shape required by `npu_dequant_swiglu_quant` in the MC2 path
* convert the prepared scales to the dtype required by the corresponding NPU operator
* preserve the original tensor shape for single-element scale lists, avoiding regressions in the non-EPLB packed scale path
* keep the existing behavior unchanged for other activation paths

The issue was found while validating MiniMax M3 W8A8 with dynamic EPLB.

### Does this PR introduce *any* user-facing change?

No.

This PR does not change public APIs, CLI arguments, configuration fields, routing policy, EPLB policy, or request behavior.

It only fixes the internal W8A8 MoE scale preparation for the `swigluoai_uninterleave` path and preserves the existing behavior of other activation paths and the non-EPLB packed scale path.

### How was this patch tested?

Targeted unit tests were added for:

* All-to-All with dynamic EPLB: verify that all local expert scales are passed to grouped matmul
* MC2 with dynamic EPLB: verify that multiple local expert scales are stacked into the expected shape and converted to `float32`
* MC2 without dynamic EPLB: verify that a single-element packed scale list preserves its original tensor shape

Related unit tests:

```bash
pytest -sv \
  tests/ut/ops/test_moe_mlp.py \
  tests/ut/ops/test_moe_runtime_args.py \
  tests/ut/ops/test_fused_moe.py \
  tests/ut/ops/test_moe_comm_method.py \
  tests/ut/quantization/methods/test_moe_logical_experts.py \
  tests/ut/quantization/methods/a2/test_w8a8_dynamic.py \
  tests/ut/eplb
```

Result:

```text
95 passed, 16 warnings in 15.13s
```

Real model validation on an 8-card Ascend NPU environment:

* MiniMax M3 W8A8 with dynamic EPLB enabled:

  * service startup passed
  * text request passed
  * image request passed
  * video request passed
  * EPLB expert hotness collection and expert weight update logs were observed

* MiniMax M3 W8A8 without EPLB:

  * service startup passed
  * text request passed
  * image request passed
  * video request passed
  * verified that the non-EPLB packed scale path was not regressed

* vLLM version: v0.26.0

* vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
