### PR TITLE
[BugFix][v0.23.0][KV Pool] Align scheduler num_layers with registered MTP layers

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -23,6 +23,7 @@ import pytest
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     LoadSpec,
+    extract_physical_layer_index,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
     KVPoolScheduler,
@@ -96,6 +97,77 @@ class TestKVPoolScheduler(unittest.TestCase):
         config.model_config.get_total_num_kv_heads.return_value = 1
         config.model_config.get_num_layers.return_value = 2
         return config
+
+    def _make_kv_cache_config(self, layer_names):
+        """Build a single-group KVCacheConfig mock with the given layer names.
+
+        ``kv_cache_spec`` is shaped so the scheduler's family/SWA inference
+        (which only inspects spec attributes for non-uniform/hybrid specs)
+        treats it as a plain full-attention group.
+        """
+        group = MagicMock(
+            layer_names=list(layer_names),
+            kv_cache_spec=MagicMock(kv_cache_specs=None, compress_ratio=None),
+        )
+        return MagicMock(kv_cache_groups=[group])
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_num_layers_includes_deepseek_mtp_layer(self, mock_client_cls):
+        # num_hidden_layers == 2, so model.layers.2.* is the MTP draft layer.
+        config = self._make_config()
+        config.model_config.hf_text_config = MagicMock(num_hidden_layers=2)
+        kv_cache_config = self._make_kv_cache_config(
+            [
+                "model.layers.0.self_attn.attn",
+                "model.layers.1.self_attn.attn",
+                "model.layers.2.self_attn.attn",  # MTP: index >= num_hidden_layers
+            ]
+        )
+        scheduler = KVPoolScheduler(
+            config, use_layerwise=True, kv_cache_config=kv_cache_config, page_size_bytes=16
+        )
+        self.assertEqual(scheduler.num_layers, 3)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_num_layers_includes_mtp_prefix_layer(self, mock_client_cls):
+        config = self._make_config()
+        config.model_config.hf_text_config = MagicMock(num_hidden_layers=2)
+        kv_cache_config = self._make_kv_cache_config(
+            [
+                "model.layers.0.self_attn",
+                "model.layers.1.self_attn",
+                "model.mtp.0.self_attn",  # MTP via prefix -> num_hidden_layers + 0
+            ]
+        )
+        scheduler = KVPoolScheduler(
+            config, use_layerwise=True, kv_cache_config=kv_cache_config, page_size_bytes=16
+        )
+        self.assertEqual(scheduler.num_layers, 3)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_num_layers_without_kv_cache_config_falls_back(self, mock_client_cls):
+        # get_num_layers.return_value == 2 in _make_config.
+        scheduler = KVPoolScheduler(self._make_config(), use_layerwise=True)
+        self.assertEqual(scheduler.num_layers, 2)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_keys_per_block_hash_includes_mtp_for_gva(self, mock_client_cls):
+        config = self._make_config(extra_config={"backend": "memcache"})
+        config.model_config.hf_text_config = MagicMock(num_hidden_layers=2)
+        kv_cache_config = self._make_kv_cache_config(
+            [
+                "model.layers.0.self_attn.attn",
+                "model.layers.1.self_attn.attn",
+                "model.layers.2.self_attn.attn",  # MTP
+            ]
+        )
+        scheduler = KVPoolScheduler(
+            config, use_layerwise=True, kv_cache_config=kv_cache_config, page_size_bytes=16
+        )
+        self.assertTrue(scheduler.use_gva_layerwise)
+        self.assertEqual(scheduler.num_layers, 3)
+        # pcp=1, dcp=1, tp_size//put_step=1, num_layer_keys=num_layers under gva.
+        self.assertEqual(scheduler.keys_per_block_hash, 1 * 1 * 1 * 3)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_consumer_no_load(self, mock_client_cls):
@@ -1261,6 +1333,32 @@ class TestKVPoolSchedulerUpdateStateAfterAllocBranches(unittest.TestCase):
         scheduler.update_state_after_alloc(request, blocks, 0)
         # layerwise + kvpool_cached > 0 => can_load = True
         self.assertTrue(scheduler.load_specs["r1"].can_load)
