### PR TITLE
[Refactor][Platform] Move fused MoE expert routing into router classes

### DIFF
--- a/tests/ut/_310p/fused_moe/test_experts_selector_310.py
+++ b/tests/ut/_310p/fused_moe/test_experts_selector_310.py
@@ -19,13 +19,23 @@ import pytest
 import torch
 
 from vllm_ascend._310p.fused_moe.experts_selector import select_experts
+from vllm_ascend._310p.fused_moe.grouped_topk_router import AscendGroupedTopKRouter310
+from vllm_ascend.ops.fused_moe.router.router_factory import create_ascend_fused_moe_router
 
 
 class TestExpertsSelector310:
     @pytest.mark.parametrize("global_num_experts", [256, 128])
-    def test_select_experts(self, global_num_experts):
+    def test_grouped_topk_router_310_select_experts(self, global_num_experts):
         hidden_states = torch.randn(8, 16)
         router_logits = torch.randn(8, 8)
+        router = AscendGroupedTopKRouter310(
+            top_k=2,
+            global_num_experts=global_num_experts,
+            num_expert_group=None,
+            topk_group=None,
+            use_grouped_topk=False,
+            renormalize=True,
+        )
 
         with patch("torch_npu.npu_moe_gating_top_k_softmax") as mock_npu:
             mock_npu.return_value = (
@@ -34,29 +44,25 @@ class TestExpertsSelector310:
                 None,
             )
 
-            topk_weights, topk_ids = select_experts(
-                hidden_states=hidden_states,
-                router_logits=router_logits,
-                top_k=2,
-                use_grouped_topk=False,
-                renormalize=True,
-                topk_group=None,
-                num_expert_group=None,
-                custom_routing_function=None,
-                scoring_func="softmax",
-                e_score_correction_bias=None,
-                global_num_experts=global_num_experts,
-            )
+            topk_weights, topk_ids = router._select_experts(hidden_states=hidden_states, router_logits=router_logits)
 
             mock_npu.assert_called_once()
 
         assert topk_weights.shape == (8, 2)
         assert topk_ids.shape == (8, 2)
 
-    def test_select_experts_chunks_large_token_batch(self):
+    def test_grouped_topk_router_310_chunks_large_token_batch(self):
         num_tokens = 2050
         hidden_states = torch.randn(num_tokens, 16)
         router_logits = torch.randn(num_tokens, 8)
+        router = AscendGroupedTopKRouter310(
+            top_k=2,
+            global_num_experts=8,
+            num_expert_group=None,
+            topk_group=None,
+            use_grouped_topk=False,
+            renormalize=True,
+        )
 
         def mock_gating(logits, k):
             return (
@@ -69,17 +75,46 @@ class TestExpertsSelector310:
             "torch_npu.npu_moe_gating_top_k_softmax",
             side_effect=mock_gating,
         ) as mock_npu:
+            topk_weights, topk_ids = router._select_experts(hidden_states=hidden_states, router_logits=router_logits)
+
+        assert [call.args[0].shape[0] for call in mock_npu.call_args_list] == [1024, 1024, 2]
+        assert topk_weights.shape == (num_tokens, 2)
+        assert topk_ids.shape == (num_tokens, 2)
+        assert torch.all(topk_weights == 0.5)
+
+    def test_select_experts_wrapper_uses_310p_router(self):
+        hidden_states = torch.randn(8, 16)
+        router_logits = torch.randn(8, 8)
+
+        with patch.object(
+            AscendGroupedTopKRouter310,
+            "_select_experts",
+            return_value=(
+                torch.ones(8, 2, dtype=torch.float32),
+                torch.zeros(8, 2, dtype=torch.int32),
+            ),
+        ) as mock_select:
             topk_weights, topk_ids = select_experts(
                 hidden_states=hidden_states,
                 router_logits=router_logits,
                 top_k=2,
                 use_grouped_topk=False,
                 renormalize=True,
-                custom_routing_function=None,
-                scoring_func="softmax",
+                global_num_experts=8,
             )
 
-        assert [call.args[0].shape[0] for call in mock_npu.call_args_list] == [1024, 1024, 2]
-        assert topk_weights.shape == (num_tokens, 2)
-        assert topk_ids.shape == (num_tokens, 2)
-        assert torch.all(topk_weights == 0.5)
+        mock_select.assert_called_once_with(hidden_states=hidden_states, router_logits=router_logits)
+        assert topk_weights.shape == (8, 2)
+        assert topk_ids.shape == (8, 2)
+
+    def test_router_factory_returns_310p_router(self, monkeypatch):
+        monkeypatch.setattr("vllm_ascend.ops.fused_moe.router.router_factory.is_310p", lambda: True)
+
+        router = create_ascend_fused_moe_router(
+            top_k=2,
+            global_num_experts=8,
+            renormalize=True,
+            use_grouped_topk=False,
+        )
+
+        assert isinstance(router, AscendGroupedTopKRouter310)

--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -135,6 +135,44 @@ def test_process_weights_after_loading_310_uses_version_specific_layout(
     assert layer.w2_weight.is_contiguous() is True
 
 
+def test_unquantized_apply_310_uses_preselected_experts():
+    method = AscendUnquantizedFusedMoEMethod310.__new__(AscendUnquantizedFusedMoEMethod310)
+    expert_map = torch.tensor([0, 1], dtype=torch.int32)
+    layer = SimpleNamespace(
+        w13_weight=torch.randn(2, 4, 6),
+        w2_weight=torch.randn(2, 6, 4),
+        ascend_expert_map=expert_map,
+        apply_router_weight_on_input=True,
+    )
+    hidden_states = torch.randn(3, 6)
+    topk_weights = torch.rand(3, 2)
+    topk_ids = torch.tensor([[0, 1], [1, 0], [0, 1]], dtype=torch.int32)
+    expected_output = object()
+    comm_method = MagicMock()
+    comm_method.fused_experts.return_value = expected_output
+
+    with patch.object(
+        fused_moe_310_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(moe_comm_method=comm_method),
+    ):
+        output = method.apply(
+            layer=layer,
+            x=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
+        )
+
+    assert output is expected_output
+    fused_experts_input = comm_method.fused_experts.call_args.kwargs["fused_experts_input"]
+    assert fused_experts_input.topk_weights is topk_weights
+    assert fused_experts_input.topk_ids is topk_ids
+    assert fused_experts_input.routing.expert_map is expert_map
+    assert fused_experts_input.routing.apply_router_weight_on_input is True
+
+
 class _Projection(nn.Module):
     def forward(self, hidden_states):
         return hidden_states * 2.0 + 1.0, None

--- a/tests/ut/_310p/quantization/test_w8a8_dynamic_moe_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_dynamic_moe_310.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend._310p.quantization.methods import w8a8_dynamic as w8a8_dynamic_310_module
+from vllm_ascend._310p.quantization.methods.w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod310
+
+
+def test_w8a8_dynamic_moe_apply_310_uses_preselected_experts():
+    method = AscendW8A8DynamicFusedMoEMethod310.__new__(AscendW8A8DynamicFusedMoEMethod310)
+    method.in_dtype = torch.float16
+    expert_map = torch.tensor([0, 1], dtype=torch.int32)
+    layer = SimpleNamespace(
+        w13_weight=torch.randint(-8, 8, (2, 4, 6), dtype=torch.int8),
+        w2_weight=torch.randint(-8, 8, (2, 6, 4), dtype=torch.int8),
+        w13_weight_scale=torch.ones(2, 4),
+        w2_weight_scale=torch.ones(2, 6),
+        ascend_expert_map=expert_map,
+        apply_router_weight_on_input=True,
+    )
+    hidden_states = torch.randn(3, 6, dtype=torch.float16)
+    topk_weights = torch.rand(3, 2, dtype=torch.float32)
+    topk_ids = torch.tensor([[0, 1], [1, 0], [0, 1]], dtype=torch.int32)
+    expected_output = object()
+    comm_method = MagicMock()
+    comm_method.fused_experts.return_value = expected_output
+
+    with patch.object(
+        w8a8_dynamic_310_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(moe_comm_method=comm_method),
+    ):
+        output = method.apply(
+            layer=layer,
+            x=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
+        )
+
+    assert output is expected_output
+    fused_experts_input = comm_method.fused_experts.call_args.kwargs["fused_experts_input"]
+    torch.testing.assert_close(fused_experts_input.topk_weights, topk_weights.to(torch.float16))
+    assert fused_experts_input.topk_ids is topk_ids
+    assert fused_experts_input.routing.expert_map is expert_map
+    assert fused_experts_input.routing.apply_router_weight_on_input is True

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -39,6 +39,13 @@ def _build_apply_layer():
         zero_expert_type=None,
         n_shared_experts=0,
         swiglu_limit=0.0,
+        activation="gelu",
+        apply_router_weight_on_input=True,
+        ascend_expert_map=None,
+        global_redundant_expert_num=0,
+        log2phy=None,
+        _ascend_pertoken_scale=None,
+        _ascend_mc2_mask=None,
     )
 
 
@@ -218,26 +225,17 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
         "_EXTRA_CTX",
         SimpleNamespace(moe_comm_type=moe_comm_type, moe_comm_method=moe_comm_method),
     )
-    monkeypatch.setattr(routed_experts_module, "get_moe_num_logical_experts", lambda *args, **kwargs: 4)
-    monkeypatch.setattr(routed_experts_module, "get_forward_context", lambda: SimpleNamespace(input_ids=None))
-    monkeypatch.setattr(routed_experts_module, "get_current_vllm_config", lambda: None)
-    select_experts = MagicMock(return_value=(topk_weights, topk_ids))
-    monkeypatch.setattr(routed_experts_module, "select_experts", select_experts)
 
     result = method.apply(
         layer=layer,
         x=hidden_states,
-        use_grouped_topk=False,
-        top_k=2,
-        router_logits=torch.randn(2, 4),
-        renormalize=True,
-        num_experts=4,
-        apply_router_weight_on_input=True,
-        activation="gelu",
+        topk_weights=topk_weights.to(hidden_states.dtype),
+        topk_ids=topk_ids,
+        shared_experts=None,
+        shared_experts_input=None,
     )
 
     assert result is routed_out
-    select_experts.assert_called_once()
     fused_input = moe_comm_method.fused_experts.call_args.kwargs["fused_experts_input"]
     assert fused_input.hidden_states is hidden_states
     torch.testing.assert_close(fused_input.topk_weights, topk_weights.to(hidden_states.dtype))
