### PR TITLE
[BugFix][v0.23.0] Count DeepSeek-V3-style reasoning tokens

### DIFF
--- a/tests/ut/patch/platform/test_patch_deepseek_v3_reasoning_usage_accounting.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v3_reasoning_usage_accounting.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.reasoning import ReasoningParserManager
+from vllm.reasoning.deepseek_v3_reasoning_parser import (
+    DeepSeekV3ReasoningParser,
+    DeepSeekV3ReasoningWithThinkingParser,
+)
+
+from vllm_ascend.patch.platform import (
+    patch_deepseek_v3_reasoning_usage_accounting as reasoning_usage_patch,  # noqa: F401
+)
+from vllm_ascend.patch.platform import patch_minimax_usage_accounting as usage_patch
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {"<think>": 1, "</think>": 2}
+
+
+PARSER_CASES = [
+    pytest.param("deepseek_v3", {"thinking": True}, id="deepseek-v3"),
+    pytest.param("deepseek_v4", {"thinking": True}, id="deepseek-v4"),
+    pytest.param("glm45", None, id="glm45"),
+    pytest.param("holo2", None, id="holo2"),
+]
+
+
+def _reasoning_parser(parser_name, chat_template_kwargs=None):
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    kwargs = {}
+    if chat_template_kwargs is not None:
+        kwargs["chat_template_kwargs"] = chat_template_kwargs
+    return parser_cls(FakeTokenizer(), **kwargs)
+
+
+def test_reasoning_parser_registration_is_unchanged():
+    assert ReasoningParserManager.get_reasoning_parser("deepseek_v3") is DeepSeekV3ReasoningParser
+    assert ReasoningParserManager.get_reasoning_parser("deepseek_v4") is DeepSeekV3ReasoningParser
+    assert ReasoningParserManager.get_reasoning_parser("glm45") is DeepSeekV3ReasoningWithThinkingParser
+    assert ReasoningParserManager.get_reasoning_parser("holo2") is DeepSeekV3ReasoningWithThinkingParser
+
+
+@pytest.mark.parametrize(("parser_name", "chat_template_kwargs"), PARSER_CASES)
+@pytest.mark.parametrize(
+    ("token_ids", "expected"),
+    [
+        pytest.param([1, 10, 11, 2, 20], 2, id="explicit-start"),
+        pytest.param([99, 1, 10, 11, 2, 20], 2, id="prefix-before-start"),
+        pytest.param([10, 11, 2, 20], 2, id="implicit-start"),
+        pytest.param([10, 11], 2, id="truncated-reasoning"),
+        pytest.param([2, 20], 0, id="end-token-first"),
+        pytest.param([], 0, id="empty-output"),
+    ],
+)
+def test_reasoning_token_count(
+    parser_name,
+    chat_template_kwargs,
+    token_ids,
+    expected,
+):
+    parser = _reasoning_parser(parser_name, chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens(token_ids) == expected
+
+
+@pytest.mark.parametrize("parser_name", ["deepseek_v3", "deepseek_v4"])
+@pytest.mark.parametrize("chat_template_kwargs", [{"thinking": False}, {"enable_thinking": False}])
+def test_reasoning_tokens_when_thinking_is_disabled(parser_name, chat_template_kwargs):
+    parser = _reasoning_parser(parser_name, chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+@pytest.mark.parametrize("parser_name", ["glm45", "holo2"])
+@pytest.mark.parametrize(
+    "chat_template_kwargs",
+    [
+        {"thinking": False, "enable_thinking": False},
+        {"thinking": False, "enable_thinking": None},
+        {"thinking": None, "enable_thinking": False},
+    ],
+)
+def test_reasoning_tokens_when_default_thinking_is_disabled(parser_name, chat_template_kwargs):
+    parser = _reasoning_parser(parser_name, chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+@pytest.mark.parametrize("parser_name", ["deepseek_r1", "nemotron_v3", "qwen3"])
+def test_non_wrapper_reasoning_parsers_are_unchanged(parser_name):
+    parser = _reasoning_parser(parser_name)
+
+    assert parser.count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+def test_full_response_usage_reports_reasoning_tokens():
+    class FakeServing:
+        enable_prompt_tokens_details = False
+
+        def _make_usage_info(self, **kwargs):
+            return usage_patch._make_usage_info(self, **kwargs)
+
+    state = usage_patch._create_usage_tracking_state(
+        num_choices=1,
+        reasoning_parser=_reasoning_parser("glm45"),
+    )
+    state.num_prompt_tokens = 3
+    state.final_res = SimpleNamespace(num_cached_tokens=None)
+    state.completion_tokens = [4]
+    state.raw_output_token_ids = [[10, 11, 2, 20]]
+
+    usage = usage_patch._make_full_response_usage(FakeServing(), state)
+
+    assert usage.completion_tokens_details.reasoning_tokens == 2
+
+
+def test_stream_usage_reports_reasoning_tokens():
+    state = usage_patch._create_usage_tracking_state(
+        num_choices=1,
+        reasoning_parser=_reasoning_parser("glm45"),
+    )
+    state.raw_output_token_ids = [[10, 11, 2, 20]]
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 7,
+        },
+    }
+
+    data = usage_patch._inject_stream_usage_details(
+        f"data: {json.dumps(chunk)}\n\n",
+        state,
+    )
+    payload = json.loads(data.removeprefix("data: ").removesuffix("\n\n"))
+
+    assert payload["usage"]["completion_tokens_details"] == {
+        "reasoning_tokens": 2,
+    }
+
+
+def test_chat_usage_wrapper_is_bound_for_glm_instances():
+    serving = object.__new__(OpenAIServingChat)
+
+    serving.reasoning_parser_cls = DeepSeekV3ReasoningWithThinkingParser
+
+    assert serving._ascend_reasoning_usage_patched
+    assert "chat_completion_stream_generator" in serving.__dict__
+    assert "chat_completion_full_generator" in serving.__dict__

--- a/tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
+++ b/tests/ut/patch/platform/test_patch_minimax_usage_accounting.py
@@ -195,7 +195,7 @@ def test_count_reasoning_tokens_accepts_minimax_unified_parser():
     parser = parser_cls(FakeTokenizer(), tools=[])
 
     assert not hasattr(parser, "count_reasoning_tokens")
-    assert usage_patch._count_minimax_reasoning_tokens_for_usage([10, 11, 2, 20], parser) == 2
+    assert usage_patch._count_reasoning_tokens_for_usage([10, 11, 2, 20], parser) == 2
 
 
 def test_count_reasoning_tokens_accepts_wrapped_minimax_parser():
@@ -203,11 +203,11 @@ def test_count_reasoning_tokens_accepts_wrapped_minimax_parser():
         reasoning_parser=MiniMaxM2ReasoningParser(FakeTokenizer()),
     )
 
