### PR TITLE
[Doc] fix DeepSeek V4 Flash&Pro model tutorial docs link error

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -922,7 +922,7 @@ Refer to [Using AISBench for performance evaluation](../../developer_guide/evalu
 
 ### Using vLLM Benchmark
 
-Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/) for more details.
+Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
 
 ## 9 Performance Tuning
 

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -1247,7 +1247,7 @@ Refer to [Using AISBench for performance evaluation](../../developer_guide/evalu
 
 ### Using vLLM Benchmark
 
-Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/contributing/) for more details.
+Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more details.
 
 ## 9 Performance Tuning
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the doc link bug on model tutorials docs of DeepSeek-V4-Flash and DeepSeek-V4-Pro.

### Does this PR introduce _any_ user-facing change?
No. This is a documentation-only update.

### How was this patch tested?
Run docs server locally and verified the affected documentation pages.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
