### PR TITLE
[Feature] support eagle3 pp in mrv2

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -516,6 +516,7 @@
 # ** 21. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
+#   2. `vllm.config.vllm.VllmConfig._get_v2_model_runner_unsupported_features`
 #    Why:
 #       Upstream vLLM enables the v2 model runner not only via the
 #       VLLM_USE_V2_MODEL_RUNNER env var but also based on model
@@ -525,9 +526,13 @@
 #       enabling by model architecture can crash. We override the
 #       property to read only VLLM_USE_V2_MODEL_RUNNER, deferring
 #       model/framework checks to the NPU runner itself.
+#       Eagle3 PP remains in upstream's unsupported-feature list, which
+#       prevents Ascend from validating the supported Qwen3 target.
 #    How:
 #       Monkey-patch VllmConfig.use_v2_model_runner to return
 #       envs.VLLM_USE_V2_MODEL_RUNNER (defaulting to False when unset).
+#       Remove only the Eagle3 PP marker during V2 validation, while preserving
+#       all other upstream unsupported-feature checks.
 #       worker/patch_v2/patch_use_v2_model_runner.py reuses this platform
 #       patch so EngineCore and worker processes share the same behavior.
 #    Related PR (if no, explain why):
@@ -604,7 +609,8 @@
 #    How：
 #       Patch the affected Eagle3 draft models to use
 #       `get_total_num_hidden_layers()` instead, which matches the checkpoint's
-#       global layer indices and keeps `target_layer_count` correct.
+#       global layer indices and keeps `target_layer_count` correct, including
+#       native Qwen3 Eagle3 draft models.
 #    Related PR (if no, explain why):
 #       No, vllm-ascend-specific Eagle3 + PP weight-loading fix.
 #    Future Plan:
@@ -1074,6 +1080,26 @@
 #       Define AscendModelState and initialize it in init_model_state.
 #    Future Plan:
 #       remove this when vllm-ascend's attention metadata is align with vllm.
+#
+# ** 27a. File: worker/patch_v2/patch_spec_decode_pp.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. Qwen3Model.forward and PP intermediate tensor allocation
+#   2. PPHandler sampled-token broadcast methods
+#    Why:
+#       Upstream numbers Eagle3 layers locally on each PP rank and does not carry
+#       auxiliary states to the next rank. Upstream PP also broadcasts accepted
+#       target tokens before the last rank has generated the next draft tokens,
+#       leaving non-last ranks with stale local draft state.
+#    How:
+#       Use global Qwen3 layer indices, append auxiliary states to MRV2
+#       `IntermediateTensors`, mirror them in dummy buffers, and send accepted
+#       target tokens plus next-step draft tokens through the same fixed-shape
+#       V2 PP queue slot for Qwen3 Eagle3 and DeepSeek-V4 MTP.
+#    Related PR (if no, explain why):
+#       No, this enables the Ascend MRV2 implementation.
+#    Future Plan:
+#       Remove when vLLM natively transports Eagle3 states and speculative draft
+#       tokens through PP. Method-specific PP restrictions remain unchanged.
 #
 # ** 28. File: worker/patch_v2/patch_triton.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_use_v2_model_runner.py
+++ b/vllm_ascend/patch/platform/patch_use_v2_model_runner.py
@@ -1,6 +1,8 @@
 import vllm.envs as envs
 from vllm.config.vllm import VllmConfig
 