@@ -277,6 +275,34 @@ def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_ena
     assert runner._maybe_reduce_shared_expert_output(shared_output) is shared_output
 
 
+def test_routed_experts_select_experts_validates_router_logits(monkeypatch):
+    routed_experts = AscendRoutedExperts.__new__(AscendRoutedExperts)
+    hidden_states = torch.randn(2, 4)
+    router_logits = torch.randn(2, 3)
+    routed_experts.router = SimpleNamespace(
+        _select_experts=MagicMock(
+            return_value=(
+                torch.randn(2, 2, dtype=torch.float32),
+                torch.randint(0, 3, (2, 2), dtype=torch.int64),
+            )
+        )
+    )
+    routed_experts.moe_config = SimpleNamespace(num_experts=4)
+    routed_experts.global_redundant_expert_num = 0
+    routed_experts.n_shared_experts = 0
+    routed_experts.zero_expert_num = 0
+    routed_experts.zero_expert_type = None
+    monkeypatch.setattr(routed_experts_module, "get_forward_context", lambda: SimpleNamespace(input_ids=None))
+    monkeypatch.setattr(routed_experts_module, "get_current_vllm_config", lambda: None)
+
+    with pytest.raises(AssertionError, match="router_logits.shape\\[1\\]=3"):
+        routed_experts._select_experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            enable_force_load_balance=False,
+        )
+
+
 @pytest.mark.parametrize("return_with_event", [False, True])
 def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_event):
     routed_experts = AscendRoutedExperts.__new__(AscendRoutedExperts)
@@ -286,24 +312,28 @@ def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_
     prepared_router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     finalized = torch.randn(2, 4)
-    quant_method = MagicMock()
-    quant_method.quant_method = SimpleNamespace(quant_type=QuantType.NONE)
-    quant_method.apply.return_value = SimpleNamespace(
-        routed_out=routed_out,
-        expert_tokens=None,
-        group_list_type=1,
-        before_dispatch_evt=None,
-        before_gmm2_evt=None,
-        before_combine_evt=None,
-        swiglu_limit=0.0,
+    quant_method = AscendUnquantizedFusedMoEMethod.__new__(AscendUnquantizedFusedMoEMethod)
+    quant_method.apply = MagicMock(
+        return_value=SimpleNamespace(
+            routed_out=routed_out,
+            expert_tokens=None,
+            group_list_type=1,
+            before_dispatch_evt=None,
+            before_gmm2_evt=None,
+            before_combine_evt=None,
+            swiglu_limit=0.0,
+        )
     )
     routed_experts.enable_npugraph_ex_static_kernel = False
     routed_experts.enable_shared_expert_dp = False
-    routed_experts.quant_method = quant_method
+    object.__setattr__(routed_experts, "quant_method", quant_method)
+    topk_weights = torch.tensor([[0.25, 0.75], [0.6, 0.4]], dtype=torch.float32)
+    topk_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int64)
+    routed_experts.router = SimpleNamespace(_select_experts=MagicMock(return_value=(topk_weights, topk_ids)))
     routed_experts.top_k = 2
     routed_experts.renormalize = True
     routed_experts.use_grouped_topk = False
-    routed_experts.moe_config = SimpleNamespace(num_experts=4)
+    routed_experts.moe_config = SimpleNamespace(num_experts=3)
     routed_experts.ascend_expert_map = None
     routed_experts.topk_group = None
     routed_experts.num_expert_group = None
@@ -315,6 +345,7 @@ def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_
     routed_experts.apply_router_weight_on_input = True
     routed_experts.log2phy = None
     routed_experts.global_redundant_expert_num = 0
+    routed_experts.n_shared_experts = 0
     routed_experts.dynamic_eplb = False
     routed_experts.return_with_event = return_with_event
     moe_comm_method = MagicMock()
@@ -337,6 +368,8 @@ def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_
         ),
     )
     monkeypatch.setattr(routed_experts_module, "get_forward_context", lambda: SimpleNamespace(all_moe_layers=None))
+    monkeypatch.setattr(routed_experts_module, "get_current_vllm_config", lambda: None)
+    monkeypatch.setattr(routed_experts_module, "get_moe_num_logical_experts", lambda *args, **kwargs: 3)
 
     result = routed_experts.forward_impl(
         hidden_states=hidden_states,
@@ -358,8 +391,16 @@ def test_routed_experts_forward_impl_runs_current_flow(monkeypatch, return_with_
     quant_method.apply.assert_called_once()
     assert quant_method.apply.call_args.kwargs["layer"] is routed_experts
     assert quant_method.apply.call_args.kwargs["x"] is prepared_hidden_states
-    assert quant_method.apply.call_args.kwargs["router_logits"] is prepared_router_logits
-    assert quant_method.apply.call_args.kwargs["activation"] == "gelu"
+    torch.testing.assert_close(
+        quant_method.apply.call_args.kwargs["topk_weights"],
+        topk_weights.to(hidden_states.dtype),
+    )
+    assert torch.equal(quant_method.apply.call_args.kwargs["topk_ids"], topk_ids)
+    routed_experts.router._select_experts.assert_called_once_with(
+        hidden_states=prepared_hidden_states,
+        router_logits=prepared_router_logits,
+        input_ids=None,
+    )
     moe_comm_method.finalize.assert_called_once_with(
         hidden_states=routed_out,
         reduce_results=False,

--- a/tests/ut/quantization/methods/a2/test_w4a16.py
+++ b/tests/ut/quantization/methods/a2/test_w4a16.py
@@ -280,20 +280,21 @@ class TestAscendW4A16FusedMoEMethod(TestBase):
         self.assertTrue(layer.w13_weight_scale.data.is_contiguous())
 
     @patch("vllm_ascend.quantization.methods.w4a16._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w4a16.select_experts")
-    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_select_experts, mock_extra_ctx):
+    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_extra_ctx):
         tokens = 3
         hidden_size = self.output_size
         layer = self.build_layer()
         x = torch.randn(tokens, hidden_size, dtype=torch.float32)
-        router_logits = torch.randn(tokens, self.experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2, dtype=torch.float32)
         topk_ids = torch.randint(0, self.experts, (tokens, 2), dtype=torch.int64)
         mc2_mask = torch.tensor([1, 0, 1], dtype=torch.bool)
         pertoken_scale = torch.randn(tokens, dtype=torch.float32)
         layer.swiglu_limit = 1000000
+        layer.activation = "gelu"
+        layer.apply_router_weight_on_input = True
+        layer._ascend_mc2_mask = mc2_mask
+        layer._ascend_pertoken_scale = pertoken_scale
 
-        mock_select_experts.return_value = (topk_weights, topk_ids)
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, hidden_size, dtype=torch.float32)
         mock_extra_ctx.moe_comm_method = mock_comm
@@ -302,33 +303,14 @@ class TestAscendW4A16FusedMoEMethod(TestBase):
         self.quant_method.apply(
             layer=layer,
             x=x,
-            router_logits=router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.experts,
-            activation="gelu",
-            apply_router_weight_on_input=True,
-            mc2_mask=mc2_mask,
-            pertoken_scale=pertoken_scale,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
 
-        mock_select_experts.assert_called_once()
         fused_experts_input = mock_comm.fused_experts.call_args.kwargs["fused_experts_input"]
         self.assertEqual(fused_experts_input.activation, "gelu")
         self.assertTrue(fused_experts_input.routing.apply_router_weight_on_input)
         self.assertIs(fused_experts_input.routing.mc2_mask, mc2_mask)
         self.assertIs(fused_experts_input.routing.pertoken_scale, pertoken_scale)
-
-    @patch("vllm_ascend.quantization.methods.w4a16._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w4a16.select_experts")
-    def test_apply_router_logits_mismatch_raises(self, mock_select, mock_ctx):
-        layer = self.build_layer()
-        x = torch.randn(4, self.output_size, dtype=torch.float32)
-        router_logits = torch.randn(4, self.experts + 1, dtype=torch.float32)
-        message = (
-            "Number of global experts mismatch (excluding redundancy): router_logits.shape[1]=9, num_logical_experts=8"
-        )
-
-        with self.assertRaisesRegex(AssertionError, re.escape(message)):
-            self.quant_method.apply(layer, x, router_logits, top_k=2, renormalize=True, num_experts=self.experts)
-        mock_select.assert_not_called()

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -367,9 +367,8 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.assertEqual(per_channel_layer.w2_weight_scale.data.shape, (self.experts, 1, self.output_size))
 
     @patch("vllm_ascend.quantization.methods.w4a8._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w4a8.select_experts")
     @patch("vllm_ascend.quantization.methods.w4a8.build_fused_experts_input")
-    def test_apply_comprehensive(self, mock_build_input, mock_select, mock_ctx):
+    def test_apply_comprehensive(self, mock_build_input, mock_ctx):
         tokens = 4
         num_experts = self.experts
         hidden_size = self.output_size
@@ -379,16 +378,18 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.quant_method.is_per_channel_weight = True
         layer.swiglu_limit = 1000000
         x = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
-        router_logits = torch.randn(tokens, num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, top_k, dtype=torch.float32)
         topk_ids = torch.randint(0, num_experts, (tokens, top_k), dtype=torch.int64)
         expert_map = torch.randint(0, num_experts, (num_experts,), dtype=torch.int64)
         mc2_mask = torch.tensor([1, 0, 1, 0], dtype=torch.bool)
         pertoken_scale = torch.randn(tokens, dtype=torch.float32)
         log2phy = torch.randint(0, num_experts, (num_experts,), dtype=torch.int64)
-        e_score_correction_bias = torch.randn(num_experts, dtype=torch.float32)
-
-        mock_select.return_value = (topk_weights, topk_ids)
+        layer.ascend_expert_map = expert_map
+        layer.log2phy = log2phy
+        layer._ascend_mc2_mask = mc2_mask
+        layer._ascend_pertoken_scale = pertoken_scale
+        layer.activation = "silu"
+        layer.apply_router_weight_on_input = False
 
         mock_fused_input = Mock()
         mock_fused_input.hidden_states = x
@@ -405,30 +406,11 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         output = self.quant_method.apply(
             layer=layer,
             x=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            renormalize=True,
-            use_grouped_topk=False,
-            num_experts=num_experts,
-            expert_map=expert_map,
-            scoring_func="softmax",
-            routed_scaling_factor=1.0,
-            e_score_correction_bias=e_score_correction_bias,
-            is_prefill=True,
-            enable_force_load_balance=False,
-            log2phy=log2phy,
-            global_redundant_expert_num=0,
-            pertoken_scale=pertoken_scale,
-            activation="silu",
-            apply_router_weight_on_input=False,
-            mc2_mask=mc2_mask,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
-
-        mock_select.assert_called_once()
-        select_call_args = mock_select.call_args
-        self.assertTrue(torch.equal(select_call_args.kwargs["hidden_states"], x))
-        self.assertEqual(select_call_args.kwargs["top_k"], top_k)
-        self.assertEqual(select_call_args.kwargs["num_experts"], num_experts)
 
         mock_build_input.assert_called_once()
         build_kwargs = mock_build_input.call_args.kwargs
@@ -441,22 +423,3 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         mock_comm.fused_experts.assert_called_once()
         self.assertEqual(mock_comm.fused_experts.call_args.kwargs["fused_experts_input"], mock_fused_input)
         self.assertTrue(torch.equal(output, expected_output))
-
-    def test_apply_asserts_router_logits_expert_mismatch(self):
-        layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
-        x = torch.randn(4, self.output_size, dtype=torch.bfloat16)
-        router_logits = torch.randn(4, self.experts - 1, dtype=torch.float32)
-        expected_message = (
-            "Number of global experts mismatch (excluding redundancy): "
-            f"router_logits.shape[1]={self.experts - 1}, num_logical_experts={self.experts}"
-        )
-
-        with self.assertRaisesRegex(AssertionError, re.escape(expected_message)):
-            self.quant_method.apply(
-                layer=layer,
-                x=x,
-                router_logits=router_logits,
-                top_k=2,
-                renormalize=True,
-                num_experts=self.experts,
-            )

--- a/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
@@ -130,8 +130,7 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertEqual(param_dict["w2_weight_offset"].shape, (self.num_experts, self.hidden_size, 1))
 
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.select_experts")
-    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_select_experts, mock_extra_ctx):
+    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_extra_ctx):
         tokens = 4
         hidden_size = self.hidden_size
         layer = torch.nn.Module()
