### PR TITLE
[0.26.0rc][BugFix][Model] Align Kimi K3 frontend with upstream

### DIFF
--- a/docs/source/developer_guide/Design_Documents/patch.md
+++ b/docs/source/developer_guide/Design_Documents/patch.md
@@ -37,7 +37,12 @@ Before writing a patch, following the principle above, we should patch the least
 
 1. Decide which version of vLLM we should patch. For example, after analysis, here we want to patch both `0.10.0` and `main` of vLLM.
 2. Decide which process we should patch. For example, here `distributed` belongs to the vLLM main process, so we should patch `platform`.
-3. Create the patch file in the right folder. The file should be named as `patch_{module_name}.py`. The example here is `vllm_ascend/patch/platform/patch_distributed.py`.
+3. Create the patch entry file in the right folder. Entry files imported directly
+   from the `platform` or `worker` package's `__init__.py` should be named
+   `patch_{module_name}.py`. Supporting implementation modules imported by an
+   entry file may use descriptive names and should not be imported directly from
+   the patch package's `__init__.py`. The example entry file here is
+   `vllm_ascend/patch/platform/patch_distributed.py`.
 4. Write your patch code in the new file. Here is an example:
 
     ```python

--- a/tests/ut/patch/platform/test_patch_kimi_k3_parsers.py
+++ b/tests/ut/patch/platform/test_patch_kimi_k3_parsers.py
@@ -19,7 +19,10 @@ import json
 from types import SimpleNamespace
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedFunction,
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage, ErrorResponse
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
@@ -27,6 +30,7 @@ from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
 from vllm.parser import ParserManager
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
 from vllm.tool_parsers.abstract_tool_parser import ToolParserManager
+from vllm.tool_parsers.structural_tag_registry import get_model_structural_tag
 
 from vllm_ascend.patch.platform import patch_kimi_k3_parsers as parser_patch
 from vllm_ascend.patch.platform.kimi_k3_parser import KimiK3Parser
@@ -158,6 +162,34 @@ def test_kimi_k3_parsers_are_registered_and_composed_like_upstream():
     assert reasoning_only.tool_parser_cls is None
 
 
+def test_named_tool_choice_structural_tag_forces_only_selected_tool():
+    tools = [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": name,
+                "parameters": {"type": "object"},
+            },
+        )
+        for name in ("get_weather", "get_time")
+    ]
+    tool_choice = ChatCompletionNamedToolChoiceParam(
+        type="function",
+        function=ChatCompletionNamedFunction(name="get_time"),
+    )
+
+    tag = get_model_structural_tag(
+        model="kimi_k3",
+        tools=tools,
+        tool_choice=tool_choice,
+        reasoning=False,
+    )
+
+    assert tag is not None
+    assert 'call tool="get_time"' in str(tag)
+    assert 'call tool="get_weather"' not in str(tag)
+
+
 def test_nonstream_accepts_response_without_message_close():
     reasoning, content, calls = _parser().parse(
         _response("answer"),
@@ -283,6 +315,15 @@ def test_typed_arguments_and_whitespace_tolerant_markers():
     }
 
 
+def test_tool_call_ids_are_unique_across_messages():
+    output = _tools(_call())
+
+    first = KimiK3ToolParser(TOKENIZER).extract_tool_calls(output, _request())
+    second = KimiK3ToolParser(TOKENIZER).extract_tool_calls(output, _request())
+
+    assert first.tool_calls[0].id != second.tool_calls[0].id
+
+
 def test_streaming_split_markers_do_not_leak():
     parser = KimiK3ToolParser(TOKENIZER)
     request = _request()
@@ -374,6 +415,51 @@ def test_reasoning_parser_handles_consumed_prefix_and_stale_close():
     current_open = [1, 2, 3]
     assert not parser.is_reasoning_end([*stale_close, *current_open])
     assert parser.is_reasoning_end([*stale_close, *current_open, *stale_close])
+
+
+def test_reasoning_end_streaming_only_scans_the_step_window():
+    parser = KimiK3ReasoningParser(TOKENIZER)
+    close_ids = [4, 2, 3]
+    open_ids = [1, 2, 3]
+    prompt = [*close_ids, *open_ids, 9, 9, 9]
+
+    assert not parser.is_reasoning_end_streaming([*prompt, 7], [7])
+    assert parser.is_reasoning_end_streaming([*prompt, *close_ids], close_ids)
+    assert "is_reasoning_end_streaming" in KimiK3ReasoningParser.__dict__
+
+
+def test_reasoning_end_streaming_detects_marker_across_step_boundary():
+    parser = KimiK3ReasoningParser(TOKENIZER)
+    close_ids = [4, 2, 3]
+    history = [1, 2, 3, 5, *close_ids[:2]]
+
+    assert not parser.is_reasoning_end_streaming(history, [close_ids[1]])
+    assert parser.is_reasoning_end_streaming(
+        [*history, close_ids[2]],
+        [close_ids[2]],
+    )
+
+
+def test_reasoning_end_streaming_uses_the_newest_marker():
+    parser = KimiK3ReasoningParser(TOKENIZER)
+    close_ids = [4, 2, 3]
+    open_ids = [1, 2, 3]
+    window = [*close_ids, *open_ids]
+
+    assert not parser.is_reasoning_end_streaming(
+        [*open_ids, 5, *window],
+        window,
+    )
+
+
+def test_reasoning_end_streaming_accepts_iterator_delta():
+    parser = KimiK3ReasoningParser(TOKENIZER)
+    close_ids = [4, 2, 3]
+
+    assert parser.is_reasoning_end_streaming(
+        [1, 2, 3, 5, *close_ids],
+        iter(close_ids),
+    )
 
 
 def test_remote_decode_d02_glue_bypasses_parser():

--- a/tests/ut/patch/platform/test_patch_kimi_k3_real_tokenizer.py
+++ b/tests/ut/patch/platform/test_patch_kimi_k3_real_tokenizer.py
@@ -24,6 +24,11 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.tokenizers import get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 
+from vllm_ascend.patch.platform.kimi_k3_protocol import (
+    CLOSE_TOKEN,
+    OPEN_TOKEN,
+    SEP_TOKEN,
+)
 from vllm_ascend.patch.platform.patch_kimi_k3_parsers import (
     ARGUMENT_END,
     CALL_END,
@@ -48,7 +53,7 @@ _TOKENIZER_PATH_ENV = "KIMI_K3_TOKENIZER_PATH"
 _KIMI_K3_TOKENIZER_FILE_SHA256 = {
     "tiktoken.model": "b6c497a7469b33ced9c38afb1ad6e47f03f5e5dc05f15930799210ec050c5103",
     "tokenization_kimi.py": "f28ea66e2d862a2a5814970b2ce40c2f7d8296ff09aed90a7e7def689b906944",
-    "encoding_k3.py": "c3869cdb7c5a81b1ee621e55ba589d8f3ffae83063c1085571ee96e2feb826a8",
+    "encoding_k3.py": "b9cb7ae100fed34b9337f80dacee5abbf7e261fe9b74bc0e76366701d46f5333",
     "tokenizer_config.json": "5d0803c94db9cd78763499e0956c95fd5a225c14a727e5a6cf5db3f96f010a6e",
 }
 
@@ -308,10 +313,15 @@ def test_real_renderer_defaults_to_thinking_generation(
 
 
 @pytest.mark.parametrize(
-    ("reasoning_effort", "generation_marker", "has_effort_instruction"),
+    (
+        "reasoning_effort",
+        "generation_marker",
+        "has_effort_instruction",
+        "has_history_reasoning",
+    ),
     [
-        ("high", THINK_START, True),
-        ("none", RESPONSE_START, False),
+        ("high", THINK_START, True, True),
+        ("none", RESPONSE_START, False, False),
     ],
 )
 def test_real_renderer_preserves_multiturn_system_and_reasoning_controls(
@@ -319,6 +329,7 @@ def test_real_renderer_preserves_multiturn_system_and_reasoning_controls(
     reasoning_effort,
     generation_marker,
     has_effort_instruction,
+    has_history_reasoning,
 ):
     tools = [_tool("get_weather")]
     conversation = [
@@ -375,7 +386,86 @@ def test_real_renderer_preserves_multiturn_system_and_reasoning_controls(
     assert 'message role="tool" tool="get_weather" index="1"' in prompt
     assert prompt.endswith(generation_marker)
     assert ('type="thinking-effort"' in prompt) is has_effort_instruction
-    assert "need tool" in prompt
+    assert ("need tool" in prompt) is has_history_reasoning
+
+
+def test_real_renderer_preserves_tool_schema_fields(real_kimi_k3_tokenizer):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": ["integer", "null"],
+                            "default": None,
+                        }
+                    },
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search records",
+                "parameters": {"type": "object"},
+                "strict": False,
+            },
+        },
+    ]
+
+    prompt_ids = real_kimi_k3_tokenizer.apply_chat_template(
+        [{"role": "user", "content": "find it"}],
+        tools=tools,
+        tokenize=True,
+        thinking=False,
+    )
+    prompt = _decode(real_kimi_k3_tokenizer, prompt_ids)
+
+    assert (
+        '{"function":{"name":"lookup","parameters":{"properties":'
+        '{"limit":{"default":null,"type":["integer","null"]}},'
+        '"type":"object"}},"type":"function"}'
+    ) in prompt
+    assert (
+        '{"function":{"description":"Search records","name":"search",'
+        '"parameters":{"type":"object"},"strict":false},"type":"function"}'
+    ) in prompt
+
+
+def test_real_renderer_preserves_malformed_tool_arguments_as_json_block(
+    real_kimi_k3_tokenizer,
+):
+    malformed = '  {"city":"Beijing"  '
+    conversation = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "arguments": malformed,
+                    },
+                }
+            ],
+        }
+    ]
+
+    prompt_ids = real_kimi_k3_tokenizer.apply_chat_template(
+        conversation,
+        tokenize=True,
+        add_generation_prompt=False,
+        thinking=False,
+    )
+    prompt = _decode(real_kimi_k3_tokenizer, prompt_ids)
+
+    assert f'{OPEN_TOKEN}json type="object"{SEP_TOKEN}{malformed}{CLOSE_TOKEN}json{SEP_TOKEN}' in prompt
 
 
 def test_real_segmented_encoding_blocks_prompt_marker_injection(

--- a/tests/ut/patch/platform/test_patch_kimi_k3_renderer.py
+++ b/tests/ut/patch/platform/test_patch_kimi_k3_renderer.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from vllm.config import ModelConfig
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.exceptions import VLLMValidationError
@@ -58,6 +59,37 @@ def test_explicit_kimi_k3_mode_registers_renderer_and_hf_loader():
         OpenAIServingChat._effective_chat_template_kwargs.__module__
         == "vllm.entrypoints.openai.chat_completion.serving"
     )
+
+
+@pytest.mark.parametrize(
+    ("architecture", "tokenizer_mode", "expected"),
+    [
+        ("KimiK3ForConditionalGeneration", "auto", "kimi_k3"),
+        ("KimiK3ForConditionalGeneration", "hf", "hf"),
+        ("LlamaForCausalLM", "auto", "auto"),
+    ],
+)
+def test_kimi_k3_model_config_selects_tokenizer_mode_by_architecture(
+    monkeypatch,
+    architecture,
+    tokenizer_mode,
+    expected,
+):
+    def original_post_init(config, *args, **kwargs):
+        del args, kwargs
+        config._architecture = architecture
+
+    monkeypatch.setattr(
+        ModelConfig,
+        renderer_patch._ORIGINAL_MODEL_CONFIG_POST_INIT_ATTR,
+        original_post_init,
+    )
+    config = object.__new__(ModelConfig)
+    config.tokenizer_mode = tokenizer_mode
+
+    ModelConfig.__post_init__(config)
+
+    assert config.tokenizer_mode == expected
 
 
 def test_renderer_calls_tokenizer_python_encoder_without_jinja():
@@ -516,6 +548,39 @@ def test_auto_tool_choice_survives_vllm_default_merging():
     assert calls[0]["tool_choice"] == "auto"
     assert [tool["function"]["name"] for tool in calls[0]["tools"]] == ["get_time"]
     assert KIMI_K3_PROMPT_TOOL_CHOICE_KEY not in calls[0]
+
+
+def test_named_tool_choice_preserves_full_tool_list_for_python_encoder():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "parameters": {"type": "object"},
+            },
+        }
+        for name in ("get_weather", "get_time")
+    ]
+    request = _request(
+        tools=tools,
+        tool_choice={
+            "type": "function",
+            "function": {"name": "get_time"},
+        },
+    )
+
+    renderer_patch.prepare_kimi_k3_chat_template_kwargs(request)
+
+    kwargs = request.chat_template_kwargs
+    assert kwargs is not None
+    assert [tool["function"]["name"] for tool in kwargs["tools"]] == [
+        "get_weather",
+        "get_time",
+    ]
+    assert kwargs["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "get_time"},
+    }
 
 
 @pytest.mark.parametrize(("renderer_cls", "expected_thinking"), [(KimiK3Renderer, True), (object, None)])

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -158,7 +158,58 @@
 #    Future Plan:
 #       Remove this patch once both upstream fixes are in the supported vLLM.
 #
-# ** 7. File: platform/patch_kv_cache_coordinator.py**
+# ** 7. File: platform/patch_kimi_k3_parsers.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.parser.parser_manager.ParserManager`
+#      `vllm.reasoning.abs_reasoning_parsers.ReasoningParserManager`
+#      `vllm.tool_parsers.abstract_tool_parser.ToolParserManager`
+#      `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#      `vllm.entrypoints.openai.responses.serving.OpenAIServingResponses`
+#    Why:
+#       The vLLM revision pinned by v0.26.0 predates the native Kimi K3 XTML
+#       parser stack. It cannot compose the K3 reasoning and tool parsers or
+#       preserve their token-aware Chat Completions behavior. Ascend PD prefill
+#       also returns an incomplete internal transfer output that must not be
+#       parsed as a final K3 response.
+#    How:
+#       Register the K3 reasoning, tool, structural-tag, and delegating parsers;
+#       extend ParserManager composition for `kimi_k3`; preserve token IDs and
+#       engine finish reasons in Chat Completions; bypass parsing only for PD
+#       prefill remote-decode output; and reject the unsupported Responses API.
+#    Related PR:
+#       https://github.com/vllm-project/vllm/pull/50093
+#       https://github.com/vllm-project/vllm/pull/50420
+#       https://github.com/vllm-project/vllm/pull/50886
+#       The PD prefill bypass is Ascend-specific and has no upstream PR.
+#    Future Plan:
+#       Remove this patch when every supported vLLM revision contains the native
+#       Kimi K3 parser stack and the Ascend PD path no longer sends incomplete
+#       prefill output through the response parser.
+#
+# ** 8. File: platform/patch_kimi_k3_renderer.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.config.model.ModelConfig.__post_init__`
+#      `vllm.tokenizers.TokenizerRegistry`
+#      `vllm.renderers.registry.RENDERER_REGISTRY`
+#      `vllm.renderers.online_renderer.OnlineRenderer.render_chat`
+#      `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#    Why:
+#       The vLLM revision pinned by v0.26.0 has no Kimi K3 renderer or automatic
+#       tokenizer-mode selection. K3 has no Jinja chat template; its trusted
+#       tokenizer-owned Python `encoding_k3.py` implements the XTML protocol.
+#    How:
+#       Register the `kimi_k3` renderer and HF tokenizer loader, select that mode
+#       automatically for `KimiK3ForConditionalGeneration`, and map typed OpenAI
+#       reasoning, tool-choice, response-format, multimodal, and conversation
+#       controls into the official Python encoder.
+#    Related PR:
+#       https://github.com/vllm-project/vllm/pull/50093
+#       https://github.com/vllm-project/vllm/pull/50540
+#    Future Plan:
+#       Remove this patch when every supported vLLM revision contains the native
+#       Kimi K3 Python renderer, request mapping, and automatic tokenizer mode.
+#
+# ** 9. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.HybridKVCacheCoordinator.find_longest_cache_hit_per_group`
 #    Why:
