### PR TITLE
[BugFix][Model] Support MiniMax-M3 DSpark speculative decoding

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -27,6 +27,19 @@ LARGE_HEAD_PREFILL_PATH = "vllm_ascend.device.utils.npu_large_head_prefill_atten
 
 
 class TestAttentionGraphHelpers(TestBase):
+    def tearDown(self):
+        needs_layer_aware_fia_graph_replay.cache_clear()
+
+    def test_minimax_m3_uses_layer_aware_fia_graph_replay(self):
+        for model_type in ("minimax_m3", "minimax_m3_vl"):
+            config = MagicMock()
+            config.model_config.hf_config = SimpleNamespace(model_type=model_type)
+            config.model_config.hf_text_config = None
+            needs_layer_aware_fia_graph_replay.cache_clear()
+
+            with patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=config):
+                self.assertTrue(needs_layer_aware_fia_graph_replay())
+
     def test_cache_graph_workspace_keeps_first_workspace_by_default(self):
         graph_params = SimpleNamespace(workspaces={1: torch.empty(4)})
         candidate_workspace = torch.empty(8)

--- a/tests/ut/models/test_minimax_m3_dspark.py
+++ b/tests/ut/models/test_minimax_m3_dspark.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+from vllm_ascend.models.minimax_m3.minimax_m3 import _uses_aux_hidden_states
+from vllm_ascend.worker.model_runner_v1 import (
+    _get_dspark_aux_hidden_state_layers,
+    _get_sfa_indexer_kernel_num_blocks,
+    _get_unpacked_kv_cache_tensor_size,
+    _normalize_sfa_indexer_cache_spec,
+)
+
+
+@pytest.mark.parametrize(
+    ("method", "uses_dspark", "expected"),
+    [
+        ("eagle3", False, True),
+        ("dspark", True, True),
+        ("draft_model", False, False),
+    ],
+)
+def test_minimax_m3_aux_hidden_states_are_enabled_for_dspark(
+    method: str,
+    uses_dspark: bool,
+    expected: bool,
+) -> None:
+    speculative_config = SimpleNamespace(
+        method=method,
+        use_dspark=lambda: uses_dspark,
+    )
+    vllm_config = SimpleNamespace(speculative_config=speculative_config)
+
+    assert _uses_aux_hidden_states(vllm_config) is expected
+
+
+def test_minimax_m3_aux_hidden_states_are_disabled_without_speculation() -> None:
+    vllm_config = SimpleNamespace(speculative_config=None)
+
+    assert not _uses_aux_hidden_states(vllm_config)
+
+
+def test_dspark_layers_are_read_from_nested_dflash_config() -> None:
+    hf_config = SimpleNamespace(
+        dflash_config={
+            "target_layer_ids": [1, 12, 23, 35, 46, 57],
+        }
+    )
+
+    assert _get_dspark_aux_hidden_state_layers(hf_config) == (
+        2,
+        13,
+        24,
+        36,
+        47,
+        58,
+    )
+
+
+@pytest.mark.parametrize(
+    "hf_config",
+    [
+        SimpleNamespace(dspark_target_layer_ids=[1, 3]),
+        SimpleNamespace(target_layer_ids=[1, 3]),
+    ],
+)
+def test_dspark_layers_support_existing_top_level_configs(
+    hf_config: SimpleNamespace,
+) -> None:
+    assert _get_dspark_aux_hidden_state_layers(hf_config) == (2, 4)
+
+
+def test_stale_minimax_indexer_cache_spec_is_rebuilt() -> None:
+    stale_spec_type = type("AscendSFAIndexerCacheSpec", (SimpleNamespace,), {})
+    stale_spec = stale_spec_type(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        cache_dtype_str=None,
+        scale_dim=0,
+        scale_dtype=torch.int8,
+        cache_sparse_li_c8=False,
+        sfa_dcp_replicated_indexer_size=1,
+    )
+
+    normalized = _normalize_sfa_indexer_cache_spec(stale_spec)
+
+    assert isinstance(normalized, AscendSFAIndexerCacheSpec)
+    assert normalized.block_size == 128
+    assert normalized.head_size == 128
+
+
+def test_packed_kv_tensor_is_unpacked_to_its_layer_slice() -> None:
+    kv_tensor = SimpleNamespace(
+        size=4096,
+        block_stride=1024,
+        offset=256,
+        shared_by=["index_cache"],
+    )
+    specs = {"index_cache": SimpleNamespace(page_size_bytes=128)}
+
+    assert _get_unpacked_kv_cache_tensor_size(kv_tensor, specs) == 512
+
+
+def test_packed_kv_tensor_rejects_slice_outside_block_stride() -> None:
+    kv_tensor = SimpleNamespace(
+        size=4096,
+        block_stride=1024,
+        offset=960,
+        shared_by=["index_cache"],
+    )
+    specs = {"index_cache": SimpleNamespace(page_size_bytes=128)}
+
+    with pytest.raises(ValueError, match="slice exceeds block stride"):
+        _get_unpacked_kv_cache_tensor_size(kv_tensor, specs)
+
+
+def test_sfa_indexer_expands_physical_blocks_for_kernel_block_table() -> None:
+    assert _get_sfa_indexer_kernel_num_blocks(
+        num_physical_blocks=2216,
+        physical_block_size=2048,
+        kernel_block_size=128,
+        replicated_size=1,
+    ) == 35456

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -28,6 +29,9 @@ import pytest
 import torch
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel,
+)
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
@@ -62,7 +66,11 @@ class _DSparkProposerTestBase:
         """Build the minimal config consumed by the DSpark initializer."""
         draft_model_config = SimpleNamespace(hf_config=hf_config, get_hidden_size=lambda: _HIDDEN_SIZE)
         return SimpleNamespace(
-            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config)
+            speculative_config=SimpleNamespace(
+                draft_sample_method="greedy",
+                draft_model_config=draft_model_config,
+                enforce_eager=True,
+            )
         )
 
     @classmethod
@@ -99,6 +107,8 @@ class _DSparkProposerTestBase:
                 if draft_attn_causal is not None
                 else SimpleNamespace()
             )
+            proposer.use_cuda_graph = not vllm_config.speculative_config.enforce_eager
+            proposer.maybe_eager_context = nullcontext()
 
         with patch.object(AscendDSparkProposer.__base__, "__init__", mock_parent_init):
             proposer = AscendDSparkProposer(vllm_config, device)
@@ -420,10 +430,12 @@ class TestDSparkInitValidation:
         max_num_tokens,
         draft_sample_method,
         hidden_size=8,
