### PR TITLE
[BugFix] Fix DeepSeek-OCR-2 startup failure: assign missing attention_type

### DIFF
--- a/vllm_ascend/ops/qwen2_decoder.py
+++ b/vllm_ascend/ops/qwen2_decoder.py
@@ -249,6 +249,12 @@ class AscendQwen2Model(Qwen2Model):
 class AscendQwen2DecoderLayer(Qwen2DecoderLayer):
     def __init__(self, config: Qwen2Config, layer_idx: int):
         super().__init__(config, layer_idx)
+        layer_types = getattr(config, "layer_types", None)
+        self.attention_type = (
+            layer_types[layer_idx]
+            if isinstance(layer_types, list) and 0 <= layer_idx < len(layer_types)
+            else "full_attention"
+        )
         self.self_attn = AscendQwen2Attention(config=config, layer_idx=layer_idx)
         self.input_layernorm = AscendQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = AscendQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
### Bug Description

DeepSeek-OCR-2 (`https://huggingface.co/deepseek-ai/DeepSeek-OCR-2`) fails to
start with `vllm` on Ascend NPU. The error is an `AttributeError` raised in
`AscendQwen2Model.forward()`:

AttributeError: 'AscendQwen2DecoderLayer' object has no attribute 'attention_type'

The forward path iterates over `self.layers[: self.config.num_hidden_layers]`
and reads `decoder_layer.attention_type` to look up the correct causal mask from
`causal_mask_mapping` (see `vllm_ascend/ops/qwen2_decoder.py:233`). But
`AscendQwen2DecoderLayer` never assigns `self.attention_type` in its
`__init__`, so every inference request crashes.

### Root Cause

`AscendQwen2DecoderLayer` subclasses `transformers.Qwen2DecoderLayer`, which
does not hold an `attention_type` attribute on its own. In vLLM upstream this
attribute is injected by `Qwen2Model`'s layer registry — a code path that is
bypassed here because the Ascend replacement (`AscendQwen2Model` /
`AscendQwen2DecoderLayer`) replaces the upstream `Qwen2Model` entirely. The
`__init__` simply forgot to initialize `attention_type`, so the read in
`forward()` threw.

### Fix

Initialize `attention_type` in `AscendQwen2DecoderLayer.__init__`, matching the
behavior of the vLLM upstream `Qwen2Model`::

```python
layer_types = getattr(config, "layer_types", None)
self.attention_type = (
    layer_types[layer_idx]
    if layer_types is not None and layer_idx < len(layer_types)
    else "full_attention"
)
If the config provides layer_types (used by sliding-window Qwen2), use the type for the given layer index.
Otherwise fall back to "full_attention" (the classic Qwen2 behavior).
The bounds guard (layer_idx < len(layer_types)) prevents an IndexError when the config length mismatches, and safely defaults back to "full_attention".
Diff

class AscendQwen2DecoderLayer(Qwen2DecoderLayer):
    def __init__(self, config: Qwen2Config, layer_idx: int):
        super().__init__(config, layer_idx)
+        layer_types = getattr(config, "layer_types", None)
+        self.attention_type = (
+            layer_types[layer_idx]
+            if layer_types is not None and layer_idx < len(layer_types)
+            else "full_attention"
+        )
        self.self_attn = AscendQwen2Attention(config=config, layer_idx=layer_idx)
        self.input_layernorm = AscendQwen2RMSNorm(
            config.hidden_size, eps=config.rms_norm_eps
        )
        self.post_attention_layernorm = AscendQwen2RMSNorm(
            config.hidden_size, eps=config.rms_norm_eps
        )
Test
Could not run a full e2e model startup in this environment. Recommended
verification before merging:

Instantiate AscendQwen2DecoderLayer and assert attention_type defaults to "full_attention".
Boot DeepSeek-OCR-2 on Ascend NPU and confirm a forward pass no longer raises AttributeError.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