@@ -182,7 +233,7 @@
 #       Remove this patch when vLLM PR #42524 and #44243 is included in the supported
 #       upstream vLLM version.
 #
-# ** 8. File: platform/patch_kv_cache_utils.py**
+# ** 10. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
 #      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
@@ -201,7 +252,7 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
-# ** 9. File: platform/patch_mamba_config.py**
+# ** 11. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -213,7 +264,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM merges the PR.
 #
-# ** 10. File: platform/patch_mamba_config_310.py**
+# ** 12. File: platform/patch_mamba_config_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -230,7 +281,7 @@
 #    Future Plan:
 #       Remove this patch once upstream supports 310P-aligned mamba block sizing.
 #
-# ** 11. File: platform/patch_mamba_manager.py**
+# ** 13. File: platform/patch_mamba_manager.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.single_type_kv_cache_manager.MambaManager`
 #    Why:
@@ -250,7 +301,7 @@
 #          hybrid prefix cache lookup for DCP.
 #       2. Remove this patch once upstream accept 46892 pr or fixed the bug by other pr.
 #
-# ** 12. File: platform/patch_media_connector.py**
+# ** 14. File: platform/patch_media_connector.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.multimodal.media.connector.MediaConnector`
 #      `vllm.multimodal.media.image.ImageMediaIO`