@@ -152,13 +151,15 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         layer.swiglu_limit = 1000000
 
         x = torch.randn(tokens, hidden_size, dtype=torch.float32)
-        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2, dtype=torch.float32)
         topk_ids = torch.randint(0, self.num_experts, (tokens, 2), dtype=torch.int64)
         mc2_mask = torch.tensor([1, 0, 1, 0], dtype=torch.bool)
         pertoken_scale = torch.randn(tokens, dtype=torch.float32)
+        layer.activation = "gelu"
+        layer.apply_router_weight_on_input = True
+        layer._ascend_mc2_mask = mc2_mask
+        layer._ascend_pertoken_scale = pertoken_scale
 
-        mock_select_experts.return_value = (topk_weights, topk_ids)
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, hidden_size, dtype=torch.float32)
         mock_extra_ctx.moe_comm_method = mock_comm
@@ -168,14 +169,10 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.quant_method.apply(
             layer=layer,
             x=x,
-            router_logits=router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.num_experts,
-            activation="gelu",
-            apply_router_weight_on_input=True,
-            mc2_mask=mc2_mask,
-            pertoken_scale=pertoken_scale,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
 
         fused_experts_input = mock_comm.fused_experts.call_args.kwargs["fused_experts_input"]

--- a/tests/ut/quantization/methods/test_w4a16_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a16_mxfp4.py
@@ -64,8 +64,7 @@ class TestAscendW4A16MXFP4MoEMethod(TestBase):
 
     @patch("vllm_ascend.quantization.methods.w4a16_mxfp4.torch_npu")
     @patch("vllm_ascend.quantization.methods.w4a16_mxfp4._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w4a16_mxfp4.select_experts")
-    def test_apply_full_params(self, mock_select, mock_ctx, mock_npu):
+    def test_apply_full_params(self, mock_ctx, mock_npu):
         tokens = 4
         layer = nn.Module()
         layer.swiglu_limit = 0.0
@@ -78,10 +77,11 @@ class TestAscendW4A16MXFP4MoEMethod(TestBase):
             torch.randint(0, 255, (8, 128, 64, 2), dtype=torch.uint8), requires_grad=False
         )
         x = torch.randn(tokens, self.hidden_size, dtype=torch.bfloat16)
-        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2)
         topk_ids = torch.randint(0, self.num_experts, (tokens, 2))
-        mock_select.return_value = (topk_weights, topk_ids)
+        layer.activation = "silu"
+        layer._ascend_pertoken_scale = torch.randn(tokens)
+        layer.apply_router_weight_on_input = True
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, self.hidden_size)
         mock_ctx.moe_comm_method = mock_comm
@@ -89,12 +89,9 @@ class TestAscendW4A16MXFP4MoEMethod(TestBase):
         self.scheme.apply(
             layer,
             x,
-            router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.num_experts,
-            activation="silu",
-            pertoken_scale=torch.randn(tokens),
-            apply_router_weight_on_input=True,
+            topk_weights,
+            topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
         mock_comm.fused_experts.assert_called_once()

--- a/tests/ut/quantization/methods/test_w4a4_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a4_mxfp4.py
@@ -105,8 +105,7 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
 
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.torch_npu")
     @patch("vllm_ascend.quantization.methods.w4a4_mxfp4._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w4a4_mxfp4.select_experts")
-    def test_apply_full_params(self, mock_select, mock_ctx, mock_npu):
+    def test_apply_full_params(self, mock_ctx, mock_npu):
         tokens = 4
         layer = nn.Module()
         layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 64, 256), dtype=torch.uint8), requires_grad=False)
@@ -118,10 +117,11 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
             torch.randint(0, 255, (8, 128, 64, 2), dtype=torch.uint8), requires_grad=False
         )
         x = torch.randn(tokens, self.hidden_size, dtype=torch.bfloat16)
-        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2)
         topk_ids = torch.randint(0, self.num_experts, (tokens, 2))
-        mock_select.return_value = (topk_weights, topk_ids)
+        layer.activation = "silu"
+        layer._ascend_pertoken_scale = torch.randn(tokens)
+        layer.apply_router_weight_on_input = True
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, self.hidden_size)
         mock_ctx.moe_comm_method = mock_comm
@@ -129,12 +129,9 @@ class TestAscendW4A4MXFP4MoEMethod(TestBase):
         self.scheme.apply(
             layer,
             x,
-            router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.num_experts,
-            activation="silu",
-            pertoken_scale=torch.randn(tokens),
-            apply_router_weight_on_input=True,
+            topk_weights,
+            topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
         mock_comm.fused_experts.assert_called_once()

--- a/tests/ut/quantization/methods/test_w4a8_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a8_mxfp4.py
@@ -128,8 +128,7 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
 
     @patch("vllm_ascend.quantization.methods.w4a8_mxfp4.torch_npu")
     @patch("vllm_ascend.quantization.methods.w4a8_mxfp4._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w4a8_mxfp4.select_experts")
-    def test_apply_full_params(self, mock_select, mock_ctx, mock_npu):
+    def test_apply_full_params(self, mock_ctx, mock_npu):
         tokens = 4
         layer = nn.Module()
         layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 64, 256), dtype=torch.uint8), requires_grad=False)
@@ -141,11 +140,16 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
             torch.randint(0, 255, (8, 4, 128, 2), dtype=torch.uint8), requires_grad=False
         )
         layer.swiglu_limit = 0.0
+        layer.activation = "silu"
+        layer._ascend_pertoken_scale = torch.randn(tokens)
+        layer.apply_router_weight_on_input = True
+        layer.ascend_expert_map = None
+        layer.global_redundant_expert_num = 0
+        layer.log2phy = None
+        layer._ascend_mc2_mask = None
         x = torch.randn(tokens, self.hidden_size, dtype=torch.bfloat16)
-        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2)
         topk_ids = torch.randint(0, self.num_experts, (tokens, 2))
-        mock_select.return_value = (topk_weights, topk_ids)
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, self.hidden_size)
         mock_ctx.moe_comm_method = mock_comm
@@ -153,12 +157,9 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
         self.scheme.apply(
             layer,
             x,
-            router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.num_experts,
-            activation="silu",
-            pertoken_scale=torch.randn(tokens),
-            apply_router_weight_on_input=True,
+            topk_weights,
+            topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
         mock_comm.fused_experts.assert_called_once()

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8.py
@@ -138,8 +138,7 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         self.assertEqual(layer.w13_weight.shape, original_w13_shape)
 
     @patch("vllm_ascend.quantization.methods.w8a8_mxfp8._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w8a8_mxfp8.select_experts")
-    def test_apply_full_params(self, mock_select, mock_ctx):
+    def test_apply_full_params(self, mock_ctx):
         tokens = 4
         layer = create_mxfp_moe_layer(
             num_experts=self.num_experts, hidden_size=self.hidden_size, intermediate_size=self.intermediate_size
@@ -147,10 +146,10 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         self.scheme.process_weights_after_loading(layer)
         layer.swiglu_limit = 1000000
         x = torch.randn(tokens, self.hidden_size, dtype=torch.bfloat16)
-        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2)
         topk_ids = torch.randint(0, self.num_experts, (tokens, 2))
-        mock_select.return_value = (topk_weights, topk_ids)
+        layer.activation = "silu"
+        layer._ascend_pertoken_scale = torch.randn(tokens)
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, self.hidden_size)
         mock_ctx.moe_comm_method = mock_comm
@@ -158,12 +157,9 @@ class TestAscendW8A8MXFP8MoEMethod(TestBase):
         self.scheme.apply(
             layer,
             x,
-            router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.num_experts,
-            activation="silu",
-            pertoken_scale=torch.randn(tokens),
+            topk_weights,
+            topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
-        mock_select.assert_called_once()
         mock_comm.fused_experts.assert_called_once()

--- a/tests/ut/quantization/methods/test_w8a8fp8_dynamic.py
+++ b/tests/ut/quantization/methods/test_w8a8fp8_dynamic.py
@@ -84,8 +84,7 @@ class TestAscendW8A8FP8FusedMoEMethod(TestBase):
             self.assertEqual(param_dict["w2_weight"].shape[0], num_experts)
 
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
-    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.select_experts")
-    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_select_experts, mock_extra_ctx):
+    def test_apply_uses_explicit_dispatch_and_mlp_args(self, mock_extra_ctx):
         tokens = 4
         hidden_size = self.hidden_size
         layer = torch.nn.Module()
@@ -100,13 +99,15 @@ class TestAscendW8A8FP8FusedMoEMethod(TestBase):
         layer.swiglu_limit = 1000000
 
         x = torch.randn(tokens, hidden_size, dtype=torch.float32)
