### PR TITLE
[Refactor]Refactor token dispatcher routing initialization for quantized alltoall MoE

### DIFF
--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -492,7 +492,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
         dst_type = token_dispatch_input.quant.get_dst_type
-        scale_type = token_dispatch_input.quant.get_scale_type
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
@@ -541,7 +540,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                 global_input_tokens_local_experts_indices,
                 with_quant,
                 dst_type,
-                scale_type,
             )
         )
 
@@ -670,7 +668,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         global_input_tokens_local_experts_indices,
         with_quant,
         dst_type,
-        scale_type,
     ):
         # Early return if no local experts or no tokens
         if self.num_local_experts <= 1:
@@ -689,6 +686,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
                     expert_num=self.num_experts,
                     expert_tokens_num_flag=True,
                     active_expert_range=[0, self.num_local_experts],
+                    x_dtype=dst_type,
                 )
             )
         else:

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -681,36 +681,20 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         )
 
         if with_quant:
-            if scale_type == torch.float8_e8m0fnu:
-                experts_indices_2d_copy = global_input_tokens_local_experts_indices.reshape(
-                    global_input_tokens_local_experts_indices.shape[0], 1
+            global_input_tokens, reversed_global_input_permutation_mapping, _, dynamic_scale_after_all2all = (
+                torch_npu.npu_moe_init_routing_v2(
+                    global_input_tokens,
+                    global_input_tokens_local_experts_indices.unsqueeze(-1),
+                    scale=dynamic_scale_after_all2all,
+                    expert_num=self.num_experts,
+                    expert_tokens_num_flag=True,
+                    active_expert_range=[0, self.num_local_experts],
                 )
-                dynamic_scale_for_routing = dynamic_scale_after_all2all.view(torch.float8_e8m0fnu)
-                global_input_tokens, reversed_global_input_permutation_mapping, _, routed_scale = (
-                    torch_npu.npu_moe_init_routing_v2(
-                        global_input_tokens,
-                        experts_indices_2d_copy,
-                        scale=dynamic_scale_for_routing,
-                        active_num=experts_indices_2d_copy.shape[0],
-                        expert_num=self.num_local_experts,
-                        expert_tokens_num_type=1,
-                        expert_tokens_num_flag=True,
-                        active_expert_range=[0, self.num_local_experts],
-                        x_dtype=dst_type,
-                    )
-                )
-                dynamic_scale_after_all2all = routed_scale.view(torch.uint8)
-                experts_indices_2d_copy.untyped_storage().resize_(0)
-                return global_input_tokens, dynamic_scale_after_all2all, reversed_global_input_permutation_mapping
-            dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
-                dynamic_scale_after_all2all.unsqueeze(-1), global_input_tokens_local_experts_indices
             )
-            dynamic_scale_after_all2all = dynamic_scale_after_all2all.squeeze(-1)
-
-        # Non-quantized case
-        global_input_tokens, reversed_global_input_permutation_mapping = torch_npu.npu_moe_token_permute(
-            global_input_tokens, global_input_tokens_local_experts_indices
-        )
+        else:
+            global_input_tokens, reversed_global_input_permutation_mapping = torch_npu.npu_moe_token_permute(
+                global_input_tokens, global_input_tokens_local_experts_indices
+            )
         if self.lora_context is not None:
             postprocess_lora_indices(
                 self.lora_context,


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request refactors the token dispatching post-processing logic in `vllm_ascend/ops/fused_moe/token_dispatcher.py` for quantized scenarios by consolidating the routing initialization into a single `torch_npu.npu_moe_init_routing_v2` call.

However, the refactoring introduces several critical bugs: it omits the required `active_num` parameter, incorrectly uses global experts (`self.num_experts`) instead of local experts (`self.num_local_experts`), misses `expert_tokens_num_type` and `x_dtype` parameters, and removes the necessary FP8/MXFP scale handling. These issues will cause runtime errors and break FP8/MXFP quantization.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

the performance is tested with deepseek v4 w8a8 dynamic: 
two permute -> one initrouting   
231.6us -> 192.1us


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