@@ -267,7 +318,7 @@
 #    Future Plan:
 #       Remove this patch when all supported vLLM releases contain PR #49159.
 #
-# ** 13. File: platform/patch_minimax_m2_config.py**
+# ** 15. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.ModelConfig._verify_quantization`
 #    Why:
@@ -328,7 +379,7 @@
 #       Drop the alias once upstream registry includes it or the checkpoint
 #       standardizes architecture strings.
 #
-# ** 14. File: platform/patch_mla_prefill_backend.py**
+# ** 16. File: platform/patch_mla_prefill_backend.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.attention.backends.mla.common.get_mla_prefill_backend`
 #    Why:
@@ -350,7 +401,7 @@
 #       platform/device hook so Ascend can be selected (or skipped) without
 #       monkey-patching.
 #
-# ** 15. File: platform/patch_multiproc_executor.py**
+# ** 17. File: platform/patch_multiproc_executor.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.executor.multiproc_executor.MultiprocExecutor`
 #    Why:
@@ -363,7 +414,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM fix the issue.
 #
-# ** 16. File: platform/patch_pp_mtp.py**
+# ** 18. File: platform/patch_pp_mtp.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.outputs.ModelRunnerOutput`
 #    Why:
@@ -453,7 +504,7 @@
 #       supports local drafter models with PP > 1, or moves the PP validation to a
 #       separate hook that can be overridden per-model-type.
 #