-        router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
         topk_weights = torch.randn(tokens, 2, dtype=torch.float32)
         topk_ids = torch.randint(0, self.num_experts, (tokens, 2), dtype=torch.int64)
         mc2_mask = torch.tensor([1, 0, 1, 0], dtype=torch.bool)
         pertoken_scale = torch.randn(tokens, dtype=torch.float32)
+        layer.activation = "gelu"
+        layer.apply_router_weight_on_input = True
+        layer._ascend_mc2_mask = mc2_mask
+        layer._ascend_pertoken_scale = pertoken_scale
 
-        mock_select_experts.return_value = (topk_weights, topk_ids)
         mock_comm = Mock()
         mock_comm.fused_experts.return_value = torch.randn(tokens, hidden_size, dtype=torch.float32)
         mock_extra_ctx.moe_comm_method = mock_comm
@@ -116,14 +117,10 @@ class TestAscendW8A8FP8FusedMoEMethod(TestBase):
         self.quant_method.apply(
             layer=layer,
             x=x,
-            router_logits=router_logits,
-            top_k=2,
-            renormalize=True,
-            num_experts=self.num_experts,
-            activation="gelu",
-            apply_router_weight_on_input=True,
-            mc2_mask=mc2_mask,
-            pertoken_scale=pertoken_scale,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
         )
 
         fused_experts_input = mock_comm.fused_experts.call_args.kwargs["fused_experts_input"]

--- a/tests/ut/quantization/test_method_adapters.py
+++ b/tests/ut/quantization/test_method_adapters.py
@@ -183,9 +183,15 @@ class TestAscendFusedMoEMethod(TestBase):
     def test_apply_method(self):
         layer = torch.nn.Module()
         x = torch.randn(8, 64)
-        router_logits = torch.randn(8, 64)
-        top_k = 3
-        renormalize = True
+        topk_weights = torch.randn(8, 3)
+        topk_ids = torch.randint(0, 64, (8, 3), dtype=torch.int64)
         self.mock_scheme.apply.return_value = None
-        self.method.apply(layer, x, router_logits, top_k, renormalize)
+        self.method.apply(
+            layer,
+            x,
+            topk_weights,
+            topk_ids,
+            shared_experts=None,
+            shared_experts_input=None,
+        )
         self.mock_scheme.apply.assert_called_once()

--- a/vllm_ascend/_310p/fused_moe/experts_selector.py
+++ b/vllm_ascend/_310p/fused_moe/experts_selector.py
@@ -17,9 +17,8 @@
 from collections.abc import Callable
 
 import torch
-import torch_npu
 