+_original_get_unsupported_features = VllmConfig._get_v2_model_runner_unsupported_features
+
 
 def _patched_use_v2_model_runner(self) -> bool:
     """Return VLLM_USE_V2_MODEL_RUNNER env directly.
@@ -17,4 +19,19 @@ def _patched_use_v2_model_runner(self) -> bool:
     return False
 
 
+def _patched_get_unsupported_features(self) -> list[str]:
+    unsupported = _original_get_unsupported_features(self)
+    speculative_config = self.speculative_config
+    if (
+        speculative_config is not None
+        and speculative_config.method == "eagle3"
+        and self.model_config.architecture == "Qwen3ForCausalLM"
+        and self.parallel_config.pipeline_parallel_size > 1
+        and "EAGLE3 with pipeline parallelism" in unsupported
+    ):
+        unsupported.remove("EAGLE3 with pipeline parallelism")
+    return unsupported
+
+
 VllmConfig.use_v2_model_runner = property(_patched_use_v2_model_runner)
+VllmConfig._get_v2_model_runner_unsupported_features = _patched_get_unsupported_features

--- a/vllm_ascend/patch/worker/patch_eagle3_init.py
+++ b/vllm_ascend/patch/worker/patch_eagle3_init.py
@@ -32,6 +32,7 @@ checkpoint's global layer indices and keeps ``target_layer_count`` correct.
 
 Currently patches:
 - Eagle3LlamaForCausalLM (Qwen, LLaMA-based Eagle3 targets)
+- Eagle3Qwen3ForCausalLM (native Qwen3 Eagle3 targets)
 - Eagle3DeepseekV2ForCausalLM / Eagle3DeepseekV3ForCausalLM (DeepSeek-V2/V3,
   Kimi K2/K2.6)
 """
@@ -51,9 +52,11 @@ from vllm.model_executor.models.llama_eagle3 import (
     LlamaModel,
     get_draft_quant_config,
 )
+from vllm.model_executor.models.qwen3_eagle3 import Eagle3Qwen3ForCausalLM
 from vllm.model_executor.models.utils import maybe_prefix
 
 logger = logging.getLogger(__name__)
+_original_eagle3_qwen3_init = Eagle3Qwen3ForCausalLM.__init__
 
 
 def _patched_eagle3_llama_init(self, *, vllm_config, prefix: str = ""):
@@ -120,10 +123,23 @@ def _patched_eagle3_deepseek_v2_init(self, *, vllm_config, prefix: str = ""):
     )
 
 
+def _patched_eagle3_qwen3_init(self, *, vllm_config, prefix: str = ""):
+    model_config = vllm_config.model_config
+    original_get_num_layers = model_config.get_num_layers
+    total_num_layers = model_config.get_total_num_hidden_layers()
+    model_config.get_num_layers = lambda _: total_num_layers
+    try:
+        _original_eagle3_qwen3_init(self, vllm_config=vllm_config, prefix=prefix)
+    finally:
+        model_config.get_num_layers = original_get_num_layers
+
+
 Eagle3LlamaForCausalLM.__init__ = _patched_eagle3_llama_init
 Eagle3DeepseekV2ForCausalLM.__init__ = _patched_eagle3_deepseek_v2_init
+Eagle3Qwen3ForCausalLM.__init__ = _patched_eagle3_qwen3_init
 
 logger.info(
-    "Patched Eagle3LlamaForCausalLM and Eagle3DeepseekV2ForCausalLM "
+    "Patched Eagle3LlamaForCausalLM, Eagle3Qwen3ForCausalLM, and "
+    "Eagle3DeepseekV2ForCausalLM "
     "__init__ to use get_total_num_hidden_layers() for target_layer_num."
 )

