### PR TITLE
[BugFix][Attention] Remove power-of-two padding from MLA decode

### DIFF
--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1061,9 +1061,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
-        # 256 is power of 2, so padding should be 0
-        self.assertEqual(self.impl.num_heads_padded, 256)
-        self.assertEqual(self.impl.head_padding, 0)
+        self.assertFalse(self.impl.prefill_uses_combined_qk)
 
     @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
@@ -1228,8 +1226,8 @@ class TestAscendMLAImpl(TestBase):
         torch.testing.assert_close(self.impl.g_proj.call_args.args[0], hidden_states)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):
-        """Test head padding computation for num_heads that are not power of 2 (e.g. GLM-4.7-Flash with 20 heads)."""
+    def test_init_prefill_combined_qk_for_non_power_of_two_heads(self, mock_get_current_vllm_config):
+        """Test the prefill Q/K fallback for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         kwargs = {
             "kv_lora_rank": 32,
@@ -1262,8 +1260,7 @@ class TestAscendMLAImpl(TestBase):
             **kwargs,
         )
         self.assertEqual(impl.num_heads, 20)
-        self.assertEqual(impl.num_heads_padded, 32)  # next power of 2
-        self.assertEqual(impl.head_padding, 12)  # 32 - 20
+        self.assertTrue(impl.prefill_uses_combined_qk)
 
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
@@ -1705,7 +1702,7 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
-        """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
+        """Test prefill retains its Q/K concat fallback for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -1761,7 +1758,7 @@ class TestAscendMLAImpl(TestBase):
 
         result = impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
 
-        # FIA should be called without query_rope/key_rope when head_padding > 0
+        # Prefill FIA uses concatenated Q/K instead of rope kwargs for this layout.
         mock_fia.assert_called_once()
         call_kwargs = mock_fia.call_args.kwargs
         self.assertNotIn("query_rope", call_kwargs)
@@ -2405,7 +2402,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
+        """Test speculative decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2456,9 +2453,8 @@ class TestAscendMLAImpl(TestBase):
         impl.enable_kv_nz = True
         impl.fa_quant_layer = False
 
-        # Return padded output so slice logic works
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, impl.kv_lora_rank),
+            torch.randn(num_heads, B, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2468,10 +2464,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[1], num_heads)
         self.assertEqual(result.shape[2], HD)
 
