### PR TITLE
[BugFix][v0.23.0][P/D] Prevent premature SWA KV reuse under async scheduling

### DIFF
--- a/tests/ut/core/test_recompute_scheduler.py
+++ b/tests/ut/core/test_recompute_scheduler.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import MethodType
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock
 
 from vllm.sampling_params import SamplingParams
 from vllm.v1.request import Request
@@ -41,3 +42,37 @@ def test_pd_consumer_first_step_injects_placeholder_spec_tokens():
     assert scheduler.requests[request.request_id] is request
     assert request.spec_token_ids == [PLACEHOLDER_TOKEN_ID]
     assert request.num_tokens_with_spec == request.num_tokens + 1
+
+
+def test_update_from_output_settles_finished_request_in_flight_tokens():
+    scheduler = RecomputeScheduler.__new__(RecomputeScheduler)
+    request = SimpleNamespace(
+        num_in_flight_tokens=1,
+        is_finished=lambda: True,
+    )
+    scheduler.requests = {"request": request}
+    scheduler.perf_metrics = None
+    scheduler.connector = None
+    scheduler.enable_return_routed_experts = False
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.kv_cache_manager.take_events.return_value = None
+    scheduler.finished_req_ids_dict = {}
+    scheduler.make_stats = MagicMock(return_value=None)
+
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"request": 1},
+        recomputed_reqs=None,
+    )
+    model_runner_output = SimpleNamespace(
+        sampled_token_ids=[],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        cudagraph_stats=None,
+        routed_experts=None,
+    )
+
+    assert scheduler.update_from_output(scheduler_output, model_runner_output) == {}
+    assert request.num_in_flight_tokens == 0