--- a/vllm_ascend/patch/worker/patch_v2/patch_spec_decode_pp.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_spec_decode_pp.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+"""Speculative decoding support for Model Runner V2 PP."""
+
+from itertools import islice
+
+import numpy as np
+import torch
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.sequence import IntermediateTensors
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+
+_AUX_PREFIX = "eagle3_aux_"
+_FORWARD_PATCHED = "_vllm_ascend_eagle3_pp_forward_patched"
+_BROADCAST_PATCHED = "_vllm_ascend_spec_decode_pp_broadcast_patched"
+
+
+def _get_aux_states(
+    intermediate_tensors: IntermediateTensors | None,
+) -> list[torch.Tensor]:
+    if intermediate_tensors is None:
+        return []
+    keys = sorted(
+        (key for key in intermediate_tensors.tensors if key.startswith(_AUX_PREFIX)),
+        key=lambda key: int(key.removeprefix(_AUX_PREFIX)),
+    )
+    return [intermediate_tensors[key] for key in keys]
+
+
+def _qwen3_eagle3_pp_forward(
+    self,
+    input_ids: torch.Tensor | None,
+    positions: torch.Tensor,
+    intermediate_tensors: IntermediateTensors | None = None,
+    inputs_embeds: torch.Tensor | None = None,
+):
+    pp_group = get_pp_group()
+    aux_hidden_states = _get_aux_states(intermediate_tensors)
+
+    if pp_group.is_first_rank:
+        hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+        residual = None
+        self._maybe_add_hidden_state(aux_hidden_states, 0, hidden_states, residual)
+    else:
+        assert intermediate_tensors is not None
+        hidden_states = intermediate_tensors["hidden_states"]
+        residual = intermediate_tensors["residual"]
+
+    for layer_idx, layer in enumerate(
+        islice(self.layers, self.start_layer, self.end_layer),
+        start=self.start_layer,
+    ):
+        hidden_states, residual = layer(positions, hidden_states, residual)
+        self._maybe_add_hidden_state(
+            aux_hidden_states,
+            layer_idx + 1,
+            hidden_states,
+            residual,
+        )
+
+    if not pp_group.is_last_rank:
+        tensors = {"hidden_states": hidden_states, "residual": residual}
+        tensors.update({f"{_AUX_PREFIX}{idx}": aux_state for idx, aux_state in enumerate(aux_hidden_states)})
+        return IntermediateTensors(tensors)
+
+    if len(aux_hidden_states) != len(self.aux_hidden_state_layers):
+        raise RuntimeError(
+            "Eagle3 PP did not collect every auxiliary hidden state: "
+            f"expected {len(self.aux_hidden_state_layers)}, got {len(aux_hidden_states)}."
+        )
+    hidden_states, _ = self.norm(hidden_states, residual)
+    return hidden_states, aux_hidden_states
+
+
+def prepare_qwen3_eagle3_pp_forward() -> None:
+    """Patch before model loading so torch.compile captures the PP forward."""
+    from vllm.model_executor.models.qwen3 import Qwen3Model
+
+    if getattr(Qwen3Model, _FORWARD_PATCHED, False):
+        return
+    Qwen3Model.forward = _qwen3_eagle3_pp_forward
+    setattr(Qwen3Model, _FORWARD_PATCHED, True)
+
+
+def install_qwen3_eagle3_pp_aux(model):
+    inner_model = model.model
+    original_make_empty = inner_model.make_empty_intermediate_tensors
+    incoming_aux_count = sum(layer_idx <= inner_model.start_layer for layer_idx in inner_model.aux_hidden_state_layers)
+
+    def make_empty_intermediate_tensors(batch_size, dtype, device):
+        result = original_make_empty(batch_size, dtype, device)
+        for idx in range(incoming_aux_count):
+            result.tensors[f"{_AUX_PREFIX}{idx}"] = torch.zeros_like(result["hidden_states"])
+        return result
+
+    inner_model.make_empty_intermediate_tensors = make_empty_intermediate_tensors
+    return inner_model
+
+
+def install_spec_decode_pp_token_broadcast(pp_handler) -> None:
+    """Send accepted and next-draft tokens through the same V2 PP slot."""
+    if getattr(pp_handler, _BROADCAST_PATCHED, False):
+        return
+
+    max_sample_len = pp_handler.max_sample_len
+    draft_width = max_sample_len - 1
+    token_payload_width = max_sample_len + draft_width
+    original_get_prev_sampled_outputs = pp_handler.get_prev_sampled_outputs
+    original_broadcast = pp_handler.broadcast
+    pending_send = None
+
+    def get_prev_sampled_outputs():
+        slot = pp_handler.queue[0] if pp_handler.queue else None
+        outputs = original_get_prev_sampled_outputs()
+        if outputs is None:
+            return None
+        assert slot is not None
+        token_payload = outputs["sampled_tokens"]
+        outputs["sampled_tokens"] = token_payload[:, :max_sample_len]
+        outputs["draft_tokens"] = token_payload[:, max_sample_len:]
+
+        # Preserve valid rows on CPU; NPU bool indexing lowers to NonzeroV2.
+        freed = pp_handler.req_idx_gen_np[slot.idx_mapping_np] != slot.gen_at_receive_np
+        exclude_mask = freed | ~slot.need_sampled_mask
+        draft_update_indices = None
+        if exclude_mask.any():
+            valid_rows = np.flatnonzero(~exclude_mask)
+            update_indices = np.stack(
+                (valid_rows, slot.idx_mapping_np[valid_rows]),
+            )
+            draft_update_indices = async_copy_to_gpu(
+                update_indices,
+                device=pp_handler.device,
+            )
+        outputs["draft_update_indices"] = draft_update_indices
+        return outputs
+
+    def broadcast(sampled_token_ids, num_sampled, num_rejected, input_batch):
+        nonlocal pending_send
+        assert pp_handler.is_last_rank
+        if pending_send is not None:
+            raise RuntimeError("Speculative PP already has a pending sampled-token broadcast.")
+        pending_send = (
+            sampled_token_ids,
+            num_sampled,
+            num_rejected,
+            input_batch,
+        )
+
+    def broadcast_draft_tokens(draft_tokens):
+        nonlocal pending_send
+        if pending_send is None:
+            return
+
+        sampled_token_ids, num_sampled, num_rejected, input_batch = pending_send
+        pending_send = None
+        num_reqs = input_batch.num_reqs
+        token_payload = sampled_token_ids.new_zeros((num_reqs, token_payload_width))
+        token_payload[:, : sampled_token_ids.shape[1]].copy_(sampled_token_ids)
+        token_payload[:, max_sample_len:].copy_(draft_tokens)
+        original_broadcast(
+            token_payload,
+            num_sampled,
+            num_rejected,
+            input_batch,
+        )
+
+    pp_handler.max_sample_len = token_payload_width
+    pp_handler.get_prev_sampled_outputs = get_prev_sampled_outputs
+    pp_handler.broadcast = broadcast
+    pp_handler.broadcast_draft_tokens = broadcast_draft_tokens
+    setattr(pp_handler, _BROADCAST_PATCHED, True)

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -112,6 +112,30 @@ def flashcomm_dispatch_wrapper(vllm_config: VllmConfig):
         vllm_model_runner.dispatch_cg_and_sync_dp = original_dispatch
 
 
