### PR TITLE
[v0.25.1rc][BugFix][Frontend] Align DeepSeek V4 reasoning effort with vLLM

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -52,7 +52,34 @@ def test_reasoning_effort_enables_thinking_unless_user_overrides():
     assert params.chat_template_kwargs["enable_thinking"] is False
 
 
-def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
+@pytest.mark.parametrize(
+    ("kwargs", "expected_mode", "expected_effort"),
+    [
+        ({}, "thinking", "high"),
+        ({"enable_thinking": True}, "thinking", "high"),
+        ({"enable_thinking": False}, "chat", None),
+        ({"thinking": False}, "chat", None),
+        ({"reasoning_effort": "none"}, "chat", None),
+        ({"reasoning_effort": "minimal"}, "thinking", "low"),
+        ({"reasoning_effort": "low"}, "thinking", "low"),
+        ({"reasoning_effort": "medium"}, "thinking", "low"),
+        ({"reasoning_effort": "high"}, "thinking", "high"),
+        ({"reasoning_effort": "xhigh"}, "thinking", "high"),
+        ({"reasoning_effort": "max"}, "thinking", "max"),
+        ({"reasoning_effort": "unexpected"}, "thinking", "high"),
+        (
+            {"enable_thinking": False, "reasoning_effort": "max"},
+            "chat",
+            "max",
+        ),
+    ],
+)
+def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(
+    monkeypatch,
+    kwargs,
+    expected_mode,
+    expected_effort,
+):
     captured_kwargs = []
 
     def fake_encode_messages(messages, **kwargs):
@@ -62,25 +89,42 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
 
-    cases = [
-        ("none", "chat", None),
-        ("minimal", "thinking", "high"),
-        ("low", "thinking", None),
-        ("medium", "thinking", "high"),
-        ("high", "thinking", "high"),
-        ("xhigh", "thinking", "max"),
-        ("max", "thinking", "max"),
-        ("unexpected", "thinking", "high"),
-    ]
-    for reasoning_effort, expected_mode, expected_effort in cases:
-        tokenizer.apply_chat_template(
-            [{"role": "user", "content": "hi"}],
-            tokenize=False,
-            enable_thinking=True,
-            reasoning_effort=reasoning_effort,
-        )
-        assert captured_kwargs[-1]["thinking_mode"] == expected_mode
-        assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+    tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+    assert captured_kwargs[-1]["thinking_mode"] == expected_mode
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+
+
+def test_deepseek_v4_defaults_to_thinking_with_high_effort():
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+    )
+
+    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum")
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"reasoning_effort": "none"},
+        {"enable_thinking": False, "reasoning_effort": "max"},
+    ],
+)
+def test_deepseek_v4_explicit_disable_overrides_reasoning_effort(kwargs):
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+
+    assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>hi<｜Assistant｜></think>")
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -77,9 +77,10 @@
 #       and max uses the new "Beyond maximum" prefix. The supported vLLM
 #       Python tokenizer predates this 0731 prompt mapping.
 #    How:
-#       Monkey-patch the tokenizer wrapper to preserve low as the default
-#       no-prefix mode, and wrap render_message to prepend the official 0731
-#       high or max prompt before the first message in thinking mode.
+#       Monkey-patch tokenizer normalization so omitted options select
+#       thinking with high effort and compatibility aliases map to canonical
+#       low, high, or max. Wrap render_message to prepend the official 0731
+#       prompt before the first message in thinking mode.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/50580
 #    Future Plan:

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -43,6 +43,7 @@ REASONING_EFFORT_PROMPTS = {
         "remains unchecked and no error remains undiscovered.\n\n"
     ),
 }
+DEFAULT_REASONING_EFFORT = "low"
 
 _original_render_message = deepseek_v4_encoding.render_message
 _original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
@@ -55,7 +56,7 @@ def _patched_render_message(
     drop_thinking: bool = True,
     reasoning_effort: str | None = None,
 ) -> str:
