### PR TITLE
[Doc][BugFix] Fix Qwen3-Reranker deploy guide

### DIFF
--- a/docs/source/tutorials/models/Qwen3-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-Reranker.md
@@ -120,7 +120,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     vllm serve Qwen/Qwen3-Reranker-0.6B \
         --served-model-name Qwen/Qwen3-Reranker-0.6B \
         --runner pooling \
-        --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
+        --hf_overrides '{"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
         --port 8000 \
         --max-model-len 1024
     ```
@@ -132,7 +132,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     vllm serve Qwen/Qwen3-Reranker-0.6B \
         --served-model-name Qwen/Qwen3-Reranker-0.6B \
         --runner pooling \
-        --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
+        --hf_overrides '{"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
         --compilation-config '{"cudagraph_capture_sizes": [1024,512]}' \
         --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
         --dtype float16 \
@@ -256,7 +256,7 @@ Here are two accuracy evaluation methods.
                                     dtype="float16",
                                     enforce_eager=True,
                                     max_model_len=10240,
-                                    hf_overrides={"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": True})
+                                    hf_overrides={"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": True})
 
         cache = mteb.ResultCache("/home/data/mteb_data")
         tasks = mteb.get_tasks(

--- a/docs/source/tutorials/models/Qwen3-VL-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-VL-Reranker.md
@@ -117,6 +117,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 The Qwen3-VL-Reranker model requires a specific chat template for proper formatting. Create a file named `qwen3_vl_reranker.jinja` with the following content:
 
 ```jinja
+{% raw %}
 <|im_start|>system
 Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>
 <|im_start|>user
@@ -139,7 +140,7 @@ Judge whether the Document meets the requirements based on the Query and the Ins
     | first
 }}<|im_end|>
 <|im_start|>assistant
-
+{% endraw %}
 ```
 
 Save this file to a location of your choice (e.g., `./qwen3_vl_reranker.jinja`).


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects a typo in the `Qwen3-Reranker` deployment guide. The `architectures` override within the `hf_overrides` parameter was incorrectly specified as `Qwen3VLForSequenceClassification`. This has been corrected to `Qwen3ForSequenceClassification` to match the text-based nature of the reranker model.

This fix is applied consistently across all command-line examples and code snippets in the document, ensuring that users can follow the guide without encountering errors.

fix [Issue](https://github.com/vllm-project/vllm-ascend/issues/13446)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update and does not affect any user-facing functionality.

### How was this patch tested?

The changes are limited to documentation and have been visually verified for correctness. The corrected commands are now aligned with the model's expected configuration.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