+        enforce_eager=True,
     ):
         speculative_config = SimpleNamespace(
             num_speculative_tokens=num_speculative_tokens,
             draft_sample_method=draft_sample_method,
+            enforce_eager=enforce_eager,
             draft_model_config=SimpleNamespace(
                 hf_config=SimpleNamespace(),
                 get_hidden_size=lambda: hidden_size
@@ -451,6 +463,8 @@ class TestDSparkInitValidation:
             self.dtype = dtype
             self.device = device
             self.draft_model_config = vllm_config.speculative_config.draft_model_config
+            self.use_cuda_graph = not vllm_config.speculative_config.enforce_eager
+            self.maybe_eager_context = nullcontext()
             # present so the ``del`` in DSpark.__init__ succeeds
             self.hidden_size = 0
             self.hidden_states = None
@@ -508,7 +522,7 @@ class TestDSparkInitValidation:
         assert proposer.hidden_size == hidden
         assert proposer.hidden_states.shape == (max_num_tokens, hidden)
         assert proposer._dflash_hidden_states.shape == (max_num_tokens, hidden)
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
+        # The launch config requests eager execution for the draft model.
         assert proposer.use_cuda_graph is False
         # anchor-first: N query tokens per request, no bonus token (unlike
         # DFlash's 1+N).
@@ -520,6 +534,28 @@ class TestDSparkInitValidation:
         assert proposer._per_group_block_tables == {}
         assert proposer._per_group_slot_mappings == {}
         assert proposer._context_slot_mapping_buffers is None
+
+    def test_graph_mode_follows_speculative_config(self, monkeypatch):
+        device = torch.device("cpu")
+        self._stub_dflash_init(
+            monkeypatch,
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            dtype=torch.float32,
+            device=device,
+        )
+        vllm_config = self._make_vllm_config(
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            draft_sample_method="greedy",
+            enforce_eager=False,
+        )
+
+        proposer = AscendDSparkProposer(vllm_config, device)
+
+        assert proposer.use_cuda_graph is True
 
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
@@ -681,6 +717,19 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         assert kwargs["HAS_NUM_REJECTED"] is True
         assert kwargs["num_rejected_tokens_ptr"] is rejected
         assert kwargs["SAMPLE_FROM_ANCHOR"] is True
+        assert kwargs["block_table_num_cols"] == 16
+
+    def test_kernel_guards_fully_rejected_request(self):
+        """A zero-valid-token row must not read ``ctx_start - 1`` or write
+        rejected target tokens into the draft KV cache."""
+        kernel = copy_and_expand_dflash_and_dspark_inputs_kernel
+        source = inspect.getsource(getattr(kernel, "fn", kernel))
+
+        assert "num_rejected = tl.minimum(tl.maximum(num_rejected, 0), num_ctx)" in source
+        assert "last_valid_idx = tl.maximum(valid_ctx_end - 1, ctx_start)" in source
+        assert "tl.where(valid_ctx_end > ctx_start, last_pos, last_pos - 1)" in source
+        assert "tl.where(is_valid_context, slot, -1)" in source
+        assert "block_num_q < block_table_num_cols" in source
 
 
 class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -28,6 +29,9 @@ import pytest
 import torch
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid,
+)
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
@@ -49,7 +53,11 @@ class _DSparkProposerTestBase:
         """Build the minimal config consumed by the DSpark initializer."""
         draft_model_config = SimpleNamespace(hf_config=hf_config, get_hidden_size=lambda: _HIDDEN_SIZE)
         return SimpleNamespace(
-            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config)
+            speculative_config=SimpleNamespace(
+                draft_sample_method="greedy",
+                draft_model_config=draft_model_config,
+                enforce_eager=True,
+            )
         )
 
     @classmethod
@@ -80,6 +88,8 @@ class _DSparkProposerTestBase:
             proposer.hidden_size = _HIDDEN_SIZE
             proposer.hidden_states = torch.empty(0)
             proposer._dflash_hidden_states = torch.empty(0)
+            proposer.use_cuda_graph = not vllm_config.speculative_config.enforce_eager
+            proposer.maybe_eager_context = nullcontext()
 
         with patch.object(AscendDSparkProposer.__base__, "__init__", mock_parent_init):
             proposer = AscendDSparkProposer(vllm_config, device)
@@ -402,10 +412,12 @@ class TestDSparkInitValidation:
         max_num_tokens,
         draft_sample_method,
         hidden_size=8,
+        enforce_eager=True,
     ):
         speculative_config = SimpleNamespace(
             num_speculative_tokens=num_speculative_tokens,
             draft_sample_method=draft_sample_method,
+            enforce_eager=enforce_eager,
             draft_model_config=SimpleNamespace(
                 hf_config=SimpleNamespace(),
                 get_hidden_size=lambda: hidden_size
@@ -433,6 +445,8 @@ class TestDSparkInitValidation:
             self.dtype = dtype
             self.device = device
             self.draft_model_config = vllm_config.speculative_config.draft_model_config
+            self.use_cuda_graph = not vllm_config.speculative_config.enforce_eager
+            self.maybe_eager_context = nullcontext()
             # present so the ``del`` in DSpark.__init__ succeeds
             self.hidden_size = 0
             self.hidden_states = None
@@ -490,7 +504,7 @@ class TestDSparkInitValidation:
         assert proposer.hidden_size == hidden
         assert proposer.hidden_states.shape == (max_num_tokens, hidden)
         assert proposer._dflash_hidden_states.shape == (max_num_tokens, hidden)
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
+        # The launch config requests eager execution for the draft model.
         assert proposer.use_cuda_graph is False
         # anchor-first: N query tokens per request, no bonus token (unlike
         # DFlash's 1+N).
@@ -502,6 +516,28 @@ class TestDSparkInitValidation:
         assert proposer._per_group_block_tables == {}
         assert proposer._per_group_slot_mappings == {}
         assert proposer._context_slot_mapping_buffers is None
+
+    def test_graph_mode_follows_speculative_config(self, monkeypatch):
+        device = torch.device("cpu")
+        self._stub_dflash_init(
+            monkeypatch,
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            dtype=torch.float32,
+            device=device,
+        )
+        vllm_config = self._make_vllm_config(
+            num_speculative_tokens=5,
+            max_batch_size=16,
+            max_num_tokens=256,
+            draft_sample_method="greedy",
+            enforce_eager=False,
+        )
+
+        proposer = AscendDSparkProposer(vllm_config, device)
+
+        assert proposer.use_cuda_graph is True
 
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
@@ -649,6 +685,19 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         assert kwargs["HAS_NUM_REJECTED"] is True
         assert kwargs["num_rejected_tokens_ptr"] is rejected
         assert kwargs["SAMPLE_FROM_ANCHOR"] is True
+        assert kwargs["block_table_num_cols"] == 16
+
+    def test_kernel_guards_fully_rejected_request(self):
+        """A zero-valid-token row must not read ``ctx_start - 1`` or write
+        rejected target tokens into the draft KV cache."""
+        kernel = copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
+        source = inspect.getsource(getattr(kernel, "fn", kernel))
+
+        assert "num_rejected = tl.minimum(tl.maximum(num_rejected, 0), num_ctx)" in source
+        assert "last_valid_idx = tl.maximum(valid_ctx_end - 1, ctx_start)" in source
+        assert "tl.where(valid_ctx_end > ctx_start, last_pos, last_pos - 1)" in source
+        assert "tl.where(is_valid_context, slot, -1)" in source
+        assert "block_num_q < block_table_num_cols" in source
 
 
 class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -328,6 +328,129 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(indexer_spec.page_size_bytes, 2 * 16 * (128 + 2))
         self.assertFalse(hasattr(main_spec, "sfa_dcp_replicated_indexer_size"))
 
+    def test_shared_indexer_raw_cache_is_joined_once(self):
+        runner = self._build_runner()
+        layer_names = [
+            "model.layers.1.self_attn.indexer.k_cache",
+            "model.layers.2.self_attn.indexer.k_cache",
+        ]
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            scale_dim=0,
+            scale_dtype=torch.int8,
+            cache_sparse_li_c8=False,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=indexer_spec.page_size_bytes * 2,
+                    shared_by=layer_names,
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=layer_names,
+                    kv_cache_spec=indexer_spec,
+                )
+            ],
+        )
+        raw_cache = (
+            torch.zeros(indexer_spec.page_size_bytes, dtype=torch.int8),
+            torch.zeros(indexer_spec.page_size_bytes, dtype=torch.int8),
+        )
+        raw_caches = {layer_name: raw_cache for layer_name in layer_names}
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=indexer_spec,
+                backend=backend,
+                layer_names=layer_names,
+            )
+        ]
+
+        with patch("torch.cat", wraps=torch.cat) as mock_cat:
+            caches = runner._reshape_kv_cache_tensors(
+                kv_cache_config,
+                raw_caches,
+            )
+
+        mock_cat.assert_called_once_with(raw_cache)
+        first_cache = caches[layer_names[0]][0]
+        second_cache = caches[layer_names[1]][0]
+        self.assertEqual(first_cache.shape, (2, 2, 1, 4))
+        self.assertEqual(first_cache.data_ptr(), second_cache.data_ptr())
+
+    def test_packed_indexer_cache_matches_logical_block_table_capacity(self):
+        runner = self._build_runner()
+        runner.kernel_block_sizes = [[2]]
+        layer_name = "model.layers.1.self_attn.attn.index_cache"
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=8,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+        )
+        num_physical_blocks = 3
+        block_stride = indexer_spec.page_size_bytes + 64
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_physical_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=block_stride * num_physical_blocks,
+                    shared_by=[layer_name],
+                    offset=64,
+                    block_stride=block_stride,
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=indexer_spec,
+                )
+            ],
+        )
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_group_id=0,
+                kv_cache_spec=indexer_spec,
+                backend=backend,
+                layer_names=[layer_name],
+            )
+        ]
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        (raw_indexer_cache,) = raw_caches[layer_name]
+        (indexer_cache,) = runner._reshape_kv_cache_tensors(
+            kv_cache_config, raw_caches
+        )[layer_name]
+
+        self.assertEqual(
+            raw_indexer_cache.numel(),
+            num_physical_blocks * indexer_spec.page_size_bytes,
+        )
+        self.assertEqual(indexer_cache.shape, (12, 2, 1, 4))
+
     def test_sparse_sfa_and_li_c8_allocate_and_reshape_independently(self):
         runner = self._build_runner()
         runner.use_sparse = True

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -289,6 +289,129 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(indexer_spec.page_size_bytes, 2 * 16 * (128 + 2))
         self.assertFalse(hasattr(main_spec, "sfa_dcp_replicated_indexer_size"))
 
