### PR TITLE
[Feature][MLA] Support Kimi K3 no-RoPE MLAPO on A5

### DIFF
--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1750,7 +1750,6 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.weight_uq_qr.shape, (q_lora_rank, num_heads_padded * q_head_dim))
         self.assertEqual(self.impl.mlapo_W_UK_T.shape, (num_heads_padded, 10, kv_lora_rank))
         self.assertEqual(self.impl.mlapo_num_heads, num_heads_padded)
-        self.assertEqual(self.impl.mlapo_rope_empty.shape, (0, rope_dim))
         self.assertEqual(self.impl.mlapo_weight_quant_mode, 0)
         self.assertFalse(hasattr(self.impl, "weight_dq_scale"))
         self.assertFalse(hasattr(self.impl, "weight_dkv_kr_scale"))

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1068,7 +1068,7 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    def test_kimi_k3_no_rope_disables_fused_rotary_preprocess(
+    def test_kimi_k3_no_rope_keeps_a5_fused_preprocess(
         self,
         mock_get_current_vllm_config,
         mock_enabling_mlapo,
@@ -1093,23 +1093,83 @@ class TestAscendMLAImpl(TestBase):
             "use_mla_rope": False,
         }
 
-        impl = AscendMLAImpl(
-            num_heads=12,
-            head_size=96,
-            scale=0.1,
-            num_kv_heads=1,
-            alibi_slopes=None,
-            sliding_window=None,
-            kv_cache_dtype="auto",
-            blocksparse_params=None,
-            logits_soft_cap=None,
-            attn_type=None,
-            kv_sharing_target_layer_name=None,
-            **kwargs,
-        )
+        from vllm_ascend.attention.mla_v1 import AscendDeviceType
 
-        self.assertFalse(impl.fa_quant_layer)
-        self.assertFalse(impl.enable_mlapo)
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_device_type",
+            return_value=AscendDeviceType.A5,
+        ):
+            impl = AscendMLAImpl(
+                num_heads=12,
+                head_size=96,
+                scale=0.1,
+                num_kv_heads=1,
+                alibi_slopes=None,
+                sliding_window=None,
+                kv_cache_dtype="auto",
+                blocksparse_params=None,
+                logits_soft_cap=None,
+                attn_type=None,
+                kv_sharing_target_layer_name=None,
+                **kwargs,
+            )
+
+        self.assertTrue(impl.fa_quant_layer)
+        self.assertTrue(impl.enable_mlapo)
+
+    @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
+    @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad", side_effect=lambda value, enabled: value)
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
+    def test_kimi_k3_forwards_no_rope_to_fused_decode_preprocess(
+        self,
+        mock_device_operator,
+        mock_gather_unpad,
+        mock_save_kv,
+    ):
+        num_tokens = 2
+        self.impl.enable_mlapo = True
+        self.impl.fa_quant_layer = False
+        self.impl.use_mla_rope = False
+        self.impl.num_heads = 2
+        self.impl.v_head_dim = 4
+        hidden_states = torch.randn(num_tokens, 16)
+        attention_output = torch.randn(num_tokens, self.impl.num_heads * self.impl.v_head_dim)
+        projected = torch.randn_like(hidden_states)
+        decode_result = DecodeMLAPreprocessResult(
+            ql_nope=MagicMock(),
+            q_pe=MagicMock(),
+            k_nope=MagicMock(),
+            k_pe=MagicMock(),
+        )
+        mock_device_operator.mla_preprocess_only_decode.return_value = (decode_result, None)
+        self.impl._forward_decode = MagicMock(return_value=attention_output)
+        self.impl.o_proj = MagicMock(return_value=(projected,))
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=num_tokens,
+            num_decodes=num_tokens,
+            num_prefills=0,
+            num_decode_tokens=num_tokens,
+        )
+        kv_cache = (torch.empty(1, 4), torch.empty(1, 4))
+        output = torch.empty_like(projected)
+
+        with patch("vllm_ascend.attention.mla_v1._EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens)):
+            self.impl.forward(
+                "model.layers.3.self_attn.attn",
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                output=output,
+            )
+
+        mock_device_operator.mla_preprocess_only_decode.assert_called_once_with(
+            self.impl,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            use_mla_rope=False,
+        )
+        torch.testing.assert_close(output, projected)
 
     @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1701,6 +1701,7 @@ class TestAscendMLAImpl(TestBase):
         self.impl.q_proj.weight.data = torch.randn(128, 128)
         self.impl.q_proj.weight_scale.data = torch.randn(128, 128, 128)
         self.impl.q_lora_rank = 32
+        self.impl._mlapo_quant_type = object
 
         self.impl._process_weights_for_fused_mlapo_a5(torch.float16)
         self.assertTrue(hasattr(self.impl, "weight_dq"))
@@ -1708,6 +1709,66 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(hasattr(self.impl, "weight_dkv_kr"))
         self.assertTrue(hasattr(self.impl, "weight_dq_scale"))
         self.assertTrue(hasattr(self.impl, "weight_dkv_kr_scale"))
+        self.assertEqual(self.impl.mlapo_weight_quant_mode, 3)
+
+    @patch("torch_npu.npu_format_cast", side_effect=lambda weight, _: weight)
+    def test_process_weights_for_fused_mlapo_a5_native_bf16(self, mock_format_cast):
+        hidden_size = 128
+        q_lora_rank = 32
+        kv_lora_rank = 24
+        rope_dim = 8
+        num_heads = 12
+        num_heads_padded = 16
+        q_head_dim = 16
+
+        self.impl.fused_qkv_a_proj = MagicMock()
+        self.impl.fused_qkv_a_proj.weight.data = torch.randn(
+            q_lora_rank + kv_lora_rank + rope_dim,
+            hidden_size,
+            dtype=torch.bfloat16,
+        )
+        self.impl.q_proj = MagicMock()
+        self.impl.q_proj.weight.data = torch.randn(
+            num_heads * q_head_dim,
+            q_lora_rank,
+            dtype=torch.bfloat16,
+        )
+        self.impl.q_lora_rank = q_lora_rank
+        self.impl.qk_head_dim = q_head_dim
+        self.impl.qk_rope_head_dim = rope_dim
+        self.impl.num_heads = num_heads
+        self.impl.num_heads_padded = num_heads_padded
+        self.impl.head_padding = num_heads_padded - num_heads
+        self.impl.W_UK_T = torch.randn(num_heads, 10, kv_lora_rank, dtype=torch.bfloat16)
+        self.impl.use_mla_rope = False
+        self.impl._mlapo_quant_type = None
+
+        self.impl._process_weights_for_fused_mlapo_a5(torch.bfloat16)
+
+        self.assertEqual(self.impl.weight_dq.shape, (hidden_size, q_lora_rank))
+        self.assertEqual(self.impl.weight_dkv_kr.shape, (hidden_size, kv_lora_rank + rope_dim))
+        self.assertEqual(self.impl.weight_uq_qr.shape, (q_lora_rank, num_heads_padded * q_head_dim))
+        self.assertEqual(self.impl.mlapo_W_UK_T.shape, (num_heads_padded, 10, kv_lora_rank))
+        self.assertEqual(self.impl.mlapo_num_heads, num_heads_padded)
+        self.assertEqual(self.impl.mlapo_rope_empty.shape, (0, rope_dim))
+        self.assertEqual(self.impl.mlapo_weight_quant_mode, 0)
+        self.assertFalse(hasattr(self.impl, "weight_dq_scale"))
+        self.assertFalse(hasattr(self.impl, "weight_dkv_kr_scale"))
+        self.assertFalse(hasattr(self.impl, "weight_uq_qr_scale"))
+        self.assertEqual(mock_format_cast.call_count, 3)
+
+    def test_reorg_decode_q_removes_prolog_head_padding(self):
+        self.impl.num_heads = 12
+        self.impl.mlapo_num_heads = 16
+        q_nope = torch.randn(2, 16, 32)
+        q_pe = torch.randn(2, 16, 8)
+
+        q_nope_reorg, q_pe_reorg = self.impl.reorg_decode_q(q_nope, q_pe)
+
+        self.assertEqual(q_nope_reorg.shape, (2, 12, 32))
+        self.assertEqual(q_pe_reorg.shape, (2, 12, 8))
+        torch.testing.assert_close(q_nope_reorg, q_nope[:, :12])
+        torch.testing.assert_close(q_pe_reorg, q_pe[:, :12])
 
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
@@ -1916,6 +1977,34 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_keeps_native_mlapo_on_a5(
+        self, mock_format_cast, mock_get_ascend_device_type
+    ):
+        layer = MagicMock(spec=LinearBase)
+        layer.input_size_per_partition = 10
+        layer.quant_method = MagicMock(spec=UnquantizedLinearMethod)
+        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        layer.weight = torch.randn(shape_0, self.impl.kv_lora_rank)
+        self.impl.kv_b_proj = layer
+        mock_format_cast.return_value = layer.weight
+
+        self.impl.enable_mlapo = True
+        self.impl.fused_qkv_a_proj = MagicMock()
+        self.impl.fused_qkv_a_proj.quant_method = MagicMock(spec=UnquantizedLinearMethod)
+
+        from vllm_ascend.attention.mla_v1 import AscendDeviceType
+
+        mock_get_ascend_device_type.return_value = AscendDeviceType.A5
+        self.impl._process_weights_for_fused_mlapo_a5 = MagicMock()
+
+        self.impl.process_weights_after_loading(torch.bfloat16)
+
+        self.assertTrue(self.impl.enable_mlapo)
+        self.assertIsNone(self.impl._mlapo_quant_type)
+        self.impl._process_weights_for_fused_mlapo_a5.assert_called_once_with(torch.bfloat16)
 
     @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
     @patch("torch_npu.npu_format_cast")

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -40,6 +40,7 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
         fak_descale_reciprocal=None,
         num_heads=num_heads,
         kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=rope_dim,
         reorg_decode_q=mock.MagicMock(side_effect=lambda q_nope, q_pe: (q_nope, q_pe)),
     )
     query_nope = torch.randn(num_tokens, num_heads, kv_lora_rank)