+
+
+class TestExtractPhysicalLayerIndex(unittest.TestCase):
+    def test_deepseek_style_main_and_mtp(self):
+        # MTP reuses layers.{N} with N >= num_hidden_layers.
+        self.assertEqual(
+            extract_physical_layer_index("model.layers.0.self_attn.attn", 2, 2), 0
+        )
+        self.assertEqual(
+            extract_physical_layer_index("model.layers.60.self_attn.attn", 61, 61), 60
+        )
+        # First MTP layer for a 61-layer model (index == num_hidden_layers).
+        self.assertEqual(
+            extract_physical_layer_index("model.layers.61.self_attn.attn", 61, 61), 61
+        )
+
+    def test_mtp_prefix_maps_after_main_layers(self):
+        self.assertEqual(
+            extract_physical_layer_index("model.mtp.0.self_attn", 2, 2), 2
+        )
+        self.assertEqual(
+            extract_physical_layer_index("model.mtp.1.self_attn", 2, 2), 3
+        )
+
+    def test_fallback_when_no_numeric_token(self):
+        self.assertEqual(extract_physical_layer_index("no_index", 2, 2), 0)
 
 
 if __name__ == "__main__":

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -21,6 +21,42 @@ _GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 GroupedBlockHashCache = dict[int, Sequence[BlockHash | str]]
 
 
+def extract_physical_layer_index(
+    layer_name: str, num_hidden_layers: int, fallback: int
+) -> int:
+    """Extract the physical layer index from a registered KV cache layer name.
+
+    MTP draft layers are mapped after the main model layers so they sort
+    behind the standard attention layers:
+
+    * DeepSeek-style MTP reuses the ``layers.{N}`` naming with
+      ``N >= num_hidden_layers`` (e.g. ``model.layers.61.self_attn.attn``).
+    * Other models use an ``mtp.{N}`` prefix (e.g. ``model.mtp.0.self_attn``)
+      which is mapped to ``num_hidden_layers + N``.
+
+    Shared by ``KVPoolWorker`` and ``KVPoolScheduler`` so both sides derive an
+    identical layer layout (including MTP) from the registered layer names.
+
+    Args:
+        layer_name: registered KV cache layer name.
+        num_hidden_layers: main model hidden layer count, used to offset MTP
+            layers that use the ``mtp.{N}`` prefix.
+        fallback: value used when an ``mtp.{N}`` prefix is matched but no main
+            layer count is available.
+    """
+    import re
+
+    m = re.search(r"layers\.(\d+)", layer_name)
+    if m:
+        return int(m.group(1))
+    if ".mtp." in f".{layer_name}.":
+        m = re.search(r"mtp\.(\d+)", layer_name)
+        if m:
+            return num_hidden_layers + int(m.group(1))
+    m = re.search(r"(\d+)", layer_name)
+    return int(m.group(1)) if m else 0
+
+
 # Parameters related to the key
 @dataclass
 class KeyMetadata:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -36,6 +36,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     RequestTracker,
     block_hash_to_str,
+    extract_physical_layer_index,
     get_block_hashes,
     get_cache_family_granularity,
     infer_cache_family_ratio,
@@ -173,7 +174,7 @@ class KVPoolScheduler:
             self.put_step = self.tp_size // self.num_kv_head
         else:
             self.put_step = 1
-        self.num_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.num_layers = self._compute_registered_num_layers(vllm_config, kv_cache_config)
         self.model_name = model_config.model.split("/")[-1]
 
         # Keep this in sync with pool_worker.py because it affects GVA allocation size.
@@ -182,6 +183,45 @@ class KVPoolScheduler:
         self.keys_per_block_hash = keys_per_block_hash
 
         self.client: LookupKeyClient | None = None
+
+    def _compute_registered_num_layers(
+        self, vllm_config: "VllmConfig", kv_cache_config: KVCacheConfig | None
+    ) -> int:
+        """Derive the layer count from the registered KV cache layer names.
+
+        ``model_config.get_num_layers()`` only reports the local PP target
+        layers and does not include registered MTP draft layers. Build the
+        count from ``kv_cache_config.kv_cache_groups[*].layer_names`` - the
+        same authoritative source used by ``KVPoolWorker`` - so MTP layers
+        are included and the scheduler's per-layer key generation and GVA
+        allocation sizing stay in sync with the worker.
+
+        For pipeline parallelism the scheduler receives ``kv_cache_configs[0]``
+        (PP rank 0), whose ``layer_names`` only cover PP rank 0. Since the
+        scheduler only emits per-layer keys for ``[self.pp_rank]`` this stays
+        consistent: PP rank 0 has no MTP layers (they live on the last rank),
+        so its count matches the main layers alone.
+        """
+        fallback = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        if kv_cache_config is None:
+            return fallback
+        num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", fallback)
+        physical_layers: set[int] = set()
+        for group in kv_cache_config.kv_cache_groups:
+            for layer_name in group.layer_names:
+                physical_layers.add(
+                    extract_physical_layer_index(layer_name, num_hidden_layers, fallback)
+                )
+        if not physical_layers:
+            return fallback
+        registered_num_layers = len(physical_layers)
+        if registered_num_layers != fallback:
+            logger.info(
+                "KVPoolScheduler: configured %d registered layers (was %d).",
+                registered_num_layers,
+                fallback,
+            )
+        return registered_num_layers
 
     def _get_or_create_request_tracker(self, req_id: str) -> RequestTracker:
         tracker = self._request_trackers.get(req_id)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -39,8 +39,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     LayerMultiBlockReqMeta,
     LayerTransferTask,
     ReqMeta,