+    def test_shared_indexer_raw_cache_is_joined_once(self):
+        runner = self._build_runner()
+        layer_names = [
+            "model.layers.1.self_attn.indexer.k_cache",
+            "model.layers.2.self_attn.indexer.k_cache",
+        ]
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            scale_dim=0,
+            scale_dtype=torch.int8,
+            cache_sparse_li_c8=False,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=indexer_spec.page_size_bytes * 2,
+                    shared_by=layer_names,
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=layer_names,
+                    kv_cache_spec=indexer_spec,
+                )
+            ],
+        )
+        raw_cache = (
+            torch.zeros(indexer_spec.page_size_bytes, dtype=torch.int8),
+            torch.zeros(indexer_spec.page_size_bytes, dtype=torch.int8),
+        )
+        raw_caches = {layer_name: raw_cache for layer_name in layer_names}
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=indexer_spec,
+                backend=backend,
+                layer_names=layer_names,
+            )
+        ]
+
+        with patch("torch.cat", wraps=torch.cat) as mock_cat:
+            caches = runner._reshape_kv_cache_tensors(
+                kv_cache_config,
+                raw_caches,
+            )
+
+        mock_cat.assert_called_once_with(raw_cache)
+        first_cache = caches[layer_names[0]][0]
+        second_cache = caches[layer_names[1]][0]
+        self.assertEqual(first_cache.shape, (2, 2, 1, 4))
+        self.assertEqual(first_cache.data_ptr(), second_cache.data_ptr())
+
+    def test_packed_indexer_cache_matches_logical_block_table_capacity(self):
+        runner = self._build_runner()
+        runner.kernel_block_sizes = [[2]]
+        layer_name = "model.layers.1.self_attn.attn.index_cache"
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=8,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+        )
+        num_physical_blocks = 3
+        block_stride = indexer_spec.page_size_bytes + 64
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_physical_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=block_stride * num_physical_blocks,
+                    shared_by=[layer_name],
+                    offset=64,
+                    block_stride=block_stride,
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=indexer_spec,
+                )
+            ],
+        )
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_group_id=0,
+                kv_cache_spec=indexer_spec,
+                backend=backend,
+                layer_names=[layer_name],
+            )
+        ]
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        (raw_indexer_cache,) = raw_caches[layer_name]
+        (indexer_cache,) = runner._reshape_kv_cache_tensors(
+            kv_cache_config, raw_caches
+        )[layer_name]
+
+        self.assertEqual(
+            raw_indexer_cache.numel(),
+            num_physical_blocks * indexer_spec.page_size_bytes,
+        )
+        self.assertEqual(indexer_cache.shape, (12, 2, 1, 4))
+
     def test_sparse_sfa_and_li_c8_allocate_and_reshape_independently(self):
         runner = self._build_runner()
         runner.use_sparse = True

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -136,7 +136,17 @@ def needs_layer_aware_fia_graph_replay() -> bool:
         getattr(hf_text_config, "model_type", None),
         getattr(text_config, "model_type", None),
     )
-    return any(model_type in {"gemma4", "gemma4_text"} for model_type in model_types)
+    # Mixed-attention models cannot rely on metadata insertion order during
+    # graph replay. MiniMax-M3 interleaves dense FIA and sparse-attention
+    # layers, so a captured dense FIA op must resolve metadata by layer name;
+    # otherwise it can be paired with AscendMiniMaxM3SparseMetadata.
+    layer_aware_model_types = {
+        "gemma4",
+        "gemma4_text",
+        "minimax_m3",
+        "minimax_m3_vl",
+    }
+    return any(model_type in layer_aware_model_types for model_type in model_types)
 
 
 def ascend_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:

--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -412,6 +412,11 @@ def _get_text_config(vllm_config: VllmConfig) -> PretrainedConfig:
     return vllm_config.model_config.hf_text_config
 
 
+def _uses_aux_hidden_states(vllm_config: VllmConfig) -> bool:
+    speculative_config = vllm_config.speculative_config
+    return speculative_config is not None and (speculative_config.method == "eagle3" or speculative_config.use_dspark())
+
+
 def _get_max_position_embeddings(config: PretrainedConfig) -> int:
     max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
     max_model_len = getattr(config, "max_model_len", None)
@@ -805,9 +810,7 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
         self.config = config
-        self._enable_eagle3_aux_hidden_states = (
-            vllm_config.speculative_config is not None and vllm_config.speculative_config.method == "eagle3"
-        )
+        self._enable_aux_hidden_states = _uses_aux_hidden_states(vllm_config)
 
         self.vocab_size = text_config.vocab_size
         self.num_hidden_layers = text_config.num_hidden_layers
@@ -877,7 +880,7 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         return hidden_states
 
     def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
-        if self._enable_eagle3_aux_hidden_states:
+        if self._enable_aux_hidden_states:
             EagleModelMixin._set_aux_hidden_state_layers(self, layers)
         else:
             EagleModelMixin._set_aux_hidden_state_layers(self, ())

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -81,6 +81,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     # Block table
     block_table_ptr,  # [max_reqs, max_blocks]
     block_table_stride,  # stride of block_table dim 0 (in elements)
+    block_table_num_cols,  # number of valid columns in each block-table row
     # Metadata
     query_start_loc_ptr,  # [num_reqs + 1]
     seq_lens_ptr,  # [num_reqs]
@@ -114,8 +115,38 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         offs = block_start + tl.arange(0, TILE_SIZE)
         mask = offs < total_input_tokens
         pos = tl.load(target_positions_ptr + offs, mask=mask)
-        tl.store(out_context_positions_ptr + offs, pos, mask=mask)
         slot = tl.load(context_slot_mapping_ptr + offs, mask=mask)
+        if HAS_NUM_REJECTED:
+            # Resolve each flattened context offset back to its request. This
+            # branch is compiled out for DFlash and the no-rejection fast path.
+            context_req_idx = tl.zeros([TILE_SIZE], dtype=tl.int32)
+            for req_boundary in range(1, batch_size):
+                req_start = tl.load(query_start_loc_ptr + req_boundary)
+                context_req_idx += (offs >= req_start).to(tl.int32)
+            context_end = tl.load(
+                query_start_loc_ptr + context_req_idx + 1,
+                mask=mask,
+                other=0,
+            )
+            context_start = tl.load(
+                query_start_loc_ptr + context_req_idx,
+                mask=mask,
+                other=0,
+            )
+            context_num_tokens = tl.maximum(context_end - context_start, 0)
+            context_num_rejected = tl.load(
+                num_rejected_tokens_ptr + context_req_idx,
+                mask=mask,
+                other=0,
+            )
+            context_num_rejected = tl.minimum(
+                tl.maximum(context_num_rejected, 0),
+                context_num_tokens,
+            )
+            is_valid_context = offs < context_end - context_num_rejected
+            pos = tl.where(is_valid_context, pos, -1)
+            slot = tl.where(is_valid_context, slot, -1)
+        tl.store(out_context_positions_ptr + offs, pos, mask=mask)
         tl.store(out_context_slot_mapping_ptr + offs, slot, mask=mask)
         block_start += block_start_step
 
@@ -131,16 +162,49 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         req_idx = offs // num_query_per_req
         q_idx = offs % num_query_per_req
 
-        ctx_end = tl.load(query_start_loc_ptr + req_idx + 1, mask=mask, other=0)
+        ctx_start = tl.minimum(
+            tl.maximum(
+                tl.load(query_start_loc_ptr + req_idx, mask=mask, other=0),
+                0,
+            ),
+            total_input_tokens,
+        )
+        ctx_end = tl.minimum(
+            tl.maximum(
+                tl.load(
+                    query_start_loc_ptr + req_idx + 1,
+                    mask=mask,
+                    other=0,
+                ),
+                ctx_start,
+            ),
+            total_input_tokens,
+        )
+        num_ctx = ctx_end - ctx_start
         if HAS_NUM_REJECTED:
