### PR TITLE
[CI] Allow superseded E2E runs to cancel promptly

### DIFF
--- a/.github/workflows/_analyze_failure.yaml
+++ b/.github/workflows/_analyze_failure.yaml
@@ -114,7 +114,7 @@ jobs:
 
       # ---- Step 4: Upload report ----
       - name: Upload failure analysis report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: failure-analysis-report

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -323,7 +323,7 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage data
-        if: ${{ always() && inputs.enable-coverage }}
+        if: ${{ !cancelled() && inputs.enable-coverage }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -336,7 +336,7 @@ jobs:
           compression-level: 0
 
       - name: Upload selected test logs
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -347,7 +347,7 @@ jobs:
           compression-level: 0
 
   upload-coverage-to-obs:
-      if: ${{ always() && inputs.enable-coverage }}
+      if: ${{ !cancelled() && inputs.enable-coverage }}
       needs: selected-tests
       runs-on: ubuntu-latest
       continue-on-error: true

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -327,7 +327,7 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&
         needs.select-tests.outputs.has_tests == 'true' &&
@@ -354,7 +354,7 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&
         contains(github.event.pull_request.labels.*.name, 'ready') &&
@@ -468,7 +468,7 @@ jobs:
   # in GitHub branch protection rules instead of tracking individual matrix job names.
   ci-gate:
     needs: [pre-commit, select-tests, run-selected-tests]
-    if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'ready') }}
+    if: ${{ !cancelled() && contains(github.event.pull_request.labels.*.name, 'ready') }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Check all required jobs
@@ -511,7 +511,7 @@ jobs:
   analyze-failure-report:
     name: Analyze failure report
     needs: [run-selected-tests, recommend-tests-from-coverage]
-    if: always()
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_analyze_failure.yaml
     with:
       log_artifact_pattern: selected-test-logs-*


### PR DESCRIPTION
### What this PR does / why we need it?

This PR replaces cancellation-resistant `always()` conditions with cancellation-aware `!cancelled()` conditions in the pull request E2E workflow and its reusable artifact/report workflows.

The workflow already uses `cancel-in-progress: true`, but running jobs guarded by `always()` continue to evaluate as true after GitHub requests cancellation. As a result, an older E2E run can keep its concurrency group occupied after a new commit is pushed, leaving the new run waiting for the old E2E to finish.

The updated conditions preserve failure artifact collection and the CI gate during normal, non-cancelled runs, while allowing superseded runs to terminate and release the concurrency slot.

### Does this PR introduce _any_ user-facing change?

No API or runtime behavior changes. CI behavior changes so a newer pull request commit can cancel the superseded E2E run instead of waiting for it to complete.

### How was this patch tested?

- Parsed all three modified workflow files with PyYAML.
- Ran `git diff --check`.
- Verified the branch is one commit ahead of `main`.
- Verified the diff contains only the three intended workflow files and eight condition replacements.

https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
