### PR TITLE
[BugFix][v0.26.0rc][KV Pool] Include MTP KV in layerwise AscendStore transfer

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -142,6 +142,57 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
         worker.token_database.process_tokens.assert_not_called()
 
+    def test_registered_layer_layout_includes_mtp_multi_group_and_pp(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 2
+        worker.hf_config = MagicMock(num_hidden_layers=4)
+        caches = [MagicMock(), MagicMock(), MagicMock()]
+        for address, cache in zip((1000, 2000, 3000), caches):
+            cache.data_ptr.return_value = address
+        worker.kv_caches = {
+            "model.layers.2.self_attn": (caches[0],),
+            "model.layers.3.self_attn": (caches[1],),
+            "model.mtp.0.self_attn": (caches[2],),
+        }
+        worker._get_cache_block_metadata = MagicMock(return_value=(160, 160, 160, 1))
+        worker.group_kv_caches_base_addr = {}
+        worker.group_block_len = {}
+        worker.group_block_stride = {}
+        worker.group_num_layers = {}
+
+        worker._infer_cache_group_metadata(0, list(worker.kv_caches))
+        self.assertEqual(worker.group_kv_caches_base_addr[0], [1000, 2000, 3000])
+        self.assertEqual(worker.group_num_layers[0], 3)
+        worker.layer_load_tasks = [[], []]
+        worker.layer_save_tasks = [[], []]
+
+        worker._configure_registered_layerwise_layers(
+            [
+                (
+                    0,
+                    [
+                        "model.layers.2.self_attn",
+                        "model.layers.3.self_attn",
+                        "model.mtp.0.self_attn",
+                    ],
+                ),
+                (1, ["model.layers.2.indexer", "model.layers.3.indexer"]),
+            ]
+        )
+
+        self.assertEqual(worker.num_layers, 3)
+        self.assertEqual(
+            worker.local_layer_to_group_layers,
+            {
+                0: [(0, 0), (1, 0)],
+                1: [(0, 1), (1, 1)],
+                2: [(0, 2)],
+            },
+        )
+        self.assertEqual(worker._extract_physical_layer_index("model.layers.4.self_attn"), 4)
+        self.assertEqual(len(worker.layer_load_tasks), 3)
+
 
 class TestKVPoolWorkerInit(unittest.TestCase):
     """Test KVPoolWorker initialization with mocked dependencies."""

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -323,38 +323,10 @@ class KVPoolWorker:
         self._allocated_gvas: dict[str, int] = {}
 
     def _init_layerwise_config(self) -> None:
-        # Build mapping: physical_layer -> [(group_id, layer_idx_in_group), ...]
-        # layer_idx_in_group is the index of the physical layer within the
-        # group (not the index in layer_names). Multiple layer_names at the
-        # same physical layer (e.g. indexer.k_cache + attn) are treated as
-        # multiple cache tensors of ONE layer (caches_per_layer > 1).
-        self.physical_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
-
-        if self.kv_cache_config is not None and self.num_kv_cache_groups > 1:
-            for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
-                # Map each unique physical layer to a sequential layer_idx_in_group
-                phys_to_layer_idx: dict[int, int] = {}
-                for layer_name in group_spec.layer_names:
-                    physical_layer = self._extract_physical_layer_index(layer_name)
-                    if physical_layer >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
-                        continue
-                    if physical_layer not in phys_to_layer_idx:
-                        phys_to_layer_idx[physical_layer] = len(phys_to_layer_idx)
-
-                # Add one entry per unique physical layer (no duplicates)
-                for physical_layer, layer_idx_in_group in phys_to_layer_idx.items():
-                    existing = self.physical_layer_to_group_layers.setdefault(physical_layer, [])
-                    entry = (group_id, layer_idx_in_group)
-                    if entry not in existing:
-                        existing.append(entry)
-
-                logger.info(
-                    "layerwise group %d: %d layer_names, %d unique physical layers, caches_per_layer=%d",
-                    group_id,
-                    len(group_spec.layer_names),
-                    len(phys_to_layer_idx),
-                    len(group_spec.layer_names) // max(1, len(phys_to_layer_idx)),
-                )
+        # Registration provides the authoritative layer layout.  In
+        # particular, model_config.get_num_layers() only reports the local PP
+        # target layers and does not include registered MTP draft layers.
+        self.local_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
 
         self.layer_load_tasks: list[list[LayerTransferTask]] = [[] for _ in range(self.num_layers)]
         self.layer_save_tasks: list[list[LayerTransferTask]] = [[] for _ in range(self.num_layers)]
@@ -366,10 +338,9 @@ class KVPoolWorker:
         self.sync_save_events: list[torch.npu.Event] | None = None
 
         logger.info(
-            "layerwise config: num_layers=%d num_groups=%d physical_layer_to_group_layers_sample=%s",
+            "layerwise config: num_layers=%d num_groups=%d",
             self.num_layers,
             self.num_kv_cache_groups,
-            {k: v for k, v in list(self.physical_layer_to_group_layers.items())[:3]},
         )
 
     def _build_group_layer_builders(self) -> list[LayerBatchBuilder]:
@@ -659,8 +630,6 @@ class KVPoolWorker:
         physical_layers = set()
         for layer_name in layer_names:
             phys = self._extract_physical_layer_index(layer_name)
-            if phys >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
-                continue
             physical_layers.add(phys)
             cache_or_caches = self.kv_caches[layer_name]
             for cache in self._as_cache_tuple(cache_or_caches):
@@ -673,6 +642,38 @@ class KVPoolWorker:
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides
         self.group_num_layers[group_id] = len(physical_layers)
+
+    def _configure_registered_layerwise_layers(self, cache_groups: list[tuple[int, list[str]]]) -> None:
+        """Map registered physical layers to dense local and group indices."""
+        groups_by_physical: dict[int, list[tuple[int, int]]] = {}
+
+        for group_id, layer_names in cache_groups:
+            group_physical_layers: list[int] = []
+            seen_in_group: set[int] = set()
+            for layer_name in layer_names:
+                physical_layer = self._extract_physical_layer_index(layer_name)
+                if physical_layer not in seen_in_group:
+                    seen_in_group.add(physical_layer)
+                    group_physical_layers.append(physical_layer)
+
+            for layer_idx_in_group, physical_layer in enumerate(group_physical_layers):
+                groups_by_physical.setdefault(physical_layer, []).append((group_id, layer_idx_in_group))
+
+        physical_layers = sorted(groups_by_physical)
+        self.local_layer_to_group_layers = {
+            local_layer: groups_by_physical[physical_layer]
+            for local_layer, physical_layer in enumerate(physical_layers)
+        }
+
+        original_num_layers = self.num_layers
+        self.num_layers = len(physical_layers)
+        self.layer_load_tasks = [[] for _ in range(self.num_layers)]
+        self.layer_save_tasks = [[] for _ in range(self.num_layers)]
+        logger.info(
+            "KVPoolWorker: configured %d registered layers (was %d).",
+            self.num_layers,
+            original_num_layers,
+        )
 
     def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
         """
@@ -750,27 +751,17 @@ class KVPoolWorker:
         ptrs = [start for start, _ in registered_regions.values()]
         lengths = [end - start for start, end in registered_regions.values()]
 
+        cache_groups: list[tuple[int, list[str]]]
         if self.kv_cache_config is not None and self.use_hybrid:
-            for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
-                self._infer_cache_group_metadata(group_id, group_spec.layer_names)
+            cache_groups = [
+                (group_id, [layer_name for layer_name in group_spec.layer_names if layer_name in kv_caches])
+                for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups)
+            ]
         else:
-            self._infer_cache_group_metadata(0, list(kv_caches.keys()))
-
-        # group_num_layers is computed from the actual kv_caches dict which
-        # includes ALL attention layers (main + MTP). For single-group models,
-        # sum(group_num_layers.values()) equals the physical layer count
-        # (including MTP). For multi-group models, it counts (group, layer)
-        # pairs which is NOT the physical layer count — keep the original
-        # num_layers (physical layers) in that case.
-        original_num_layers = self.num_layers
-        new_num_layers = sum(self.group_num_layers.values())
-        if self.num_kv_cache_groups == 1 and new_num_layers != original_num_layers:
-            self.num_layers = new_num_layers
-            logger.info(
-                "KVPoolWorker: updated num_layers %d -> %d (includes MTP/spec-decode draft layers).",
-                original_num_layers,
-                self.num_layers,
-            )
+            cache_groups = [(0, list(kv_caches.keys()))]
+        for group_id, layer_names in cache_groups:
+            self._infer_cache_group_metadata(group_id, layer_names)
+        self._configure_registered_layerwise_layers(cache_groups)
 
         self.page_size_bytes = sum(self.block_len)
         self.token_database.set_group_buffers(
@@ -1398,17 +1389,17 @@ class KVPoolWorker:
     def process_layer_data(self, requests: list[ReqMeta]) -> None:
         if not requests:
             return
-        for physical_layer in range(self.num_layers):
-            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
+        for local_layer in range(self.num_layers):
+            group_layers = self.local_layer_to_group_layers.get(local_layer, [(0, local_layer)])
             for group_id, layer_idx_in_group in group_layers:
-                self._process_save_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
+                self._process_save_for_layer_batch(requests, local_layer, group_id, layer_idx_in_group)
         self._alloc_gvas_for_save(requests)
         self._build_shared_save_data()
         self._prepare_load_gvas(requests)
-        for physical_layer in range(self.num_layers):
-            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
+        for local_layer in range(self.num_layers):
+            group_layers = self.local_layer_to_group_layers.get(local_layer, [(0, local_layer)])
             for group_id, layer_idx_in_group in group_layers:
-                self._process_load_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
+                self._process_load_for_layer_batch(requests, local_layer, group_id, layer_idx_in_group)
         self._build_shared_load_data()
 
     def _submit_ready_layer_loads(self) -> None:


### PR DESCRIPTION
## What this PR does / why we need it?

Cherry-pick of #13454 onto `releases/v0.26.0rc`.

Build layerwise execution and group offsets from the KV caches registered on each worker. This includes MTP caches while keeping PP-local task indices and dense per-group storage indices for hybrid models.

## Does this PR introduce _any_ user-facing change?

No user-facing API changes. Internal fix for KV pool layer registration including MTP layers.

## How was this patch tested?

- Unit tests added/updated: `tests/ut/distributed/ascend_store/test_pool_worker.py`
  - `test_registered_layer_layout_includes_mtp_multi_group_and_pp`
- CI verification
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
