### PR TITLE
[BugFix][Core] Fix Qwen3-VL MoE residual corruption under FlashComm1 with deepstack

### DIFF
--- a/vllm_ascend/compilation/passes/sequence_parallelism.py
+++ b/vllm_ascend/compilation/passes/sequence_parallelism.py
@@ -265,7 +265,7 @@ class Qwen3VLMiddleAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
         ) -> tuple[torch.Tensor, torch.Tensor]:
             x = self._all_reduce(input)
             add_ = x + deepstack_input_embeds
-            residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
+            residual = torch.ops.vllm.maybe_chunk_residual(add_, residual)
             result, _, residual = self._add_rms_norm_bias(add_, residual, weight)
 
             return result, residual
@@ -279,7 +279,7 @@ class Qwen3VLMiddleAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
             reduce_scatter = self._reduce_scatter(input)
             chunk = deepstack_input_embeds.chunk(self.tp_size)[self.tp_rank]
             add_ = reduce_scatter + chunk
-            residual = torch.ops.vllm.maybe_chunk_residual(reduce_scatter, residual)
+            residual = torch.ops.vllm.maybe_chunk_residual(add_, residual)
             result, _, residual = self._add_rms_norm_bias(add_, residual, weight)
             all_gather = self._all_gather(result)
             return all_gather, residual
@@ -295,7 +295,7 @@ class Qwen3VLMiddleAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
             x = self._maybe_all_reduce(input)
             x = torch.ops.aten.alias(x)
             add_ = x + deepstack_input_embeds
-            residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
+            residual = torch.ops.vllm.maybe_chunk_residual(add_, residual)
             result, _, residual = self._add_rms_norm_bias(add_, residual, weight)
             return result, residual
 

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -17,6 +17,8 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.rotary_embedding import rope_forward_oot
 from vllm_ascend.ops.triton.muls_add import muls_add_triton
 from vllm_ascend.utils import enable_sp_by_pass, is_vl_model
+from vllm.logger import logger
+
 
 
 def _maybe_chunk_residual_impl(x: torch.Tensor, residual: torch.Tensor) -> torch.Tensor:
@@ -26,18 +28,12 @@ def _maybe_chunk_residual_impl(x: torch.Tensor, residual: torch.Tensor) -> torch
         return residual
 
     if x.size(0) != residual.size(0):
-        if residual.size(0) < x.size(0):
-            # A preceding SP RMSNorm leaves a local residual, while a MoE
-            # communication path can restore the full sequence before the
-            # next residual add.
-            residual = tensor_model_parallel_all_gather(residual, 0)
-        else:
-            pad_size = _EXTRA_CTX.pad_size
-            if pad_size > 0:
-                residual = F.pad(residual, (0, 0, 0, pad_size))
-            tp_size = get_tensor_model_parallel_world_size()
-            tp_rank = get_tensor_model_parallel_rank()
-            residual = torch.chunk(residual, tp_size, dim=0)[tp_rank]
+        pad_size = _EXTRA_CTX.pad_size
+        if pad_size > 0:
+            residual = F.pad(residual, (0, 0, 0, pad_size))
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        residual = torch.chunk(residual, tp_size, dim=0)[tp_rank]
 
     return residual
 

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -17,8 +17,6 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.rotary_embedding import rope_forward_oot
 from vllm_ascend.ops.triton.muls_add import muls_add_triton
 from vllm_ascend.utils import enable_sp_by_pass, is_vl_model
-from vllm.logger import logger
-
 
 
 def _maybe_chunk_residual_impl(x: torch.Tensor, residual: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