-# ** 17. File: platform/patch_profiling_chunk.py**
+# ** 19. File: platform/patch_profiling_chunk.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCore.__init__`
 #   2. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
@@ -481,7 +532,7 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 18. File: platform/patch_speculative_config.py**
+# ** 20. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -504,7 +555,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 19. File: platform/patch_structured_output.py**
+# ** 21. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -526,7 +577,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 20. File: platform/patch_torch_accelerator.py**
+# ** 22. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -546,7 +597,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 21. File: platform/patch_tool_choice_none_content.py**
+# ** 23. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -562,7 +613,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 22. File: platform/patch_use_v2_model_runner.py**
+# ** 24. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:
@@ -587,7 +638,7 @@
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
 #
-# ** 23. File: platform/patch_weight_transfer_engine.py**
+# ** 25. File: platform/patch_weight_transfer_engine.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["nccl"]`
 #    Why:

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -122,7 +122,58 @@
 #       Remove this patch once upstream exposes a backend dispatch / plugin hook
 #       for selecting the MoE runner implementation.
 #
-# ** 6. File: platform/patch_kv_cache_coordinator.py**
+# ** 6. File: platform/patch_kimi_k3_parsers.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.parser.parser_manager.ParserManager`
+#      `vllm.reasoning.abs_reasoning_parsers.ReasoningParserManager`
+#      `vllm.tool_parsers.abstract_tool_parser.ToolParserManager`
+#      `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#      `vllm.entrypoints.openai.responses.serving.OpenAIServingResponses`
+#    Why:
+#       The vLLM revision pinned by v0.26.0 predates the native Kimi K3 XTML
+#       parser stack. It cannot compose the K3 reasoning and tool parsers or
+#       preserve their token-aware Chat Completions behavior. Ascend PD prefill
+#       also returns an incomplete internal transfer output that must not be
+#       parsed as a final K3 response.
+#    How:
+#       Register the K3 reasoning, tool, structural-tag, and delegating parsers;
+#       extend ParserManager composition for `kimi_k3`; preserve token IDs and
+#       engine finish reasons in Chat Completions; bypass parsing only for PD
+#       prefill remote-decode output; and reject the unsupported Responses API.
+#    Related PR:
+#       https://github.com/vllm-project/vllm/pull/50093
+#       https://github.com/vllm-project/vllm/pull/50420
+#       https://github.com/vllm-project/vllm/pull/50886
+#       The PD prefill bypass is Ascend-specific and has no upstream PR.
+#    Future Plan:
+#       Remove this patch when every supported vLLM revision contains the native
+#       Kimi K3 parser stack and the Ascend PD path no longer sends incomplete
+#       prefill output through the response parser.
+#
+# ** 7. File: platform/patch_kimi_k3_renderer.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.config.model.ModelConfig.__post_init__`
+#      `vllm.tokenizers.TokenizerRegistry`
+#      `vllm.renderers.registry.RENDERER_REGISTRY`
+#      `vllm.renderers.online_renderer.OnlineRenderer.render_chat`
+#      `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#    Why:
+#       The vLLM revision pinned by v0.26.0 has no Kimi K3 renderer or automatic
+#       tokenizer-mode selection. K3 has no Jinja chat template; its trusted
+#       tokenizer-owned Python `encoding_k3.py` implements the XTML protocol.
+#    How:
+#       Register the `kimi_k3` renderer and HF tokenizer loader, select that mode
+#       automatically for `KimiK3ForConditionalGeneration`, and map typed OpenAI
+#       reasoning, tool-choice, response-format, multimodal, and conversation
+#       controls into the official Python encoder.
+#    Related PR:
+#       https://github.com/vllm-project/vllm/pull/50093
+#       https://github.com/vllm-project/vllm/pull/50540
+#    Future Plan:
+#       Remove this patch when every supported vLLM revision contains the native
+#       Kimi K3 Python renderer, request mapping, and automatic tokenizer mode.
+#
+# ** 8. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.HybridKVCacheCoordinator.find_longest_cache_hit_per_group`
 #    Why:
@@ -146,7 +197,7 @@
 #       Remove this patch when vLLM PR #42524 and #44243 is included in the supported
 #       upstream vLLM version.
 #
-# ** 7. File: platform/patch_kv_cache_utils.py**
+# ** 9. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
 #      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
@@ -165,7 +216,7 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
-# ** 8. File: platform/patch_mamba_config.py**
+# ** 10. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -177,7 +228,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM merges the PR.
 #
-# ** 9. File: platform/patch_mamba_config_310.py**
+# ** 11. File: platform/patch_mamba_config_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -194,7 +245,7 @@
 #    Future Plan:
 #       Remove this patch once upstream supports 310P-aligned mamba block sizing.
 #
-# ** 10. File: platform/patch_mamba_manager.py**
+# ** 12. File: platform/patch_mamba_manager.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.single_type_kv_cache_manager.MambaManager`
 #    Why:
@@ -214,7 +265,7 @@
 #          hybrid prefix cache lookup for DCP.
 #       2. Remove this patch once upstream accept 46892 pr or fixed the bug by other pr.
 #
-# ** 11. File: platform/patch_media_connector.py**
+# ** 13. File: platform/patch_media_connector.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.multimodal.media.connector.MediaConnector`
 #      `vllm.multimodal.media.image.ImageMediaIO`
@@ -231,7 +282,7 @@
 #    Future Plan:
 #       Remove this patch when all supported vLLM releases contain PR #49159.
 #