-        # Verify num_query_heads passed to FIA is padded
+        # Verify v2 receives the model's native head count and unpadded Q.
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -2479,7 +2478,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads_normal(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
+        """Test normal decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2533,7 +2532,7 @@ class TestAscendMLAImpl(TestBase):
         impl.speculative_config = None
 
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, 1, impl.kv_lora_rank),
+            torch.randn(num_heads, B, 1, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2544,8 +2543,11 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[2], HD)
 
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, 1, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, 1, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1061,9 +1061,6 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
-        # 256 is power of 2, so padding should be 0
-        self.assertEqual(self.impl.num_heads_padded, 256)
-        self.assertEqual(self.impl.head_padding, 0)
 
     @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
@@ -1226,44 +1223,6 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(mock_gather_unpad.call_args.args[1])
         self.impl.g_proj.assert_called_once()
         torch.testing.assert_close(self.impl.g_proj.call_args.args[0], hidden_states)
-
-    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):
-        """Test head padding computation for num_heads that are not power of 2 (e.g. GLM-4.7-Flash with 20 heads)."""
-        mock_get_current_vllm_config.return_value = MagicMock()
-        kwargs = {
-            "kv_lora_rank": 32,
-            "qk_nope_head_dim": 64,
-            "qk_rope_head_dim": 32,
-            "qk_head_dim": 96,
-            "v_head_dim": 128,
-            "q_lora_rank": 64,
-            "q_proj": MagicMock(),
-            "q_b_proj": MagicMock(),
-            "kv_b_proj": MagicMock(),
-            "o_proj": MagicMock(),
-            "kv_a_proj_with_mqa": MagicMock(),
-            "fused_qkv_a_proj": MagicMock(),
-            "kv_a_layernorm": MagicMock(),
-            "rotary_emb": MagicMock(),
-        }
-        impl = AscendMLAImpl(
-            num_heads=20,
-            head_size=1024,
-            scale=0.1,
-            num_kv_heads=20,
-            alibi_slopes=None,
-            sliding_window=None,
-            kv_cache_dtype="auto",
-            blocksparse_params=None,
-            logits_soft_cap=None,
-            attn_type=None,
-            kv_sharing_target_layer_name=None,
-            **kwargs,
-        )
-        self.assertEqual(impl.num_heads, 20)
-        self.assertEqual(impl.num_heads_padded, 32)  # next power of 2
-        self.assertEqual(impl.head_padding, 12)  # 32 - 20
 
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
@@ -1705,7 +1664,7 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
-        """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
+        """Test prefill passes RoPE tensors for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -1761,11 +1720,13 @@ class TestAscendMLAImpl(TestBase):
 
         result = impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
 
-        # FIA should be called without query_rope/key_rope when head_padding > 0
         mock_fia.assert_called_once()
+        call_args = mock_fia.call_args
         call_kwargs = mock_fia.call_args.kwargs
-        self.assertNotIn("query_rope", call_kwargs)
-        self.assertNotIn("key_rope", call_kwargs)
+        self.assertEqual(call_args.args[0].shape, q_nope.shape)
+        self.assertEqual(call_args.args[1].shape, k_nope.shape)
+        self.assertEqual(call_kwargs["query_rope"].shape, q_pe.shape)
+        self.assertEqual(call_kwargs["key_rope"].shape, k_pe.shape)
         self.assertEqual(call_kwargs.get("num_heads"), num_heads)
         self.assertEqual(result.shape, (batch_size, num_heads * impl.v_head_dim))
 
@@ -2051,7 +2012,7 @@ class TestAscendMLAImpl(TestBase):
     def test_compute_prefill_context_non_power_of_two_heads(
         self, mock_fia, mock_update, mock_load, mock_get_current_vllm_config
     ):
-        """Test prefill context with non-power-of-2 heads uses concat for query and key."""
+        """Test prefill context passes RoPE tensors for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2119,9 +2080,12 @@ class TestAscendMLAImpl(TestBase):
         out, lse = impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse)
 
         mock_fia.assert_called_once()
+        call_args = mock_fia.call_args
         call_kwargs = mock_fia.call_args.kwargs
-        self.assertNotIn("query_rope", call_kwargs)
-        self.assertNotIn("key_rope", call_kwargs)
+        self.assertEqual(call_args.args[0].shape, q_nope.shape)
+        self.assertEqual(call_args.args[1].shape[-1], impl.qk_nope_head_dim)
+        self.assertEqual(call_kwargs["query_rope"].shape, q_pe.shape)
+        self.assertEqual(call_kwargs["key_rope"].shape[-1], impl.qk_rope_head_dim)
         self.assertEqual(out.shape, prefix_out.shape)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -2405,7 +2369,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
+        """Test speculative decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2456,9 +2420,8 @@ class TestAscendMLAImpl(TestBase):
         impl.enable_kv_nz = True
         impl.fa_quant_layer = False
 
-        # Return padded output so slice logic works
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, impl.kv_lora_rank),
+            torch.randn(num_heads, B, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2468,10 +2431,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[1], num_heads)
         self.assertEqual(result.shape[2], HD)
 
-        # Verify num_query_heads passed to FIA is padded
+        # Verify v2 receives the model's native head count and unpadded Q.
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -2479,7 +2445,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads_normal(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
+        """Test normal decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2533,7 +2499,7 @@ class TestAscendMLAImpl(TestBase):
         impl.speculative_config = None
 
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, 1, impl.kv_lora_rank),
+            torch.randn(num_heads, B, 1, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2544,8 +2510,11 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[2], HD)
 
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, 1, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, 1, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -942,11 +942,6 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
         else:
             self.dtype = self.vllm_config.model_config.dtype