-            num_rejected = tl.load(num_rejected_tokens_ptr + req_idx, mask=mask, other=0)
+            num_rejected = tl.load(
+                num_rejected_tokens_ptr + req_idx,
+                mask=mask,
+                other=0,
+            )
+            num_rejected = tl.minimum(tl.maximum(num_rejected, 0), num_ctx)
         else:
             num_rejected = tl.zeros([TILE_SIZE], dtype=tl.int32)
         valid_ctx_end = ctx_end - num_rejected
 
         seq_len = tl.load(seq_lens_ptr + req_idx, mask=mask, other=0)
-        effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1, mask=mask, other=0)
+        effective_seq_len = tl.maximum(seq_len - num_rejected, 0)
+        last_valid_idx = tl.maximum(valid_ctx_end - 1, ctx_start)
+        last_pos = tl.load(
+            target_positions_ptr + last_valid_idx,
+            mask=mask,
+            other=0,
+        )
+        last_pos = tl.where(
+            valid_ctx_end > ctx_start,
+            last_pos,
+            last_pos - 1,
+        )
 
         # RoPE position id of the query token, derived from the last context
         # token's position. Written to out_query_positions for position embeddings.
@@ -156,10 +220,27 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         # identical, so this only changes behaviour for multimodal inputs.
         query_kv_slot_pos = effective_seq_len + q_idx
         block_num_q = query_kv_slot_pos // block_size
-        block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q, mask=mask, other=0).to(
-            tl.int64
+        valid_block_num = (
+            (block_num_q >= 0)
+            & (block_num_q < block_table_num_cols)
         )
+        safe_block_num = tl.minimum(
+            tl.maximum(block_num_q, 0),
+            block_table_num_cols - 1,
+        )
+        block_id_q = tl.load(
+            block_table_ptr
+            + req_idx * block_table_stride
+            + safe_block_num,
+            mask=mask,
+            other=-1,
+        ).to(tl.int64)
         slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
+        slot_q = tl.where(
+            valid_block_num & (block_id_q >= 0),
+            slot_q,
+            -1,
+        )
         tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=mask)
 
         bonus = tl.load(next_token_ids_ptr + req_idx, mask=mask, other=0)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -81,6 +81,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     # Block table
     block_table_ptr,  # [max_reqs, max_blocks]
     block_table_stride,  # stride of block_table dim 0 (in elements)
+    block_table_num_cols,  # number of valid columns in each block-table row
     # Metadata
     query_start_loc_ptr,  # [num_reqs + 1]
     seq_lens_ptr,  # [num_reqs]
@@ -96,28 +97,52 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
 ):
     for req_idx in range(0, batch_size):
-        ctx_start = tl.load(query_start_loc_ptr + req_idx)
-        ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
+        # A request may have no valid sampled token (for example when the
+        # target runner discards sampling for a partial request).  Keep all
+        # pointer arithmetic inside this step's input range even in that case.
+        ctx_start = tl.minimum(
+            tl.maximum(tl.load(query_start_loc_ptr + req_idx), 0),
+            total_input_tokens,
+        )
+        ctx_end = tl.minimum(
+            tl.maximum(tl.load(query_start_loc_ptr + req_idx + 1), ctx_start),
+            total_input_tokens,
+        )
         num_ctx = ctx_end - ctx_start
+
+        if HAS_NUM_REJECTED:
+            num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
+            num_rejected = tl.minimum(tl.maximum(num_rejected, 0), num_ctx)
+        else:
+            num_rejected = 0
+        valid_ctx_end = ctx_end - num_rejected
 
         for j in range(0, num_ctx):
             ctx_pos_idx = ctx_start + j
             pos = tl.load(target_positions_ptr + ctx_pos_idx)
-            tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
-
             slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
-            tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
 
-        if HAS_NUM_REJECTED:
-            num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
-            valid_ctx_end = ctx_end - num_rejected
-        else:
-            num_rejected = 0
-            valid_ctx_end = ctx_end
+            # Rejected target tokens must not populate the draft KV cache.
+            # In particular, a fully discarded row has no valid context slot.
+            is_valid_context = ctx_pos_idx < valid_ctx_end
+            tl.store(
+                out_context_positions_ptr + ctx_pos_idx,
+                tl.where(is_valid_context, pos, -1),
+            )
+            tl.store(
+                out_context_slot_mapping_ptr + ctx_pos_idx,
+                tl.where(is_valid_context, slot, -1),
+            )
 
         seq_len = tl.load(seq_lens_ptr + req_idx)
-        effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+        effective_seq_len = tl.maximum(seq_len - num_rejected, 0)
+
+        # ``valid_ctx_end - 1`` points before the input buffer when the first
+        # request has zero valid tokens.  Use the first scheduled position as
+        # the boundary in that case: the last valid position is one before it.
+        last_valid_idx = tl.maximum(valid_ctx_end - 1, ctx_start)
+        last_pos = tl.load(target_positions_ptr + last_valid_idx)
+        last_pos = tl.where(valid_ctx_end > ctx_start, last_pos, last_pos - 1)
 
         for q_idx in range(0, num_query_per_req):
             query_pos = last_pos + 1 + q_idx
@@ -127,8 +152,16 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
 
             query_cache_pos = effective_seq_len + q_idx
             block_num_q = query_cache_pos // block_size
-            block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
+            valid_block_num = (block_num_q >= 0) & (block_num_q < block_table_num_cols)
+            safe_block_num = tl.minimum(
+                tl.maximum(block_num_q, 0),
+                block_table_num_cols - 1,
+            )
+            block_id_q = tl.load(
+                block_table_ptr + req_idx * block_table_stride + safe_block_num
+            ).to(tl.int64)
             slot_q = block_id_q * block_size + (query_cache_pos % block_size)
+            slot_q = tl.where(valid_block_num & (block_id_q >= 0), slot_q, -1)
             tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
 
             if q_idx == 0:

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -144,6 +144,7 @@ class AscendDflashProposer(AscendEagleProposer):
             # Block table
             block_table_ptr=cad.block_table_tensor,
             block_table_stride=cad.block_table_tensor.stride(0),
+            block_table_num_cols=cad.block_table_tensor.shape[1],
             # Metadata
             query_start_loc_ptr=cad.query_start_loc,
             seq_lens_ptr=cad.seq_lens,

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -107,6 +107,7 @@ class AscendDflashProposer(AscendEagleProposer):
             # Block table
             block_table_ptr=cad.block_table_tensor,
             block_table_stride=cad.block_table_tensor.stride(0),
+            block_table_num_cols=cad.block_table_tensor.shape[1],
             # Metadata
             query_start_loc_ptr=cad.query_start_loc,
             seq_lens_ptr=cad.seq_lens,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -13,9 +13,17 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
-from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
-from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel,
+)
+from vllm_ascend.spec_decode.dflash_proposer import (
+    AscendDflashProposer,
+    _compute_num_programs,
+)
+from vllm_ascend.spec_decode.utils import (
+    DynamicSpecScheduler,
+    _maybe_eager_context,
+)
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -72,8 +80,14 @@ class AscendDSparkProposer(AscendDflashProposer):
                 num_speculative_tokens=self.num_speculative_tokens,
                 device=device,
             )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
+
+        # ``use_cuda_graph`` is initialized by the base proposer from the
+        # target graph mode and speculative_config.enforce_eager. Keep that
+        # decision instead of forcing DSpark eager here. When the resulting
+        # path is eager, disable compilation while constructing the draft
+        # model as well because its VllmConfig is derived from the target.
+        if not self.use_cuda_graph:
+            self.maybe_eager_context = _maybe_eager_context(vllm_config)
         # Max query tokens depend on whether sampling from anchor or not.
         self.max_query_tokens = self.max_batch_size * self.num_query_per_req
         # Position ids for the draft query block [max_query_tokens].
@@ -286,6 +300,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 # Block table
                 block_table_ptr=gid_block_table,
                 block_table_stride=gid_block_table.stride(0),
