### PR TITLE
[CI]When the PR modifies any files in the CSRC folder, skip the test case filtering logic and execute all test cases by default.

### DIFF
--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -689,18 +689,19 @@ class TestSelector:
                             if covered_in_func:
                                 # Get intersection of test covered lines and actual changed lines (for display)
                                 covered_changed_lines = covered_lines & display_changed_lines
-                                func_to_tests[func_name].append((test_case, covered_changed_lines))
+                                func_to_tests[func_name].append((test_case, covered_in_func, covered_changed_lines))
 
                 # Select tests that cover other lines of changed functions (deduplication)
                 for changed_file, func_to_lines in changed_functions.items():
                     for func_name in func_to_lines:
                         if func_name in func_to_tests:
-                            for test_case, covered_changed_lines in func_to_tests[func_name]:
+                            for test_case, covered_in_func, covered_changed_lines in func_to_tests[func_name]:
                                 existing = [s[0] for s in func_results]
-                                if test_case not in existing and covered_changed_lines:
-                                    # Display actual changed line coverage, not full function coverage
+                                if test_case not in existing and covered_in_func:
+                                    # Display changed lines coverage if available, otherwise function coverage
                                     display_lines = covered_changed_lines if covered_changed_lines else set()
-                                    func_results.append((test_case, {changed_file: display_lines}, len(display_lines)))
+                                    func_results.append((test_case, {changed_file: display_lines}, len(display_lines) or len(covered_in_func)))
+                                    print(f"  [Function match] {test_case} covers function '{func_name}' in {changed_file}")
 
                 func_results.sort(key=lambda x: x[2], reverse=True)
 
@@ -723,6 +724,7 @@ class TestSelector:
             selected.sort(key=lambda x: x[2], reverse=True)
 
             if selected:
+                print(f"  Line match: {len(line_results)} tests, Function match: {len(func_results)} tests, Total: {len(selected)} tests")
                 return selected, "line+function"
 
             # ===== Stage 3: Function-level matching (only when first two levels are empty) =====
@@ -1108,6 +1110,11 @@ def main():
         change_detector.scan_source_files()
         changed_files_with_lines = change_detector.detect_changes_by_comparison()
         print(f"Detected {len(changed_files_with_lines)} changed files")
+
+    if not changed_files_with_lines:
+        print("\n=== No product source code changes found in PR ===")
+        print("skipping test recommendation.")
+        return
 
     # 3. Select test cases
     print("\n=== Selecting Affected Test Cases ===")

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -700,10 +700,17 @@ class TestSelector:
                                 if test_case not in existing and covered_in_func:
                                     # Display changed lines coverage if available, otherwise function coverage
                                     display_lines = covered_changed_lines if covered_changed_lines else set()
-                                    func_results.append((test_case, {changed_file: display_lines}, len(display_lines)
-                                                         or len(covered_in_func)))
-                                    print(f"  [Function match] {test_case} covers function '{func_name}' in"
-                                          f" {changed_file}")
+                                    func_results.append(
+                                        (
+                                            test_case,
+                                            {changed_file: display_lines},
+                                            len(display_lines) or len(covered_in_func),
+                                        )
+                                    )
+                                    print(
+                                        f"  [Function match] {test_case} covers function '{func_name}' in"
+                                        f" {changed_file}"
+                                    )
 
                 func_results.sort(key=lambda x: x[2], reverse=True)
 
@@ -726,8 +733,10 @@ class TestSelector:
             selected.sort(key=lambda x: x[2], reverse=True)
 
             if selected:
-                print(f"  Line match: {len(line_results)} tests, Function match: {len(func_results)} tests, "
-                      f"Total: {len(selected)} tests")
+                print(
+                    f"  Line match: {len(line_results)} tests, Function match: {len(func_results)} tests, "
+                    f"Total: {len(selected)} tests"
+                )
                 return selected, "line+function"
 
             # ===== Stage 3: Function-level matching (only when first two levels are empty) =====

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -86,6 +86,33 @@ def _get_test_files_from_pr_diff(diff_file: str) -> list[str]:
     return test_files_found
 
 