@@ -53,7 +54,11 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
         mock.patch(
             "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
             return_value=(query_nope, query_rope, None, None, None),
-        ) as mock_prolog,
+        ) as mock_rope_prolog,
+        mock.patch(
+            "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
+            return_value=(query_nope, query_rope, None, None, None),
+        ) as mock_no_rope_prolog,
     ):
         A5DeviceAdaptor.mla_preprocess_only_decode(
             atten_obj,
@@ -63,13 +68,80 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
             use_mla_rope=use_mla_rope,
         )
 
+    mock_prolog = mock_rope_prolog if use_mla_rope else mock_no_rope_prolog
     call_kwargs = mock_prolog.call_args.kwargs
     if use_mla_rope:
         torch.testing.assert_close(call_kwargs["rope_cos"], cos.view(num_tokens, 1, rope_dim))
         torch.testing.assert_close(call_kwargs["rope_sin"], sin.view(num_tokens, 1, rope_dim))
     else:
-        assert call_kwargs["rope_cos"] is None
-        assert call_kwargs["rope_sin"] is None
+        assert call_kwargs["rope_cos"].shape == (0, 1, rope_dim)
+        assert call_kwargs["rope_sin"].shape == (0, 1, rope_dim)
+        assert call_kwargs["rope_cos"].numel() == 0
+        assert call_kwargs["rope_sin"].numel() == 0
+
+
+def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
+    num_tokens = 2
+    num_heads = 4
+    kv_lora_rank = 8
+    rope_dim = 6
+    hidden_states = torch.randn(num_tokens, 16, dtype=torch.bfloat16)
+    kv_cache = (
+        torch.randn(4, 1, 1, kv_lora_rank, dtype=torch.bfloat16),
+        torch.randn(4, 1, 1, rope_dim, dtype=torch.bfloat16),
+    )
+    attn_metadata = SimpleNamespace(
+        num_decode_tokens=num_tokens,
+        decode=SimpleNamespace(cos=None, sin=None),
+        slot_mapping=torch.arange(num_tokens, dtype=torch.int32),
+    )
+    atten_obj = SimpleNamespace(
+        weight_dq=mock.MagicMock(),
+        weight_uq_qr=mock.MagicMock(),
+        W_UK_T=mock.MagicMock(),
+        weight_dkv_kr=mock.MagicMock(),
+        q_a_layernorm=SimpleNamespace(weight=SimpleNamespace(data=mock.MagicMock())),
+        kv_a_layernorm=SimpleNamespace(weight=SimpleNamespace(data=mock.MagicMock())),
+        mlapo_weight_quant_mode=0,
+        fa_quant_layer=False,
+        fak_descale_reciprocal=None,
+        num_heads=num_heads,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=rope_dim,
+        reorg_decode_q=mock.MagicMock(side_effect=lambda q_nope, q_pe: (q_nope, q_pe)),
+    )
+    query_nope = torch.randn(num_tokens, num_heads, kv_lora_rank, dtype=torch.bfloat16)
+    query_rope = torch.randn(num_tokens, num_heads, rope_dim, dtype=torch.bfloat16)
+
+    with (
+        mock.patch("vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant") as mock_quant,
+        mock.patch(
+            "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
+            return_value=(query_nope, query_rope, None, None, None),
+        ) as mock_prolog,
+    ):
+        A5DeviceAdaptor.mla_preprocess_only_decode(
+            atten_obj,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            use_mla_rope=False,
+        )
+
+    mock_quant.assert_not_called()
+    call_kwargs = mock_prolog.call_args.kwargs
+    torch.testing.assert_close(call_kwargs["token_x"], hidden_states)
+    assert call_kwargs["token_x"].shape == hidden_states.shape
+    assert call_kwargs["weight_quant_mode"] == 0
+    assert call_kwargs["dequant_scale_x"] is None
+    assert call_kwargs["dequant_scale_w_dq"] is None
+    assert call_kwargs["dequant_scale_w_uq_qr"] is None
+    assert call_kwargs["dequant_scale_w_dkv_kr"] is None
+    assert call_kwargs["rope_cos"].shape == (0, rope_dim)
+    assert call_kwargs["rope_sin"].shape == (0, rope_dim)
+    assert call_kwargs["rope_cos"].numel() == 0
+    assert call_kwargs["rope_sin"].numel() == 0
+    assert call_kwargs["cache_index"].shape == (num_tokens,)
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -54,11 +54,7 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
         mock.patch(
             "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
             return_value=(query_nope, query_rope, None, None, None),
-        ) as mock_rope_prolog,
-        mock.patch(
-            "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
-            return_value=(query_nope, query_rope, None, None, None),
-        ) as mock_no_rope_prolog,
+        ) as mock_prolog,
     ):
         A5DeviceAdaptor.mla_preprocess_only_decode(
             atten_obj,
@@ -68,16 +64,13 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
             use_mla_rope=use_mla_rope,
         )
 