--- a/tests/ut/patch/platform/test_patch_async_swa_kv_lifetime.py
+++ b/tests/ut/patch/platform/test_patch_async_swa_kv_lifetime.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.core.single_type_kv_cache_manager import MambaManager
+from vllm.v1.kv_cache_interface import MambaSpec, SlidingWindowSpec
+
+import vllm_ascend.patch.platform.patch_async_swa_kv_lifetime as patch
+
+
+def test_schedule_output_tracks_in_flight_tokens(monkeypatch):
+    request = SimpleNamespace(num_in_flight_tokens=0)
+    scheduler = SimpleNamespace(requests={"request": request})
+    scheduler_output = SimpleNamespace(num_scheduled_tokens={"request": 3})
+
+    monkeypatch.setattr(patch, "_original_update_after_schedule", lambda *_args: None)
+    monkeypatch.setattr(patch, "_original_update_from_output", lambda *_args: "output")
+
+    patch._patched_update_after_schedule(scheduler, scheduler_output)
+    assert request.num_in_flight_tokens == 3
+
+    assert patch._patched_update_from_output(scheduler, scheduler_output, SimpleNamespace()) == "output"
+    assert request.num_in_flight_tokens == 0
+
+
+def test_allocate_prunes_on_processed_token_basis(monkeypatch):
+    pruned_at = []
+    swa_manager = SimpleNamespace(
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=512,
+        )
+    )
+    mamba_manager = MambaManager.__new__(MambaManager)
+    mamba_manager.kv_cache_spec = MambaSpec(
+        block_size=1,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        num_speculative_blocks=1,
+    )
+    mamba_manager.num_speculative_blocks = 1
+    mamba_manager.mamba_cache_mode = "none"
+    request = SimpleNamespace(
+        request_id="request",
+        num_in_flight_tokens=1,
+    )
+
+    monkeypatch.setattr(
+        patch,
+        "_original_remove_skipped_blocks",
+        lambda manager, _request_id, num_tokens: pruned_at.append((type(manager.kv_cache_spec), num_tokens)),
+    )
+
+    def original_allocate_slots(_self, current_request):
+        patch._patched_remove_skipped_blocks(swa_manager, current_request.request_id, 159)
+        mamba_manager.remove_skipped_blocks(current_request.request_id, 159)
+
+    monkeypatch.setattr(patch, "_original_allocate_slots", original_allocate_slots)
+
+    patch._patched_allocate_slots(SimpleNamespace(), request)
+    assert pruned_at == [(SlidingWindowSpec, 158), (MambaSpec, 158)]
+
+    patch._patched_remove_skipped_blocks(swa_manager, request.request_id, 159)
+    assert pruned_at == [
+        (SlidingWindowSpec, 158),
+        (MambaSpec, 158),
+        (SlidingWindowSpec, 159),
+    ]
+
+
+def test_connector_prunes_on_processed_token_basis(monkeypatch):
+    pruned_at = []
+    manager = SimpleNamespace(
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=512,
+        )
+    )
+    request = SimpleNamespace(
+        request_id="request",
+        num_in_flight_tokens=1,
+    )
+
+    monkeypatch.setattr(
+        patch,
+        "_original_remove_skipped_blocks",
+        lambda _self, _request_id, num_tokens: pruned_at.append(num_tokens),
+    )
+
+    def original_connector_finished(_self, current_request):
+        patch._patched_remove_skipped_blocks(manager, current_request.request_id, 159)
+        return False, None
+
+    monkeypatch.setattr(patch, "_original_connector_finished", original_connector_finished)
+
+    assert patch._patched_connector_finished(SimpleNamespace(), request) == (
+        False,
+        None,
+    )
+    assert pruned_at == [158]
+
+
+def test_swa_admission_accounts_for_concurrent_batches(monkeypatch):
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=512,
+    )
+    manager = SimpleNamespace(
+        kv_cache_spec=spec,
+        _max_admission_blocks_per_request=None,
+    )
+    vllm_config = SimpleNamespace(
+        max_concurrent_batches=2,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=512),
+        model_config=SimpleNamespace(max_model_len=2048),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+    )
+
+    def original_scheduler_init(scheduler, _vllm_config):
+        scheduler.max_model_len = 2048
+        scheduler.kv_cache_manager = SimpleNamespace(coordinator=SimpleNamespace(single_type_managers=(manager,)))
+
+    monkeypatch.setattr(patch, "_original_scheduler_init", original_scheduler_init)
+
+    scheduler = SimpleNamespace()
+    patch._patched_scheduler_init(scheduler, vllm_config)
+
+    assert manager._max_admission_blocks_per_request == 97
+    assert spec.max_memory_usage_bytes(vllm_config) == 97 * spec.page_size_bytes

--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -902,10 +902,12 @@ class RecomputeScheduler(Scheduler):
         stopped_preempted_reqs: set[Request] = set()
         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
             assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
                 # skip failed or rescheduled requests from KV load failure
                 continue
-            request = self.requests.get(req_id)
             if request is None or request.is_finished():
                 # The request is already finished. This can happen if the
                 # request is aborted while the model is executing it (e.g.,

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -32,6 +32,7 @@ import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 
 if vllm_version_is("0.23.0"):
+    import vllm_ascend.patch.platform.patch_async_swa_kv_lifetime  # noqa
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa

