### PR TITLE
[Refactor][Attn] eliminate useless code of attn_mask_builder

### DIFF
--- a/vllm_ascend/attention/attention_mask.py
+++ b/vllm_ascend/attention/attention_mask.py
@@ -36,7 +36,6 @@ class AttentionMaskBuilder:
         self.attn_mask_cache = None
         self._seq_len_cached = 0
         self.device = device
-        self.mla_mask = None
         self.chunked_prefill_attn_mask = None
 
     def get_attn_mask(self, max_seq_len: int, dtype: torch.dtype):
@@ -55,16 +54,6 @@ class AttentionMaskBuilder:
             )
         return self.chunked_prefill_attn_mask
 
-    def get_mla_mask(self, dtype: torch.dtype) -> torch.Tensor:
-        if self.mla_mask is None or self.mla_mask.dtype != dtype:
-            if dtype == torch.float16:
-                mask_value = torch.finfo(torch.float32).min
-            else:
-                mask_value = 1
-            prefill_mask = torch.triu(torch.ones(512, 512, device=self.device, dtype=dtype), 1)
-            self.mla_mask = torch.where(prefill_mask == 1, mask_value, 0).to(dtype)
-        return self.mla_mask
-
     def get_attention_mask(self, causal: bool, model_config: ModelConfig):
         if not causal:
             # FIA applies any provided mask as defaultMask (sparse_mode=0),
@@ -79,7 +68,3 @@ class AttentionMaskBuilder:
             return self.get_attn_mask(2048, torch.bool)
 
         return self.get_splitfuse_attn_mask()
-
-    def get_final_mla_mask(self, model_config: ModelConfig):
-        # Prefill stages use 512x512 mask with appropriate dtype
-        return self.get_mla_mask(model_config.dtype)

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -19,7 +19,6 @@ from vllm.v1.attention.backend import (
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -500,8 +499,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.graph_pad_size = 0
         self.query_lens: torch.Tensor = None
         self.seq_lens: torch.Tensor = None
-        self.attn_mask_builder = AttentionMaskBuilder(self.device)
-
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
         hf_config = self.model_config.hf_config
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -42,7 +42,6 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
-from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
@@ -145,7 +144,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
         self.decode_threshold = 1 + self.num_speculative_tokens
         self.query_start_loc = self.runner._make_buffer(self.runner.max_num_reqs + 2, dtype=torch.int32)
-        self.attn_mask_builder = AttentionMaskBuilder(self.device)
 
         self.enable_shared_expert_dp = shared_expert_dp_enabled()
 


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request removes unused and dead code related to `AttentionMaskBuilder` and `mla_mask` across the `vllm_ascend` codebase. Specifically, it:
1) removes the unused `mla_mask`, `get_mla_mask`, and `get_final_mla_mask` methods from `AttentionMaskBuilder` in `vllm_ascend/attention/attention_mask.py`.
2) removes unused imports and instantiations of `AttentionMaskBuilder` in `vllm_ascend/attention/dsa_v1.py` and `vllm_ascend/spec_decode/llm_base_proposer.py`.
3) removes the unused `get_attn_mask_builder` function and its associated global variable `_ATTENTION_MASK_BUILDER` from `vllm_ascend/worker/v2/attn_utils.py`.

This cleanup improves codebase maintainability and readability by eliminating dead code.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI cases passed.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