-    mock_prolog = mock_rope_prolog if use_mla_rope else mock_no_rope_prolog
     call_kwargs = mock_prolog.call_args.kwargs
     if use_mla_rope:
         torch.testing.assert_close(call_kwargs["rope_cos"], cos.view(num_tokens, 1, rope_dim))
         torch.testing.assert_close(call_kwargs["rope_sin"], sin.view(num_tokens, 1, rope_dim))
     else:
-        assert call_kwargs["rope_cos"].shape == (0, 1, rope_dim)
-        assert call_kwargs["rope_sin"].shape == (0, 1, rope_dim)
-        assert call_kwargs["rope_cos"].numel() == 0
-        assert call_kwargs["rope_sin"].numel() == 0
+        assert call_kwargs["rope_cos"] is None
+        assert call_kwargs["rope_sin"] is None
 
 
 def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
@@ -116,7 +109,7 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
     with (
         mock.patch("vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant") as mock_quant,
         mock.patch(
-            "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
+            "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
             return_value=(query_nope, query_rope, None, None, None),
         ) as mock_prolog,
     ):
@@ -137,10 +130,8 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
     assert call_kwargs["dequant_scale_w_dq"] is None
     assert call_kwargs["dequant_scale_w_uq_qr"] is None
     assert call_kwargs["dequant_scale_w_dkv_kr"] is None
-    assert call_kwargs["rope_cos"].shape == (0, rope_dim)
-    assert call_kwargs["rope_sin"].shape == (0, rope_dim)
-    assert call_kwargs["rope_cos"].numel() == 0
-    assert call_kwargs["rope_sin"].numel() == 0
+    assert call_kwargs["rope_cos"] is None
+    assert call_kwargs["rope_sin"] is None
     assert call_kwargs["cache_index"].shape == (num_tokens,)
 
 

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -54,7 +54,11 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
         mock.patch(
             "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
             return_value=(query_nope, query_rope, None, None, None),
-        ) as mock_prolog,
+        ) as mock_rope_prolog,
+        mock.patch(
+            "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
+            return_value=(query_nope, query_rope, None, None, None),
+        ) as mock_no_rope_prolog,
     ):
         A5DeviceAdaptor.mla_preprocess_only_decode(
             atten_obj,
@@ -64,6 +68,7 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
             use_mla_rope=use_mla_rope,
         )
 
