### PR TITLE
[BugFix][Kimi K3] Fix W4A8 shared-expert weights

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -438,7 +438,7 @@ def test_unquantized_shared_situ_uses_split_bf16_path(monkeypatch):
     runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
 
 
-def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
+def test_per_channel_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
     hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
@@ -455,12 +455,13 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     down_proj = MagicMock()
     down_proj.weight = torch.ones(2, 4, dtype=torch.int8)
     down_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
     runner._shared_experts = SimpleNamespace(
         gate_up_proj=gate_up_proj,
         down_proj=down_proj,
         act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
     )
-    runner.quant_type = QuantType.W4A8
+    runner.quant_type = QuantType.W8A8
     runner.multistream_overlap_shared_expert = False
     stream = MagicMock()
     events = fused_moe_module.FusedMoEEvents(
@@ -498,12 +499,122 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     down_proj.assert_not_called()
     fast_dynamic_quant.assert_called_once_with(hidden_states)
     assert fast_quant_matmul.call_count == 2
+    gate_up_call = fast_quant_matmul.call_args_list[0]
+    assert gate_up_call.args == (quantized_input, gate_up_proj.weight, gate_up_proj.weight_scale)
+    assert gate_up_call.kwargs["pertoken_scale"] is None
+    assert gate_up_call.kwargs["output_dtype"] == torch.int32
     situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
     assert situ_call["x"] is gate_up
     assert situ_call["weight_scale"] is gate_up_proj.weight_scale_fp32
     assert situ_call["activation_scale"] is input_scale
     assert situ_call["beta"] == 4.0
     assert situ_call["linear_beta"] == 25.0
+    down_call = fast_quant_matmul.call_args_list[1]
+    assert down_call.args == (quantized_situ, down_proj.weight, down_proj.weight_scale)
+    assert down_call.kwargs["pertoken_scale"] is situ_scale
+    assert down_call.kwargs["output_dtype"] == hidden_states.dtype
+
+
+def test_per_channel_w4a8_shared_experts_use_weight_only_fallback(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(
+            weight_scale=torch.ones(8),
+            weight_scale_fp32=torch.ones(8),
+        ),
+        down_proj=SimpleNamespace(
+            weight_scale=torch.ones(4),
+            weight_scale_fp32=torch.ones(4),
+        ),
+        act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
+    )
+    runner._shared_experts_part1 = MagicMock(return_value=gate_up)
+    runner._shared_experts_part2 = MagicMock(return_value=down_out)
+    runner.quant_type = QuantType.W4A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    quant_matmul = MagicMock()
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", quant_matmul)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    runner._shared_experts_part1.assert_called_once_with(hidden_states)
+    runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
+    quant_matmul.assert_not_called()
+
+
+def test_per_group_w4a8_shared_experts_use_quantized_linear_path(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(weight_scale=torch.ones(1)),
+        down_proj=SimpleNamespace(weight_scale=torch.ones(1)),
+        act_fn=nn.Identity(),
+    )
+    runner._shared_experts_part1 = MagicMock(return_value=gate_up)
+    runner._shared_experts_part2 = MagicMock(return_value=down_out)
+    runner.quant_type = QuantType.W4A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    quant_matmul = MagicMock()
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", quant_matmul)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    runner._shared_experts_part1.assert_called_once_with(hidden_states)
+    runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
+    quant_matmul.assert_not_called()
 
 
 @pytest.mark.parametrize("quant_type", [QuantType.W4A8MXFP, QuantType.W8A8MXFP])

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import regex as re
@@ -53,6 +54,104 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="row")
         self.assertEqual(params["scale_bias"].dtype, torch.float32)
         self.assertEqual(params["scale_bias"].shape, (32, 16))