--- a/vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py
+++ b/vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextvars import ContextVar
+from functools import wraps
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
+
+_prune_context: ContextVar[tuple[str, int] | None] = ContextVar("ascend_swa_prune_context", default=None)
+
+
+def _max_in_flight_tokens(vllm_config: VllmConfig) -> int:
+    return vllm_config.max_concurrent_batches * vllm_config.scheduler_config.max_num_batched_tokens
+
+
+_original_request_init = Request.__init__
+
+
+@wraps(_original_request_init)
+def _patched_request_init(self: Request, *args: Any, **kwargs: Any) -> None:
+    _original_request_init(self, *args, **kwargs)
+    self.num_in_flight_tokens = 0
+
+
+_original_update_after_schedule = Scheduler._update_after_schedule
+
+
+@wraps(_original_update_after_schedule)
+def _patched_update_after_schedule(self: Scheduler, scheduler_output: SchedulerOutput) -> None:
+    _original_update_after_schedule(self, scheduler_output)
+    for request_id, num_scheduled_tokens in scheduler_output.num_scheduled_tokens.items():
+        self.requests[request_id].num_in_flight_tokens += num_scheduled_tokens
+
+
+_original_update_from_output = Scheduler.update_from_output
+
+
+@wraps(_original_update_from_output)
+def _patched_update_from_output(
+    self: Scheduler,
+    scheduler_output: SchedulerOutput,
+    model_runner_output: Any,
+) -> Any:
+    for request_id, num_scheduled_tokens in scheduler_output.num_scheduled_tokens.items():
+        if request := self.requests.get(request_id):
+            request.num_in_flight_tokens -= num_scheduled_tokens
+    return _original_update_from_output(self, scheduler_output, model_runner_output)
+
+
+_original_allocate_slots = KVCacheManager.allocate_slots
+
+
+@wraps(_original_allocate_slots)
+def _patched_allocate_slots(self: KVCacheManager, request: Request, *args: Any, **kwargs: Any) -> Any:
+    token = _prune_context.set((request.request_id, request.num_in_flight_tokens))
+    try:
+        return _original_allocate_slots(self, request, *args, **kwargs)
+    finally:
+        _prune_context.reset(token)
+
+
+_original_connector_finished = Scheduler._connector_finished
+
+
+@wraps(_original_connector_finished)
+def _patched_connector_finished(self: Scheduler, request: Request) -> tuple[bool, dict[str, Any] | None]:
+    token = _prune_context.set((request.request_id, request.num_in_flight_tokens))
+    try:
+        return _original_connector_finished(self, request)
+    finally:
+        _prune_context.reset(token)
+
+
+_original_remove_skipped_blocks = SingleTypeKVCacheManager.remove_skipped_blocks
+
+
+@wraps(_original_remove_skipped_blocks)
+def _patched_remove_skipped_blocks(
+    self: SingleTypeKVCacheManager,
+    request_id: str,
+    total_computed_tokens: int,
+) -> None:
+    context = _prune_context.get()
+    if (
+        context is not None
+        and context[0] == request_id
+        and isinstance(self.kv_cache_spec, (ChunkedLocalAttentionSpec, SlidingWindowSpec))
+    ):
+        total_computed_tokens = max(0, total_computed_tokens - context[1])
+    _original_remove_skipped_blocks(self, request_id, total_computed_tokens)
+
+
+def _patched_chunked_local_max_memory_usage_bytes(self: ChunkedLocalAttentionSpec, vllm_config: VllmConfig) -> int:
+    max_blocks = self.max_admission_blocks_per_request(
+        max_num_batched_tokens=_max_in_flight_tokens(vllm_config),
+        max_model_len=vllm_config.model_config.max_model_len,
+    )
+    return max_blocks * self.page_size_bytes
+
+
+def _patched_swa_max_memory_usage_bytes(self: SlidingWindowSpec, vllm_config: VllmConfig) -> int:
+    assert vllm_config.parallel_config.decode_context_parallel_size == 1, "DCP not support sliding window."
+    max_blocks = self.max_admission_blocks_per_request(
+        max_num_batched_tokens=_max_in_flight_tokens(vllm_config),
+        max_model_len=vllm_config.model_config.max_model_len,
+    )
+    return max_blocks * self.page_size_bytes
+
+
+_original_scheduler_init = Scheduler.__init__
+
+
+@wraps(_original_scheduler_init)
+def _patched_scheduler_init(self: Scheduler, vllm_config: VllmConfig, *args: Any, **kwargs: Any) -> None:
+    _original_scheduler_init(self, vllm_config, *args, **kwargs)
+    max_in_flight_tokens = _max_in_flight_tokens(vllm_config)
+    for manager in self.kv_cache_manager.coordinator.single_type_managers:
+        spec = manager.kv_cache_spec
+        if isinstance(spec, (ChunkedLocalAttentionSpec, SlidingWindowSpec)):
+            manager._max_admission_blocks_per_request = spec.max_admission_blocks_per_request(
+                max_num_batched_tokens=max_in_flight_tokens,
+                max_model_len=self.max_model_len,
+            )
+
+
+Request.__init__ = _patched_request_init
+Scheduler.__init__ = _patched_scheduler_init
+Scheduler._update_after_schedule = _patched_update_after_schedule
+Scheduler.update_from_output = _patched_update_from_output
+Scheduler._connector_finished = _patched_connector_finished
+KVCacheManager.allocate_slots = _patched_allocate_slots
+SingleTypeKVCacheManager.remove_skipped_blocks = _patched_remove_skipped_blocks
+ChunkedLocalAttentionSpec.max_memory_usage_bytes = _patched_chunked_local_max_memory_usage_bytes
+SlidingWindowSpec.max_memory_usage_bytes = _patched_swa_max_memory_usage_bytes


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #13501.