+    mock_prolog = mock_rope_prolog if use_mla_rope else mock_no_rope_prolog
     call_kwargs = mock_prolog.call_args.kwargs
     if use_mla_rope:
         torch.testing.assert_close(call_kwargs["rope_cos"], cos.view(num_tokens, 1, rope_dim))
@@ -109,7 +114,7 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
     with (
         mock.patch("vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant") as mock_quant,
         mock.patch(
-            "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
+            "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
             return_value=(query_nope, query_rope, None, None, None),
         ) as mock_prolog,
     ):

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -50,10 +50,12 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
         mock.patch(
             "vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant",
             return_value=(hidden_states.unsqueeze(1), mock.MagicMock()),
+            create=True,
         ),
         mock.patch(
             "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
             return_value=(query_nope, query_rope, None, None, None),
+            create=True,
         ) as mock_rope_prolog,
         mock.patch(
             "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
@@ -115,10 +117,11 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights(use_mla_rope
     query_rope = torch.randn(num_tokens, num_heads, rope_dim, dtype=torch.bfloat16)
 
     with (
-        mock.patch("vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant") as mock_quant,
+        mock.patch("vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant", create=True) as mock_quant,
         mock.patch(
             "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
             return_value=(query_nope, query_rope, None, None, None),
+            create=True,
         ) as mock_rope_prolog,
         mock.patch(
             "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -1,9 +1,75 @@
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 import torch
 
 from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+
+
+@pytest.mark.parametrize("use_mla_rope", [True, False])
+def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
+    num_tokens = 2
+    num_heads = 4
+    kv_lora_rank = 8
+    rope_dim = 6
+    hidden_size = 16
+    hidden_states = torch.randn(num_tokens, hidden_size)
+    cos = torch.randn(num_tokens, 1, 1, rope_dim)
+    sin = torch.randn_like(cos)
+    kv_cache = (
+        torch.randn(4, 1, 1, kv_lora_rank),
+        torch.randn(4, 1, 1, rope_dim),
+    )
+    attn_metadata = SimpleNamespace(
+        num_decode_tokens=num_tokens,
+        decode=SimpleNamespace(cos=cos, sin=sin),
+        slot_mapping=torch.arange(num_tokens, dtype=torch.int32),
+    )
+    atten_obj = SimpleNamespace(
+        weight_dq=mock.MagicMock(),
+        weight_uq_qr=mock.MagicMock(),
+        W_UK_T=mock.MagicMock(),
+        weight_dkv_kr=mock.MagicMock(),
+        q_a_layernorm=SimpleNamespace(weight=SimpleNamespace(data=mock.MagicMock())),
+        kv_a_layernorm=SimpleNamespace(weight=SimpleNamespace(data=mock.MagicMock())),
+        weight_dq_scale=mock.MagicMock(),
+        weight_uq_qr_scale=mock.MagicMock(),
+        weight_dkv_kr_scale=mock.MagicMock(),
+        fa_quant_layer=False,
+        fak_descale_reciprocal=None,
+        num_heads=num_heads,
+        kv_lora_rank=kv_lora_rank,
+        reorg_decode_q=mock.MagicMock(side_effect=lambda q_nope, q_pe: (q_nope, q_pe)),
+    )
+    query_nope = torch.randn(num_tokens, num_heads, kv_lora_rank)
+    query_rope = torch.randn(num_tokens, num_heads, rope_dim)
+
+    with (
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant",
+            return_value=(hidden_states.unsqueeze(1), mock.MagicMock()),
+        ),
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
+            return_value=(query_nope, query_rope, None, None, None),
+        ) as mock_prolog,
+    ):
+        A5DeviceAdaptor.mla_preprocess_only_decode(
+            atten_obj,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            use_mla_rope=use_mla_rope,
+        )
+
+    call_kwargs = mock_prolog.call_args.kwargs
+    if use_mla_rope:
+        torch.testing.assert_close(call_kwargs["rope_cos"], cos.view(num_tokens, 1, rope_dim))
+        torch.testing.assert_close(call_kwargs["rope_sin"], sin.view(num_tokens, 1, rope_dim))
+    else:
+        assert call_kwargs["rope_cos"] is None
+        assert call_kwargs["rope_sin"] is None
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -78,7 +78,8 @@ def test_a5_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
         assert call_kwargs["rope_sin"] is None
 
 
-def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
+@pytest.mark.parametrize("use_mla_rope", [True, False])
+def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights(use_mla_rope):
     num_tokens = 2
     num_heads = 4
     kv_lora_rank = 8
@@ -88,9 +89,11 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
         torch.randn(4, 1, 1, kv_lora_rank, dtype=torch.bfloat16),
         torch.randn(4, 1, 1, rope_dim, dtype=torch.bfloat16),
     )
+    cos = torch.randn(num_tokens, 1, 1, rope_dim, dtype=torch.bfloat16)
+    sin = torch.randn_like(cos)
     attn_metadata = SimpleNamespace(
         num_decode_tokens=num_tokens,
-        decode=SimpleNamespace(cos=None, sin=None),
+        decode=SimpleNamespace(cos=cos, sin=sin),
         slot_mapping=torch.arange(num_tokens, dtype=torch.int32),
     )
     atten_obj = SimpleNamespace(
@@ -114,19 +117,24 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
     with (
         mock.patch("vllm_ascend.device.device_op.torch_npu.npu_dynamic_mx_quant") as mock_quant,
         mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_mla_prolog_v3",
+            return_value=(query_nope, query_rope, None, None, None),
+        ) as mock_rope_prolog,
+        mock.patch(
             "vllm_ascend.device.device_op._npu_mla_prolog_v3_no_rope",
             return_value=(query_nope, query_rope, None, None, None),
-        ) as mock_prolog,
+        ) as mock_no_rope_prolog,
     ):
         A5DeviceAdaptor.mla_preprocess_only_decode(
             atten_obj,
             hidden_states,
             kv_cache,
             attn_metadata,
-            use_mla_rope=False,
+            use_mla_rope=use_mla_rope,
         )
 
     mock_quant.assert_not_called()