-    assert usage_patch._count_minimax_reasoning_tokens_for_usage([10, 11, 2, 20], parser) == 2
-    assert usage_patch._is_minimax_reasoning_parser(parser)
+    assert usage_patch._count_reasoning_tokens_for_usage([10, 11, 2, 20], parser) == 2
+    assert usage_patch._is_reasoning_usage_parser(parser)
 
 
-def test_count_reasoning_tokens_skips_non_minimax_parser_manager_wrapper():
+def test_count_reasoning_tokens_accepts_deepseek_v3_parser_manager_wrapper():
     parser_cls = ParserManager.get_parser(
         tool_parser_name="deepseek_v4",
         reasoning_parser_name="deepseek_v4",
@@ -217,8 +217,8 @@ def test_count_reasoning_tokens_skips_non_minimax_parser_manager_wrapper():
     parser = parser_cls(FakeTokenizer(), tools=[])
 
     assert not hasattr(parser, "count_reasoning_tokens")
-    assert usage_patch._count_minimax_reasoning_tokens_for_usage([10, 11], parser) is None
-    assert not usage_patch._is_minimax_reasoning_parser(parser)
+    assert usage_patch._count_reasoning_tokens_for_usage([10, 11], parser) == 0
+    assert usage_patch._is_reasoning_usage_parser(parser)
 
 
 def test_non_minimax_parser_does_not_enable_tracking_by_default():
@@ -228,8 +228,8 @@ def test_non_minimax_parser_does_not_enable_tracking_by_default():
 
     parser = FakeReasoningParser()
 
-    assert usage_patch._count_minimax_reasoning_tokens_for_usage([10, 11], parser) is None
-    assert not usage_patch._is_minimax_reasoning_parser(parser)
+    assert usage_patch._count_reasoning_tokens_for_usage([10, 11], parser) is None
+    assert not usage_patch._is_reasoning_usage_parser(parser)
     assert usage_patch._sum_reasoning_tokens_for_usage([[10, 11]], parser) is None
 
 

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -201,6 +201,23 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       GLM47 inline zero-argument streaming parser fix.
 #
+# ** 7c. File: platform/patch_deepseek_v3_reasoning_usage_accounting.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.reasoning.deepseek_v3_reasoning_parser.DeepSeekV3ReasoningParser`
+#    Why:
+#       DeepSeek-V3/V4, GLM, and Holo2 share a reasoning wrapper that does not
+#       delegate token counting. Their chat templates may also place the opening
+#       `<think>` token in the prompt, leaving only `</think>` in generated ids.
+#    How:
+#       Delegate explicit spans to the wrapped parser and count the implicit
+#       leading reasoning span when the generated opening token is absent.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/41077
+#       https://github.com/vllm-project/vllm/pull/49743
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains the upstream
+#       reasoning-token counting fix.
+#
 # ** 10a. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -33,6 +33,7 @@ import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 
 if vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_async_swa_kv_lifetime  # noqa
+    import vllm_ascend.patch.platform.patch_deepseek_v3_reasoning_usage_accounting  # noqa
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v3_reasoning_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v3_reasoning_usage_accounting.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# DeepSeek-V3-style reasoning usage: backport reasoning-token counting.
+#
+
+from collections.abc import Sequence
+
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
+
+
+def _count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+    parser = self._parser
+    if not isinstance(parser, BaseThinkingReasoningParser):
+        return parser.count_reasoning_tokens(token_ids)
+
+    if parser.start_token_id in token_ids:
+        return parser.count_reasoning_tokens(token_ids)
+
+    # Some templates put the opening marker in the prompt. A missing closing
+    # marker therefore means generation was truncated while still reasoning.
+    try:
+        return token_ids.index(parser.end_token_id)
+    except ValueError:
+        return len(token_ids)
+
+
+DeepSeekV3ReasoningParser.count_reasoning_tokens = _count_reasoning_tokens

--- a/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_minimax_usage_accounting.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# MiniMax-M2 usage accounting: backport reasoning-token usage details.
+# Reasoning usage accounting: backport reasoning-token usage details.
 #
 
 from __future__ import annotations
@@ -30,10 +30,12 @@ from vllm.entrypoints.openai.chat_completion import serving as chat_serving
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine import protocol as engine_protocol
 from vllm.reasoning import minimax_m2_reasoning_parser as minimax_parser
+from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
 
-_MINIMAX_REASONING_PARSER_TYPES = (
+_REASONING_USAGE_PARSER_TYPES = (
     minimax_parser.MiniMaxM2ReasoningParser,
     minimax_parser.MiniMaxM2AppendThinkReasoningParser,
+    DeepSeekV3ReasoningParser,
 )
 
 
@@ -52,7 +54,7 @@ CompletionTokenUsageInfo.__module__ = engine_protocol.__name__
 UsageInfo.__module__ = engine_protocol.__name__
 
 # The OpenAI usage schema is process-wide. Keep only this schema backfill
-# global; the expensive token tracking below is bound to MiniMax instances.
+# global; token tracking below is bound to selected reasoning parser instances.
 engine_protocol.CompletionTokenUsageInfo = CompletionTokenUsageInfo
 engine_protocol.UsageInfo = UsageInfo
 chat_protocol.UsageInfo = UsageInfo
@@ -92,12 +94,12 @@ minimax_parser.MiniMaxM2ReasoningParser.count_reasoning_tokens = _patched_count_
 minimax_parser.MiniMaxM2AppendThinkReasoningParser.count_reasoning_tokens = _patched_count_reasoning_tokens
 
 
-def _count_minimax_reasoning_tokens_for_usage(
+def _count_reasoning_tokens_for_usage(
     token_ids: Sequence[int],
     reasoning_parser,
 ) -> int | None:
     reasoning_parser = _resolve_reasoning_parser(reasoning_parser)
-    if reasoning_parser is None or not _is_minimax_reasoning_parser(reasoning_parser):
+    if reasoning_parser is None or not _is_reasoning_usage_parser(reasoning_parser):
         return None
 
     count_reasoning_tokens = getattr(reasoning_parser, "count_reasoning_tokens", None)
@@ -112,10 +114,10 @@ def _resolve_reasoning_parser(reasoning_parser):
     return getattr(reasoning_parser, "reasoning_parser", reasoning_parser)
 
 
-def _is_minimax_reasoning_parser(reasoning_parser) -> bool:
+def _is_reasoning_usage_parser(reasoning_parser) -> bool:
     return isinstance(
         _resolve_reasoning_parser(reasoning_parser),
-        _MINIMAX_REASONING_PARSER_TYPES,
+        _REASONING_USAGE_PARSER_TYPES,
     )
 
 
@@ -149,10 +151,10 @@ def _make_usage_info(
     return usage
 
 
-def _is_minimax_reasoning_parser_cls(reasoning_parser_cls) -> bool:
+def _is_reasoning_usage_parser_cls(reasoning_parser_cls) -> bool:
     return isinstance(reasoning_parser_cls, type) and issubclass(
         reasoning_parser_cls,
-        _MINIMAX_REASONING_PARSER_TYPES,
+        _REASONING_USAGE_PARSER_TYPES,
     )
 
 
@@ -218,7 +220,7 @@ def _sum_reasoning_tokens_for_usage(
     if reasoning_parser is None:
         return None
     reasoning_token_counts = [
-        _count_minimax_reasoning_tokens_for_usage(token_ids, reasoning_parser) for token_ids in raw_output_token_ids
+        _count_reasoning_tokens_for_usage(token_ids, reasoning_parser) for token_ids in raw_output_token_ids
     ]
     if all(reasoning_tokens is None for reasoning_tokens in reasoning_token_counts):
         return None
@@ -233,7 +235,7 @@ def _reasoning_tokens_for_choice(
         return None
     if not 0 <= choice_index < len(state.raw_output_token_ids):
         return None
-    return _count_minimax_reasoning_tokens_for_usage(
+    return _count_reasoning_tokens_for_usage(
         state.raw_output_token_ids[choice_index],
         state.reasoning_parser,
     )
@@ -416,11 +418,11 @@ _wrapped_chat_completion_full_generator.__qualname__ = (
 
 
 def _should_patch_chat_usage_instance(self) -> bool:
-    return _is_minimax_reasoning_parser_cls(self.reasoning_parser_cls)
+    return _is_reasoning_usage_parser_cls(self.reasoning_parser_cls)
 
 
 def _patch_chat_usage_instance(self) -> None:
-    if getattr(self, "_ascend_minimax_usage_patched", False):
+    if getattr(self, "_ascend_reasoning_usage_patched", False):
         return
     self._make_usage_info = MethodType(_make_usage_info, self)
     self._ascend_original_chat_completion_stream_generator = MethodType(
@@ -439,7 +441,7 @@ def _patch_chat_usage_instance(self) -> None:
         _wrapped_chat_completion_full_generator,
         self,
     )
-    self._ascend_minimax_usage_patched = True
+    self._ascend_reasoning_usage_patched = True
 
 
 class _ReasoningParserClsDescriptor:
@@ -453,7 +455,7 @@ class _ReasoningParserClsDescriptor:
 
     def __set__(self, instance, value) -> None:
         instance.__dict__["_ascend_reasoning_parser_cls"] = value
-        if _is_minimax_reasoning_parser_cls(value):
+        if _is_reasoning_usage_parser_cls(value):
             _patch_chat_usage_instance(instance)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This is the v0.23.0 follow-up to #13079 for #13070.

GLM chat templates can place the opening `<think>` marker in the prompt, so generated token IDs contain the reasoning span followed by `</think>` but no generated opening marker. On vLLM v0.23.0, the shared `DeepSeekV3ReasoningParser` wrapper also does not delegate reasoning-token counting to its wrapped parser. As a result, explicit, prompt-opened, and truncated reasoning all report zero reasoning tokens.

This PR:

- delegates explicit `<think>...</think>` spans to the wrapped parser;
- counts tokens before the first generated `</think>` when the opening marker came from the prompt;
- counts all generated tokens as reasoning when generation is truncated before `</think>`;
- preserves thinking-disabled behavior;
- extends the existing instance-scoped MiniMax usage accounting path to `DeepSeekV3ReasoningParser` instead of adding another global serving wrapper.

The parser patch is limited to the existing `DeepSeekV3ReasoningParser` wrapper and its `deepseek_v3`, `deepseek_v4`, `glm45`, and `holo2` aliases. DeepSeek-R1, Nemotron, Qwen, model execution, and the NPU decode path are unchanged.

Related upstream work is still open:

- https://github.com/vllm-project/vllm/pull/41077
- https://github.com/vllm-project/vllm/pull/49743

No duplicate vLLM Ascend PR was found for this v0.23.0 backport. The patch should be removed once the supported vLLM release contains the upstream fix.

Related #13070 and #13079.

### Does this PR introduce _any_ user-facing change?

Yes. Thinking-enabled chat completions using the affected parser aliases now report the actual reasoning token count instead of zero. Thinking-disabled requests remain unchanged.

### How was this patch tested?

- `pytest -q tests/ut/patch/platform/test_patch_deepseek_v3_reasoning_usage_accounting.py tests/ut/patch/platform/test_patch_minimax_usage_accounting.py tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py tests/ut/patch/platform/test_patch_glm47_tool_call_parser.py tests/ut/patch/platform/test_patch_glm_tool_call_streaming.py tests/ut/patch/platform/test_patch_minimax_m2_tool_call_parser.py` (`91 passed`)
- `ruff check` and `ruff format --check` on all changed Python files
- `python -m py_compile` on all changed Python files
- `git diff --check`
- Actual GLM-5.1 tokenizer probe confirmed the chat prompt ends with `<|assistant|><think>` and changed explicit / prompt-opened / truncated counts from `0 / 0 / 0` to `4 / 4 / 4`.

The real checkpoint was not served through the OpenAI API in this validation, so this PR does not claim real-weight NPU HTTP end-to-end sign-off.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
