### PR TITLE
[Doc] Fix link errors and update documentation structure

### DIFF
--- a/docs/source/developer_guide/contribution/testing.md
+++ b/docs/source/developer_guide/contribution/testing.md
@@ -316,8 +316,6 @@ For running nightly multi-node model test cases locally, refer to the `Running L
 #### E2E test examples
 
 - Offline test example: [`tests/e2e/pull_request/one_card/test_camem.py`](https://github.com/vllm-project/vllm-ascend/blob/main/tests/e2e/pull_request/one_card/test_camem.py)
-- Online test example: [`tests/e2e/pull_request/two_card/aclgraph/test_single_request_aclgraph.py`](https://github.com/vllm-project/vllm-ascend/blob/main/tests/e2e/pull_request/two_card/aclgraph/test_single_request_aclgraph.py)
-- Correctness test example: [`tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_accuracy.py`](https://github.com/vllm-project/vllm-ascend/blob/main/tests/e2e/pull_request/one_card/aclgraph/test_aclgraph_accuracy.py)
 
 The CI resource is limited, and you might need to reduce the number of layers of a model. Below is an example of how to generate a reduced layer model:
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -491,7 +491,7 @@ First, check physical layer connectivity, then verify each node, and finally ver
 
 #### Physical Layer Requirements
 
-- The physical machines must be located on the same WLAN, with network connectivity.
+- The physical machines must be located on the same LAN, with network connectivity.
 - All NPUs are connected with optical modules, and the connection status must be normal.
 
 #### Each Node Verification

--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3-235B-A22B.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3-235B-A22B.po
@@ -647,7 +647,7 @@ msgid "Configuration"
 msgstr "配置"
 
 #: ../../source/tutorials/models/Qwen3-235B-A22B.md:583
-msgid "#NPUs"
+msgid "NPUs"
 msgstr "NPU数量"
 
 #: ../../source/tutorials/models/Qwen3-235B-A22B.md:583

--- a/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3-Dense.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/tutorials/models/Qwen3-Dense.po
@@ -694,7 +694,7 @@ msgid "Configuration"
 msgstr "配置"
 
 #: ../../source/tutorials/models/Qwen3-Dense.md:378
-msgid "#NPUs"
+msgid "NPUs"
 msgstr "NPU数量"
 
 #: ../../source/tutorials/models/Qwen3-Dense.md:378

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -63,7 +63,7 @@ Atlas 200I Pro requires additional device nodes and driver mounts. See [Set up u
 
 ## Setup environment using container
 
-Before using containers, make sure Docker is installed on your system. If Docker is not installed, please refer to the [Docker installation guide](https://docs.docker.com/get-docker/) for installation instructions.
+Before using containers, make sure Docker is installed on your system. If Docker is not installed, please refer to the [Docker installation guide](https://docs.docker.com/get-started/get-docker/) for installation instructions.
 
 :::::{tab-set}
 ::::{tab-item} Ubuntu

--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -27,7 +27,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `DeepSeek-V3.1`(BF16 version): [Download model weight](https://www.modelscope.cn/models/deepseek-ai/DeepSeek-V3.1).
 - `DeepSeek-V3.1-w8a8-mtp-QuaRot`(Quantized version with mix mtp): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V3.1-w8a8-mtp-QuaRot).
 - `DeepSeek-V3.1-Terminus-w4a8-mtp-QuaRot`(Quantized version with mix mtp): [Download model weight](https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V3.1-Terminus-w4a8-mtp-QuaRot).
-- `Quantization method`: [msmodelslim](https://gitcode.com/Ascend/msit/blob/master/msmodelslim/example/DeepSeek/README.md#deepseek-v31-w8a8-%E6%B7%B7%E5%90%88%E9%87%8F%E5%8C%96-mtp-%E9%87%8F%E5%8C%96). You can use this method to quantize the model.
+- `Quantization method`: [msmodelslim](https://gitcode.com/Ascend/msmodelslim/blob/master/example/DeepSeek/README.md). You can use this method to quantize the model.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 

--- a/docs/source/tutorials/models/GLM4.x.md
+++ b/docs/source/tutorials/models/GLM4.x.md
@@ -1,6 +1,6 @@
 # GLM-4.5/4.6/4.7
 
-## Introduction
+## 1 Introduction
 
 GLM-4.x series models use a Mixture-of-Experts (MoE) architecture and are foundational models specifically designed for agent applications.
 
@@ -8,15 +8,15 @@ The `GLM-4.5` model is first supported in `vllm-ascend:v0.10.0rc1`.
 
 This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
 
-## Supported Features
+## 2 Supported Features
 
 Refer to [supported features](../../user_guide/support_matrix/supported_models.md) to get the model's supported feature matrix.
 
 Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the feature's configuration.
 
-## Environment Preparation
+## 3 Prerequisites
 
-### Model Weight
+### 3.1 Model Weight
 
 - `GLM-4.5`(BF16 version): [Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-4.5).
 - `GLM-4.6`(BF16 version): [Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-4.6).
@@ -28,7 +28,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 
-### Installation
+## 4 Installation
 
 You can use our official docker image to run `GLM-4.x` directly.
 
@@ -121,9 +121,9 @@ In addition, if you don't want to use the docker image as above, you can also bu
 
 If you want to deploy multi-node environment, you need to set up environment on each node.
 
-## Deployment
+## 5 Online Service Deployment
 
-### Single-node Deployment
+### 5.1 Single-node Deployment
 
 - In low-latency scenarios, we recommend a single-machine deployment.
 - Quantized model `glm4.7_w8a8_with_float_mtp` can be deployed on 1 Atlas 800 A3 (64G × 16) or 1 Atlas 800 A2 (64G × 8).
@@ -163,7 +163,7 @@ The parameters are explained as follows:
 - `fusion_ops_gmmswigluquant` The performance of the GmmSwigluQuant fusion operator tends to degrade when the total number of NPUs is ≤ 16.
 - `VLLM_ASCEND_ENABLE_FLASHCOMM1` Due to the FD feature of the FIA operator being invalidated by padding data introduced by this feature, we recommend disabling the `flashcomm1` feature for long-sequence (≥16k) and low-concurrency (≤8 batch size) scenarios.For long-sequence and high-concurrency scenarios, you may enable this feature to achieve improved Prefill performance.
 
-### Multi-node Deployment
+### 5.2 Multi-node Deployment
 
 While the previous documentation advises against multi-node deployment on the Atlas 800 A2 (64G × 8) platform, this configuration can still be implemented for the GLM-4.x model if required. To proceed with a dual-node setup, execute the following scripts on each respective node.
 
@@ -265,7 +265,7 @@ vllm serve Eco-Tech/GLM-4.7-W8A8-floatmtp \
   --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'
 ```
 