+                block_table_num_cols=gid_block_table.shape[1],
                 # Metadata
                 query_start_loc_ptr=cad.query_start_loc,
                 seq_lens_ptr=cad.seq_lens,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -14,6 +14,7 @@ from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.spec_decode.utils import _maybe_eager_context
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -59,8 +60,13 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=self.dtype,
             device=self.device,
         )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
+        # ``use_cuda_graph`` is initialized by the base proposer from the
+        # target graph mode and speculative_config.enforce_eager.  Keep that
+        # decision instead of forcing DSpark eager here.  When the resulting
+        # path is eager, disable compilation while constructing the draft
+        # model as well because its VllmConfig is derived from the target.
+        if not self.use_cuda_graph:
+            self.maybe_eager_context = _maybe_eager_context(vllm_config)
         # Max query tokens depend on whether sampling from anchor or not.
         self.max_query_tokens = self.max_batch_size * self.num_query_per_req
         # Position ids for the draft query block [max_query_tokens].
@@ -252,6 +258,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 # Block table
                 block_table_ptr=gid_block_table,
                 block_table_stride=gid_block_table.stride(0),
+                block_table_num_cols=gid_block_table.shape[1],
                 # Metadata
                 query_start_loc_ptr=cad.query_start_loc,
                 seq_lens_ptr=cad.seq_lens,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1134,7 +1134,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 
-        if get_ascend_config().enable_reduce_sample:
+        if get_ascend_config().enable_reduce_sample and self.method != "dspark":
             if self.method in ("eagle3", "dflash", "mtp"):
                 draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                 if lmhead_tp_enable():

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1110,7 +1110,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 
-        if get_ascend_config().enable_reduce_sample:
+        if get_ascend_config().enable_reduce_sample and self.method != "dspark":
             if self.method in ("eagle3", "dflash", "mtp"):
                 draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                 if lmhead_tp_enable():

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -80,6 +80,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheTensor,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -287,6 +288,112 @@ class ExecuteModelState(NamedTuple):
     ec_connector_output: "ECConnectorOutput | None"
     cudagraph_stats: CUDAGraphStat | None
     batch_desc: BatchDescriptor
+
+
+def _get_dspark_aux_hidden_state_layers(hf_config) -> tuple[int, ...] | None:
+    layer_ids = getattr(hf_config, "dspark_target_layer_ids", None)
+    if layer_ids is None:
+        layer_ids = getattr(hf_config, "target_layer_ids", None)
+    if layer_ids is None:
+        dflash_config = getattr(hf_config, "dflash_config", None) or {}
+        layer_ids = dflash_config.get("target_layer_ids")
+    if not layer_ids:
+        return None
+    return tuple(layer_id + 1 for layer_id in layer_ids)
+
+
+def _normalize_sfa_indexer_cache_spec(spec: KVCacheSpec) -> KVCacheSpec:
+    """Rebuild an indexer spec that was created before KV-cache patching.
+
+    MiniMax-M3 registers its indexer layers while the model module is loaded.
+    If that happens before ``patch_kv_cache_interface`` replaces the upstream
+    cache classes, the returned spec has the right fields but fails the
+    runner's ``isinstance`` checks and is allocated as a regular K/V cache.
+    """
+    if spec.__class__.__name__ != AscendSFAIndexerCacheSpec.__name__:
+        return spec
+    return AscendSFAIndexerCacheSpec(
+        block_size=spec.block_size,
+        num_kv_heads=spec.num_kv_heads,
+        head_size=spec.head_size,
+        dtype=spec.dtype,
+        cache_dtype_str=spec.cache_dtype_str,
+        scale_dim=spec.scale_dim,
+        scale_dtype=spec.scale_dtype,
+        cache_sparse_li_c8=spec.cache_sparse_li_c8,
+        sfa_dcp_replicated_indexer_size=spec.sfa_dcp_replicated_indexer_size,
+    )
+
+
+def _is_sfa_indexer_cache_spec(spec: KVCacheSpec) -> bool:
+    return (
+        isinstance(spec, AscendSFAIndexerCacheSpec)
+        or spec.__class__.__name__ == AscendSFAIndexerCacheSpec.__name__
+    )
+
+
+def _get_unpacked_kv_cache_tensor_size(
+    kv_cache_tensor: KVCacheTensor,
+    layer_kv_cache_spec: dict[str, KVCacheSpec],
+) -> int:
+    """Return the bytes needed for one contiguous packed-layout slice.
+
+    vLLM's packed KV-cache planner emits one descriptor per page-size slot.
+    ``size`` describes the shared packed backing, while ``block_stride`` is
+    the byte size of a complete physical block across every slot. Ascend
+    kernels currently require each layer slice to be contiguous, so allocate
+    the descriptor's slice independently instead of treating the whole packed
+    backing as that layer's cache.
+
+    The sum of all returned slice sizes equals the packed backing size, so
+    this changes layout rather than total KV-cache capacity.
+    """
+    block_stride = getattr(kv_cache_tensor, "block_stride", 0)
+    if block_stride <= 0:
+        return kv_cache_tensor.size
+
+    if kv_cache_tensor.size % block_stride != 0:
+        raise ValueError(
+            "Packed KV cache size must be divisible by block stride: "
+            f"size={kv_cache_tensor.size}, block_stride={block_stride}"
+        )
+    page_sizes = {
+        layer_kv_cache_spec[layer_name].page_size_bytes
+        for layer_name in kv_cache_tensor.shared_by
+    }
+    if len(page_sizes) != 1:
+        raise ValueError(
+            "Layers sharing a packed KV cache tensor must have the same page "
+            f"size, got {page_sizes} for {kv_cache_tensor.shared_by}"
+        )
+    page_size = page_sizes.pop()
+    offset = getattr(kv_cache_tensor, "offset", 0)
+    if offset + page_size > block_stride:
+        raise ValueError(
+            "Packed KV cache slice exceeds block stride: "
+            f"offset={offset}, page_size={page_size}, "
+            f"block_stride={block_stride}"
+        )
+    num_physical_blocks = kv_cache_tensor.size // block_stride
+    return num_physical_blocks * page_size
+
+
+def _get_sfa_indexer_kernel_num_blocks(
+    num_physical_blocks: int,
+    physical_block_size: int,
+    kernel_block_size: int,
+    replicated_size: int,
+) -> int:
+    if kernel_block_size <= 0 or physical_block_size % kernel_block_size != 0:
+        raise ValueError(
+            "SFA indexer kernel block size must divide the physical block "
+            f"size: physical={physical_block_size}, kernel={kernel_block_size}"
+        )
+    return (
+        num_physical_blocks
+        * (physical_block_size // kernel_block_size)
+        * replicated_size
+    )
 
 
 class NPUModelRunner(GPUModelRunner):
@@ -650,14 +757,7 @@ class NPUModelRunner(GPUModelRunner):
             return layer_ids
         if self.speculative_config.use_dspark():
             hf_config = self.speculative_config.draft_model_config.hf_config
-            # deepseek v4 dspark
-            dspark_layer_ids = getattr(hf_config, "dspark_target_layer_ids", None)
-            if dspark_layer_ids:
-                return tuple(i + 1 for i in dspark_layer_ids)
-            # gqa backend dspark
-            dspark_layer_ids = getattr(hf_config, "target_layer_ids", None)
-            if dspark_layer_ids:
-                return tuple(i + 1 for i in dspark_layer_ids)
+            return _get_dspark_aux_hidden_state_layers(hf_config)
         return None
 
     def _use_aclgraph(self) -> bool:
@@ -3921,6 +4021,9 @@ class NPUModelRunner(GPUModelRunner):
         # have only linear or attention layers, for example, the mtp layer.
         self.hybrid_with_attn_and_mamba = False
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            tensor_size = _get_unpacked_kv_cache_tensor_size(
+                kv_cache_tensor, layer_kv_cache_spec
+            )
             use_mamba, use_attn = False, False
             for layer_name in kv_cache_tensor.shared_by:
                 if isinstance(layer_kv_cache_spec[layer_name], MambaSpec):
@@ -3950,11 +4053,11 @@ class NPUModelRunner(GPUModelRunner):
                         for ln in kv_cache_tensor.shared_by
                     )
                     if self.vllm_config.kv_transfer_config is None:
-                        tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=self.device)
+                        tensor = torch.zeros(tensor_size, dtype=torch.int8, device=self.device)
                     else:
