### PR TITLE
[SpecDecode][Performance] DSpark graph compile for model runner v1

### DIFF
--- a/vllm_ascend/patch/worker/patch_qwen3_dflash.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_dflash.py
@@ -10,7 +10,7 @@ def precompute_and_store_context_kv(
     self,
     context_states: torch.Tensor,
     context_positions: torch.Tensor,
-    context_slot_mapping: torch.Tensor | None = None,
+    context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
 ) -> None:
     if not hasattr(self, "_num_attn_layers"):
         self._build_fused_kv_buffers()

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -5,13 +5,15 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 
@@ -59,10 +61,13 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=self.dtype,
             device=self.device,
         )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
-        # Max query tokens depend on whether sampling from anchor or not.
-        self.max_query_tokens = self.max_batch_size * self.num_query_per_req
+        # DSpark ACLGraph is now supported; use_cuda_graph is inherited from
+        # AscendSpecDecodeBaseProposer (which checks runner._use_aclgraph() and
+        # speculative_config.enforce_eager).  Do NOT override it here.
+        # Keep enough capacity for both native DSpark query graphs and the
+        # target model's larger 1+N context/capture descriptors. Bonus-anchor
+        # DSpark also uses the full 1+N query width.
+        self.max_query_tokens = self.max_batch_size * (1 + self.num_speculative_tokens)
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -99,8 +104,24 @@ class AscendDSparkProposer(AscendDflashProposer):
         # per-gid context slot_mapping buffer
         self._per_group_context_slot_mapping_buffers: dict[int, torch.Tensor] = {}
 
+        # Populated by initialize_attn_backend after memory profiling and KV
+        # cache configuration have completed.
+        self._layer_group_idx: list[int] = []
+
         # per-layer context slot mappings as a flat list
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
+
+    def get_graph_num_input_tokens(self, batch_descriptor: BatchDescriptor) -> int:
+        """Use DSpark's native query width for uniform decode graphs.
+
+        The target verifies ``1 + N`` tokens per request, while anchor-first
+        DSpark only evaluates ``N`` query tokens. The target descriptor remains
+        the ACLGraph cache key, but the draft model and FIA graph are captured
+        with their own token count.
+        """
+        if batch_descriptor.uniform and batch_descriptor.num_reqs is not None:
+            return batch_descriptor.num_reqs * self.num_query_per_req
+        return batch_descriptor.num_tokens
 
     def initialize_attn_backend(self, kv_cache_config, kernel_block_sizes=None) -> None:
         # Find draft layers (attention layers added by draft model)
@@ -180,6 +201,24 @@ class AscendDSparkProposer(AscendDflashProposer):
             attn_group.kv_cache_group_id: torch.zeros(self.max_num_tokens, dtype=torch.int32, device=self.device)
             for attn_group in self.draft_attn_groups
         }
+        # Bind the per-layer view as soon as the persistent per-group buffers
+        # exist. ACLGraph capture runs before the first real request; delaying
+        # this binding until set_inputs_first_pass makes the Qwen context-KV
+        # precompute return early and permanently omits all cache-update ops
+        # from the captured graph.
+        self._bind_context_slot_mapping_buffers()
+
+    def _bind_context_slot_mapping_buffers(self) -> None:
+        """Bind each draft layer to its persistent context slot buffer.
+
+        The list itself is only model-facing bookkeeping. Its tensors are the
+        persistent per-group buffers populated in-place for every request, so
+        their addresses stay stable across ACLGraph capture and replay.
+        """
+        self._context_slot_mapping_buffers = [
+            self._per_group_context_slot_mapping_buffers[group_idx]
+            for group_idx in self._layer_group_idx
+        ]
 
     def set_per_group_attn_metadata(
         self,
@@ -213,12 +252,12 @@ class AscendDSparkProposer(AscendDflashProposer):
         num_sample_total = batch_size * self.num_speculative_tokens
         has_num_rejected = num_rejected_tokens_gpu is not None
         primary_gid = getattr(self, "kv_cache_gid", 0)
+        num_context = int(cad.query_start_loc_cpu[batch_size])
         self._per_group_block_table_buffers = {
             attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
             for attn_group in self.draft_attn_groups
         }
-        self._context_slot_mapping_buffers = None
-        self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
+        self._dflash_num_context = num_context
         self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
 
         token_indices_to_sample = torch.empty(
@@ -266,10 +305,9 @@ class AscendDSparkProposer(AscendDflashProposer):
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
             )
-        # to compute self._context_slot_mapping_buffers from dict to list
-        self._context_slot_mapping_buffers = [
-            self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx
-        ]
+        # Rebind defensively in case attention groups were rebuilt. The tensor
+        # objects remain the persistent buffers filled by the kernel above.
+        self._bind_context_slot_mapping_buffers()
 
         effective_seq_lens = cad.seq_lens
         if has_num_rejected:
@@ -311,7 +349,28 @@ class AscendDSparkProposer(AscendDflashProposer):
         **kwargs,
     ) -> None:
         num_query_total = num_reqs * self.num_query_per_req
