### PR TITLE
[Feature][Kernel] Enable fused W8A8 MC2 on Ascend 910B

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -124,6 +124,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "dequant_swiglu_quant"
         "grouped_matmul_swiglu_quant"
         "grouped_matmul_swiglu_quant_v2"
+        "dispatch_ffn_combine"
         "recurrent_gated_delta_rule"
         "chunk_fwd_o"
         "chunk_gated_delta_rule_fwd_h"

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine.h
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine.h
@@ -71,6 +71,7 @@ private:
     GM_ADDR outGM_;
     GM_ADDR gmExpertTokenNums_;
     GM_ADDR workspaceGM_;
+    GM_ADDR mc2InitTiling_;
 
     GM_ADDR moeInitRoutingQuantV2Scale = nullptr;
     GM_ADDR moeInitRoutingQuantV2Offset = nullptr;
@@ -161,6 +162,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Init(GM_ADDR xGM,
     initRoutingQuantTilingKey = tilingData.cocTiling.initRoutingQuantTilingKey;
 
     auto contextGM0 = AscendC::GetHcclContext<HCCL_GROUP_ID_0>();
+    mc2InitTiling_ = reinterpret_cast<GM_ADDR>(&(tiling->mc2InitTiling));
     __gm__ HcclOpResParamCustom *WinContext_{nullptr};
     WinContext_ = (__gm__ HcclOpResParamCustom *)contextGM0;
 
@@ -281,7 +283,8 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Process()
         outGM_, layoutD1, layoutD2,
         expertIdGM_, moeInitRoutingQuantV2Scale, moeInitRoutingQuantV2Offset,
         expertTokensBeforeCapacity, probs_,
-        workspaceGM_, gmExpertTokenNums_, ubMoveNum, xActiveMaskGM_, moeInitRoutingQuantV2TilingData, swigluLimit};
+        workspaceGM_, gmExpertTokenNums_, ubMoveNum, xActiveMaskGM_, moeInitRoutingQuantV2TilingData,
+        mc2InitTiling_, swigluLimit};
     //Call kernel
     MatmulKernel kernel(params);
     kernel(params);

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
@@ -59,6 +59,11 @@ namespace Catlass::Gemm::Kernel {
 
 constexpr uint16_t SYNCFLAGC2V = 9;
 constexpr uint16_t SYNCFLAGV2C = 10;
+// A high-byte tag distinguishes a published count cache line from the plain
+// counts left behind after the consumer normalizes it. Unlike the old
+// nonzero marker, this makes the next wave safe without clearing the matrix.
+constexpr uint32_t INGRESS_READY_MAGIC = 0x4D000000U;
+constexpr uint32_t INGRESS_READY_MAGIC_MASK = 0xFF000000U;
 
 template <
     class BlockMmad_,
@@ -123,6 +128,7 @@ public:
         uint32_t rankSize;
         int32_t ubMoveNum;
         GM_ADDR symmetricPtr;
+        GM_ADDR mc2InitTiling;
         //--------------
         GM_ADDR expertIdx;
         GM_ADDR moeInitRoutingQuantV2Scale;
@@ -164,6 +170,7 @@ public:
             GM_ADDR ptrWorkspace_, GM_ADDR gmExpertTokenNums_, int32_t ubMoveNum_,
             GM_ADDR ptrXActiveMask_,
             optiling::MoeInitRoutingQuantV2TilingData moeInitRoutingQuantV2TilingData_,
+            GM_ADDR mc2InitTiling_,
             float swigluLimit_
         ) : problemShape(problemShape_),
             EP(EP_), listLen(listLen_), expertPerRank(expertPerRank_), maxOutputSize(maxOutputSize_),
@@ -181,6 +188,7 @@ public:
             expertTokensBeforeCapacity(expertTokensBeforeCapacity_), probs(probs_),
             ptrWorkspace(ptrWorkspace_), ptrExpertTokenNums(gmExpertTokenNums_), ubMoveNum(ubMoveNum_),
             ptrXActiveMask(ptrXActiveMask_),
