### PR TITLE
[BugFix][Ops] Resolve packaged custom ops after bootstrap

### DIFF
--- a/csrc/aclnn_torch_adapter/op_api_common.h
+++ b/csrc/aclnn_torch_adapter/op_api_common.h
@@ -253,12 +253,34 @@ inline std::vector<std::string> get_default_custom_lib_path()
     return default_vendors_list;
 }
 
-const std::vector<std::string> g_custom_lib_path = get_custom_lib_path();
-const std::vector<std::string> g_default_custom_lib_path = get_default_custom_lib_path();
-
 inline const char *GetOpApiLibName(void) { return "libopapi.so"; }
 
 inline const char *GetCustOpApiLibName(void) { return "libcust_opapi.so"; }
+
+inline std::vector<std::string> get_packaged_custom_lib_path()
+{
+    Dl_info dl_info;
+    if (dladdr(reinterpret_cast<void *>(&GetOpApiLibName), &dl_info) == 0 || dl_info.dli_fname == nullptr) {
+        return std::vector<std::string>();
+    }
+
+    std::string module_path = real_path(dl_info.dli_fname);
+    if (module_path.empty()) {
+        module_path = std::string(dl_info.dli_fname);
+    }
+    auto last_slash = module_path.find_last_of('/');
+    if (last_slash == std::string::npos) {
+        return std::vector<std::string>();
+    }
+
+    std::string packaged_lib_path =
+        module_path.substr(0, last_slash) + "/_cann_ops_custom/vendors/custom_transformer/op_api/lib/";
+    packaged_lib_path = real_path(packaged_lib_path);
+    if (packaged_lib_path.empty()) {
+        return std::vector<std::string>();
+    }
+    return std::vector<std::string>{packaged_lib_path};
+}
 
 inline void *GetOpApiFuncAddrInLib(void *handler, const char *libName,
                                    const char *apiName) {
@@ -273,8 +295,15 @@ inline void *GetOpApiLibHandler(const char *libName) {
 
 inline void *GetOpApiFuncAddr(const char *apiName)
 {
-    if (!g_custom_lib_path.empty()) {
-        for (auto &it : g_custom_lib_path) {
+    // The packaged custom-op environment is initialized after this extension
+    // can be loaded. Resolve the search paths at lookup time instead of
+    // freezing an empty ASCEND_CUSTOM_OPP_PATH during shared-library startup.
+    std::vector<std::string> custom_lib_path = get_custom_lib_path();
+    std::vector<std::string> default_custom_lib_path = get_default_custom_lib_path();
+    std::vector<std::string> packaged_custom_lib_path = get_packaged_custom_lib_path();
+
+    if (!custom_lib_path.empty()) {
+        for (auto &it : custom_lib_path) {
             auto cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
             if (cust_opapi_lib.empty()) {
                 continue;
@@ -290,8 +319,8 @@ inline void *GetOpApiFuncAddr(const char *apiName)
         }
     }
 
-    if (!g_default_custom_lib_path.empty()) {
-        for (auto &it : g_default_custom_lib_path) {
+    if (!default_custom_lib_path.empty()) {
+        for (auto &it : default_custom_lib_path) {
             auto default_cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
             if (default_cust_opapi_lib.empty()) {
                 continue;
@@ -303,6 +332,20 @@ inline void *GetOpApiFuncAddr(const char *apiName)
                 if (funcAddr != nullptr) {
                     return funcAddr;
                 }
+            }
+        }
+    }
+
+    for (auto &it : packaged_custom_lib_path) {
+        auto packaged_cust_opapi_lib = real_path(it + "/" + GetCustOpApiLibName());
+        if (packaged_cust_opapi_lib.empty()) {
+            continue;
+        }
+        auto custOpApiHandler = GetOpApiLibHandler(packaged_cust_opapi_lib.c_str());
+        if (custOpApiHandler != nullptr) {
+            auto funcAddr = GetOpApiFuncAddrInLib(custOpApiHandler, GetCustOpApiLibName(), apiName);
+            if (funcAddr != nullptr) {
+                return funcAddr;
             }
         }
     }


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #11896.

`vllm_ascend_C` cached `ASCEND_CUSTOM_OPP_PATH` and the default CANN vendor paths in global vectors while the shared library was loading. The platform bootstrap registers the wheel/image's packaged `custom_transformer` vendor later, so the loader kept searching the empty startup-time path set and fell through to CANN's built-in `libopapi.so`. CANN 9.0 does not export `aclnnCausalConv1d`, which produced the reported late startup failure even though the image already contains `libcust_opapi.so` and the CausalConv1d kernel package.

This change:

- resolves custom-op search paths at each ACLNN symbol lookup, after platform bootstrap has had a chance to update the environment;
- adds a module-relative fallback for the packaged `custom_transformer` op API library; and
- removes the stale startup-time path caches.

The implementation adapts vLLM-Ascend-HUST commit `1089282fc6976201af46b6c9f9b53dbbc3369787` by Shuhao Zhang, correcting its packaged vendor path to the `custom_transformer` directory emitted by `build_aclnn.sh`.

### Does this PR introduce _any_ user-facing change?

Yes. Packaged AscendC custom operators remain discoverable when their vendor environment is initialized after `vllm_ascend_C` loads. This allows Qwen3.6 GDN initialization to use the packaged CausalConv1d implementation on CANN versions that do not provide the built-in ACLNN symbol.

### How was this patch tested?

- Reproduced the issue with `quay.io/ascend/vllm-ascend:v0.22.1rc1` on Atlas 800I A2 / Ascend 910B2: importing `vllm_ascend_C` before registering the packaged vendor causes `npu_causal_conv1d_custom` to report that `aclnnCausalConv1d` is missing.
- Inspected the same image's packaged `libcust_opapi.so` and confirmed it exports both `aclnnCausalConv1d` and `aclnnCausalConv1dGetWorkspaceSize`.
- Built the patched `vllm_ascend_C` from source against CANN 9.0.0 for `ascend910b1` successfully.
- Repeated the late-registration probe with the patched extension. Symbol resolution advanced into the packaged operator instead of falling through to the missing built-in ACLNN API. The full operator invocation was not used as an accuracy result because current `main`'s tensor-metadata ABI differs from the v0.22.1rc1 packaged operator ABI; CI should rebuild the matching package and run the existing CausalConv1d coverage.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