vLLM v0.23 advances `request.num_computed_tokens` when a batch is scheduled. Under async scheduling, this optimistic value can include tokens from device steps whose outputs have not been processed yet. SWA and chunked-local pruning currently use that value as the release boundary, so a KV block can return to the pool while an in-flight attention step can still read it. A P/D KV consumer can then reuse the block as a load destination and overwrite it on an unordered transfer stream.

This PR backports the processed-token accounting from https://github.com/vllm-project/vllm/pull/47728 through a v0.23-only vLLM-Ascend monkey patch:

- track scheduled but unprocessed tokens per request;
- prune on `num_computed_tokens - num_in_flight_tokens` in allocation and connector-finish paths;
- account for all overlapping batches in SWA/chunked-local startup sizing and runtime admission;
- settle the counter in the Ascend `RecomputeScheduler` override before failed-load and finished-request early exits.

Synchronous scheduling is unchanged because its in-flight count is zero.

### Does this PR introduce _any_ user-facing change?

Yes. Async P/D serving no longer returns SWA/chunked-local KV blocks to the free pool while an unprocessed step can still read them. The corrected admission bound is intentionally more conservative for KV-constrained, near-maximum-length workloads because overlapping batches may keep an additional chunk in flight.

### How was this patch tested?

Unit and static checks:

```bash
PYTHONPATH=<vllm-v0.23.0>:<this-vllm-ascend-worktree> \
  pytest -q \
    tests/ut/core/test_recompute_scheduler.py \
    tests/ut/patch/platform/test_patch_async_swa_kv_lifetime.py

ruff check \
  vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py \
  tests/ut/patch/platform/test_patch_async_swa_kv_lifetime.py \
  vllm_ascend/core/recompute_scheduler.py \
  tests/ut/core/test_recompute_scheduler.py
```

Result: `6 passed`; Ruff and format checks passed.

Real-model NPU A/B:

- model: DeepSeek-V4-Flash W4A8;
- topology: 16 NPUs, 1P1D, TP8+EP on each side;
- decode: async scheduling, recompute scheduler, KV consumer, `block_size=32`, `max_num_seqs=30`;
- workload: the same 60 requests, 30-way concurrency, 67K completion tokens in the patched run;
- native vLLM-Ascend binaries were identical between baseline and patched runs.

Observed by a read-only block-lifetime tracer:

| Event | v0.23 baseline | Patched |
| --- | ---: | ---: |
| premature out-of-window prune | 42,652 | 0 |
| block reuse before source step settled | 22,299 | 0 |
| HTTP 200 | 60/60 | 60/60 |

No Chinese fragment appeared in either local A/B run, so this validates elimination of the unsafe KV lifetime transition rather than claiming a complete DeepSeek-V4-Pro GPQA accuracy sign-off.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
