### PR TITLE
[BugFix] Forward decode backend errors from load balance proxy

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -665,6 +665,15 @@
   tests:
     - tests/ut/test_dependency_documentation.py
 
+- name: load_balance_proxy_example
+  optional: true
+  cpu_only: true
+  source_file_dependencies:
+    - examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+    - tests/ut/test_load_balance_proxy_errors.py
+  tests:
+    - tests/ut/test_load_balance_proxy_errors.py
+
 - name: misc
   optional: false
   source_file_dependencies:

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -634,6 +634,15 @@
   tests:
     - tests/ut/test_dependency_documentation.py
 
+- name: load_balance_proxy_example
+  optional: true
+  cpu_only: true
+  source_file_dependencies:
+    - examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+    - tests/ut/test_load_balance_proxy_errors.py
+  tests:
+    - tests/ut/test_load_balance_proxy_errors.py
+
 - name: misc
   optional: false
   source_file_dependencies:

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -126,7 +126,7 @@ import tempfile
 import threading
 import time
 import uuid
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from multiprocessing.managers import BaseManager
@@ -801,6 +801,8 @@ def with_cancellation(handler_func):
         done, pending = await asyncio.wait([handler_task, cancellation_task], return_when=asyncio.FIRST_COMPLETED)
         for task in pending:
             task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         if handler_task in done:
             return handler_task.result()
         return None
@@ -868,33 +870,143 @@ async def stream_service_response_with_retry(
     max_retries: int = 3,
     base_delay: float = 0.2,
 ):
+    response, chunk_iterator, first_chunk = await open_stream_service_response_with_retry(
+        client,
+        endpoint,
+        req_data,
+        request_id,
+        max_retries=max_retries,
+        base_delay=base_delay,
+    )
+    try:
+        response.raise_for_status()
+        if first_chunk:
+            yield first_chunk
+        async for chunk in chunk_iterator:
+            yield chunk
+    finally:
+        await response.aclose()
+
+
+async def open_stream_service_response_with_retry(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    req_data: dict,
+    request_id: str,
+    max_retries: int = 3,
+    base_delay: float = 0.2,
+) -> tuple[httpx.Response, Any, bytes]:
     headers = auth_headers(request_id)
     for attempt in range(1, max_retries + 1):
+        response: httpx.Response | None = None
         try:
-            async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
-                response.raise_for_status()
-                first_chunk_sent = False
-                async for chunk in response.aiter_bytes():
-                    first_chunk_sent = True
-                    yield chunk
-                return
-        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            request = client.build_request("POST", endpoint, json=req_data, headers=headers)
+            response = await client.send(request, stream=True)
+            if not response.is_success:
+                await response.aread()
+                should_retry = response.status_code >= 500 and attempt < max_retries
+                if should_retry:
+                    logger.warning(
+                        "Attempt %s failed for streaming %s with status %s",
+                        attempt,
+                        endpoint,
+                        response.status_code,
+                    )
+                    await response.aclose()
+                    await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
+                    continue
+                return response, response.aiter_bytes().__aiter__(), b""
+
+            chunk_iterator = response.aiter_bytes().__aiter__()
+            try:
+                first_chunk = await anext(chunk_iterator)
+            except StopAsyncIteration:
+                first_chunk = b""
+            return response, chunk_iterator, first_chunk
+        except httpx.RequestError as exc:
+            if response is not None:
+                await response.aclose()
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
                 logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise exc
+        except asyncio.CancelledError:
+            if response is not None:
+                await response.aclose()
+            raise
         except Exception as exc:
-            if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error("Streaming to client interrupted after response started: %s", exc)
-                return
+            if response is not None:
+                await response.aclose()
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
                 logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise exc