-    block_hash_to_bytes,
     block_hash_to_str,
+    block_hash_to_bytes,
+    extract_physical_layer_index,
     get_block_hashes,
     get_cache_family_granularity,
     infer_cache_family_ratio,
@@ -562,20 +563,8 @@ class KVPoolWorker:
             return cache.storage().data_ptr()
 
     def _extract_physical_layer_index(self, layer_name: str) -> int:
-        import regex as re
-
-        m = re.search(r"layers\.(\d+)", layer_name)
-        if m:
-            return int(m.group(1))
-        # MTP layers have names like "mtp.0.self_attn.xxx" without "layers."
-        # prefix. Map them after the main model layers.
-        if ".mtp." in f".{layer_name}.":
-            m = re.search(r"mtp\.(\d+)", layer_name)
-            if m:
-                num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
-                return num_hidden_layers + int(m.group(1))
-        m = re.search(r"(\d+)", layer_name)
-        return int(m.group(1)) if m else 0
+        num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
+        return extract_physical_layer_index(layer_name, num_hidden_layers, self.num_layers)
 
     def _infer_cache_group_metadata(self, group_id: int, layer_names: list[str]):
         group_addrs: list[int] = []


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up to #13454, which only updated `KVPoolWorker.num_layers` to include MTP draft layers. `KVPoolScheduler.num_layers` was left at `model_config.get_num_layers()`, which excludes MTP -- breaking the "Keep this in sync with pool_worker.py" invariant (pool_scheduler.py:179) and leaving the scheduler's per-layer lookup keys / GVA allocation sizing (`num_layer_keys`, `keys_per_block_hash`, `split_layers`) short of the MTP layer. Under memcache/gva layerwise this caused fluctuating MTP draft acceptance: the scheduler declared a block "hit" without verifying the MTP layer key, then the worker attempted an MTP load that could fail depending on whether the producer had saved the MTP KV yet.

Changes:
- `config_data.py`: add shared `extract_physical_layer_index` helper (stdlib `re`; mirrors `KVPoolWorker._extract_physical_layer_index`). Covers both DeepSeek-style `model.layers.{N>=num_hidden_layers}` and `model.mtp.{N}` naming.
- `pool_scheduler.py`: `KVPoolScheduler` now derives `num_layers` (and recomputes `keys_per_block_hash`) from `kv_cache_config.kv_cache_groups[*].layer_names`, so MTP layers are counted. For PP, the scheduler receives `kv_cache_configs[0]` (PP rank 0, no MTP), matching its `[self.pp_rank]` query scope.
- `pool_worker.py`: `_extract_physical_layer_index` delegates to the shared helper (behavior-preserving; drops the inline `regex` dependency).
- `tests/ut/distributed/ascend_store/test_pool_scheduler.py`: add tests for DeepSeek-style MTP, `mtp..`-prefix MTP, no-config fallback, and `keys_per_block_hash` under gva layerwise, plus direct `extract_physical_layer_index` unit tests.

Refs #13454.

### Does this PR introduce _any_ user-facing change?

No user-facing API changes. Internal fix for KV pool scheduler layer accounting including MTP layers.

### How was this patch tested?

- Unit tests added/updated: `tests/ut/distributed/ascend_store/test_pool_scheduler.py`
  - `test_num_layers_includes_deepseek_mtp_layer`
  - `test_num_layers_includes_mtp_prefix_layer`
  - `test_num_layers_without_kv_cache_config_falls_back`
  - `test_keys_per_block_hash_includes_mtp_for_gva`
  - `TestExtractPhysicalLayerIndex` (helper unit tests)
- Manual verification (standalone script with project `_mock_deps` shims): helper extraction, worker delegation, scheduler `num_layers`/`keys_per_block_hash` for MTP/gva all pass; `py_compile` clean.
- CI verification (please run `pytest tests/ut/distributed/ascend_store/test_pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_worker.py` + `bash format.sh ci`).

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