-                        cache_size_aligned = kv_cache_tensor.size + alignment
+                        cache_size_aligned = tensor_size + alignment
                         tensor = torch.zeros(cache_size_aligned, dtype=torch.int8, device=self.device)
-                        tensor = self._align_memory(tensor, alignment)[: kv_cache_tensor.size]
+                        tensor = self._align_memory(tensor, alignment)[:tensor_size]
 
                     if has_mamba and has_hidden:
                         # Allocate separate tensor for HiddenStateCacheSpec layers
@@ -3976,23 +4079,23 @@ class NPUModelRunner(GPUModelRunner):
 
                 elif "attn" in layer_name and self.use_compress and layer_name not in kv_cache_raw_tensors:
                     if self.vllm_config.kv_transfer_config is None:
-                        tensor = torch.zeros(kv_cache_tensor.size,
+                        tensor = torch.zeros(tensor_size,
                                                 dtype=torch.int8,
                                                 device=self.device)
                     else:
-                        cache_size_aligned = kv_cache_tensor.size + alignment
+                        cache_size_aligned = tensor_size + alignment
                         tensor = torch.zeros(cache_size_aligned, dtype=torch.int8, device=self.device)
-                        tensor = self._align_memory(tensor, alignment)[: kv_cache_tensor.size]
+                        tensor = self._align_memory(tensor, alignment)[:tensor_size]
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the kvcache between the self_attn specs in the same group
                         kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif (
-                    isinstance(layer_kv_cache_spec[layer_name], AscendSFAIndexerCacheSpec)
-                    and layer_name not in kv_cache_raw_tensors
+                    _is_sfa_indexer_cache_spec(layer_kv_cache_spec[layer_name])
+                    and (idx == 0 or layer_name not in kv_cache_raw_tensors)
                 ):
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     raw_cache: tuple[torch.Tensor, ...]
-                    num_blocks = kv_cache_tensor.size // current_kv_cache_spec.page_size_bytes
+                    num_blocks = tensor_size // current_kv_cache_spec.page_size_bytes
                     k_tensor_size = (
                         num_blocks
                         * current_kv_cache_spec.sfa_dcp_replicated_indexer_size
@@ -4039,7 +4142,7 @@ class NPUModelRunner(GPUModelRunner):
                     )
 
                     if current_sparse_sfa_c8:
-                        k_tensor_size = kv_cache_tensor.size
+                        k_tensor_size = tensor_size
                         v_tensor_size = None
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
@@ -4054,8 +4157,8 @@ class NPUModelRunner(GPUModelRunner):
                             )
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
-                        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                        k_tensor_size = int(tensor_size // k_tensor_split_factor)
+                        v_tensor_size = int(tensor_size // v_tensor_split_factor)
                     if self.sparse_kv_offload_enabled:
                         assert self.use_sparse, "Sparse KV offload only support sparse attention."
                         assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
@@ -4153,6 +4256,13 @@ class NPUModelRunner(GPUModelRunner):
             corresponding memory buffer for KV cache.
         """
         kv_caches: dict[str, torch.Tensor] = {}
+        # Uniform hybrid cache groups can expose the same pair of raw K/V
+        # tensors through multiple indexer and padding layers. Rejoining that
+        # pair once per layer retains a full-size duplicate for every alias and
+        # can exhaust device memory while initializing long-context caches.
+        # Cache the joined storage by the shared tensor objects so all aliases
+        # only create views of one concatenated buffer.
+        joined_indexer_raw_caches: dict[tuple[int, ...], torch.Tensor] = {}
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
         for group in self._kv_cache_spec_attn_group_iterator():
             attn_backend = group.backend
@@ -4219,14 +4329,25 @@ class NPUModelRunner(GPUModelRunner):
                                            )
 
                     kv_caches[layer_name] = kv_cache
-                elif isinstance(current_kv_cache_spec, AscendSFAIndexerCacheSpec):
+                elif _is_sfa_indexer_cache_spec(current_kv_cache_spec):
                     raw_cache = kv_cache_raw_tensors[layer_name]
                     assert isinstance(raw_cache, tuple)
                     if current_kv_cache_spec.scale_dim:
                         raw_k_tensor, raw_scale_tensor = raw_cache
                         sum_page_size_bytes = raw_k_tensor.numel() + raw_scale_tensor.numel()
                     else:
-                        (raw_k_tensor,) = raw_cache
+                        # A uniform hybrid cache group may initially allocate
+                        # this single-tensor indexer spec through the generic
+                        # K/V path. Rejoin the two byte buffers before applying
+                        # the indexer layout.
+                        if len(raw_cache) == 1:
+                            raw_k_tensor = raw_cache[0]
+                        else:
+                            raw_cache_key = tuple(id(tensor) for tensor in raw_cache)
+                            raw_k_tensor = joined_indexer_raw_caches.get(raw_cache_key)
+                            if raw_k_tensor is None:
+                                raw_k_tensor = torch.cat(raw_cache)
+                                joined_indexer_raw_caches[raw_cache_key] = raw_k_tensor
                         raw_scale_tensor = None
                         sum_page_size_bytes = raw_k_tensor.numel()
 
@@ -4234,9 +4355,36 @@ class NPUModelRunner(GPUModelRunner):
                     num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
                     assert num_blocks >= kv_cache_config.num_blocks
 
-                    kv_cache_shape = attn_backend.get_kv_cache_shape(
-                        num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                    kv_cache_group_id = getattr(group, "kv_cache_group_id", None)
+                    kernel_block_size = current_kv_cache_spec.block_size
+                    if (
+                        kv_cache_group_id is not None
+                        and hasattr(self, "kernel_block_sizes")
+                    ):
+                        kernel_block_size = self.kernel_block_sizes[
+                            kv_cache_group_id
+                        ][0]
+                    kernel_num_blocks = _get_sfa_indexer_kernel_num_blocks(
+                        num_blocks,
                         current_kv_cache_spec.block_size,
+                        kernel_block_size,
+                        current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                    )
+                    min_kernel_num_blocks = _get_sfa_indexer_kernel_num_blocks(
+                        kv_cache_config.num_blocks,
+                        current_kv_cache_spec.block_size,
+                        kernel_block_size,
+                        current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                    )
+                    assert kernel_num_blocks >= min_kernel_num_blocks, (
+                        "SFA indexer cache has fewer logical blocks than the "
+                        "scheduler can allocate: "
+                        f"cache={kernel_num_blocks}, "
+                        f"required={min_kernel_num_blocks}"
+                    )
+                    kv_cache_shape = attn_backend.get_kv_cache_shape(
+                        kernel_num_blocks,
+                        kernel_block_size,
                         current_kv_cache_spec.num_kv_heads,
                         current_kv_cache_spec.head_size,
                     )
@@ -4245,8 +4393,8 @@ class NPUModelRunner(GPUModelRunner):
                         kv_caches[layer_name] = (indexer_k_cache,)
                     else:
                         indexer_scale_cache_shape = attn_backend.get_kv_cache_shape(
-                            num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
-                            current_kv_cache_spec.block_size,
+                            kernel_num_blocks,
+                            kernel_block_size,
                             current_kv_cache_spec.num_kv_heads,
                             current_kv_cache_spec.scale_dim,
                         )
@@ -4582,6 +4730,8 @@ class NPUModelRunner(GPUModelRunner):
         """
         Initialize the attention backends and attention metadata builders.
         """
+        from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+
         assert len(self.attn_groups) == 0, "Attention backends are already initialized"
 
         class AttentionGroupKey(NamedTuple):
@@ -4624,6 +4774,7 @@ class NPUModelRunner(GPUModelRunner):
                 attn_backend = layers[layer_name].get_attn_backend()
                 if (
                     isinstance(layer_kv_cache_spec, AscendSFAIndexerCacheSpec)
+                    and isinstance(layers[layer_name], DeepseekV32IndexerCache)
                     and not backend_supports_kernel_block_size(
                         attn_backend,
                         layer_kv_cache_spec.block_size,
@@ -4803,6 +4954,7 @@ class NPUModelRunner(GPUModelRunner):
                     attn_layer_names.add(layer_name)
 
             elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
+                spec = _normalize_sfa_indexer_cache_spec(spec)
                 kv_cache_spec[layer_name] = spec
                 if isinstance(spec, AttentionSpec):
                     attn_layer_names.add(layer_name)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -80,6 +80,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheTensor,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -282,6 +283,112 @@ class ExecuteModelState(NamedTuple):
     ec_connector_output: "ECConnectorOutput | None"
     cudagraph_stats: CUDAGraphStat | None
     batch_desc: BatchDescriptor
+
+
+def _get_dspark_aux_hidden_state_layers(hf_config) -> tuple[int, ...] | None:
+    layer_ids = getattr(hf_config, "dspark_target_layer_ids", None)
+    if layer_ids is None:
+        layer_ids = getattr(hf_config, "target_layer_ids", None)
+    if layer_ids is None:
+        dflash_config = getattr(hf_config, "dflash_config", None) or {}
+        layer_ids = dflash_config.get("target_layer_ids")
+    if not layer_ids:
+        return None
+    return tuple(layer_id + 1 for layer_id in layer_ids)
+
+
+def _normalize_sfa_indexer_cache_spec(spec: KVCacheSpec) -> KVCacheSpec:
+    """Rebuild an indexer spec that was created before KV-cache patching.
+
+    MiniMax-M3 registers its indexer layers while the model module is loaded.
+    If that happens before ``patch_kv_cache_interface`` replaces the upstream
+    cache classes, the returned spec has the right fields but fails the
+    runner's ``isinstance`` checks and is allocated as a regular K/V cache.
+    """
+    if spec.__class__.__name__ != AscendSFAIndexerCacheSpec.__name__:
+        return spec
+    return AscendSFAIndexerCacheSpec(
+        block_size=spec.block_size,
+        num_kv_heads=spec.num_kv_heads,
+        head_size=spec.head_size,
+        dtype=spec.dtype,
+        cache_dtype_str=spec.cache_dtype_str,
+        scale_dim=spec.scale_dim,
+        scale_dtype=spec.scale_dtype,
+        cache_sparse_li_c8=spec.cache_sparse_li_c8,
+        sfa_dcp_replicated_indexer_size=spec.sfa_dcp_replicated_indexer_size,
+    )
+
+
+def _is_sfa_indexer_cache_spec(spec: KVCacheSpec) -> bool:
+    return (
+        isinstance(spec, AscendSFAIndexerCacheSpec)
+        or spec.__class__.__name__ == AscendSFAIndexerCacheSpec.__name__
+    )
+
+
+def _get_unpacked_kv_cache_tensor_size(
+    kv_cache_tensor: KVCacheTensor,
+    layer_kv_cache_spec: dict[str, KVCacheSpec],
+) -> int:
+    """Return the bytes needed for one contiguous packed-layout slice.
+
+    vLLM's packed KV-cache planner emits one descriptor per page-size slot.
+    ``size`` describes the shared packed backing, while ``block_stride`` is
+    the byte size of a complete physical block across every slot. Ascend
+    kernels currently require each layer slice to be contiguous, so allocate
+    the descriptor's slice independently instead of treating the whole packed
+    backing as that layer's cache.
+
+    The sum of all returned slice sizes equals the packed backing size, so
+    this changes layout rather than total KV-cache capacity.
+    """
+    block_stride = getattr(kv_cache_tensor, "block_stride", 0)
+    if block_stride <= 0:
+        return kv_cache_tensor.size
+
+    if kv_cache_tensor.size % block_stride != 0:
+        raise ValueError(
+            "Packed KV cache size must be divisible by block stride: "
+            f"size={kv_cache_tensor.size}, block_stride={block_stride}"
+        )
+    page_sizes = {
+        layer_kv_cache_spec[layer_name].page_size_bytes
+        for layer_name in kv_cache_tensor.shared_by
+    }
+    if len(page_sizes) != 1:
+        raise ValueError(
+            "Layers sharing a packed KV cache tensor must have the same page "
+            f"size, got {page_sizes} for {kv_cache_tensor.shared_by}"
+        )
+    page_size = page_sizes.pop()
+    offset = getattr(kv_cache_tensor, "offset", 0)
+    if offset + page_size > block_stride:
+        raise ValueError(
+            "Packed KV cache slice exceeds block stride: "
+            f"offset={offset}, page_size={page_size}, "
+            f"block_stride={block_stride}"
+        )
+    num_physical_blocks = kv_cache_tensor.size // block_stride
+    return num_physical_blocks * page_size
+
+
+def _get_sfa_indexer_kernel_num_blocks(
+    num_physical_blocks: int,
+    physical_block_size: int,
+    kernel_block_size: int,
+    replicated_size: int,
+) -> int:
+    if kernel_block_size <= 0 or physical_block_size % kernel_block_size != 0:
+        raise ValueError(
+            "SFA indexer kernel block size must divide the physical block "
+            f"size: physical={physical_block_size}, kernel={kernel_block_size}"
+        )
+    return (
+        num_physical_blocks
+        * (physical_block_size // kernel_block_size)
+        * replicated_size
+    )
 
 
 class NPUModelRunner(GPUModelRunner):
@@ -648,14 +755,7 @@ class NPUModelRunner(GPUModelRunner):
             return layer_ids
         if self.speculative_config.use_dspark():
             hf_config = self.speculative_config.draft_model_config.hf_config
-            # deepseek v4 dspark
-            dspark_layer_ids = getattr(hf_config, "dspark_target_layer_ids", None)
-            if dspark_layer_ids:
-                return tuple(i + 1 for i in dspark_layer_ids)
-            # gqa backend dspark
-            dspark_layer_ids = getattr(hf_config, "target_layer_ids", None)
-            if dspark_layer_ids:
-                return tuple(i + 1 for i in dspark_layer_ids)
+            return _get_dspark_aux_hidden_state_layers(hf_config)
         return None
 
     def _use_aclgraph(self) -> bool:
@@ -3877,6 +3977,9 @@ class NPUModelRunner(GPUModelRunner):
         # have only linear or attention layers, for example, the mtp layer.
         self.hybrid_with_attn_and_mamba = False
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            tensor_size = _get_unpacked_kv_cache_tensor_size(
+                kv_cache_tensor, layer_kv_cache_spec
+            )
             use_mamba, use_attn = False, False
             for layer_name in kv_cache_tensor.shared_by:
                 if isinstance(layer_kv_cache_spec[layer_name], MambaSpec):
@@ -3895,34 +3998,34 @@ class NPUModelRunner(GPUModelRunner):
                 ) and layer_name not in kv_cache_raw_tensors:
                     # for mamba linear attention, attn-linear hybrid, or cache_only_layers (extract_hidden_states)
                     if self.vllm_config.kv_transfer_config is None:
-                        tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=self.device)
+                        tensor = torch.zeros(tensor_size, dtype=torch.int8, device=self.device)
                     else:
-                        cache_size_aligned = kv_cache_tensor.size + alignment
+                        cache_size_aligned = tensor_size + alignment
                         tensor = torch.zeros(cache_size_aligned, dtype=torch.int8, device=self.device)
-                        tensor = self._align_memory(tensor, alignment)[: kv_cache_tensor.size]
+                        tensor = self._align_memory(tensor, alignment)[:tensor_size]
 
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the kvcache for all shared layers
                         kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif "attn" in layer_name and self.use_compress and layer_name not in kv_cache_raw_tensors:
                     if self.vllm_config.kv_transfer_config is None:
-                        tensor = torch.zeros(kv_cache_tensor.size,
+                        tensor = torch.zeros(tensor_size,
                                                 dtype=torch.int8,
                                                 device=self.device)
                     else:
-                        cache_size_aligned = kv_cache_tensor.size + alignment
+                        cache_size_aligned = tensor_size + alignment
                         tensor = torch.zeros(cache_size_aligned, dtype=torch.int8, device=self.device)
-                        tensor = self._align_memory(tensor, alignment)[: kv_cache_tensor.size]
+                        tensor = self._align_memory(tensor, alignment)[:tensor_size]
                     for layer_name_inner in kv_cache_tensor.shared_by:
                         # shared the kvcache between the self_attn specs in the same group
                         kv_cache_raw_tensors[layer_name_inner] = tensor
                 elif (
-                    isinstance(layer_kv_cache_spec[layer_name], AscendSFAIndexerCacheSpec)
-                    and layer_name not in kv_cache_raw_tensors
+                    _is_sfa_indexer_cache_spec(layer_kv_cache_spec[layer_name])
+                    and (idx == 0 or layer_name not in kv_cache_raw_tensors)
                 ):
                     current_kv_cache_spec = layer_kv_cache_spec[layer_name]
                     raw_cache: tuple[torch.Tensor, ...]
-                    num_blocks = kv_cache_tensor.size // current_kv_cache_spec.page_size_bytes
+                    num_blocks = tensor_size // current_kv_cache_spec.page_size_bytes
                     k_tensor_size = (
                         num_blocks
                         * current_kv_cache_spec.sfa_dcp_replicated_indexer_size
@@ -3969,7 +4072,7 @@ class NPUModelRunner(GPUModelRunner):
                     )
 
                     if current_sparse_sfa_c8:
-                        k_tensor_size = kv_cache_tensor.size
+                        k_tensor_size = tensor_size
                         v_tensor_size = None
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
@@ -3984,8 +4087,8 @@ class NPUModelRunner(GPUModelRunner):
                             )
                         else:
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
-                        k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
-                        v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                        k_tensor_size = int(tensor_size // k_tensor_split_factor)
+                        v_tensor_size = int(tensor_size // v_tensor_split_factor)
                     if self.sparse_kv_offload_enabled:
                         assert self.use_sparse, "Sparse KV offload only support sparse attention."
                         assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
@@ -4083,6 +4186,13 @@ class NPUModelRunner(GPUModelRunner):
             corresponding memory buffer for KV cache.
         """
         kv_caches: dict[str, torch.Tensor] = {}
+        # Uniform hybrid cache groups can expose the same pair of raw K/V
+        # tensors through multiple indexer and padding layers. Rejoining that
+        # pair once per layer retains a full-size duplicate for every alias and
+        # can exhaust device memory while initializing long-context caches.
+        # Cache the joined storage by the shared tensor objects so all aliases
+        # only create views of one concatenated buffer.
+        joined_indexer_raw_caches: dict[tuple[int, ...], torch.Tensor] = {}
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
         for group in self._kv_cache_spec_attn_group_iterator():
             attn_backend = group.backend
@@ -4149,14 +4259,25 @@ class NPUModelRunner(GPUModelRunner):
                                            )
 
                     kv_caches[layer_name] = kv_cache
-                elif isinstance(current_kv_cache_spec, AscendSFAIndexerCacheSpec):
+                elif _is_sfa_indexer_cache_spec(current_kv_cache_spec):
                     raw_cache = kv_cache_raw_tensors[layer_name]
                     assert isinstance(raw_cache, tuple)
                     if current_kv_cache_spec.scale_dim:
                         raw_k_tensor, raw_scale_tensor = raw_cache
                         sum_page_size_bytes = raw_k_tensor.numel() + raw_scale_tensor.numel()
                     else:
-                        (raw_k_tensor,) = raw_cache
+                        # A uniform hybrid cache group may initially allocate
+                        # this single-tensor indexer spec through the generic
+                        # K/V path. Rejoin the two byte buffers before applying
+                        # the indexer layout.
+                        if len(raw_cache) == 1:
+                            raw_k_tensor = raw_cache[0]
+                        else:
+                            raw_cache_key = tuple(id(tensor) for tensor in raw_cache)
+                            raw_k_tensor = joined_indexer_raw_caches.get(raw_cache_key)
+                            if raw_k_tensor is None:
+                                raw_k_tensor = torch.cat(raw_cache)
+                                joined_indexer_raw_caches[raw_cache_key] = raw_k_tensor
                         raw_scale_tensor = None
                         sum_page_size_bytes = raw_k_tensor.numel()
 
@@ -4164,9 +4285,36 @@ class NPUModelRunner(GPUModelRunner):
                     num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
                     assert num_blocks >= kv_cache_config.num_blocks
 
-                    kv_cache_shape = attn_backend.get_kv_cache_shape(
-                        num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                    kv_cache_group_id = getattr(group, "kv_cache_group_id", None)
+                    kernel_block_size = current_kv_cache_spec.block_size
+                    if (
+                        kv_cache_group_id is not None
+                        and hasattr(self, "kernel_block_sizes")
+                    ):
+                        kernel_block_size = self.kernel_block_sizes[
+                            kv_cache_group_id
+                        ][0]
+                    kernel_num_blocks = _get_sfa_indexer_kernel_num_blocks(
+                        num_blocks,
                         current_kv_cache_spec.block_size,
+                        kernel_block_size,
+                        current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                    )
+                    min_kernel_num_blocks = _get_sfa_indexer_kernel_num_blocks(
+                        kv_cache_config.num_blocks,
+                        current_kv_cache_spec.block_size,
+                        kernel_block_size,
+                        current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
+                    )
+                    assert kernel_num_blocks >= min_kernel_num_blocks, (
+                        "SFA indexer cache has fewer logical blocks than the "
+                        "scheduler can allocate: "
+                        f"cache={kernel_num_blocks}, "
+                        f"required={min_kernel_num_blocks}"
+                    )
+                    kv_cache_shape = attn_backend.get_kv_cache_shape(
+                        kernel_num_blocks,
+                        kernel_block_size,
                         current_kv_cache_spec.num_kv_heads,
                         current_kv_cache_spec.head_size,
                     )
@@ -4175,8 +4323,8 @@ class NPUModelRunner(GPUModelRunner):
                         kv_caches[layer_name] = (indexer_k_cache,)
                     else:
                         indexer_scale_cache_shape = attn_backend.get_kv_cache_shape(
-                            num_blocks * current_kv_cache_spec.sfa_dcp_replicated_indexer_size,
-                            current_kv_cache_spec.block_size,
+                            kernel_num_blocks,
+                            kernel_block_size,
                             current_kv_cache_spec.num_kv_heads,
                             current_kv_cache_spec.scale_dim,
                         )
@@ -4511,6 +4659,8 @@ class NPUModelRunner(GPUModelRunner):
         """
         Initialize the attention backends and attention metadata builders.
         """
+        from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+
         assert len(self.attn_groups) == 0, "Attention backends are already initialized"
 
         class AttentionGroupKey(NamedTuple):
@@ -4553,6 +4703,7 @@ class NPUModelRunner(GPUModelRunner):
                 attn_backend = layers[layer_name].get_attn_backend()
                 if (
                     isinstance(layer_kv_cache_spec, AscendSFAIndexerCacheSpec)
+                    and isinstance(layers[layer_name], DeepseekV32IndexerCache)
                     and not backend_supports_kernel_block_size(
                         attn_backend,
                         layer_kv_cache_spec.block_size,
@@ -4732,6 +4883,7 @@ class NPUModelRunner(GPUModelRunner):
                     attn_layer_names.add(layer_name)
 
             elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
+                spec = _normalize_sfa_indexer_cache_spec(spec)
                 kv_cache_spec[layer_name] = spec
                 if isinstance(spec, AttentionSpec):
                     attn_layer_names.add(layer_name)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes MiniMax-M3 target-model execution with the DSpark speculative decoding method on Ascend.

- Enable auxiliary hidden-state capture for DSpark and resolve target layers from nested dflash_config metadata.
- Use layer-aware FIA graph replay for MiniMax-M3 mixed-attention layers and honor the configured draft graph mode.
- Guard DSpark and DFlash input expansion against fully rejected rows, invalid context positions, and block-table bounds.
- Normalize SFA indexer cache specs created before Ascend patching, unpack packed KV-cache slices correctly, reuse joined indexer buffers, and translate physical blocks to kernel block-table capacity.
- Disable reduce-sample for DSpark, whose sampling path requires per-rank results.

The failures came from several assumptions that do not hold for MiniMax-M3: DSpark layer IDs can live in dflash_config, packed KV descriptors describe a shared backing rather than one layer slice, and the SFA kernel block size can differ from the physical cache block size. Together these could prevent hidden-state capture, over-allocate or mis-shape indexer caches, and produce invalid slot mappings after token rejection.

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax-M3 can use DSpark speculative decoding on Ascend with safer rejected-token handling and corrected KV-cache initialization. There is no CLI or API change.

### How was this patch tested?

- pytest -q tests/ut/attention/a2/test_attention_v1.py tests/ut/models/test_minimax_m3_dspark.py tests/ut/spec_decode/test_dspark_proposer.py tests/ut/worker/a2/test_model_runner_v1.py
  - 85 passed, 14 warnings
- git diff --check
- TP8 NPU end-to-end validation has not been run from this rebased branch and is left for follow-up or CI hardware coverage.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