+def _is_eagle3_pp(vllm_config: VllmConfig) -> bool:
+    speculative_config = vllm_config.speculative_config
+    return (
+        speculative_config is not None
+        and speculative_config.method == "eagle3"
+        and vllm_config.model_config.architecture == "Qwen3ForCausalLM"
+        and vllm_config.parallel_config.pipeline_parallel_size > 1
+    )
+
+
+def _is_dsv4_mtp_pp(vllm_config: VllmConfig) -> bool:
+    speculative_config = vllm_config.speculative_config
+    return (
+        speculative_config is not None
+        and speculative_config.method == "mtp"
+        and vllm_config.model_config.architecture == "DeepseekV4ForCausalLM"
+        and vllm_config.parallel_config.pipeline_parallel_size > 1
+    )
+
+
+def _is_spec_decode_pp(vllm_config: VllmConfig) -> bool:
+    return _is_eagle3_pp(vllm_config) or _is_dsv4_mtp_pp(vllm_config)
+
+
 class NPUModelRunner(GPUModelRunner):
     """Model runner for Ascend NPUs."""
 
@@ -129,8 +153,29 @@ class NPUModelRunner(GPUModelRunner):
         if parallel_config.prefill_context_parallel_size > 1 or parallel_config.decode_context_parallel_size > 1:
             raise NotImplementedError("Context parallelism is not supported by Ascend NPU model runner v2.")
 