-### Prefill-Decode Disaggregation
+### 5.3 Prefill-Decode Disaggregation
 
 We'd like to show the deployment guide of `GLM-4.7` in a multi-node environment with 2P1D for better performance.
 
@@ -665,7 +665,7 @@ Once the preparation is done, you can start the server with the following comman
     python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 12778 --vllm-start-port 9300
     ```
 
-### Request Forwarding
+### 5.4 Request Forwarding
 
 To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
 
@@ -696,7 +696,7 @@ python load_balance_proxy_server_example.py \
       9300 9301 9302 9303
 ```
 
-## Functional Verification
+## 6 Functional Verification
 
 Once your server is started, you can query the model with input prompts:
 
@@ -717,7 +717,7 @@ curl -H "Accept: application/json" \
     }' http://<node0_ip>:<port>/v1/chat/completions
 ```
 
-## Accuracy Evaluation
+## 7 Accuracy Evaluation
 
 Here are two accuracy evaluation methods.
 
@@ -736,7 +736,7 @@ Here are two accuracy evaluation methods.
 
 Not tested yet.
 
-## Performance
+## 8 Performance Evaluation
 
 ### Using AISBench
 
@@ -778,7 +778,7 @@ vllm bench serve \
 
 After about several minutes, you can get the performance evaluation result.
 
-## Best Practices
+## 9 Performance Tuning
 
 In this chapter, we recommend best practices for three scenarios:
 
@@ -787,9 +787,9 @@ In this chapter, we recommend best practices for three scenarios:
 - High-throughput: For short sequences with high throughput: we also recommend setting `dp2 tp8`
 
 **Notice:**
-`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#deployment)** chapter.
+`max-model-len` and `max-num-seqs` need to be set according to the actual usage scenario. For other settings, please refer to the **[Deployment](#5-online-service-deployment)** chapter.
 
-## FAQ
+## 10 FAQ
 
 - **Q: Startup fails with HCCL port conflicts (address already bound). What should I do?**
 

--- a/docs/source/tutorials/models/Qwen3-235B-A22B.md
+++ b/docs/source/tutorials/models/Qwen3-235B-A22B.md
@@ -747,7 +747,7 @@ After several minutes, you will get the performance evaluation result.
 
 #### Table 2: Detailed Node Configuration
 
-| Scenario | Configuration | #NPUs | TP | DP | MTP Speculation Num | FUSED_MC2 | EP Switch | Async Scheduling |
+| Scenario | Configuration | NPUs | TP | DP | MTP Speculation Num | FUSED_MC2 | EP Switch | Async Scheduling |
 |----------|---------------|-------|----|-------------|--------------------|-----------|-----------|--------------|
 | High Throughput | Single-Node | 16 | 4 | 4 | none | On | On  | On |
 | Low Latency | Single-Node | 16 | 16 | 1 | 3 | Off | On | On |

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -549,7 +549,7 @@ After several minutes, you will get the performance evaluation result.
 
 #### Table 2: Detailed Node Configuration
 
-| Scenario | Configuration | #NPUs | TP | DP | FUSED_MC2 | EP Switch | Async Scheduling |
+| Scenario | Configuration | NPUs | TP | DP | FUSED_MC2 | EP Switch | Async Scheduling |
 |----------|---------------|-------|----|----|-------------|--------------|--------------|
 | High Throughput | Single-Node | 4 | 4 | 1 | Off | Off | On |
 | Long Context | Single-Node | 4 | 4 | 1 | Off | Off | On |

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -88,7 +88,7 @@ The following features and optimizations are planned for deprecation in a future
 
 ## v0.22.1rc1 - 2026.06.30
 
-We're excited to announce the release of v0.22.1rc1 for vLLM Ascend. This is the first release candidate for the v0.22.1 release line, building on v0.21.0rc1 and aligning the plugin with upstream vLLM v0.22.1. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/releases-v0.22.1rc) to get started.
+We're excited to announce the release of v0.22.1rc1 for vLLM Ascend. This is the first release candidate for the v0.22.1 release line, building on v0.21.0rc1 and aligning the plugin with upstream vLLM v0.22.1. Please follow the [official doc](https://docs.vllm.ai/projects/ascend/en/v0.22.1rc/) to get started.
 
 ### Highlights
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes several broken or outdated links in the documentation, corrects a terminology error (WLAN to LAN) in the installation guide, and updates the headings in the GLM-4.x tutorial to follow a numbered hierarchical structure. It also fixes table headers (`#NPUs` to `NPUs`) in the Qwen3 tutorials and their corresponding translation files.

### Does this PR introduce _any_ user-facing change?
No. Documentation-only updates are not considered user-facing changes.

### How was this patch tested?
Tested by validating the links and building the documentation locally.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