+
+    def test_per_channel_weight_uses_only_first_level_scale(self):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16)
+
+        self.assertEqual(params["weight_scale"].shape, (32, 1))
+        self.assertEqual(params["weight_offset"].shape, (32, 1))
+        self.assertNotIn("weight_scale_second", params)
+        self.assertNotIn("weight_offset_second", params)
+        self.assertEqual(params["scale_bias"].shape, (32, 1))
+
+    @patch("torch_npu.npu_quant_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_weight_uses_per_token_activation_scale(self, mock_dynamic_quant, mock_matmul):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(8, 4, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.bfloat16), requires_grad=False)
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_matmul.return_value = torch.empty(2, 8, dtype=torch.bfloat16)
+
+        self.method.apply(layer, x)
+
+        mock_dynamic_quant.assert_called_once_with(x)
+        self.assertEqual(mock_matmul.call_args.args, (quantized_x, layer.weight, layer.weight_scale))
+        self.assertIs(mock_matmul.call_args.kwargs["pertoken_scale"], pertoken_scale)
+        self.assertEqual(mock_matmul.call_args.kwargs["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_dynamic_quant")
+    @patch("torch_npu.npu_weight_quant_batchmatmul")
+    def test_apply_kimi_shared_expert_uses_weight_only_fallback(self, mock_weight_only_matmul, mock_dynamic_quant):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.bfloat16), requires_grad=False)
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        expected = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_weight_only_matmul.return_value = expected
+
+        output = self.method.apply(layer, x)
+
+        self.assertIs(output, expected)
+        mock_dynamic_quant.assert_not_called()
+        mock_weight_only_matmul.assert_called_once()
+        call = mock_weight_only_matmul.call_args
+        self.assertIs(call.args[0], x)
+        self.assertIs(call.args[1], layer.weight)
+        torch.testing.assert_close(call.kwargs["antiquant_scale"], layer.weight_scale)
+        self.assertEqual(call.kwargs["antiquant_group_size"], 0)
+
+    @patch("vllm_ascend.quantization.methods.w4a8.get_tensor_model_parallel_world_size", return_value=1)
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    def test_kimi_k3_text_config_marks_only_shared_expert(self, mock_get_current_vllm_config, _mock_get_tp_world_size):
+        """Text-only K3 loading exposes kimi_linear as its immediate config."""
+        mock_get_current_vllm_config.return_value = SimpleNamespace(
+            quant_config=SimpleNamespace(quant_description={"group_size": 256}),
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type="kimi_linear"),
+                hf_text_config=SimpleNamespace(
+                    model_type="kimi_linear",
+                    mla_use_output_gate=True,
+                    routed_expert_hidden_size=3584,
+                ),
+            ),
+        )
+        method = AscendW4A8DynamicLinearMethod()
+        shared_layer = SimpleNamespace(prefix="model.layers.0.block_sparse_moe.shared_experts.gate_up_proj")
+        routed_layer = SimpleNamespace(prefix="model.layers.0.block_sparse_moe.experts")
+
+        self.assertTrue(method._uses_per_channel_shared_expert(shared_layer))
+        self.assertFalse(method._uses_per_channel_shared_expert(routed_layer))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_per_channel_weight_without_second_level_scale(self, _mock_maybe_trans_nz):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight.data.shape, (8, 4))
+        self.assertEqual(layer.weight_scale.data.shape, (32,))
+        self.assertEqual(layer.weight_scale.dtype, torch.bfloat16)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        torch.testing.assert_close(layer.weight_scale_fp32, layer.weight_scale.data.float())
+        self.assertFalse(hasattr(layer, "weight_scale_second"))
 
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_convert_weight_to_int4pack")
@@ -127,6 +226,27 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
             self.assertRaisesRegex(AssertionError, re.escape(expected_message)),
         ):
             self.method.process_weights_after_loading(layer)
+
+    @patch("torch_npu.npu_convert_weight_to_int4pack")
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    def test_process_per_channel_kimi_shared_expert_weight_keeps_int4pack_nd(self, mock_maybe_trans_nz, mock_int4pack):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        packed_weight = torch.zeros((8, 4), dtype=torch.int32)
+        mock_int4pack.return_value = packed_weight
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((32, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        mock_maybe_trans_nz.assert_not_called()
+        mock_int4pack.assert_called_once()
+        self.assertEqual(mock_int4pack.call_args.args[0].shape, torch.Size([8, 32]))
+        self.assertEqual(mock_int4pack.call_args.args[0].dtype, torch.int32)
+        self.assertEqual(layer.weight.data.data_ptr(), packed_weight.data_ptr())
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        self.assertEqual(layer.weight_scale_fp32.shape, torch.Size([32]))
 
 
 class TestAscendW4A8DynamicLinearMethodWithNpu(TestBase):

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -13,6 +13,7 @@ from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
@@ -191,6 +192,57 @@ class TestAscendModelSlimConfig(TestBase):
             "experts.0.up_proj",
             "experts.0.down_proj",
         ]
+
+    def test_kimi_k3_shared_expert_w4a8_uses_per_channel_scheme(self):
+        prefix = "model.layers.0.mlp.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig({f"{prefix}.weight": "W4A8_DYNAMIC"})
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "kimi_k3"
+        vllm_config.model_config.hf_text_config = MagicMock()
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_per_channel_for_kimi_shared_expert.assert_called_once_with()
+
+    def test_kimi_k3_text_config_shared_expert_w4a8_uses_per_channel_scheme(self):
+        """Keep the K3 override when vLLM exposes only the nested text config."""
+        prefix = "model.layers.0.block_sparse_moe.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig({f"{prefix}.weight": "W4A8_DYNAMIC"})
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "kimi_linear"
+        vllm_config.model_config.hf_text_config.model_type = "kimi_linear"
+        vllm_config.model_config.hf_text_config.mla_use_output_gate = True
+        vllm_config.model_config.hf_text_config.routed_expert_hidden_size = 3584
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_per_channel_for_kimi_shared_expert.assert_called_once_with()
 
     def test_missing_linear_weight_without_gate_capability_does_not_fall_back(self):
         config = AscendModelSlimConfig({})

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -781,7 +781,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._shared_experts.down_proj, "weight_scale"
             )
             shared_uses_situ = isinstance(self._shared_experts.act_fn, AscendSituAndMul)
