### PR TITLE
[v0.26.0rc][BugFix] Restore synchronous AscendStore save

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -586,7 +586,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.start_load_kv(meta)
         # No get called since no load_spec
 
-    def test_wait_for_save_enqueues_async(self):
+    def test_wait_for_save_waits_for_save(self):
         worker = self._make_worker()
         worker.kv_send_thread = MagicMock()
 
@@ -602,7 +602,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.wait_for_save(meta)
         worker.kv_send_thread.add_stored_request.assert_called_with("r1")
         worker.kv_send_thread.add_request.assert_called_once()
-        worker.kv_send_thread.request_queue.join.assert_not_called()
+        worker.kv_send_thread.request_queue.join.assert_called_once()
 
     def test_wait_for_save_skip_non_save(self):
         worker = self._make_worker()
@@ -619,6 +619,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         meta.add_request(req)
         worker.wait_for_save(meta)
         worker.kv_send_thread.add_stored_request.assert_not_called()
+        worker.kv_send_thread.request_queue.join.assert_not_called()
 
     def test_get_finished_producer(self):
         worker = self._make_worker(kv_role="kv_producer")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1504,6 +1504,9 @@ class KVPoolWorker:
             send_thread.add_stored_request(request.req_id)
             send_thread.add_request(request)
 
+        if current_event is not None:
+            send_thread.request_queue.join()
+
     def retrieve_layer(
         self,
         request: ReqMeta,


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #13120 to `releases/v0.26.0rc`.

Restore the `request_queue.join()` barrier in AscendStore `wait_for_save()` so queued saves complete before returning.

This keeps key-construction, mask, and store-skip optimizations unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStore waits for queued saves to complete before returning from `wait_for_save()`, trading asynchronous overlap for deterministic visibility.

### How was this patch tested?

- 81 tests passed in `tests.ut.distributed.ascend_store.test_pool_worker` with CPU-side NPU event mocking.
- Changed-file pre-commit hooks passed.
- `git diff --check` passed.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
