### PR TITLE
[BugFix][Core][Scheduler] Sync recompute cache handling

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -146,6 +146,8 @@ class RecomputeScheduler(Scheduler):
         if request.request_id in self.failed_recving_kv_req_ids:
             if request.num_computed_tokens:
                 self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
+                if self.needs_kv_cache_zeroing:
+                    self.kv_cache_manager.record_blocks_for_zeroing(request.request_id, request.num_computed_tokens)
             else:
                 self.kv_cache_manager.free(request)
             self.failed_recving_kv_req_ids.remove(request.request_id)
@@ -774,6 +776,14 @@ class RecomputeScheduler(Scheduler):
                     # only the successfully loaded tokens.
                     request.num_computed_tokens = num_computed_tokens
                     self._inflight_prefills.add(request)
+                    if self.needs_kv_cache_zeroing:
+                        self._skip_zero_block_ids.update(
+                            self.kv_cache_manager.get_zeroing_block_ids_in_range(
+                                request.request_id,
+                                num_new_local_computed_tokens,
+                                num_computed_tokens,
+                            )
+                        )
                     continue
 
                 self.running.append(request)
@@ -874,10 +884,10 @@ class RecomputeScheduler(Scheduler):
             self.prev_step_scheduled_req_ids.clear()
             self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
-        # Drain new attention block ids every step so the manager-side list
-        # does not grow unbounded; only kv-cache zeroing consumes them.
-        new_attn_block_ids = self.kv_cache_manager.take_new_block_ids()
-        new_block_ids_to_zero = (new_attn_block_ids or None) if self.needs_kv_cache_zeroing else None
+        kv_cache_block_copies, cow_retained_blocks = self.kv_cache_manager.take_kv_cache_block_copies()
+        if kv_cache_block_copies:
+            self._free_cow_retained_blocks(cow_retained_blocks, self.sched_step_seq + 1)
+        pending_kv_cache_block_copies = kv_cache_block_copies or None
 
         # Dynamic speculative decoding: compute optimal K.
         num_spec_tokens_to_schedule = self.num_spec_tokens
@@ -899,7 +909,8 @@ class RecomputeScheduler(Scheduler):
             # the previous and the current steps.
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
-            new_block_ids_to_zero=new_block_ids_to_zero,
+            new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
+            kv_cache_block_copies=pending_kv_cache_block_copies,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             preempted_reqs=preempted_req_data,
             recomputed_reqs=recomputed_reqs,


### PR DESCRIPTION
### What this PR does / why we need it?

`RecomputeScheduler` copies the upstream scheduling loop so that decode-side allocation pressure can trigger the PD recompute flow. The main branch already carries the current Mamba split and transfer-parameter contracts, but its copied loop is still missing two upstream hybrid-cache behaviors:

- blocks populated by an asynchronous KV load must be excluded from same-step zeroing, and unwritten blocks must be re-recorded for zeroing after a failed load;
- hybrid partial-prefix copy-on-write operations must be forwarded in `SchedulerOutput`, with their endpoint blocks retained until the execution fence completes.

Without the first behavior, zeroing may race an out-of-band KV/KDA load. Without the second, a partial hybrid-cache hit may observe an uncopied or prematurely reused tail block.

This main-branch fix is intended to land before the corresponding v0.26 backport in #13408.

No open main-branch PR was found covering these `RecomputeScheduler` gaps.

### Does this PR introduce _any_ user-facing change?

Yes. Recompute scheduling preserves asynchronously loaded state and hybrid partial-prefix cache copies consistently with the upstream scheduler.

### How was this patch tested?

Static checks completed locally:

```bash
git diff --check
uvx ruff check vllm_ascend/core/recompute_scheduler.py
uvx ruff format --check vllm_ascend/core/recompute_scheduler.py
```

All checks passed. The full v0.26 synchronization patch in #13408 has been confirmed to start a Kimi K3 deployment; forced-recompute accuracy validation is still required on Ascend hardware.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
