### PR TITLE
[BugFix][v0.26.0rc] Report GLM reasoning token usage

### DIFF
--- a/tests/ut/patch/platform/test_patch_glm_reasoning_usage_accounting.py
+++ b/tests/ut/patch/platform/test_patch_glm_reasoning_usage_accounting.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.parser import ParserManager
+from vllm.reasoning import ReasoningParserManager
+
+from vllm_ascend.patch.platform import patch_glm_reasoning_usage_accounting as patch
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {"<think>": 1, "</think>": 2}
+
+
+def _reasoning_parser(parser_name="glm45", chat_template_kwargs=None):
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    kwargs = {}
+    if chat_template_kwargs is not None:
+        kwargs["chat_template_kwargs"] = chat_template_kwargs
+    return parser_cls(FakeTokenizer(), **kwargs)
+
+
+async def _result_generator(result):
+    yield result
+
+
+@pytest.mark.parametrize("parser_name", ["glm45", "glm47"])
+@pytest.mark.parametrize(
+    ("token_ids", "expected"),
+    [
+        pytest.param([1, 10, 11, 2, 20], 2, id="explicit-start"),
+        pytest.param([99, 1, 10, 11, 2, 20], 2, id="prefix-before-start"),
+        pytest.param([10, 11, 2, 20], 2, id="implicit-start"),
+        pytest.param([10, 11], 2, id="truncated-reasoning"),
+        pytest.param([2, 20], 0, id="end-token-first"),
+        pytest.param([], 0, id="empty-output"),
+    ],
+)
+def test_reasoning_token_count(parser_name, token_ids, expected):
+    assert _reasoning_parser(parser_name).count_reasoning_tokens(token_ids) == expected
+
+
+@pytest.mark.parametrize(
+    "chat_template_kwargs",
+    [
+        {"thinking": False, "enable_thinking": False},
+        {"thinking": False, "enable_thinking": None},
+        {"thinking": None, "enable_thinking": False},
+    ],
+)
+def test_reasoning_token_count_when_thinking_is_disabled(chat_template_kwargs):
+    parser = _reasoning_parser(chat_template_kwargs=chat_template_kwargs)
+
+    assert parser.count_reasoning_tokens([10, 11, 2, 20]) == 0
+
+
+@pytest.mark.parametrize(
+    "token_chunks",
+    [
+        [[10], [11, 2], [20]],
+        [[99], [1, 10], [11, 2, 20]],
+        [[10], [11]],
+    ],
+)
+def test_incremental_counter_matches_batch_count(token_chunks):
+    counter = patch._IncrementalReasoningCounter(1, 2, enabled=True)
+    token_ids = []
+
+    for chunk in token_chunks:
+        token_ids.extend(chunk)
+        counter.update(chunk)
+        assert counter.count == _reasoning_parser().count_reasoning_tokens(token_ids)
+
+
+def test_stream_usage_reports_reasoning_tokens():
+    counter = patch._IncrementalReasoningCounter(1, 2, enabled=True)
+    counter.update([10, 11, 2, 20])
+    state = patch._StreamUsageState(counters=[counter])
+    chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 7,
+        },
+    }
+
+    data = patch._inject_stream_usage_details(
+        f"data: {json.dumps(chunk)}\n\n",
+        state,
+    )
+    payload = json.loads(data.removeprefix("data: ").removesuffix("\n\n"))
+
+    assert payload["usage"]["completion_tokens_details"] == {
+        "reasoning_tokens": 2,
+    }
+
+
+def test_full_response_usage_reports_reasoning_tokens():
+    parser_cls = ParserManager.get_parser(reasoning_parser_name="glm45")
+    parser = parser_cls(FakeTokenizer())
+    final_res = SimpleNamespace(outputs=[SimpleNamespace(token_ids=[10, 11, 2, 20])])
+    usage = patch.UsageInfo(
+        prompt_tokens=3,
+        completion_tokens=4,
+        total_tokens=7,
+    )
+
+    reasoning_tokens = patch._count_full_response_reasoning_tokens(parser, final_res)
+    patch._set_usage_details(usage, reasoning_tokens)
+
+    assert usage.completion_tokens_details.reasoning_tokens == 2
+
+
+def test_stream_wrapper_injects_usage_and_updates_metadata():
+    result = SimpleNamespace(outputs=[SimpleNamespace(index=0, token_ids=[10, 11, 2, 20])])
+    request = SimpleNamespace(n=1)
+    request_metadata = SimpleNamespace(final_usage_info=None)
+
+    async def original(
+        request,
+        result_generator,
+        request_id,
+        model_name,
+        conversation,
+        tokenizer,
+        request_metadata,
+        **kwargs,
+    ):
+        async for _ in result_generator:
+            pass
+        request_metadata.final_usage_info = patch.UsageInfo(
+            prompt_tokens=3,
+            completion_tokens=4,
+            total_tokens=7,
+        )
+        yield ('data: {"choices": [], "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}}\n\n')
+        yield "data: [DONE]\n\n"
+
+    serving = SimpleNamespace(_ascend_original_chat_completion_stream_generator=original)
+
+    async def collect_chunks():
+        return [
+            chunk
+            async for chunk in patch._wrapped_chat_completion_stream_generator(
+                serving,
+                request,
+                _result_generator(result),
+                "chatcmpl-test",
+                "test-model",
+                [],
+                FakeTokenizer(),
+                request_metadata,
+            )
+        ]
+
+    chunks = asyncio.run(collect_chunks())
+
+    usage_chunk = json.loads(chunks[0].removeprefix("data: ").removesuffix("\n\n"))
+    assert usage_chunk["usage"]["completion_tokens_details"] == {
+        "reasoning_tokens": 2,
+    }
+    assert request_metadata.final_usage_info.completion_tokens_details.reasoning_tokens == 2
+
+
+def test_full_wrapper_updates_response_and_metadata():
+    final_res = SimpleNamespace(outputs=[SimpleNamespace(token_ids=[10, 11, 2, 20])])
+    request_metadata = SimpleNamespace(final_usage_info=None)
+    parser_cls = ParserManager.get_parser(reasoning_parser_name="glm45")
+    parser = parser_cls(FakeTokenizer())
+
+    async def original(
+        request,
+        result_generator,
+        request_id,
+        model_name,
+        conversation,
+        tokenizer,
+        request_metadata,
+        **kwargs,
+    ):
+        async for _ in result_generator:
+            pass
+        usage = patch.UsageInfo(
+            prompt_tokens=3,
+            completion_tokens=4,
+            total_tokens=7,
+        )
+        request_metadata.final_usage_info = usage
+        return patch.chat_protocol.ChatCompletionResponse(
+            model=model_name,
+            choices=[],
+            usage=usage,
+        )
+
+    serving = SimpleNamespace(_ascend_original_chat_completion_full_generator=original)
+    response = asyncio.run(
+        patch._wrapped_chat_completion_full_generator(
+            serving,
+            SimpleNamespace(),
+            _result_generator(final_res),
+            "chatcmpl-test",
+            "test-model",
+            [],
+            FakeTokenizer(),
+            request_metadata,
+            parser=parser,
+        )
+    )
+
+    assert response.usage.completion_tokens_details.reasoning_tokens == 2
+    assert request_metadata.final_usage_info.completion_tokens_details.reasoning_tokens == 2
+
+
+def test_chat_usage_wrapper_is_bound_only_for_glm_instances():
+    glm_parser_cls = ParserManager.get_parser(reasoning_parser_name="glm45")
+    qwen_parser_cls = ParserManager.get_parser(reasoning_parser_name="qwen3")
+    glm_serving = object.__new__(OpenAIServingChat)
+    qwen_serving = object.__new__(OpenAIServingChat)
+
+    glm_serving.parser_cls = glm_parser_cls
+    qwen_serving.parser_cls = qwen_parser_cls
+
+    assert glm_serving._ascend_glm_reasoning_usage_patched
+    assert "chat_completion_stream_generator" in glm_serving.__dict__
+    assert "chat_completion_full_generator" in glm_serving.__dict__
+    assert not hasattr(qwen_serving, "_ascend_glm_reasoning_usage_patched")
+    assert "chat_completion_stream_generator" not in qwen_serving.__dict__
+    assert "chat_completion_full_generator" not in qwen_serving.__dict__

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -122,6 +122,23 @@
 #       Remove this patch once upstream exposes a backend dispatch / plugin hook
 #       for selecting the MoE runner implementation.
 #
