### PR TITLE
[BugFix][MRV2] Unify update_stream across main and draft to fix fullgraph deadlock

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -773,6 +773,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/lora/test_qwen3moe_lora.py: 500
   tests/e2e/pull_request/two_card/lora/test_qwen35_densemodel_lora_tp.py: 600
   tests/e2e/pull_request/two_card/model_runner_v2/test_data_parallel.py: 520
+  tests/e2e/pull_request/two_card/model_runner_v2/test_spec_decode_data_parallel.py: 600
   tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py: 740
   tests/e2e/pull_request/two_card/test_data_parallel.py: 570
   tests/e2e/pull_request/two_card/test_deepseek_multistream_moe.py: 150

--- a/tests/e2e/pull_request/two_card/model_runner_v2/test_spec_decode_data_parallel.py
+++ b/tests/e2e/pull_request/two_card/model_runner_v2/test_spec_decode_data_parallel.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Speculative decoding under DP with Model Runner V2."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from vllm import SamplingParams
+
+from tests.e2e.conftest import DPVllmRunner, wait_until_npu_memory_free
+
+MTP_MODELS = ["wemaster/deepseek_mtp_main_random_bf16"]
+
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+
+@pytest.mark.parametrize("model", MTP_MODELS)
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize(
+    "compilation_config",
+    [
+        pytest.param(
+            {"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 8]},
+            id="full_decode_only",
+        ),
+        pytest.param({}, id="default_full_and_piecewise"),
+    ],
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "HCCL_BUFFSIZE": "1024",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.7)
+def test_mtp_spec_decoding_dp(
+    model: str,
+    max_tokens: int,
+    enforce_eager: bool,
+    compilation_config: dict,
+) -> None:
+    num_speculative_tokens = 3
+    sampling_params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+    with DPVllmRunner(
+        model,
+        data_parallel_size=2,
+        tensor_parallel_size=1,
+        max_model_len=1024,
+        enforce_eager=enforce_eager,
+        async_scheduling=True,
+        enable_expert_parallel=True,
+        distributed_executor_backend="mp",
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": num_speculative_tokens,
+        },
+        compilation_config=compilation_config,
+    ) as vllm_model:
+        outputs = vllm_model.generate(PROMPTS, sampling_params=sampling_params)
+
+    assert len(outputs) == len(PROMPTS)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -502,7 +502,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 self.use_eagle,
                 self.enable_enpu,
             )
-            self.update_stream = torch.npu.Stream()
+            self.update_stream = None
             self._runnable = ACLGraphWrapper(
                 self._run_merged_draft,
                 self.vllm_config,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3585,6 +3585,12 @@ class NPUModelRunner(GPUModelRunner):
                 use_eagle=self.use_eagle,
                 enable_enpu=self.enable_enpu,
             )
+            # Share the main-model update_stream with the draft drafter so that
+            # both main and draft updates are serialized on the same stream.
+            # The drafter created its own update_stream in its load_model (which
+            # runs BEFORE this point), so overwrite it here with the main one.
+            if self.drafter is not None:
+                self.drafter.update_stream = self.update_stream
 
         if self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
             self._start_dump_data()

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -76,9 +76,8 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # when call `run_fullgraph` method in CudaGraphManager,
         # then we don't need to # copy `execute_model` method in `NPUModelRunner` class.
         self.model_runner = model_runner
-        self.update_stream: torch.npu.Stream | None = None
-        if cudagraph_mode.has_full_cudagraphs():
-            self.update_stream = torch.npu.Stream()
+        # Reuse the public update_stream from model_runner (shared with draft).
+        self.update_stream = self.model_runner.update_stream
         # The attention backend keys its per-size graph params by the actual
         # captured token counts (rounded up to decode_query_len when using
         # speculative decoding), so derive them from the capture descriptors

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -133,6 +133,10 @@ class NPUModelRunner(GPUModelRunner):
             and not self.model_config.enforce_eager
         )
 
+        self.update_stream = None
+        if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            self.update_stream = torch.npu.Stream()
+
         # because we will override these attribute, delete these attribute to
         # make sure it's collected by python gc immediately.
         del self.req_states
@@ -145,6 +149,9 @@ class NPUModelRunner(GPUModelRunner):
         self.speculator: AscendEagleSpeculator | None = None
         if self.speculative_config is not None:
             self.speculator = init_speculator(self.vllm_config, self.device)
+            # Shared update_stream: main model (ModelAclGraphManager) and draft
+            # (Eagle/DFlash/DSpark AclGraphManager) all use this same stream.
+            self.speculator.update_stream = self.update_stream
 
         # AscendRequestState has extra `num_computed_tokens_cpu` attribute.
         # so reinitialize req_states here.

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -105,11 +105,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 for _ in range(self.num_speculative_steps - 1)
             ]
 
-        # we need to update full graph params in run_fullgraph,
-        # so create a stream to update full graph params.
-        if cudagraph_mode.has_full_cudagraphs():
-            self.update_stream: torch.npu.Stream = torch.npu.Stream()
-
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
@@ -121,6 +116,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # They need this speculator to update full-graph params, so set it here.
         self.prefill_cudagraph_manager.speculator = self
         self.decode_cudagraph_manager.speculator = self
