### PR TITLE
[Doc][Feature] Add Qwen3.6-27B model support of Ascend 950

### DIFF
--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -135,7 +135,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | Model   | Support   | Note   | BF16 | Supported Hardware | W8A8 | Chunked Prefill | Automatic Prefix Cache | LoRA | Speculative Decoding | Async Scheduling | Tensor Parallel | Pipeline Parallel | Expert Parallel | Data Parallel | Prefill-decode Disaggregation | Piecewise AclGraph | Fullgraph AclGraph | max-model-len | MLP Weight Prefetch | Doc |
 |-------|--------|--------|------|------|------|---------|-------|------|------|--------|-------|--------|--------|-------|-------|--------|----------|---------|----------|-----|
 |Qwen3.5-397B-A17B|||||||||||||||||||||
-|Qwen3.6-27B|||||||||||||||||||||
+|Qwen3.6-27B|✅|  |✅| Ascend 950 Products |✅|✅|✅||✅|✅|✅||✅|✅|✅|✅|✅|262144|| [Qwen3.5-27B / Qwen3.6-27B](../../tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md) |
 
 ::::
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the supported models matrix for the Ascend 950 Products in
the documentation.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Documentation update only, no code changes.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
