### PR TITLE
[v0.23.0][BugFix] Isolate layerwise GVA keys by parallel rank

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -29,6 +29,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler imp
     LookupKeyClient,
     get_zmq_rpc_path_lookup,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+    KVPoolWorker,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1139,6 +1142,24 @@ class TestKVPoolSchedulerGetLayerwiseGvaHitTokens(unittest.TestCase):
         request.block_hashes = [b"\xaa", b"\xbb"]
         result = scheduler._get_layerwise_gva_hit_tokens(request, 32, 0)
         self.assertEqual(result, 32)
+
+    def test_gva_hit_check_includes_all_pp_ranks(self):
+        scheduler = object.__new__(KVPoolScheduler)
+        scheduler.model_name = "llama-7b"
+        scheduler.tp_size = 2
+        scheduler.put_step = 1
+        scheduler.pp_size = 2
+        worker = object.__new__(KVPoolWorker)
+        worker.model_name = scheduler.model_name
+
+        for num_groups, group_id in ((1, 0), (2, 1)):
+            scheduler.kv_cache_group_ids = list(range(num_groups))
+            worker.num_kv_cache_groups = num_groups
+            keys = scheduler._make_layerwise_gva_keys_for_hit_check(group_id, "deadbeef")
+            self.assertEqual(len(keys), scheduler.tp_size * scheduler.pp_size)
+            for worker.head_or_tp_rank in range(scheduler.tp_size):
+                for worker.pp_rank in range(scheduler.pp_size):
+                    self.assertIn(worker._make_layerwise_gva_key(group_id, "deadbeef"), keys)
 
     def test_partial_hit(self):
         scheduler = self._make_scheduler()

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -1143,11 +1143,13 @@ class TestKVPoolSchedulerGetLayerwiseGvaHitTokens(unittest.TestCase):
         result = scheduler._get_layerwise_gva_hit_tokens(request, 32, 0)
         self.assertEqual(result, 32)
 
-    def test_gva_hit_check_includes_all_pp_ranks(self):
+    def test_gva_hit_check_includes_all_parallel_ranks(self):
         scheduler = object.__new__(KVPoolScheduler)
         scheduler.model_name = "llama-7b"
         scheduler.tp_size = 2
-        scheduler.put_step = 1
+        scheduler.put_step = 2
+        scheduler.pcp_size = 2
+        scheduler.dcp_size = 2
         scheduler.pp_size = 2
         worker = object.__new__(KVPoolWorker)
         worker.model_name = scheduler.model_name
@@ -1156,10 +1158,15 @@ class TestKVPoolSchedulerGetLayerwiseGvaHitTokens(unittest.TestCase):
             scheduler.kv_cache_group_ids = list(range(num_groups))
             worker.num_kv_cache_groups = num_groups
             keys = scheduler._make_layerwise_gva_keys_for_hit_check(group_id, "deadbeef")
