### PR TITLE
[BugFix][v0.23.0] Fix SFA async all-gather tensor lifetime with Task Queue

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -75,42 +75,6 @@ class TestAscendSFABackend(TestBase):
         self.assertIsNotNone(impl_cls)
 
 
-class TestAscendSFABytePackedGather(TestBase):
-    @patch("vllm_ascend.attention.sfa_v1.get_tp_group")
-    def test_byte_packed_gather_preserves_mixed_dtype_tensors(self, mock_get_tp_group):
-        mock_get_tp_group.return_value = SimpleNamespace(world_size=1)
-        sfa_kv = torch.arange(12, dtype=torch.float16).view(2, 6)
-        k_li = torch.arange(16, dtype=torch.int8).view(2, 1, 8)
-        k_li_scale = torch.arange(2, dtype=torch.float32).view(2, 1)
-
-        gathered, handle, metadata = AscendSFAImpl._all_gather_byte_packed_async(
-            [
-                ("sfa_kv", sfa_kv),
-                ("k_li", k_li),
-                ("k_li_scale", k_li_scale),
-            ],
-            async_op=True,
-        )
-
-        self.assertIsNone(handle)
-        self.assertEqual(gathered.dtype, torch.int8)
-        restored = AscendSFAImpl._restore_byte_gathered_tensors(gathered, metadata)
-        for name, expected in (("sfa_kv", sfa_kv), ("k_li", k_li), ("k_li_scale", k_li_scale)):
-            self.assertEqual(restored[name].shape, expected.shape)
-            self.assertEqual(restored[name].dtype, expected.dtype)
-            self.assertTrue(torch.equal(restored[name], expected))
-
-    def test_byte_packed_gather_rejects_mismatched_token_counts(self):
-        with self.assertRaisesRegex(RuntimeError, "different token counts"):
-            AscendSFAImpl._all_gather_byte_packed_async(
-                [
-                    ("sfa_kv", torch.zeros(2, 6, dtype=torch.float16)),
-                    ("k_li", torch.zeros(3, 8, dtype=torch.int8)),
-                ],
-                async_op=True,
-            )
-
-
 class TestAscendSFADeviceOperator(TestBase):
     def _make_common_inputs(self):
         ql_nope = torch.randn(3, 4, 8)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1728,7 +1728,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 fused_kv_no_split, kv_ag_handle = all_gather_async(
                     fused_kv_input,
                     get_tp_group(),
-                    async_op=async_op,
+                    async_op=False,
                 )
                 if kv_ag_handle is not None:
                     kv_ag_handles.append(kv_ag_handle)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -80,14 +80,6 @@ if TYPE_CHECKING:
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
 