-        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
+        # The target descriptor is based on the verification width (1 + N),
+        # but anchor-first DSpark's query backbone only consumes N tokens per
+        # request. Keep the descriptor for ACLGraph dispatch and capture the
+        # draft computation at its native width.
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and batch_descriptor is not None:
+            graph_query_tokens = self.get_graph_num_input_tokens(batch_descriptor)
+        else:
+            graph_query_tokens = num_query_total if num_reqs > 0 else num_tokens
+        num_query_tokens = min(graph_query_tokens, self.max_query_tokens)
+
+        # Context K/V precomputation consumes the target model's verification
+        # hidden states and therefore retains the original 1 + N token width.
+        # This is intentionally independent from num_query_tokens.
+        num_context_tokens = min(num_tokens, self.max_num_tokens)
+
+        # Memory profiling also enters dummy_run, but it runs before KV-cache
+        # initialization and therefore has no layer-to-group mapping yet. Bind
+        # only after initialize_attn_backend has created that mapping. The
+        # subsequent ACLGraph capture then records the context cache updates,
+        # while the pre-KV profile keeps the original no-cache behavior.
+        if getattr(self, "_layer_group_idx", None):
+            self._bind_context_slot_mapping_buffers()
 
         (
             num_input_tokens,
@@ -322,14 +381,93 @@ class AscendDSparkProposer(AscendDflashProposer):
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
-        context_positions = self._context_positions_buffer[:num_input_tokens]
-        context_states = self.hidden_states[:num_input_tokens]
+        context_positions = self._context_positions_buffer[:num_context_tokens]
+        context_states = self.hidden_states[:num_context_tokens]
+
+        # Build capture metadata for ACLGraph FULL mode, mirroring dFlash but
+        # with DSpark-specific query geometry and per-group block table / slot
+        # mapping.
+        multi_steps_attn_metadata: list[dict[str, Any]] = []
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.draft_attn_groups) > 0:
+            # The native DSpark graph normally has exactly N query tokens per
+            # captured request. Retain a fallback tail request only for
+            # non-uniform or externally padded descriptors.
+            qsl_cpu = (torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * self.num_query_per_req).to(
+                torch.int32
+            )
+            self.query_start_loc.cpu[: num_reqs + 1].copy_(qsl_cpu)
+            # Add virtual-request padding
+            num_reqs_padded = num_reqs
+            if self.query_start_loc.np[num_reqs] < num_input_tokens:
+                self.query_start_loc.np[num_reqs + 1] = num_input_tokens
+                num_reqs_padded = num_reqs + 1
+            self.query_start_loc.copy_to_gpu()
+
+            per_layer_attn_metadata: dict[str, Any] = {}
+            for attn_group in self.draft_attn_groups:
+                gid = attn_group.kv_cache_group_id
+                builder = attn_group.get_metadata_builder()
+                block_table = self._per_group_block_table_buffers.get(gid)
+                if block_table is None:
+                    # Fallback: read from runner's input_batch (populated during
+                    # _dummy_run per-kv-group loop).
+                    block_table = self.runner.input_batch.block_table[gid].get_device_tensor()[:num_reqs_padded]
+
+                # Pad block_table for the fallback virtual request above
+                # (mirrors the builder's own replay-path padding).
+                if block_table.shape[0] < num_reqs_padded:
+                    block_table = torch.cat(
+                        [
+                            block_table,
+                            block_table.new_zeros((num_reqs_padded - block_table.shape[0], block_table.shape[1])),
+                        ],
+                        dim=0,
+                    )
+
+                # Pad seq_lens for the dummy request; its KV length is
+                # irrelevant because the FIA output for padding tokens is
+                # ignored, but the list/tensor length must match
+                # num_reqs_padded.
+                seq_lens = self.runner.seq_lens[:num_reqs]
+                if seq_lens.shape[0] < num_reqs_padded:
+                    seq_lens = torch.cat([seq_lens, seq_lens.new_ones(num_reqs_padded - seq_lens.shape[0])])
+
+                common_attn_metadata = AscendCommonAttentionMetadata(
+                    query_start_loc=self.query_start_loc.gpu[: num_reqs_padded + 1],
+                    query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs_padded + 1],
+                    seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
+                    seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu,
+                    seq_lens=seq_lens,
+                    num_reqs=num_reqs_padded,
+                    num_actual_tokens=num_input_tokens,
+                    num_input_tokens=num_input_tokens,
+                    max_query_len=self.num_query_per_req,
+                    max_seq_len=0,
+                    slot_mapping=self._per_group_query_slot_mapping_buffers[gid][:num_input_tokens],
+                    positions=self.positions,
+                    attn_state=AscendAttentionState.ChunkedPrefill,
+                    causal=False,
+                    is_prefilling=torch.zeros(num_reqs_padded, dtype=torch.bool),
+                    block_table_tensor=block_table,
+                )
+
+                attn_metadata = builder.build_for_graph_capture(
+                    common_attn_metadata,
+                    AscendAttentionState.ChunkedPrefill,
+                )
+                attn_metadata.attn_mask = None
+                attn_metadata.attn_state = AscendAttentionState.ChunkedPrefill
+
+                for layer_name in attn_group.layer_names:
+                    per_layer_attn_metadata[layer_name] = attn_metadata
+
+            multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         self.token_indices_to_sample.fill_(0)
         self._pad_draft_buffers(num_query_total, num_input_tokens)
 
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
@@ -338,7 +476,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=[],
+            draft_attn_metadatas=multi_steps_attn_metadata,
         ):
             if is_profile:
                 self.model.precompute_and_store_context_kv(context_states, context_positions)