-        with torch_cuda_wrapper():
-            super().__init__(vllm_config, device)
+        is_spec_decode_pp = _is_spec_decode_pp(vllm_config)
+        is_eagle3_pp = _is_eagle3_pp(vllm_config)
+        speculative_config = vllm_config.speculative_config
+        if is_eagle3_pp:
+            assert speculative_config is not None
+            object.__setattr__(speculative_config, "method", "eagle")
+        try:
+            with torch_cuda_wrapper():
+                super().__init__(vllm_config, device)
+        finally:
+            if is_eagle3_pp:
+                object.__setattr__(speculative_config, "method", "eagle3")
+
+        if is_spec_decode_pp:
+            from vllm_ascend.patch.worker.patch_v2.patch_spec_decode_pp import (
+                install_spec_decode_pp_token_broadcast,
+            )
+
+            assert self.pp_handler is not None
+            install_spec_decode_pp_token_broadcast(self.pp_handler)
+
+        if is_eagle3_pp:
+            self.use_aux_hidden_state_outputs = True
 
         self.use_aclgraph = (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
@@ -154,11 +199,11 @@ class NPUModelRunner(GPUModelRunner):
         del self.input_buffers
         del self.speculator
 
-        # we define AscendEagleSpeculator in vllm_ascend.worker.v2.spec_decode.eagle.speculator
-        # init_speculator will return AscendEagleSpeculator when eagle is used.
-        # so here we just call init_speculator to reinitialize speculator.
+        # Reinitialize the Ascend speculator only where proposals are generated.
         self.speculator: AscendEagleSpeculator | None = None
-        if self.speculative_config is not None:
+        if self.speculative_config is not None and (
+            not is_spec_decode_pp or self.is_last_pp_rank
+        ):
             self.speculator = init_speculator(self.vllm_config, self.device)
             # Shared update_stream: main model (ModelAclGraphManager) and draft
             # (Eagle/DFlash/DSpark AclGraphManager) all use this same stream.
@@ -204,6 +249,65 @@ class NPUModelRunner(GPUModelRunner):
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
         set_potential_max_tokens(vllm_config)
+
+    def load_model(self, load_dummy_weights: bool = False, *args, **kwargs) -> None:
+        is_eagle3_pp = _is_eagle3_pp(self.vllm_config)
+        if is_eagle3_pp:
+            from vllm_ascend.patch.worker.patch_v2.patch_spec_decode_pp import (
+                install_qwen3_eagle3_pp_aux,
+                prepare_qwen3_eagle3_pp_forward,
+            )
+
+            prepare_qwen3_eagle3_pp_forward()
+
+        super().load_model(load_dummy_weights, *args, **kwargs)
+
+        if is_eagle3_pp:
+            inner_model = install_qwen3_eagle3_pp_aux(self.model)
+            self.model.make_empty_intermediate_tensors = inner_model.make_empty_intermediate_tensors
+            if not self.is_first_pp_rank:
+                self.intermediate_tensors = self.model.make_empty_intermediate_tensors(
+                    batch_size=self.max_num_tokens,
+                    dtype=self.model_config.dtype,
+                    device=self.device,
+                )
+
+    def sample_tokens(self, grammar_output):
+        input_batch = None
+        if _is_spec_decode_pp(self.vllm_config) and self.is_last_pp_rank and self.execute_model_state is not None:
+            input_batch = self.execute_model_state.input_batch
+
+        output = super().sample_tokens(grammar_output)
+        if input_batch is not None:
+            assert self.pp_handler is not None
+            # The base PP broadcast is deferred until propose() has populated
+            # the next-step draft tokens for this same in-flight slot.
+            draft_tokens = self.req_states.draft_tokens[input_batch.idx_mapping]
+            self.pp_handler.broadcast_draft_tokens(draft_tokens)
+        return output
+
+    def update_pp_decode_requests(self):
+        if not _is_spec_decode_pp(self.vllm_config):
+            return super().update_pp_decode_requests()
+
+        if self.pp_handler is None:
+            return
+        outputs = self.pp_handler.get_prev_sampled_outputs()
+        if outputs is None:
+            return
+
+        draft_tokens = outputs.pop("draft_tokens")
+        draft_update_indices = outputs.pop("draft_update_indices")
+        idx_mapping = outputs["idx_mapping"]
+        self.postprocess_sampled(**outputs)
+        # AsyncScheduler carries placeholders; every PP rank needs the actual
+        # draft tokens in its local RequestState before preparing the next step.
+        if draft_update_indices is None:
+            self.req_states.draft_tokens.index_copy_(0, idx_mapping, draft_tokens)
+        else:
+            draft_rows, draft_req_indices = draft_update_indices.unbind(dim=0)
+            valid_draft_tokens = draft_tokens.index_select(0, draft_rows)
+            self.req_states.draft_tokens.index_copy_(0, draft_req_indices, valid_draft_tokens)
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         with graph_manager_wrapper(self):
@@ -511,9 +615,7 @@ class NPUModelRunner(GPUModelRunner):
             query_start_loc,
         )
 
