### PR TITLE
[Perf][Model] Fuse Kimi K3 residual and sigmoid RMSNorm gate

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fused_ops.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fused_ops.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.kimi_k3 import fused_attention_residual
+from vllm_ascend.ops.triton.layernorm_gated import layer_norm_fwd_npu
+
+
+@pytest.mark.parametrize("num_tokens", [1, 32])
+def test_kimi_k3_fused_attention_residual(num_tokens: int):
+    torch.manual_seed(0)
+    hidden_size = 7168
+    num_residuals = 4
+    eps = 1e-5
+    prefix_sum = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16).npu()
+    block_residual = torch.randn(
+        num_tokens,
+        num_residuals,
+        hidden_size,
+        dtype=torch.bfloat16,
+    ).npu()
+    projection_weight = (torch.randn(hidden_size, dtype=torch.bfloat16) * 0.01).npu()
+    norm_weight = torch.randn(hidden_size, dtype=torch.bfloat16).npu()
+
+    actual = fused_attention_residual(
+        prefix_sum,
+        block_residual,
+        projection_weight,
+        norm_weight,
+        eps,
+    )
+
+    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1).float()
+    inverse_rms = torch.rsqrt(values.square().mean(-1) + eps)
+    scores = torch.matmul(values, (norm_weight * projection_weight).float()) * inverse_rms
+    probabilities = scores.softmax(-1)
+    expected = torch.sum(probabilities.unsqueeze(-1) * values, dim=1).to(prefix_sum.dtype)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_kimi_k3_fused_rmsnorm_sigmoid_gate():
+    torch.manual_seed(0)
+    eps = 1e-5
+    x = torch.randn(33, 128, dtype=torch.bfloat16).npu()
+    gate = torch.randn_like(x)
+    weight = torch.randn(128, dtype=torch.bfloat16).npu()
+
+    actual, _, _ = layer_norm_fwd_npu(
+        x,
+        weight,
+        None,
+        eps,
+        z=gate,
+        norm_before_gate=True,
+        is_rms_norm=True,
+        activation="sigmoid",
+    )
+
+    x_fp32 = x.float()
+    expected = x_fp32 * torch.rsqrt(x_fp32.square().mean(-1, keepdim=True) + eps)
+    expected = (expected * weight.float() * gate.float().sigmoid()).to(x.dtype)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)

--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -464,6 +464,33 @@ def test_text_model_captures_materialized_dspark_aux_stream(monkeypatch: pytest.
     assert [layer_idx for layer_idx, _ in residual_calls] == [1, 0]
 
 
+def test_kimi_k3_attention_residual_uses_fused_kernel(monkeypatch: pytest.MonkeyPatch):
+    prefix_sum = torch.randn(2, 4)
+    block_residual = torch.randn(2, 3, 4)
+    projection = SimpleNamespace(weight=torch.randn(1, 4))
+    norm = SimpleNamespace(weight=torch.randn(4), variance_epsilon=1e-5)
+    expected = torch.randn_like(prefix_sum)
+    captured: dict[str, object] = {}
+
+    def fake_fused_attention_residual(*args):
+        captured["args"] = args
+        return expected
+
+    monkeypatch.setattr(kimi_k3, "fused_attention_residual", fake_fused_attention_residual)
+    monkeypatch.setattr(kimi_k3._EXTRA_CTX, "flash_comm_v1_enabled", False)
+
+    actual = kimi_k3._apply_attention_residual(prefix_sum, block_residual, projection, norm)
+
+    assert actual is expected
+    args = captured["args"]
+    assert isinstance(args, tuple)
+    assert args[0] is prefix_sum
+    assert args[1] is block_residual
+    torch.testing.assert_close(args[2], projection.weight.squeeze(0))
+    assert args[3] is norm.weight
+    assert args[4] == norm.variance_epsilon
+
+
 def test_kimi_k3_dspark_aux_capture_mode_is_forwarded():
     causal_model = AscendKimiK3ForCausalLM.__new__(AscendKimiK3ForCausalLM)
     nn.Module.__init__(causal_model)

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -20,6 +20,9 @@ from unittest.mock import patch
 import pytest
 import torch
 from torch import nn
+from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
+    KimiGatedDeltaNetAttention,
+)
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload import (
     finalize_layerwise_reload,
@@ -109,6 +112,57 @@ def _expected_packed_conv_weights(
         ],
         dim=1,
     ).to(attention.model_config.dtype)
