### PR TITLE
 [CI][Spec Decode] Add e2e MTP acceptance test for Qwen3.6-27B

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -492,6 +492,7 @@
     - tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py
     - tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py
     - tests/e2e/pull_request/eight_card/test_glm5_2.py
+    - tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
     - tests/ut/spec_decode/test_speculators_vwn_eagle3.py
 
 - name: spec_decode_dspark
@@ -837,6 +838,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py: 840
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py: 480
+  tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py: 450
   tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py: 0
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_step3p5.py: 40
   tests/e2e/pull_request/eight_card/test_glm5_2.py: 1890

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -475,6 +475,7 @@
     - tests/e2e/pull_request/one_card/spec_decode/test_mtp_eagle_correctness.py
     - tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py
     - tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py
+    - tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
     - tests/ut/spec_decode/test_speculators_vwn_eagle3.py
 
 - name: spec_decode_dspark
@@ -798,6 +799,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: 2040
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py: 450
+  tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py: 450
   tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py: 0
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_step3p5.py: 30
   tests/e2e/pull_request/four_card/test_data_parallel_tp2.py: 20

--- a/tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
@@ -76,4 +76,3 @@ def test_qwen36_27b_mtp_acceptance_tp4(model_name):
     match = all((a >= b) or (b - a < 0.06) for a, b in zip(acceptance_per_pos, golden))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden} (num_drafts={num_drafts})"
     cleanup_dist_env_and_memory()
-

--- a/tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
@@ -27,7 +27,8 @@ from vllm.v1.metrics.reader import Counter, Vector
 from tests.e2e.conftest import VllmRunner, cleanup_dist_env_and_memory
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-
+os.environ["HCCL_DETERMINISTIC"] = "true"
+os.environ["CLOSE_MATMUL_K_SHIFT"] = "1"
 MODELS = ["Qwen/Qwen3.6-27B"]
 
 

--- a/tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+# Adapted from tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py
+#
+
+
+import os
+
+import pytest
+from vllm.config import CompilationConfig
+from vllm.v1.metrics.reader import Counter, Vector
+
+from tests.e2e.conftest import VllmRunner, cleanup_dist_env_and_memory
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+MODELS = ["Qwen/Qwen3.6-27B"]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_qwen36_27b_mtp_acceptance_tp4(model_name):
+    golden = [0.8752, 0.7017, 0.5646]
+
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    max_tokens = 1024
+
+    with VllmRunner(
+        model_name,
+        tensor_parallel_size=4,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        distributed_executor_backend="mp",
+        disable_log_stats=False,
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": 3,
+        },
+        compilation_config=CompilationConfig(cudagraph_mode="FULL_DECODE_ONLY", cudagraph_capture_sizes=[20]),
+    ) as spec_vllm_model:
+        _ = spec_vllm_model.generate_greedy(example_prompts, max_tokens)
+        metrics = spec_vllm_model.model.get_metrics()
+
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * 3
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+
+    acceptance_per_pos = [num_accepted_tokens / num_drafts for num_accepted_tokens in num_accepted_tokens_per_pos]
+
+    match = all((a >= b) or (b - a < 0.06) for a, b in zip(acceptance_per_pos, golden))
+    assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden} (num_drafts={num_drafts})"
+    cleanup_dist_env_and_memory()
+


### PR DESCRIPTION
### What this PR does / why we need it?
 Adds `tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen36_27b.py`, an
  end-to-end guardrail for the MTP speculative-decoding acceptance rate of
  Qwen3.6-27B on Ascend (TP=4, `method=mtp`, `num_speculative_tokens=3`).
### Does this PR introduce _any_ user-facing change?
 No. Test-only addition; no runtime, API, or behavior changes.
### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