-            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+            if has_quantized_shared and self.quant_type == QuantType.W8A8:
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
@@ -878,6 +878,9 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
+                # Kimi K3 per-channel W4A8 shared experts also use this
+                # path. Their Linear scheme runs the W4-native weight-only
+                # matmul, avoiding QuantMatmul WeightNZ for INT4Pack weights.
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -35,6 +35,28 @@ from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_lo
 from .registry import register_scheme
 
 
+def _is_kimi_k3_model(vllm_config: Any) -> bool:
+    """Identify K3 from either its outer multimodal or inner text config.
+
+    The full K3 checkpoint has ``hf_config.model_type == "kimi_k3"``. Some
+    text-only loading paths expose the nested K3 text config instead, whose
+    inherited model type is ``"kimi_linear"``. The latter is distinguished
+    from a regular Kimi Linear model by the K3 MLA/output-gate and routed-MoE
+    fields.
+    """
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_config = getattr(model_config, "hf_config", None)
+    if getattr(hf_config, "model_type", None) == "kimi_k3":
+        return True
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    return (
+        getattr(hf_text_config, "model_type", None) == "kimi_linear"
+        and bool(getattr(hf_text_config, "mla_use_output_gate", False))
+        and getattr(hf_text_config, "routed_expert_hidden_size", None) is not None
+    )
+
+
 @register_scheme("W4A8_DYNAMIC", "linear")
 class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     """Linear method for Ascend W4A8_DYNAMIC.
@@ -48,7 +70,8 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     The names below use ``linear`` as the checkpoint prefix of a linear layer,
     ``input_size`` as the logical input dimension, ``output_size`` as the
     logical output dimension, and ``group_size`` as the number of input
-    channels per weight quantization group.
+    channels per weight quantization group. A ``group_size`` of ``0`` selects
+    per-channel weight quantization.
 
     For ``quant_version != "1.0.0"``, the original linear weights are:
 
@@ -56,10 +79,11 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
       Each int8 element stores one 4-bit weight value.
     - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
     - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
-    - ``linear.weight_scale_second``: ``params_dtype``,
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
       ``[output_size, input_size // group_size]``.
-    - ``linear.weight_offset_second``: ``torch.int64``,
-      ``[output_size, input_size // group_size]``.
+    - For per-channel quantization, ``weight_scale`` and ``weight_offset``
+      are the only scale tensors; no second-level tensors are present.
 
     For ``quant_version == "1.0.0"``, the original linear weights are:
 
@@ -68,10 +92,10 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
       dimension.
     - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
     - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
-    - ``linear.weight_scale_second``: ``params_dtype``,
-      ``[output_size, input_size // group_size]``.
-    - ``linear.weight_offset_second``: ``torch.int64``,
-      ``[output_size, input_size // group_size]``.
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
+      ``[output_size, input_size // group_size]``. Per-channel quantization
+      does not store second-level scale or offset tensors.
     - ``linear.scale_bias``: ``torch.float32``, ``[output_size, 1]`` for
       column-parallel linear layers and ``[output_size, 16]`` for
       row-parallel linear layers.
@@ -86,17 +110,37 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     After processing, ``torch_npu.npu_weight_quant_batchmatmul`` is called with
     ``weight`` as ``torch.int32`` in the operator-required packed layout
     with shape ``[input_size, output_size // 8]`` and
-    ``antiquant_scale`` as ``weight_scale * weight_scale_second`` converted to
-    ``x.dtype`` with shape ``[input_size // group_size, output_size]``.
+    ``antiquant_scale`` as either the per-channel ``weight_scale`` or the
+    per-group product ``weight_scale * weight_scale_second``, converted to
+    ``x.dtype``.
     """
 
     def __init__(self):
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
+        self.is_per_channel_weight = self.group_size == 0
         quant_version = vllm_config.quant_config.quant_description.get("version", "0")
         self.new_quant_version = quant_version == "1.0.0"