@@ -349,13 +487,17 @@ class AscendDSparkProposer(AscendDflashProposer):
                 )
 
             else:
-                self._dflash_num_context = num_input_tokens
+                self._dflash_num_context = num_context_tokens
                 self._runnable(
                     num_input_tokens=num_input_tokens,
                     batch_size=num_reqs,
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                     target_positions=self._get_positions(num_input_tokens),
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=[],
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
                     num_tokens=num_input_tokens,
                 )
+
+            forward_context = get_forward_context()
+            if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
+                self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -65,6 +65,7 @@ from vllm_ascend.utils import check_gdn_layer, enable_sp, lmhead_tp_enable, shar
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
+_GRAPH_PADDING_REQUEST_KV_LEN = 1
 
 
 # split hidden states along dimension of sequence
@@ -737,6 +738,16 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL:
             self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
+    def get_graph_num_input_tokens(self, batch_descriptor: BatchDescriptor) -> int:
+        """Return the token count used by the draft model graph.
+
+        Most speculative methods use the same padded token count as the
+        target model. Methods whose draft and verification geometries differ
+        can override this while retaining the target descriptor as the graph
+        dispatch key.
+        """
+        return batch_descriptor.num_tokens
+
     def _propose(
         self,
         # [num_tokens]
@@ -806,7 +817,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
                 num_tokens=num_tokens, uniform_decode=uniform_decode, has_lora=has_lora
             )
-            num_input_tokens = batch_descriptor.num_tokens
+            num_input_tokens = self.get_graph_num_input_tokens(batch_descriptor)
         else:
             num_input_tokens = num_tokens
 
@@ -820,7 +831,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
                 num_tokens=num_input_tokens, uniform_decode=uniform_decode, has_lora=has_lora
             )
-            num_input_tokens = batch_descriptor.num_tokens
+            num_input_tokens = self.get_graph_num_input_tokens(batch_descriptor)
         else:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
             batch_descriptor = None
@@ -834,14 +845,28 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             num_reqs = common_attn_metadata.query_start_loc.shape[0]
             self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
             self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