+        self.prefill_cudagraph_manager.update_stream = self.update_stream
+        self.decode_cudagraph_manager.update_stream = self.update_stream
 
     def propose(
         self,

--- a/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/aclgraph.py
@@ -86,7 +86,7 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
             desc.num_reqs,
             self.speculator.input_batch.seq_lens_cpu_upper_bound,
         )
-
+        self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
@@ -112,7 +112,7 @@ class DFlashAclGraphManager(DFlashCudaGraphManager):
             update_full_graph_params(
                 # FIXME(Ronald1995): support hybrid attn backend
                 list(self.speculator.attn_backends.values())[0],
-                self.speculator.update_stream,
+                self.update_stream,
                 forward_context,
                 num_tokens,
                 self.vllm_config,

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -58,18 +58,13 @@ class AscendDFlashSpeculator(DFlashSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
 
-        # we need to update full graph params in run_fullgraph,
-        # so create a stream to update full graph params.
-        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
-        if cudagraph_mode.has_full_cudagraphs():
-            self.update_stream: torch.npu.Stream = torch.npu.Stream()
-
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)
         # The Ascend graph manager is patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.
         # It needs this speculator to update full-graph params, so set it here.
         self.query_cudagraph_manager.speculator = self
+        self.query_cudagraph_manager.update_stream = self.update_stream
 
     def set_attn(
         self,

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -39,18 +39,13 @@ class AscendDSparkSpeculator(DSparkSpeculator):
         super().__init__(vllm_config, device)
         self.input_batch: InputBatch | None = None
 
-        # we need to update full graph params in run_fullgraph,
-        # so create a stream to update full graph params.
-        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
-        if cudagraph_mode.has_full_cudagraphs():
-            self.update_stream: torch.npu.Stream = torch.npu.Stream()
-
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)
         # The Ascend graph manager is patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.
         # It needs this speculator to update full-graph params, so set it here.
         self.query_cudagraph_manager.speculator = self
+        self.query_cudagraph_manager.update_stream = self.update_stream
 
     def set_attn(
         self,

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -152,7 +152,7 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
             logger.info_once("DecodeEagleAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
 
         draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
-
+        self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
@@ -177,7 +177,7 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
             update_full_graph_params(
                 # FIXME(Ronald1995): support hybrid attn backend
                 list(self.speculator.attn_backends.values())[0],
-                self.speculator.update_stream,
+                self.update_stream,
                 forward_context,
                 num_tokens,
                 self.vllm_config,


### PR DESCRIPTION
### What this PR does / why we need it?

In modelrunner v1 and modelrunnerv2, the main model and draft model each initialize **their own update stream** to update the parameters required by the graph pattern. 

PR:[12944](https://github.com/vllm-project/vllm-ascend/pull/12944) solved the following issues in the graph mode of the main model, **and the draft model has the same issues**([13639](https://github.com/vllm-project/vllm-ascend/issues/13639)).
 

> If cpu is fast enough, device will hang on event_wait in iteration $i+1$.
<img width="1211" height="204" alt="image" src="https://github.com/user-attachments/assets/467cf983-45df-424d-ba7e-2f4d82168acd" />

> Solution: Update the parameters of the update stream of the main model after the previous forward computation is completed.
<img width="1159" height="168" alt="image" src="https://github.com/user-attachments/assets/5cf306bb-c486-4fe8-8686-287c192cce26" />

**In this PR, the main model and draft model in modelrunnerv1 and modelrunnerv2 are both reused with the same update stream to rebuild modelrunnerv1 and fix the bug in modelrunnerv2.**

<img width="1521" height="816" alt="image" src="https://github.com/user-attachments/assets/0ce178ef-345b-4262-83e6-8fbc8d2bc7b5" />

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
```
export HCCL_OP_EXPANSION_MODE="AIV"
export HCCL_BUFFSIZE=1024
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export OMP_NUM_THREADS=1
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl kernel.sched_migration_cost_ns=50000
export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
export TASK_QUEUE_ENABLE=1
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_ASCEND_BALANCE_SCHEDULING=0

vllm serve /mnt/a800_weight/MiniMax-M2.7-w8a8-QuaRot \
    --served-model-name "MiniMax-M2.7" \
    --host 0.0.0.0 \
    --port 7000 \
    --trust-remote-code \
    --quantization ascend \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
    --enable-expert-parallel \
    --tensor-parallel-size 4 \
    --data-parallel-size 2 \
    --max-num-seqs 48 \
    --max-model-len 40690 \
    --max-num-batched-tokens 16384 \
    --gpu-memory-utilization 0.85 \
    --speculative_config '{"enforce_eager": true, "method": "eagle3", "model": "/mnt/a800_weight/MiniMax-M2.7-eagle-model-2/", "num_speculative_tokens": 3}'
```
**__V1__________Shared update stream________________________|____________ V1___________unshared update stream_________**

<img width="1270" height="765" alt="image" src="https://github.com/user-attachments/assets/dd268f4e-6cdc-4dcb-90e0-6d285345edcc" />


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
