### PR TITLE
[BugFix] Fix AscendStore lookup TypeError at ZMQ boundary

### DIFF
--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -25,6 +25,7 @@ from vllm.distributed.kv_events import KVCacheEvent
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector import (
     AscendStoreConnector,
     AscendStoreKVEvents,
+    LookupKeyServer,
 )
 
 # isort: on
@@ -364,6 +365,55 @@ class TestAscendStoreConnector(unittest.TestCase):
         result = connector.get_kv_connector_kv_cache_events()
         self.assertIsNotNone(result)
         self.assertIsInstance(result, AscendStoreKVEvents)
+
+
+class TestLookupKeyServer(unittest.TestCase):
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.threading.Thread")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.make_zmq_socket")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.zmq")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.MsgpackDecoder")
+    def test_legacy_hex_hashes_are_converted_to_bytes(
+        self,
+        mock_decoder_cls,
+        mock_zmq,
+        mock_make_socket,
+        mock_thread_cls,
+    ):
+        config = MagicMock()
+        config.parallel_config.data_parallel_rank = 0
+        config.kv_transfer_config.kv_connector_extra_config = {}
+
+        block_hash = bytes(range(32))
+        mock_decoder_cls.return_value.decode.side_effect = [
+            [0],
+            [block_hash.hex()],
+        ]
+        mock_socket = mock_make_socket.return_value
+        mock_socket.recv_multipart.return_value = [
+            (16).to_bytes(4, "big"),
+            b"groups",
+            (0).to_bytes(4, "big"),
+            b"hashes",
+        ]
+        pool_worker = MagicMock()
+        server = LookupKeyServer(pool_worker, config)
+
+        def lookup_scheduler(*args, **kwargs):
+            server.running = False
+            return 16
+
+        pool_worker.lookup_scheduler.side_effect = lookup_scheduler
+        process_request = mock_thread_cls.call_args.kwargs["target"]
+        process_request()
+
+        pool_worker.lookup_scheduler.assert_called_once_with(
+            16,
+            [block_hash],
+            [0],
+            use_layerwise=False,
+            hbm_hit_tokens=0,
+        )
+        mock_socket.send.assert_called_once_with((16).to_bytes(4, "big"))
 
 
 class TestAscendStoreConnectorLayerwise(unittest.TestCase):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -316,6 +316,16 @@ class LookupKeyServer:
                 kv_group_ids = self.decoder.decode([all_frames[1]])
                 hbm_hit_tokens = int.from_bytes(all_frames[2], byteorder="big")
                 hashes_str = self.decoder.decode(all_frames[3:])
+                # Fix lookup TypeError: ZMQ lookup delivers hex strings; downstream grouped
+                # hashing (kv_cache_utils BlockHash join) requires bytes-like elements.
+                hashes_str = [
+                    (
+                        bytes.fromhex(h)
+                        if isinstance(h, str) and len(h) == 64
+                        else (h.encode() if isinstance(h, str) else h)
+                    )
+                    for h in hashes_str
+                ]
                 result = self.pool_worker.lookup_scheduler(
                     token_len,
                     hashes_str,


### PR DESCRIPTION
### What this PR does / why we need it?

`LookupKeyClient` serializes vLLM `BlockHash` values as hexadecimal strings for
the ZMQ lookup RPC. After msgpack decoding, `LookupKeyServer` forwarded those
strings directly to `KVPoolWorker.lookup_scheduler()`, although downstream
grouped-hash code expects bytes-like `BlockHash` elements.

In a v0.23.0rc1-based AscendStore deployment with the grouped-hash changes from
#12814 and #13110 backported, this produced:

```text
TypeError: sequence item 0: expected a bytes-like object, str found
```

The lookup exception handler then returned zero external-cache hits.

This PR fixes the type mismatch at the ZMQ decode boundary, without changing
the existing RPC protocol:

- 64-character hex strings are restored with `bytes.fromhex()`.
- Other strings are encoded as bytes.
- Values that are already bytes are passed through unchanged.

As a result, all internal lookup paths receive bytes-like block hashes while
the scheduler-side serialization and wire format remain unchanged.

### Does this PR introduce _any_ user-facing change?

No public API, configuration, RPC framing, or cache-key format changes. The fix
prevents affected AscendStore lookups from failing and degrading to zero cache
hits.

### How was this patch tested?

- Added a `LookupKeyServer` regression test that feeds a 64-character hex hash
  through the decoded ZMQ request and verifies that `lookup_scheduler()`
  receives the corresponding 32-byte `BlockHash`.
- Verified the regression test fails before the production change because the
  worker receives `str`, and passes after the boundary conversion is added.
- Ran 50 targeted AscendStore unit tests covering the lookup client, lookup
  server, connector, and byte/string key construction paths.
- Ran `ruff check`, `ruff format --check`, and `git diff --check` on the changed
  files.

No NPU hardware is required for this RPC type-conversion fix.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
