### PR TITLE
[Performance][SFA] Replace DCP sparse-index remap with Ascend C

### DIFF
--- a/csrc/kernels/sfa_remap_sparse_indices.cpp
+++ b/csrc/kernels/sfa_remap_sparse_indices.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernel_operator.h"
+
+namespace {
+
+// GLM-5.2 uses 2048. Keeping a larger static UB capacity also covers other
+// sparse-attention configurations without changing the kernel ABI.
+constexpr uint32_t kMaxTopK = 8192;
+constexpr uint32_t kBufferBytes = kMaxTopK * sizeof(int32_t);
+
+class SfaRemapSparseIndices {
+public:
+    __aicore__ inline explicit SfaRemapSparseIndices(AscendC::TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(
+        __gm__ int32_t* input,
+        __gm__ int32_t* output,
+        uint32_t rows,
+        uint32_t topK,
+        uint32_t dcpSize,
+        uint32_t dcpRank,
+        uint32_t interleaveSize,
+        uint32_t interleaveShift,
+        uint32_t dcpInterleaveShift,
+        uint32_t usePowerOfTwo,
+        uint32_t rowsPerCore)
+    {
+        inputGm_.SetGlobalBuffer(input, rows * topK);
+        outputGm_.SetGlobalBuffer(output, rows * topK);
+        rows_ = rows;
+        topK_ = topK;
+        dcpSize_ = dcpSize;
+        dcpRank_ = dcpRank;
+        interleaveSize_ = interleaveSize;
+        interleaveShift_ = interleaveShift;
+        dcpInterleaveShift_ = dcpInterleaveShift;
+        usePowerOfTwo_ = usePowerOfTwo;
+        rowsPerCore_ = rowsPerCore;
+        pipe_->InitBuffer(inputQueue_, 1, kBufferBytes);
+        pipe_->InitBuffer(outputQueue_, 1, kBufferBytes);
+    }
+
+    __aicore__ inline void Process()
+    {
+        const uint32_t core = AscendC::GetBlockIdx();
+        const uint32_t start = core * rowsPerCore_;
+        uint32_t end = start + rowsPerCore_;
+        if (end > rows_) {
+            end = rows_;
+        }
+        for (uint32_t row = start; row < end; ++row) {
+            CopyIn(row);
+            Compute();
+            CopyOut(row);
+        }
+    }
+
+private:
+    __aicore__ inline void CopyIn(uint32_t row)
+    {
+        AscendC::LocalTensor<int32_t> input = inputQueue_.AllocTensor<int32_t>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(topK_ * sizeof(int32_t)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<int32_t> padParams{false, 0, 0, 0};
+        AscendC::DataCopyPad(input, inputGm_[row * topK_], copyParams, padParams);
+        inputQueue_.EnQue(input);
+    }
+
+    __aicore__ inline void Compute()
+    {
+        AscendC::LocalTensor<int32_t> input = inputQueue_.DeQue<int32_t>();
+        AscendC::LocalTensor<int32_t> output = outputQueue_.AllocTensor<int32_t>();
+        uint32_t writePos = 0;
+
+        // Stable compaction has a scalar prefix dependency. Vector initializes
+        // the invalid tail, then Scalar only writes locally-owned values.
+        AscendC::Duplicate(output, static_cast<int32_t>(-1), topK_);
+        event_t vectorToScalar = static_cast<event_t>(pipe_->FetchEventID(AscendC::HardEvent::V_S));
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(vectorToScalar);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(vectorToScalar);
+
+        for (uint32_t column = 0; column < topK_; ++column) {
+            const int32_t value = input.GetValue(column);
+            if (value < 0) {
+                continue;
+            }
+            const uint32_t unsignedValue = static_cast<uint32_t>(value);
+            uint32_t owner = 0;
+            int32_t remapped = -1;
+            if (usePowerOfTwo_ != 0) {
+                owner = (unsignedValue >> interleaveShift_) & (dcpSize_ - 1);
+                remapped = static_cast<int32_t>(
+                    ((unsignedValue >> dcpInterleaveShift_) << interleaveShift_)
+                    | (unsignedValue & (interleaveSize_ - 1)));
+            } else {
+                const uint32_t block = unsignedValue / interleaveSize_;
+                owner = block % dcpSize_;
+                remapped = static_cast<int32_t>(
+                    (block / dcpSize_) * interleaveSize_ + unsignedValue % interleaveSize_);
+            }
+            if (owner == dcpRank_) {
+                output.SetValue(writePos, remapped);
+                ++writePos;
+            }
+        }
+
+        event_t scalarToMte3 = static_cast<event_t>(pipe_->FetchEventID(AscendC::HardEvent::S_MTE3));
+        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(scalarToMte3);
+        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(scalarToMte3);
+
+        inputQueue_.FreeTensor(input);
+        outputQueue_.EnQue(output);
+    }
+
+    __aicore__ inline void CopyOut(uint32_t row)
+    {
+        AscendC::LocalTensor<int32_t> output = outputQueue_.DeQue<int32_t>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(topK_ * sizeof(int32_t)), 0, 0, 0};
+        AscendC::DataCopyPad(outputGm_[row * topK_], output, copyParams);
+        outputQueue_.FreeTensor(output);
+    }
+
+    AscendC::TPipe* pipe_;
+    AscendC::TQue<AscendC::QuePosition::VECIN, 1> inputQueue_;
+    AscendC::TQue<AscendC::QuePosition::VECOUT, 1> outputQueue_;
+    AscendC::GlobalTensor<int32_t> inputGm_;
+    AscendC::GlobalTensor<int32_t> outputGm_;
+    uint32_t rows_;
+    uint32_t topK_;
+    uint32_t dcpSize_;
+    uint32_t dcpRank_;
+    uint32_t interleaveSize_;
+    uint32_t interleaveShift_;
+    uint32_t dcpInterleaveShift_;
+    uint32_t usePowerOfTwo_;
+    uint32_t rowsPerCore_;
+};
+
+}  // namespace
+
+extern "C" __global__ __aicore__ void sfa_remap_sparse_indices_kernel(
+    __gm__ int32_t* input,
+    __gm__ int32_t* output,
+    uint32_t rows,
+    uint32_t topK,
+    uint32_t dcpSize,
+    uint32_t dcpRank,
+    uint32_t interleaveSize,
+    uint32_t interleaveShift,
+    uint32_t dcpInterleaveShift,
+    uint32_t usePowerOfTwo,
+    uint32_t rowsPerCore)
+{
+    AscendC::TPipe pipe;
+    SfaRemapSparseIndices op(&pipe);
+    op.Init(input, output, rows, topK, dcpSize, dcpRank, interleaveSize,
+            interleaveShift, dcpInterleaveShift, usePowerOfTwo, rowsPerCore);
+    op.Process();
+}
+
+namespace vllm_ascend {
+
+extern void sfa_remap_sparse_indices_impl(
+    void* stream,
+    void* input,
+    void* output,
+    uint32_t rows,
+    uint32_t topK,
+    uint32_t dcpSize,
+    uint32_t dcpRank,
+    uint32_t interleaveSize,
+    uint32_t interleaveShift,
+    uint32_t dcpInterleaveShift,
+    uint32_t usePowerOfTwo,
+    uint32_t vectorCoreCount)
+{
+    const uint32_t blockDim = rows < vectorCoreCount ? rows : vectorCoreCount;
+    const uint32_t rowsPerCore = (rows + blockDim - 1) / blockDim;
+    sfa_remap_sparse_indices_kernel<<<blockDim, nullptr, stream>>>(
+        static_cast<int32_t*>(input), static_cast<int32_t*>(output), rows, topK,
+        dcpSize, dcpRank, interleaveSize, interleaveShift,
+        dcpInterleaveShift, usePowerOfTwo, rowsPerCore);
+}
+
+}  // namespace vllm_ascend

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -131,4 +131,19 @@ namespace vllm_ascend {
         void* gm_tiling_data,
         const uint32_t block_dim
     );
+
+    extern void sfa_remap_sparse_indices_impl(
+        void* stream,
+        void* input,
+        void* output,
+        uint32_t rows,
+        uint32_t top_k,
+        uint32_t dcp_size,
+        uint32_t dcp_rank,
+        uint32_t interleave_size,
+        uint32_t interleave_shift,
+        uint32_t dcp_interleave_shift,
+        uint32_t use_power_of_two,
+        uint32_t vector_core_count
+    );
 }

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -485,6 +485,67 @@ at::Tensor sgmv_expand(at::Tensor &x, at::Tensor &weight, at::Tensor &lora_indic
     cmd.Run();
     return y_out;
 }