+def _has_csrc_changes(diff_file: str) -> bool:
+    """
+    Check if diff file contains changes to csrc directory.
+    If csrc changes detected, full test suite should be run.
+
+    Args:
+        diff_file: Path to the PR diff file
+
+    Returns:
+        True if csrc directory changes detected, False otherwise
+    """
+    try:
+        with open(diff_file, encoding="utf-8") as f:
+            diff_content = f.read()
+    except Exception as e:
+        print(f"  Warning: Failed to read diff file for csrc detection: {e}")
+        return False
+
+    # Pattern to match csrc directory in diff paths (csrc as root directory)
+    # Match lines like: +++ b/csrc/xxx.cpp or --- a/csrc/xxx.cpp
+    csrc_pattern = re.compile(r"^\+{3} [ab]/csrc/|^\-{3} a/csrc/", re.MULTILINE)
+    if csrc_pattern.search(diff_content):
+        print("  CSRC directory changes detected in PR diff")
+        return True
+    return False
+
+
 def _get_deleted_test_files_from_pr(diff_file: str, test_case_map: dict) -> list[str]:
     """
     Extract deleted test files from PR diff.
@@ -1119,6 +1146,39 @@ def main():
         print(f"  PR diff saved to: {diff_file}")
         changed_files_with_lines = change_detector.parse_pr_diff_file(diff_file)
         print(f"Parsed {len(changed_files_with_lines)} changed files")
+
+        # Check if csrc directory changes detected - if so, run full test suite
+        # NOTE: csrc files are not .py, so they don't appear in changed_files_with_lines
+        # We must check before the "if not changed_files_with_lines" return
+        if _has_csrc_changes(diff_file):
+            print("\n=== CSRC Directory Changes Detected - Running Full Test Suite ===")
+            # Use all tests from test_case_map (full coverage)
+            selected = [(test_name, {}, 0) for test_name in selector.test_case_map.keys()]
+
+            # Add new/modified test files from PR
+            test_file_tests = _get_test_files_from_pr_diff(diff_file)
+            existing_test_names = set(s[0] for s in selected)
+            for test_name in test_file_tests:
+                if test_name not in existing_test_names:
+                    selected.append((test_name, {}, 0))
+
+            # Remove deleted test files from PR
+            deleted_tests = _get_deleted_test_files_from_pr(diff_file, selector.test_case_map)
+            if deleted_tests:
+                print("\n=== Deleted Test Files in PR (Full Suite Mode) ===")
+                print(f"Removing {len(deleted_tests)} deleted test file(s): {deleted_tests}")
+                deleted_set = set(deleted_tests)
+                selected = [(name, detail, count) for name, detail, count in selected if name not in deleted_set]
+
+            # Skip select_tests, go directly to output
+            test_names = [s[0] for s in selected]
+            print(f"\n=== Recommended Test Cases ({len(test_names)} tests - Full Suite) ===")
+            print(test_names)
+            with open("recommended_pytest_paths.txt", "w", encoding="utf-8") as f:
+                for test_name in test_names:
+                    f.write(test_name + "\n")
+            print("\nResults saved to: recommended_pytest_paths.txt")
+            return
     else:
         # Get from file comparison (default)
         change_detector.scan_source_files()

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -1114,6 +1114,10 @@ def main():
     if not changed_files_with_lines:
         print("\n=== No product source code changes found in PR ===")
         print("skipping test recommendation.")
+        # Write empty result file
+        with open("recommended_pytest_paths.txt", "w", encoding="utf-8") as f:
+            pass
+        print("\nResults saved to: recommended_pytest_paths.txt")
         return
 
     # 3. Select test cases

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -700,8 +700,10 @@ class TestSelector:
                                 if test_case not in existing and covered_in_func:
                                     # Display changed lines coverage if available, otherwise function coverage
                                     display_lines = covered_changed_lines if covered_changed_lines else set()
-                                    func_results.append((test_case, {changed_file: display_lines}, len(display_lines) or len(covered_in_func)))
-                                    print(f"  [Function match] {test_case} covers function '{func_name}' in {changed_file}")
+                                    func_results.append((test_case, {changed_file: display_lines}, len(display_lines)
+                                                         or len(covered_in_func)))
+                                    print(f"  [Function match] {test_case} covers function '{func_name}' in"
+                                          f" {changed_file}")
 
                 func_results.sort(key=lambda x: x[2], reverse=True)
 
@@ -724,7 +726,8 @@ class TestSelector:
             selected.sort(key=lambda x: x[2], reverse=True)
 
             if selected:
-                print(f"  Line match: {len(line_results)} tests, Function match: {len(func_results)} tests, Total: {len(selected)} tests")
+                print(f"  Line match: {len(line_results)} tests, Function match: {len(func_results)} tests, "
+                      f"Total: {len(selected)} tests")
                 return selected, "line+function"
 
             # ===== Stage 3: Function-level matching (only when first two levels are empty) =====

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -61,10 +61,12 @@ def _get_test_files_from_pr_diff(diff_file: str) -> list[str]:
         print(f"  Warning: Failed to read diff file for test file detection: {e}")
         return test_files_found
 
-    # Pattern to match test file paths: tests/[subdirs/]test_*.py
+    # Pattern to match test file paths: tests/e2e/pull_request/ or tests/ut/ directory
     # In diff output: +++ b/tests/ut/core/test_xxx.py
-    # Test files must be in tests/ directory and start with test_
-    test_file_pattern = re.compile(r"^\+\+\+ [ab]/(tests/.+/test_\w+\.py)", re.MULTILINE)
+    # Test files must be in tests/e2e/pull_request/ or tests/ut/ directory and start with test_
+    test_file_pattern = re.compile(
+        r"^\+\+\+ [ab]/(?:tests/e2e/pull_request(?:/.+)?/test_\w+\.py|tests/ut(?:/.+)?/test_\w+\.py)", re.MULTILINE
+    )
 
     changed_test_files = set()
     for match in test_file_pattern.finditer(diff_content):

--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -65,7 +65,7 @@ def _get_test_files_from_pr_diff(diff_file: str) -> list[str]:
     # In diff output: +++ b/tests/ut/core/test_xxx.py
     # Test files must be in tests/e2e/pull_request/ or tests/ut/ directory and start with test_
     test_file_pattern = re.compile(
-        r"^\+\+\+ [ab]/(?:tests/e2e/pull_request(?:/.+)?/test_\w+\.py|tests/ut(?:/.+)?/test_\w+\.py)", re.MULTILINE
+        r"^\+\+\+ [ab]/(tests/e2e/pull_request(?:/.+)?/test_\w+\.py|tests/ut(?:/.+)?/test_\w+\.py)", re.MULTILINE
     )
 
     changed_test_files = set()


### PR DESCRIPTION
### What this PR does / why we need it?
When the PR modifies any files in the CSRC folder, skip the test case filtering logic and execute all test cases by default.

### Does this PR introduce _any_ user-facing change?
No. This PR does not introduce any user-facing changes.
### How was this patch tested?
The following scenarios have been manually verified:

When the PR modifies files in the CSRC folder, the full test suite is executed as expected.

For changes in folders other than CSRC, the process follows the original workflow without any regression.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