+    mock_prolog = mock_rope_prolog if use_mla_rope else mock_no_rope_prolog
     call_kwargs = mock_prolog.call_args.kwargs
     torch.testing.assert_close(call_kwargs["token_x"], hidden_states)
     assert call_kwargs["token_x"].shape == hidden_states.shape
@@ -135,8 +143,12 @@ def test_a5_mla_preprocess_only_decode_supports_native_bf16_weights():
     assert call_kwargs["dequant_scale_w_dq"] is None
     assert call_kwargs["dequant_scale_w_uq_qr"] is None
     assert call_kwargs["dequant_scale_w_dkv_kr"] is None
-    assert call_kwargs["rope_cos"] is None
-    assert call_kwargs["rope_sin"] is None
+    if use_mla_rope:
+        torch.testing.assert_close(call_kwargs["rope_cos"], cos.view(num_tokens, rope_dim))
+        torch.testing.assert_close(call_kwargs["rope_sin"], sin.view(num_tokens, rope_dim))
+    else:
+        assert call_kwargs["rope_cos"] is None
+        assert call_kwargs["rope_sin"] is None
     assert call_kwargs["cache_index"].shape == (num_tokens,)
 
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -931,13 +931,6 @@ class AscendMLAImpl(MLAAttentionImpl):
 
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
-        if not self.use_mla_rope and (self.fa_quant_layer or self.enable_mlapo):
-            # Both optimized preprocess paths fuse rotary reordering into the
-            # q/kv prolog. A no-RoPE positional slice must remain in checkpoint
-            # order, so use the explicit no-RoPE baseline instead.
-            logger.warning_once("FA quant/MLAPO is disabled for MLA layers with RoPE disabled.")
-            self.fa_quant_layer = False
-            self.enable_mlapo = False
         if self.fa_quant_layer:
             self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
         else:
@@ -2082,7 +2075,11 @@ class AscendMLAImpl(MLAAttentionImpl):
                 hidden_states.contiguous(), need_gather_q_kv
             )
             decode_preprocess_res, prefill_preprocess_res = DeviceOperator.mla_preprocess_only_decode(
-                self, hidden_states, kv_cache, attn_metadata
+                self,
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                use_mla_rope=self.use_mla_rope,
             )
         else:
             decode_preprocess_res, prefill_preprocess_res = self._mla_preprocess(

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1299,13 +1299,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
 
         self.mlapo_weight_quant_mode = 0 if is_native else 3
-        if not self.use_mla_rope:
-            rope_shape = (0, self.qk_rope_head_dim) if is_native else (0, 1, self.qk_rope_head_dim)
-            self.mlapo_rope_empty = torch.empty(
-                rope_shape,
-                dtype=act_dtype,
-                device=self.weight_dq.device,
-            )
         if is_native:
             self.mlapo_num_heads = self.num_heads_padded
             self.mlapo_W_UK_T = self.W_UK_T

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1149,21 +1149,21 @@ class AscendMLAImpl(MLAAttentionImpl):
         # self.W_UV = maybe_trans_nz(self.W_UV)
 
         if self.enable_mlapo:
-            # Currently mlapo only supports W8A8 and W8A8MXFP8 quantization in MLA scenario
-            # TODO(whx): modify this limitation when mlapo supports floating point
-            if self.fused_qkv_a_proj is None or (
-                not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None), AscendW8A8LinearMethod
-                )
-                and not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None),
-                    AscendW8A8MXFP8DynamicLinearMethod,
-                )
-            ):
+            device_type = get_ascend_device_type()
+            layer_quant_method = None if self.fused_qkv_a_proj is None else self.fused_qkv_a_proj.quant_method
+            quant_method = getattr(layer_quant_method, "quant_method", None)
+            self._mlapo_quant_type = type(quant_method) if quant_method is not None else None
+            supports_quantized_weights = isinstance(
+                quant_method, (AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod)
+            )
+            supports_native_weights = device_type == AscendDeviceType.A5 and isinstance(
+                layer_quant_method, UnquantizedLinearMethod
+            )
+            if self.fused_qkv_a_proj is None or not (supports_quantized_weights or supports_native_weights):
                 self.enable_mlapo = False
                 logger.warning_once(
-                    "mlapo only supports W8A8 quantization in MLA. "
-                    "Some layers not W8A8 quantized, mlapo disabled for these layers."
+                    "MLAPO supports W8A8/W8A8-MXFP8 weights, plus native floating-point weights on A5. "
+                    "Some layers use an unsupported weight type, so MLAPO is disabled for these layers."
                 )
         if self.enable_mlapo:
             if get_ascend_device_type() == AscendDeviceType.A5:
@@ -1275,24 +1275,53 @@ class AscendMLAImpl(MLAAttentionImpl):
     def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
         assert self.fused_qkv_a_proj is not None
 
-        weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
+        is_native = self._mlapo_quant_type is None
+        fused_weight = self.fused_qkv_a_proj.weight.data
+        if is_native:
+            # Unquantized Linear weights are stored as [out_features, in_features],
+            # whereas npu_mla_prolog_v3 consumes [in_features, out_features].
+            fused_weight = fused_weight.T
+
+        weight_dq = fused_weight[..., : self.q_lora_rank].contiguous()
         self.weight_dq = torch_npu.npu_format_cast(weight_dq, 29)
 
