### PR TITLE
[BugFix][v0.23.0][P/D] Preserve exact token history across recompute retries

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -605,6 +605,7 @@
     - vllm_ascend/meta_registration.py
     - vllm_ascend/platform.py
     - vllm_ascend/profiling_config.py
+    - vllm_ascend/recompute_proxy.py
     - vllm_ascend/utils.py
     - setup.py
   tests:
@@ -616,6 +617,7 @@
     - tests/ut/test_flash_common3_context.py
     - tests/ut/test_meta_registration.py
     - tests/ut/test_profiling_config.py
+    - tests/ut/test_recompute_proxy.py
     - tests/ut/test_utils.py
     - tests/ut/test_platform.py
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
@@ -820,7 +822,6 @@ partition:
   a3_x2: 3
   a3_x4: 3
   cpu_x0: 1
-
 
 
 

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -137,6 +137,12 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from vllm_ascend.recompute_proxy import (
+    RECOMPUTE_TOKEN_IDS_KEY,
+    RecomputeContext,
+    iter_sse_events,
+)
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -789,6 +795,7 @@ def auth_headers(request_id: str) -> dict[str, str]:
 
 def build_prefill_request(req_data: dict) -> dict:
     payload = req_data.copy()
+    recompute_token_ids = (req_data.get("kv_transfer_params") or {}).get(RECOMPUTE_TOKEN_IDS_KEY)
     payload["kv_transfer_params"] = {
         "do_remote_decode": True,
         "do_remote_prefill": False,
@@ -797,7 +804,10 @@ def build_prefill_request(req_data: dict) -> dict:
         "remote_host": None,
         "remote_port": None,
     }
+    if recompute_token_ids is not None:
+        payload["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] = recompute_token_ids
     payload["stream"] = False
+    payload["return_token_ids"] = False
     payload["max_tokens"] = 1
     payload["min_tokens"] = 1
     if "max_completion_tokens" in payload:
@@ -922,8 +932,11 @@ async def assign_instances(
         await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
         raise
 
+    recompute_token_ids = (req_data.get("kv_transfer_params") or {}).get(RECOMPUTE_TOKEN_IDS_KEY)
     kv_transfer_params = response.json().get("kv_transfer_params", {})
     if kv_transfer_params:
+        if recompute_token_ids is not None:
+            kv_transfer_params[RECOMPUTE_TOKEN_IDS_KEY] = recompute_token_ids
         req_data["kv_transfer_params"] = kv_transfer_params
 
     try:
@@ -966,27 +979,15 @@ async def handle_completions_impl(api: str, request: Request):
         req_data = await request.json()
         req_body = await request.body()
         request_length = len(req_body)
+        recompute_context = RecomputeContext.from_request(req_data)
         instance_info = await assign_instances(api, req_data, request_length, is_initial_request=True)
-        stream_flag = bool(req_data.get("stream", False))
-        chat_flag = "messages" in req_data
-
-        if "prompt" in req_data:
-            origin_prompt = req_data["prompt"]
-        elif chat_flag:
-            messages = req_data["messages"]
-            origin_prompt = messages[0].get("content", "")
-        else:
-            origin_prompt = ""
-        origin_max_tokens = req_data.get("max_tokens", 16)
+        stream_flag = recompute_context.stream
 
         async def generate_stream():
             nonlocal instance_info
             nonlocal request_released
-            generated_token = ""
             released_kv = False
-            retry_count = 0
             retry = True
-            completion_tokens = 0
 
             async def release_prefill_kv_once() -> None:
                 nonlocal released_kv
@@ -996,73 +997,70 @@ async def handle_completions_impl(api: str, request: Request):
                     )
                     released_kv = True
 
+            async def response_chunks(decoder_client: httpx.AsyncClient):
+                async for chunk in stream_service_response_with_retry(
+                    decoder_client,
+                    api,
+                    req_data,
+                    request_id=instance_info.request_id,
+                    max_retries=args.max_retries,
+                    base_delay=args.retry_delay,
+                ):
+                    if not released_kv and chunk:
+                        await release_prefill_kv_once()
+                    yield chunk
+
             try:
                 while retry:
                     retry = False
                     decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response_with_retry(
-                        decoder_client,
-                        api,
-                        req_data,
-                        request_id=instance_info.request_id,
-                        max_retries=args.max_retries,
-                        base_delay=args.retry_delay,
-                    ):
-                        if not released_kv and chunk:
-                            await release_prefill_kv_once()
-                        try:
-                            chunk_str = chunk.decode("utf-8").strip()
-                        except UnicodeDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk)
-                            yield chunk
-                            continue
-                        if not chunk_str:
-                            continue
-                        if chunk_str.startswith("data: "):
-                            chunk_str = chunk_str[len("data: ") :]
-                        try:
-                            chunk_json = json.loads(chunk_str)
-                        except json.JSONDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk_str)
-                            yield chunk
-                            continue
-                        choices = chunk_json.get("choices", [])
-                        if not choices:
-                            yield chunk
-                            continue
+                    chunks = response_chunks(decoder_client)
+                    if stream_flag:
+                        async for event in iter_sse_events(chunks):
+                            data_lines = [line[5:].lstrip() for line in event.splitlines() if line.startswith(b"data:")]
+                            if not data_lines:
+                                yield event
+                                continue
+                            data = b"\n".join(data_lines)
+                            if data == b"[DONE]":
+                                yield event
+                                continue
+                            try:
+                                payload = json.loads(data)
+                            except json.JSONDecodeError:
+                                logger.debug("Skipping SSE event: %s", event)
+                                yield event
+                                continue
 
