### PR TITLE
[Doc][BugFix] Update proxy script name in DeepSeek-V3.2 tutorial

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -749,13 +749,13 @@ Parameter descriptions:
 
 3. Run the `proxy.sh` script on the prefill master node
 
-    Run a proxy server on the same node with the prefiller service instance. You can get the proxy program in the repository's examples: [load_balance_proxy_layerwise_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_layerwise_server_example.py)
+    Run a proxy server on the same node with the prefiller service instance. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
 
     ```shell
     unset http_proxy
     unset https_proxy
 
-    python load_balance_proxy_layerwise_server_example.py \
+    python load_balance_proxy_server_example.py \
         --port 8000 \
         --host 141.61.39.105 \
         --prefiller-hosts \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR corrects the proxy script name in the DeepSeek-V3.2 tutorial. It updates the references from `load_balance_proxy_layerwise_server_example.py` to `load_balance_proxy_server_example.py` because DeepSeek-V3.2 uses Mooncake disaggregated prefill, which relies on the standard load balance proxy rather than the layerwise one.
Fixes #13534 

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only update, no functional code changes.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