-        weight_uq_qr = self.q_proj.weight.data.contiguous()
-        self.weight_uq_qr_scale = self.q_proj.weight_scale.data.transpose(0, 1)
-        self.weight_uq_qr_scale = self.weight_uq_qr_scale.reshape(
-            -1, self.weight_uq_qr_scale.shape[1] * self.weight_uq_qr_scale.shape[2]
-        )
+        weight_uq_qr = self.q_proj.weight.data
+        if is_native:
+            weight_uq_qr = weight_uq_qr.T.contiguous()
+            if self.head_padding > 0:
+                weight_uq_qr = weight_uq_qr.view(self.q_lora_rank, self.num_heads, self.qk_head_dim)
+                weight_uq_qr = F.pad(weight_uq_qr, (0, 0, 0, self.head_padding))
+                weight_uq_qr = weight_uq_qr.view(self.q_lora_rank, self.num_heads_padded * self.qk_head_dim)
+        weight_uq_qr = weight_uq_qr.contiguous()
         self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, 29)
 
-        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
+        weight_dkv_kr = fused_weight[..., self.q_lora_rank :].contiguous()
         self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
 
-        weight_scale = self.fused_qkv_a_proj.weight_scale
-        weight_scale = weight_scale.transpose(0, 1)
-        weight_scale = weight_scale.reshape(-1, weight_scale.shape[1] * weight_scale.shape[2])
-        self.weight_dq_scale = weight_scale[: self.q_lora_rank, ...]
-        self.weight_dkv_kr_scale = weight_scale[self.q_lora_rank :, ...]
+        self.mlapo_weight_quant_mode = 0 if is_native else 3
+        if not self.use_mla_rope:
+            rope_shape = (0, self.qk_rope_head_dim) if is_native else (0, 1, self.qk_rope_head_dim)
+            self.mlapo_rope_empty = torch.empty(
+                rope_shape,
+                dtype=act_dtype,
+                device=self.weight_dq.device,
+            )
+        if is_native:
+            self.mlapo_num_heads = self.num_heads_padded
+            self.mlapo_W_UK_T = self.W_UK_T
+            if self.head_padding > 0:
+                self.mlapo_W_UK_T = F.pad(self.W_UK_T, (0, 0, 0, 0, 0, self.head_padding))
+        if not is_native:
+            weight_uq_qr_scale = self.q_proj.weight_scale.data.transpose(0, 1)
+            self.weight_uq_qr_scale = weight_uq_qr_scale.reshape(
+                -1, weight_uq_qr_scale.shape[1] * weight_uq_qr_scale.shape[2]
+            )
+
+            weight_scale = self.fused_qkv_a_proj.weight_scale
+            weight_scale = weight_scale.transpose(0, 1)
+            weight_scale = weight_scale.reshape(-1, weight_scale.shape[1] * weight_scale.shape[2])
+            self.weight_dq_scale = weight_scale[: self.q_lora_rank, ...]
+            self.weight_dkv_kr_scale = weight_scale[self.q_lora_rank :, ...]
         if self.fa_quant_layer:
             layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
             self.quant_kscale = layer.quant_kscale
@@ -1911,6 +1940,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):
+        if getattr(self, "mlapo_num_heads", self.num_heads) > self.num_heads:
+            decode_q_nope = decode_q_nope[:, : self.num_heads]
+            decode_q_pe = decode_q_pe[:, : self.num_heads]
         return decode_q_nope, decode_q_pe
 
     def mla_preprocess_prefill(self, q_c, kv_no_split, kv_cache, attn_metadata):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1430,8 +1430,13 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             dynamic_scale = dynamic_scale.reshape(token_x.shape[0] * token_x.shape[1], -1)
         if use_mla_rope:
             cos_shape = attn_metadata.decode.cos.shape
-            cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
-            sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
+            rope_shape = (
+                (cos_shape[0], 1, cos_shape[-1])
+                if token_x.dim() == 3
+                else (cos_shape[0], cos_shape[-1])
+            )
+            cos = attn_metadata.decode.cos.view(rope_shape)
+            sin = attn_metadata.decode.sin.view(rope_shape)
             prolog_op = torch_npu.npu_mla_prolog_v3
         else:
             cos = None

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -307,7 +307,15 @@ class BaseDeviceAdaptor:
         )
 
     @staticmethod
-    def mla_preprocess_only_decode(atten_obj, hidden_states, kv_cache, attn_metadata):
+    def mla_preprocess_only_decode(
+        atten_obj,
+        hidden_states,
+        kv_cache,
+        attn_metadata,
+        use_mla_rope: bool = True,
+    ):
+        if not use_mla_rope:
+            raise NotImplementedError("MLAPO without RoPE is only supported on A5.")
         bsz = attn_metadata.num_decode_tokens
         hidden_states = hidden_states[:bsz]
 
@@ -1397,14 +1405,25 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
 
     @staticmethod
-    def mla_preprocess_only_decode(atten_obj, hidden_states, kv_cache, attn_metadata):
+    def mla_preprocess_only_decode(
+        atten_obj,
+        hidden_states,
+        kv_cache,
+        attn_metadata,
+        use_mla_rope: bool = True,
+    ):
         bsz = attn_metadata.num_decode_tokens
         hidden_states = hidden_states[:bsz].unsqueeze(1)
         hidden_states, dynamic_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
         dynamic_scale = dynamic_scale.reshape(hidden_states.shape[0] * hidden_states.shape[1], -1)
-        cos_shape = attn_metadata.decode.cos.shape
-        cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
-        sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
+        if use_mla_rope:
+            cos_shape = attn_metadata.decode.cos.shape
+            cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
+            sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
+        else:
+            # A5 MLA prolog treats two absent rotary inputs as RoPE disabled.
+            cos = None
+            sin = None
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
             token_x=hidden_states,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -38,7 +38,7 @@ from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 def _npu_mla_prolog_v3_no_rope(**kwargs):
     """Call the AscendC MLA prolog that supports no-RoPE inputs."""