-# ** 12. File: platform/patch_minimax_m2_config.py**
+# ** 14. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.ModelConfig._verify_quantization`
 #    Why:
@@ -292,7 +343,7 @@
 #       Drop the alias once upstream registry includes it or the checkpoint
 #       standardizes architecture strings.
 #
-# ** 13. File: platform/patch_mla_prefill_backend.py**
+# ** 15. File: platform/patch_mla_prefill_backend.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.attention.backends.mla.common.get_mla_prefill_backend`
 #    Why:
@@ -314,7 +365,7 @@
 #       platform/device hook so Ascend can be selected (or skipped) without
 #       monkey-patching.
 #
-# ** 14. File: platform/patch_multiproc_executor.py**
+# ** 16. File: platform/patch_multiproc_executor.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.executor.multiproc_executor.MultiprocExecutor`
 #    Why:
@@ -327,7 +378,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM fix the issue.
 #
-# ** 15. File: platform/patch_pp_mtp.py**
+# ** 17. File: platform/patch_pp_mtp.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.outputs.ModelRunnerOutput`
 #    Why:
@@ -417,7 +468,7 @@
 #       supports local drafter models with PP > 1, or moves the PP validation to a
 #       separate hook that can be overridden per-model-type.
 #
-# ** 16. File: platform/patch_profiling_chunk.py**
+# ** 18. File: platform/patch_profiling_chunk.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCore.__init__`
 #   2. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
@@ -445,7 +496,7 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 17. File: platform/patch_speculative_config.py**
+# ** 19. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -468,7 +519,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 18. File: platform/patch_structured_output.py**
+# ** 20. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -490,7 +541,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 19. File: platform/patch_torch_accelerator.py**
+# ** 21. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -510,7 +561,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 20. File: platform/patch_tool_choice_none_content.py**
+# ** 22. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -526,7 +577,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 21. File: platform/patch_use_v2_model_runner.py**
+# ** 23. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:
@@ -551,7 +602,7 @@
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
 #
-# ** 22. File: platform/patch_weight_transfer_engine.py**
+# ** 24. File: platform/patch_weight_transfer_engine.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["nccl"]`
 #    Why:

--- a/vllm_ascend/patch/platform/kimi_k3_reasoning_parser.py
+++ b/vllm_ascend/patch/platform/kimi_k3_reasoning_parser.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Reasoning parser for the Kimi K3 (XTML) chat format.
 
-Vendored from vLLM commit f5a7cce9b6a61f4d995629a7418c7ea822e34a64.
+Vendored from vLLM commit adbf08d977fb3fa26c4f19826745a02abd6dd7ca.
 """
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -20,14 +20,33 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
+def _match_at(haystack: Sequence[int], index: int, needle: Sequence[int]) -> bool:
+    return all(haystack[index + offset] == token for offset, token in enumerate(needle))
+
+
 def _subseq_index(haystack: Sequence[int], needle: Sequence[int]) -> int:
     """Return start index of the last occurrence of needle in haystack, or -1."""
     n = len(needle)
     if n == 0:
         return -1
+    first = needle[0]
     for i in range(len(haystack) - n, -1, -1):
-        if list(haystack[i : i + n]) == list(needle):
+        if haystack[i] == first and _match_at(haystack, i, needle):
             return i
+    return -1
+
+
+def _newest_marker(haystack: Sequence[int], first: Sequence[int], second: Sequence[int]) -> int:
+    """Return 0 or 1 for the newest marker, or -1 if neither occurs."""
+    if not first or not second:
+        return -1
+    first_head, second_head = first[0], second[0]
+    for index in range(len(haystack) - min(len(first), len(second)), -1, -1):
+        token = haystack[index]
+        if token == first_head and index + len(first) <= len(haystack) and _match_at(haystack, index, first):
+            return 0
+        if token == second_head and index + len(second) <= len(haystack) and _match_at(haystack, index, second):
+            return 1
     return -1
 
 
@@ -88,11 +107,22 @@ class KimiK3ReasoningParser(ReasoningParser):
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         if not self._thinking_enabled:
             return True
-        last_close = _subseq_index(input_ids, self._think_close_ids)
-        last_open = _subseq_index(input_ids, self._think_open_ids)
-        if last_open == -1:
-            return last_close != -1
-        return last_close > last_open
+        return _newest_marker(input_ids, self._think_close_ids, self._think_open_ids) == 0
+
+    def is_reasoning_end_streaming(
+        self,
+        input_ids: Sequence[int],
+        delta_ids: Iterable[int],
+    ) -> bool:
+        if not self._thinking_enabled:
+            return True
+        delta = list(delta_ids)
+        if not delta:
+            return False
+        carry = max(len(self._think_close_ids), len(self._think_open_ids)) - 1
+        delta_start = len(input_ids) - len(delta)
+        window = list(input_ids[max(0, delta_start - carry) : delta_start]) + delta
+        return _newest_marker(window, self._think_close_ids, self._think_open_ids) == 0
 
     def _extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if not self._thinking_enabled:

--- a/vllm_ascend/patch/platform/kimi_k3_tool_parser.py
+++ b/vllm_ascend/patch/platform/kimi_k3_tool_parser.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tool-call parser for the Kimi K3 (XTML) chat format.
 
-Vendored from vLLM commit f5a7cce9b6a61f4d995629a7418c7ea822e34a64.
+Vendored from vLLM commit ab98034d4ccccd62e814ebcdc3f3831586b1c8d7.
 """
 
 import json
