### PR TITLE
[BugFix][releases/v0.25.1rc] fix fiaV2 contiguous err in GQA

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -1310,8 +1310,8 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 sparse_mode = 3
             attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
                 query,
-                key,
-                value,
+                key.contiguous(),
+                value.contiguous(),
                 num_query_heads=self.num_heads,
                 num_key_value_heads=self.num_kv_heads,
                 input_layout="TND",


### PR DESCRIPTION
### What this PR does / why we need it?
When CANN is updated to 9.1.0, the fused_infer_attention operator added a new constraint that key and value should be contiguous when input into this FIAV2 operator. This PR makes the implementation.

### Does this PR introduce _any_ user-facing change?
NO.

### How was this patch tested?
CI passed.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
