### PR TITLE
[Performance][Model] Fuse Kimi K3 learned attention residual

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fused_attention_residual.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fused_attention_residual.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.kimi_k3 import fused_attention_residual
+
+
+@pytest.mark.parametrize("num_tokens", [1, 32])
+def test_kimi_k3_fused_attention_residual(num_tokens: int):
+    torch.manual_seed(0)
+    hidden_size = 7168
+    num_residuals = 4
+    eps = 1e-5
+    prefix_sum = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16).npu()
+    block_residual = torch.randn(
+        num_tokens,
+        num_residuals,
+        hidden_size,
+        dtype=torch.bfloat16,
+    ).npu()
+    projection_weight = (torch.randn(hidden_size, dtype=torch.bfloat16) * 0.01).npu()
+    norm_weight = torch.randn(hidden_size, dtype=torch.bfloat16).npu()
+
+    actual = fused_attention_residual(
+        prefix_sum,
+        block_residual,
+        projection_weight,
+        norm_weight,
+        eps,
+    )
+
+    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1).float()
+    inverse_rms = torch.rsqrt(values.square().mean(-1) + eps)
+    scores = torch.matmul(values, (norm_weight * projection_weight).float()) * inverse_rms
+    probabilities = scores.softmax(-1)
+    expected = torch.sum(probabilities.unsqueeze(-1) * values, dim=1).to(prefix_sum.dtype)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)