@@ -130,7 +130,6 @@ class KimiK3ToolParser(ToolParser):
     def _decode_call(self, attrs: str, body: str) -> ToolCall | None:
         call_attrs = self._attrs(attrs)
         tool_name = call_attrs.get("tool", "")
-        tool_index = call_attrs.get("index", "")
         arguments: dict = {}
         for arg_match in self._arg_re.finditer(body):
             arg_attrs = self._attrs(arg_match["attrs"])
@@ -146,14 +145,7 @@ class KimiK3ToolParser(ToolParser):
                     arguments[key] = raw_value
         if not tool_name:
             return None
-        tool_call_id = tool_name
-        if tool_index:
-            try:
-                tool_call_id = f"{tool_name}:{int(tool_index) - 1}"
-            except ValueError:
-                tool_call_id = f"{tool_name}:{tool_index}"
         return ToolCall(
-            id=tool_call_id,
             type="function",
             function=FunctionCall(
                 name=tool_name,

--- a/vllm_ascend/patch/platform/patch_kimi_k3_renderer.py
+++ b/vllm_ascend/patch/platform/patch_kimi_k3_renderer.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import Any
 
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
@@ -57,6 +57,7 @@ _KIMI_K3_PROMPT_TOOL_CHOICE_PREFIX = "kimi_k3:"
 _KIMI_K3_PROMPT_TOOL_CHOICES = frozenset({"none", "auto", "required"})
 _ORIGINAL_RENDER_CHAT_ATTR = "_ascend_original_kimi_k3_render_chat"
 _ORIGINAL_EFFECTIVE_KWARGS_ATTR = "_ascend_original_kimi_k3_effective_chat_template_kwargs"
+_ORIGINAL_MODEL_CONFIG_POST_INIT_ATTR = "_ascend_original_kimi_k3_model_config_post_init"
 _PREPARED_ATTR = "_kimi_k3_chat_params_prepared"
 _K3_MEDIA_IO_DEFAULTS: dict[str, dict[str, Any]] = {
     "image": {"image_mode": None},
@@ -120,23 +121,6 @@ def _apply_k3_thinking_kwargs(kwargs: dict[str, Any]) -> None:
             parameter="thinking_effort",
             value=thinking_effort,
         )
-
-
-def _tool_name(tool: Any) -> str | None:
-    if isinstance(tool, dict):
-        function = tool.get("function")
-        if isinstance(function, dict):
-            return function.get("name")
-        return getattr(function, "name", None)
-    return getattr(getattr(tool, "function", None), "name", None)
-
-
-def _named_tool_choice(request: ChatCompletionRequest) -> str | None:
-    choice = request.tool_choice
-    function = choice.get("function") if isinstance(choice, dict) else getattr(choice, "function", None)
-    if isinstance(function, dict):
-        return function.get("name")
-    return getattr(function, "name", None)
 
 
 def prepare_kimi_k3_chat_template_kwargs(request: ChatCompletionRequest) -> None:
@@ -216,21 +200,10 @@ def prepare_kimi_k3_chat_template_kwargs(request: ChatCompletionRequest) -> None
 
     template_kwargs["tools"] = request_tools
 
-    named_tool = _named_tool_choice(request)
-    if named_tool:
-        matching_tools = [tool for tool in request_tools if _tool_name(tool) == named_tool]
-        if not matching_tools:
-            raise VLLMValidationError(
-                f"Named Kimi K3 tool choice {named_tool!r} is not declared.",
-                parameter="tool_choice",
-            )
-        template_kwargs["tool_choice"] = "required"
-        template_kwargs["tools"] = matching_tools
+    if request.tool_choice is not None:
+        template_kwargs["tool_choice"] = _model_dump(request.tool_choice)
     else:
-        if isinstance(request.tool_choice, str):
-            template_kwargs["tool_choice"] = request.tool_choice
-        elif request.tool_choice is None:
-            template_kwargs["tool_choice"] = "auto" if template_kwargs.get("tools") else "none"
+        template_kwargs["tool_choice"] = "auto" if template_kwargs.get("tools") else "none"
 
     prompt_tool_choice = template_kwargs.get("tool_choice")
     if isinstance(prompt_tool_choice, str) and prompt_tool_choice in _KIMI_K3_PROMPT_TOOL_CHOICES:
@@ -455,6 +428,29 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             prompt["multi_modal_uuids"] = mm_uuids
 
         return conversation, prompt
+
+
+if not hasattr(ModelConfig, _ORIGINAL_MODEL_CONFIG_POST_INIT_ATTR):
+    setattr(
+        ModelConfig,
+        _ORIGINAL_MODEL_CONFIG_POST_INIT_ATTR,
+        ModelConfig.__post_init__,
+    )
+
+
+@wraps(getattr(ModelConfig, _ORIGINAL_MODEL_CONFIG_POST_INIT_ATTR))
+def _model_config_post_init_with_kimi_k3_tokenizer_mode(
+    self: ModelConfig,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    original = getattr(ModelConfig, _ORIGINAL_MODEL_CONFIG_POST_INIT_ATTR)
+    original(self, *args, **kwargs)
+    if self.tokenizer_mode == "auto" and self._architecture == "KimiK3ForConditionalGeneration":
+        self.tokenizer_mode = KIMI_K3_RENDERER_MODE
+
+
+ModelConfig.__post_init__ = _model_config_post_init_with_kimi_k3_tokenizer_mode
 
 
 if KIMI_K3_RENDERER_MODE not in TokenizerRegistry.tokenizers:


### PR DESCRIPTION
### What this PR does / why we need it?

本 PR 将 `releases/v0.26.0rc` 中的 Kimi K3 Python frontend 行为对齐到当前上游 vLLM 已合入实现，改动限于 K3 patch、对应单测和 patch 文档：

- 回移 https://github.com/vllm-project/vllm/pull/50886：reasoning-end streaming 检查从每步扫描完整历史改为只扫描当前 delta 和 marker carry window，避免长上下文下 O(context/step) 开销。
- 回移 https://github.com/vllm-project/vllm/pull/50420：不再用 `name:index` 构造 tool-call ID，改用 vLLM 默认随机 ID，保证多轮会话中 ID 唯一。
- 对齐 https://github.com/vllm-project/vllm/pull/50093：named tool choice 保留完整 tools 和原始 choice，由 K3 structural tag 强制目标函数，不再通过过滤工具列表并改写成 `required` 来近似。
- 对齐 K3 架构默认 tokenizer mode：当 `KimiK3ForConditionalGeneration` 使用默认 `tokenizer_mode=auto` 时自动选择 `kimi_k3`；用户显式指定的 mode 和其他模型保持不变。
- https://github.com/vllm-project/vllm/pull/50540 修改的是 Rust renderer；Ascend 0.26 使用模型官方 Python `encoding_k3.py`，该行为已经存在，因此不复制 Rust renderer，只增加官方 tokenizer 契约测试，覆盖缺省 description、`strict`、schema `null` 和 malformed tool arguments。
- 补充 K3 parser/renderer patch 清单，并明确 `patch_*.py` 命名只约束由 patch package `__init__.py` 直接导入的入口模块；入口引用的支撑实现可以使用领域名称。
- 2026-08-11 复核 vLLM latest main https://github.com/vllm-project/vllm/commit/d8f840071efd631f71b06d4b31cb6dba2275a356：K3 parser、reasoning parser、tool parser、renderer 和 tokenizer-mode 自动选择在本 PR 覆盖范围内没有新的已合入行为差异。

以下上游 PR 截至本次复核均未合入，本 PR 不提前回移未定语义：

- https://github.com/vllm-project/vllm/pull/50229
- https://github.com/vllm-project/vllm/pull/50291
- https://github.com/vllm-project/vllm/pull/50367
- https://github.com/vllm-project/vllm/pull/50543
- https://github.com/vllm-project/vllm/pull/50627
- https://github.com/vllm-project/vllm/pull/50628

### Does this PR introduce _any_ user-facing change?

是：Kimi K3 不再需要手动传 `--tokenizer-mode kimi_k3`；tool-call ID、named tool choice、reasoning streaming 和官方 Python chat-template 行为与上游已合入实现一致。其他架构和显式 tokenizer mode 不受影响。

### How was this patch tested?

- 在基于 `3fd0e217fe59ac07bdf7bb484580d69ddbfbefcc`、检出 head `03f6ca8aba0f027355b51b8866df95e1dc9edf8d` 的临时干净 detached worktree 中，`python -m pytest -q tests/ut/patch`：`231 passed, 1 skipped, 0 failed`。唯一 skip 是仅适用于 vLLM Git source checkout 的 balance-scheduler tag drift guard；wheel 环境是该测试明确支持的 skip 条件。
- K3 parser/renderer/官方 tokenizer 三个测试文件：`58 passed, 0 skipped, 0 failed`。
- 变更路径 Ruff format/check：通过。
- 变更实现定向 mypy（Python 3.10/3.11/3.12）：通过。
- 文档 codespell/typos：通过。
- `py_compile`、`git diff --check`：通过。

本次验证以官方 tokenizer 和协议级单测为准，未执行真权重 NPU serving。


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