-        # Skip D2H copy without MTP: num_computed_tokens_cpu is synced
-        # from num_computed_tokens_np in _update_seq_lens_cpu instead.
-        if self.speculator is not None:
+        if self.speculator is not None or _is_spec_decode_pp(self.vllm_config):
             self._copy_num_computed_tokens_to_cpu()
 
     def _copy_num_computed_tokens_to_cpu(self):
@@ -536,20 +638,40 @@ class NPUModelRunner(GPUModelRunner):
         req_ids: list[str],
     ):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
-
-        # MTP needs D2H copy to get reverted num_computed_tokens after rejection.
-        # Without MTP, num_computed_tokens_np is already correct from update_requests.
-        if self.speculator is not None:
-            self.num_computed_tokens_event.synchronize()
+        if not _is_spec_decode_pp(self.vllm_config):
+            use_device_counts = self.speculator is not None
+            if use_device_counts:
+                self.num_computed_tokens_event.synchronize()
+            source = (
+                self.num_computed_tokens_cpu
+                if use_device_counts
+                else self.req_states.num_computed_tokens_np
+            )
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
                 req_index = self.req_states.req_id_to_index[req_id]
-                self.req_states.num_computed_tokens_cpu[req_index] = self.num_computed_tokens_cpu[req_index]
+                self.req_states.num_computed_tokens_cpu[req_index] = source[req_index]
         else:
-            for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
-                req_index = self.req_states.req_id_to_index[req_id]
-                self.req_states.num_computed_tokens_cpu[req_index] = self.req_states.num_computed_tokens_np[req_index]
+            cached_req_indices = [
+                self.req_states.req_id_to_index[req_id]
+                for req_id in scheduler_output.scheduled_cached_reqs.req_ids
+            ]
+            is_prefilling = (
+                self.req_states.num_computed_tokens_np[cached_req_indices]
+                < self.req_states.prefill_len.np[cached_req_indices]
+            )
+            if not is_prefilling.all():
+                self.num_computed_tokens_event.synchronize()
 
-        # update seq_lens_cpu
+            for req_index, req_is_prefilling in zip(cached_req_indices, is_prefilling):
+                # Non-final PP chunks have no sampled-token postprocess/D2H
+                # copy, so the scheduler count is authoritative in prefill.
+                source = (
+                    self.req_states.num_computed_tokens_np
+                    if req_is_prefilling
+                    else self.num_computed_tokens_cpu
+                )
+                self.req_states.num_computed_tokens_cpu[req_index] = source[req_index]
+
         for i, req_id in enumerate(req_ids):  # type: ignore
             req_index = self.req_states.req_id_to_index[req_id]
             num_computed_tokens = self.req_states.num_computed_tokens_cpu[req_index]


### PR DESCRIPTION
### What this PR does / why we need it?

Enable Qwen3 Eagle3 with pipeline parallelism on Model Runner V2 while reusing the existing `PPHandler` and request-state flow.

- Carry Eagle3 auxiliary hidden states across PP stages with global target-layer indices and matching dummy buffers.
- Bundle accepted target tokens and next-step draft tokens in one fixed-shape PP queue payload so all ranks update the same request state at the same pipeline slot.
- Create the speculative model only on the last PP rank, matching upstream MRV2 behavior.
- Keep Qwen3.5 MTP compatible with ACL graph model wrappers, hybrid GDN metadata, and PP rank-local multimodal encoder ownership.
- Keep chunked prefill on the scheduler-side token count until a decode step has produced the asynchronous device-to-host update.

### Does this PR introduce _any_ user-facing change?

Yes. Ascend MRV2 can run Qwen3 Eagle3 with pipeline parallelism; the shared PP state propagation also supports MTP.

### How was this patch tested?

- `python3 -m compileall` for all changed Python files.
- `git diff --check upstream/main...HEAD`.
- Qwen3 Eagle3 PP accuracy, chunked prefill, repeated requests, and Qwen3.5 MTP PP were exercised on NPU during development. The latest upstream rebase and code-only cleanup still require CI/NPU rerun.
- Local Ruff/pre-commit was not available; GitHub pre-commit is pending.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