+            mc2InitTiling(mc2InitTiling_),
             moeInitRoutingQuantV2TilingData(moeInitRoutingQuantV2TilingData_),
             swigluLimit(swigluLimit_)
         {
@@ -232,7 +240,9 @@ public:
 
 private:
     CATLASS_DEVICE void initBuffer(Params const &params) {
-        #ifndef HCCL_COMM
+        #ifdef HCCL_COMM
+            shmem.initHccl(params.mc2InitTiling);
+        #else
             shmem.initShmem(params.symmetricPtr, params.rank, params.rankSize);
         #endif
         workspaceInfo = WorkspaceInfo(params);
@@ -652,20 +662,22 @@ private:
 
 
     CATLASS_DEVICE
-    void CrossRankSyncAndlocalTokenPerExpertAllGatherAndGetSumPreRankV2(Params const &params, int64_t localTokenPerExpertOffset){
+    void TaggedTokenPerExpertGatherAndGetSumPreRank(Params const &params,
+                                                     int64_t localTokenPerExpertOffset) {
         uint32_t numPerCore = paddedExpertNumAligned;
         AscendC::LocalTensor<int32_t> tmpBuffer = resource.ubBuf.template GetBufferByByte<int32_t>(0);
         AscendC::LocalTensor<int32_t> prevSumBuf = tmpBuffer[numPerCore];
 
-        for(int32_t dstEpIdx = coreIdx; dstEpIdx < params.EP; dstEpIdx += coreNum) {
+        for (int32_t dstEpIdx = coreIdx; dstEpIdx < params.EP; dstEpIdx += coreNum) {
             if (dstEpIdx == params.rank) {
                 continue;
             }
-            AscendC::GlobalTensor<int32_t> srcAddress;
-            srcAddress.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(shmem() + localTokenPerExpertOffset));
-            AscendC::GlobalTensor<int32_t> dstAddress;
-            __gm__ void* dstPeermemPtr = shmem(localTokenPerExpertOffset, coreIdx);
-            dstAddress.SetGlobalBuffer((__gm__ int32_t * )dstPeermemPtr);
+            AscendC::GlobalTensor<int32_t> sourceCounts;
+            sourceCounts.SetGlobalBuffer(
+                reinterpret_cast<__gm__ int32_t *>(shmem() + localTokenPerExpertOffset));
+            AscendC::GlobalTensor<int32_t> destinationCounts;
+            destinationCounts.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(
+                shmem(localTokenPerExpertOffset, dstEpIdx)));
 
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
             using TType = Gemm::GemmType<int32_t, layout::RowMajor>;
@@ -673,44 +685,55 @@ private:
             using CopyUbToGm = Epilogue::Tile::CopyUb2Gm<ArchTag, TType>;
             CopyGmToUb copyGmToUb;
             CopyUbToGm copyUbToGm;
-            
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
-            
-            copyGmToUb(tmpBuffer, srcAddress[0], 
-                layout::RowMajor{ 1, numPerCore}, 
-                layout::RowMajor{1, numPerCore});
-
+            copyGmToUb(tmpBuffer, sourceCounts[0],
+                       layout::RowMajor{1, numPerCore},
+                       layout::RowMajor{1, numPerCore});
             AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
-            AscendC::Adds(tmpBuffer, tmpBuffer, 0x800000, numPerCore);
+            AscendC::Adds(tmpBuffer, tmpBuffer, static_cast<int32_t>(INGRESS_READY_MAGIC), numPerCore);
             AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-            copyUbToGm(dstAddress[0], tmpBuffer, 
-                layout::RowMajor{ 1, numPerCore}, 
-                layout::RowMajor{1, numPerCore});
+            copyUbToGm(destinationCounts[0], tmpBuffer,
+                       layout::RowMajor{1, numPerCore},
+                       layout::RowMajor{1, numPerCore});
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
         }
-        for(int32_t dstEpIdx = coreIdx; dstEpIdx < params.EP; dstEpIdx += coreNum) {
-            if (dstEpIdx != params.rank) {
-                int32_t intPer512 = CACHE_LINE / sizeof(int);
-                for(int32_t checkIdx = 0; checkIdx < paddedExpertNumAligned; checkIdx += intPer512) {
-                    __gm__ int32_t* sync_check = reinterpret_cast<__gm__ int32_t*>(shmem() + peermemInfo.offsetPeerTokenPerExpert) + tokenPerExpertLayout(dstEpIdx, 0, checkIdx);
-                    gm_signal_wait_until_ne(sync_check, 0);
+        for (int32_t srcEpIdx = coreIdx; srcEpIdx < params.EP; srcEpIdx += coreNum) {
+            int64_t rowOffset = tokenPerExpertLayout(srcEpIdx, 0, 0);
+            if (srcEpIdx != params.rank) {
+                int32_t intsPerCacheLine = CACHE_LINE / sizeof(int32_t);
+                for (int32_t checkIdx = 0; checkIdx < paddedExpertNumAligned;
+                     checkIdx += intsPerCacheLine) {
+                    AscendC::GlobalTensor<int32_t> ready;
+                    ready.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(
+                        shmem() + peermemInfo.offsetPeerTokenPerExpert +
+                        (rowOffset + checkIdx) * sizeof(int32_t)));
+                    uint32_t observed = 0;
+                    do {
+                        AscendC::DataCopy(tmpBuffer, ready, 8);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
+                        observed = static_cast<uint32_t>(tmpBuffer.GetValue(0));
+                    } while ((observed & INGRESS_READY_MAGIC_MASK) != INGRESS_READY_MAGIC);
                 }
-                AscendC::DataCopy(tmpBuffer, tokenPerExpert[tokenPerExpertLayout(dstEpIdx, 0, 0)], numPerCore);
+            }
+
+            AscendC::DataCopy(tmpBuffer, tokenPerExpert[rowOffset], numPerCore);
+            if (srcEpIdx != params.rank) {
                 AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
-                AscendC::Adds(tmpBuffer, tmpBuffer, -0x800000, numPerCore);
+                AscendC::Adds(tmpBuffer, tmpBuffer, -static_cast<int32_t>(INGRESS_READY_MAGIC), numPerCore);
                 AscendC::PipeBarrier<PIPE_V>();
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::DataCopy(tokenPerExpert[tokenPerExpertLayout(dstEpIdx, 0, 0)], tmpBuffer, numPerCore);
+                AscendC::DataCopy(tokenPerExpert[rowOffset], tmpBuffer, numPerCore);
             } else {
-                AscendC::DataCopy(tmpBuffer, tokenPerExpert[tokenPerExpertLayout(dstEpIdx, 0, 0)], numPerCore);
-                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
             }
+
             AscendC::PipeBarrier<PIPE_ALL>();
             int32_t prevSum = 0;
             int32_t j = 0;
@@ -723,7 +746,7 @@ private:
             }
             AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
             AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
-            AscendC::DataCopyPad(preSumBeforeRank[dstEpIdx * params.expertPerRank], prevSumBuf,
+            AscendC::DataCopyPad(preSumBeforeRank[srcEpIdx * params.expertPerRank], prevSumBuf,
             AscendC::DataCopyParams{1, static_cast<uint16_t>(params.expertPerRank * sizeof(int32_t)), 0, 0});
         }
 
@@ -808,7 +831,7 @@ private:
 
         AscendC::SyncAll<true>();
 
-        CrossRankSyncAndlocalTokenPerExpertAllGatherAndGetSumPreRankV2(params, localTokenPerExpertOffset);
+        TaggedTokenPerExpertGatherAndGetSumPreRank(params, localTokenPerExpertOffset);
 
         if (coreIdx == 0) {
             GetCumsumForMMAIV(tokenPerExpert, cumsumMM, params.expertPerRank, params.rank, params.EP);
@@ -966,7 +989,6 @@ private:
         
         
         AscendC::SyncAll<true>();
-        ResetTokenPerExpert(params.EP * paddedExpertNumAligned);
 
         shmem.CrossRankSync();
 

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/dispatch_ffn_combine_kernel.hpp
@@ -729,6 +729,8 @@ private:
                 AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
                 AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
                 AscendC::DataCopy(tokenPerExpert[rowOffset], tmpBuffer, numPerCore);
+                AscendC::SetFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::V_S>(EVENT_ID0);
             } else {
                 AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID0);

--- a/csrc/mc2/dispatch_ffn_combine/op_kernel/utils/hccl_shmem.hpp
+++ b/csrc/mc2/dispatch_ffn_combine/op_kernel/utils/hccl_shmem.hpp
@@ -96,6 +96,14 @@ public:
             m_rankSize = WinContext_->rankSize;
             m_segmentSize = WinContext_->winSize;
         }
+
+        FORCE_INLINE_AICORE
+        void initHccl(GM_ADDR initTiling) {
+            auto contextGM0 = AscendC::GetHcclContext<HCCL_GROUP_ID_0>();
+            hccl_.Init(contextGM0, reinterpret_cast<__gm__ void *>(initTiling));
+            m_rank = hccl_.GetRankId();
+            m_rankSize = hccl_.GetRankDim();
+        }
     #else
         FORCE_INLINE_AICORE
         HcclShmem(){
@@ -110,26 +118,25 @@ public:
     #endif
 
     FORCE_INLINE_AICORE
-    GM_ADDR operator() () const {   // No parameters: return pointer to local peermem
+    GM_ADDR operator() () {   // No parameters: return pointer to local peermem
         #ifdef HCCL_COMM
-            return (GM_ADDR)(WinContext_->localWindowsIn);
+            return hccl_.GetWindowsInAddr(m_rank);
         #else
             return reinterpret_cast<GM_ADDR>(shmem_ptr(symmetricPtr, m_rank));
         #endif
     }
 
     FORCE_INLINE_AICORE
-    GM_ADDR operator() (int32_t index) const {  // With index parameter: return pointer to the base address of remote peermem
+    GM_ADDR operator() (int32_t index) {  // With index parameter: return pointer to the base address of remote peermem
         #ifdef HCCL_COMM
-            return (GM_ADDR)((index == m_rank) ? WinContext_->localWindowsIn :
-                                    ((HcclRankRelationResV2Custom *)(WinContext_->remoteRes[index].nextDevicePtr))->windowsIn);
+            return hccl_.GetWindowsInAddr(index);
         #else
             return reinterpret_cast<GM_ADDR>(shmem_ptr(symmetricPtr, index));
         #endif
     }
 
     FORCE_INLINE_AICORE
-    GM_ADDR operator () (int64_t offset, int32_t rankId) const  {  
+    GM_ADDR operator () (int64_t offset, int32_t rankId) {
         #ifdef HCCL_COMM
             if (offset < 0 || offset >= m_segmentSize) {
                 return nullptr;
@@ -137,8 +144,7 @@ public:
             if (rankId < 0 || rankId >= m_rankSize) {
                 return nullptr;
             }
-            return (GM_ADDR)((rankId == m_rank) ? WinContext_->localWindowsIn :
-                                    ((HcclRankRelationResV2Custom *)(WinContext_->remoteRes[rankId].nextDevicePtr))->windowsIn) + offset;
+            return hccl_.GetWindowsInAddr(rankId) + offset;
         #else
             return reinterpret_cast<GM_ADDR>(shmem_ptr((symmetricPtr + offset), rankId));
         #endif

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_dispatch_ffn_combine_w8a8.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_dispatch_ffn_combine_w8a8.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import random
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+import torch_npu
+from torch.distributed.distributed_c10d import _get_default_group
+
+from vllm_ascend.quantization.methods.w8a8_dynamic import scale_from_float_to_int64
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+
+def _get_hcomm_name(rank: int) -> str:
+    default_group = _get_default_group()
+    backend = default_group._get_backend(torch.device("npu"))
+    return backend.get_hccl_comm_name(rank)
+
+
+def _expert_value(global_expert: torch.Tensor) -> torch.Tensor:
+    # Keep the encoded GMM2 coefficient representable by signed INT8 while
+    # still making every route except the wrap point directly observable.
+    return global_expert.remainder(127) + 1
+
+
+def _routes(tokens: int, top_k: int, global_experts: int, source_rank: int, generation: int) -> torch.Tensor:
+    routes = torch.arange(tokens * top_k, dtype=torch.int32)
+    routes = (routes * (2 * generation + 9) + source_rank * 23 + generation * 7) % global_experts
+    return routes.reshape(tokens, top_k)
+
+
+def _run_rank(rank: int, world_size: int, port: int) -> None:
+    torch_npu.npu.set_device(rank)
+    dist.init_process_group(
+        backend="hccl",
+        rank=rank,
+        world_size=world_size,
+        init_method=f"tcp://127.0.0.1:{port}",
+    )
+
+    try:
+        # EP * local_experts sits exactly on the old 128-entry alignment
+        # boundary, so the masked-row sentinel must receive its own stride.
+        local_experts = 64
+        tokens = 32
+        top_k = 4
+        hidden_size = 256
+        ffn_size = 256
+        gate_up_size = 2 * ffn_size
+        global_experts = world_size * local_experts
+
+        torch_npu.npu.config.allow_internal_format = True
+
+        x = torch.zeros((tokens, hidden_size), dtype=torch.bfloat16)
+        x[:, 0] = 1
+
+        # Dynamic quantization maps the unit input to INT8 and its per-token
+        # scale. GMM1 reconstructs unit gate/up values, and GMM2 writes an
+        # expert-specific coefficient into output column zero.
+        weight1 = torch.zeros((local_experts, hidden_size, gate_up_size), dtype=torch.int8)
+        weight1[:, 0, 0] = 1
+        weight1[:, 0, ffn_size] = 1
+        weight2 = torch.zeros((local_experts, ffn_size, hidden_size), dtype=torch.int8)
+        for local_expert in range(local_experts):
+            global_expert = rank * local_experts + local_expert
+            weight2[local_expert, 0, 0] = global_expert % 127 + 1
+
+        weight1_nz = [torch_npu.npu_format_cast(weight1.npu(), 29)]
+        weight2_nz = [torch_npu.npu_format_cast(weight2.npu(), 29)]
+        scale1 = [scale_from_float_to_int64(torch.ones((local_experts, gate_up_size))).npu()]
+        scale2 = [scale_from_float_to_int64(torch.ones((local_experts, hidden_size))).npu()]
+        empty_bias = [torch.empty(0, dtype=torch.float32)]
+
+        probs_cpu = torch.arange(1, top_k + 1, dtype=torch.float32).repeat(tokens, 1)
+        probs_cpu /= probs_cpu.sum(dim=-1, keepdim=True)
+        probs = probs_cpu.npu()
+        x = x.npu()
+        out = torch.empty_like(x)
+        expert_token_nums = torch.zeros(local_experts, dtype=torch.int32).npu()
+        silu_one = F.silu(torch.tensor(1, dtype=torch.bfloat16))
+
+        for generation in range(1, 5):
+            routes_by_rank = [
+                _routes(tokens, top_k, global_experts, source_rank, generation) for source_rank in range(world_size)
+            ]
+            expert_idx = routes_by_rank[rank]
+            expected = torch.zeros((tokens, hidden_size), dtype=torch.bfloat16)
+            expected[:, 0] = (_expert_value(expert_idx) * probs_cpu).sum(dim=-1).to(torch.bfloat16) * silu_one
+            expected_counts = torch.bincount(
+                torch.cat([routes.reshape(-1) for routes in routes_by_rank]),
+                minlength=global_experts,
+            ).to(torch.int32)
+            expected_counts = expected_counts[rank * local_experts : (rank + 1) * local_experts]
+
+            out.fill_(torch.nan)
+            expert_token_nums.fill_(-1)
+            torch.ops._C_ascend.dispatch_ffn_combine(
+                x=x,
+                weight1=weight1_nz,
+                weight2=weight2_nz,
+                expert_idx=expert_idx.npu(),
+                scale1=scale1,
+                scale2=scale2,
+                bias1=empty_bias,
+                bias2=empty_bias,
+                probs=probs,
+                group=_get_hcomm_name(rank),
+                max_output_size=512,
+                out=out,
+                expert_token_nums=expert_token_nums,
+            )
+            torch_npu.npu.synchronize()
+
+            torch.testing.assert_close(out.cpu(), expected, rtol=0.04, atol=0.04)
+            torch.testing.assert_close(expert_token_nums.cpu(), expected_counts)
+
+        # Publish a real all-zero count row, then reuse the same HCCL windows
+        # again. A stale plain-zero row must not satisfy the tagged ready
+        # predicate for the following wave.
+        x_active_mask = torch.zeros(tokens, dtype=torch.bool)
+        expert_idx = _routes(tokens, top_k, global_experts, rank, generation=5)
+        out.fill_(torch.nan)
+        expert_token_nums.fill_(-1)
+        torch.ops._C_ascend.dispatch_ffn_combine(
+            x=x,
+            weight1=weight1_nz,
+            weight2=weight2_nz,
+            expert_idx=expert_idx.npu(),
+            scale1=scale1,
+            scale2=scale2,
+            bias1=empty_bias,
+            bias2=empty_bias,
+            probs=probs,
+            group=_get_hcomm_name(rank),
+            max_output_size=512,
+            x_active_mask=x_active_mask.npu(),
+            out=out,
+            expert_token_nums=expert_token_nums,
+        )
+        torch_npu.npu.synchronize()
+        torch.testing.assert_close(expert_token_nums.cpu(), torch.zeros(local_experts, dtype=torch.int32))
+
+        # Reuse the same HCCL windows with only one real token in a graph-sized
+        # buffer. Inactive rows must not contribute expert work.
+        active_tokens = 1
+        x_active_mask = torch.zeros(tokens, dtype=torch.bool)
+        x_active_mask[:active_tokens] = True
+        routes_by_rank = [
+            _routes(tokens, top_k, global_experts, source_rank, generation=6) for source_rank in range(world_size)
+        ]
+        expert_idx = routes_by_rank[rank]
+        expected = torch.zeros((tokens, hidden_size), dtype=torch.bfloat16)
+        expected[:active_tokens, 0] = (_expert_value(expert_idx[:active_tokens]) * probs_cpu[:active_tokens]).sum(
+            dim=-1
+        ).to(torch.bfloat16) * silu_one
+        expected_counts = torch.bincount(
+            torch.cat([routes[:active_tokens].reshape(-1) for routes in routes_by_rank]),
+            minlength=global_experts,
+        ).to(torch.int32)
+        expected_counts = expected_counts[rank * local_experts : (rank + 1) * local_experts]
+
+        out.fill_(torch.nan)
+        expert_token_nums.fill_(-1)
+        torch.ops._C_ascend.dispatch_ffn_combine(
+            x=x,
+            weight1=weight1_nz,
+            weight2=weight2_nz,
+            expert_idx=expert_idx.npu(),
+            scale1=scale1,
+            scale2=scale2,
+            bias1=empty_bias,
+            bias2=empty_bias,
+            probs=probs,
+            group=_get_hcomm_name(rank),
+            max_output_size=512,
+            x_active_mask=x_active_mask.npu(),
+            out=out,
+            expert_token_nums=expert_token_nums,
+        )
+        torch_npu.npu.synchronize()
+
+        torch.testing.assert_close(out[:active_tokens].cpu(), expected[:active_tokens], rtol=0.04, atol=0.04)
+        torch.testing.assert_close(expert_token_nums.cpu(), expected_counts)
+    finally:
+        dist.destroy_process_group()
+
+
+@torch.inference_mode()
+def test_dispatch_ffn_combine_w8a8_two_ranks():
+    world_size = 2
+    port = 29501 + random.randint(0, 10000)
+    mp.spawn(_run_rank, args=(world_size, port), nprocs=world_size, join=True)

--- a/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
@@ -186,6 +186,57 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertIs(fused_experts_input.topk_weights, topk_weights)
         self.assertIs(fused_experts_input.topk_ids, topk_ids)
 
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.select_experts")
+    def test_fused_placeholders_follow_activation_device(self, mock_select_experts, mock_extra_ctx, mock_ascend):
+        tokens = 4
+        device = torch.device("meta")
+        layer = torch.nn.Module()
+        layer.w13_weight = torch.empty(
+            self.num_experts,
+            2 * self.intermediate_size,
+            self.hidden_size,
+            dtype=torch.int8,
+            device=device,
+        )
+        layer.w2_weight = torch.empty(
+            self.num_experts,
+            self.hidden_size,
+            self.intermediate_size,
+            dtype=torch.int8,
+            device=device,
+        )
+        layer.fused_w1_scale = torch.empty(1, dtype=torch.int64, device=device)
+        layer.fused_w2_scale = torch.empty(1, dtype=torch.int64, device=device)
+        layer.swiglu_limit = 0.0
+
+        x = torch.empty(tokens, self.hidden_size, dtype=torch.bfloat16, device=device)
+        router_logits = torch.empty(tokens, self.num_experts, dtype=torch.float32, device=device)
+        topk_weights = torch.empty(tokens, 2, dtype=torch.float32, device=device)
+        topk_ids = torch.empty(tokens, 2, dtype=torch.int64, device=device)
+
+        mock_select_experts.return_value = (topk_weights, topk_ids)
+        mock_comm = Mock()
+        mock_comm.fused_experts.return_value = x
+        mock_extra_ctx.moe_comm_method = mock_comm
+        mock_extra_ctx.moe_comm_type = MoECommType.FUSED_MC2
+        mock_ascend.return_value = MagicMock(enable_fused_mc2=1)
+        self.quant_method.multistream_overlap_gate = False
+
+        self.quant_method.apply(
+            layer=layer,
+            x=x,
+            router_logits=router_logits,
+            top_k=2,
+            renormalize=True,
+            num_experts=self.num_experts,
+        )
+
+        weights = mock_comm.fused_experts.call_args.kwargs["fused_experts_input"].weights
+        self.assertEqual(weights.w1_scale_bias[0].device, device)
+        self.assertEqual(weights.w2_scale_bias[0].device, device)
+
     @patch("torch_npu.npu_format_cast")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
     def test_process_weights_after_loading(self, mock_get_config, mock_format_cast):

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -148,6 +148,40 @@ def test_select_moe_comm_method_uses_allgather_without_effective_expert_parallel
 
 
 @pytest.mark.parametrize(
+    ("enable_fused_mc2", "quant_type", "ep_world_size", "local_experts", "expected"),
+    [
+        (1, "w8a8_dynamic", 2, 8, MoECommType.FUSED_MC2),
+        (1, "w8a8_dynamic", 2, 2, MoECommType.ALLGATHER),
+        (1, "w8a8_dynamic", 16, 8, MoECommType.MC2),
+        (0, "w8a8_dynamic", 2, 8, MoECommType.ALLGATHER),
+        (1, "w4a8_dynamic", 2, 8, MoECommType.ALLGATHER),
+        (1, None, 2, 8, MoECommType.ALLGATHER),
+    ],
+)
+def test_select_moe_comm_method_a2_fused_w8a8(
+    monkeypatch,
+    enable_fused_mc2,
+    quant_type,
+    ep_world_size,
+    local_experts,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A2,
+        ep_world_size=ep_world_size,
+        enable_fused_mc2=enable_fused_mc2,
+    )
+    vllm_config = _make_vllm_config(
+        world_size=ep_world_size,
+        num_experts=ep_world_size * local_experts,
+        quant_type=quant_type,
+    )
+
+    assert afc.select_moe_comm_method(16, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
     ("num_tokens", "expected"),
     [
         (128, MoECommType.MC2),

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -44,6 +44,8 @@ _MEGA_MOE_SUPPORTED = importlib.util.find_spec("cann_ops_transformer") is not No
 _MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
 _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
 _MC2_TOKENS_PER_RANK_LIMIT = 512
+_MAX_A2_FUSED_MC2_EP_SIZE = 8
+_MIN_A2_FUSED_MC2_LOCAL_EXPERTS = 3
 
 
 @contextmanager
@@ -296,6 +298,19 @@ def _select_a2_moe_comm_method(
         vllm_config.parallel_config.world_size_across_dp // vllm_config.parallel_config.pipeline_parallel_size
     )
     num_experts_per_device = num_experts // ep_world_size
+    quant_type = getattr(
+        vllm_config.model_config.hf_text_config,
+        "moe_quantize",
+        getattr(vllm_config.model_config.hf_text_config, "quantize", None),
+    )
+    quant_name = str(getattr(quant_type, "name", quant_type)).lower()
+    if (
+        get_ascend_config().enable_fused_mc2 == 1
+        and quant_name == "w8a8_dynamic"
+        and ep_world_size <= _MAX_A2_FUSED_MC2_EP_SIZE
+        and num_experts_per_device >= _MIN_A2_FUSED_MC2_LOCAL_EXPERTS
+    ):
+        return MoECommType.FUSED_MC2
     if (
         num_experts_per_device <= 24
         and ep_world_size >= 16
@@ -347,8 +362,10 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
 
     1. Non-MoE models return `None`.
     2. Without expert parallel, fall back to all-gather.
-    3. On A2 with expert parallel, pick MC2 when tokens fit the MC2 capacity
-       and the DP size is large enough; otherwise use all-gather.
+    3. On A2 with expert parallel, prefer the explicitly enabled dynamic-W8A8
+       fused path for a small EP group with enough local experts. Otherwise,
+       pick MC2 when tokens fit the MC2 capacity and the DP size is large
+       enough, or use all-gather.
     4. On A3 with expert parallel, prefer fused MC2 when enabled and the EP
        group size is small enough; otherwise use MC2 within capacity or
        all-to-all.

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -87,7 +87,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Whether to enable fused MC2 (`dispatch_ffn_combine/mega_moe`).
     # 0, or not set: default ALLTOALL and MC2 will be used.
     # 1: ALLTOALL and MC2 might be replaced by `dispatch_ffn_combine/mega_moe` operator.
-    # `dispatch_ffn_combine` can be used only for moe layer with W8A8, EP<=32, non-mtp, non-dynamic-eplb.
+    # On A2, `dispatch_ffn_combine` supports dynamic W8A8 with EP<=8 and at
+    # least three local experts. On A3 it supports W8A8 with EP<=32,
+    # non-mtp, and non-dynamic-eplb.
     # `mega_moe` can be used only for moe layer with W8A8/W4A8/bf16(none quant), EP<=64, non-dynamic-eplb.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
     # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -306,8 +306,8 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
             w2 = layer.w2_weight_list
             w2_scale = layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
-            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            w1_scale_bias = [x.new_empty((0,), dtype=torch.float32)] if fused_scale_flag else None
+            w2_scale_bias = [x.new_empty((0,), dtype=torch.float32)] if fused_scale_flag else None
 
         elif fused_scale_flag and _MEGA_MOE_SUPPORTED:
             w1 = layer.cann_mega_moe_w13_weight_list
@@ -322,8 +322,12 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1_scale = [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
             w2 = [layer.w2_weight]
             w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
-            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            # The fused operator requires placeholder bias lists even though
+            # W8A8 does not consume an additive bias. Keep them on the
+            # activation device so torch.compile/ACL graph capture does not
+            # see a mixed NPU/CPU node.
+            w1_scale_bias = [x.new_empty((0,), dtype=torch.float32)] if fused_scale_flag else None
+            w2_scale_bias = [x.new_empty((0,), dtype=torch.float32)] if fused_scale_flag else None
 
         final_hidden_states = moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(


### PR DESCRIPTION
### What this PR does / why we need it?

The dynamic-W8A8 `dispatch_ffn_combine` kernel already implements in-kernel activation quantization, INT8 GMM1/GMM2, expert-granular GMM2 publication, and AIV combine. On Ascend 910B/910B2, however, it is neither built nor selected and its communication helper still assumes the A3 private HCCL-window layout.

This patch makes the existing implementation usable on A2:

- initialize the public `AscendC::Hccl` abstraction from `Mc2InitTiling` and resolve local/peer input windows through `GetWindowsInAddr()`;
- build `dispatch_ffn_combine` in the Ascend 910B package;
- use producer-owned tagged count publication so reused HCCL windows cannot accept stale count rows, without clearing the complete count matrix on every invocation;
- select it only for the existing explicit `enable_fused_mc2=1` opt-in, dynamic W8A8, `EP <= 8`, and at least three local experts; and
- keep optional W8A8 bias placeholders on the activation device so FakeTensor propagation and FULL decode graph capture do not see a mixed NPU/CPU node.

This is a semantic port of the independently maintained downstream adoption in [vLLM-HUST/vllm-ascend-hust#203](https://github.com/vLLM-HUST/vllm-ascend-hust/pull/203), rebased onto current upstream `main` and adapted to its refactored communication selector and test layout.

### Does this PR introduce _any_ user-facing change?

Yes, but only behind the existing opt-in. Ascend 910B/910B2 dynamic-W8A8 MoE workloads that set `enable_fused_mc2=1` may select the fused dispatch/FFN/combine operator when the A2 EP/local-expert constraints are met. Default behavior remains unchanged.

### Performance and numerical evidence

An equivalent downstream implementation was measured on `Qwen3-30B-A3B-W8A8`, TP2/EP2, 32 requests per cell, four warmups, fixed lengths/seed, and two fresh-server repeats per implementation:

| mode | workload | output throughput delta | mean TPOT delta |
|---|---|---:|---:|
| eager | 462x16, QPS 4 | +5.88% | -14.90% |
| eager | 462x16, QPS 8 | +3.77% | -6.97% |
| eager | 462x256, QPS 4 | +11.01% | -11.56% |
| eager | 462x256, QPS 8 | +15.91% | -14.62% |
| graph | 462x16, QPS 4 | -0.92% | +9.96% |
| graph | 462x16, QPS 8 | -0.01% | -14.64% |
| graph | 462x256, QPS 4 | -2.78% | +2.10% |
| graph | 462x256, QPS 8 | -3.71% | +3.48% |

Graph replay itself improves output throughput by 29-349% over matching fused eager runs; the table measures only the fused operator's *incremental* effect after graph replay. This supports an eager/selective opt-in, not a universal graph-mode default.

A bounded eager quality receipt found no non-finite output or route/count corruption. On 4,699 teacher-forced GSM8K tokens, mean NLL moved from 1.405828 to 1.434388 (`+0.028560`, perplexity `+2.90%`); the first 64 GSM8K test items moved from 61/64 to 60/64 exact answers. This is disclosed as a small movement, not claimed as statistical equivalence, and is another reason this PR does not change the default.

### DeepSeek-V4 exact-shape TP8/EP8 evidence

A follow-up eight-rank microbenchmark moved the measurement boundary below
the noisy server and fixed the real DeepSeek shape: `H=4096`, `FFN=2048`,
top-k 6, 256 global / 32 local experts, TP8/EP8,
`max_output_size=131072`, and `enable_sp=False`. Fresh processes ran in
ABBA order with 20 warmups and 50 measured waves per cell; each sample is the
maximum device-event latency across all eight ranks.

| tokens/rank | baseline r1 | fused r1 | reduction r1 | baseline r2 | fused r2 | reduction r2 |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 1059.55 us | 468.04 us | 55.83% | 1034.22 us | 490.32 us | 52.59% |
| 7 | 1044.09 us | 467.20 us | 55.25% | 1001.66 us | 477.88 us | 52.29% |

These shapes cover 9,976 / 10,332 (96.55%) rank-normalized selector events in
the long-output QPS-4 DeepSeek server receipts, with a corrected
observed-mixture saving of about 554 us per MoE layer. The exact-shape operator
claim is therefore reproduced. A receipt-only accounting bounds the covered
shape contribution at 0.169-7.250 ms per output token because the existing log
does not distinguish 43-layer base forwards from one-layer MTP draft forwards;
even the ceiling is only 1.93% of stock mean TPOT. The prior hand-entered mix
combined QPS-1 and QPS-4 4-token counts while leaving the 7-token count
QPS-4-only; no operator timing sample changed.

The matching eager DeepSeek server matrix completed all 16 cells and selected
ALLGATHER/FUSED_MC2 as intended, but fresh-server drift was comparable to the
end-to-end deltas and the long QPS-4 repeat changed direction. The server-level
performance verdict remains **INSUFFICIENT_EVIDENCE**. This PR claims the
operator mechanism and opt-in capability, not a universal server throughput
gain.

### How was this patch tested?

On current upstream head `e8f25e304`:

- built and installed an Ascend 910B custom-op package containing `dispatch_ffn_combine`;
- `pytest -q tests/ut/test_ascend_forward_context.py tests/ut/quantization/methods/a2/test_w8a8_dynamic.py` — 41 passed;
- `pytest -q tests/e2e/nightly/single_node/ops/multicard_ops_a2/test_dispatch_ffn_combine_w8a8.py` — 1 passed on two Ascend 910B2 devices (four changing route generations, a zero-count wave, and active-row/window-reuse checks);
- targeted Ruff, Ruff format, and codespell checks for all changed Python files;
- `bash -n csrc/build_aclnn.sh` and `git diff --check`.

The downstream real-model performance and quality campaign above is documented in [#203](https://github.com/vLLM-HUST/vllm-ascend-hust/pull/203). This PR remains draft while upstream reviewers decide the desired quality threshold and graph-mode policy.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e