-    import vllm_ascend.vllm_ascend_C  # noqa: F401
+    import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401
 
     return torch.ops._C_ascend.npu_mla_prolog_v3(**kwargs)
 

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -35,6 +35,20 @@ from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
+
+def _npu_mla_prolog_v3_no_rope(**kwargs):
+    """Convert empty RoPE sentinels to null ACL inputs via the custom wrapper."""
+    # A5 deliberately disables the generic custom-op loader. This binding is
+    # only an op-api adapter (it does not dispatch a custom kernel), so load it
+    # lazily for the no-RoPE path instead of enabling every custom op on A5.
+    from vllm_ascend.utils import bootstrap_custom_op_env
+
+    bootstrap_custom_op_env(include_vendor_lib=True)
+    import vllm_ascend.vllm_ascend_C  # noqa: F401
+
+    return torch.ops._C_ascend.npu_mla_prolog_v3(**kwargs)
+
+
 DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
 
@@ -1411,23 +1425,44 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         use_mla_rope: bool = True,
     ):
         bsz = attn_metadata.num_decode_tokens
-        hidden_states = hidden_states[:bsz].unsqueeze(1)
-        hidden_states, dynamic_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
-        dynamic_scale = dynamic_scale.reshape(hidden_states.shape[0] * hidden_states.shape[1], -1)
+        hidden_states = hidden_states[:bsz]
+        weight_quant_mode = getattr(atten_obj, "mlapo_weight_quant_mode", 3)
+        if weight_quant_mode == 0:
+            token_x = hidden_states
+            dynamic_scale = None
+        else:
+            token_x = hidden_states.unsqueeze(1)
+            token_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(token_x, dst_type=torch.float8_e4m3fn)
+            dynamic_scale = dynamic_scale.reshape(token_x.shape[0] * token_x.shape[1], -1)
         if use_mla_rope:
             cos_shape = attn_metadata.decode.cos.shape
             cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
             sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
+            prolog_op = torch_npu.npu_mla_prolog_v3
         else:
-            # A5 MLA prolog treats two absent rotary inputs as RoPE disabled.
-            cos = None
-            sin = None
+            # torch_npu declares RoPE tensors as required and cannot pass Python
+            # None through to ACL. The custom wrapper converts correctly-ranked
+            # empty sentinels into null ACL inputs.
+            rope_shape = (0, atten_obj.qk_rope_head_dim)
+            if token_x.dim() == 3:
+                rope_shape = (0, 1, atten_obj.qk_rope_head_dim)
+            rope_empty = getattr(atten_obj, "mlapo_rope_empty", None)
+            if rope_empty is None or rope_empty.shape != rope_shape:
+                rope_empty = hidden_states.new_empty(rope_shape)
+            cos = rope_empty
+            sin = rope_empty
+            prolog_op = _npu_mla_prolog_v3_no_rope
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
-        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
-            token_x=hidden_states,
+        cache_index = attn_metadata.slot_mapping[:bsz].to(torch.int64)
+        if token_x.dim() == 3:
+            cache_index = cache_index.view(bsz, -1)
+        else:
+            cache_index = cache_index.view(-1)
+        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = prolog_op(
+            token_x=token_x,
             weight_dq=atten_obj.weight_dq,
             weight_uq_qr=atten_obj.weight_uq_qr,
-            weight_uk=atten_obj.W_UK_T,
+            weight_uk=getattr(atten_obj, "mlapo_W_UK_T", atten_obj.W_UK_T),
             weight_dkv_kr=atten_obj.weight_dkv_kr,
             rmsnorm_gamma_cq=atten_obj.q_a_layernorm.weight.data,
             rmsnorm_gamma_ckv=atten_obj.kv_a_layernorm.weight.data,
@@ -1435,19 +1470,26 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             rope_cos=cos,
             kv_cache=decode_k_nope,
             kr_cache=decode_k_pe,
-            cache_index=attn_metadata.slot_mapping[:bsz].view(bsz, -1).to(torch.int64),
-            dequant_scale_x=dynamic_scale.view(torch.float8_e8m0fnu),
-            dequant_scale_w_dq=atten_obj.weight_dq_scale.view(torch.float8_e8m0fnu),
-            dequant_scale_w_uq_qr=atten_obj.weight_uq_qr_scale.view(torch.float8_e8m0fnu),
-            dequant_scale_w_dkv_kr=atten_obj.weight_dkv_kr_scale.view(torch.float8_e8m0fnu),
+            cache_index=cache_index,
+            dequant_scale_x=None if dynamic_scale is None else dynamic_scale.view(torch.float8_e8m0fnu),
+            dequant_scale_w_dq=(
+                None if weight_quant_mode == 0 else atten_obj.weight_dq_scale.view(torch.float8_e8m0fnu)
+            ),
+            dequant_scale_w_uq_qr=(
+                None if weight_quant_mode == 0 else atten_obj.weight_uq_qr_scale.view(torch.float8_e8m0fnu)
+            ),
+            dequant_scale_w_dkv_kr=(
+                None if weight_quant_mode == 0 else atten_obj.weight_dkv_kr_scale.view(torch.float8_e8m0fnu)
+            ),
             cache_mode="PA_BSND",
             query_quant_mode=1 if atten_obj.fa_quant_layer else 0,
-            weight_quant_mode=3,
+            weight_quant_mode=weight_quant_mode,
             kv_cache_quant_mode=1 if atten_obj.fa_quant_layer else 0,
             quant_scale_ckv=atten_obj.fak_descale_reciprocal if atten_obj.fa_quant_layer else None,
         )