+        self._uses_kimi_k3_shared_expert_per_channel = _is_kimi_k3_model(vllm_config)
+        self._force_kimi_shared_expert_weight_only = False
 
         self.tp_size = get_tensor_model_parallel_world_size()
+
+    def _uses_per_channel_shared_expert(self, layer: torch.nn.Module) -> bool:
+        # This is deliberately not a model-wide K3 flag: only K3 shared
+        # experts have per-channel W4A8 scales. Routed experts stay per-group.
+        return self._force_kimi_shared_expert_weight_only or (
+            self._uses_kimi_k3_shared_expert_per_channel and ".shared_experts." in getattr(layer, "prefix", "")
+        )
+
+    def enable_per_channel_for_kimi_shared_expert(self) -> None:
+        """Select the per-channel weight-only path for a Kimi shared expert."""
+        self.group_size = 0
+        self.is_per_channel_weight = True
+        # This scheme instance is attached to one shared-expert projection.
+        # Retain that selection through weight loading, where layer.prefix is
+        # not a reliable discriminator for every vLLM Linear wrapper.
+        self._force_kimi_shared_expert_weight_only = True
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
         """Create weight parameters.
@@ -127,10 +171,13 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         params_dict = {}
         params_dict["weight_scale"] = torch.empty(output_size, 1, dtype=params_dtype)
         params_dict["weight_offset"] = torch.empty(output_size, 1, dtype=params_dtype)
-        params_dict["weight_scale_second"] = torch.empty(output_size, input_size // self.group_size, dtype=params_dtype)
-        params_dict["weight_offset_second"] = torch.empty(
-            output_size, input_size // self.group_size, dtype=params_dtype
-        )
+        if not self.is_per_channel_weight:
+            params_dict["weight_scale_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
+            params_dict["weight_offset_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
 
         # NOTE: In w4a8 quantization implementation,
         #       for down_proj and o_proj(layer_type == "row") scale_bias shape is [output_size, 16],
@@ -182,7 +229,36 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         bias: torch.Tensor | None = None,
         tp_rank: int | None = None,
     ) -> torch.Tensor:
-        # NOTE: activation `x` is not quantized
+        if self.is_per_channel_weight:
+            if self._uses_per_channel_shared_expert(layer):
+                # K3 shared experts use W4 INT4Pack weights. The generic
+                # QuantMatmul WeightNZ path cannot consume that representation
+                # on A3, so use the W4-native weight-only kernel as a
+                # functional fallback. It consumes BF16 activations and a
+                # per-channel antiquant scale directly.
+                return torch_npu.npu_weight_quant_batchmatmul(
+                    x,
+                    layer.weight,
+                    antiquant_scale=layer.weight_scale.to(x.dtype),
+                    antiquant_group_size=0,
+                )
+            quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x)
+            need_unsqueeze = pertoken_scale.dim() == 2
+            if need_unsqueeze:
+                quantized_x = quantized_x.squeeze(dim=1)
+                pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+            output = torch_npu.npu_quant_matmul(
+                quantized_x,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=bias,
+                output_dtype=x.dtype,
+            )
+            return output.unsqueeze(dim=1) if need_unsqueeze else output
+
+        # Per-group INT4 weights use the weight-only quantized operator.
         return torch_npu.npu_weight_quant_batchmatmul(
             x,
             layer.weight,
@@ -191,16 +267,29 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         )
 
     def process_weights_after_loading(self, layer: torch.nn.Module):
+        uses_per_channel_shared_expert = self._uses_per_channel_shared_expert(layer)
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight.data = maybe_trans_nz(layer.weight.data)
-        layer.weight_scale.data = layer.weight_scale.data.flatten().to(torch.float32)
+        # Keep K3 shared-expert INT4Pack weights in ND. The weight-only
+        # fallback accepts ND INT32 INT4Pack, while a per-channel INT4
+        # WeightNZ operand has a different transpose contract and cannot be
+        # passed to the generic QuantMatmul WeightNZ path.
+        if not uses_per_channel_shared_expert:
+            layer.weight.data = maybe_trans_nz(layer.weight.data)
+        layer.weight_scale.data = layer.weight_scale.data.flatten()
         layer.weight_offset.data = layer.weight_offset.data.flatten()
-        layer.weight_scale_second.data, scale_bias = self.process_scale_second(
-            layer.weight.data,
-            layer.weight_scale.data,
-            layer.weight_scale_second.data.transpose(0, 1).contiguous(),
-            is_new_quant=self.new_quant_version,
-        )
+        if self.is_per_channel_weight:
+            # QuantMatmul consumes the checkpoint dtype, while the fused SiTU
+            # dequantization step requires an FP32 copy of the same scale.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+        scale_bias = None
+        if not self.is_per_channel_weight:
+            layer.weight_scale.data = layer.weight_scale.data.to(torch.float32)
+            layer.weight_scale_second.data, scale_bias = self.process_scale_second(
+                layer.weight.data,
+                layer.weight_scale.data,
+                layer.weight_scale_second.data.transpose(0, 1).contiguous(),
+                is_new_quant=self.new_quant_version,
+            )
 
         if self.new_quant_version:
             # Process the loaded data based on layer type
@@ -209,22 +298,19 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
                     layer.scale_bias.data = layer.scale_bias.data.flatten()
                 else:
                     layer.scale_bias.data = layer.scale_bias.data.contiguous()
-        else:
-            if scale_bias is not None:
-                param = torch.nn.Parameter(scale_bias, requires_grad=False)
-                layer.register_parameter("weight_scale_bias", param)
+        elif scale_bias is not None:
+            param = torch.nn.Parameter(scale_bias, requires_grad=False)
+            layer.register_parameter("weight_scale_bias", param)
 
-        # Convert to NPU-specific int4pack format
+        # Convert to NPU-specific int4pack format.
         if self.new_quant_version:
-            # weights on disk are already in packed int4 format
-            # pack 4 int8(int4*2) to int32
+            # Weights on disk are already in packed int4 format; group four
+            # int8 bytes into one int32 storage element.
             assert layer.weight.data.shape[-1] % 4 == 0, (
                 f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
             )
             layer.weight.data = layer.weight.data.view(torch.int32).contiguous()
         else:
-            # weights are not compressed
-            # need to be packed via npu_convert_weight_to_int4pack
             layer.weight.data = torch_npu.npu_convert_weight_to_int4pack(layer.weight.data.to(torch.int32))
 
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -49,6 +49,7 @@ from vllm_ascend.utils import (
 )
 
 from .methods import get_scheme_class
+from .methods.w4a8 import _is_kimi_k3_model
 
 
 def _is_fused_moe_layer(layer: torch.nn.Module) -> bool:
@@ -713,6 +714,13 @@ class AscendModelSlimConfig(QuantizationConfig):
                 logger.debug("Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
                 return AscendUnquantizedLinearMethod()
             scheme = create_scheme_for_layer(self.quant_description, prefix, "linear", self.packed_modules_mapping)
+            if _is_kimi_k3_model(vllm_config) and ".shared_experts." in prefix:
+                # Kimi K3 stores W4A8 shared-expert linears with per-channel
+                # scales, while its routed experts remain per-group.
+                from .methods.w4a8 import AscendW4A8DynamicLinearMethod
+
+                if isinstance(scheme, AscendW4A8DynamicLinearMethod):
+                    scheme.enable_per_channel_for_kimi_shared_expert()
             logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
             return AscendLinearMethod(scheme)
         elif isinstance(layer, AttentionLayerBase) and (


### PR DESCRIPTION
### What this PR does / why we need it?

Consolidates the five Kimi K3 W4A8 shared-expert fixes from #13225 into one focused commit.

- Detect K3 per-channel shared-expert weights.
- Preserve the ND INT4Pack layout required by the native W4 weight-only matmul.
- Route shared experts away from the incompatible QuantMatmul WeightNZ path.
- Cover loading, quantization and fused-MoE dispatch behavior.

### Does this PR introduce _any_ user-facing change?

Yes. Kimi K3 checkpoints using per-channel W4A8 shared-expert weights can load and execute through the correct weight-only fallback.

### How was this patch tested?

- Passed: Python syntax checks for the three changed runtime modules.
- Passed: `git diff --check`.
- Added/updated targeted unit tests under `tests/ut/quantization/` and `tests/ut/ops/`.
- Not run locally: `pytest` and `ruff` are unavailable in this development environment; NPU W4A8 coverage is pending CI or hardware validation.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