+    raise RuntimeError(f"All {max_retries} attempts failed for streaming {endpoint}.")
+
+
+def backend_response_headers(response: httpx.Response) -> dict[str, str] | None:
+    content_type = response.headers.get("content-type")
+    return {"content-type": content_type} if content_type else None
+
+
+def decoder_error_payload(response: httpx.Response) -> dict[str, Any]:
+    body = response.content.decode("utf-8", errors="replace")
+    try:
+        parsed_body = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        parsed_body = {}
+
+    if isinstance(parsed_body, dict) and isinstance(parsed_body.get("error"), dict):
+        return parsed_body
+
+    message = body or response.reason_phrase or f"Decoder returned HTTP {response.status_code}"
+    return {
+        "error": {
+            "message": message,
+            "type": "upstream_error",
+            "code": response.status_code,
+        }
+    }
+
+
+def decoder_error_chunk(response: httpx.Response, stream_flag: bool) -> bytes:
+    payload = json.dumps(decoder_error_payload(response), ensure_ascii=False)
+    if stream_flag:
+        return f"event: error\ndata: {payload}\n\n".encode()
+    return payload.encode()
+
+
+def decoder_stream_error_chunk(exc: Exception, stream_flag: bool) -> bytes:
+    payload = json.dumps(
+        {
+            "error": {
+                "message": str(exc),
+                "type": "upstream_error",
+                "code": "decode_backend_stream_error",
+            }
+        },
+        ensure_ascii=False,
+    )
+    if stream_flag:
+        return f"event: error\ndata: {payload}\n\n".encode()
+    return payload.encode()
+
+
+def decoder_unavailable_response(endpoint: str, exc: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=502,
+        content={
+            "error": {
+                "message": f"Decode backend request to {endpoint} failed: {exc}",
+                "type": "upstream_error",
+                "code": "decode_backend_unavailable",
+            }
+        },
+    )
 
 
 async def _abort_prefill_selection(
@@ -1013,6 +1125,11 @@ async def handle_completions_impl(api: str, request: Request):
         async def generate_stream():
             nonlocal instance_info
             nonlocal request_released
+            decoder_stream: tuple[httpx.Response, Any, bytes] | None = (
+                decoder_response,
+                decoder_chunk_iterator,
+                first_decoder_chunk,
+            )
             generated_token = ""
             released_kv = False
             retry_count = 0
@@ -1031,74 +1148,106 @@ async def handle_completions_impl(api: str, request: Request):
             try:
                 while retry:
                     retry = False
-                    decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response_with_retry(
-                        decoder_client,
-                        api,
-                        req_data,
-                        request_id=instance_info.request_id,
-                        max_retries=args.max_retries,
-                        base_delay=args.retry_delay,
-                    ):
-                        if not released_kv and chunk:
-                            await release_prefill_kv_once()
-                        try:
-                            chunk_str = chunk.decode("utf-8").strip()
-                        except UnicodeDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk)
-                            yield chunk
-                            continue
-                        if not chunk_str:
-                            continue
-                        is_sse = chunk_str.startswith("data: ")
-                        if is_sse:
-                            chunk_str = chunk_str[len("data: ") :]
-                        try:
-                            chunk_json = json.loads(chunk_str)
-                        except json.JSONDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk_str)
-                            yield chunk
-                            continue
-                        choices = chunk_json.get("choices", [])
-                        if not choices or not stream_flag:
-                            if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
-                                chunk = encode_response_chunk(chunk_json, is_sse)
-                                if not choices:
-                                    yield chunk
-                                    continue
-
-                        choice = choices[0]
-                        delta = choice.get("delta") or {}
-                        message = choice.get("message") or {}
-                        content = delta.get("content") or message.get("content") or choice.get("text") or ""
-                        generated_token += content
-
-                        stop_reason = choice.get("stop_reason")
-                        usage = chunk_json.get("usage", {})
-                        completion_tokens = (
-                            (completion_tokens + 1)
-                            if stream_flag
-                            else (completion_tokens + usage.get("completion_tokens", 0))
+                    if decoder_stream is None:
+                        decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+                        decoder_stream = await open_stream_service_response_with_retry(
+                            decoder_client,
+                            api,
+                            req_data,
+                            request_id=instance_info.request_id,
+                            max_retries=args.max_retries,
+                            base_delay=args.retry_delay,
                         )
-                        if stop_reason == "recomputed":
-                            retry = True
-                            retry_count += 1
-                            if chat_flag:
-                                messages[0]["content"] = origin_prompt + generated_token
+
+                    current_response, chunk_iterator, first_chunk = decoder_stream
+                    decoder_stream = None
+                    if not current_response.is_success:
+                        logger.error(
+                            "Decoder %s:%s returned status %s after response started for request %s",
+                            instance_info.decoder_host,
+                            instance_info.decoder_port,
+                            current_response.status_code,
+                            instance_info.request_id,
+                        )
+                        yield decoder_error_chunk(current_response, stream_flag)
+                        await current_response.aclose()
+                        return
+
+                    try:
+                        pending_first_chunk = first_chunk
+                        while True:
+                            if pending_first_chunk:
+                                chunk = pending_first_chunk
+                                pending_first_chunk = b""
                             else:
-                                req_data["prompt"] = origin_prompt + generated_token
-                            req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
-                            tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
-                            released_kv = False
-                            break
-                        if retry_count > 0 and not stream_flag:
-                            if chat_flag:
-                                choice["message"]["content"] = generated_token
-                            else:
-                                choice["text"] = generated_token
-                            chunk = encode_response_chunk(chunk_json, is_sse)
-                        yield chunk
+                                try:
+                                    chunk = await anext(chunk_iterator)
+                                except StopAsyncIteration:
+                                    break
+                            if not released_kv and chunk:
+                                await release_prefill_kv_once()
+                            try:
+                                chunk_str = chunk.decode("utf-8").strip()
+                            except UnicodeDecodeError:
+                                logger.debug("Skipping chunk: %s", chunk)
+                                yield chunk
+                                continue
+                            if not chunk_str:
+                                continue
+                            is_sse = chunk_str.startswith("data: ")
+                            if is_sse:
+                                chunk_str = chunk_str[len("data: ") :]
+                            try:
+                                chunk_json = json.loads(chunk_str)
+                            except json.JSONDecodeError:
+                                logger.debug("Skipping chunk: %s", chunk_str)
+                                yield chunk
+                                continue
+                            choices = chunk_json.get("choices", [])
+                            if not choices or not stream_flag:
+                                if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
+                                    chunk = encode_response_chunk(chunk_json, is_sse)
+                                    if not choices:
+                                        yield chunk
+                                        continue
+
+                            choice = choices[0]
+                            delta = choice.get("delta") or {}
+                            message = choice.get("message") or {}
+                            content = delta.get("content") or message.get("content") or choice.get("text") or ""
+                            generated_token += content
+
+                            stop_reason = choice.get("stop_reason")
+                            usage = chunk_json.get("usage", {})
+                            completion_tokens = (
+                                (completion_tokens + 1)
+                                if stream_flag
+                                else (completion_tokens + usage.get("completion_tokens", 0))
+                            )
+                            if stop_reason == "recomputed":
+                                retry = True
+                                retry_count += 1
+                                if chat_flag:
+                                    messages[0]["content"] = origin_prompt + generated_token
+                                else:
+                                    req_data["prompt"] = origin_prompt + generated_token
+                                req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
+                                tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
+                                await current_response.aclose()
+                                instance_info = await reassign_instances(
+                                    api, req_data, tmp_request_length, instance_info
+                                )
+                                released_kv = False
+                                break
+                            if retry_count > 0 and not stream_flag:
+                                if chat_flag:
+                                    choice["message"]["content"] = generated_token
+                                else:
+                                    choice["text"] = generated_token
+                                chunk = encode_response_chunk(chunk_json, is_sse)
+                            yield chunk
+                    finally:
+                        await current_response.aclose()
             except asyncio.CancelledError:
                 logger.warning(
                     "Streaming from decoder %s:%s was cancelled; releasing request %s resources",
@@ -1115,13 +1264,53 @@ async def handle_completions_impl(api: str, request: Request):
                     exc,
                     instance_info.request_id,
                 )
+                yield decoder_stream_error_chunk(exc, stream_flag)
             finally:
                 await _finish_instance(runtime, instance_info, release_prefill_kv=not released_kv)
                 released_kv = True
                 request_released = True
 
+        try:
+            decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+            decoder_stream = await open_stream_service_response_with_retry(
+                decoder_client,
+                api,
+                req_data,
+                request_id=instance_info.request_id,
+                max_retries=args.max_retries,
+                base_delay=args.retry_delay,
+            )
+            decoder_response, decoder_chunk_iterator, first_decoder_chunk = decoder_stream
+        except asyncio.CancelledError:
+            if "decoder_response" in locals():
+                with suppress(Exception):
+                    await decoder_response.aclose()
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            raise
+        except httpx.RequestError as exc:
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            return decoder_unavailable_response(api, exc)
+
+        if not decoder_response.is_success:
+            response = Response(
+                content=decoder_response.content,
+                status_code=decoder_response.status_code,
+                headers=backend_response_headers(decoder_response),
+            )
+            await decoder_response.aclose()
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            return response
+
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
-        return StreamingResponse(generate_stream(), media_type=media_type)
+        return StreamingResponse(
+            generate_stream(),
+            status_code=decoder_response.status_code,
+            media_type=media_type,
+            headers=backend_response_headers(decoder_response),
+        )
     except Exception as e:
         import traceback
 

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -126,7 +126,7 @@ import tempfile
 import threading
 import time
 import uuid
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from multiprocessing.managers import BaseManager
@@ -801,6 +801,8 @@ def with_cancellation(handler_func):
         done, pending = await asyncio.wait([handler_task, cancellation_task], return_when=asyncio.FIRST_COMPLETED)
         for task in pending:
             task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         if handler_task in done:
             return handler_task.result()
         return None
@@ -868,33 +870,143 @@ async def stream_service_response_with_retry(
     max_retries: int = 3,
     base_delay: float = 0.2,
 ):
+    response, chunk_iterator, first_chunk = await open_stream_service_response_with_retry(
+        client,
+        endpoint,
+        req_data,
+        request_id,
+        max_retries=max_retries,
+        base_delay=base_delay,
+    )
+    try:
+        response.raise_for_status()
+        if first_chunk:
+            yield first_chunk
+        async for chunk in chunk_iterator:
+            yield chunk
+    finally:
+        await response.aclose()
+
+
+async def open_stream_service_response_with_retry(
+    client: httpx.AsyncClient,
+    endpoint: str,
+    req_data: dict,
+    request_id: str,
+    max_retries: int = 3,
+    base_delay: float = 0.2,
+) -> tuple[httpx.Response, Any, bytes]:
     headers = auth_headers(request_id)
     for attempt in range(1, max_retries + 1):
+        response: httpx.Response | None = None
         try:
-            async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
-                response.raise_for_status()
-                first_chunk_sent = False
-                async for chunk in response.aiter_bytes():
-                    first_chunk_sent = True
-                    yield chunk
-                return
-        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            request = client.build_request("POST", endpoint, json=req_data, headers=headers)
+            response = await client.send(request, stream=True)
+            if not response.is_success:
+                await response.aread()
+                should_retry = response.status_code >= 500 and attempt < max_retries
+                if should_retry:
+                    logger.warning(
+                        "Attempt %s failed for streaming %s with status %s",
+                        attempt,
+                        endpoint,
+                        response.status_code,
+                    )
+                    await response.aclose()
+                    await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
+                    continue
+                return response, response.aiter_bytes().__aiter__(), b""
+
+            chunk_iterator = response.aiter_bytes().__aiter__()
+            try:
+                first_chunk = await anext(chunk_iterator)
+            except StopAsyncIteration:
+                first_chunk = b""
+            return response, chunk_iterator, first_chunk
+        except httpx.RequestError as exc:
+            if response is not None:
+                await response.aclose()
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
                 logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise exc
+        except asyncio.CancelledError:
+            if response is not None:
+                await response.aclose()
+            raise
         except Exception as exc:
-            if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error("Streaming to client interrupted after response started: %s", exc)
-                return
+            if response is not None:
+                await response.aclose()
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
             else:
                 logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise exc
+    raise RuntimeError(f"All {max_retries} attempts failed for streaming {endpoint}.")
+
+
+def backend_response_headers(response: httpx.Response) -> dict[str, str] | None:
+    content_type = response.headers.get("content-type")
+    return {"content-type": content_type} if content_type else None
+
+
+def decoder_error_payload(response: httpx.Response) -> dict[str, Any]:
+    body = response.content.decode("utf-8", errors="replace")
+    try:
+        parsed_body = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        parsed_body = {}
+
+    if isinstance(parsed_body, dict) and isinstance(parsed_body.get("error"), dict):
+        return parsed_body
+
+    message = body or response.reason_phrase or f"Decoder returned HTTP {response.status_code}"
+    return {
+        "error": {
+            "message": message,
+            "type": "upstream_error",
+            "code": response.status_code,
+        }
+    }
+
+
+def decoder_error_chunk(response: httpx.Response, stream_flag: bool) -> bytes:
+    payload = json.dumps(decoder_error_payload(response), ensure_ascii=False)
+    if stream_flag:
+        return f"event: error\ndata: {payload}\n\n".encode()
+    return payload.encode()
+
+
+def decoder_stream_error_chunk(exc: Exception, stream_flag: bool) -> bytes:
+    payload = json.dumps(
+        {
+            "error": {
+                "message": str(exc),
+                "type": "upstream_error",
+                "code": "decode_backend_stream_error",
+            }
+        },
+        ensure_ascii=False,
+    )
+    if stream_flag:
+        return f"event: error\ndata: {payload}\n\n".encode()
+    return payload.encode()
+
+
+def decoder_unavailable_response(endpoint: str, exc: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=502,
+        content={
+            "error": {
+                "message": f"Decode backend request to {endpoint} failed: {exc}",
+                "type": "upstream_error",
+                "code": "decode_backend_unavailable",
+            }
+        },
+    )
 
 
 async def _abort_prefill_selection(
@@ -1013,6 +1125,11 @@ async def handle_completions_impl(api: str, request: Request):
         async def generate_stream():
             nonlocal instance_info
             nonlocal request_released
+            decoder_stream: tuple[httpx.Response, Any, bytes] | None = (
+                decoder_response,
+                decoder_chunk_iterator,
+                first_decoder_chunk,
+            )
             generated_token = ""
             released_kv = False
             retry_count = 0
@@ -1031,74 +1148,106 @@ async def handle_completions_impl(api: str, request: Request):
             try:
                 while retry:
                     retry = False
-                    decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response_with_retry(
-                        decoder_client,
-                        api,
-                        req_data,
-                        request_id=instance_info.request_id,
-                        max_retries=args.max_retries,
-                        base_delay=args.retry_delay,
-                    ):
-                        if not released_kv and chunk:
-                            await release_prefill_kv_once()
-                        try:
-                            chunk_str = chunk.decode("utf-8").strip()
-                        except UnicodeDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk)
-                            yield chunk
-                            continue
-                        if not chunk_str:
-                            continue
-                        is_sse = chunk_str.startswith("data: ")
-                        if is_sse:
-                            chunk_str = chunk_str[len("data: ") :]
-                        try:
-                            chunk_json = json.loads(chunk_str)
-                        except json.JSONDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk_str)
-                            yield chunk
-                            continue
-                        choices = chunk_json.get("choices", [])
-                        if not choices or not stream_flag:
-                            if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
-                                chunk = encode_response_chunk(chunk_json, is_sse)
-                                if not choices:
-                                    yield chunk
-                                    continue
-
-                        choice = choices[0]
-                        delta = choice.get("delta") or {}
-                        message = choice.get("message") or {}
-                        content = delta.get("content") or message.get("content") or choice.get("text") or ""
-                        generated_token += content
-
-                        stop_reason = choice.get("stop_reason")
-                        usage = chunk_json.get("usage", {})
-                        completion_tokens = (
-                            (completion_tokens + 1)
-                            if stream_flag
-                            else (completion_tokens + usage.get("completion_tokens", 0))
+                    if decoder_stream is None:
+                        decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+                        decoder_stream = await open_stream_service_response_with_retry(
+                            decoder_client,
+                            api,
+                            req_data,
+                            request_id=instance_info.request_id,
+                            max_retries=args.max_retries,
+                            base_delay=args.retry_delay,
                         )
-                        if stop_reason == "recomputed":
-                            retry = True
-                            retry_count += 1
-                            if chat_flag:
-                                messages[0]["content"] = origin_prompt + generated_token
+
+                    current_response, chunk_iterator, first_chunk = decoder_stream
+                    decoder_stream = None
+                    if not current_response.is_success:
+                        logger.error(
+                            "Decoder %s:%s returned status %s after response started for request %s",
+                            instance_info.decoder_host,
+                            instance_info.decoder_port,
+                            current_response.status_code,
+                            instance_info.request_id,
+                        )
+                        yield decoder_error_chunk(current_response, stream_flag)
+                        await current_response.aclose()
+                        return
+
+                    try:
+                        pending_first_chunk = first_chunk
+                        while True:
+                            if pending_first_chunk:
+                                chunk = pending_first_chunk
+                                pending_first_chunk = b""
                             else:
-                                req_data["prompt"] = origin_prompt + generated_token
-                            req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
-                            tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
-                            released_kv = False
-                            break
-                        if retry_count > 0 and not stream_flag:
-                            if chat_flag:
-                                choice["message"]["content"] = generated_token
-                            else:
-                                choice["text"] = generated_token
-                            chunk = encode_response_chunk(chunk_json, is_sse)
-                        yield chunk
+                                try:
+                                    chunk = await anext(chunk_iterator)
+                                except StopAsyncIteration:
+                                    break
+                            if not released_kv and chunk:
+                                await release_prefill_kv_once()
+                            try:
+                                chunk_str = chunk.decode("utf-8").strip()
+                            except UnicodeDecodeError:
+                                logger.debug("Skipping chunk: %s", chunk)
+                                yield chunk
+                                continue
+                            if not chunk_str:
+                                continue
+                            is_sse = chunk_str.startswith("data: ")
+                            if is_sse:
+                                chunk_str = chunk_str[len("data: ") :]
+                            try:
+                                chunk_json = json.loads(chunk_str)
+                            except json.JSONDecodeError:
+                                logger.debug("Skipping chunk: %s", chunk_str)
+                                yield chunk
+                                continue
+                            choices = chunk_json.get("choices", [])
+                            if not choices or not stream_flag:
+                                if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
+                                    chunk = encode_response_chunk(chunk_json, is_sse)
+                                    if not choices:
+                                        yield chunk
+                                        continue
+
+                            choice = choices[0]
+                            delta = choice.get("delta") or {}
+                            message = choice.get("message") or {}
+                            content = delta.get("content") or message.get("content") or choice.get("text") or ""
+                            generated_token += content
+
+                            stop_reason = choice.get("stop_reason")
+                            usage = chunk_json.get("usage", {})
+                            completion_tokens = (
+                                (completion_tokens + 1)
+                                if stream_flag
+                                else (completion_tokens + usage.get("completion_tokens", 0))
+                            )
+                            if stop_reason == "recomputed":
+                                retry = True
+                                retry_count += 1
+                                if chat_flag:
+                                    messages[0]["content"] = origin_prompt + generated_token
+                                else:
+                                    req_data["prompt"] = origin_prompt + generated_token
+                                req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
+                                tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
+                                await current_response.aclose()
+                                instance_info = await reassign_instances(
+                                    api, req_data, tmp_request_length, instance_info
+                                )
+                                released_kv = False
+                                break
+                            if retry_count > 0 and not stream_flag:
+                                if chat_flag:
+                                    choice["message"]["content"] = generated_token
+                                else:
+                                    choice["text"] = generated_token
+                                chunk = encode_response_chunk(chunk_json, is_sse)
+                            yield chunk
+                    finally:
+                        await current_response.aclose()
             except asyncio.CancelledError:
                 logger.warning(
                     "Streaming from decoder %s:%s was cancelled; releasing request %s resources",
@@ -1115,13 +1264,53 @@ async def handle_completions_impl(api: str, request: Request):
                     exc,
                     instance_info.request_id,
                 )
+                yield decoder_stream_error_chunk(exc, stream_flag)
             finally:
                 await _finish_instance(runtime, instance_info, release_prefill_kv=not released_kv)
                 released_kv = True
                 request_released = True
 
+        try:
+            decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
+            decoder_stream = await open_stream_service_response_with_retry(
+                decoder_client,
+                api,
+                req_data,
+                request_id=instance_info.request_id,
+                max_retries=args.max_retries,
+                base_delay=args.retry_delay,
+            )
+            decoder_response, decoder_chunk_iterator, first_decoder_chunk = decoder_stream
+        except asyncio.CancelledError:
+            if "decoder_response" in locals():
+                with suppress(Exception):
+                    await decoder_response.aclose()
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            raise
+        except httpx.RequestError as exc:
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            return decoder_unavailable_response(api, exc)
+
+        if not decoder_response.is_success:
+            response = Response(
+                content=decoder_response.content,
+                status_code=decoder_response.status_code,
+                headers=backend_response_headers(decoder_response),
+            )
+            await decoder_response.aclose()
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+            return response
+
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
-        return StreamingResponse(generate_stream(), media_type=media_type)
+        return StreamingResponse(
+            generate_stream(),
+            status_code=decoder_response.status_code,
+            media_type=media_type,
+            headers=backend_response_headers(decoder_response),
+        )
     except Exception:
         import traceback
 

--- a/tests/ut/test_load_balance_proxy_errors.py
+++ b/tests/ut/test_load_balance_proxy_errors.py
@@ -1,0 +1,291 @@
+import argparse
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.responses import Response, StreamingResponse
+from starlette.requests import Request
+
+from examples.disaggregated_prefill_v1 import load_balance_proxy_server_example as proxy
+
+
+def make_request(payload: dict) -> Request:
+    body = json.dumps(payload).encode("utf-8")
+    sent = False
+
+    async def receive():
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [(b"content-type", b"application/json")],
+        },
+        receive,
+    )
+
+
+class FakeRuntime:
+    def __init__(self, decoder_client: httpx.AsyncClient):
+        self.decoder_client = decoder_client
+        self.schedule_calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def get_client(self, role: proxy.ServerRole, key: str) -> httpx.AsyncClient:
+        assert role is proxy.ServerRole.DECODE
+        assert key == "decode"
+        return self.decoder_client
+
+    async def schedule(self, method: str, /, *args: Any, **kwargs: Any) -> None:
+        self.schedule_calls.append((method, args, kwargs))
+
+
+class BlockingStream(httpx.AsyncByteStream):
+    def __init__(self):
+        self.started = asyncio.Event()
+        self.closed = False
+
+    async def __aiter__(self):
+        self.started.set()
+        await asyncio.Event().wait()
+        yield b""
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class ListStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]):
+        self.chunks = chunks
+        self.closed = False
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_decode_4xx_response_is_returned_before_streaming(monkeypatch, stream: bool):
+    requests_seen = 0
+    error_body = {
+        "error": {
+            "message": "This model's maximum context length is 8192 tokens.",
+            "type": "BadRequestError",
+            "code": 400,
+        }
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal requests_seen
+        requests_seen += 1
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(400, json=error_body)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://decoder/v1",
+    ) as decoder_client:
+        fake_runtime = FakeRuntime(decoder_client)
+
+        async def fake_assign_instances(*args, **kwargs):
+            return proxy.InstanceInfo(
+                request_id="request-id",
+                prefiller_key="prefill",
+                prefiller_score=1.0,
+                decoder_key="decode",
+                decoder_score=1.0,
+                decoder_host="decoder",
+                decoder_port=8000,
+                prefiller_cached_tokens=0,
+            )
+
+        monkeypatch.setattr(proxy, "get_runtime", lambda: fake_runtime)
+        monkeypatch.setattr(proxy, "get_global_args", lambda: argparse.Namespace(max_retries=3, retry_delay=0))
+        monkeypatch.setattr(proxy, "assign_instances", fake_assign_instances)
+
+        response = await proxy.handle_completions_impl(
+            "/chat/completions",
+            make_request(
+                {
+                    "model": "m",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 9000,
+                    "stream": stream,
+                }
+            ),
+        )
+
+    assert isinstance(response, Response)
+    assert not isinstance(response, StreamingResponse)
+    assert response.status_code == 400
+    assert json.loads(response.body) == error_body
+    assert requests_seen == 1
+    assert fake_runtime.schedule_calls == [("finish_request", ("prefill", 1.0, "decode", 1.0, True), {})]
+
+
+@pytest.mark.asyncio
+async def test_decode_5xx_response_is_retried_then_returned():
+    requests_seen = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal requests_seen
+        requests_seen += 1
+        return httpx.Response(503, json={"error": {"message": "busy"}})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://decoder/v1",
+    ) as decoder_client:
+        response, _, _ = await proxy.open_stream_service_response_with_retry(
+            decoder_client,
+            "/chat/completions",
+            {},
+            "request-id",
+            max_retries=2,
+            base_delay=0,
+        )
+        try:
+            assert response.status_code == 503
+            assert response.json() == {"error": {"message": "busy"}}
+        finally:
+            await response.aclose()
+
+    assert requests_seen == 2
+
+
+@pytest.mark.asyncio
+async def test_success_response_replays_first_chunk_once():
+    chunks = [b"first", b"second"]
+    stream = ListStream(chunks)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://decoder/v1",
+    ) as decoder_client:
+        response, chunk_iterator, first_chunk = await proxy.open_stream_service_response_with_retry(
+            decoder_client,
+            "/chat/completions",
+            {},
+            "request-id",
+            max_retries=1,
+            base_delay=0,
+        )
+        try:
+            observed = [first_chunk]
+            async for chunk in chunk_iterator:
+                observed.append(chunk)
+        finally:
+            await response.aclose()
+
+    assert observed == chunks
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_decode_connection_error_returns_502(monkeypatch):
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://decoder/v1",
+    ) as decoder_client:
+        fake_runtime = FakeRuntime(decoder_client)
+
+        async def fake_assign_instances(*args, **kwargs):
+            return proxy.InstanceInfo(
+                request_id="request-id",
+                prefiller_key="prefill",
+                prefiller_score=1.0,
+                decoder_key="decode",
+                decoder_score=1.0,
+                decoder_host="decoder",
+                decoder_port=8000,
+                prefiller_cached_tokens=0,
+            )
+
+        monkeypatch.setattr(proxy, "get_runtime", lambda: fake_runtime)
+        monkeypatch.setattr(proxy, "get_global_args", lambda: argparse.Namespace(max_retries=1, retry_delay=0))
+        monkeypatch.setattr(proxy, "assign_instances", fake_assign_instances)
+
+        response = await proxy.handle_completions_impl(
+            "/chat/completions",
+            make_request(
+                {
+                    "model": "m",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 16,
+                    "stream": False,
+                }
+            ),
+        )
+
+    assert isinstance(response, Response)
+    assert response.status_code == 502
+    assert json.loads(response.body)["error"]["code"] == "decode_backend_unavailable"
+    assert fake_runtime.schedule_calls == [("finish_request", ("prefill", 1.0, "decode", 1.0, True), {})]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_during_first_decode_chunk_releases_resources(monkeypatch):
+    stream = BlockingStream()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://decoder/v1",
+    ) as decoder_client:
+        fake_runtime = FakeRuntime(decoder_client)
+
+        async def fake_assign_instances(*args, **kwargs):
+            return proxy.InstanceInfo(
+                request_id="request-id",
+                prefiller_key="prefill",
+                prefiller_score=1.0,
+                decoder_key="decode",
+                decoder_score=1.0,
+                decoder_host="decoder",
+                decoder_port=8000,
+                prefiller_cached_tokens=0,
+            )
+
+        monkeypatch.setattr(proxy, "get_runtime", lambda: fake_runtime)
+        monkeypatch.setattr(proxy, "get_global_args", lambda: argparse.Namespace(max_retries=1, retry_delay=0))
+        monkeypatch.setattr(proxy, "assign_instances", fake_assign_instances)
+
+        task = asyncio.create_task(
+            proxy.handle_completions_impl(
+                "/chat/completions",
+                make_request(
+                    {
+                        "model": "m",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 16,
+                        "stream": False,
+                    }
+                ),
+            )
+        )
+        await asyncio.wait_for(stream.started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert stream.closed
+    assert fake_runtime.schedule_calls == [("finish_request", ("prefill", 1.0, "decode", 1.0, True), {})]


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #12166.
Related to #12168.

`load_balance_proxy_server_example.py` previously returned a `StreamingResponse` before sending the decode request. When the decode backend returned an error, the proxy had already committed HTTP 200 and then swallowed the exception in the response generator, so clients received an empty successful response.

This PR opens the decode response before creating the proxy `StreamingResponse`. Decode backend errors are now propagated to clients:

- 4xx responses are returned immediately without retry.
- 5xx responses keep the retry behavior and return the final backend error.
- decode connection failures return a 502 JSON error.
- errors after the response has started are surfaced as SSE/JSON error bodies.

### Does this PR introduce _any_ user-facing change?

Yes. Clients now receive visible decode backend errors instead of an empty HTTP 200 response.

### How was this patch tested?

- Added unit coverage for decode 400 propagation in both streaming and non-streaming requests.
- Added unit coverage for decode 5xx retry behavior.
- Added unit coverage for decode connection failures returning 502.
- Added unit coverage for replaying the first successful decoder chunk once.
- Added unit coverage for cancelling while waiting for the first decoder chunk, ensuring the decoder response and scheduler resources are released.
- Ran lightweight mock behavior assertions for non-streaming/streaming 400, 503 retry, and connection failure 502.
- Ran container pytest for the added test itself: `pytest --noconftest tests/ut/test_load_balance_proxy_errors.py -q` with `quay.io/ascend/vllm-ascend:v0.23.0rc1`, `TORCH_DEVICE_BACKEND_AUTOLOAD=0`, and `pytest-asyncio==0.23.8`: `6 passed in 0.35s`.
- Ran `ruff check` on the modified files.
- Ran `py_compile` and `git diff --check`.

Full `pytest tests/ut/test_load_balance_proxy_errors.py -q` could not run in the local lightweight environment because `tests/ut/conftest.py` imports `torch`. It also could not run inside the `v0.23.0rc1` container because that image's preinstalled vLLM API does not fully match current main. The full conftest path is intended for the normal development environment / upstream CI.

### Relationship with #12168

There is already an open PR #12168 for the same issue. This PR is submitted as an alternative implementation because #12168 still appears to open the decode request inside the `StreamingResponse` body iterator. That means non-streaming initial decoder errors can still commit HTTP 200 before the proxy sees the upstream 4xx. This PR opens the decoder response before returning the proxy response, so initial decoder 4xx/5xx status and body can be forwarded before the ASGI response starts.

### AI assistance

AI assistance was used to investigate the code paths and prepare the change. The human submitter reviewed every changed line and ran the listed tests.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