--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -464,6 +464,33 @@ def test_text_model_captures_materialized_dspark_aux_stream(monkeypatch: pytest.
     assert [layer_idx for layer_idx, _ in residual_calls] == [1, 0]
 
 
+def test_kimi_k3_attention_residual_uses_fused_kernel(monkeypatch: pytest.MonkeyPatch):
+    prefix_sum = torch.randn(2, 4)
+    block_residual = torch.randn(2, 3, 4)
+    projection = SimpleNamespace(weight=torch.randn(1, 4))
+    norm = SimpleNamespace(weight=torch.randn(4), variance_epsilon=1e-5)
+    expected = torch.randn_like(prefix_sum)
+    captured: dict[str, object] = {}
+
+    def fake_fused_attention_residual(*args):
+        captured["args"] = args
+        return expected
+
+    monkeypatch.setattr(kimi_k3, "fused_attention_residual", fake_fused_attention_residual)
+    monkeypatch.setattr(kimi_k3._EXTRA_CTX, "flash_comm_v1_enabled", False)
+
+    actual = kimi_k3._apply_attention_residual(prefix_sum, block_residual, projection, norm)
+
+    assert actual is expected
+    args = captured["args"]
+    assert isinstance(args, tuple)
+    assert args[0] is prefix_sum
+    assert args[1] is block_residual
+    torch.testing.assert_close(args[2], projection.weight.squeeze(0))
+    assert args[3] is norm.weight
+    assert args[4] == norm.variance_epsilon
+
+
 def test_kimi_k3_dspark_aux_capture_mode_is_forwarded():
     causal_model = AscendKimiK3ForCausalLM.__new__(AscendKimiK3ForCausalLM)
     nn.Module.__init__(causal_model)

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -23,7 +23,6 @@ from typing import Annotated, Any, Literal, cast
 
 import numpy as np
 import torch
-import torch_npu
 from torch import nn
 from transformers import BatchFeature
 from vllm.compilation.decorators import support_torch_compile
@@ -107,6 +106,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.activation import AscendSituAndMul, SituActivationConfig
 from vllm_ascend.ops.kimi_kda import uses_kimi_k3_global_inputs_embeds
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
+from vllm_ascend.ops.triton.kimi_k3 import fused_attention_residual
 from vllm_ascend.transformers_utils.configs.kimi_k3 import KimiK3Config, KimiK3TextConfig, KimiK3VisionConfig
 from vllm_ascend.transformers_utils.processors.kimi_k3 import KimiK3Processor
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
@@ -884,16 +884,13 @@ def _apply_attention_residual(
     norm: RMSNorm,
 ) -> torch.Tensor:
     """Apply K3's learned normalized mixture over residual block starts."""
-    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
-    values_fp32 = values.float()
-    normalized, _ = torch_npu.npu_rms_norm(
-        values_fp32,
-        norm.weight.float(),
+    mixed = fused_attention_residual(
+        prefix_sum,
+        block_residual,
+        projection.weight.squeeze(0),
+        norm.weight,
         norm.variance_epsilon,
     )
-    scores = torch.matmul(normalized, projection.weight.t().float()).squeeze(-1)
-    probabilities = scores.softmax(-1).unsqueeze(1)
-    mixed = torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
     if _EXTRA_CTX.flash_comm_v1_enabled:
         # FlashComm changes the first decoder layer from the global token
         # layout to a TP-local layout.  The learned-residual arithmetic above

--- a/vllm_ascend/ops/triton/kimi_k3.py
+++ b/vllm_ascend/ops/triton/kimi_k3.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+# Adapted from https://github.com/sgl-project/sglang/pull/32544.
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit(do_not_specialize=["num_tokens", "num_residuals"])
+def _attention_residual_kernel(
+    block_residual_ptr,
+    prefix_sum_ptr,
+    norm_weight_ptr,
+    projection_weight_ptr,
+    output_ptr,
+    num_tokens,
+    hidden_size: tl.constexpr,
+    num_residuals,
+    eps: tl.constexpr,
+    num_cores: tl.constexpr,
+    residual_block_size: tl.constexpr,
+):
+    tokens_per_core = (num_tokens - 1) // num_cores + 1
+    core_idx = tl.program_id(0)
+    token_start = core_idx * tokens_per_core
+    if token_start >= num_tokens:
+        return
+    token_end = tl.minimum(token_start + tokens_per_core, num_tokens)
+
+    hidden_offsets = tl.arange(0, hidden_size)
+    residual_offsets = tl.arange(0, residual_block_size)
+
+    norm_weight = tl.load(norm_weight_ptr + hidden_offsets).to(tl.float32)
+    projection_weight = tl.load(projection_weight_ptr + hidden_offsets).to(tl.float32)
+    score_weight = norm_weight * projection_weight
+    block_stride = num_residuals * hidden_size
+
+    for token_idx in range(token_start, token_end):
+        scores = tl.full([residual_block_size], -float("inf"), dtype=tl.float32)
+        for residual_idx in range(num_residuals + 1):
+            if residual_idx < num_residuals:
+                value = tl.load(
+                    block_residual_ptr + token_idx * block_stride + residual_idx * hidden_size + hidden_offsets
+                ).to(tl.float32)
+            else:
+                value = tl.load(prefix_sum_ptr + token_idx * hidden_size + hidden_offsets).to(tl.float32)
+            inverse_rms = tl.rsqrt(tl.sum(value * value) / hidden_size + eps)
+            scores = tl.where(
+                residual_offsets == residual_idx,
+                tl.sum(value * inverse_rms * score_weight),
+                scores,
+            )
+
+        max_score = tl.max(scores)
+        probabilities = tl.exp(scores - max_score)
+        probabilities /= tl.sum(probabilities)
+
+        output = tl.zeros([hidden_size], dtype=tl.float32)
+        for residual_idx in range(num_residuals + 1):
+            if residual_idx < num_residuals:
+                value = tl.load(
+                    block_residual_ptr + token_idx * block_stride + residual_idx * hidden_size + hidden_offsets
+                ).to(tl.float32)
+            else:
+                value = tl.load(prefix_sum_ptr + token_idx * hidden_size + hidden_offsets).to(tl.float32)
+            probability = tl.sum(tl.where(residual_offsets == residual_idx, probabilities, 0.0))
+            output += probability * value
+
+        tl.store(
+            output_ptr + token_idx * hidden_size + hidden_offsets,
+            output.to(output_ptr.dtype.element_ty),
+        )
+
+
+def fused_attention_residual(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    projection_weight: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Apply Kimi K3's learned mixture over residual block starts."""
+    num_tokens, hidden_size = prefix_sum.shape
+    num_residuals = block_residual.shape[1]
+    output = torch.empty_like(prefix_sum)
+    residual_block_size = triton.next_power_of_2(num_residuals + 1)
+    num_cores = get_vectorcore_num()
+
+    _attention_residual_kernel[(num_cores,)](
+        block_residual,
+        prefix_sum,
+        norm_weight,
+        projection_weight,
+        output,
+        num_tokens,
+        hidden_size,
+        num_residuals,
+        eps,
+        num_cores,
+        residual_block_size,
+        multibuffer=True,
+    )
+    return output


### PR DESCRIPTION
### What this PR does / why we need it?

* Replaces Kimi K3's materialized `cat -> FP32 RMSNorm -> score matmul -> softmax -> weighted matmul` learned-residual path with one Ascend Triton kernel.
* Wires all Kimi K3 attention/MLP/output residual-mixture call sites through the fused helper.
* Keeps ordinary Transformer residual adds and layer norms unchanged.

### Does this PR introduce any user-facing change?

No API or configuration change. Kimi K3 uses a fused implementation of the existing learned attention-residual semantics.

### How was this patch tested?

* Added a unit test for model-to-kernel wiring.
* Added an NPU BF16 numerical test at Kimi K3 hidden size 7168.
* `git diff --check` passed locally.
* Ascend 950DT single-operator validation passed:
  * `tokens=1, hidden=7168, residuals=4`: maximum absolute error `0.0078125`.
  * `tokens=32, hidden=7168, residuals=4`: maximum absolute error `0.015625`.
  * Both cases passed `torch.testing.assert_close(rtol=2e-2, atol=2e-2)`.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
