### PR TITLE
[BugFix][KV Cache] Honor packed compressed cache layout

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -143,6 +143,22 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(first.stride(), (16, 1))
         self.assertEqual(second.stride(), (16, 1))
 
+    def test_adjust_packed_kv_layout_reinterprets_noncontiguous_pages(self):
+        runner = self._build_runner()
+        raw_tensor = torch.arange(64, dtype=torch.int8)
+
+        (tensor,) = runner._adjust_kv_layout(
+            raw_tensor,
+            [(4, 2)],
+            [torch.float16],
+            page_size_bytes=4,
+            packing=(4, 16),
+        )
+
+        expected = raw_tensor.view(4, 16)[:, 4:8].clone().view(torch.float16)
+        torch.testing.assert_close(tensor, expected)
+        self.assertEqual(tensor.stride(), (8, 1))
+
     def test_reshape_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()
         kv_cache_spec = FullAttentionSpec(

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -69,6 +69,80 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(k_cache_raw.numel(), kv_cache_spec.page_size_bytes)
         self.assertEqual(v_cache_raw.numel(), kv_cache_spec.page_size_bytes)
 
+    def test_allocate_compressed_packed_kv_cache_reuses_backing(self):
+        runner = self._build_runner()
+        runner.use_compress = True
+        kv_cache_spec = FullAttentionSpec(
+            block_size=1,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.int8,
+        )
+        layer_names = ["layers.0.attn", "layers.1.attn"]
+        kv_cache_config = KVCacheConfig(
+            num_blocks=4,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=64,
+                    shared_by=[layer_names[0]],
+                    offset=0,
+                    block_stride=16,
+                ),
+                KVCacheTensor(
+                    size=64,
+                    shared_by=[layer_names[1]],
+                    offset=8,
+                    block_stride=16,
+                ),
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=layer_names,
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+
+        with patch.object(
+            runner,
+            "_allocate_int8_cache_tensor",
+            wraps=runner._allocate_int8_cache_tensor,
+        ) as allocate:
+            raw_tensors = runner._allocate_kv_cache_tensors(kv_cache_config)
+
+        self.assertEqual(allocate.call_count, 1)
+        self.assertEqual(raw_tensors[layer_names[0]].numel(), 64)
+        self.assertEqual(
+            raw_tensors[layer_names[0]].data_ptr(),
+            raw_tensors[layer_names[1]].data_ptr(),
+        )
+
+    def test_adjust_kv_layout_uses_packed_offset_and_block_stride(self):
+        runner = self._build_runner()
+        raw_tensor = torch.arange(64, dtype=torch.int8)
+
+        first, second = runner._adjust_kv_layout(
+            raw_tensor,
+            [(4, 2), (4, 1)],
+            [torch.int8, torch.int8],
+            page_size_bytes=3,
+            packing=(4, 16),
+        )
+
+        torch.testing.assert_close(
+            first,
+            torch.tensor(
+                [[4, 5], [20, 21], [36, 37], [52, 53]],
+                dtype=torch.int8,
+            ),
+        )
+        torch.testing.assert_close(
+            second,
+            torch.tensor([[6], [22], [38], [54]], dtype=torch.int8),
+        )
+        self.assertEqual(first.stride(), (16, 1))
+        self.assertEqual(second.stride(), (16, 1))
+
     def test_reshape_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()
         kv_cache_spec = FullAttentionSpec(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -22,7 +22,7 @@ import math
 import sys
 import time
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import contextmanager, nullcontext
 from copy import copy, deepcopy
 from dataclasses import dataclass, replace
@@ -3962,8 +3962,8 @@ class NPUModelRunner(GPUModelRunner):
     def _adjust_kv_layout(
         self,
         raw_tensor: torch.Tensor,
-        kv_cache_shape_list: list[int],
-        kv_cache_dtype_list: list[int],
+        kv_cache_shape_list: Sequence[Sequence[int]],
+        kv_cache_dtype_list: Sequence[torch.dtype],
         page_size_bytes: int,
         overlap_full_kv_cache: bool = False,
         packing: tuple[int, int] | None = None,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3802,6 +3802,7 @@ class NPUModelRunner(GPUModelRunner):
         """
         # init kv cache tensors
         kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, ...]] = {}
+        packed_backing: torch.Tensor | None = None
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
@@ -3838,14 +3839,21 @@ class NPUModelRunner(GPUModelRunner):
                         # shared the kvcache for all shared layers
                         kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif "attn" in layer_name and self.use_compress and layer_name not in kv_cache_raw_tensors:
-                    if self.vllm_config.kv_transfer_config is None:
-                        tensor = torch.zeros(kv_cache_tensor.size,
-                                                dtype=torch.int8,
-                                                device=self.device)
+                    if kv_cache_tensor.block_stride > 0:
+                        # Packed KV tensors describe per-layer pages within one
+                        # block-strided backing allocation. Allocate that backing
+                        # only once and create the per-layer views during reshape.
+                        if packed_backing is None:
+                            packed_backing = self._allocate_int8_cache_tensor(
+                                kv_cache_tensor.size,
+                                alignment,
+                            )
+                        tensor = packed_backing
                     else:
-                        cache_size_aligned = kv_cache_tensor.size + alignment
-                        tensor = torch.zeros(cache_size_aligned, dtype=torch.int8, device=self.device)
-                        tensor = self._align_memory(tensor, alignment)[: kv_cache_tensor.size]
+                        tensor = self._allocate_int8_cache_tensor(
+                            kv_cache_tensor.size,
+                            alignment,
+                        )
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the kvcache between the self_attn specs in the same group
                         kv_cache_raw_tensors[layer_name_inner] = tensor
@@ -3958,8 +3966,32 @@ class NPUModelRunner(GPUModelRunner):
         kv_cache_dtype_list: list[int],
         page_size_bytes: int,
         overlap_full_kv_cache: bool = False,
+        packing: tuple[int, int] | None = None,
     ):
         reshaped_kv_tensors = []
+        if packing is not None:
+            offset, block_stride = packing
+            page_offset_bytes = 0
+            packed_pages = raw_tensor.view(-1, block_stride)
+            for idx, (shape, dtype) in enumerate(
+                zip(kv_cache_shape_list, kv_cache_dtype_list)
+            ):
+                if overlap_full_kv_cache and idx == 2:
+                    page_offset_bytes = 0
+                dtype_size = get_dtype_size(dtype)
+                page_bytes = math.prod(shape[1:]) * dtype_size
+                start = offset + page_offset_bytes
+                end = start + page_bytes
+                assert end <= block_stride
+                tensor = (
+                    packed_pages[: shape[0], start:end]
+                    .view(dtype)
+                    .view(shape)
+                )
+                reshaped_kv_tensors.append(tensor)
+                page_offset_bytes += page_bytes
+            return reshaped_kv_tensors
+
         base_storage_offset_bytes = raw_tensor.storage_offset()
         storage_offset_bytes = base_storage_offset_bytes
         for idx, (shape, dtype) in enumerate(zip(kv_cache_shape_list, kv_cache_dtype_list)):
@@ -4002,6 +4034,14 @@ class NPUModelRunner(GPUModelRunner):
         """
         kv_caches: dict[str, torch.Tensor] = {}
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
+        layer_packing: dict[str, tuple[int, int]] = {}
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            if kv_cache_tensor.block_stride > 0:
+                for layer_name in kv_cache_tensor.shared_by:
+                    layer_packing[layer_name] = (
+                        kv_cache_tensor.offset,
+                        kv_cache_tensor.block_stride,
+                    )
         for group in self._kv_cache_spec_attn_group_iterator():
             attn_backend = group.backend
             current_kv_cache_spec = group.kv_cache_spec
@@ -4016,8 +4056,13 @@ class NPUModelRunner(GPUModelRunner):
                 if self.use_compress and isinstance(current_kv_cache_spec,
                                                     (AscendMLAAttentionSpec, AscendSlidingWindowMLASpec)):
                     kv_tensor = kv_cache_raw_tensors[layer_name]
-                    sum_page_size_bytes = kv_tensor.numel()
-                    num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
+                    packing = layer_packing.get(layer_name)
+                    if packing is not None:
+                        _, block_stride = packing
+                        num_blocks = kv_tensor.numel() // block_stride
+                    else:
+                        sum_page_size_bytes = kv_tensor.numel()
+                        num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
                     assert num_blocks == kv_cache_config.num_blocks, \
                         f"num_blocks: {num_blocks} should be equal to " \
                         f"kv_cache_config.num_blocks: {kv_cache_config.num_blocks}"
@@ -4064,6 +4109,7 @@ class NPUModelRunner(GPUModelRunner):
                                            kv_cache_dtype_list,
                                            current_kv_cache_spec.page_size_bytes,
                                            overlap_full_kv_cache=overlap_full_kv_cache,
+                                           packing=packing,
                                            )
 
                     kv_caches[layer_name] = kv_cache

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3971,8 +3971,9 @@ class NPUModelRunner(GPUModelRunner):
         reshaped_kv_tensors = []
         if packing is not None:
             offset, block_stride = packing
+            assert raw_tensor.numel() % block_stride == 0
+            num_packed_blocks = raw_tensor.numel() // block_stride
             page_offset_bytes = 0
-            packed_pages = raw_tensor.view(-1, block_stride)
             for idx, (shape, dtype) in enumerate(
                 zip(kv_cache_shape_list, kv_cache_dtype_list)
             ):
@@ -3983,10 +3984,16 @@ class NPUModelRunner(GPUModelRunner):
                 start = offset + page_offset_bytes
                 end = start + page_bytes
                 assert end <= block_stride
-                tensor = (
-                    packed_pages[: shape[0], start:end]
-                    .view(dtype)
-                    .view(shape)
+                assert shape[0] <= num_packed_blocks
+                assert start % dtype_size == 0
+                assert block_stride % dtype_size == 0
+                stride = torch.empty(shape).stride()
+                target_stride = (block_stride // dtype_size, *stride[1:])
+                tensor = torch.as_strided(
+                    raw_tensor.view(dtype),
+                    size=shape,
+                    stride=target_stride,
+                    storage_offset=start // dtype_size,
                 )
                 reshaped_kv_tensors.append(tensor)
                 page_offset_bytes += page_bytes


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM can describe several logical KV-cache tensors as views into one packed
backing allocation using `KVCacheTensor.offset` and `block_stride`. The
compressed Ascend V1 allocation and reshape path ignored those fields: it
allocated the declared backing once per descriptor, treated the full backing
as a contiguous per-layer page array, and derived the block count from the
logical layer page size.

On DeepSeek-V4-Flash TP8 this turned a 142-block packed cache into an inferred
27,589 blocks and prevented the engine from reaching readiness.

This patch:

- allocates a packed compressed-cache backing only once;
- reuses it for every logical layer described by the packed tensors;
- creates block-strided byte-offset views with explicit `torch.as_strided`
  metadata using `offset` and `block_stride`, including dtype-alignment
  guards; and
- derives the packed block count from the backing stride rather than a logical
  layer's page size.

It is intentionally independent of the fused-MoE work in #13426.

### Does this PR introduce _any_ user-facing change?

Yes. Models using packed compressed KV-cache layouts can initialize the
declared number of blocks without duplicate backing allocations or invalid
contiguous views. Non-packed cache descriptors retain the existing path.

### Validation

- `tests/ut/worker/a2/test_model_runner_v1.py`: **22 passed** against the
  repository's verified vLLM head `0351e9aa1`.
- `uvx ruff@0.14.0 check` passed for both changed Python files.
- `uvx ruff@0.14.0 format --check` passed for both changed Python files.
- `mypy==1.11.1` passed for `vllm_ascend/worker/model_runner_v1.py` with
  Python 3.10 target semantics; this also addresses the initial CI finding on
  the pre-existing shape/dtype annotations now exercised by the packed path.
- `git diff --check` passed.
- The original downstream fix also allowed the eight-rank
  DeepSeek-V4-Flash W8A8 engine to allocate and reshape the expected 142
  blocks and complete its fixed TP8/EP8 experiment matrix.

Duplicate-work checks found no open PR specifically handling
`KVCacheTensor.offset` / `block_stride` in the compressed model-runner
path. The nearby open DeepSeek cache and transfer PRs address different
features.

This is a semantic transplant of the human-authored and hardware-validated
fix from `91f1f70f`; Codex assisted with rebasing and validation.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