+
+
+def _initialize_minimal_kimi_attention(self, config, vllm_config, prefix):
+    nn.Module.__init__(self)
+    self.head_dim = 8
+    self.num_heads = 2
+    self.local_num_heads = 2
+    self.conv_size = 4
+    self.quant_config = None
+    self.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    self.A_log = nn.Parameter(torch.empty(1))
+    self.q_conv1d = nn.Module()
+    self.k_conv1d = nn.Module()
+    self.v_conv1d = nn.Module()
+
+
+def test_kimi_kda_replaces_upstream_output_norm_with_ascend_fused_norm():
+    config = SimpleNamespace(
+        linear_attn_config={"use_full_rank_gate": False},
+        rms_norm_eps=1e-6,
+    )
+
+    with (
+        patch.object(
+            KimiGatedDeltaNetAttention,
+            "__init__",
+            _initialize_minimal_kimi_attention,
+        ),
+        patch.object(
+            AscendKimiGatedDeltaNetAttention,
+            "_wrap_conv_process_weights",
+        ),
+        patch(
+            "vllm_ascend.ops.kimi_kda.uses_kimi_k3_global_inputs_embeds",
+            return_value=False,
+        ),
+        patch("vllm_ascend.ops.kimi_kda.AscendRMSNormGated") as mock_norm,
+    ):
+        attention = AscendKimiGatedDeltaNetAttention(
+            config,
+            SimpleNamespace(),
+            prefix="model.layers.0.self_attn",
+        )
+
+    mock_norm.assert_called_once_with(
+        8,
+        eps=1e-6,
+        norm_before_gate=True,
+        activation="sigmoid",
+    )
+    assert attention.o_norm is mock_norm.return_value
 
 
 def test_load_a_log_slices_padded_1d_checkpoint_by_tp_rank():

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -5,6 +5,7 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 
+from vllm_ascend.ops.layernorm import AscendRMSNormGated, LayerNormFn
 from vllm_ascend.utils import enable_custom_op
 from vllm_ascend.utils import is_310p as is_310p_hw
 
@@ -82,3 +83,19 @@ def test_RMSNorm_forward_310p(mock_add_rmsnorm, mock_rmsnorm, residual, dummy_te
         expected_out_x = dummy_tensor + 1
         mock_rmsnorm.assert_called_once()
         assert torch.allclose(out_x, expected_out_x)
+
+
+def test_rmsnorm_gated_forwards_sigmoid_activation():
+    layer = AscendRMSNormGated(hidden_size=8, activation="sigmoid")
+    x = torch.randn(2, 8)
+    gate = torch.randn_like(x)
+    expected = torch.randn_like(x)
+
+    with patch.object(LayerNormFn, "apply", return_value=expected) as mock_apply:
+        actual = layer.forward_oot(x, gate)
+
+    assert actual is expected
+    args = mock_apply.call_args.args
+    assert args[0] is x
+    assert args[3] is gate
+    assert args[-1] == "sigmoid"

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -23,7 +23,6 @@ from typing import Annotated, Any, Literal, cast
 
 import numpy as np
 import torch
-import torch_npu
 from torch import nn
 from transformers import BatchFeature
 from vllm.compilation.decorators import support_torch_compile
@@ -107,6 +106,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.activation import AscendSituAndMul, SituActivationConfig
 from vllm_ascend.ops.kimi_kda import uses_kimi_k3_global_inputs_embeds
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
+from vllm_ascend.ops.triton.kimi_k3 import fused_attention_residual
 from vllm_ascend.transformers_utils.configs.kimi_k3 import KimiK3Config, KimiK3TextConfig, KimiK3VisionConfig
 from vllm_ascend.transformers_utils.processors.kimi_k3 import KimiK3Processor
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
@@ -884,16 +884,13 @@ def _apply_attention_residual(
     norm: RMSNorm,
 ) -> torch.Tensor:
     """Apply K3's learned normalized mixture over residual block starts."""
-    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
-    values_fp32 = values.float()
-    normalized, _ = torch_npu.npu_rms_norm(
-        values_fp32,
-        norm.weight.float(),
+    mixed = fused_attention_residual(
+        prefix_sum,
+        block_residual,
+        projection.weight.squeeze(0),
+        norm.weight,
         norm.variance_epsilon,
     )
-    scores = torch.matmul(normalized, projection.weight.t().float()).squeeze(-1)
-    probabilities = scores.softmax(-1).unsqueeze(1)
-    mixed = torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
     if _EXTRA_CTX.flash_comm_v1_enabled:
         # FlashComm changes the first decoder layer from the global token
         # layout to a TP-local layout.  The learned-residual arithmetic above

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -46,6 +46,7 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
+from vllm_ascend.ops.layernorm import AscendRMSNormGated
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.kda.kda import fused_kda_gate
 from vllm_ascend.utils import is_vl_model, parse_layer_idx
@@ -174,9 +175,15 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
                 prefix=f"{prefix}.g_proj",
             )
 
-        # The upstream class used FusedRMSNormGated's default epsilon.  K3's
-        # checkpoint config is authoritative and uses the sigmoid gate path.
-        self.o_norm.eps = config.rms_norm_eps
+        # Upstream builds FusedRMSNormGated, which does not match the
+        # RMSNormGated OOT registration used by vllm-ascend. Replace it
+        # explicitly so K3's output norm uses the Ascend fused kernel.
+        self.o_norm = AscendRMSNormGated(
+            self.head_dim,
+            eps=config.rms_norm_eps,
+            norm_before_gate=True,
+            activation="sigmoid",
+        )
 
         # Multimodal inputs_embeds are built before the Ascend forward context,
         # so the first decoder layer receives the full token sequence.  Every
@@ -258,7 +265,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             core_attn_out,
             self.prefix,
         )
