### PR TITLE
[CI]Add post-processing for nightly and weekly benchmark results

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -90,6 +90,8 @@ on:
         required: false
       OBS_SECRET_ACCESS_KEY:
         required: false
+      OPENLIBING_SECRET:
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -116,6 +118,7 @@ jobs:
       env:
         KUBECONFIG: /tmp/kubeconfig
         NAMESPACE: vllm-project
+        OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
     steps:
       - name: Decode kubeconfig
         run: echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > "$KUBECONFIG"
@@ -237,6 +240,7 @@ jobs:
             -D runner="$runner" \
             -D aop_multi_enabled="${{ inputs.aop_multi_enabled }}" \
             -D good_table="/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch || 'main' }}/${{ inputs.test_frequency }}/good_table.csv" \
+            -D openlibing_secret="$OPENLIBING_SECRET" \
             -D soc_version="${{ inputs.soc_version }}" \
             -D max_good_age_days="${{ inputs.test_frequency == 'weekly' && 8 || 3 }}" \
             --outfile lws.yaml

--- a/.github/workflows/_e2e_nightly_multi_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node_560t.yaml
@@ -119,6 +119,8 @@ on:
         required: false
       OBS_SECRET_ACCESS_KEY:
         required: false
+      OPENLIBING_SECRET:
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -143,6 +145,7 @@ jobs:
       env:
         KUBECONFIG: /tmp/kubeconfig
         NAMESPACE: vllm-project
+        OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
     steps:
       - name: Decode kubeconfig
         run: echo "${{ secrets.KUBECONFIG_B64_560T }}" | base64 -d > "$KUBECONFIG"
@@ -255,6 +258,7 @@ jobs:
             -D runner="$runner" \
             -D aop_multi_enabled="${{ inputs.aop_multi_enabled }}" \
             -D good_table="/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch || 'main' }}/${{ inputs.test_frequency }}/good_table.csv" \
+            -D openlibing_secret="$OPENLIBING_SECRET" \
             -D soc_version="${{ inputs.soc_version }}" \
             -D max_good_age_days="${{ inputs.test_frequency == 'weekly' && 8 || 3 }}" \
             --outfile lws.yaml

--- a/.github/workflows/_e2e_nightly_single_node.yaml
+++ b/.github/workflows/_e2e_nightly_single_node.yaml
@@ -83,6 +83,8 @@ on:
         required: false
       OBS_SECRET_ACCESS_KEY:
         required: false
+      OPENLIBING_SECRET:
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -114,6 +116,7 @@ jobs:
       UV_NO_CACHE: 1
       UV_SYSTEM_PYTHON: 1
       VLLM_ENGINE_READY_TIMEOUT_S: 1800
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/_e2e_nightly_single_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_single_node_560t.yaml
@@ -83,6 +83,8 @@ on:
         required: false
       OBS_SECRET_ACCESS_KEY:
         required: false
+      OPENLIBING_SECRET:
+        required: false
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -113,6 +115,7 @@ jobs:
       UV_NO_CACHE: 1
       UV_SYSTEM_PYTHON: 1
       VLLM_ENGINE_READY_TIMEOUT_S: 1800
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -233,6 +233,7 @@ jobs:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_HK_001_INTERNAL_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   remove-taints:
     name: Remove node taints
@@ -288,6 +289,7 @@ jobs:
     secrets:
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
 
   generate-accuracy-matrix:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -232,6 +232,7 @@ jobs:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   double-node-tests:
     name: double-node
@@ -271,6 +272,7 @@ jobs:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   single-node-tests:
     name: single-node
@@ -302,6 +304,8 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+    secrets:
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   multi-card-tests:
     name: single-node
