### PR TITLE
[Misc] Replace _npu_rotary_embedding with public npu_mrope API

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -175,42 +175,20 @@ def rope_forward_oot(
             is_neox_style=is_neox_style,
         )
     else:
-        if rotary_dim < head_size:
-            num_tokens = query.shape[0]
-            query = query.view(num_tokens, -1, head_size)
-            key = key.view(num_tokens, -1, head_size)
-            q_rot = query[..., :rotary_dim]
-            q_pass = query[..., rotary_dim:]
-            k_rot = key[..., :rotary_dim]
-            k_pass = key[..., rotary_dim:]
-            q_rot = q_rot.contiguous().view(num_tokens, -1)
-            k_rot = k_rot.contiguous().view(num_tokens, -1)
-            # only the rotary part is processed here,
-            # the dimension should be rotary_dim
-            torch_npu._npu_rotary_embedding(
-                positions,
-                q_rot,
-                k_rot,
-                rotary_dim,
-                cos_sin_cache,
-                is_neox_style,
-            )
-            q_rot = q_rot.view(num_tokens, -1, rotary_dim)
-            k_rot = k_rot.view(num_tokens, -1, rotary_dim)
-            query = torch.cat((q_rot, q_pass), dim=-1).reshape(query_shape)
-            key = torch.cat((k_rot, k_pass), dim=-1).reshape(key_shape)
-        else:
-            # TODO: Remove the contiguous in the future.
-            query = query.contiguous().view(query.shape[0], -1)
-            key = key.contiguous().view(key.shape[0], -1)
-            torch_npu._npu_rotary_embedding(
-                positions,
-                query,
-                key,
-                head_size,
-                cos_sin_cache,
-                is_neox_style,
-            )
+        # npu_mrope handles both full and partial rotary internally:
+        # it splits query into queryRot[..., :rotary_dim] and queryPass[..., rotary_dim:],
+        # where rotary_dim is inferred from cos_sin_cache.shape[-1].
+        rotary_mode = "half" if is_neox_style else "interleaved"
+        query, key = torch_npu.npu_mrope(
+            positions,
+            query.contiguous().view(query.shape[0], -1),
+            key.contiguous().view(key.shape[0], -1),
+            cos_sin_cache,
+            head_size,
+            mrope_section=[0, 0, 0],
+            rotary_mode=rotary_mode,
+            cache_mode="default",
+        )
     return query.view(query_shape), key.view(key_shape)
 
 


### PR DESCRIPTION
## Motivation

The `rope_forward_oot` function uses the internal `torch_npu._npu_rotary_embedding` API (prefixed with underscore), which is not a stable public interface. Replace it with the public `torch_npu.npu_mrope` API for better forward compatibility.

## Modifications

- Replaced `torch_npu._npu_rotary_embedding` with `torch_npu.npu_mrope` in the non-Triton path of `rope_forward_oot`
- Merged the two branches (`rotary_dim < head_size` partial rotary vs full rotary) into a single call, since `npu_mrope` handles partial rotary internally by splitting `queryRot[..., :rotary_dim]` / `queryPass[..., rotary_dim:]` where `rotary_dim` is inferred from `cos_sin_cache.shape[-1]`
- Parameter mapping:
  - `is_neox_style=True` → `rotary_mode="half"` (NeoX style)
  - `is_neox_style=False` → `rotary_mode="interleaved"` (GPT-J style)
  - `mrope_section=[0, 0, 0]` → standard RoPE mode (not multimodal)
- Switched from in-place modification (old API) to return value assignment (new API)

## Test

No functional change. Verified on Ascend910B with standard RoPE models.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