-    reasoning_effort = reasoning_effort or "low"
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
     if reasoning_effort not in REASONING_EFFORT_PROMPTS:
         raise ValueError(
             f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
@@ -76,7 +77,6 @@ def _patched_render_message(
 def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
     dsv4_tokenizer = _original_get_deepseek_v4_tokenizer(tokenizer)
     tokenizer_cls = type(dsv4_tokenizer)
-    original_apply_chat_template = tokenizer_cls.apply_chat_template
 
     def apply_chat_template(
         self,
@@ -84,15 +84,48 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
         tools: list[dict[str, Any]] | None = None,
         **kwargs,
     ) -> str | list[int]:
-        if kwargs.get("reasoning_effort") == "low":
-            kwargs = dict(kwargs)
-            kwargs["reasoning_effort"] = None
-        return original_apply_chat_template(
-            self,
+        thinking = kwargs.get("thinking")
+        enable_thinking = kwargs.get("enable_thinking")
+        thinking_enabled = bool(thinking) or bool(enable_thinking)
+        if "thinking" not in kwargs and "enable_thinking" not in kwargs:
+            thinking_enabled = True
+        thinking_mode = "thinking" if thinking_enabled else "chat"
+
+        conversation = kwargs.get("conversation", messages)
+        messages = conversation.copy()
+        if tools is not None and len(tools) > 0:
+            messages.insert(0, {"role": "system"})
+            messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+
+        reasoning_effort = kwargs.get("reasoning_effort")
+        if not isinstance(reasoning_effort, str):
+            reasoning_effort = "high" if thinking_enabled else None
+        elif reasoning_effort == "none":
+            thinking_mode = "chat"
+            reasoning_effort = None
+        elif reasoning_effort == "max":
+            reasoning_effort = "max"
+        elif reasoning_effort in ("low", "minimal", "medium"):
+            reasoning_effort = "low"
+        else:
+            reasoning_effort = "high"
+
+        prompt_str = deepseek_v4.encode_messages(
             messages,
-            tools=tools,
-            **kwargs,
+            thinking_mode=thinking_mode,
+            drop_thinking=kwargs.get("drop_thinking", True),
+            reasoning_effort=reasoning_effort,
         )
+
+        if kwargs.get("tokenize", True):
+            tokenizer_kwargs = {key: kwargs[key] for key in ("truncation", "max_length") if key in kwargs}
+            return self.encode(
+                prompt_str,
+                add_special_tokens=False,
+                **tokenizer_kwargs,
+            )
+
+        return prompt_str
 
     tokenizer_cls.apply_chat_template = apply_chat_template
     return dsv4_tokenizer


### PR DESCRIPTION
### What this PR does / why we need it?

This is a follow-up to #13314 that aligns the v0.25.1 release implementation with the behavior merged in https://github.com/vllm-project/vllm/pull/50580.

The vLLM v0.25.1 stack predates that merge, and vLLM Ascend does not include the upstream Rust frontend renderer. This PR updates the existing Python monkey patch so the release stack uses the same request normalization and 0731 renderer behavior:

- omitted thinking and effort select thinking with `high`
- `minimal`, `medium`, and `low` normalize to `low`
- `high`, `xhigh`, and unknown strings normalize to `high`
- `max` remains `max`
- `none` or explicit thinking disablement selects chat mode

The renderer continues to accept canonical `low`, `high`, and `max` values and emits the exact 0731 prefixes introduced by #13314.

### Does this PR introduce _any_ user-facing change?

Yes. On the v0.25.1 release stack, DeepSeek-V4-Flash-0731 now defaults to thinking with high effort and its compatibility aliases match upstream vLLM. Explicit thinking disablement continues to override the requested effort.

### How was this patch tested?

- Tested against the vLLM `v0.25.1` tag at commit `752a3a504485790a2e8491cacbb35c137339ad34`.
- `VLLM_VERSION=0.25.1 python -m pytest -q tests/ut/patch/platform/test_deepseek_v4_thinking.py`
  - Result: `22 passed`
- `bash format.sh ci`
  - Result: all configured checks passed, including ruff, codespell, typos, markdownlint, gitleaks, and repository-local checks.
- Coverage includes omitted options, explicit thinking enable/disable, every supported effort alias, unknown strings, canonical 0731 prompt prefixes, and invalid direct renderer input.

https://github.com/vllm-project/vllm/commit/752a3a504485790a2e8491cacbb35c137339ad34

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