+# ** 5a. File: platform/patch_glm_reasoning_usage_accounting.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.parser.glm47_moe.Glm47MoeParser`
+#      `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
+#    Why:
+#       GLM starts reasoning from the prompt and may generate only `</think>`,
+#       while the parser counter starts at depth zero. Chat completions also do
+#       not yet expose parser-derived reasoning usage on this vLLM release.
+#    How:
+#       Count GLM's implicit leading reasoning span and bind token tracking plus
+#       usage injection only to serving instances configured with the GLM parser.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/41077
+#       https://github.com/vllm-project/vllm/pull/45802
+#    Future Plan:
+#       Remove this patch once both upstream fixes are in the supported vLLM.
+#
 # ** 6. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.HybridKVCacheCoordinator.find_longest_cache_hit_per_group`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,6 +18,7 @@ import os
 
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
+import vllm_ascend.patch.platform.patch_glm_reasoning_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_kimi_k3_parsers  # noqa
 import vllm_ascend.patch.platform.patch_kimi_k3_renderer  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa

--- a/vllm_ascend/patch/platform/patch_glm_reasoning_usage_accounting.py
+++ b/vllm_ascend/patch/platform/patch_glm_reasoning_usage_accounting.py
@@ -1,0 +1,359 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# GLM reasoning usage: backport chat usage reporting and implicit-start counts.
+#
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from types import MethodType
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion import protocol as chat_protocol
+from vllm.entrypoints.openai.chat_completion import serving as chat_serving
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine import protocol as engine_protocol
+from vllm.parser.glm47_moe import THINK_END, THINK_START, Glm47MoeParser
+from vllm.reasoning.glm47_moe_reasoning_parser import (
+    Glm47MoeParserReasoningAdapter,
+)
+
+_ORIGINAL_COUNT_REASONING_TOKENS = Glm47MoeParser.count_reasoning_tokens
+
+
+def _count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+    start_id = self._reasoning_start_token_id
+    end_id = self._reasoning_end_token_id
+    if start_id is None or end_id is None or start_id in token_ids:
+        return _ORIGINAL_COUNT_REASONING_TOKENS(self, token_ids)
+
+    try:
+        return token_ids.index(end_id)
+    except ValueError:
+        return len(token_ids)
+
+
+Glm47MoeParser.count_reasoning_tokens = _count_reasoning_tokens
+
+
+class CompletionTokenUsageInfo(engine_protocol.OpenAIBaseModel):
+    reasoning_tokens: int | None = None
+    audio_tokens: int | None = None
+    accepted_prediction_tokens: int | None = None
+    rejected_prediction_tokens: int | None = None
+
+
+class UsageInfo(engine_protocol.UsageInfo):
+    completion_tokens_details: CompletionTokenUsageInfo | None = None
+
+
+CompletionTokenUsageInfo.__module__ = engine_protocol.__name__
+UsageInfo.__module__ = engine_protocol.__name__
+engine_protocol.CompletionTokenUsageInfo = CompletionTokenUsageInfo
+engine_protocol.UsageInfo = UsageInfo
+chat_protocol.UsageInfo = UsageInfo
+chat_serving.CompletionTokenUsageInfo = CompletionTokenUsageInfo
+chat_serving.UsageInfo = UsageInfo
+
+
+def _rebuild_model_field(model_cls, field_name: str, annotation) -> None:
+    model_cls.__annotations__[field_name] = annotation
+    model_cls.model_fields[field_name].annotation = annotation
+    model_cls.model_rebuild(force=True)
+
+
+_rebuild_model_field(chat_protocol.ChatCompletionResponse, "usage", UsageInfo)
+_rebuild_model_field(chat_protocol.ChatCompletionStreamResponse, "usage", UsageInfo | None)
+_rebuild_model_field(
+    engine_protocol.RequestResponseMetadata,
+    "final_usage_info",
+    UsageInfo | None,
+)
+
+
+@dataclass
+class _IncrementalReasoningCounter:
+    start_token_id: int | None
+    end_token_id: int | None
+    enabled: bool
+    count: int = 0
+    depth: int = 0
+    saw_start: bool = False
+    implicit_end_seen: bool = False
+
+    def update(self, token_ids: Sequence[int]) -> None:
+        if not self.enabled or self.start_token_id is None or self.end_token_id is None:
+            return
+
+        for token_id in token_ids:
+            if token_id == self.start_token_id:
+                if not self.saw_start:
+                    self.saw_start = True
+                    self.count = 0
+                    self.depth = 1
+                else:
+                    self.depth += 1
+                continue
+
+            if token_id == self.end_token_id:
+                if self.saw_start:
+                    self.depth = max(0, self.depth - 1)
+                else:
+                    self.implicit_end_seen = True
+                continue
+
+            if self.saw_start:
+                if self.depth > 0:
+                    self.count += 1
+            elif not self.implicit_end_seen:
+                self.count += 1
+
+
+@dataclass
+class _StreamUsageState:
+    counters: list[_IncrementalReasoningCounter]
+
+
+@dataclass
+class _FullUsageState:
+    final_res: Any = None
+
+
+def _thinking_enabled(chat_template_kwargs: dict[str, Any] | None) -> bool:
+    chat_kwargs = chat_template_kwargs or {}
+    thinking = chat_kwargs.get("thinking", None)
+    enable_thinking = chat_kwargs.get("enable_thinking", None)
+    if thinking is None and enable_thinking is None:
+        return True
+    return bool(thinking) or bool(enable_thinking)
+
+
+def _create_stream_usage_state(
+    request,
+    tokenizer,
+    chat_template_kwargs: dict[str, Any] | None,
+) -> _StreamUsageState:
+    vocab = tokenizer.get_vocab()
+    num_choices = 1 if request.n is None else request.n
+    counters = [
+        _IncrementalReasoningCounter(
+            start_token_id=vocab.get(THINK_START),
+            end_token_id=vocab.get(THINK_END),
+            enabled=_thinking_enabled(chat_template_kwargs),
+        )
+        for _ in range(num_choices)
+    ]
+    return _StreamUsageState(counters=counters)
+
+
+async def _tracked_stream_results(
+    result_generator: AsyncIterator,
+    state: _StreamUsageState,
+):
+    async for res in result_generator:
+        for output in res.outputs:
+            if 0 <= output.index < len(state.counters):
+                state.counters[output.index].update(chat_serving.as_list(output.token_ids))
+        yield res
+
+
+async def _tracked_full_results(
+    result_generator: AsyncIterator,
+    state: _FullUsageState,
+):
+    async for res in result_generator:
+        state.final_res = res
+        yield res
+
+
+def _reasoning_tokens_for_stream_chunk(
+    state: _StreamUsageState,
+    chunk: dict[str, Any],
+) -> int:
+    choices = chunk.get("choices") or []
+    if choices:
+        choice_index = choices[0].get("index", 0)
+        if 0 <= choice_index < len(state.counters):
+            return state.counters[choice_index].count
+    return sum(counter.count for counter in state.counters)
+
+
+def _inject_stream_usage_details(data: str, state: _StreamUsageState) -> str:
+    prefix = "data: "
+    suffix = "\n\n"
+    if not data.startswith(prefix):
+        return data
+
+    payload = data[len(prefix) :]
+    if payload.endswith(suffix):
+        payload = payload[: -len(suffix)]
+    if payload == "[DONE]":
+        return data
+
+    try:
+        chunk = json.loads(payload)
+    except json.JSONDecodeError:
+        return data
+
+    usage = chunk.get("usage")
+    if not isinstance(usage, dict):
+        return data
+
+    completion_details = usage.setdefault("completion_tokens_details", {})
+    completion_details["reasoning_tokens"] = _reasoning_tokens_for_stream_chunk(state, chunk)
+    return f"{prefix}{json.dumps(chunk, ensure_ascii=False)}{suffix}"
+
+
+def _set_usage_details(usage, reasoning_tokens: int) -> None:
+    if usage is not None:
+        usage.completion_tokens_details = CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+
+
+def _count_full_response_reasoning_tokens(
+    parser,
+    final_res,
+) -> int:
+    if parser is None or final_res is None:
+        return 0
+    reasoning_parser = parser.reasoning_parser
+    if reasoning_parser is None:
+        return 0
+    return sum(
+        reasoning_parser.count_reasoning_tokens(chat_serving.as_list(output.token_ids)) for output in final_res.outputs
+    )
+
+
+async def _wrapped_chat_completion_stream_generator(
+    self,
+    request,
+    result_generator,
+    request_id,
+    model_name,
+    conversation,
+    tokenizer,
+    request_metadata,
+    chat_template_kwargs=None,
+    mm_token_counts=None,
+    **extra_kwargs,
+):
+    state = _create_stream_usage_state(
+        request,
+        tokenizer,
+        chat_template_kwargs,
+    )
+    original = self._ascend_original_chat_completion_stream_generator
+    async for data in original(
+        request,
+        _tracked_stream_results(result_generator, state),
+        request_id,
+        model_name,
+        conversation,
+        tokenizer,
+        request_metadata,
+        chat_template_kwargs=chat_template_kwargs,
+        mm_token_counts=mm_token_counts,
+        **extra_kwargs,
+    ):
+        yield _inject_stream_usage_details(data, state)
+
+    _set_usage_details(
+        request_metadata.final_usage_info,
+        sum(counter.count for counter in state.counters),
+    )
+
+
+async def _wrapped_chat_completion_full_generator(
+    self,
+    request,
+    result_generator,
+    request_id,
+    model_name,
+    conversation,
+    tokenizer,
+    request_metadata,
+    parser=None,
+    mm_token_counts=None,
+    **extra_kwargs,
+):
+    state = _FullUsageState()
+    original = self._ascend_original_chat_completion_full_generator
+    response = await original(
+        request,
+        _tracked_full_results(result_generator, state),
+        request_id,
+        model_name,
+        conversation,
+        tokenizer,
+        request_metadata,
+        parser=parser,
+        mm_token_counts=mm_token_counts,
+        **extra_kwargs,
+    )
+
+    if not isinstance(response, chat_protocol.ChatCompletionResponse):
+        return response
+
+    reasoning_tokens = _count_full_response_reasoning_tokens(parser, state.final_res)
+    _set_usage_details(response.usage, reasoning_tokens)
+    _set_usage_details(request_metadata.final_usage_info, reasoning_tokens)
+    return response
+
+
+def _is_glm_parser_cls(parser_cls) -> bool:
+    reasoning_parser_cls = getattr(parser_cls, "reasoning_parser_cls", None)
+    return isinstance(reasoning_parser_cls, type) and issubclass(
+        reasoning_parser_cls,
+        Glm47MoeParserReasoningAdapter,
+    )
+
+
+def _patch_chat_usage_instance(self) -> None:
+    if getattr(self, "_ascend_glm_reasoning_usage_patched", False):
+        return
+    self._ascend_original_chat_completion_stream_generator = self.chat_completion_stream_generator
+    self._ascend_original_chat_completion_full_generator = self.chat_completion_full_generator
+    self.chat_completion_stream_generator = MethodType(
+        _wrapped_chat_completion_stream_generator,
+        self,
+    )
+    self.chat_completion_full_generator = MethodType(
+        _wrapped_chat_completion_full_generator,
+        self,
+    )
+    self._ascend_glm_reasoning_usage_patched = True
+
+
+class _ParserClsDescriptor:
+    def __init__(self, default_value=None):
+        self.default_value = default_value
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self.default_value
+        return instance.__dict__.get("_ascend_parser_cls", self.default_value)
+
+    def __set__(self, instance, value) -> None:
+        instance.__dict__["_ascend_parser_cls"] = value
+        if _is_glm_parser_cls(value):
+            _patch_chat_usage_instance(instance)
+
+
+_current_parser_cls = OpenAIServingChat.__dict__.get("parser_cls")
+if not isinstance(_current_parser_cls, _ParserClsDescriptor):
+    OpenAIServingChat.parser_cls = _ParserClsDescriptor(_current_parser_cls)