@@ -336,6 +340,7 @@ jobs:
     secrets:
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -234,6 +234,7 @@ jobs:
       KUBECONFIG_B64_560T: ${{ secrets.KUBECONFIG_B64_560T }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   double-node-tests:
     name: double-node
@@ -276,6 +277,7 @@ jobs:
       KUBECONFIG_B64_560T: ${{ secrets.KUBECONFIG_B64_560T }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   double-node-pods-started:
     name: Wait for all double-node pods launched
@@ -321,6 +323,8 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+    secrets:
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   multi-card-tests:
     name: single-node
@@ -355,6 +359,7 @@ jobs:
     secrets:
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0-cn12-001

--- a/.github/workflows/schedule_nightly_test_a5.yaml
+++ b/.github/workflows/schedule_nightly_test_a5.yaml
@@ -228,6 +228,7 @@ jobs:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_A5_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   single-node-tests:
     name: single-node
@@ -259,6 +260,8 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+    secrets:
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a5-0

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -230,6 +230,8 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+    secrets:
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   merge-benchmark-artifacts:
     name: Merge benchmark artifacts into weekly-310p.zip

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -279,6 +279,7 @@ jobs:
       KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
       OBS_ACCESS_KEY_ID: ${{ secrets.OBS_ACCESS_KEY_ID }}
       OBS_SECRET_ACCESS_KEY: ${{ secrets.OBS_SECRET_ACCESS_KEY }}
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   single-node-tests:
     name: single-node
@@ -314,6 +315,8 @@ jobs:
       request_id: ${{ inputs.request_id || '' }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || '' }}
       aop_single_enabled: ${{ inputs.aop_enabled }}
+    secrets:
+      OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
 
   clear-pre-logs:
     runs-on: linux-aarch64-a3-0

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
@@ -22,6 +22,7 @@ from tests.e2e.nightly.multi_node.scripts.benchmark_results import (
     get_vllm_version,
     write_results_json,
 )
+from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
 
 logger = logging.getLogger(__name__)
 
@@ -233,4 +234,10 @@ def write_benchmark_results_json(
 ) -> Path:
     output = build_benchmark_results(config=config, ranks=ranks, commands=commands, results=results)
     job_name = os.environ.get("BENCHMARK_JOB_NAME", "") or config.test_name.replace(" ", "-")
-    return write_results_json(output, job_name=job_name, output_dir=output_dir)
+    path = write_results_json(output, job_name=job_name, output_dir=output_dir)
+    valid_items = [(case["case_name"], case) for case in config.benchmark_cases]
+    postprocess_benchmark_results(
+        [(key, case, result) for (key, case), result in zip(valid_items, results)],
+        job_name=job_name,
+    )
+    return path

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
@@ -239,6 +239,5 @@ def write_benchmark_results_json(
     postprocess_benchmark_results(
         [(key, case, result) for (key, case), result in zip(valid_items, results)],
         job_name=job_name,
-        model_name=config.model,
     )
     return path

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/utils.py
@@ -22,6 +22,7 @@ from tests.e2e.nightly.multi_node.scripts.benchmark_results import (
     get_vllm_version,
     write_results_json,
 )
+from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
 
 logger = logging.getLogger(__name__)
 
@@ -233,4 +234,11 @@ def write_benchmark_results_json(
 ) -> Path:
     output = build_benchmark_results(config=config, ranks=ranks, commands=commands, results=results)
     job_name = os.environ.get("BENCHMARK_JOB_NAME", "") or config.test_name.replace(" ", "-")
-    return write_results_json(output, job_name=job_name, output_dir=output_dir)
+    path = write_results_json(output, job_name=job_name, output_dir=output_dir)
+    valid_items = [(case["case_name"], case) for case in config.benchmark_cases]
+    postprocess_benchmark_results(
+        [(key, case, result) for (key, case), result in zip(valid_items, results)],
+        job_name=job_name,
+        model_name=config.model,
+    )
+    return path

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
@@ -21,6 +21,7 @@ from tests.e2e.nightly.multi_node.scripts.benchmark_results import (
     filter_environment,
     write_results_json,
 )
+from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
 from tools.aisbench import run_aisbench_cases
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,11 @@ def _save_benchmark_results_json(config: MultiNodeConfig, results: list[Any]) ->
 
     job_name = os.environ.get("BENCHMARK_JOB_NAME", "")
     write_results_json(output, job_name=job_name)
+
+    postprocess_benchmark_results(
+        [(key, case_cfg, result) for (key, case_cfg), result in zip(valid_items, results)],
+        job_name=job_name or config.test_name,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
@@ -154,7 +154,6 @@ def _save_benchmark_results_json(config: MultiNodeConfig, results: list[Any]) ->
     postprocess_benchmark_results(
         [(key, case_cfg, result) for (key, case_cfg), result in zip(valid_items, results)],
         job_name=job_name or config.test_name,
-        model_name=config.model,
     )
 
 

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
@@ -21,6 +21,7 @@ from tests.e2e.nightly.multi_node.scripts.benchmark_results import (
     filter_environment,
     write_results_json,
 )
+from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
 from tools.aisbench import run_aisbench_cases
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,12 @@ def _save_benchmark_results_json(config: MultiNodeConfig, results: list[Any]) ->
 
     job_name = os.environ.get("BENCHMARK_JOB_NAME", "")
     write_results_json(output, job_name=job_name)
+
+    postprocess_benchmark_results(
+        [(key, case_cfg, result) for (key, case_cfg), result in zip(valid_items, results)],
+        job_name=job_name or config.test_name,
+        model_name=config.model,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -49,6 +49,8 @@ spec:
                 value: "{{ aop_multi_enabled }}"
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
+              - name: OPENLIBING_SECRET
+                value: "{{ openlibing_secret | default("") }}"
             command:
               - sh
               - -c

--- a/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws_560t.yaml.jinja2
@@ -49,6 +49,8 @@ spec:
                 value: "{{ aop_multi_enabled }}"
               - name: GOOD_TABLE
                 value: "{{ good_table | default("/root/.cache/vllm-ascend/nightly/good_table.csv") }}"
+              - name: OPENLIBING_SECRET
+                value: "{{ openlibing_secret | default("") }}"
               - name: HCCL_INTER_HCCS_DISABLE
                 value: "TRUE"
               - name: HCCL_IF_BASE_PORT

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Post-process nightly/weekly benchmark results into per-case JSON files.
+
+For each accuracy/performance benchmark entry:
+  1. Read a preset JSON template
+  2. Patch nested testcase_info fields (preserve base_info)
+  3. Write a new JSON file
+  4. Upload via tools/upload_to_openlibing.py
+
+Missing preset/script files only emit warnings and never fail the test.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PRESET_JSON_PATH = Path("/root/.cache/upload_perf/test.json")
+OUTPUT_DIR = Path("/root/.cache/upload_perf/results")
+UPLOAD_LABEL = "performance"
+_DATASET_PREFIX = "vllm-ascend/"
+
+
+def _default_upload_script_path() -> Path:
+    cwd_candidate = Path("tools/upload_to_openlibing.py")
+    if cwd_candidate.is_file():
+        return cwd_candidate.resolve()
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "tools" / "upload_to_openlibing.py"
+        if candidate.is_file():
+            return candidate
+    return cwd_candidate
+
+
+POSTPROCESS_SCRIPT_PATH = _default_upload_script_path()
+
+
+def _safe_name(name: str) -> str:
+    return name.replace("/", "_").replace(" ", "_")
+
+
+def resolve_suite_name(config_base_path: str | None = None) -> str:
+    """Return 'weekly' or 'nightly' from CONFIG_BASE_PATH."""
+    base = config_base_path if config_base_path is not None else os.getenv("CONFIG_BASE_PATH", "")
+    normalized = base.replace("\\", "/")
+    return "weekly" if "weekly" in normalized else "nightly"
+
+
+def resolve_testcase_name(config_yaml_path: str | None = None, fallback: str = "") -> str:
+    """Return YAML stem from CONFIG_YAML_PATH (without .yaml/.yml)."""
+    raw = config_yaml_path if config_yaml_path is not None else os.getenv("CONFIG_YAML_PATH", "")
+    if not raw:
+        return fallback
+    name = Path(raw).name
+    for suffix in (".yaml", ".yml"):
+        if name.lower().endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _extract_dataset_name(case_config: dict[str, Any]) -> str:
+    dataset_path = str(case_config.get("dataset_path", "") or "")
+    if dataset_path.startswith(_DATASET_PREFIX):
+        return dataset_path[len(_DATASET_PREFIX) :]
+    return ""
+
+
+def _extract_output_tps(result: Any) -> float | None:
+    if not (isinstance(result, list) and len(result) == 2):
+        return None
+    _, result_json = result
+    if not isinstance(result_json, dict):
+        return None
+    metric = result_json.get("Output Token Throughput", {})
+    if not isinstance(metric, dict):
+        return None
+    total_str = metric.get("total", "")
+    try:
+        return round(float(str(total_str).replace("token/s", "").strip()), 4)
+    except (ValueError, AttributeError):
+        return None
+
+
+def merge_postprocess_payload(
+    preset: dict[str, Any],
+    case_config: dict[str, Any],
+    result: Any,
+    *,
+    testcase_name: str,
+    suite_name: str | None = None,
+) -> dict[str, Any]:
+    """Deep-copy preset and patch nested fields per the preset JSON schema."""
+    payload = copy.deepcopy(preset)
+    testcase_info = payload.setdefault("testcase_info", {})
+    if not isinstance(testcase_info, dict):
+        testcase_info = {}
+        payload["testcase_info"] = testcase_info
+
+    testcase_info["featureFullName"] = suite_name or resolve_suite_name()
+    testcase_info["Testcase_Name"] = testcase_name
+
+    test_env = testcase_info.get("testEnv")
+    if not isinstance(test_env, dict):
+        test_env = {}
+        testcase_info["testEnv"] = test_env
+
+    test_env["request_rate"] = case_config.get("request_rate", 0)
+    if "max_out_len" in case_config:
+        test_env["output_len"] = case_config["max_out_len"]
+    if "batch_size" in case_config:
+        test_env["Concurrency"] = case_config["batch_size"]
+    if "num_prompts" in case_config:
+        test_env["data_num"] = case_config["num_prompts"]
+    test_env["data_set"] = _extract_dataset_name(case_config)
+
+    testcase_info["extraTestEnv"] = {}
+
+    indicator: dict[str, Any] = {}
+    case_type = case_config.get("case_type")
+    if case_type == "accuracy":
+        if isinstance(result, (int, float)):
+            indicator["accuracy"] = round(float(result), 4)
+    elif case_type == "performance":
+        output_tps = _extract_output_tps(result)
+        if output_tps is not None:
+            indicator["output_tps"] = output_tps
+    testcase_info["testIndicator"] = indicator
+
+    return payload
+
+
+def _load_preset_json(preset_path: Path) -> dict[str, Any] | None:
+    if not preset_path.is_file():
+        print(f"Warning: Preset JSON not found, skip postprocess: {preset_path}")
+        return None
+    try:
+        return json.loads(preset_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Warning: Failed to read preset JSON {preset_path}: {exc}")
+        return None
+
+
+def _run_postprocess_script(script_path: Path, output_path: Path) -> None:
+    if not script_path.is_file():
+        print(f"Warning: Postprocess script not found, skip running: {script_path}")
+        return
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--label",
+        UPLOAD_LABEL,
+        "--files",
+        str(output_path),
+    ]
+    env = os.environ.copy()
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except OSError as exc:
+        print(f"Warning: Failed to run postprocess script {script_path}: {exc}")
+        return
+    if completed.stdout:
+        print(completed.stdout.rstrip())
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        print(
+            f"Warning: Postprocess script exited with code {completed.returncode} "
+            f"for {output_path}" + (f": {stderr}" if stderr else "")
+        )
+
+
+def postprocess_one_benchmark(
+    case_key: str,
+    case_config: dict[str, Any],
+    result: Any,
+    *,
+    job_name: str,
+    testcase_name: str | None = None,
+    preset_path: Path = PRESET_JSON_PATH,
+    script_path: Path | None = None,
+    output_dir: Path = OUTPUT_DIR,
+) -> Path | None:
+    """Read preset JSON, patch nested fields, write output JSON, and upload."""
+    if script_path is None:
+        script_path = POSTPROCESS_SCRIPT_PATH
+
+    preset = _load_preset_json(preset_path)
+    if preset is None:
+        return None
+
+    resolved_name = testcase_name or resolve_testcase_name(fallback=job_name)
+    payload = merge_postprocess_payload(
+        preset,
+        case_config,
+        result,
+        testcase_name=resolved_name,
+    )
+
+    safe_job = _safe_name(job_name or "benchmark")
+    safe_case = _safe_name(case_key)
+    output_path = output_dir / f"{safe_job}_{safe_case}.json"
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        print(f"Warning: Failed to write postprocess JSON {output_path}: {exc}")
+        return None
+
+    print(f"Postprocess JSON written to {output_path}")
+    _run_postprocess_script(script_path, output_path)
+    return output_path
+
+
+def postprocess_benchmark_results(
+    items: list[tuple[str, dict[str, Any], Any]],
+    *,
+    job_name: str,
+    testcase_name: str | None = None,
+    preset_path: Path = PRESET_JSON_PATH,
+    script_path: Path | None = None,
+    output_dir: Path = OUTPUT_DIR,
+) -> list[Path]:
+    """Post-process every (case_key, case_config, result) entry."""
+    resolved_name = testcase_name or resolve_testcase_name(fallback=job_name)
+    written: list[Path] = []
+    for case_key, case_config, result in items:
+        path = postprocess_one_benchmark(
+            case_key,
+            case_config,
+            result,
+            job_name=job_name,
+            testcase_name=resolved_name,
+            preset_path=preset_path,
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+        if path is not None:
+            written.append(path)
+    return written

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -21,7 +21,7 @@ For each accuracy/performance benchmark entry:
   1. Read a preset JSON template
   2. Patch nested testcase_info fields (preserve base_info)
   3. Write a new JSON file
-  4. Invoke an external Python script on that file
+  4. Upload via tools/upload_to_openlibing.py
 
 Missing preset/script files only emit warnings and never fail the test.
 """
@@ -30,58 +30,76 @@ from __future__ import annotations
 
 import copy
 import json
-import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
 PRESET_JSON_PATH = Path("/root/.cache/xxx/test.json")
-POSTPROCESS_SCRIPT_PATH = Path("/root/.cache/xxx/xxx.py")
 OUTPUT_DIR = Path("/root/.cache/xxx/results")
+UPLOAD_LABEL = "performance"
+_DATASET_PREFIX = "vllm-ascend/"
 
-PERF_METRIC_RENAME: dict[str, str] = {
-    "Benchmark Duration": "Benchmark_Duration(BD)",
-    "Prefill Token Throughput": "Prefill_Token_Throughput(PTT)",
-    "Input Token Throughput": "Input_Token_Throughput(ITT)",
-    "Output Token Throughput": "Output_Token_Throughput(OTT)",
-    "Total Token Throughput": "Total_Token_Throughput(TTT)",
-}
+
+def _default_upload_script_path() -> Path:
+    cwd_candidate = Path("tools/upload_to_openlibing.py")
+    if cwd_candidate.is_file():
+        return cwd_candidate.resolve()
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "tools" / "upload_to_openlibing.py"
+        if candidate.is_file():
+            return candidate
+    return cwd_candidate
+
+
+POSTPROCESS_SCRIPT_PATH = _default_upload_script_path()
 
 
 def _safe_name(name: str) -> str:
     return name.replace("/", "_").replace(" ", "_")
 
 
+def resolve_suite_name(config_base_path: str | None = None) -> str:
+    """Return 'weekly' or 'nightly' from CONFIG_BASE_PATH."""
+    base = config_base_path if config_base_path is not None else os.getenv("CONFIG_BASE_PATH", "")
+    normalized = base.replace("\\", "/")
+    return "weekly" if "weekly" in normalized else "nightly"
+
+
+def resolve_testcase_name(config_yaml_path: str | None = None, fallback: str = "") -> str:
+    """Return YAML stem from CONFIG_YAML_PATH (without .yaml/.yml)."""
+    raw = config_yaml_path if config_yaml_path is not None else os.getenv("CONFIG_YAML_PATH", "")
+    if not raw:
+        return fallback
+    name = Path(raw).name
+    for suffix in (".yaml", ".yml"):
+        if name.lower().endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
 def _extract_dataset_name(case_config: dict[str, Any]) -> str:
-    dataset_path = case_config.get("dataset_path", "")
-    dataset_conf = case_config.get("dataset_conf", "")
-    if dataset_path:
-        return dataset_path.split("/", 1)[-1]
-    if dataset_conf:
-        return dataset_conf.split("/")[0]
+    dataset_path = str(case_config.get("dataset_path", "") or "")
+    if dataset_path.startswith(_DATASET_PREFIX):
+        return dataset_path[len(_DATASET_PREFIX) :]
     return ""
 
 
-def _extract_perf_metrics(result: Any) -> dict[str, float]:
-    metrics: dict[str, float] = {}
+def _extract_output_tps(result: Any) -> float | None:
     if not (isinstance(result, list) and len(result) == 2):
-        return metrics
+        return None
     _, result_json = result
     if not isinstance(result_json, dict):
-        return metrics
-    for metric_name, metric_data in result_json.items():
-        if not isinstance(metric_data, dict):
-            continue
-        total_str = metric_data.get("total", "")
-        try:
-            value = float(str(total_str).replace("token/s", "").replace("ms", "").replace("s", "").strip())
-            metrics[PERF_METRIC_RENAME.get(metric_name, metric_name)] = round(value, 4)
-        except (ValueError, AttributeError):
-            continue
-    return metrics
+        return None
+    metric = result_json.get("Output Token Throughput", {})
+    if not isinstance(metric, dict):
+        return None
+    total_str = metric.get("total", "")
+    try:
+        return round(float(str(total_str).replace("token/s", "").strip()), 4)
+    except (ValueError, AttributeError):
+        return None
 
 
 def merge_postprocess_payload(
@@ -89,21 +107,18 @@ def merge_postprocess_payload(
     case_config: dict[str, Any],
     result: Any,
     *,
-    model_name: str,
+    testcase_name: str,
+    suite_name: str | None = None,
 ) -> dict[str, Any]:
-    """Deep-copy preset and patch nested fields per the preset JSON schema.
-
-    Hierarchy follows:
-      testcase_info.featureFullName / testEnv / extraTestEnv / testIndicator
-      base_info (left unchanged)
-    """
+    """Deep-copy preset and patch nested fields per the preset JSON schema."""
     payload = copy.deepcopy(preset)
     testcase_info = payload.setdefault("testcase_info", {})
     if not isinstance(testcase_info, dict):
         testcase_info = {}
         payload["testcase_info"] = testcase_info
 
-    testcase_info["featureFullName"] = model_name
+    testcase_info["featureFullName"] = suite_name or resolve_suite_name()
+    testcase_info["Testcase_Name"] = testcase_name
 
     test_env = testcase_info.get("testEnv")
     if not isinstance(test_env, dict):
@@ -117,22 +132,19 @@ def merge_postprocess_payload(
         test_env["Concurrency"] = case_config["batch_size"]
     if "num_prompts" in case_config:
         test_env["data_num"] = case_config["num_prompts"]
-
-    case_type = case_config.get("case_type")
-    if case_type == "accuracy":
-        test_env["data_set"] = _extract_dataset_name(case_config)
-    else:
-        # Performance cases leave data_set empty.
-        test_env["data_set"] = ""
+    test_env["data_set"] = _extract_dataset_name(case_config)
 
     testcase_info["extraTestEnv"] = {}
 
     indicator: dict[str, Any] = {}
+    case_type = case_config.get("case_type")
     if case_type == "accuracy":
         if isinstance(result, (int, float)):
             indicator["accuracy"] = round(float(result), 4)
     elif case_type == "performance":
-        indicator.update(_extract_perf_metrics(result))
+        output_tps = _extract_output_tps(result)
+        if output_tps is not None:
+            indicator["output_tps"] = output_tps
     testcase_info["testIndicator"] = indicator
 
     return payload
@@ -140,36 +152,44 @@ def merge_postprocess_payload(
 
 def _load_preset_json(preset_path: Path) -> dict[str, Any] | None:
     if not preset_path.is_file():
-        logger.warning("Preset JSON not found, skip postprocess: %s", preset_path)
+        print(f"Warning: Preset JSON not found, skip postprocess: {preset_path}")
         return None
     try:
         return json.loads(preset_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("Failed to read preset JSON %s: %s", preset_path, exc)
+        print(f"Warning: Failed to read preset JSON {preset_path}: {exc}")
         return None
 
 
 def _run_postprocess_script(script_path: Path, output_path: Path) -> None:
     if not script_path.is_file():
-        logger.warning("Postprocess script not found, skip running: %s", script_path)
+        print(f"Warning: Postprocess script not found, skip running: {script_path}")
         return
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--label",
+        UPLOAD_LABEL,
+        "--files",
+        str(output_path),
+    ]
     try:
         completed = subprocess.run(
-            [sys.executable, str(script_path), str(output_path)],
+            cmd,
             check=False,
             capture_output=True,
             text=True,
         )
     except OSError as exc:
-        logger.warning("Failed to run postprocess script %s: %s", script_path, exc)
+        print(f"Warning: Failed to run postprocess script {script_path}: {exc}")
         return
+    if completed.stdout:
+        print(completed.stdout.rstrip())
     if completed.returncode != 0:
         stderr = (completed.stderr or "").strip()
-        logger.warning(
-            "Postprocess script exited with code %s for %s%s",
-            completed.returncode,
-            output_path,
-            f": {stderr}" if stderr else "",
+        print(
+            f"Warning: Postprocess script exited with code {completed.returncode} "
+            f"for {output_path}" + (f": {stderr}" if stderr else "")
         )
 
 
@@ -179,21 +199,25 @@ def postprocess_one_benchmark(
     result: Any,
     *,
     job_name: str,
-    model_name: str,
+    testcase_name: str | None = None,
     preset_path: Path = PRESET_JSON_PATH,
-    script_path: Path = POSTPROCESS_SCRIPT_PATH,
+    script_path: Path | None = None,
     output_dir: Path = OUTPUT_DIR,
 ) -> Path | None:
-    """Read preset JSON, patch nested fields, write output JSON, and run xxx.py."""
+    """Read preset JSON, patch nested fields, write output JSON, and upload."""
+    if script_path is None:
+        script_path = POSTPROCESS_SCRIPT_PATH
+
     preset = _load_preset_json(preset_path)
     if preset is None:
         return None
 
+    resolved_name = testcase_name or resolve_testcase_name(fallback=job_name)
     payload = merge_postprocess_payload(
         preset,
         case_config,
         result,
-        model_name=model_name,
+        testcase_name=resolved_name,
     )
 
     safe_job = _safe_name(job_name or "benchmark")
@@ -203,10 +227,10 @@ def postprocess_one_benchmark(
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     except OSError as exc:
-        logger.warning("Failed to write postprocess JSON %s: %s", output_path, exc)
+        print(f"Warning: Failed to write postprocess JSON {output_path}: {exc}")
         return None
 
-    logger.info("Postprocess JSON written to %s", output_path)
+    print(f"Postprocess JSON written to {output_path}")
     _run_postprocess_script(script_path, output_path)
     return output_path
 
@@ -215,12 +239,13 @@ def postprocess_benchmark_results(
     items: list[tuple[str, dict[str, Any], Any]],
     *,
     job_name: str,
-    model_name: str,
+    testcase_name: str | None = None,
     preset_path: Path = PRESET_JSON_PATH,
-    script_path: Path = POSTPROCESS_SCRIPT_PATH,
+    script_path: Path | None = None,
     output_dir: Path = OUTPUT_DIR,
 ) -> list[Path]:
     """Post-process every (case_key, case_config, result) entry."""
+    resolved_name = testcase_name or resolve_testcase_name(fallback=job_name)
     written: list[Path] = []
     for case_key, case_config, result in items:
         path = postprocess_one_benchmark(
@@ -228,7 +253,7 @@ def postprocess_benchmark_results(
             case_config,
             result,
             job_name=job_name,
-            model_name=model_name,
+            testcase_name=resolved_name,
             preset_path=preset_path,
             script_path=script_path,
             output_dir=output_dir,

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Post-process nightly/weekly benchmark results into per-case JSON files.
+
+For each accuracy/performance benchmark entry:
+  1. Read a preset JSON template
+  2. Patch nested testcase_info fields (preserve base_info)
+  3. Write a new JSON file
+  4. Invoke an external Python script on that file
+
+Missing preset/script files only emit warnings and never fail the test.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PRESET_JSON_PATH = Path("/root/.cache/xxx/test.json")
+POSTPROCESS_SCRIPT_PATH = Path("/root/.cache/xxx/xxx.py")
+OUTPUT_DIR = Path("/root/.cache/xxx/results")
+
+PERF_METRIC_RENAME: dict[str, str] = {
+    "Benchmark Duration": "Benchmark_Duration(BD)",
+    "Prefill Token Throughput": "Prefill_Token_Throughput(PTT)",
+    "Input Token Throughput": "Input_Token_Throughput(ITT)",
+    "Output Token Throughput": "Output_Token_Throughput(OTT)",
+    "Total Token Throughput": "Total_Token_Throughput(TTT)",
+}
+
+
+def _safe_name(name: str) -> str:
+    return name.replace("/", "_").replace(" ", "_")
+
+
+def _extract_dataset_name(case_config: dict[str, Any]) -> str:
+    dataset_path = case_config.get("dataset_path", "")
+    dataset_conf = case_config.get("dataset_conf", "")
+    if dataset_path:
+        return dataset_path.split("/", 1)[-1]
+    if dataset_conf:
+        return dataset_conf.split("/")[0]
+    return ""
+
+
+def _extract_perf_metrics(result: Any) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    if not (isinstance(result, list) and len(result) == 2):
+        return metrics
+    _, result_json = result
+    if not isinstance(result_json, dict):
+        return metrics
+    for metric_name, metric_data in result_json.items():
+        if not isinstance(metric_data, dict):
+            continue
+        total_str = metric_data.get("total", "")
+        try:
+            value = float(str(total_str).replace("token/s", "").replace("ms", "").replace("s", "").strip())
+            metrics[PERF_METRIC_RENAME.get(metric_name, metric_name)] = round(value, 4)
+        except (ValueError, AttributeError):
+            continue
+    return metrics
+
+
+def merge_postprocess_payload(
+    preset: dict[str, Any],
+    case_config: dict[str, Any],
+    result: Any,
+    *,
+    model_name: str,
+) -> dict[str, Any]:
+    """Deep-copy preset and patch nested fields per the preset JSON schema.
+
+    Hierarchy follows:
+      testcase_info.featureFullName / testEnv / extraTestEnv / testIndicator
+      base_info (left unchanged)
+    """
+    payload = copy.deepcopy(preset)
+    testcase_info = payload.setdefault("testcase_info", {})
+    if not isinstance(testcase_info, dict):
+        testcase_info = {}
+        payload["testcase_info"] = testcase_info
+
+    testcase_info["featureFullName"] = model_name
+
+    test_env = testcase_info.get("testEnv")
+    if not isinstance(test_env, dict):
+        test_env = {}
+        testcase_info["testEnv"] = test_env
+
+    test_env["request_rate"] = case_config.get("request_rate", 0)
+    if "max_out_len" in case_config:
+        test_env["output_len"] = case_config["max_out_len"]
+    if "batch_size" in case_config:
+        test_env["Concurrency"] = case_config["batch_size"]
+    if "num_prompts" in case_config:
+        test_env["data_num"] = case_config["num_prompts"]
+
+    case_type = case_config.get("case_type")
+    if case_type == "accuracy":
+        test_env["data_set"] = _extract_dataset_name(case_config)
+    else:
+        # Performance cases leave data_set empty.
+        test_env["data_set"] = ""
+
+    testcase_info["extraTestEnv"] = {}
+
+    indicator: dict[str, Any] = {}
+    if case_type == "accuracy":
+        if isinstance(result, (int, float)):
+            indicator["accuracy"] = round(float(result), 4)
+    elif case_type == "performance":
+        indicator.update(_extract_perf_metrics(result))
+    testcase_info["testIndicator"] = indicator
+
+    return payload
+
+
+def _load_preset_json(preset_path: Path) -> dict[str, Any] | None:
+    if not preset_path.is_file():
+        logger.warning("Preset JSON not found, skip postprocess: %s", preset_path)
+        return None
+    try:
+        return json.loads(preset_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read preset JSON %s: %s", preset_path, exc)
+        return None
+
+
+def _run_postprocess_script(script_path: Path, output_path: Path) -> None:
+    if not script_path.is_file():
+        logger.warning("Postprocess script not found, skip running: %s", script_path)
+        return
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(script_path), str(output_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        logger.warning("Failed to run postprocess script %s: %s", script_path, exc)
+        return
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        logger.warning(
+            "Postprocess script exited with code %s for %s%s",
+            completed.returncode,
+            output_path,
+            f": {stderr}" if stderr else "",
+        )
+
+
+def postprocess_one_benchmark(
+    case_key: str,
+    case_config: dict[str, Any],
+    result: Any,
+    *,
+    job_name: str,
+    model_name: str,
+    preset_path: Path = PRESET_JSON_PATH,
+    script_path: Path = POSTPROCESS_SCRIPT_PATH,
+    output_dir: Path = OUTPUT_DIR,
+) -> Path | None:
+    """Read preset JSON, patch nested fields, write output JSON, and run xxx.py."""
+    preset = _load_preset_json(preset_path)
+    if preset is None:
+        return None
+
+    payload = merge_postprocess_payload(
+        preset,
+        case_config,
+        result,
+        model_name=model_name,
+    )
+
+    safe_job = _safe_name(job_name or "benchmark")
+    safe_case = _safe_name(case_key)
+    output_path = output_dir / f"{safe_job}_{safe_case}.json"
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Failed to write postprocess JSON %s: %s", output_path, exc)
+        return None
+
+    logger.info("Postprocess JSON written to %s", output_path)
+    _run_postprocess_script(script_path, output_path)
+    return output_path
+
+
+def postprocess_benchmark_results(
+    items: list[tuple[str, dict[str, Any], Any]],
+    *,
+    job_name: str,
+    model_name: str,
+    preset_path: Path = PRESET_JSON_PATH,
+    script_path: Path = POSTPROCESS_SCRIPT_PATH,
+    output_dir: Path = OUTPUT_DIR,
+) -> list[Path]:
+    """Post-process every (case_key, case_config, result) entry."""
+    written: list[Path] = []
+    for case_key, case_config, result in items:
+        path = postprocess_one_benchmark(
+            case_key,
+            case_config,
+            result,
+            job_name=job_name,
+            model_name=model_name,
+            preset_path=preset_path,
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+        if path is not None:
+            written.append(path)
+    return written

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -13,6 +13,7 @@ import pytest
 import vllm
 
 from tests.e2e.conftest import DisaggEpdProxy, RemoteEPDServer, RemoteOpenAIServer
+from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
 from tests.e2e.nightly.single_node.models.scripts.single_node_config import (
     SingleNodeConfig,
     SingleNodeConfigLoader,
@@ -381,6 +382,11 @@ def _save_benchmark_results_json(config: SingleNodeConfig, benchmark_keys: list[
         json.dump(output, f, indent=2, ensure_ascii=False)
     logger.info("Benchmark results saved to %s", output_path)
     print(f"Benchmark results saved to {output_path}")
+
+    postprocess_benchmark_results(
+        list(zip(benchmark_keys, case_configs, results)),
+        job_name=job_name,
+    )
 
 
 def _run_benchmarks(config: SingleNodeConfig, port: int) -> None:

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -386,7 +386,6 @@ def _save_benchmark_results_json(config: SingleNodeConfig, benchmark_keys: list[
     postprocess_benchmark_results(
         list(zip(benchmark_keys, case_configs, results)),
         job_name=job_name,
-        model_name=config.model,
     )
 
 

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -13,6 +13,7 @@ import pytest
 import vllm
 
 from tests.e2e.conftest import DisaggEpdProxy, RemoteEPDServer, RemoteOpenAIServer
+from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
 from tests.e2e.nightly.single_node.models.scripts.single_node_config import (
     SingleNodeConfig,
     SingleNodeConfigLoader,
@@ -381,6 +382,12 @@ def _save_benchmark_results_json(config: SingleNodeConfig, benchmark_keys: list[
         json.dump(output, f, indent=2, ensure_ascii=False)
     logger.info("Benchmark results saved to %s", output_path)
     print(f"Benchmark results saved to {output_path}")
+
+    postprocess_benchmark_results(
+        list(zip(benchmark_keys, case_configs, results)),
+        job_name=job_name,
+        model_name=config.model,
+    )
 
 
 def _run_benchmarks(config: SingleNodeConfig, port: int) -> None:

--- a/tools/upload_to_openlibing.py
+++ b/tools/upload_to_openlibing.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import mimetypes
+import os
+from contextlib import ExitStack
+from pathlib import Path
+
+import requests
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", handlers=[logging.StreamHandler()]
+)
+logger = logging.getLogger(__name__)
+
+# Default OpenLibing upload URL
+DEFAULT_UPLOAD_URL = "https://apig.openlibing.com/openlibing-sync/sync/testcase/metadata/upload"
+
+
+def _process_json_param(param: str) -> dict:
+    """
+    Process JSON parameter that may be in simplified format (without quotes).
+
+    Supports both:
+    - Standard JSON: {"key": "value", ...}
+    - Simplified format: {key: value, ...} or {key:value,key:value}
+
+    Args:
+        param: Input string to process
+
+    Returns:
+        Dict: Parsed JSON dictionary, empty dict if parsing fails
+    """
+    try:
+        if param and param.find('"') == -1:
+            inner = param.strip("{}")
+            pairs = [p.strip() for p in inner.split(",")]
+            json_pairs = []
+            for pair in pairs:
+                if ":" in pair:
+                    k, v = pair.split(":", 1)
+                    json_pairs.append(f'"{k.strip()}":"{v.strip()}"')
+            tmp_secret = "{" + ",".join(json_pairs) + "}"
+            parsed: dict = json.loads(tmp_secret)
+        else:
+            parsed = json.loads(param)
+    except Exception as e:
+        logger.info("process special json err: %s", e, exc_info=True)
+        parsed = {}
+
+    return parsed
+
+
+def upload_data_to_openlibing(
+    file_paths: list[Path],
+    openlibing_secret: dict[str, str],
+    upload_config: dict[str, str] | None = None,
+) -> requests.Response:
+    """
+    Upload files to OpenLibing OBS bucket.
+
+    Args:
+        file_paths: List of file paths to upload
+        openlibing_secret: Dictionary containing apig_code, apig_key, apig_secret
+        upload_config: Configuration dictionary containing:
+            - pipeline_id: Pipeline ID (optional)
+            - pipeline_run_id: Pipeline run ID (optional)
+            - job_id: Job ID (optional)
+            - url: Upload URL (default: OpenLibing production URL)
+            - label: Optional label string for identifying this upload
+            - archive_path: Custom archive path, must be used with label
+
+    Returns:
+        requests.Response: The HTTP response object from the upload request
+
+    Raises:
+        FileNotFoundError: If no valid files to upload
+        Exception: If upload fails
+    """
+    upload_config = upload_config or {}
+
+    pipeline_id = upload_config.get("pipeline_id", "")
+    pipeline_run_id = upload_config.get("pipeline_run_id", "")
+    job_id = upload_config.get("job_id", "")
+    url = upload_config.get("url", DEFAULT_UPLOAD_URL)
+    label = upload_config.get("label", "")
+    archive_path = upload_config.get("archive_path", "")
+    label_info = f" (label: {label})" if label else ""
+    logger.info("Uploading %s files to OpenLibing%s", len(file_paths), label_info)
+
+    if not file_paths:
+        raise FileNotFoundError("No files to upload")
+
+    headers = {
+        "X-Apig-Appcode": openlibing_secret.get("apig_code", ""),
+        "AppKey": openlibing_secret.get("apig_key", ""),
+        "AppSecret": openlibing_secret.get("apig_secret", ""),
+        "User-Agent": "Python-requests/2.25.0",
+    }
+
+    form_data = {}
+    if pipeline_id:
+        form_data["pipelineId"] = pipeline_id
+    if pipeline_run_id:
+        form_data["pipelineRunId"] = pipeline_run_id
+    if job_id:
+        form_data["jobId"] = job_id
+
+    archive_config = {}
+    if label:
+        archive_config["label"] = label
+    if archive_path:
+        archive_config["archivePath"] = archive_path
+    if archive_config:
+        form_data["archiveConfig"] = json.dumps(archive_config)
+
+    try:
+        with ExitStack() as stack:
+            files_for_upload = []
+            for file_path in file_paths:
+                if not file_path.exists():
+                    logger.warning("File not found, skipping: %s", file_path)
+                    continue
+
+                f = stack.enter_context(open(file_path, "rb"))
+                mime_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+                files_for_upload.append(("files", (file_path.name, f, mime_type)))
+
+            if not files_for_upload:
+                raise FileNotFoundError("No valid files to upload")
+
+            logger.info("Uploading %s files to %s", len(files_for_upload), url)
+
+            response = requests.post(
+                url=url,
+                headers=headers,
+                data=form_data,
+                files=files_for_upload,
+                verify=False,
+            )
+
+            logger.info("Upload response status: %s", response.status_code)
+            logger.info("Upload response text: %s", response.text)
+
+            response.raise_for_status()
+
+            logger.info("Successfully uploaded files to OpenLibing")
+
+            return response
+
+    except Exception:
+        logger.exception("Failed to upload files to OpenLibing")
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload files to OpenLibing OBS bucket", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--files", nargs="+", required=True, type=Path, help="List of file paths to upload (supports any file type)"
+    )
+
+    parser.add_argument("--pipeline-id", default="", help="Pipeline ID (optional)")
+
+    parser.add_argument("--pipeline-run-id", default="", help="Pipeline run ID (optional)")
+
+    parser.add_argument("--job-id", default="", help="Job ID (optional)")
+
+    parser.add_argument(
+        "--label",
+        default="",
+        help="Label string. Can be used alone (archive path: /{label}/{filename}) "
+        "or with --archive-path (archive path: /{label}/{archive_path}/{filename}).",
+    )
+
+    parser.add_argument(
+        "--archive-path",
+        default="",
+        help="Custom archive path, must be used with --label. "
+        "Archive path becomes /{label}/{archive_path}/{filename}. "
+        "Can be used together with --pipeline-id/--pipeline-run-id/--job-id, "
+        "in which case --archive-path takes precedence. "
+        "Must provide at least --label or pipeline params.",
+    )
+
+    parser.add_argument(
+        "--openlibing-secret",
+        default="",
+        help="JSON string containing apig_code, apig_key, apig_secret. "
+        'Supports both standard JSON format {"key": "value"} and '
+        "simplified format {key: value} without quotes. "
+        "If not provided, reads from environment variable OPENLIBING_SECRET. "
+        "Errors if neither is available.",
+    )
+
+    parser.add_argument("--url", default=DEFAULT_UPLOAD_URL, help=f"Upload URL (default: {DEFAULT_UPLOAD_URL})")
+
+    args = parser.parse_args()
+
+    try:
+        has_archive_path = bool(args.archive_path)
+        has_label = bool(args.label)
+        has_pipeline_params = bool(args.pipeline_id or args.pipeline_run_id or args.job_id)
+
+        if has_archive_path and not has_label:
+            parser.error("--archive-path requires --label")
+        if not has_label and not has_pipeline_params:
+            parser.error("must provide either --label or --pipeline-id/--pipeline-run-id/--job-id")
+
+        secret_raw = args.openlibing_secret or os.environ.get("OPENLIBING_SECRET", "")
+        if not secret_raw:
+            logger.error("openlibing-secret not provided via --openlibing-secret or OPENLIBING_SECRET env var")
+            exit(1)
+
+        openlibing_secret = _process_json_param(secret_raw)
+
+        if not openlibing_secret:
+            logger.error("Failed to parse openlibing-secret")
+            exit(1)
+
+        response = upload_data_to_openlibing(
+            file_paths=args.files,
+            openlibing_secret=openlibing_secret,
+            upload_config={
+                "pipeline_id": args.pipeline_id,
+                "pipeline_run_id": args.pipeline_run_id,
+                "job_id": args.job_id,
+                "url": args.url,
+                "label": args.label,
+                "archive_path": args.archive_path,
+            },
+        )
+
+        logger.info("=== Upload Response Details ===")
+        logger.info("Status Code: %s", response.status_code)
+        logger.info("Content-Type: %s", response.headers.get("Content-Type", "N/A"))
+        logger.info("Response Text: %s", response.text)
+        logger.info("===============================")
+
+    except Exception as e:
+        logger.error("Upload failed: %s", e)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/upload_to_openlibing.py
+++ b/tools/upload_to_openlibing.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import mimetypes
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import requests
+
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler()]
+)
+logger = logging.getLogger(__name__)
+
+# Default OpenLibing upload URL
+DEFAULT_UPLOAD_URL = "https://apig.openlibing.com/openlibing-sync/sync/testcase/metadata/upload"
+
+
+def _process_json_param(param: str) -> Dict:
+    """
+    Process JSON parameter that may be in simplified format (without quotes).
+    
+    Supports both:
+    - Standard JSON: {"key": "value", ...}
+    - Simplified format: {key: value, ...} or {key:value,key:value}
+    
+    Args:
+        param: Input string to process
+        
+    Returns:
+        Dict: Parsed JSON dictionary, empty dict if parsing fails
+    """
+    try:
+        if param and param.find('"') == -1:
+            inner = param.strip('{}')
+            pairs = [p.strip() for p in inner.split(',')]
+            json_pairs = []
+            for pair in pairs:
+                if ':' in pair:
+                    k, v = pair.split(':', 1)
+                    json_pairs.append(f'"{k.strip()}":"{v.strip()}"')
+            tmp_secret = '{' + ','.join(json_pairs) + '}'
+            param: dict = json.loads(tmp_secret)
+        else:
+            param: dict = json.loads(param)
+    except Exception as e:
+        logger.info(f"process special json err: {e}", exc_info=True)
+        param = {}
+
+    return param
+
+
+def upload_data_to_openlibing(
+    file_paths: List[Path],
+    openlibing_secret: Dict[str, str],
+    upload_config: Dict[str, str] = None
+) -> requests.Response:
+    """
+    Upload files to OpenLibing OBS bucket.
+
+    Args:
+        file_paths: List of file paths to upload
+        openlibing_secret: Dictionary containing apig_code, apig_key, apig_secret
+        upload_config: Configuration dictionary containing:
+            - pipeline_id: Pipeline ID (optional)
+            - pipeline_run_id: Pipeline run ID (optional)
+            - job_id: Job ID (optional)
+            - url: Upload URL (default: OpenLibing production URL)
+            - label: Optional label string for identifying this upload
+            - archive_path: Custom archive path, must be used with label
+
+    Returns:
+        requests.Response: The HTTP response object from the upload request
+
+    Raises:
+        FileNotFoundError: If no valid files to upload
+        Exception: If upload fails
+    """
+    upload_config = upload_config or {}
+
+    pipeline_id = upload_config.get("pipeline_id", "")
+    pipeline_run_id = upload_config.get("pipeline_run_id", "")
+    job_id = upload_config.get("job_id", "")
+    url = upload_config.get("url", DEFAULT_UPLOAD_URL)
+    label = upload_config.get("label", "")
+    archive_path = upload_config.get("archive_path", "")
+    label_info = f" (label: {label})" if label else ""
+    logger.info(f"Uploading {len(file_paths)} files to OpenLibing{label_info}")
+    
+    if not file_paths:
+        raise FileNotFoundError("No files to upload")
+
+    headers = {
+        "X-Apig-Appcode": openlibing_secret.get("apig_code", ""),
+        "AppKey": openlibing_secret.get("apig_key", ""),
+        "AppSecret": openlibing_secret.get("apig_secret", ""),
+        "User-Agent": "Python-requests/2.25.0",
+    }
+
+    form_data = {}
+    if pipeline_id:
+        form_data["pipelineId"] = pipeline_id
+    if pipeline_run_id:
+        form_data["pipelineRunId"] = pipeline_run_id
+    if job_id:
+        form_data["jobId"] = job_id
+
+    archive_config = {}
+    if label:
+        archive_config["label"] = label
+    if archive_path:
+        archive_config["archivePath"] = archive_path
+    if archive_config:
+        form_data["archiveConfig"] = json.dumps(archive_config)
+
+    opened_files = []
+    files_for_upload = []
+
+    try:
+        for file_path in file_paths:
+            if not file_path.exists():
+                logger.warning(f"File not found, skipping: {file_path}")
+                continue
+
+            f = open(file_path, 'rb')
+            opened_files.append(f)
+
+            mime_type = mimetypes.guess_type(file_path.name)[0] or 'application/octet-stream'
+
+            files_for_upload.append((
+                'files',
+                (file_path.name, f, mime_type)
+            ))
+
+        if not files_for_upload:
+            raise FileNotFoundError("No valid files to upload")
+
+        logger.info(f"Uploading {len(files_for_upload)} files to {url}")
+        
+        response = requests.post(
+            url=url,
+            headers=headers,
+            data=form_data,
+            files=files_for_upload,
+            verify=False,
+        )
+
+        logger.info(f"Upload response status: {response.status_code}")
+        logger.info(f"Upload response text: {response.text}")
+
+        response.raise_for_status()
+        
+        logger.info("Successfully uploaded files to OpenLibing")
+        
+        return response
+
+    except Exception as e:
+        logger.error(f"Failed to upload files to OpenLibing: {e}", exc_info=True)
+        raise
+
+    finally:
+        for f in opened_files:
+            try:
+                f.close()
+            except Exception as close_err:
+                logger.warning(f"Failed to close file: {close_err}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload files to OpenLibing OBS bucket",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    
+    parser.add_argument(
+        "--files",
+        nargs='+',
+        required=True,
+        type=Path,
+        help="List of file paths to upload (supports any file type)"
+    )
+    
+    parser.add_argument(
+        "--pipeline-id",
+        default="",
+        help="Pipeline ID (optional)"
+    )
+    
+    parser.add_argument(
+        "--pipeline-run-id",
+        default="",
+        help="Pipeline run ID (optional)"
+    )
+    
+    parser.add_argument(
+        "--job-id",
+        default="",
+        help="Job ID (optional)"
+    )
+    
+    parser.add_argument(
+        "--label",
+        default="",
+        help="Label string. Can be used alone (archive path: /{label}/{filename}) "
+             "or with --archive-path (archive path: /{label}/{archive_path}/{filename})."
+    )
+    
+    parser.add_argument(
+        "--archive-path",
+        default="",
+        help="Custom archive path, must be used with --label. "
+             "Archive path becomes /{label}/{archive_path}/{filename}. "
+             "Can be used together with --pipeline-id/--pipeline-run-id/--job-id, "
+             "in which case --archive-path takes precedence. "
+             "Must provide at least --label or pipeline params."
+    )
+    
+    parser.add_argument(
+        "--openlibing-secret",
+        default="",
+        help="JSON string containing apig_code, apig_key, apig_secret. "
+             "Supports both standard JSON format {\"key\": \"value\"} and "
+             "simplified format {key: value} without quotes. "
+             "If not provided, reads from environment variable OPENLIBING_SECRET. "
+             "Errors if neither is available."
+    )
+    
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_UPLOAD_URL,
+        help=f"Upload URL (default: {DEFAULT_UPLOAD_URL})"
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        has_archive_path = bool(args.archive_path)
+        has_label = bool(args.label)
+        has_pipeline_params = bool(args.pipeline_id or args.pipeline_run_id or args.job_id)
+
+        if has_archive_path and not has_label:
+            parser.error("--archive-path requires --label")
+        if not has_label and not has_pipeline_params:
+            parser.error("must provide either --label or --pipeline-id/--pipeline-run-id/--job-id")
+
+        secret_raw = args.openlibing_secret or os.environ.get("OPENLIBING_SECRET", "")
+        if not secret_raw:
+            logger.error("openlibing-secret not provided via --openlibing-secret or OPENLIBING_SECRET env var")
+            exit(1)
+
+        openlibing_secret = _process_json_param(secret_raw)
+        
+        if not openlibing_secret:
+            logger.error("Failed to parse openlibing-secret")
+            exit(1)
+            
+        response = upload_data_to_openlibing(
+            file_paths=args.files,
+            openlibing_secret=openlibing_secret,
+            upload_config={
+                "pipeline_id": args.pipeline_id,
+                "pipeline_run_id": args.pipeline_run_id,
+                "job_id": args.job_id,
+                "url": args.url,
+                "label": args.label,
+                "archive_path": args.archive_path
+            }
+        )
+        
+        logger.info("=== Upload Response Details ===")
+        logger.info(f"Status Code: {response.status_code}")
+        logger.info(f"Content-Type: {response.headers.get('Content-Type', 'N/A')}")
+        logger.info(f"Response Text: {response.text}")
+        logger.info("===============================")
+        
+    except Exception as e:
+        logger.error(f"Upload failed: {e}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/upload_to_openlibing.py
+++ b/tools/upload_to_openlibing.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
 import mimetypes
 import os
+from contextlib import ExitStack
 from pathlib import Path
-from typing import List, Dict
 
 import requests
 
-
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler()]
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", handlers=[logging.StreamHandler()]
 )
 logger = logging.getLogger(__name__)
 
@@ -23,44 +22,44 @@ logger = logging.getLogger(__name__)
 DEFAULT_UPLOAD_URL = "https://apig.openlibing.com/openlibing-sync/sync/testcase/metadata/upload"
 
 
-def _process_json_param(param: str) -> Dict:
+def _process_json_param(param: str) -> dict:
     """
     Process JSON parameter that may be in simplified format (without quotes).
-    
+
     Supports both:
     - Standard JSON: {"key": "value", ...}
     - Simplified format: {key: value, ...} or {key:value,key:value}
-    
+
     Args:
         param: Input string to process
-        
+
     Returns:
         Dict: Parsed JSON dictionary, empty dict if parsing fails
     """
     try:
         if param and param.find('"') == -1:
-            inner = param.strip('{}')
-            pairs = [p.strip() for p in inner.split(',')]
+            inner = param.strip("{}")
+            pairs = [p.strip() for p in inner.split(",")]
             json_pairs = []
             for pair in pairs:
-                if ':' in pair:
-                    k, v = pair.split(':', 1)
+                if ":" in pair:
+                    k, v = pair.split(":", 1)
                     json_pairs.append(f'"{k.strip()}":"{v.strip()}"')
-            tmp_secret = '{' + ','.join(json_pairs) + '}'
-            param: dict = json.loads(tmp_secret)
+            tmp_secret = "{" + ",".join(json_pairs) + "}"
+            parsed: dict = json.loads(tmp_secret)
         else:
-            param: dict = json.loads(param)
+            parsed = json.loads(param)
     except Exception as e:
-        logger.info(f"process special json err: {e}", exc_info=True)
-        param = {}
+        logger.info("process special json err: %s", e, exc_info=True)
+        parsed = {}
 
-    return param
+    return parsed
 
 
 def upload_data_to_openlibing(
-    file_paths: List[Path],
-    openlibing_secret: Dict[str, str],
-    upload_config: Dict[str, str] = None
+    file_paths: list[Path],
+    openlibing_secret: dict[str, str],
+    upload_config: dict[str, str] | None = None,
 ) -> requests.Response:
     """
     Upload files to OpenLibing OBS bucket.
@@ -92,8 +91,8 @@ def upload_data_to_openlibing(
     label = upload_config.get("label", "")
     archive_path = upload_config.get("archive_path", "")
     label_info = f" (label: {label})" if label else ""
-    logger.info(f"Uploading {len(file_paths)} files to OpenLibing{label_info}")
-    
+    logger.info("Uploading %s files to OpenLibing%s", len(file_paths), label_info)
+
     if not file_paths:
         raise FileNotFoundError("No files to upload")
 
@@ -120,126 +119,91 @@ def upload_data_to_openlibing(
     if archive_config:
         form_data["archiveConfig"] = json.dumps(archive_config)
 
-    opened_files = []
-    files_for_upload = []
-
     try:
-        for file_path in file_paths:
-            if not file_path.exists():
-                logger.warning(f"File not found, skipping: {file_path}")
-                continue
+        with ExitStack() as stack:
+            files_for_upload = []
+            for file_path in file_paths:
+                if not file_path.exists():
+                    logger.warning("File not found, skipping: %s", file_path)
+                    continue
 
-            f = open(file_path, 'rb')
-            opened_files.append(f)
+                f = stack.enter_context(open(file_path, "rb"))
+                mime_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+                files_for_upload.append(("files", (file_path.name, f, mime_type)))
 
-            mime_type = mimetypes.guess_type(file_path.name)[0] or 'application/octet-stream'
+            if not files_for_upload:
+                raise FileNotFoundError("No valid files to upload")
 
-            files_for_upload.append((
-                'files',
-                (file_path.name, f, mime_type)
-            ))
+            logger.info("Uploading %s files to %s", len(files_for_upload), url)
 
-        if not files_for_upload:
-            raise FileNotFoundError("No valid files to upload")
+            response = requests.post(
+                url=url,
+                headers=headers,
+                data=form_data,
+                files=files_for_upload,
+                verify=False,
+            )
 
-        logger.info(f"Uploading {len(files_for_upload)} files to {url}")
-        
-        response = requests.post(
-            url=url,
-            headers=headers,
-            data=form_data,
-            files=files_for_upload,
-            verify=False,
-        )
+            logger.info("Upload response status: %s", response.status_code)
+            logger.info("Upload response text: %s", response.text)
 
-        logger.info(f"Upload response status: {response.status_code}")
-        logger.info(f"Upload response text: {response.text}")
+            response.raise_for_status()
 
-        response.raise_for_status()
-        
-        logger.info("Successfully uploaded files to OpenLibing")
-        
-        return response
+            logger.info("Successfully uploaded files to OpenLibing")
 
-    except Exception as e:
-        logger.error(f"Failed to upload files to OpenLibing: {e}", exc_info=True)
+            return response
+
+    except Exception:
+        logger.exception("Failed to upload files to OpenLibing")
         raise
-
-    finally:
-        for f in opened_files:
-            try:
-                f.close()
-            except Exception as close_err:
-                logger.warning(f"Failed to close file: {close_err}")
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Upload files to OpenLibing OBS bucket",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description="Upload files to OpenLibing OBS bucket", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    
+
     parser.add_argument(
-        "--files",
-        nargs='+',
-        required=True,
-        type=Path,
-        help="List of file paths to upload (supports any file type)"
+        "--files", nargs="+", required=True, type=Path, help="List of file paths to upload (supports any file type)"
     )
-    
-    parser.add_argument(
-        "--pipeline-id",
-        default="",
-        help="Pipeline ID (optional)"
-    )
-    
-    parser.add_argument(
-        "--pipeline-run-id",
-        default="",
-        help="Pipeline run ID (optional)"
-    )
-    
-    parser.add_argument(
-        "--job-id",
-        default="",
-        help="Job ID (optional)"
-    )
-    
+
+    parser.add_argument("--pipeline-id", default="", help="Pipeline ID (optional)")
+
+    parser.add_argument("--pipeline-run-id", default="", help="Pipeline run ID (optional)")
+
+    parser.add_argument("--job-id", default="", help="Job ID (optional)")
+
     parser.add_argument(
         "--label",
         default="",
         help="Label string. Can be used alone (archive path: /{label}/{filename}) "
-             "or with --archive-path (archive path: /{label}/{archive_path}/{filename})."
+        "or with --archive-path (archive path: /{label}/{archive_path}/{filename}).",
     )
-    
+
     parser.add_argument(
         "--archive-path",
         default="",
         help="Custom archive path, must be used with --label. "
-             "Archive path becomes /{label}/{archive_path}/{filename}. "
-             "Can be used together with --pipeline-id/--pipeline-run-id/--job-id, "
-             "in which case --archive-path takes precedence. "
-             "Must provide at least --label or pipeline params."
+        "Archive path becomes /{label}/{archive_path}/{filename}. "
+        "Can be used together with --pipeline-id/--pipeline-run-id/--job-id, "
+        "in which case --archive-path takes precedence. "
+        "Must provide at least --label or pipeline params.",
     )
-    
+
     parser.add_argument(
         "--openlibing-secret",
         default="",
         help="JSON string containing apig_code, apig_key, apig_secret. "
-             "Supports both standard JSON format {\"key\": \"value\"} and "
-             "simplified format {key: value} without quotes. "
-             "If not provided, reads from environment variable OPENLIBING_SECRET. "
-             "Errors if neither is available."
+        'Supports both standard JSON format {"key": "value"} and '
+        "simplified format {key: value} without quotes. "
+        "If not provided, reads from environment variable OPENLIBING_SECRET. "
+        "Errors if neither is available.",
     )
-    
-    parser.add_argument(
-        "--url",
-        default=DEFAULT_UPLOAD_URL,
-        help=f"Upload URL (default: {DEFAULT_UPLOAD_URL})"
-    )
-    
+
+    parser.add_argument("--url", default=DEFAULT_UPLOAD_URL, help=f"Upload URL (default: {DEFAULT_UPLOAD_URL})")
+
     args = parser.parse_args()
-    
+
     try:
         has_archive_path = bool(args.archive_path)
         has_label = bool(args.label)
@@ -256,11 +220,11 @@ def main():
             exit(1)
 
         openlibing_secret = _process_json_param(secret_raw)
-        
+
         if not openlibing_secret:
             logger.error("Failed to parse openlibing-secret")
             exit(1)
-            
+
         response = upload_data_to_openlibing(
             file_paths=args.files,
             openlibing_secret=openlibing_secret,
@@ -270,18 +234,18 @@ def main():
                 "job_id": args.job_id,
                 "url": args.url,
                 "label": args.label,
-                "archive_path": args.archive_path
-            }
+                "archive_path": args.archive_path,
+            },
         )
-        
+
         logger.info("=== Upload Response Details ===")
-        logger.info(f"Status Code: {response.status_code}")
-        logger.info(f"Content-Type: {response.headers.get('Content-Type', 'N/A')}")
-        logger.info(f"Response Text: {response.text}")
+        logger.info("Status Code: %s", response.status_code)
+        logger.info("Content-Type: %s", response.headers.get("Content-Type", "N/A"))
+        logger.info("Response Text: %s", response.text)
         logger.info("===============================")
-        
+
     except Exception as e:
-        logger.error(f"Upload failed: {e}")
+        logger.error("Upload failed: %s", e)
         exit(1)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request introduces a new post-processing utility `result_postprocess.py` to format nightly and weekly benchmark results into per-case JSON files, patch nested fields based on a preset template, and run an external script. This post-processing step is integrated into the benchmark pipelines for multi-node (external and internal DP) and single-node tests.

Feedback was provided to validate that the loaded preset JSON is a dictionary to prevent potential `AttributeError` crashes if the JSON file is corrupted or contains a non-dictionary root.

### Does this PR introduce _any_ user-facing change?
No, this change only affects internal benchmark post-processing.

### How was this patch tested?
CI passed with existing and updated test scripts.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