-        # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
-        # with 20 heads), ascend attention ops require padding heads to the
-        # next power of 2.
-        self.num_heads_padded = 1 << (self.num_heads - 1).bit_length()
-        self.head_padding = self.num_heads_padded - self.num_heads
 
     @staticmethod
     def update_graph_params(
@@ -1362,9 +1357,6 @@ class AscendMLAImpl(MLAAttentionImpl):
         out_list = [prefix_output.reshape(num_tokens * H, D)]
         lse_list = [prefix_lse.reshape(num_tokens * H)]
 
-        if self.head_padding > 0:
-            query = torch.cat((q_nope, q_pe), dim=-1)
-
         common_kwargs = {
             "num_heads": self.num_heads,
             "num_key_value_heads": self.num_heads,
@@ -1412,13 +1404,10 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
             common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
-            if self.head_padding > 0:
-                key = torch.cat((k_nope, k_pe), dim=-1)
-            else:
-                common_kwargs["query_rope"] = q_pe
-                common_kwargs["key_rope"] = k_pe.contiguous()
-                query = q_nope
-                key = k_nope
+            common_kwargs["query_rope"] = q_pe
+            common_kwargs["key_rope"] = k_pe.contiguous()
+            query = q_nope
+            key = k_nope
 
             chunk_out, chunk_lse = torch_npu.npu_fused_infer_attention_score(
                 query, key.contiguous(), v.contiguous(), **common_kwargs
@@ -1482,13 +1471,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         }
         record_attention_compute_start()
 
-        if self.head_padding > 0:
-            query = torch.cat((q_nope, q_pe), dim=-1)
-            key = torch.cat((k_nope, k_pe), dim=-1)
-        else:
-            common_kwargs["query_rope"] = q_pe
-            common_kwargs["key_rope"] = k_pe.contiguous()
-            query, key = q_nope, k_nope
+        common_kwargs["query_rope"] = q_pe
+        common_kwargs["key_rope"] = k_pe.contiguous()
+        query, key = q_nope, k_nope
 
         attn_output, attn_lse = torch_npu.npu_fused_infer_attention_score(
             query, key.contiguous(), value.contiguous(), **common_kwargs
@@ -1641,9 +1626,6 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
-        # TODO: The CANN package is expected to support num_heads that are not
-        # powers of 2 in 2026 Q2. Once supported, all padding operations under
-        # `if self.head_padding > 0` in this function can be removed.
         num_tokens = q_nope.size(0)
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
@@ -1687,11 +1669,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             # Input shape: [num_tokens, num_heads, dim]
             q_nope = q_nope.view(num_tokens, self.num_heads, -1).contiguous()
             q_pe = q_pe.view(num_tokens, self.num_heads, -1)
-            if self.head_padding > 0:
-                q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, self.kv_lora_rank)
             sparse_mode = 3
             attn_mask = attn_metadata.decode.attn_mask  # type:ignore
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
@@ -1705,20 +1684,14 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-                attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
             else:
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1727,19 +1700,13 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             else:
                 # Input shape: [num_tokens, num_heads, seq_len, dim]
                 input_layout = "BNSD_NBSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
             sparse_mode = 0
             attn_mask = None
 
@@ -1778,18 +1745,18 @@ class AscendMLAImpl(MLAAttentionImpl):
 
             split_batch_size = num_tokens * fia_num_splits
             if input_layout.endswith("_NBSD"):
-                attn_output_shape = (self.num_heads_padded, split_batch_size, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, split_batch_size, 1, self.kv_lora_rank)
             elif input_layout.startswith("BNSD"):
-                attn_output_shape = (split_batch_size, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (split_batch_size, self.num_heads, 1, self.kv_lora_rank)
             elif input_layout.startswith("BSND"):
-                attn_output_shape = (split_batch_size, 1, self.num_heads_padded, self.kv_lora_rank)
+                attn_output_shape = (split_batch_size, 1, self.num_heads, self.kv_lora_rank)
             else:
                 raise ValueError(f"Unsupported MLA FIA split input layout: {input_layout}")
 
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
-            "num_query_heads": self.num_heads_padded,
+            "num_query_heads": self.num_heads,
             "num_key_value_heads": self.num_kv_heads,
             "input_layout": input_layout,
             "atten_mask": attn_mask,
@@ -1831,7 +1798,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             attn_output = torch.empty(attn_output_shape, dtype=q_pe.dtype, device=q_pe.device)
             if fia_num_splits > 1:
                 softmax_lse = torch.empty(
-                    (split_batch_size, self.num_heads_padded, 1, 1),
+                    (split_batch_size, self.num_heads, 1, 1),
                     dtype=torch.float32,
                     device=q_nope.device,
                 )
@@ -1842,7 +1809,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 weak_ref_tensors(k_nope),
                 weak_ref_tensors(q_pe),
                 weak_ref_tensors(k_pe),
-                self.num_heads_padded,
+                self.num_heads,
                 self.num_kv_heads,
                 input_layout,
                 weak_ref_tensors(attn_mask) if attn_mask is not None else None,
@@ -1893,7 +1860,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout=input_layout,
                 batch_size=num_tokens,
                 num_splits=fia_num_splits,
-                num_heads=self.num_heads_padded,
+                num_heads=self.num_heads,
                 head_dim=self.kv_lora_rank,
                 seq_lens_device=decode_meta.seq_lens_device,
                 chunk_tokens=fia_blocks_per_split * block_size,
@@ -1907,14 +1874,12 @@ class AscendMLAImpl(MLAAttentionImpl):
                     attn_output,
                     input_layout=input_layout,
                     batch_size=num_tokens,
-                    num_heads=self.num_heads_padded,
+                    num_heads=self.num_heads,
                     head_dim=self.kv_lora_rank,
                 )
                 .permute(1, 0, 2)
                 .contiguous()
             )
-        if self.head_padding > 0:
-            attn_output = attn_output[: self.num_heads]
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -942,11 +942,10 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
         else:
             self.dtype = self.vllm_config.model_config.dtype
-        # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
-        # with 20 heads), ascend attention ops require padding heads to the
-        # next power of 2.
-        self.num_heads_padded = 1 << (self.num_heads - 1).bit_length()
-        self.head_padding = self.num_heads_padded - self.num_heads
+        # The prefill fused-attention operator requires combined Q/K inputs
+        # for models whose head count is not a power of two. Decode uses v2,
+        # which accepts the original head count and does not require padding.
+        self.prefill_uses_combined_qk = self.num_heads & (self.num_heads - 1) != 0
 
     @staticmethod
     def update_graph_params(
@@ -1362,7 +1361,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         out_list = [prefix_output.reshape(num_tokens * H, D)]
         lse_list = [prefix_lse.reshape(num_tokens * H)]
 
-        if self.head_padding > 0:
+        if self.prefill_uses_combined_qk:
             query = torch.cat((q_nope, q_pe), dim=-1)
 
         common_kwargs = {
@@ -1412,7 +1411,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
             common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
-            if self.head_padding > 0:
+            if self.prefill_uses_combined_qk:
                 key = torch.cat((k_nope, k_pe), dim=-1)
             else:
                 common_kwargs["query_rope"] = q_pe
@@ -1482,7 +1481,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         }
         record_attention_compute_start()
 
-        if self.head_padding > 0:
+        if self.prefill_uses_combined_qk:
             query = torch.cat((q_nope, q_pe), dim=-1)
             key = torch.cat((k_nope, k_pe), dim=-1)
         else:
@@ -1641,9 +1640,6 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
-        # TODO: The CANN package is expected to support num_heads that are not
-        # powers of 2 in 2026 Q2. Once supported, all padding operations under
-        # `if self.head_padding > 0` in this function can be removed.
         num_tokens = q_nope.size(0)
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
@@ -1687,11 +1683,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             # Input shape: [num_tokens, num_heads, dim]
             q_nope = q_nope.view(num_tokens, self.num_heads, -1).contiguous()
             q_pe = q_pe.view(num_tokens, self.num_heads, -1)
-            if self.head_padding > 0:
-                q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, self.kv_lora_rank)
             sparse_mode = 3
             attn_mask = attn_metadata.decode.attn_mask  # type:ignore
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
@@ -1705,20 +1698,14 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-                attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
             else:
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1727,19 +1714,13 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             else:
                 # Input shape: [num_tokens, num_heads, seq_len, dim]
                 input_layout = "BNSD_NBSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
             sparse_mode = 0
             attn_mask = None
 
@@ -1778,18 +1759,18 @@ class AscendMLAImpl(MLAAttentionImpl):
 
             split_batch_size = num_tokens * fia_num_splits
             if input_layout.endswith("_NBSD"):
-                attn_output_shape = (self.num_heads_padded, split_batch_size, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, split_batch_size, 1, self.kv_lora_rank)
             elif input_layout.startswith("BNSD"):
-                attn_output_shape = (split_batch_size, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (split_batch_size, self.num_heads, 1, self.kv_lora_rank)
             elif input_layout.startswith("BSND"):
-                attn_output_shape = (split_batch_size, 1, self.num_heads_padded, self.kv_lora_rank)
+                attn_output_shape = (split_batch_size, 1, self.num_heads, self.kv_lora_rank)
             else:
                 raise ValueError(f"Unsupported MLA FIA split input layout: {input_layout}")
 
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
-            "num_query_heads": self.num_heads_padded,
+            "num_query_heads": self.num_heads,
             "num_key_value_heads": self.num_kv_heads,
             "input_layout": input_layout,
             "atten_mask": attn_mask,
@@ -1831,7 +1812,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             attn_output = torch.empty(attn_output_shape, dtype=q_pe.dtype, device=q_pe.device)
             if fia_num_splits > 1:
                 softmax_lse = torch.empty(
-                    (split_batch_size, self.num_heads_padded, 1, 1),
+                    (split_batch_size, self.num_heads, 1, 1),
                     dtype=torch.float32,
                     device=q_nope.device,
                 )
@@ -1842,7 +1823,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 weak_ref_tensors(k_nope),
                 weak_ref_tensors(q_pe),
                 weak_ref_tensors(k_pe),
-                self.num_heads_padded,
+                self.num_heads,
                 self.num_kv_heads,
                 input_layout,
                 weak_ref_tensors(attn_mask) if attn_mask is not None else None,
@@ -1893,7 +1874,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout=input_layout,
                 batch_size=num_tokens,
                 num_splits=fia_num_splits,
-                num_heads=self.num_heads_padded,
+                num_heads=self.num_heads,
                 head_dim=self.kv_lora_rank,
                 seq_lens_device=decode_meta.seq_lens_device,
                 chunk_tokens=fia_blocks_per_split * block_size,
@@ -1907,14 +1888,12 @@ class AscendMLAImpl(MLAAttentionImpl):
                     attn_output,
                     input_layout=input_layout,
                     batch_size=num_tokens,
-                    num_heads=self.num_heads_padded,
+                    num_heads=self.num_heads,
                     head_dim=self.kv_lora_rank,
                 )
                 .permute(1, 0, 2)
                 .contiguous()
             )
-        if self.head_padding > 0:
-            attn_output = attn_output[: self.num_heads]
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):


### PR DESCRIPTION
### What this PR does / why we need it?

`npu_fused_infer_attention_score_v2` now supports the original query head count and no longer requires the number of query heads to be a power of two.

This PR removes unnecessary query-head padding from the MLA decode path:

- Pass the original `num_heads` to `npu_fused_infer_attention_score_v2`.
- Remove padded query tensors and padded output shapes in decode.
- Update ACLGraph parameters, softmax LSE buffers, and FIA split merge shapes.
- Keep the prefill combined Q/K fallback because the prefill fused-attention operator still requires it.
- Update unit tests for non-power-of-two heads, including 20 query heads.

This avoids redundant padding and slicing for models such as GLM-4.7-Flash.

### Does this PR introduce any user-facing change?

No. There is no API or command-line interface change.

This is an internal MLA decode optimization and improves compatibility/performance for models whose query head count is not a power of two.

### How was this patch tested?

Static checks:

```bash
git diff --check
python -m py_compile \
  vllm_ascend/attention/mla_v1.py \
  tests/ut/attention/a2/test_mla_v1.py

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