-        core_attn_out = self.o_norm(core_attn_out, output_gate)
+        core_attn_out = self.o_norm(core_attn_out, output_gate.unsqueeze(0))
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
 

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -147,6 +147,7 @@ class LayerNormFn(torch.autograd.Function):
             group_size=group_size,
             norm_before_gate=norm_before_gate,
             is_rms_norm=is_rms_norm,
+            activation=activation,
         )
         ctx.save_for_backward(x, weight, bias, mean, rstd, z)
         ctx.x_shape_og = x_shape_og
@@ -196,4 +197,14 @@ class AscendRMSNormGated(RMSNormGated):
 
     def forward_oot(self, x, z=None):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
-        return LayerNormFn.apply(x, self.weight, self.bias, z, self.eps, self.group_size, self.norm_before_gate, True)
+        return LayerNormFn.apply(
+            x,
+            self.weight,
+            self.bias,
+            z,
+            self.eps,
+            self.group_size,
+            self.norm_before_gate,
+            True,
+            self.activation,
+        )

--- a/vllm_ascend/ops/triton/kimi_k3.py
+++ b/vllm_ascend/ops/triton/kimi_k3.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+# Adapted from https://github.com/sgl-project/sglang/pull/32544.
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit(do_not_specialize=["num_tokens", "num_residuals"])
+def _attention_residual_kernel(
+    block_residual_ptr,
+    prefix_sum_ptr,
+    norm_weight_ptr,
+    projection_weight_ptr,
+    output_ptr,
+    num_tokens,
+    hidden_size: tl.constexpr,
+    num_residuals,
+    eps: tl.constexpr,
+    num_cores: tl.constexpr,
+    residual_block_size: tl.constexpr,
+):
+    tokens_per_core = (num_tokens - 1) // num_cores + 1
+    core_idx = tl.program_id(0)
+    token_start = core_idx * tokens_per_core
+    if token_start >= num_tokens:
+        return
+    token_end = tl.minimum(token_start + tokens_per_core, num_tokens)
+
+    hidden_offsets = tl.arange(0, hidden_size)
+    residual_offsets = tl.arange(0, residual_block_size)
+
+    norm_weight = tl.load(norm_weight_ptr + hidden_offsets).to(tl.float32)
+    projection_weight = tl.load(projection_weight_ptr + hidden_offsets).to(tl.float32)
+    score_weight = norm_weight * projection_weight
+    block_stride = num_residuals * hidden_size
+
+    for token_idx in range(token_start, token_end):
+        scores = tl.full([residual_block_size], -float("inf"), dtype=tl.float32)
+        for residual_idx in range(num_residuals + 1):
+            if residual_idx < num_residuals:
+                value = tl.load(
+                    block_residual_ptr + token_idx * block_stride + residual_idx * hidden_size + hidden_offsets
+                ).to(tl.float32)
+            else:
+                value = tl.load(prefix_sum_ptr + token_idx * hidden_size + hidden_offsets).to(tl.float32)
+            inverse_rms = tl.rsqrt(tl.sum(value * value) / hidden_size + eps)
+            scores = tl.where(
+                residual_offsets == residual_idx,
+                tl.sum(value * inverse_rms * score_weight),
+                scores,
+            )
+
+        max_score = tl.max(scores)
+        probabilities = tl.exp(scores - max_score)
+        probabilities /= tl.sum(probabilities)
+
+        output = tl.zeros([hidden_size], dtype=tl.float32)
+        for residual_idx in range(num_residuals + 1):
+            if residual_idx < num_residuals:
+                value = tl.load(
+                    block_residual_ptr + token_idx * block_stride + residual_idx * hidden_size + hidden_offsets
+                ).to(tl.float32)
+            else:
+                value = tl.load(prefix_sum_ptr + token_idx * hidden_size + hidden_offsets).to(tl.float32)
+            probability = tl.sum(tl.where(residual_offsets == residual_idx, probabilities, 0.0))
+            output += probability * value
+
+        tl.store(
+            output_ptr + token_idx * hidden_size + hidden_offsets,
+            output.to(output_ptr.dtype.element_ty),
+        )
+
+
+def fused_attention_residual(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    projection_weight: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Apply Kimi K3's learned mixture over residual block starts."""
+    num_tokens, hidden_size = prefix_sum.shape
+    num_residuals = block_residual.shape[1]
+    output = torch.empty_like(prefix_sum)
+    residual_block_size = triton.next_power_of_2(num_residuals + 1)
+    num_cores = get_vectorcore_num()
+
+    _attention_residual_kernel[(num_cores,)](
+        block_residual,
+        prefix_sum,
+        norm_weight,
+        projection_weight,
+        output,
+        num_tokens,
+        hidden_size,
+        num_residuals,
+        eps,
+        num_cores,
+        residual_block_size,
+        multibuffer=True,
+    )
+    return output

--- a/vllm_ascend/ops/triton/layernorm_gated.py
+++ b/vllm_ascend/ops/triton/layernorm_gated.py
@@ -33,6 +33,7 @@ def _layer_norm_fwd_1pass_kernel_npu(
     HAS_Z: tl.constexpr,
     NORM_BEFORE_GATE: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
+    ACTIVATION: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
     pid_m = tl.program_id(0)
@@ -66,7 +67,10 @@ def _layer_norm_fwd_1pass_kernel_npu(
         z_ptrs = Z + rows[:, None] * stride_z_row + cols[None, :] + group * N
         z = tl.load(z_ptrs, mask=row_mask[:, None] & col_mask[None, :]).to(tl.float32)
         if not NORM_BEFORE_GATE:
-            x *= z * tl.sigmoid(z)
+            if ACTIVATION == "sigmoid":
+                x *= tl.sigmoid(z)
+            else:
+                x *= z * tl.sigmoid(z)
 
     # Compute statistics per row
     if not IS_RMS_NORM:
@@ -93,7 +97,10 @@ def _layer_norm_fwd_1pass_kernel_npu(
 
     # Post-gate
     if HAS_Z and NORM_BEFORE_GATE:
-        y *= z * tl.sigmoid(z)
+        if ACTIVATION == "sigmoid":
+            y *= tl.sigmoid(z)
+        else:
+            y *= z * tl.sigmoid(z)
 
     # Store output
     y_ptrs = Y + rows[:, None] * stride_y_row + cols[None, :] + group * N
@@ -110,6 +117,7 @@ def layer_norm_fwd_npu(
     group_size=None,
     norm_before_gate=True,
     is_rms_norm=False,
+    activation="swish",
 ):
     M, N = x.shape
     if group_size is None:
@@ -163,6 +171,7 @@ def layer_norm_fwd_npu(
         BLOCK_N=BLOCK_N,
         NORM_BEFORE_GATE=norm_before_gate,
         IS_RMS_NORM=is_rms_norm,
+        ACTIVATION=activation,
         # Remove multibuffer if not needed
     )
     return out, mean, rstd


### PR DESCRIPTION
### What this PR does / why we need it?

- Ports the learned Kimi K3 attention-residual Triton kernel from [sglang#32544](https://github.com/sgl-project/sglang/pull/32544), replacing the materialized `cat -> fp32 RMSNorm -> matmul -> softmax -> matmul` path.
- Propagates `RMSNormGated.activation` into the Ascend Triton kernel and adds the `sigmoid` branch required by Kimi K3. Existing `silu`/`swish` behavior is unchanged.
- Keeps the model integration minimal: one new Triton helper, one model call-site replacement, and the activation plumbing.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Kimi K3 on Ascend uses the intended sigmoid output gate and a fused learned-residual path.

### How was this patch tested?

- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- Python 3.11 `py_compile` on all changed Python files
- Added CPU unit coverage for the model/operator wiring
- Added NPU nightly numerical coverage for BF16 Kimi K3 hidden size (7168) residual fusion and sigmoid RMSNorm gate

NPU tests were not run locally because this environment has no Ascend device or torch-npu runtime.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