-
-class _ByteGatherPart(NamedTuple):
-    name: str
-    shape: tuple[int, ...]
-    dtype: torch.dtype
-    num_bytes_per_row: int
-
-
 O_PROJ_ACLNN_INPUT_PARAMS = (
     "aclnn_input_scale",
     "aclnn_input_scale_reciprocal",
@@ -1197,70 +1189,6 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             return attn_output, True
 
-    @staticmethod
-    def _flatten_for_byte_gather(tensor: torch.Tensor) -> tuple[torch.Tensor, int]:
-        if tensor.dim() == 0:
-            raise RuntimeError("Byte-packed all-gather requires tensors with a token dimension.")
-        tensor = tensor.contiguous()
-        num_rows = tensor.shape[0]
-        num_bytes_per_row = tensor.element_size()
-        for dim in tensor.shape[1:]:
-            num_bytes_per_row *= dim
-        return tensor.view(torch.int8).view(num_rows, num_bytes_per_row), num_bytes_per_row
-
-    @classmethod
-    def _all_gather_byte_packed_async(
-        cls,
-        parts: list[tuple[str, torch.Tensor]],
-        async_op: bool,
-    ) -> tuple[torch.Tensor, torch.distributed.Work | None, tuple[_ByteGatherPart, ...]]:
-        if not parts:
-            raise RuntimeError("Byte-packed all-gather requires at least one tensor.")
-
-        packed_parts = []
-        metadata = []
-        expected_num_rows: int | None = None
-        for name, tensor in parts:
-            num_rows = tensor.shape[0]
-            if expected_num_rows is None:
-                expected_num_rows = num_rows
-            elif num_rows != expected_num_rows:
-                raise RuntimeError(
-                    "Cannot byte-pack KV tensors with different token counts: "
-                    f"expected {expected_num_rows}, got {num_rows} for {name}."
-                )
-
-            packed_tensor, num_bytes_per_row = cls._flatten_for_byte_gather(tensor)
-            packed_parts.append(packed_tensor)
-            metadata.append(
-                _ByteGatherPart(
-                    name=name,
-                    shape=tuple(tensor.shape),
-                    dtype=tensor.dtype,
-                    num_bytes_per_row=num_bytes_per_row,
-                )
-            )
-
-        packed_input = torch.cat(packed_parts, dim=1) if len(packed_parts) > 1 else packed_parts[0]
-        gathered, handle = all_gather_async(
-            packed_input,
-            get_tp_group(),
-            async_op=async_op,
-        )
-        return gathered, handle, tuple(metadata)
-
-    @staticmethod
-    def _restore_byte_gathered_tensors(
-        gathered: torch.Tensor,
-        metadata: tuple[_ByteGatherPart, ...],
-    ) -> dict[str, torch.Tensor]:
-        chunks = torch.split(gathered, [part.num_bytes_per_row for part in metadata], dim=1)
-        num_rows = gathered.shape[0]
-        restored = {}
-        for part, chunk in zip(metadata, chunks):
-            restored[part.name] = chunk.contiguous().view(part.dtype).view(num_rows, *part.shape[1:])
-        return restored
-
     def _get_full_kv(self, k, attn_metadata):
         return k
 
@@ -1779,8 +1707,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 assert k_nope is not None
                 async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
                 kv_ag_handles = []
-                # Pack all KV-related tensors into one byte stream so DSA-CP only
-                # submits one KV all-gather while still preserving original dtypes.
+                # support all_gather kv async for communication calculation overlap
                 if self.enable_sparse_sfa_c8:
                     assert knope_scale is not None
                     fused_kv_parts = [
@@ -1793,25 +1720,37 @@ class AscendSFAImpl(MLAAttentionImpl):
                         k_pe.view(-1, k_pe.shape[-1]),
                         k_nope.view(-1, k_nope.shape[-1]),
                     ]
+                    if self.has_indexer and not self.enable_sparse_li_c8:
+                        assert k_li is not None
+                        fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
 
                 fused_kv_input = torch.cat(fused_kv_parts, dim=1)
-                kv_gather_parts = [("sfa_kv", fused_kv_input)]
-                if self.has_indexer:
-                    assert k_li is not None
-                    k_li_gather_input = k_li
-                    if not self.enable_sparse_sfa_c8 and not self.enable_sparse_li_c8:
-                        k_li_gather_input = k_li.view(-1, k_li.shape[-1])
-                    kv_gather_parts.append(("k_li", k_li_gather_input))
-                if self.has_indexer and self.enable_sparse_li_c8:
-                    assert k_li_scale is not None
-                    kv_gather_parts.append(("k_li_scale", k_li_scale))
-
-                kv_gathered_bytes, kv_ag_handle, kv_gather_metadata = self._all_gather_byte_packed_async(
-                    kv_gather_parts,
+                fused_kv_no_split, kv_ag_handle = all_gather_async(
+                    fused_kv_input,
+                    get_tp_group(),
                     async_op=async_op,
                 )
                 if kv_ag_handle is not None:
                     kv_ag_handles.append(kv_ag_handle)
+
+                if self.has_indexer and (self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8):
+                    assert k_li is not None
+                    k_li, kv_ag_handle = all_gather_async(
+                        k_li,
+                        get_tp_group(),
+                        async_op=async_op,
+                    )
+                    if kv_ag_handle is not None:
+                        kv_ag_handles.append(kv_ag_handle)
+                if self.has_indexer and self.enable_sparse_li_c8:
+                    assert k_li_scale is not None
+                    k_li_scale, kv_ag_handle = all_gather_async(
+                        k_li_scale,
+                        get_tp_group(),
+                        async_op=async_op,
+                    )
+                    if kv_ag_handle is not None:
+                        kv_ag_handles.append(kv_ag_handle)
 
             ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
             q_pe = self.rope_single(q_pe, cos, sin)
@@ -1820,12 +1759,6 @@ class AscendSFAImpl(MLAAttentionImpl):
             if self.enable_dsa_cp:
                 for kv_ag_handle in kv_ag_handles:
                     kv_ag_handle.wait()
-                kv_gather_outputs = self._restore_byte_gathered_tensors(kv_gathered_bytes, kv_gather_metadata)
-                fused_kv_no_split = kv_gather_outputs["sfa_kv"]
-                if self.has_indexer:
-                    k_li = kv_gather_outputs["k_li"]
-                    if self.enable_sparse_li_c8:
-                        k_li_scale = kv_gather_outputs["k_li_scale"]
 
                 if self.enable_dsa_cp_with_layer_shard:
                     for layer in self.layer_sharding_kwargs or []:
@@ -1856,6 +1789,16 @@ class AscendSFAImpl(MLAAttentionImpl):
                         )
                         k_pe = None
                         k_nope = None
+                    elif not self.has_indexer:
+                        k_pe, k_nope = fused_kv_no_split.split(
+                            [self.qk_rope_head_dim, self.kv_lora_rank],
+                            dim=-1,
+                        )
+                    elif not self.enable_sparse_li_c8:
+                        k_pe, k_nope, k_li = fused_kv_no_split.split(
+                            [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
+                            dim=-1,
+                        )
                     else:
                         k_pe, k_nope = fused_kv_no_split.split(
                             [self.qk_rope_head_dim, self.kv_lora_rank],

--- a/vllm_ascend/distributed/utils.py
+++ b/vllm_ascend/distributed/utils.py
@@ -8,6 +8,25 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.distributed.parallel_state import get_fc3_quant_x_group
 
 
+class TensorHoldingWork:
+    """Proxy async work while retaining its input and output tensors."""
+
+    def __init__(self, work: torch.distributed.Work, input: torch.Tensor, output: torch.Tensor):
+        self._work = work
+        self._input: torch.Tensor | None = input
+        self._output: torch.Tensor | None = output
+
+    def wait(self, *args, **kwargs):
+        completed = self._work.wait(*args, **kwargs)
+        if completed is not False:
+            self._input = None
+            self._output = None
+        return completed
+
+    def __getattr__(self, name):
+        return getattr(self._work, name)
+
+
 def get_decode_context_model_parallel_world_size() -> int:
     """Return DCP world size (v0.21.0 helper removed on vLLM main)."""
     return get_dcp_group().world_size
@@ -56,7 +75,10 @@ def all_gather_async(
         input_size = input.size()
         output_size = (input_size[0] * group.world_size,) + input_size[1:]
         output = torch.empty(output_size, dtype=input.dtype, device=input.device)
-    return output, dist.all_gather_into_tensor(output, input, group=group.device_group, async_op=async_op)
+    work = dist.all_gather_into_tensor(output, input, group=group.device_group, async_op=async_op)
+    if work is None:
+        return output, None
+    return output, TensorHoldingWork(work, input, output)
 
 
 def split_tensor_along_first_dim(


### PR DESCRIPTION
## Summary

This PR fixes a first-request correctness issue in SFA when the following features are enabled together:

- Task Queue
- DSA-CP
- SFA C8

Under this configuration, GLM-5.2 may produce garbled or repetitive output for the first request after service startup. Subsequent requests are typically correct.

## Root Cause

SFA launches several asynchronous all-gather operations and overlaps them with subsequent computation.

With Task Queue enabled, the collective may execute after the Python call has returned. The input or output tensor storage can therefore be released or reused before the asynchronous work has completed if its lifetime is not explicitly tied to the `Work` object.

This creates a potential use-after-free or buffer-reuse race and may result in silent data corruption.

## Changes

- Revert `ca06c9d` / #12867, restoring the separate SFA KV all-gather operations.
- Add `TensorHoldingWork`, a proxy for `torch.distributed.Work`.
- Keep the all-gather input and output tensors alive until `wait()` confirms completion.
- Release the retained tensor references after successful completion.
- Preserve the original `Work` interface by forwarding other attributes and methods.
- Keep tensors retained when `wait()` reports incomplete work.
- Leave synchronous all-gather behavior unchanged.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