-from vllm_ascend.ops.fused_moe.experts_selector import _native_select_experts, _renormalize_topk_weights
+from vllm_ascend._310p.fused_moe.grouped_topk_router import AscendGroupedTopKRouter310
 
 
 def select_experts(
@@ -57,33 +56,23 @@ def select_experts(
         topk_weights: router weights of shape (num_tokens, top_k).
         topk_ids: selected expert IDs of shape (num_tokens, top_k).
     """
-    if scoring_func == "softmax" and not use_grouped_topk and custom_routing_function is None:
-        # 310P returns invalid routing results when this op receives more than 1024 tokens.
-        if router_logits.shape[0] > 1024:
-            topk_results = [
-                torch_npu.npu_moe_gating_top_k_softmax(router_logits_chunk, k=top_k)
-                for router_logits_chunk in router_logits.split(1024, dim=0)
-            ]
-            topk_weights = torch.cat([result[0] for result in topk_results], dim=0)
-            topk_ids = torch.cat([result[1] for result in topk_results], dim=0)
-        else:
-            topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k_softmax(router_logits, k=top_k)
-        topk_weights = _renormalize_topk_weights(topk_weights, renormalize)
-    else:
-        topk_weights, topk_ids = _native_select_experts(
+    if custom_routing_function is not None:
+        return custom_routing_function(
             hidden_states=hidden_states,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
+            gating_output=router_logits,
+            topk=top_k,
             renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            e_score_correction_bias=e_score_correction_bias,
         )
-    # Apply routed scaling factor to weights
-    if routed_scaling_factor != 1.0:
-        topk_weights = topk_weights * routed_scaling_factor
 
-    return topk_weights, topk_ids
+    router = AscendGroupedTopKRouter310(
+        top_k=top_k,
+        global_num_experts=global_num_experts,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        use_grouped_topk=use_grouped_topk,
+        renormalize=renormalize,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias,
+    )
+    return router._select_experts(hidden_states=hidden_states, router_logits=router_logits)

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from collections.abc import Callable
-
 import torch
+from vllm.model_executor.layers.fused_moe import SharedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
-from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
 from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -29,7 +27,6 @@ from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import maybe_trans_nz
 
-from .experts_selector import select_experts
 from .moe_comm_method import AllGatherCommImpl310
 
 
@@ -61,46 +58,11 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        use_grouped_topk: bool,
-        top_k: int,
-        router_logits: torch.Tensor,
-        renormalize: bool,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        e_score_correction_bias: torch.Tensor | None = None,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        apply_router_weight_on_input: bool = False,
-        **kwargs,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        zero_expert_num = getattr(layer, "zero_expert_num", 0)
-        zero_expert_type = getattr(layer, "zero_expert_type", None)
-
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            e_score_correction_bias=e_score_correction_bias,
-            global_num_experts=num_experts,
-        )
-
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
-                expert_indices=topk_ids,
-                expert_scales=topk_weights,
-                num_experts=num_experts,
-                zero_expert_type=zero_expert_type,
-                hidden_states=x,
-            )
-
         topk_weights = topk_weights.to(x.dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
@@ -113,12 +75,10 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
                 w2=layer.w2_weight,
                 quant_type=QuantType.NONE,
                 dynamic_eplb=False,
-                expert_map=expert_map,
-                apply_router_weight_on_input=apply_router_weight_on_input,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
             ),
         )
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            final_hidden_states += zero_expert_result
         return final_hidden_states
 
 

--- a/vllm_ascend/_310p/fused_moe/grouped_topk_router.py
+++ b/vllm_ascend/_310p/fused_moe/grouped_topk_router.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+import torch_npu
+
+from vllm_ascend.ops.fused_moe.router.grouped_topk_router import AscendGroupedTopKRouter
+
+
+class AscendGroupedTopKRouter310(AscendGroupedTopKRouter):
+    """310P router with chunked softmax top-k routing."""
+
+    MAX_TOKENS_PER_GATING_CALL = 1024
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        indices_type: torch.dtype | None,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.scoring_func != "softmax" or self.use_grouped_topk or self.e_score_correction_bias is not None:
+            return super()._compute_routing(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                indices_type=indices_type,
+                input_ids=input_ids,
+            )
+
+        if router_logits.shape[0] > self.MAX_TOKENS_PER_GATING_CALL:
+            topk_results = [
+                torch_npu.npu_moe_gating_top_k_softmax(router_logits_chunk, k=self.top_k)
+                for router_logits_chunk in router_logits.split(self.MAX_TOKENS_PER_GATING_CALL, dim=0)
+            ]
+            topk_weights = torch.cat([result[0] for result in topk_results], dim=0)
+            topk_ids = torch.cat([result[1] for result in topk_results], dim=0)
+        else:
+            topk_weights, topk_ids, _ = torch_npu.npu_moe_gating_top_k_softmax(router_logits, k=self.top_k)
+
+        topk_weights = self._renormalize_topk_weights(topk_weights)
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return topk_weights, topk_ids.to(torch.int32)

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -15,7 +15,6 @@
 # This file is a part of the vllm-ascend project.
 #
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -23,9 +22,7 @@ import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_ep_group
 
-from vllm_ascend._310p.fused_moe.experts_selector import select_experts
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.methods.base import AscendMoEScheme, QuantType
 from vllm_ascend.utils import maybe_trans_nz
@@ -82,55 +79,11 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = False,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: Any | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        zero_expert_num = getattr(layer, "zero_expert_num", 0)
-        zero_expert_type = getattr(layer, "zero_expert_type", None)
-
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            global_num_experts=num_experts,
-        )
-
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
-                expert_indices=topk_ids,
-                expert_scales=topk_weights,
-                num_experts=num_experts,
-                zero_expert_type=zero_expert_type,
-                hidden_states=x,
-            )
-
         topk_weights = topk_weights.to(self.in_dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
@@ -144,14 +97,12 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
                 w2=layer.w2_weight,
                 quant_type=self.quant_type,
                 dynamic_eplb=False,
-                expert_map=expert_map,
-                apply_router_weight_on_input=apply_router_weight_on_input,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
             ),
         )
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            final_hidden_states += zero_expert_result
         return final_hidden_states
 
     def process_weights_after_loading(self, layer):

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -455,7 +455,6 @@ class DeepseekV4MoE(nn.Module):
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
             n_shared_experts=config.n_shared_experts if self.is_fusion_moe_shared_experts_enabled else 0,
-            hash=layer_idx < config.num_hash_layers and not is_draft_layer,
             tid2eid=self.gate.tid2eid,
         )
 

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from collections.abc import Callable
 from copy import copy
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -24,7 +23,7 @@ import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.forward_context import get_forward_context
 from vllm.logger import logger
-from vllm.model_executor.layers.fused_moe import RoutedExperts
+from vllm.model_executor.layers.fused_moe import RoutedExperts, SharedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 
@@ -33,7 +32,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_utils import init_eplb_config
 from vllm_ascend.lora.fused_moe import sync_lora_context
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
+from vllm_ascend.ops.fused_moe.experts_selector import zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
@@ -102,83 +101,14 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
     def apply(
         self,
-        layer: torch.nn.Module,
+        layer: "RoutedExperts",
         x: torch.Tensor,
-        use_grouped_topk: bool,
-        top_k: int,
-        router_logits: torch.Tensor,
-        renormalize: bool,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        apply_router_weight_on_input: bool = False,
-        activation: str = "silu",
-        enable_force_load_balance: bool = False,
-        log2phy: torch.Tensor = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: torch.Tensor | None = None,
-        mc2_mask: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        zero_expert_num = getattr(layer, "zero_expert_num", 0)
-        zero_expert_type = getattr(layer, "zero_expert_type", None)
-        input_ids = getattr(get_forward_context(), "input_ids", None)
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_logical_experts,
-            tid2eid=self.tid2eid,
-            input_ids=input_ids,
-        )
-        try:
-            _vllm_config = get_current_vllm_config()
-        except AssertionError:
-            _vllm_config = None
-        model_config = None if _vllm_config is None else _vllm_config.model_config
-        if model_config is not None and model_config.enable_return_routed_experts:
-            capturer = getattr(layer, "_ascend_routed_experts_capturer", None)
-            if capturer is not None:
-                capturer.capture(layer_id=layer.layer_id, topk_ids=topk_ids)
-
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
-                expert_indices=topk_ids,
-                expert_scales=topk_weights,
-                num_experts=num_logical_experts,
-                zero_expert_type=zero_expert_type,
-                hidden_states=x,
-            )
-
-        topk_weights = topk_weights.to(x.dtype)
-        # This is a naive implementation for experts load balance so as to
-        # avoid accumulating too much tokens on a single rank. It is only
-        # activated when doing profile runs.
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
-
+        activation = getattr(layer, "activation", "silu")
         if getattr(layer, "swigluoai_uninterleave", False):
             activation = "swigluoai_uninterleave"
 
@@ -217,12 +147,12 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 w2_bias=layer.w2_bias if self.moe.has_bias else None,
                 quant_type=QuantType.NONE,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
                 activation=activation,
                 w1_scale=w1_scale,
                 w2_scale=w2_scale,
@@ -234,8 +164,6 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 lora_context=getattr(layer, "_ascend_moe_lora_context", None),
             )
         )
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            final_hidden_states.routed_out += zero_expert_result
         return final_hidden_states
 
 
@@ -262,7 +190,14 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
 
     moe_counter = -1
 
-    def __init__(self, *args, tid2eid=None, n_shared_experts: int = 0, **kwargs):
+    def __init__(
+        self,
+        *args,
+        router=None,
+        tid2eid=None,
+        n_shared_experts: int = 0,
+        **kwargs,
+    ):
         object.__setattr__(self, "tid2eid", tid2eid)
         super().__init__(*args, **kwargs)
         if self.quant_config is None:
@@ -274,6 +209,7 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
                     tid2eid=self.tid2eid,
                 )
             )
+        self.router = router
         ascend_config = get_ascend_config()
         self.enable_npugraph_ex_static_kernel = ascend_config.ascend_compilation_config.enable_static_kernel
         self.enable_shared_expert_dp = ascend_config.enable_shared_expert_dp
@@ -417,6 +353,91 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             quant_type = getattr(method, "quant_type", QuantType.NONE)
         return quant_type
 
+    def _select_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        enable_force_load_balance: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if self.router is None:
+            raise RuntimeError("AscendRoutedExperts requires a router for expert selection.")
+
+        forward_context = get_forward_context()
+        topk_weights, topk_ids = self.router._select_experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            input_ids=getattr(forward_context, "input_ids", None),
+        )
+
+        try:
+            _vllm_config = get_current_vllm_config()
+        except AssertionError:
+            _vllm_config = None
+        model_config = None if _vllm_config is None else _vllm_config.model_config
+        if model_config is not None and model_config.enable_return_routed_experts:
+            capturer = getattr(self, "_ascend_routed_experts_capturer", None)
+            if capturer is not None:
+                capturer.capture(layer_id=self.layer_id, topk_ids=topk_ids)
+
+        num_shared_experts = self.n_shared_experts
+        if num_shared_experts is None:
+            num_shared_experts = 0
+        num_logical_experts = get_moe_num_logical_experts(
+            self,
+            self.moe_config.num_experts,
+            global_redundant_expert_num=self.global_redundant_expert_num,
+            num_shared_experts=num_shared_experts,
+        )
+
+        zero_expert_result = None
+        zero_expert_num = getattr(self, "zero_expert_num", 0)
+        zero_expert_type = getattr(self, "zero_expert_type", None)
+        if zero_expert_num == 0 or zero_expert_type is None:
+            assert router_logits.shape[1] == num_logical_experts, (
+                "Number of global experts mismatch (excluding redundancy): "
+                f"router_logits.shape[1]={router_logits.shape[1]}, "
+                f"num_logical_experts={num_logical_experts}"
+            )
+        if zero_expert_num > 0 and zero_expert_type is not None:
+            topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
+                expert_indices=topk_ids,
+                expert_scales=topk_weights,
+                num_experts=num_logical_experts,
+                zero_expert_type=zero_expert_type,
+                hidden_states=hidden_states,
+            )
+
+        if getattr(self, "mix_placement", False):
+            batch_size = topk_ids.shape[0]
+            shared_expert_ids = torch.arange(
+                num_logical_experts,
+                num_logical_experts + num_shared_experts,
+                dtype=topk_ids.dtype,
+                device=topk_ids.device,
+            ).repeat(batch_size, 1)
+            shared_expert_weights = torch.ones(
+                topk_weights.shape[0],
+                num_shared_experts,
+                dtype=topk_weights.dtype,
+                device=topk_weights.device,
+            )
+            topk_ids = torch.cat([topk_ids, shared_expert_ids], dim=1)
+            topk_weights = torch.cat([topk_weights, shared_expert_weights], dim=1)
+
+        topk_weights = topk_weights.to(hidden_states.dtype)
+        # This is a naive implementation for experts load balance so as to
+        # avoid accumulating too much tokens on a single rank. It is only
+        # activated when doing profile runs.
+        if enable_force_load_balance:
+            random_matrix = torch.rand(
+                topk_ids.size(0),
+                num_logical_experts,
+                device=topk_ids.device,
+            )
+            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
+
+        return topk_weights, topk_ids, zero_expert_result
+
     def forward_impl(
         self,
         *,
@@ -450,29 +471,27 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         padded_hidden_states_shape = prepare_output.padded_hidden_states_shape
         pertoken_scale = prepare_output.pertoken_scale
 
-        fused_experts_results: FusedExpertsResult = self.quant_method.apply(
-            layer=self,
-            x=hidden_states,
+        topk_weights, topk_ids, zero_expert_result = self._select_experts(
+            hidden_states=hidden_states,
             router_logits=router_logits,
-            pertoken_scale=pertoken_scale,
-            top_k=self.top_k,
-            renormalize=self.renormalize,
-            use_grouped_topk=self.use_grouped_topk,
-            num_experts=self.moe_config.num_experts,
-            expert_map=self.ascend_expert_map,
-            topk_group=self.topk_group,
-            num_expert_group=self.num_expert_group,
-            custom_routing_function=self.custom_routing_function,
-            scoring_func=self.scoring_func,
-            routed_scaling_factor=self.routed_scaling_factor,
-            e_score_correction_bias=self.e_score_correction_bias,
-            activation=self.activation,
-            apply_router_weight_on_input=self.apply_router_weight_on_input,
             enable_force_load_balance=enable_force_load_balance,
-            log2phy=self.log2phy,
-            global_redundant_expert_num=self.global_redundant_expert_num,
-            mc2_mask=mc2_mask,
         )
+        self._ascend_pertoken_scale = pertoken_scale
+        self._ascend_mc2_mask = mc2_mask
+        try:
+            fused_experts_results: FusedExpertsResult = self.quant_method.apply(
+                layer=self,
+                x=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                shared_experts=None,
+                shared_experts_input=None,
+            )
+        finally:
+            self._ascend_pertoken_scale = None
+            self._ascend_mc2_mask = None
+        if zero_expert_result is not None:
+            fused_experts_results.routed_out += zero_expert_result
 
         if self.dynamic_eplb and _EXTRA_CTX.eplb_heat_collection_status:
             expert_tokens = fused_experts_results.expert_tokens

--- a/vllm_ascend/ops/fused_moe/router/__init__.py
+++ b/vllm_ascend/ops/fused_moe/router/__init__.py
@@ -1,0 +1,9 @@
+from vllm_ascend.ops.fused_moe.router.fused_topk_router import (
+    AscendFusedTopKRouter as AscendFusedMoERouter,
+)
+from vllm_ascend.ops.fused_moe.router.router_factory import create_ascend_fused_moe_router
+
+__all__ = [
+    "AscendFusedMoERouter",
+    "create_ascend_fused_moe_router",
+]

--- a/vllm_ascend/ops/fused_moe/router/fused_topk_router.py
+++ b/vllm_ascend/ops/fused_moe/router/fused_topk_router.py
@@ -1,0 +1,159 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from collections.abc import Callable
+
+import torch
+from vllm.distributed import get_tp_group
+from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.forward_context import get_forward_context
+
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.utils import split_tensor_along_first_dim
+from vllm_ascend.ops.fused_moe.router.grouped_topk_router import AscendGroupedTopKRouter
+
+
+class AscendFusedTopKRouter(AscendGroupedTopKRouter):
+    """Router adapter that uses Ascend's existing expert-selection path."""
+
+    def __init__(
+        self,
+        top_k: int,
+        global_num_experts: int,
+        renormalize: bool = True,
+        use_grouped_topk: bool = False,
+        num_expert_group: int | None = None,
+        topk_group: int | None = None,
+        custom_routing_function: Callable | None = None,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        e_score_correction_bias: torch.Tensor | None = None,
+        eplb_state: EplbLayerState | None = None,
+        num_logical_experts: int | None = None,
+        tid2eid: torch.Tensor | None = None,
+        select_experts_fn: Callable[..., tuple[torch.Tensor, torch.Tensor]] | None = None,
+    ):
+        super().__init__(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            use_grouped_topk=use_grouped_topk,
+            renormalize=renormalize,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=e_score_correction_bias,
+            eplb_state=eplb_state,
+        )
+        self.custom_routing_function = custom_routing_function
+        self.num_logical_experts = num_logical_experts if num_logical_experts is not None else global_num_experts
+        self.tid2eid = tid2eid
+
+    def is_fused_supported(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> bool:
+        topk_group = self.topk_group if self.topk_group is not None else 1
+        num_expert_group = self.num_expert_group if self.num_expert_group is not None else 1
+        if not (
+            num_expert_group > 0
+            and hidden_states.shape[-1] % num_expert_group == 0
+            and hidden_states.shape[-1] // num_expert_group > 2
+        ):
+            return False
+        if self.top_k > (hidden_states.shape[-1] / (num_expert_group * topk_group)):
+            return False
+        if topk_group * hidden_states.shape[-1] / num_expert_group < self.top_k:  # noqa: SIM103
+            return False
+        return True
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        indices_type: torch.dtype | None,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not self.is_fused_supported(hidden_states):
+            return super()._compute_routing(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                indices_type=indices_type,
+                input_ids=input_ids,
+            )
+
+        topk_group = self.topk_group if self.topk_group is not None else 1
+        num_expert_group = self.num_expert_group if self.num_expert_group is not None else 1
+        renorm = int(self.renormalize)
+        if self.scoring_func == "sqrtsoftplus":
+            if self.tid2eid is not None:
+                forward_context = get_forward_context()
+                input_ids = forward_context.input_ids.to(torch.int64)
+                tid2eid_ones = self.tid2eid.to(torch.int32)
+                if forward_context.moe_comm_type == MoECommType.ALLGATHER:
+                    prepare_finalize = forward_context.moe_comm_method.prepare_finalize
+                    input_ids = prepare_finalize.all_gather_input_id_with_dp_group(input_ids)
+                else:
+                    input_ids = forward_context.moe_comm_method.pad_and_split_input_ids(input_ids)
+
+                if forward_context.flash_comm_v1_enabled and forward_context.moe_comm_type != MoECommType.ALLGATHER:
+                    # Process for Flash Comm V1
+                    tp_size = get_tp_group().world_size
+                    tp_rank = get_tp_group().rank_in_group
+                    splitted_input = split_tensor_along_first_dim(input_ids, num_partitions=tp_size)
+                    input_ids = splitted_input[tp_rank].contiguous()
+                input_ids = torch.where(input_ids == -1, 0, input_ids)
+            else:
+                input_ids = None
+                tid2eid_ones = None
+            topk_weights, topk_ids, _ = torch.ops._C_ascend.moe_gating_top_k_hash(
+                x=router_logits,
+                k=self.top_k,
+                bias=self.e_score_correction_bias,
+                input_ids=input_ids,
+                tid2eid=tid2eid_ones,
+                k_group=topk_group,
+                group_count=num_expert_group,
+                routed_scaling_factor=self.routed_scaling_factor,
+                eps=1e-20,
+                group_select_mode=1,
+                # The hash custom op currently rejects renorm != 0. Apply
+                # norm_topk_prob in Python below before returning to MoE compute.
+                renorm=0,
+                norm_type=2,
+                out_flag=False,
+            )
+            return topk_weights, topk_ids
+        norm_type = 0 if self.scoring_func == "softmax" else 1
+        if self.e_score_correction_bias is not None and self.e_score_correction_bias.dtype != router_logits.dtype:
+            self.e_score_correction_bias = self.e_score_correction_bias.to(router_logits.dtype)
+        topk_weights, topk_ids, _ = DeviceOperator.moe_gating_top_k(
+            router_logits,
+            k=self.top_k,
+            k_group=topk_group,
+            group_count=num_expert_group,
+            group_select_mode=1,
+            renorm=renorm,
+            norm_type=norm_type,  # 0: softmax; 1: sigmoid
+            out_flag=False,
+            routed_scaling_factor=self.routed_scaling_factor,
+            eps=1e-20,
+            bias_opt=self.e_score_correction_bias,
+        )
+
+        return topk_weights, topk_ids

--- a/vllm_ascend/ops/fused_moe/router/grouped_topk_router.py
+++ b/vllm_ascend/ops/fused_moe/router/grouped_topk_router.py
@@ -1,0 +1,129 @@
+import torch
+import torch.nn.functional as F
+from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.model_executor.layers.fused_moe.config import (
+    RoutingMethodType,
+    get_routing_method_type,
+)
+from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
+
+
+class AscendGroupedTopKRouter(BaseRouter):
+    def __init__(
+        self,
+        top_k: int,
+        global_num_experts: int,
+        num_expert_group: int | None,
+        topk_group: int | None,
+        use_grouped_topk: bool = False,
+        renormalize: bool = True,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        e_score_correction_bias: torch.Tensor | None = None,
+        num_fused_shared_experts: int = 0,
+        eplb_state: EplbLayerState | None = None,
+    ):
+        super().__init__(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+            eplb_state=eplb_state,
+        )
+        self.num_expert_group = num_expert_group
+        self.topk_group = topk_group
+        self.renormalize = renormalize
+        self.scoring_func = scoring_func
+        self.routed_scaling_factor = routed_scaling_factor
+        self.e_score_correction_bias = e_score_correction_bias
+        self.num_fused_shared_experts = num_fused_shared_experts
+        self.use_grouped_topk = use_grouped_topk
+
+    @property
+    def routing_method_type(self) -> RoutingMethodType:
+        return get_routing_method_type(
+            scoring_func=self.scoring_func,
+            top_k=self.top_k,
+            renormalize=self.renormalize,
+            num_expert_group=self.num_expert_group if self.use_grouped_topk else None,
+            has_e_score_bias=self.e_score_correction_bias is not None,
+            routed_scaling_factor=self.routed_scaling_factor,
+        )
+
+    def _renormalize_topk_weights(
+        self,
+        topk_weights: torch.Tensor,
+    ):
+        if self.renormalize:
+            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        return topk_weights
+
+    def _native_grouped_topk(
+        self,
+        topk_weights: torch.Tensor,
+    ):
+        topk_group = 0 if self.topk_group is None else self.topk_group
+        num_expert_group = 0 if self.num_expert_group is None else self.num_expert_group
+
+        num_token = topk_weights.shape[0]
+        grouped_weights = topk_weights.view(num_token, num_expert_group, -1).max(dim=-1).values
+        topk_group_indices = torch.topk(grouped_weights.to(torch.float32), k=topk_group, dim=-1, sorted=False)[1]
+        topk_group_mask = torch.zeros_like(grouped_weights)
+        topk_group_mask.scatter_(1, topk_group_indices, 1)
+        topk_weight_mask = (
+            topk_group_mask.unsqueeze(-1)
+            .expand(num_token, num_expert_group, topk_weights.shape[-1] // num_expert_group)
+            .reshape(num_token, -1)
+        )
+        topk_weights = topk_weights.masked_fill(~topk_weight_mask.bool(), 0.0)
+
+        return topk_weights
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        indices_type: torch.dtype | None,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.scoring_func == "softmax":
+            topk_weights = router_logits.softmax(dim=-1)
+        elif self.scoring_func == "sigmoid":
+            topk_weights = router_logits.sigmoid()
+        elif self.scoring_func == "sqrtsoftplus":
+            topk_weights = F.softplus(router_logits).sqrt()
+        else:
+            raise ValueError(f"Unsupported scoring function: {self.scoring_func}")
+
+        if self.use_grouped_topk:
+            if self.e_score_correction_bias is not None:
+                # Store original scores before applying correction bias. We use biased
+                # scores for expert selection but original scores for routing weights
+                original_weights = topk_weights
+                topk_weights = topk_weights + self.e_score_correction_bias.unsqueeze(0)
+
+            # TODO: Change to npu_group_topk when the latest CANN and NNAL is available
+            # >>> torch_npu._npu_group_topk(topk_weights, group_num=num_expert_group, k=topk_group)
+            topk_weights = self._native_grouped_topk(topk_weights)
+            # TODO bfloat16 is not supported in torch.topk with ge graph.
+            if self.e_score_correction_bias is not None:
+                topk_ids = torch.topk(topk_weights.to(torch.float32), k=self.top_k, dim=-1, sorted=False)[1]
+                # Use original unbiased scores for the routing weights
+                topk_weights = original_weights.gather(1, topk_ids)
+            else:
+                topk_weights, topk_ids = torch.topk(topk_weights.to(torch.float32), k=self.top_k, dim=-1, sorted=False)
+            topk_ids = topk_ids.to(torch.int32)
+            topk_weights = self._renormalize_topk_weights(topk_weights)
+            return topk_weights * self.routed_scaling_factor, topk_ids
+
+        if self.e_score_correction_bias is not None:
+            topk_weights = topk_weights + self.e_score_correction_bias
+
+        topk_weights, topk_ids = topk_weights.topk(self.top_k, dim=-1)
+        topk_weights = topk_weights.to(hidden_states.dtype)
+
+        # Required by npu_moe_init_routing
+        topk_ids = topk_ids.to(torch.int32)
+        topk_weights = self._renormalize_topk_weights(topk_weights)
+        topk_weights = topk_weights * self.routed_scaling_factor
+
+        return topk_weights, topk_ids

--- a/vllm_ascend/ops/fused_moe/router/router_factory.py
+++ b/vllm_ascend/ops/fused_moe/router/router_factory.py
@@ -1,0 +1,123 @@
+from collections.abc import Callable
+
+import torch
+from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.model_executor.layers.fused_moe import FusedMoERouter
+from vllm.model_executor.layers.fused_moe.router.custom_routing_router import CustomRoutingRouter
+
+from vllm_ascend.ops.fused_moe.router.fused_topk_router import (
+    AscendFusedTopKRouter as AscendFusedMoERouter,
+)
+from vllm_ascend.ops.fused_moe.router.grouped_topk_router import AscendGroupedTopKRouter
+from vllm_ascend.utils import is_310p
+
+
+def check_npu_moe_gating_top_k(
+    top_k: int,
+    renormalize: bool,
+    topk_group: int | None = None,
+    num_expert_group: int | None = None,
+    scoring_func: str = "softmax",
+    custom_routing_function: Callable | None = None,
+):
+    if scoring_func == "sigmoid" and not renormalize:  # sigmoid + renorm=0 is not supported in current branch
+        return False
+    if custom_routing_function is not None:
+        return False
+    if scoring_func != "softmax" and scoring_func != "sigmoid" and scoring_func != "sqrtsoftplus":
+        return False
+    topk_group = topk_group if topk_group is not None else 1
+    num_expert_group = num_expert_group if num_expert_group is not None else 1
+    if top_k < 1:
+        return False
+    return 1 <= topk_group <= num_expert_group
+
+
+def create_ascend_fused_moe_router(
+    top_k: int,
+    global_num_experts: int,
+    renormalize: bool = True,
+    use_grouped_topk: bool = False,
+    num_expert_group: int | None = None,
+    topk_group: int | None = None,
+    scoring_func: str = "softmax",
+    num_fused_shared_experts: int = 0,
+    shared_expert_weight: float = 1.0,
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+    custom_routing_function: Callable | None = None,
+    eplb_state: EplbLayerState | None = None,
+    zero_expert_type: str | None = None,
+    num_logical_experts: int | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+    tid2eid: torch.Tensor | None = None,
+) -> FusedMoERouter:
+    if zero_expert_type is not None:
+        if num_logical_experts is None:
+            raise ValueError("num_logical_experts is required when zero_expert_type is set")
+        if e_score_correction_bias is None:
+            raise ValueError("e_score_correction_bias is required when zero_expert_type is set")
+        # Ascend zero expert handling is still performed by the quant method
+        # after routing; the router only needs to select from the full logits.
+        global_num_experts = max(global_num_experts, e_score_correction_bias.numel())
+    if custom_routing_function is not None:
+        return CustomRoutingRouter(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+            eplb_state=eplb_state,
+            custom_routing_function=custom_routing_function,
+            renormalize=renormalize,
+        )
+    if is_310p():
+        from vllm_ascend._310p.fused_moe.grouped_topk_router import AscendGroupedTopKRouter310
+
+        return AscendGroupedTopKRouter310(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            use_grouped_topk=use_grouped_topk,
+            renormalize=renormalize,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=e_score_correction_bias,
+            num_fused_shared_experts=num_fused_shared_experts,
+            eplb_state=eplb_state,
+        )
+    is_support_npu_moe_gating_top_k = check_npu_moe_gating_top_k(
+        top_k=top_k,
+        renormalize=renormalize,
+        topk_group=topk_group,
+        num_expert_group=num_expert_group,
+        scoring_func=scoring_func,
+        custom_routing_function=custom_routing_function,
+    )
+    if is_support_npu_moe_gating_top_k:
+        return AscendFusedMoERouter(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+            eplb_state=eplb_state,
+            renormalize=renormalize,
+            use_grouped_topk=use_grouped_topk,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+            e_score_correction_bias=e_score_correction_bias,
+            num_logical_experts=num_logical_experts,
+            tid2eid=tid2eid,
+        )
+    return AscendGroupedTopKRouter(
+        top_k=top_k,
+        global_num_experts=global_num_experts,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        use_grouped_topk=use_grouped_topk,
+        renormalize=renormalize,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias,
+        num_fused_shared_experts=num_fused_shared_experts,
+        eplb_state=eplb_state,
+    )

--- a/vllm_ascend/patch/platform/patch_fused_moe.py
+++ b/vllm_ascend/patch/platform/patch_fused_moe.py
@@ -27,20 +27,25 @@
 #   2. from vllm_ascend import ops
 #   3. model loading  ->  deepseek_v2 imported  ->  gets patched FusedMoE  ✓
 
+from collections.abc import Callable
 from typing import Any
 
+import torch
 import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
 import vllm.model_executor.layers.fused_moe.layer as _fused_moe_layer
+from vllm.model_executor.layers.fused_moe.router.fused_moe_router import FusedMoERouter
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ops.fused_moe.router.router_factory import create_ascend_fused_moe_router
 from vllm_ascend.utils import is_310p
 
 # Capture the real original before fused_moe.py's module-level code runs.
 _original_FusedMoE = _fused_moe_layer.FusedMoE
 _DefaultAscendMoERunner: Any
 _DefaultAscendRoutedExperts: Any
+_IS_310P = is_310p()
 
-if is_310p():
+if _IS_310P:
     from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310, AscendRoutedExperts310
 
     _DefaultAscendMoERunner = AscendMoERunner310
@@ -54,11 +59,30 @@ else:
 
 
 def _ascend_FusedMoE(
+    num_experts: int,
+    top_k: int,
     *args,
-    runner_cls=None,
-    runner_args=None,
-    routed_experts_cls=None,
-    routed_experts_args=None,
+    renormalize: bool = True,
+    use_grouped_topk: bool = False,
+    num_expert_group: int | None = None,
+    topk_group: int | None = None,
+    custom_routing_function: Callable | None = None,
+    router: FusedMoERouter | None = None,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+    enable_eplb: bool = False,
+    num_redundant_experts: int = 0,
+    n_shared_experts: int | None = None,
+    apply_routed_scale_to_output: bool = False,
+    zero_expert_type: str | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+    runner_cls: Any | None = None,
+    runner_args: dict[str, Any] | None = None,
+    routed_experts_cls: Any | None = None,
+    routed_experts_args: dict[str, Any] | None = None,
+    hash: Any | None = None,
+    tid2eid: torch.Tensor | None = None,
     **kwargs,
 ):
     if runner_cls is None:
@@ -71,24 +95,54 @@ def _ascend_FusedMoE(
     eplb_config = get_ascend_config().eplb_config
     if eplb_config.dynamic_eplb or eplb_config.expert_map_path is not None:
         configured_redundancy = eplb_config.num_redundant_experts
-        upstream_redundancy = kwargs.get("num_redundant_experts", 0)
+        upstream_redundancy = num_redundant_experts
         if configured_redundancy and upstream_redundancy not in (0, configured_redundancy):
             raise ValueError(
                 f"Conflicting EPLB redundant expert counts: vLLM={upstream_redundancy}, Ascend={configured_redundancy}."
             )
-        kwargs["enable_eplb"] = True
-        kwargs["num_redundant_experts"] = configured_redundancy or upstream_redundancy
-    # 'hash' is a DeepSeek V4 flag already consumed before FusedMoE is called;
-    # 'tid2eid' is Ascend-specific and belongs to AscendRoutedExperts.
-    kwargs.pop("hash", None)
-    tid2eid = kwargs.pop("tid2eid", None)
-    n_shared_experts = kwargs.get("n_shared_experts", 0)
+        enable_eplb = True
+        num_redundant_experts = configured_redundancy or upstream_redundancy
+    if router is None:
+        router = create_ascend_fused_moe_router(
+            top_k=top_k,
+            global_num_experts=num_experts + num_redundant_experts,
+            renormalize=renormalize,
+            use_grouped_topk=use_grouped_topk,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor if not apply_routed_scale_to_output else 1.0,
+            e_score_correction_bias=e_score_correction_bias,
+            zero_expert_type=zero_expert_type,
+            num_logical_experts=num_experts,
+            hash_indices_table=hash_indices_table,
+            tid2eid=tid2eid,
+        )
     routed_experts_args = dict(routed_experts_args) if routed_experts_args is not None else {}
+    routed_experts_args["router"] = router
     routed_experts_args["n_shared_experts"] = n_shared_experts
     if tid2eid is not None:
         routed_experts_args["tid2eid"] = tid2eid
     return _original_FusedMoE(
         *args,
+        num_experts=num_experts,
+        top_k=top_k,
+        renormalize=renormalize,
+        use_grouped_topk=use_grouped_topk,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        custom_routing_function=custom_routing_function,
+        router=router,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias,
+        enable_eplb=enable_eplb,
+        num_redundant_experts=num_redundant_experts,
+        n_shared_experts=n_shared_experts,
+        apply_routed_scale_to_output=apply_routed_scale_to_output,
+        zero_expert_type=zero_expert_type,
+        hash_indices_table=hash_indices_table,
         runner_cls=runner_cls,
         runner_args=runner_args,
         routed_experts_cls=routed_experts_cls,

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -16,8 +16,6 @@
 # This file is a part of the vllm-ascend project.
 #
 
-from collections.abc import Callable
-
 import torch
 from vllm.distributed import get_tensor_model_parallel_rank
 from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase, FusedMoeWeightScaleSupported
@@ -250,51 +248,18 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = False,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num=0,
-        pertoken_scale: torch.Tensor | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts=None,
+        shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.quant_method.apply(
             layer=layer,
             x=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            renormalize=renormalize,
-            use_grouped_topk=use_grouped_topk,
-            num_experts=num_experts,
-            expert_map=expert_map,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            is_prefill=is_prefill,
-            enable_force_load_balance=enable_force_load_balance,
-            log2phy=log2phy,
-            global_redundant_expert_num=global_redundant_expert_num,
-            pertoken_scale=pertoken_scale,
-            activation=activation,
-            apply_router_weight_on_input=apply_router_weight_on_input,
-            mc2_mask=mc2_mask,
-            tid2eid=self.tid2eid,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
         )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/vllm_ascend/quantization/methods/base.py
+++ b/vllm_ascend/quantization/methods/base.py
@@ -17,7 +17,6 @@
 """Abstract base classes for Ascend quantization schemes."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -236,53 +235,18 @@ class AscendMoEScheme(ABC):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = False,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: Any | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         """Forward computation for MoE layer.
 
         Args:
             layer: The MoE layer module.
             x: Input hidden states.
-            router_logits: Router logits for expert selection.
-            top_k: Number of experts to select per token.
-            renormalize: Whether to renormalize expert weights.
-            use_grouped_topk: Whether to use grouped top-k selection.
-            num_experts: Number of experts.
-            expert_map: Mapping from local to global expert indices.
-            topk_group: Group size for grouped top-k.
-            num_expert_group: Number of expert groups.
-            custom_routing_function: Custom routing function.
-            scoring_func: Scoring function name.
-            routed_scaling_factor: Scaling factor for routed experts.
-            e_score_correction_bias: Expert score correction bias.
-            is_prefill: Whether in prefill phase.
-            enable_force_load_balance: Whether to force load balancing.
-            log2phy: Logical to physical expert mapping.
-            global_redundant_expert_num: Number of redundant experts.
-            pertoken_scale: Optional per-token activation scale from prepare stage.
-            activation: Expert MLP activation type.
-            apply_router_weight_on_input: Whether to pre-scale hidden states by router weights.
-            mc2_mask: Optional mask used by MC2 dispatch.
+            topk_weights: Router weights of shape (num_tokens, top_k).
+            topk_ids: Selected expert ids of shape (num_tokens, top_k).
 
         Returns:
             Output tensor after MoE computation.

--- a/vllm_ascend/quantization/methods/w4a16.py
+++ b/vllm_ascend/quantization/methods/w4a16.py
@@ -16,7 +16,6 @@
 #
 """Ascend W4A16 quantization helpers and fused MoE method."""
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -25,10 +24,9 @@ from vllm.config import get_current_vllm_config
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -249,58 +247,11 @@ class AscendW4A16FusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = True,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        assert router_logits.shape[1] == num_logical_experts, (
-            "Number of global experts mismatch (excluding redundancy): "
-            f"router_logits.shape[1]={router_logits.shape[1]}, num_logical_experts={num_logical_experts}"
-        )
-
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
-
         topk_ids = topk_ids.to(torch.int32)
         topk_weights = topk_weights.to(x.dtype)
 
@@ -314,13 +265,13 @@ class AscendW4A16FusedMoEMethod(AscendMoEScheme):
                 w2=layer.w2_weight_packed,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
-                activation=activation,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
+                activation=getattr(layer, "activation", "silu"),
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
                 w1_offset=layer.w13_weight_offset,

--- a/vllm_ascend/quantization/methods/w4a16_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a16_mxfp4.py
@@ -16,7 +16,6 @@
 #
 """Ascend W4A16_MXFP4 quantization helpers and fused MoE method."""
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -30,10 +29,9 @@ from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp4_moe_available,
 )
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -114,62 +112,11 @@ class AscendW4A16MXFP4FusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = True,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        assert router_logits.shape[1] == num_logical_experts, (
-            "Number of global experts mismatch (excluding redundancy): "
-            f"router_logits.shape[1]={router_logits.shape[1]}, num_logical_experts={num_logical_experts}"
-        )
-
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            e_score_correction_bias=e_score_correction_bias,
-            routed_scaling_factor=routed_scaling_factor,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
-
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
-
         topk_weights = topk_weights.to(x.dtype)
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
@@ -182,13 +129,13 @@ class AscendW4A16MXFP4FusedMoEMethod(AscendMoEScheme):
                 w2=layer.w2_weight,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
-                activation=activation,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
+                activation=getattr(layer, "activation", "silu"),
                 mxfp_act_quant_type=None,
                 mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -31,10 +30,9 @@ from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp4_linear_available,
     ensure_mxfp4_moe_available,
 )
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -171,60 +169,11 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = True,
-        log2phy: torch.Tensor = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: Any | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_logical_experts,
-        )
-
-        # this is a naive implementation for experts load balance so as
-        # to avoid accumulating too much tokens on a single rank.
-        # currently it is only activated when doing profile runs.
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
-
         if x.dtype not in [torch.uint8]:
             topk_weights = topk_weights.to(x.dtype)
 
@@ -238,13 +187,13 @@ class AscendW4A4MXFP4DynamicFusedMoEMethod(AscendMoEScheme):
                 w2=layer.w2_weight,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
-                activation=activation,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
+                activation=getattr(layer, "activation", "silu"),
                 mxfp_act_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -27,11 +26,10 @@ from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD, maybe_trans_nz
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -489,66 +487,11 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = False,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: torch.Tensor | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        assert router_logits.shape[1] == num_logical_experts, (
-            "Number of global experts mismatch (excluding redundancy): "
-            f"router_logits.shape[1]={router_logits.shape[1]}, num_logical_experts={num_logical_experts}"
-        )
-
-        # NOTE: now npu_moe_gating_top_k can only support `group_count=256` pattern
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
-
-        # this is a naive implementation for experts load balance so as
-        # to avoid accumulating too much tokens on a single rank.
-        # currently it is only activated when doing profile runs.
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
-
         topk_weights = topk_weights.to(x.dtype)
 
         if self.dynamic_eplb:
@@ -592,13 +535,13 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w2=w2,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
-                activation=activation,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
+                activation=getattr(layer, "activation", "silu"),
                 w1_scale=w1_scale,
                 w2_scale=w2_scale,
                 w1_scale_bias=w1_scale_bias,

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -16,7 +16,6 @@
 #
 
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -30,10 +29,9 @@ from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp4_linear_available,
 )
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -144,61 +142,11 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = True,
-        log2phy: torch.Tensor = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            e_score_correction_bias=e_score_correction_bias,
-            routed_scaling_factor=routed_scaling_factor,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
-
-        # this is a naive implementation for experts load balance so as
-        # to avoid accumulating too much tokens on a single rank.
-        # currently it is only activated when doing profile runs.
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
-
         if x.dtype not in [torch.float8_e4m3fn]:
             topk_weights = topk_weights.to(x.dtype)
 
@@ -212,13 +160,13 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 w2=layer.w2_weight,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
-                activation=activation,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
+                activation=getattr(layer, "activation", "silu"),
                 mxfp_act_quant_type=torch.float8_e4m3fn,
                 mxfp_weight_quant_type=torch_npu.float4_e2m1fn_x2,
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -26,11 +25,10 @@ from vllm.logger import logger
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, enable_dsa_cp, maybe_trans_nz
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -212,88 +210,16 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = False,
-        log2phy: torch.Tensor | None = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        zero_expert_num = getattr(layer, "zero_expert_num", 0)
-        zero_expert_type = getattr(layer, "zero_expert_type", None)
-        n_shared_experts = getattr(layer, "n_shared_experts", 0)
-        mix_placement = getattr(layer, "mix_placement", False)
-        if n_shared_experts is None:
-            n_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=n_shared_experts,
-        )
-        if zero_expert_num == 0 or zero_expert_type is None:
-            assert router_logits.shape[1] == num_logical_experts, (
-                "[vllm-ascend/W8A8_DYNAMIC] Number of global experts mismatch "
-                "(excluding redundancy). "
-                f"router_experts={router_logits.shape[1]}, "
-                f"expected_experts={num_logical_experts}, "
-                f"zero_expert_num={zero_expert_num}, "
-                f"zero_expert_type={zero_expert_type}"
-            )
-
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            mix_placement=mix_placement,
-            num_logical_experts=router_logits.shape[1],
-            num_shared_experts=n_shared_experts,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
         assert topk_ids is not None
-        assert topk_weights is not None
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            topk_ids, topk_weights, zero_expert_result = zero_experts_compute(
-                expert_indices=topk_ids,
-                expert_scales=topk_weights,
-                num_experts=num_logical_experts,
-                zero_expert_type=zero_expert_type,
-                hidden_states=x,
-            )
-        # this is a naive implementation for experts load balance so as
-        # to avoid accumulating too much tokens on a single rank.
-        # currently it is only activated when doing profile runs.
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
-
         assert topk_weights is not None
         topk_weights = topk_weights.to(self.in_dtype)
 
+        activation = getattr(layer, "activation", "silu")
         act_name = getattr(activation, "value", activation)
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (
@@ -334,12 +260,12 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w2=w2,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
                 activation=activation,
                 w1_scale=w1_scale,
                 w2_scale=w2_scale,
@@ -350,8 +276,6 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 swiglu_beta=getattr(layer, "swiglu_beta", 0.0),
             )
         )