### PR DESCRIPTION
### What this PR does / why we need it?

This is the v0.26.0rc follow-up to #13079 for #13070.

GLM chat templates place the opening `<think>` marker in the prompt. The vLLM v0.26.0 parser engine counts explicit `<think>...</think>` spans correctly, but starts generated-token counting at depth zero. Outputs containing only the generated reasoning span plus `</think>`, or truncated reasoning without `</think>`, therefore report zero reasoning tokens.

Chat Completions in this vLLM release also does not yet expose parser-derived `completion_tokens_details.reasoning_tokens`, so fixing the parser counter alone would not fix the external usage contract.

This PR:

- counts GLM prompt-opened and truncated reasoning in `Glm47MoeParser`;
- backfills the optional Chat Completions reasoning usage schema;
- binds streaming and non-streaming usage tracking only to serving instances configured with the GLM parser;
- uses per-choice incremental streaming counters, avoiding repeated full-output scans for continuous usage;
- updates both response usage and request metadata.

Non-GLM serving instances are not wrapped. Model execution and the NPU decode path are unchanged.

Related upstream work is still open:

- https://github.com/vllm-project/vllm/pull/45802
- https://github.com/vllm-project/vllm/pull/49743

No duplicate vLLM Ascend PR was found for this v0.26.0rc backport. The patch should be removed once both upstream fixes are present in the supported vLLM release.

Related #13070 and #13079.

### Does this PR introduce _any_ user-facing change?

Yes. GLM Chat Completions now report `completion_tokens_details.reasoning_tokens` for explicit, prompt-opened, and truncated reasoning in streaming and non-streaming responses.

### How was this patch tested?

- `pytest -q tests/ut/patch/platform/test_patch_glm_reasoning_usage_accounting.py tests/ut/patch/platform/test_patch_kimi_k3_parsers.py` (`35 passed`)
- `ruff check` and `ruff format --check` on all changed Python files
- `python -m py_compile` on all changed Python files
- `git diff --check`
- Actual GLM-5.1 tokenizer probe confirmed the chat prompt ends with `<|assistant|><think>` and changed explicit / prompt-opened / truncated counts from `4 / 0 / 0` to `4 / 4 / 4`.

The real checkpoint was not served through the OpenAI API in this validation, so this PR does not claim real-weight NPU HTTP end-to-end sign-off.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