-                        choice = choices[0]
-                        delta = choice.get("delta") or {}
-                        message = choice.get("message") or {}
-                        content = delta.get("content") or message.get("content") or choice.get("text") or ""
-                        generated_token += content
+                            if recompute_context.observe_response(payload):
+                                recompute_context.prepare_retry(req_data)
+                                request_length = len(json.dumps(req_data).encode("utf-8"))
+                                instance_info = await reassign_instances(api, req_data, request_length, instance_info)
+                                released_kv = False
+                                retry = True
+                                break
 
-                        stop_reason = choice.get("stop_reason")
-                        usage = chunk_json.get("usage", {})
-                        completion_tokens = (
-                            (completion_tokens + 1)
-                            if stream_flag
-                            else (completion_tokens + usage.get("completion_tokens", 0))
-                        )
-                        if stop_reason == "recomputed":
-                            retry = True
-                            retry_count += 1
-                            if chat_flag:
-                                messages[0]["content"] = origin_prompt + generated_token
-                            else:
-                                req_data["prompt"] = origin_prompt + generated_token
-                            req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
-                            tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
+                            client_payload = recompute_context.response_for_client(payload)
+                            if client_payload is not None:
+                                yield (
+                                    "data: "
+                                    + json.dumps(client_payload, ensure_ascii=False, separators=(",", ":"))
+                                    + "\n\n"
+                                ).encode("utf-8")
+                    else:
+                        body = b"".join([chunk async for chunk in chunks])
+                        payload = json.loads(body)
+                        if recompute_context.observe_response(payload):
+                            recompute_context.prepare_retry(req_data)
+                            request_length = len(json.dumps(req_data).encode("utf-8"))
+                            instance_info = await reassign_instances(api, req_data, request_length, instance_info)
                             released_kv = False
