### PR TITLE
[CI] modify default cann_version and add build_type support in nightly

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -42,7 +42,7 @@ on:
       cann_version:
         required: false
         type: string
-        default: '2026.07.29'
+        default: '2026.08.03'
         description: "CANN version for base image tag"
     secrets:
       HW_USERNAME:

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -111,7 +111,7 @@ on:
         description: 'CANN version'
         required: false
         type: string
-        default: '2026.07.29'
+        default: '2026.08.03'
       triton_ascend_version:
         description: 'Triton Ascend version'
         required: false
@@ -453,7 +453,7 @@ jobs:
         run: |
           # Get current date in YYYYMMDD format
           DATE=$(date +'%Y%m%d')
-          # Get CANN version and convert to lowercase (e.g., 2026.07.29 -> 2026.07.29)
+          # Get CANN version and convert to lowercase (e.g., 2026.08.03 -> 2026.08.03)
           CANN_VERSION=$(echo "${{ inputs.cann_version }}" | tr '[:upper:]' '[:lower:]')
           # Get the base tag pattern (e.g., main)
           PATTERN="${{ inputs.schedule_tag_pattern }}"
@@ -461,7 +461,7 @@ jobs:
           SUFFIX="${{ inputs.suffix }}"
           
           # Construct the daily tag: nightly-{PATTERN}-{SUFFIX}-cann{VERSION}-{DATE}
-          # Example: nightly-main-310p-openeuler-cann2026.07.29-20260729
+          # Example: nightly-main-310p-openeuler-cann2026.08.03-20260729
           if [ -n "$SUFFIX" ]; then
             DAILY_TAG="nightly-${PATTERN}-${SUFFIX}-cann${CANN_VERSION}-${DATE}"
           else

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -47,7 +47,7 @@ on:
       cann_version:
         description: 'CANN version for base image tag'
         required: false
-        default: '2026.07.29'
+        default: '2026.08.03'
         type: string
 
 jobs:

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -86,7 +86,7 @@ on:
       cann:
         description: 'CANN Quay URL and version (JSON array: ["url", "version"])'
         required: false
-        default: '["quay.io/atlas_inference/cann", "2026.07.29"]'
+        default: '["quay.io/atlas_inference/cann", "2026.08.03"]'
         type: string
       triton_ascend:
         description: 'Triton Ascend version and package version (JSON array: ["version", "package_version"])'
@@ -147,7 +147,7 @@ jobs:
       branch_ref: ${{ inputs.branch != 'none' && inputs.branch || '' }}
       schedule_tag_pattern: 'main'
       build_type: ${{ inputs.build_type || 'release' }}
-      cann_version: ${{ fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[1] }}
+      cann_version: ${{ fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1] }}
       
       build_args: |
         BUILD_TYPE=${{ inputs.build_type || 'release' }}
@@ -158,8 +158,8 @@ jobs:
         MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260725.3"]')[1] }}
         TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[0] }}
         TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[1] }}
-        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[0]) || '' }}
-        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[1]) || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[0]) || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1]) || '' }}
         TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
         TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
       
@@ -214,7 +214,7 @@ jobs:
       workflow_dispatch_tag: ''
       branch_ref: ''
       build_type: ${{ inputs.build_type || 'release' }}
-      cann_version: ${{ fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[1] }}
+      cann_version: ${{ fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1] }}
 
       build_args: |
         BUILD_TYPE=${{ inputs.build_type || 'release' }}
@@ -225,8 +225,8 @@ jobs:
         MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260725.3"]')[1] }}
         TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[0] }}
         TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[1] }}
-        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[0]) || '' }}
-        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[1]) || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[0]) || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1]) || '' }}
         TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
         TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
 

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -52,6 +52,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
+      cann_version:
+        description: 'CANN version for base image tag'
+        required: false
+        default: '2026.08.03'
+        type: string
 
 permissions:
   contents: read
@@ -171,10 +184,16 @@ jobs:
     with:
       target: a2
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
+      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -53,7 +53,7 @@ on:
         default: false
         type: boolean
       build_type:
-        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        description: 'Build type: daily or release.'
         required: false
         default: 'release'
         type: choice

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -53,6 +53,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
+      cann_version:
+        description: 'CANN version for base image tag'
+        required: false
+        default: '2026.08.03'
+        type: string
 
 permissions:
   contents: read
@@ -170,10 +183,16 @@ jobs:
     with:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
+      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -54,7 +54,7 @@ on:
         default: false
         type: boolean
       build_type:
-        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        description: 'Build type: daily or release.'
         required: false
         default: 'release'
         type: choice

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -53,6 +53,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
+      cann_version:
+        description: 'CANN version for base image tag'
+        required: false
+        default: '2026.08.03'
+        type: string
 
 permissions:
   contents: read
@@ -171,10 +184,16 @@ jobs:
     with:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
+      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -54,7 +54,7 @@ on:
         default: false
         type: boolean
       build_type:
-        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        description: 'Build type: daily or release.'
         required: false
         default: 'release'
         type: choice

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -58,6 +58,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
+      cann_version:
+        description: 'CANN version for base image tag'
+        required: false
+        default: '2026.08.03'
+        type: string
 
 permissions:
   contents: read
@@ -172,10 +185,16 @@ jobs:
     with:
       target: 310p
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
+      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   single-node-tests:
     name: single-node

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -59,7 +59,7 @@ on:
         default: false
         type: boolean
       build_type:
-        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        description: 'Build type: daily or release.'
         required: false
         default: 'release'
         type: choice

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -55,6 +55,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
+      cann_version:
+        description: 'CANN version for base image tag'
+        required: false
+        default: '2026.08.03'
+        type: string
 
 permissions:
   contents: read
@@ -172,10 +185,16 @@ jobs:
     with:
       target: a2
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
+      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   single-node-accuracy-tests:
     needs: [setup-vars, parse-trigger, build-image]

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -56,7 +56,7 @@ on:
         default: false
         type: boolean
       build_type:
-        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        description: 'Build type: daily or release.'
         required: false
         default: 'release'
         type: choice

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -58,6 +58,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_type:
+        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - daily
+      cann_version:
+        description: 'CANN version for base image tag'
+        required: false
+        default: '2026.08.03'
+        type: string
 
 permissions:
   contents: read
@@ -174,10 +187,16 @@ jobs:
     with:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
+      build_type: ${{ inputs.build_type }}
+      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
+      cann_version: ${{ inputs.cann_version }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
+      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
+      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -59,7 +59,7 @@ on:
         default: false
         type: boolean
       build_type:
-        description: 'Build type: daily or release. Daily uses swr.cn-north-4 and quay.io base image.'
+        description: 'Build type: daily or release.'
         required: false
         default: 'release'
         type: choice


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the default image version number of cann_version, and enhances the E2E test framework by adding support for build_type selection, allowing users to specify different configurations (e.g., daily/release) when running nightly tests.

### Does this PR introduce _any_ user-facing change?
No This is for internal nightly testing only

### How was this patch tested?
This patch was tested by running the image building stage of the existing nightly tests with both build_type configurations (daily and release).

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