-            self.assertEqual(len(keys), scheduler.tp_size * scheduler.pp_size)
-            for worker.head_or_tp_rank in range(scheduler.tp_size):
-                for worker.pp_rank in range(scheduler.pp_size):
-                    self.assertIn(worker._make_layerwise_gva_key(group_id, "deadbeef"), keys)
+            expected_key_count = (
+                scheduler.pcp_size * scheduler.dcp_size * (scheduler.tp_size // scheduler.put_step) * scheduler.pp_size
+            )
+            self.assertEqual(len(keys), expected_key_count)
+            for worker.pcp_rank in range(scheduler.pcp_size):
+                for worker.dcp_rank in range(scheduler.dcp_size):
+                    for worker.head_or_tp_rank in range(scheduler.tp_size // scheduler.put_step):
+                        for worker.pp_rank in range(scheduler.pp_size):
+                            self.assertIn(worker._make_layerwise_gva_key(group_id, "deadbeef"), keys)
 
     def test_partial_hit(self):
         scheduler = self._make_scheduler()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -290,15 +290,22 @@ class KVPoolScheduler:
     def _make_layerwise_gva_keys_for_hit_check(self, group_id: int, block_hash_hex: str) -> list[str]:
         """Generate all-rank GVA keys for scheduler-side hit check.
 
-        Single-group uses PR #11585 format; multi-group includes group_id.
-        Returns one key per head_or_tp_rank (ranks in the same put_step
-        group share one key for MLA).
+        Returns one key per PP and head_or_tp rank. Ranks in the same put_step
+        group share one key for MLA.
         """
         head_or_tp_ranks = self.tp_size // self.put_step
         if len(self.kv_cache_group_ids) > 1:
-            return [f"{self.model_name}@{group_id}@{block_hash_hex}@{h}" for h in range(head_or_tp_ranks)]
+            return [
+                f"{self.model_name}@{group_id}@{block_hash_hex}@{h}@{p}"
+                for h in range(head_or_tp_ranks)
+                for p in range(self.pp_size)
+            ]
         else:
-            return [f"{self.model_name}@{block_hash_hex}@{h}" for h in range(head_or_tp_ranks)]
+            return [
+                f"{self.model_name}@{block_hash_hex}@{h}@{p}"
+                for h in range(head_or_tp_ranks)
+                for p in range(self.pp_size)
+            ]
 
     def _get_layerwise_gva_hit_tokens(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -290,21 +290,25 @@ class KVPoolScheduler:
     def _make_layerwise_gva_keys_for_hit_check(self, group_id: int, block_hash_hex: str) -> list[str]:
         """Generate all-rank GVA keys for scheduler-side hit check.
 
-        Returns one key per PP and head_or_tp rank. Ranks in the same put_step
-        group share one key for MLA.
+        Returns one key per PCP, DCP, PP, and head_or_tp rank. Ranks in the
+        same put_step group share one key when DCP is disabled.
         """
         head_or_tp_ranks = self.tp_size // self.put_step
         if len(self.kv_cache_group_ids) > 1:
             return [
-                f"{self.model_name}@{group_id}@{block_hash_hex}@{h}@{p}"
+                f"{self.model_name}@{group_id}@{block_hash_hex}@{h}@pcp{pcp}@dcp{dcp}@pp{pp}"
+                for pcp in range(self.pcp_size)
+                for dcp in range(self.dcp_size)
                 for h in range(head_or_tp_ranks)
-                for p in range(self.pp_size)
+                for pp in range(self.pp_size)
             ]
         else:
             return [
-                f"{self.model_name}@{block_hash_hex}@{h}@{p}"
+                f"{self.model_name}@{block_hash_hex}@{h}@pcp{pcp}@dcp{dcp}@pp{pp}"
+                for pcp in range(self.pcp_size)
+                for dcp in range(self.dcp_size)
                 for h in range(head_or_tp_ranks)
-                for p in range(self.pp_size)
+                for pp in range(self.pp_size)
             ]
 
     def _get_layerwise_gva_hit_tokens(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -990,22 +990,21 @@ class KVPoolWorker:
     def _make_layerwise_gva_key(self, group_id: int, block_hash_hex: str) -> str:
         """Generate GVA key for layerwise transfer.
 
-        Single-group models use the PR #11585 format (model@hash@rank) for
-        backward compatibility. Multi-group models include group_id
-        (model@group_id@hash@rank) to distinguish groups.
+        Include the PP rank because each PP worker stores a dense local layer
+        range in its own GVA allocation.
         """
         if self.num_kv_cache_groups > 1:
-            return f"{self.model_name}@{group_id}@{block_hash_hex}@{self.head_or_tp_rank}"
+            return f"{self.model_name}@{group_id}@{block_hash_hex}@{self.head_or_tp_rank}@{self.pp_rank}"
         else:
-            return f"{self.model_name}@{block_hash_hex}@{self.head_or_tp_rank}"
+            return f"{self.model_name}@{block_hash_hex}@{self.head_or_tp_rank}@{self.pp_rank}"
 
     def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
         """Allocate per-group GVA on the worker side right before batch_copy.
 
         For multi-group models, iterates all KV cache groups and allocates
-        per-group GVAs. Key format: model@group_id@hash@head_or_tp_rank
-        (multi-group) or model@hash@head_or_tp_rank (single-group, backward
-        compat with PR #11585).
+        per-group GVAs. Key format:
+        model@group_id@hash@head_or_tp_rank@pp_rank (multi-group) or
+        model@hash@head_or_tp_rank@pp_rank (single-group).
         """
         if not self.use_gva_layerwise:
             return

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -887,10 +887,9 @@ class KVPoolWorker:
         group_id: int = 0,
         layer_idx_in_group: int = 0,
     ) -> None:
-        # Only the first rank in each put_step group saves to the
-        # pool.  Other ranks in the same group share the same KV cache
-        # (e.g. MLA latent), so they skip save to avoid redundant writes.
-        if self.tp_rank % self.put_step != 0:
+        # DCP ranks own different KV shards. Without DCP, only the first rank
+        # in each put_step group saves the shared KV cache (e.g. MLA latent).
+        if self.dcp_size <= 1 and self.tp_rank % self.put_step != 0:
             return
         block_size = self._get_effective_group_block_size(group_id)
         request_block_ranges = []
@@ -990,27 +989,34 @@ class KVPoolWorker:
     def _make_layerwise_gva_key(self, group_id: int, block_hash_hex: str) -> str:
         """Generate GVA key for layerwise transfer.
 
-        Include the PP rank because each PP worker stores a dense local layer
-        range in its own GVA allocation.
+        Include CP and PP ranks because each worker stores its local cache and
+        dense local layer range in its own GVA allocation.
         """
         if self.num_kv_cache_groups > 1:
-            return f"{self.model_name}@{group_id}@{block_hash_hex}@{self.head_or_tp_rank}@{self.pp_rank}"
+            return (
+                f"{self.model_name}@{group_id}@{block_hash_hex}@{self.head_or_tp_rank}"
+                f"@pcp{self.pcp_rank}@dcp{self.dcp_rank}@pp{self.pp_rank}"
+            )
         else:
-            return f"{self.model_name}@{block_hash_hex}@{self.head_or_tp_rank}@{self.pp_rank}"
+            return (
+                f"{self.model_name}@{block_hash_hex}@{self.head_or_tp_rank}"
+                f"@pcp{self.pcp_rank}@dcp{self.dcp_rank}@pp{self.pp_rank}"
+            )
 
     def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
         """Allocate per-group GVA on the worker side right before batch_copy.
 
         For multi-group models, iterates all KV cache groups and allocates
         per-group GVAs. Key format:
-        model@group_id@hash@head_or_tp_rank@pp_rank (multi-group) or
-        model@hash@head_or_tp_rank@pp_rank (single-group).
+        model@group_id@hash@head_or_tp_rank@pcp_rank@dcp_rank@pp_rank
+        (multi-group) or model@hash@head_or_tp_rank@pcp_rank@dcp_rank@pp_rank
+        (single-group).
         """
         if not self.use_gva_layerwise:
             return
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
             return
-        if self.tp_rank % self.put_step != 0:
+        if self.dcp_size <= 1 and self.tp_rank % self.put_step != 0:
             return
         for request in requests:
             if request.can_save is None or not request.can_save:


### PR DESCRIPTION
### What this PR does / why we need it?

Isolate AscendStore layerwise GVA entries by PCP, DCP, and PP rank, and require scheduler hit checks to find every parallel-rank and TP/head key.

With DSA CP enabled, each DCP rank owns a different local KV shard. The previous layerwise path omitted the DCP rank from its key and skipped non-leading ranks according to `put_step`, so DCP-local SFA caches could alias or never be saved. This change keeps the existing `put_step` deduplication when DCP is disabled, while allowing every DCP rank to allocate and save its local cache.

The PP rank is also part of the key because pipeline stages address dense local layer ranges from offset zero; sharing one GVA entry could otherwise make layers from different stages overwrite each other, including an MTP layer colliding with a target-model layer at the same local offset.

The change covers both single-group and multi-group KV cache layouts.

### Does this PR introduce _any_ user-facing change?

No. Existing layerwise GVA cache entries use the old key format and will be treated as cache misses.

### How was this patch tested?

- AscendStore pool worker and scheduler unit tests: 137 passed.
- All changed-file pre-commit hooks passed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