+
+void sfa_remap_sparse_indices(
+    const at::Tensor& input,
+    at::Tensor& output,
+    int64_t dcp_size,
+    int64_t dcp_rank,
+    int64_t interleave_size)
+{
+    constexpr int64_t max_top_k = 8192;
+    TORCH_CHECK(input.is_privateuseone(), "input must be on an NPU device");
+    TORCH_CHECK(output.device() == input.device(), "input and output must be on the same NPU device");
+    TORCH_CHECK(input.scalar_type() == torch::kInt32, "input must have int32 dtype");
+    TORCH_CHECK(output.scalar_type() == input.scalar_type(), "output dtype must match input dtype");
+    TORCH_CHECK(input.sizes() == output.sizes(), "output shape must match input shape");
+    TORCH_CHECK(input.is_contiguous() && output.is_contiguous(), "input and output must be contiguous");
+    TORCH_CHECK(input.dim() >= 1, "input must have at least one dimension");
+    TORCH_CHECK(dcp_size > 1, "dcp_size must be greater than one");
+    TORCH_CHECK(dcp_rank >= 0 && dcp_rank < dcp_size, "dcp_rank must be in [0, dcp_size)");
+    TORCH_CHECK(interleave_size > 0, "interleave_size must be positive");
+
+    const int64_t top_k = input.size(-1);
+    TORCH_CHECK(top_k > 0 && top_k <= max_top_k, "top_k must be in [1, ", max_top_k, "]");
+    const int64_t rows = input.numel() / top_k;
+    if (rows == 0) {
+        return;
+    }
+
+    const bool use_power_of_two =
+        (dcp_size & (dcp_size - 1)) == 0 && (interleave_size & (interleave_size - 1)) == 0;
+    uint32_t interleave_shift = 0;
+    for (int64_t value = interleave_size; value > 1; value >>= 1) {
+        ++interleave_shift;
+    }
+    uint32_t dcp_shift = 0;
+    for (int64_t value = dcp_size; value > 1; value >>= 1) {
+        ++dcp_shift;
+    }
+
+    void* input_ptr = input.data_ptr();
+    void* output_ptr = output.data_ptr();
+    const int device_id = input.get_device();
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    at_npu::native::OpCommand cmd;
+    cmd.Name("sfa_remap_sparse_indices");
+    cmd.SetCustomHandler([
+        stream, input_ptr, output_ptr, device_id, rows, top_k, dcp_size, dcp_rank,
+        interleave_size, interleave_shift, dcp_shift, use_power_of_two]() -> int {
+        int64_t vector_core_count = 0;
+        TORCH_CHECK(aclGetDeviceCapability(device_id, ACL_DEVICE_INFO_VECTOR_CORE_NUM,
+                                           &vector_core_count) == ACL_SUCCESS);
+        TORCH_CHECK(vector_core_count > 0, "vector core count must be positive");
+        sfa_remap_sparse_indices_impl(
+            stream, input_ptr, output_ptr, static_cast<uint32_t>(rows),
+            static_cast<uint32_t>(top_k), static_cast<uint32_t>(dcp_size),
+            static_cast<uint32_t>(dcp_rank), static_cast<uint32_t>(interleave_size),
+            interleave_shift, interleave_shift + dcp_shift,
+            static_cast<uint32_t>(use_power_of_two), static_cast<uint32_t>(vector_core_count));
+        return 0;
+    });
+    cmd.Run();
+}
 #endif
 
 at::Tensor npu_sign_bits_pack(const at::Tensor& input,
@@ -2162,6 +2223,12 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
 
     ops.def("swap_blocks(Tensor! x, Tensor! y, Tensor z) -> ()");
     ops.impl("swap_blocks", torch::kPrivateUse1, &vllm_ascend::swap_blocks);
+
+    ops.def(
+        "sfa_remap_sparse_indices(Tensor input, Tensor(a!) output, int dcp_size, "
+        "                         int dcp_rank, int interleave_size) -> ()");
+    ops.impl("sfa_remap_sparse_indices", torch::kPrivateUse1,
+             &vllm_ascend::sfa_remap_sparse_indices);
 #endif
 
     // swap_blocks_batch takes CPU tensors (int64 pointer/size arrays), not NPU

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sfa_remap_sparse_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sfa_remap_sparse_indices.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+
+def _reference_remap(
+    indices: torch.Tensor,
+    dcp_size: int,
+    rank: int,
+    interleave_size: int,
+) -> torch.Tensor:
+    indices_cpu = indices.cpu()
+    blocks = torch.div(indices_cpu, interleave_size, rounding_mode="floor")
+    is_local = (indices_cpu >= 0) & (blocks.remainder(dcp_size) == rank)
+    remapped = (
+        torch.div(
+            indices_cpu,
+            dcp_size * interleave_size,
+            rounding_mode="floor",
+        )
+        * interleave_size
+        + indices_cpu.remainder(interleave_size)
+    )
+    remapped = torch.where(is_local, remapped, -1)
+    result = torch.full_like(remapped, -1)
+    for source_row, local_row, result_row in zip(
+        remapped.view(-1, remapped.shape[-1]),
+        is_local.view(-1, is_local.shape[-1]),
+        result.view(-1, result.shape[-1]),
+        strict=True,
+    ):
+        values = source_row[local_row]
+        result_row[: values.numel()] = values
+    return result.to(indices.device)
+
+
+@pytest.mark.parametrize(
+    ("dcp_size", "rank", "interleave_size"),
+    [(2, 0, 1), (3, 1, 96), (8, 3, 64), (16, 7, 128)],
+)
+@pytest.mark.parametrize("num_rows", [5, 16, 64, 128])
+@torch.inference_mode()
+def test_sfa_remap_sparse_indices(
+    dcp_size: int,
+    rank: int,
+    interleave_size: int,
+    num_rows: int,
+) -> None:
+    torch.manual_seed(2026)
+    indices = torch.randint(
+        0,
+        20_000_000,
+        (num_rows, 1, 2048),
+        dtype=torch.int32,
+        device="npu",
+    )
+    indices[..., ::11] = -1
+
+    expected = _reference_remap(indices, dcp_size, rank, interleave_size)
+    actual = torch.empty_like(indices)
+    torch.ops._C_ascend.sfa_remap_sparse_indices(
+        indices,
+        actual,
+        dcp_size,
+        rank,
+        interleave_size,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("top_k", [1, 7, 512, 2048, 8192])
+@torch.inference_mode()
+def test_sfa_remap_sparse_indices_supports_dynamic_top_k(top_k: int) -> None:
+    indices = torch.arange(
+        5 * top_k,
+        dtype=torch.int32,
+        device="npu",
+    ).view(5, 1, top_k)
+    indices[..., ::11] = -1
+
+    expected = _reference_remap(indices, 16, 7, 128)
+    actual = torch.empty_like(indices)
+    torch.ops._C_ascend.sfa_remap_sparse_indices(indices, actual, 16, 7, 128)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sfa_remap_sparse_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sfa_remap_sparse_indices.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 import torch_npu  # noqa: F401
 
+from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPImpl
 from vllm_ascend.utils import enable_custom_op
 
 enable_custom_op()
@@ -88,5 +89,27 @@ def test_sfa_remap_sparse_indices_supports_dynamic_top_k(top_k: int) -> None:
     expected = _reference_remap(indices, 16, 7, 128)
     actual = torch.empty_like(indices)
     torch.ops._C_ascend.sfa_remap_sparse_indices(indices, actual, 16, 7, 128)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@torch.inference_mode()
+def test_sfa_cp_backend_uses_ascendc_remap() -> None:
+    impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+    impl.dcp_size = 16
+    impl.dcp_rank = 7
+    impl._dcp_interleave_size = 128
+    impl._dcp_index_topk = 2048
+    indices = torch.randint(
+        0,
+        20_000_000,
+        (16, 1, 2048),
+        dtype=torch.int32,
+        device="npu",
+    )
+    indices[..., ::11] = -1
+
+    expected = _reference_remap(indices, 16, 7, 128)
+    actual = impl._remap_sparse_indices(indices)
 
     torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tests/ut/attention/a2/test_sfa_cp_precision.py
+++ b/tests/ut/attention/a2/test_sfa_cp_precision.py
@@ -11,8 +11,6 @@ def _make_impl(rank: int, interleave_size: int = 2) -> AscendSFADCPImpl:
     impl.dcp_rank = rank
     impl._dcp_interleave_size = interleave_size
     impl._dcp_index_topk = 8
-    impl._remap_order = torch.arange(8, dtype=torch.float32)
-    impl._remap_invalid_index = torch.tensor(-1.0)
     return impl
 
 
@@ -29,6 +27,19 @@ def test_sfa_dcp_sparse_indices_are_compacted_per_owner_rank() -> None:
     torch.testing.assert_close(
         rank1,
         torch.tensor([[0, 1, 2, -1, -1, -1, -1, -1]], dtype=torch.int32),
+    )
+
+
+def test_sfa_dcp_sparse_indices_preserve_large_integer_precision() -> None:
+    impl = _make_impl(rank=0, interleave_size=128)
+    impl._dcp_index_topk = 4
+    replicated_indices = torch.tensor([[16_777_216, 16_777_217, 16_777_344, -1]], dtype=torch.int32)
+
+    remapped = impl._remap_sparse_indices(replicated_indices)
+
+    torch.testing.assert_close(
+        remapped,
+        torch.tensor([[8_388_608, 8_388_609, -1, -1]], dtype=torch.int32),
     )
 
 

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -442,9 +442,6 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 break
         if self._dcp_index_topk <= 0:
             raise RuntimeError("index_topk must be set in the model config for DCP SFA.")
-        device = self.q_proj.weight.device
-        self._remap_order = torch.arange(self._dcp_index_topk, dtype=torch.float32, device=device)
-        self._remap_invalid_index = torch.tensor(-1.0, dtype=torch.float32, device=device)
 
     @staticmethod
     def _has_prefill(attn_metadata: M) -> bool:
@@ -540,31 +537,37 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 f"topk_indices last dimension ({topk_count}) exceeds configured index_topk ({self._dcp_index_topk})."
             )
 
-        # Remap the topk indices from the replicated view to the DCP-local KV cache view.
-        # We use float32 for better performance on Ascend.
-        topk_indices_fp32 = topk_indices.to(torch.float32)
+        if topk_indices.device.type == "npu":
+            contiguous_indices = topk_indices.contiguous()
+            remapped_indices = torch.empty_like(contiguous_indices)
+            torch.ops._C_ascend.sfa_remap_sparse_indices(
+                contiguous_indices,
+                remapped_indices,
+                self.dcp_size,
+                self.dcp_rank,
+                self._dcp_interleave_size,
+            )
+            return remapped_indices
+
+        # CPU/reference fallback used by unit tests and non-NPU tooling.
         interleave_size = self._dcp_interleave_size
-        local_block_indices = torch.floor(topk_indices_fp32 / interleave_size)
-        local_owner_base = torch.floor(local_block_indices / self.dcp_size) * self.dcp_size
-        local_owner = local_block_indices - local_owner_base
-        local_owner_mask = (topk_indices_fp32 >= 0) & (local_owner == self.dcp_rank)
-        if interleave_size == 1:
-            remapped_indices_fp32 = torch.floor(topk_indices_fp32 / self.dcp_size)
-        else:
-            local_offsets = topk_indices_fp32 - local_block_indices * interleave_size
-            remapped_indices_fp32 = torch.floor(topk_indices_fp32 / (self.dcp_size * interleave_size))
-            remapped_indices_fp32 = remapped_indices_fp32 * interleave_size + local_offsets
-        remapped_indices = torch.where(
-            local_owner_mask,
-            remapped_indices_fp32,
-            self._remap_invalid_index,
-        ).to(topk_indices.dtype)
+        local_block_indices = torch.div(topk_indices, interleave_size, rounding_mode="floor")
+        local_owner_mask = (topk_indices >= 0) & (local_block_indices.remainder(self.dcp_size) == self.dcp_rank)
+        remapped_indices = (
+            torch.div(topk_indices, self.dcp_size * interleave_size, rounding_mode="floor") * interleave_size
+            + topk_indices.remainder(interleave_size)
+        )
+        remapped_indices = torch.where(local_owner_mask, remapped_indices, -1)
 
         # Compact local indices to the front without changing their top-k order.
-        original_order = self._remap_order[:topk_count].expand_as(topk_indices)
-        pack_keys = original_order + (~local_owner_mask).to(torch.float32) * topk_count
+        original_order = torch.arange(
+            topk_count,
+            dtype=torch.int64,
+            device=topk_indices.device,
+        ).expand_as(topk_indices)
+        pack_keys = original_order + (~local_owner_mask).to(torch.int64) * topk_count
         _, pack_order = torch.sort(pack_keys, dim=-1)
-        return torch.gather(remapped_indices, dim=-1, index=pack_order.to(torch.int32))
+        return torch.gather(remapped_indices, dim=-1, index=pack_order)
 
     def _all_to_all_dcp_tensor(
         self,


### PR DESCRIPTION
## Summary

- add an Ascend C custom operator for SFA DCP sparse-index remapping
- replace the NPU PyTorch float32/floor/sort/gather path with stable integer remap and compaction
- preserve a pure integer CPU reference fallback for unit tests and tooling
- support dynamic top-k up to 8192, non-power-of-two DCP/interleave values, and indices beyond float32 exact-integer range

## Why

The previous path launches multiple PyTorch operators and converts int32 indices through float32. The new kernel performs ownership filtering, integer remapping, stable compaction, and invalid-tail fill in one launch.

## Validation

Tested on 90-network Ascend containers with GLM-5.2 W4A8 MTP, TP8/DCP8, DSA CP, sparse C8, AG&RS, FlashComm1, NZ, MTP3 and FULL_DECODE_ONLY graph mode.

### Operator

- 22/22 exact comparisons passed with atol=0 and rtol=0
- DCP sizes 2/3/8/16
- interleave sizes 1/64/96/128
- rows 5/16/64/128
- dynamic top-k 1/7/512/2048/8192
- negative sentinels and indices above 16,777,216
- 3.31x-9.97x faster than the replaced PyTorch implementation for rows 1-128, top-k 2048

### Full network correctness

Baseline and candidate both completed reasoning (128 tokens), code generation (256 tokens), and longer decode (384 tokens) cases. Output lengths and semantic checks passed. Exact generated tokens are not used as the gate because candidate-to-candidate repeats are also non-bitwise-deterministic under TP8+DCP8+MTP3; the remap operator itself is exact.

### 42K input / 1K output rerun (MTP3)

The no-MTP 46K/1K run was stopped because it was impractically slow. The serving comparison was rerun with local `aisbench_auto_tools`, MTP3, target-model `FULL_DECODE_ONLY`, TP8/DCP8, AG&RS, one excluded full-request warmup per state, and two measured requests. A single fixed dataset was reused; AISBench observed 42,012 post-template input tokens and 1,000 generated tokens. All requests completed with zero failures.

| State | Run | TTFT ms | TPOT ms | Request duration s | Output token/s |
|---|---:|---:|---:|---:|---:|
| candidate | 1 | 1,583.6 | 245.0 | 246.3025 | 4.0600 |
| candidate | 2 | 1,130.7 | 253.5 | 254.3381 | 3.9318 |
| baseline | 1 | 1,116.7 | 247.9 | 248.8067 | 4.0192 |
| baseline | 2 | 1,199.1 | 253.6 | 254.5249 | 3.9289 |

Mean TPOT changed from 250.75 ms baseline to 249.25 ms candidate: **0.60% lower**. Mean output throughput changed from 3.9741 to 3.9959 token/s: **0.55% higher**. Candidate TPOT sample CV was 2.41% versus 1.61% baseline, so the observed delta is below run-to-run variation.

MTP acceptance also favored the candidate:

| State | Run | Accepted / drafted | Weighted draft acceptance | Derived mean acceptance length |
|---|---:|---:|---:|---:|
| candidate | 1 | 739 / 780 | 94.74% | 3.8423 |
| candidate | 2 | 736 / 792 | 92.93% | 3.7879 |
| baseline | 1 | 733 / 798 | 91.85% | 3.7556 |
| baseline | 2 | 733 / 804 | 91.17% | 3.7351 |

Combined weighted acceptance was 93.83% candidate versus 91.51% baseline (+2.32 percentage points). This gives the candidate fewer target decode iterations and biases raw TPOT in its favor. Therefore the 0.60% raw TPOT delta is **not claimed as an end-to-end gain attributable to this operator**. The rerun establishes long-context serving viability, while the isolated operator benchmark remains the evidence for kernel speedup.

The target model used `FULL_DECODE_ONLY`; current vLLM automatically falls the GLM MTP draft submodel back to eager mode. This behavior was identical for both states. Safetensors prefetch (1 thread, 64 MiB block) was enabled and confirmed in the service log.

## Limitations

- No 90-network host had 16 simultaneously free NPUs, so the exact TP16/DCP16 1M-context target script was not run. The closest available validation used TP8/DCP8 and a 49K max context.
- The 42K/1K comparison used grouped candidate-then-baseline order with two measured samples per state, not an alternating A/B design. More repetitions with acceptance-matched samples are required for an attribution-quality sub-percent TPOT claim.
- Devices 8-15 had unrelated workloads during the rerun; the experiment used only devices 0-7 and did not modify those workloads.
- The test image had vLLM/vllm-ascend revision skew requiring identical compatibility-only Python patches in both states. None are included in this PR.
- Repository pytest collection in this image was blocked by a missing optional ModelScope dependency and then an unrelated DeviceOperator circular import. A standalone script loaded the compiled extension directly and executed the same exact matrix successfully.

This remains a draft while exact TP16/DCP16 coverage and a statistically controlled end-to-end TPOT claim remain open.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
