### PR TITLE
[Perf] Avoid apply_all_penalties_kernel recompile on num_seqs

### DIFF
--- a/vllm_ascend/ops/triton/penalty.py
+++ b/vllm_ascend/ops/triton/penalty.py
@@ -27,7 +27,7 @@ from vllm_ascend.ops.triton.bincount import get_token_bin_counts_and_mask_triton
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["num_seqs"])
 def apply_all_penalties_kernel(
     logits_ptr,
     prompt_mask_ptr,


### PR DESCRIPTION
### What this PR does / why we need it?
`apply_all_penalties_kernel` currently lets Triton specialize on `num_seqs`. Triton's integer specialization classes are `1` / `N` / `D` (value == 1, not divisible by 16, divisible by 16), so online batch-size changes such as `1 → 3 → 16` each trigger a new JIT compile (~2.5s).

This PR marks `num_seqs` with `do_not_specialize` so one compiled kernel is reused across batch sizes, removing those compile spikes. Steady-state kernel latency is essentially unchanged.

### Does this PR introduce _any_ user-facing change?
No. Behavior is unchanged; only Triton specialization / compile caching for `num_seqs` is affected.

### How was this patch tested?
- Hooked `_do_compile` and swept `num_seqs=[1,3,8,16,32]`:
  - with `do_not_specialize(["num_seqs"])`: **1** compile
  - without it (default specialize): **3** compiles (`1` / `N` / `D`)
- `torch.npu.Event` steady-state timing: with vs without `do_not_specialize` within ~1% for the same shapes
- Correctness: existing `test_apply_penalties_triton` path (NPU) recommended for CI / follow-up

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