-        if zero_expert_num > 0 and zero_expert_type is not None:
-            final_hidden_states += zero_expert_result
         return final_hidden_states
 
     def process_weights_after_loading(self, layer):

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -32,10 +31,9 @@ from vllm_ascend.device.mxfp_compat import (
     ensure_mxfp8_linear_available,
     ensure_mxfp8_moe_available,
 )
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType
 from .registry import register_scheme
 
 
@@ -239,63 +237,13 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
         self,
         layer: torch.nn.Module,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
-        top_k: int,
-        renormalize: bool,
-        use_grouped_topk: bool = False,
-        num_experts: int = -1,
-        expert_map: torch.Tensor | None = None,
-        topk_group: int | None = None,
-        num_expert_group: int | None = None,
-        custom_routing_function: Callable | None = None,
-        scoring_func: str = "softmax",
-        routed_scaling_factor: float = 1.0,
-        e_score_correction_bias: torch.Tensor | None = None,
-        is_prefill: bool = True,
-        enable_force_load_balance: bool = True,
-        log2phy: torch.Tensor = None,
-        global_redundant_expert_num: int = 0,
-        pertoken_scale: Any | None = None,
-        activation: str = "silu",
-        apply_router_weight_on_input: bool = False,
-        mc2_mask: torch.Tensor | None = None,
-        tid2eid: torch.Tensor | None = None,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
-        num_shared_experts = getattr(layer, "n_shared_experts", 0)
-        if num_shared_experts is None:
-            num_shared_experts = 0
-        num_logical_experts = get_moe_num_logical_experts(
-            layer,
-            num_experts,
-            global_redundant_expert_num=global_redundant_expert_num,
-            num_shared_experts=num_shared_experts,
-        )
-        assert router_logits.shape[1] == num_logical_experts, "Number of global experts mismatch (excluding redundancy)"
-        topk_weights, topk_ids = select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-            top_k=top_k,
-            use_grouped_topk=use_grouped_topk,
-            renormalize=renormalize,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            custom_routing_function=custom_routing_function,
-            scoring_func=scoring_func,
-            routed_scaling_factor=routed_scaling_factor,
-            e_score_correction_bias=e_score_correction_bias,
-            num_experts=num_logical_experts,
-            tid2eid=tid2eid,
-        )
-
         if topk_weights is None or topk_ids is None:
             raise RuntimeError("topk_weights and topk_ids must be set before fused MoE execution.")