-            num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
-                self.query_start_loc,
-                num_input_tokens,
-                batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
-                common_attn_metadata.num_reqs,
-                aclgraph_runtime_mode,
-                batch_descriptor.num_reqs,
-            )
+            if self.method == "dspark":
+                # The native DSpark graph uses N tokens per request. It cannot
+                # use _pad_query_start_loc_for_fia because that helper assumes
+                # the target model's 1+N uniform-decode width. Usually no tail
+                # remains; preserve a fallback virtual request for a larger
+                # non-uniform or DP-padded draft bucket.
+                num_reqs_padded = common_attn_metadata.num_reqs
+                if self.query_start_loc.np[num_reqs_padded] < num_input_tokens:
+                    self.query_start_loc.np[num_reqs_padded + 1] = num_input_tokens
+                    num_reqs_padded += 1
+                self.query_start_loc.copy_to_gpu()
+            else:
+                num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
+                    self.query_start_loc,
+                    num_input_tokens,
+                    batch_descriptor.num_reqs
+                    if batch_descriptor.num_reqs is not None
+                    else common_attn_metadata.num_reqs,
+                    common_attn_metadata.num_reqs,
+                    aclgraph_runtime_mode,
+                    batch_descriptor.num_reqs,
+                )
             common_attn_metadata.num_reqs = num_reqs_padded
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
@@ -849,8 +874,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.block_table_tensor = self._adjust_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
-            if self.method == "dflash":
-                common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+            if self.method in ("dflash", "dspark"):
+                common_attn_metadata.seq_lens = self._adjust_parallel_draft_seq_lens_for_graph(
+                    common_attn_metadata.seq_lens, num_reqs_padded
+                )
             else:
                 common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
@@ -2022,12 +2049,20 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             draft_attn_metadatas=draft_attn_metadatas,
         )
 
+    def _adjust_parallel_draft_seq_lens_for_graph(self, seq_lens, desired_size):
+        # A padded DSpark request must have a positive KV length for FIA. DFlash
+        # keeps the existing zero-padding behavior. DSpark's native draft graph
+        # removes the per-request N versus N+1 token gap, but whole-request
+        # padding can still occur when dispatching to a larger batch bucket.
+        padding_value = _GRAPH_PADDING_REQUEST_KV_LEN if self.method == "dspark" else 0
+        return self._adjust_tensor(seq_lens, desired_size, padding_value=padding_value)
+
     # adjusting tensor into desired size
-    def _adjust_tensor(self, tensor, desired_size):
+    def _adjust_tensor(self, tensor, desired_size, padding_value=0):
         pad_size = desired_size - tensor.shape[0]
         if pad_size > 0:
             pad = [0] * (2 * tensor.dim() - 1) + [pad_size]
-            tensor = F.pad(tensor, pad, mode="constant", value=0)
+            tensor = F.pad(tensor, pad, mode="constant", value=padding_value)
         else:
             tensor = tensor[:desired_size]
         return tensor
@@ -2147,6 +2182,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 slot_mapping = self._per_group_query_slot_mapping_buffers[gid]
                 if slot_mapping is not None:
                     common_attn_metadata.slot_mapping = slot_mapping[:num_input_tokens]
+                # query_start_loc is already padded by _pad_query_start_loc_for_fia
+                # in the FULL graph path of _propose, so qsl[num_reqs] already
+                # equals num_input_tokens.  No tail-absorb or device-scalar
+                # check is needed here.
                 attn_metadata = builder.build_for_drafting(
                     common_attn_metadata, draft_index=1, **extra_attn_metadata_args
                 )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4791,11 +4791,12 @@ class NPUModelRunner(GPUModelRunner):
             and (
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_extract_hidden_states()
+                or self.speculative_config.use_dspark()
             )
         ):
             assert isinstance(
                 self.drafter,
-                AscendEagleProposer | AscendDflashProposer | AscendExtractHiddenStatesProposer,
+                AscendEagleProposer | AscendDflashProposer | AscendExtractHiddenStatesProposer | AscendDSparkProposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
@@ -4811,7 +4812,21 @@ class NPUModelRunner(GPUModelRunner):
         if self.use_aclgraph:
             set_graph_params(capture_sizes)
             if self.speculative_config:
-                set_draft_graph_params(capture_sizes)
+                draft_capture_sizes = capture_sizes
+                if self.drafter is not None:
+                    get_draft_graph_num_tokens = getattr(
+                        self.drafter,
+                        "get_graph_num_input_tokens",
+                        lambda desc: desc.num_tokens,
+                    )
+                    draft_capture_sizes = sorted(
+                        {
+                            get_draft_graph_num_tokens(desc)
+                            for _, descs in capture_descs
+                            for desc in descs
+                        }
+                    )
+                set_draft_graph_params(draft_capture_sizes)
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""


### PR DESCRIPTION
This PR can work for DSpark MRV1 but will not be merged due to complexity, if you need it just cherrypick it. Huge performance boost compared to eager mode.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
