### PR TITLE
[CI] Run full PR tests on 560T A3

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,8 +7,11 @@ self-hosted-runner:
     - linux-aarch64-310p-4
     - linux-aarch64-a3-1
     - linux-aarch64-a3-2
+    - linux-aarch64-a3-2-
     - linux-aarch64-a3-4
+    - linux-aarch64-a3-4-
     - linux-aarch64-a3-8
+    - linux-aarch64-a3-8-
     - linux-aarch64-a3-0
     - linux-aarch64-a3-0-cn12-001
     - linux-amd64-cpu-2-hk

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -273,16 +273,21 @@ jobs:
 
       - name: Select tests based on changed files
         id: scope
-        if: steps.filter.outputs.src == 'true'
+        if: ${{ steps.filter.outputs.src == 'true' || contains(github.event.pull_request.labels.*.name, 'ready') }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install regex
+          RUN_ALL_MODULES_FLAG=""
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'ready') }}" = "true" ]; then
+            RUN_ALL_MODULES_FLAG="--run-all-modules"
+          fi
           python3 .github/workflows/scripts/select_tests.py \
+            ${RUN_ALL_MODULES_FLAG} \
             --diff-base ${{ steps.source-snapshot.outputs.base_sha }}
 
       - name: Set no-tests output when source paths unchanged
         id: noop
-        if: steps.filter.outputs.src != 'true'
+        if: ${{ steps.filter.outputs.src != 'true' && !contains(github.event.pull_request.labels.*.name, 'ready') }}
         run: |
           {
             echo "has_tests=false"

--- a/.github/workflows/scripts/runner_label.json
+++ b/.github/workflows/scripts/runner_label.json
@@ -17,19 +17,19 @@
         "image_tag": "9.1.0-beta.1-310p-ubuntu22.04-py3.12",
         "csrc_cache_target": "310p-arm64-ubuntu"
     },
-    "linux-aarch64-a3-2": {
+    "linux-aarch64-a3-2-": {
         "chip": "a3",
         "npu_num": 2,
         "image_tag": "9.0.1-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-4": {
+    "linux-aarch64-a3-4-": {
         "chip": "a3",
         "npu_num": 4,
         "image_tag": "9.0.1-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-8": {
+    "linux-aarch64-a3-8-": {
         "chip": "a3",
         "npu_num": 8,
         "image_tag": "9.0.1-a3-ubuntu22.04-py3.12",


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables ready-labeled PR runs to select all configured test modules and routes A3 selected-test jobs to the 560T runner labels.

Changes:
- Use `--run-all-modules` in `pr_test.yaml` when the PR has the `ready` label.
- Route A3 x2/x4/x8 selected tests to `linux-aarch64-a3-2-`, `linux-aarch64-a3-4-`, and `linux-aarch64-a3-8-`.
- Add the 560T runner labels to actionlint config.

### Does this PR introduce _any_ user-facing change?

No. This only changes CI runner selection and test selection behavior.

### How was this patch tested?

- `python .github/workflows/scripts/select_tests.py --changed-files vllm_ascend/envs.py --run-all-modules`
  - Verified the generated A3 groups route to `linux-aarch64-a3-2-`, `linux-aarch64-a3-4-`, and `linux-aarch64-a3-8-`.
- Parsed `.github/workflows/pr_test.yaml`, `.github/actionlint.yaml`, and `.github/workflows/scripts/runner_label.json` locally.
- `git diff --check`
- `python -m pytest -q .github/workflows/scripts/test_select_tests.py` on Windows: 9 passed, 3 existing path-separator-related assertions failed locally.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