-
-        # this is a naive implementation for experts load balance so as
-        # to avoid accumulating too much tokens on a single rank.
-        # currently it is only activated when doing profile runs.
-        if enable_force_load_balance:
-            random_matrix = torch.rand(topk_ids.size(0), num_logical_experts, device=topk_ids.device)
-            topk_ids = torch.argsort(random_matrix, dim=1)[:, : topk_ids.size(1)].to(topk_ids.dtype)
 
         if x.dtype not in [torch.float8_e4m3fn]:
             topk_weights = topk_weights.to(x.dtype)
@@ -310,13 +258,13 @@ class AscendW8A8MXFP8DynamicFusedMoEMethod(AscendMoEScheme):
                 w2=layer.w2_weight,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb,
-                expert_map=expert_map,
-                global_redundant_expert_num=global_redundant_expert_num,
-                mc2_mask=mc2_mask,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                log2phy=log2phy,
-                pertoken_scale=pertoken_scale,
-                activation=activation,
+                expert_map=getattr(layer, "ascend_expert_map", None),
+                global_redundant_expert_num=getattr(layer, "global_redundant_expert_num", 0),
+                mc2_mask=getattr(layer, "_ascend_mc2_mask", None),
+                apply_router_weight_on_input=getattr(layer, "apply_router_weight_on_input", False),
+                log2phy=getattr(layer, "log2phy", None),
+                pertoken_scale=getattr(layer, "_ascend_pertoken_scale", None),
+                activation=getattr(layer, "activation", "silu"),
                 mxfp_act_quant_type=torch.float8_e4m3fn,
                 mxfp_weight_quant_type=torch.float8_e4m3fn,
                 mxfp_scale_dtype=FLOAT8_E8M0FNU_DTYPE,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR moves Ascend fused MoE expert routing into dedicated router classes and creates those routers from the platform patch instead of keeping expert selection inside quantization methods.

It also aligns the 310P routed-execution interfaces to consume preselected top-k weights and ids, and updates the related regression coverage for fused MoE and quantization paths.

### Does this PR introduce _any_ user-facing change?
No. This is an internal refactor of the Ascend fused MoE routing path and its related tests.

### How was this patch tested?
- `git diff --check`
- `python -m py_compile $(git diff-tree --no-commit-id --name-only -r HEAD -- '*.py')`
- Full unit tests were not run locally in this session.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