-                            break
-                        if retry_count > 0 and not stream_flag:
-                            if chat_flag:
-                                choice["message"]["content"] = generated_token
-                            else:
-                                choice["text"] = generated_token
-                            chunk = json.dumps(chunk_json).encode("utf-8")
-                        yield chunk
+                            retry = True
+                            continue
+
+                        client_payload = recompute_context.response_for_client(payload)
+                        if client_payload is not None:
+                            yield json.dumps(client_payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
             except asyncio.CancelledError:
                 logger.warning(
                     "Streaming from decoder %s:%s was cancelled; releasing request %s resources",

--- a/tests/ut/test_recompute_proxy.py
+++ b/tests/ut/test_recompute_proxy.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+import asyncio
+import copy
+import json
+from typing import Any
+
+import pytest
+
+from vllm_ascend.recompute_proxy import (
+    RECOMPUTE_TOKEN_IDS_KEY,
+    RecomputeContext,
+    iter_sse_events,
+    replace_rendered_chat_inputs,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+async def _chunks(parts: list[bytes]):
+    for part in parts:
+        yield part
+
+
+def test_iter_sse_events_handles_split_and_coalesced_chunks() -> None:
+    first = 'data: {"choices":[{"delta":{"reasoning":"think 中"}}]}\n\n'
+    second = 'data: {"choices":[{"delta":{"content":"answer"}}]}\n\n'
+    encoded = (first + second).encode()
+    han_offset = encoded.index("中".encode())
+    chunks = [
+        encoded[: han_offset + 1],
+        encoded[han_offset + 1 : len(first.encode()) + 8],
+        encoded[len(first.encode()) + 8 :],
+    ]
+
+    async def collect_events() -> list[bytes]:
+        return [event async for event in iter_sse_events(_chunks(chunks))]
+
+    events = asyncio.run(collect_events())
+
+    assert events == [first.encode(), second.encode()]
+
+
+def test_iter_sse_events_handles_split_crlf() -> None:
+    event = b'data: {"choices": []}\r\n\r\n'
+
+    async def collect_events() -> list[bytes]:
+        return [event async for event in iter_sse_events(_chunks([event[:-3], event[-3:]]))]
+
+    assert asyncio.run(collect_events()) == [b'data: {"choices": []}\n\n']
+
+
+def test_recompute_uses_exact_tokens_without_mutating_messages() -> None:
+    request: dict[str, Any] = {
+        "messages": [
+            {"role": "system", "content": "Answer carefully."},
+            {"role": "user", "content": "What was my first question?"},
+            {"role": "assistant", "content": "You asked about arithmetic."},
+            {"role": "user", "content": "What is 2 + 2?"},
+        ],
+        "stream": True,
+        "max_completion_tokens": 8,
+    }
+    original_messages = copy.deepcopy(request["messages"])
+    context = RecomputeContext.from_request(request)
+
+    context.observe_response({"prompt_token_ids": [1, 2, 3], "choices": []})
+    context.observe_response(
+        {
+            "choices": [
+                {
+                    "delta": {"reasoning": "2 + 2 is 4."},
+                    "token_ids": [10, 11],
+                    "finish_reason": None,
+                }
+            ]
+        }
+    )
+    recomputed = context.observe_response(
+        {
+            "choices": [
+                {
+                    "delta": {},
+                    "token_ids": [],
+                    "finish_reason": "stop",
+                    "stop_reason": "recomputed",
+                }
+            ]
+        }
+    )
+
+    assert recomputed
+    context.prepare_retry(request)
+    assert request["messages"] == original_messages
+    assert request["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] == [1, 2, 3, 10, 11]
+    assert request["max_completion_tokens"] == 6
+    assert request["return_token_ids"] is True
+
+
+def test_two_recomputes_extend_the_same_token_history() -> None:
+    request: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+        "max_tokens": 10,
+    }
+    context = RecomputeContext.from_request(request)
+    context.observe_response({"prompt_token_ids": [1, 2], "choices": []})
+    context.observe_response({"choices": [{"delta": {"reasoning": "R1"}, "token_ids": [3], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+    assert request["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] == [1, 2, 3]
+
+    context.observe_response({"prompt_token_ids": [1, 2, 3], "choices": []})
+    context.observe_response({"choices": [{"delta": {"content": "C1"}, "token_ids": [4, 5], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+
+    assert request["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] == [1, 2, 3, 4, 5]
+    assert request["max_tokens"] == 7
+
+
+def test_retry_rejects_changed_token_history() -> None:
+    request = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+        "max_completion_tokens": 4,
+    }
+    context = RecomputeContext.from_request(request)
+    context.observe_response({"prompt_token_ids": [1, 2], "choices": []})
+    context.observe_response({"choices": [{"delta": {"content": "C1"}, "token_ids": [3], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+
+    assert request["max_completion_tokens"] == 3
+    with pytest.raises(RuntimeError, match="exact token history"):
+        context.observe_response({"prompt_token_ids": [1, 2, 99], "choices": []})
+
+
+def test_nonstream_recompute_merges_one_logical_response() -> None:
+    request = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": False,
+        "max_tokens": 6,
+    }
+    context = RecomputeContext.from_request(request)
+    first = {
+        "id": "attempt-a",
+        "model": "model",
+        "prompt_token_ids": [1, 2],
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "reasoning": "R1", "content": "C1"},
+                "token_ids": [3, 4],
+                "finish_reason": "stop",
+                "stop_reason": "recomputed",
+            }
+        ],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
+    }
+    assert context.observe_response(first)
+    context.prepare_retry(request)
+
+    final = {
+        "id": "attempt-b",
+        "model": "model",
+        "prompt_token_ids": [1, 2, 3, 4],
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "reasoning": "R2", "content": "C2"},
+                "token_ids": [5, 6],
+                "finish_reason": "stop",
+                "stop_reason": None,
+            }
+        ],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+    }
+    assert not context.observe_response(final)
+    client_payload = context.response_for_client(final)
+
+    assert client_payload["choices"][0]["message"] == {
+        "role": "assistant",
+        "reasoning": "R1R2",
+        "content": "C1C2",
+    }
+    assert "token_ids" not in client_payload["choices"][0]
+    assert "prompt_token_ids" not in client_payload
+    assert client_payload["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 4,
+        "total_tokens": 6,
+    }
+
+
+def test_replace_rendered_chat_inputs_uses_internal_token_prefix() -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "kv_transfer_params": {RECOMPUTE_TOKEN_IDS_KEY: [7, 8, 9]},
+            "cache_salt": "salt",
+        },
+    )()
+    conversation = [{"role": "user", "content": "unchanged"}]
+    result = replace_rendered_chat_inputs(request, (conversation, [{"prompt_token_ids": [1]}]))
+
+    assert result[0] is conversation
+    assert result[1] == [
+        {
+            "type": "token",
+            "prompt_token_ids": [7, 8, 9],
+            "cache_salt": "salt",
+        }
+    ]
+    assert RECOMPUTE_TOKEN_IDS_KEY not in request.kv_transfer_params
+
+
+def test_stream_response_hides_internal_token_ids_and_rewrites_usage() -> None:
+    request = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": 6,
+    }
+    context = RecomputeContext.from_request(request)
+    initial_role = {
+        "id": "attempt-a",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "model",
+        "prompt_token_ids": [1, 2],
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": ""},
+                "token_ids": None,
+                "finish_reason": None,
+            }
+        ],
+    }
+    context.observe_response(initial_role)
+    client_initial_role = context.response_for_client(initial_role)
+    assert client_initial_role == {
+        "id": "attempt-a",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "model",
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": ""},
+                "finish_reason": None,
+            }
+        ],
+    }
+    context.observe_response({"choices": [{"delta": {"reasoning": "R1"}, "token_ids": [3, 4], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+
+    retry_role = {
+        "id": "attempt-b",
+        "object": "chat.completion.chunk",
+        "created": 2,
+        "model": "model",
+        "prompt_token_ids": [1, 2, 3, 4],
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": ""},
+                "token_ids": None,
+                "finish_reason": None,
+            }
+        ],
+    }
+    context.observe_response(retry_role)
+    assert context.response_for_client(retry_role) is None
+
+    content = {
+        "id": "attempt-b",
+        "object": "chat.completion.chunk",
+        "created": 2,
+        "model": "model",
+        "choices": [{"delta": {"content": "C2"}, "token_ids": [5], "finish_reason": None}],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5},
+    }
+    context.observe_response(content)
+    client_payload = context.response_for_client(content)
+    assert client_payload["id"] == "attempt-a"
+    assert client_payload["created"] == 1
+    assert client_payload["choices"][0] == {"delta": {"content": "C2"}, "finish_reason": None}
+    assert client_payload["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+
+    # Ensure rewritten payloads remain serializable as SSE JSON.
+    json.dumps(client_payload)
+
+    terminal = {
+        "id": "attempt-b",
+        "object": "chat.completion.chunk",
+        "created": 2,
+        "model": "model",
+        "choices": [
+            {
+                "delta": {},
+                "finish_reason": "stop",
+                "stop_reason": None,
+                "token_ids": [],
+            }
+        ],
+    }
+    context.observe_response(terminal)
+    client_terminal = context.response_for_client(terminal)
+    assert client_terminal["id"] == "attempt-a"
+    assert client_terminal["choices"] == [{"delta": {}, "finish_reason": "stop", "stop_reason": None}]

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1067,3 +1067,18 @@
 #       runner and can rely on upstream's default enablement heuristics
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
+#
+# ** 31. File: platform/patch_recompute_chat.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.serve.render.serving.OpenAIServingRender.render_chat`
+#    Why:
+#       P/D recompute retries must resume from exact token IDs. Rebuilding chat
+#       messages changes role placement and applies the chat template again.
+#    How:
+#       Replace the rendered engine input only when the proxy supplies its
+#       internal recompute token prefix through KV transfer parameters.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm-ascend/issues/13466
+#    Future Plan:
+#       Remove this patch when upstream vLLM exposes a token-native internal
+#       resume input for chat-completion P/D proxies.

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -35,6 +35,7 @@ if vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
+    import vllm_ascend.patch.platform.patch_recompute_chat  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa

--- a/vllm_ascend/patch/platform/patch_recompute_chat.py
+++ b/vllm_ascend/patch/platform/patch_recompute_chat.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+
+from vllm_ascend.recompute_proxy import replace_rendered_chat_inputs
+
+_original_render_chat = OpenAIServingRender.render_chat
+
+
+async def _render_chat_with_recompute_tokens(self, request, *, skip_mm_cache=False):
+    result = await _original_render_chat(self, request, skip_mm_cache=skip_mm_cache)
+    return replace_rendered_chat_inputs(request, result)
+
+
+OpenAIServingRender.render_chat = _render_chat_with_recompute_tokens

--- a/vllm_ascend/recompute_proxy.py
+++ b/vllm_ascend/recompute_proxy.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from __future__ import annotations
+
+import copy
+from collections.abc import AsyncIterable, AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+RECOMPUTE_TOKEN_IDS_KEY = "_vllm_ascend_recompute_token_ids"
+_STREAM_METADATA_KEYS = ("id", "object", "created", "model")
+
+
+async def iter_sse_events(chunks: AsyncIterable[bytes]) -> AsyncIterator[bytes]:
+    buffer = b""
+    async for chunk in chunks:
+        buffer += chunk
+        buffer = buffer.replace(b"\r\n", b"\n")
+        while b"\n\n" in buffer:
+            event, buffer = buffer.split(b"\n\n", 1)
+            if event:
+                yield event + b"\n\n"
+    if buffer.strip():
+        yield buffer
+
+
+def _is_recomputed(payload: dict[str, Any]) -> bool:
+    return any(choice.get("stop_reason") == "recomputed" for choice in payload.get("choices", []))
+
+
+@dataclass
+class RecomputeContext:
+    stream: bool
+    return_token_ids: bool
+    max_tokens_field: str
+    max_tokens: int
+    prompt_token_ids: list[int] | None = None
+    output_token_ids: list[int] = field(default_factory=list)
+    retry_count: int = 0
+    _message: dict[str, Any] = field(default_factory=dict)
+    _stream_metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_request(cls, request: dict[str, Any]) -> RecomputeContext:
+        max_tokens_field = "max_completion_tokens" if request.get("max_completion_tokens") is not None else "max_tokens"
+        context = cls(
+            stream=bool(request.get("stream", False)),
+            return_token_ids=bool(request.get("return_token_ids", False)),
+            max_tokens_field=max_tokens_field,
+            max_tokens=request.get(max_tokens_field) or 16,
+        )
+        request["return_token_ids"] = True
+        return context
+
+    def observe_response(self, payload: dict[str, Any]) -> bool:
+        if self.stream and not self._stream_metadata:
+            self._stream_metadata = {key: payload[key] for key in _STREAM_METADATA_KEYS if key in payload}
+
+        prompt_token_ids = payload.get("prompt_token_ids")
+        if prompt_token_ids is not None:
+            if self.prompt_token_ids is None:
+                self.prompt_token_ids = list(prompt_token_ids)
+            else:
+                expected_token_ids = self.prompt_token_ids + self.output_token_ids
+                if prompt_token_ids != expected_token_ids:
+                    raise RuntimeError("Recompute retry did not preserve the exact token history")
+
+        choices = payload.get("choices", [])
+        if choices:
+            choice = choices[0]
+            self.output_token_ids.extend(choice.get("token_ids") or [])
+            if not self.stream:
+                self._merge_message(choice.get("message") or {})
+
+        recomputed = _is_recomputed(payload)
+        if recomputed:
+            self.retry_count += 1
+        return recomputed
+
+    def _merge_message(self, message: dict[str, Any]) -> None:
+        for key, value in message.items():
+            if value is None:
+                continue
+            if key == "role":
+                self._message[key] = value
+            elif isinstance(value, str) and isinstance(self._message.get(key), str):
+                self._message[key] += value
+            elif key not in self._message:
+                self._message[key] = copy.deepcopy(value)
+
+    def prepare_retry(self, request: dict[str, Any]) -> None:
+        if self.prompt_token_ids is None:
+            raise RuntimeError("Recompute response did not include prompt_token_ids")
+
+        token_ids = self.prompt_token_ids + self.output_token_ids
+        if "messages" in request:
+            request["kv_transfer_params"] = {RECOMPUTE_TOKEN_IDS_KEY: token_ids}
+        else:
+            request["prompt"] = token_ids
+            request.pop("kv_transfer_params", None)
+        request[self.max_tokens_field] = self.max_tokens - len(self.output_token_ids)
+        request["return_token_ids"] = True
+
+    def response_for_client(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        if _is_recomputed(payload):
+            return None
+
+        result = copy.deepcopy(payload)
+        if self.stream:
+            result.update(self._stream_metadata)
+        choices = result.get("choices", [])
+        if self.stream and self.retry_count and any((choice.get("delta") or {}).get("role") for choice in choices):
+            return None
+
+        if not self.stream and choices:
+            choices[0]["message"] = copy.deepcopy(self._message)
+            if self.return_token_ids:
+                choices[0]["token_ids"] = self.output_token_ids.copy()
+
+        if self.return_token_ids:
+            if not self.stream and self.prompt_token_ids is not None:
+                result["prompt_token_ids"] = self.prompt_token_ids.copy()
+        else:
+            result.pop("prompt_token_ids", None)
+            for choice in choices:
+                choice.pop("token_ids", None)
+
+        usage = result.get("usage")
+        if usage is not None and self.prompt_token_ids is not None:
+            prompt_tokens = len(self.prompt_token_ids)
+            completion_tokens = len(self.output_token_ids)
+            usage["prompt_tokens"] = prompt_tokens
+            usage["completion_tokens"] = completion_tokens
+            usage["total_tokens"] = prompt_tokens + completion_tokens
+        return result
+
+
+def replace_rendered_chat_inputs(request: Any, result: Any) -> Any:
+    kv_transfer_params = request.kv_transfer_params or {}
+    token_ids = kv_transfer_params.pop(RECOMPUTE_TOKEN_IDS_KEY, None)
+    if token_ids is None or not isinstance(result, tuple):
+        return result
+
+    conversation, engine_inputs = result
+    if len(engine_inputs) != 1:
+        return result
+
+    engine_input = dict(engine_inputs[0])
+    engine_input["type"] = "token"
+    engine_input["prompt_token_ids"] = list(token_ids)
+    engine_input["cache_salt"] = request.cache_salt
+    engine_input.pop("prompt", None)
+    return conversation, [engine_input]


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #13466.

When the decode-side recompute scheduler returns `stop_reason="recomputed"`, the release proxy currently reconstructs the retry from parsed response text. For chat completions it appends that text to `messages[0].content` and renders the chat template again. This changes both the token sequence and role semantics: generated assistant text can become part of the system or user message, while parsed reasoning is omitted entirely.

This PR makes recompute retry token-native:

- request prompt and output token IDs internally from D;
- resume from the exact original prompt IDs plus every emitted output-token delta;
- keep the original `messages` unchanged and use a v0.23-only renderer patch to replace the retry engine input with that exact token prefix;
- parse streaming responses by SSE event framing instead of treating HTTP byte chunks as complete events;
- preserve one client-visible response identity and assistant stream across retries;
- account for the remaining generation budget and usage from token counts.

P responses do not serialize prompt token IDs. The internal retry prefix is removed after rendering so it does not enter the KV connector. No vLLM source file or native operator is changed.

Scope note: this patch restores exact prompt/output token history and prevents role/template corruption. vLLM v0.23 does not expose the decode-side device generator state to the proxy, and MTP advances RNG according to draft acceptance/recovery rather than emitted-token count. Therefore this patch does not claim bitwise-equivalent continuation for explicitly seeded sampling after a request is reassigned.

### Does this PR introduce _any_ user-facing change?

Yes. A chat or completion request that is reassigned after decode-side recomputation now continues from its exact generated-token history instead of restarting from a re-rendered and role-corrupted prompt. Internal token fields and retry role/terminal chunks are not exposed unless the client requested token IDs. Streaming retries retain the original response ID, creation time, object, and model fields.

### How was this patch tested?

Unit and static checks:

```bash
PYTHONPATH=<vllm-v0.23.0>:<this-vllm-ascend-worktree> \
  pytest -q tests/ut/test_recompute_proxy.py

ruff check \
  examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py \
  vllm_ascend/recompute_proxy.py \
  vllm_ascend/patch/platform/patch_recompute_chat.py \
  tests/ut/test_recompute_proxy.py

MYPYPATH=<vllm-v0.23.0> mypy --follow-imports skip \
  --check-untyped-defs --python-version 3.10 \
  vllm_ascend/recompute_proxy.py
```

Result: `8 passed`; mypy, Ruff, format, `py_compile`, and `git diff --check` passed.

Real-model NPU A/B:

- model: DeepSeek-V4-Flash W4A8;
- topology: 16 NPUs, 1P1D, TP8+EP on each side;
- request: 10,125 rendered prompt tokens, `temperature=1`, streaming chat completion;
- decode: async scheduling, recompute scheduler, `block_size=32`, 480 KV blocks;
- native vLLM-Ascend binaries and model weights were identical between runs.

The baseline produced client-visible restart seams after recomputation, including `active_transfers[requestLooking at this code...` and `pool.free = [1Looking at this code...`. The affected responses exposed three assistant-role attempts, and the retry prompt first differed from the required token history at token index 55 even when its total length happened to match.

With this patch, an initial stress run covered 14 recomputations; one request was recomputed 12 times between output tokens 633 and 660. Four concurrent responses each had one assistant role, zero SSE parse errors, no replacement characters or Chinese fragments, and continuous text across every retry boundary.

A second run was allowed to finish naturally and covered seven real decode-side recomputations. All four requests returned HTTP 200, exactly 800 visible token IDs, one stable response ID/creation time, one assistant role, `finish_reason="length"`, correct `10125 + 800 = 10925` usage, and exactly one `[DONE]`. The exact-token retry invariant remained valid for every retry.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