-        decode_q_nope = decode_q_nope.view(bsz, atten_obj.num_heads, atten_obj.kv_lora_rank)
-        decode_q_pe = decode_q_pe.view(bsz, atten_obj.num_heads, -1)
+        prolog_num_heads = getattr(atten_obj, "mlapo_num_heads", atten_obj.num_heads)
+        decode_q_nope = decode_q_nope.view(bsz, prolog_num_heads, atten_obj.kv_lora_rank)
+        decode_q_pe = decode_q_pe.view(bsz, prolog_num_heads, -1)
 
         decode_q_nope, decode_q_pe = atten_obj.reorg_decode_q(decode_q_nope, decode_q_pe)
         from vllm_ascend.attention.mla_v1 import DecodeMLAPreprocessResult

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1430,11 +1430,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             dynamic_scale = dynamic_scale.reshape(token_x.shape[0] * token_x.shape[1], -1)
         if use_mla_rope:
             cos_shape = attn_metadata.decode.cos.shape
-            rope_shape = (
-                (cos_shape[0], 1, cos_shape[-1])
-                if token_x.dim() == 3
-                else (cos_shape[0], cos_shape[-1])
-            )
+            rope_shape = (cos_shape[0], 1, cos_shape[-1]) if token_x.dim() == 3 else (cos_shape[0], cos_shape[-1])
             cos = attn_metadata.decode.cos.view(rope_shape)
             sin = attn_metadata.decode.sin.view(rope_shape)
             prolog_op = torch_npu.npu_mla_prolog_v3

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -36,19 +36,6 @@ from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
-def _npu_mla_prolog_v3_no_rope(**kwargs):
-    """Convert empty RoPE sentinels to null ACL inputs via the custom wrapper."""
-    # A5 deliberately disables the generic custom-op loader. This binding is
-    # only an op-api adapter (it does not dispatch a custom kernel), so load it
-    # lazily for the no-RoPE path instead of enabling every custom op on A5.
-    from vllm_ascend.utils import bootstrap_custom_op_env
-
-    bootstrap_custom_op_env(include_vendor_lib=True)
-    import vllm_ascend.vllm_ascend_C  # noqa: F401
-
-    return torch.ops._C_ascend.npu_mla_prolog_v3(**kwargs)
-
-
 DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
 
@@ -1438,27 +1425,16 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             cos_shape = attn_metadata.decode.cos.shape
             cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
             sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
-            prolog_op = torch_npu.npu_mla_prolog_v3
         else:
-            # torch_npu declares RoPE tensors as required and cannot pass Python
-            # None through to ACL. The custom wrapper converts correctly-ranked
-            # empty sentinels into null ACL inputs.
-            rope_shape = (0, atten_obj.qk_rope_head_dim)
-            if token_x.dim() == 3:
-                rope_shape = (0, 1, atten_obj.qk_rope_head_dim)
-            rope_empty = getattr(atten_obj, "mlapo_rope_empty", None)
-            if rope_empty is None or rope_empty.shape != rope_shape:
-                rope_empty = hidden_states.new_empty(rope_shape)
-            cos = rope_empty
-            sin = rope_empty
-            prolog_op = _npu_mla_prolog_v3_no_rope
+            cos = None
+            sin = None
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         cache_index = attn_metadata.slot_mapping[:bsz].to(torch.int64)
         if token_x.dim() == 3:
             cache_index = cache_index.view(bsz, -1)
         else:
             cache_index = cache_index.view(-1)
-        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = prolog_op(
+        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
             token_x=token_x,
             weight_dq=atten_obj.weight_dq,
             weight_uq_qr=atten_obj.weight_uq_qr,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -36,6 +36,13 @@ from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
+def _npu_mla_prolog_v3_no_rope(**kwargs):
+    """Call the AscendC MLA prolog that supports no-RoPE inputs."""
+    import vllm_ascend.vllm_ascend_C  # noqa: F401
+
+    return torch.ops._C_ascend.npu_mla_prolog_v3(**kwargs)
+
+
 DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
 
@@ -1425,16 +1432,18 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             cos_shape = attn_metadata.decode.cos.shape
             cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
             sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
+            prolog_op = torch_npu.npu_mla_prolog_v3
         else:
             cos = None
             sin = None
+            prolog_op = _npu_mla_prolog_v3_no_rope
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         cache_index = attn_metadata.slot_mapping[:bsz].to(torch.int64)
         if token_x.dim() == 3:
             cache_index = cache_index.view(bsz, -1)
         else:
             cache_index = cache_index.view(-1)
-        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
+        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = prolog_op(
             token_x=token_x,
             weight_dq=atten_obj.weight_dq,
             weight_uq_qr=atten_obj.weight_uq_qr,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -314,8 +314,6 @@ class BaseDeviceAdaptor:
         attn_metadata,
         use_mla_rope: bool = True,
     ):
-        if not use_mla_rope:
-            raise NotImplementedError("MLAPO without RoPE is only supported on A5.")
         bsz = attn_metadata.num_decode_tokens
         hidden_states = hidden_states[:bsz]
 


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 uses MLA without RoPE. This PR keeps the fused A5 decode preprocess available when MLA RoPE is disabled and adds the minimum native BF16 weight adaptation needed by the unquantized Kimi K3 checkpoint.

- pass `use_mla_rope` through `DeviceOperator.mla_preprocess_only_decode`;
- preserve the existing RoPE-enabled behavior;
- pass `rope_sin=None` and `rope_cos=None` through the AscendC prolog wrapper for no-RoPE A5 decode, while keeping the RoPE path on `torch_npu`;
- accept `UnquantizedLinearMethod` only on A5 instead of falling back to `enable_mlapo=False`;
- prepare native BF16 prolog weights in `[in_features, out_features]` NZ format and use `weight_quant_mode=0` without dequant scales;
- pad Kimi K3's 12 local query heads to the A5 prolog-supported 16 heads, then remove the padding before the existing attention path;
- keep the W8A8 and W8A8-MXFP8 path unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. An unquantized Kimi K3 checkpoint can keep MLAPO enabled for A5 decode while MLA RoPE is disabled.

### How was this patch tested?

- Targeted unit tests: `9 passed, 82 deselected`.
- `git diff --check` passed.
Four-node Kimi K3 service validation is intentionally pending code review of the BF16 adaptation.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
