### PR TITLE
[Feature] MultiConnector: give every sub-connector the request's real blocks in update_state_after_alloc

### DIFF
--- a/tests/ut/distributed/kv_transfer/test_ascend_multi_connector.py
+++ b/tests/ut/distributed/kv_transfer/test_ascend_multi_connector.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.ascend_multi_connector import AscendMultiConnector
+
+
+@pytest.mark.parametrize("chosen_connector", [None, 1])
+def test_update_state_after_alloc_forwards_real_blocks(chosen_connector: int | None) -> None:
+    connector: Any = AscendMultiConnector.__new__(AscendMultiConnector)
+    connector._connectors = [MagicMock(), MagicMock()]
+    connector._requests_to_connector = {}
+
+    request = SimpleNamespace(request_id="request-1")
+    blocks = MagicMock()
+    num_external_tokens = 17
+    if chosen_connector is not None:
+        connector._requests_to_connector[request.request_id] = chosen_connector
+
+    connector.update_state_after_alloc(request, blocks, num_external_tokens)
+
+    for index, sub_connector in enumerate(connector._connectors):
+        expected_external_tokens = num_external_tokens if index == chosen_connector else 0
+        sub_connector.update_state_after_alloc.assert_called_once_with(request, blocks, expected_external_tokens)
+    blocks.new_empty.assert_not_called()
+
+
+def test_update_state_after_alloc_keeps_mooncake_layerwise_transfer() -> None:
+    class FakeMooncakeLayerwiseConnector:
+        def __init__(self) -> None:
+            self.update_state_after_alloc = MagicMock()
+
+    connector: Any = AscendMultiConnector.__new__(AscendMultiConnector)
+    chosen = MagicMock()
+    layerwise = FakeMooncakeLayerwiseConnector()
+    connector._connectors = [chosen, layerwise]
+    connector._requests_to_connector = {"request-1": 0}
+    request = SimpleNamespace(request_id="request-1")
+    blocks = MagicMock()
+
+    with patch(
+        "vllm_ascend.distributed.kv_transfer.ascend_multi_connector.MooncakeLayerwiseConnector",
+        FakeMooncakeLayerwiseConnector,
+    ):
+        connector.update_state_after_alloc(request, blocks, 17)
+
+    chosen.update_state_after_alloc.assert_called_once_with(request, blocks, 17)
+    layerwise.update_state_after_alloc.assert_called_once_with(request, blocks, 17)

--- a/vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py
@@ -31,14 +31,15 @@ class AscendMultiConnector(MultiConnector, SupportsHMA):
 
     def update_state_after_alloc(self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int):
         chosen_connector = self._requests_to_connector.get(request.request_id, -1)
-        empty_blocks = blocks.new_empty()
-        for i, c in enumerate(self._connectors):
-            if i == chosen_connector or isinstance(c, MooncakeLayerwiseConnector):
-                # Forward call to the chosen connector (if any).
-                c.update_state_after_alloc(request, blocks, num_external_tokens)
+        for i, connector in enumerate(self._connectors):
+            if i == chosen_connector or isinstance(connector, MooncakeLayerwiseConnector):
+                # Mooncake layerwise must participate in P/D transfer even
+                # when another connector supplied the cache hit.
+                connector.update_state_after_alloc(request, blocks, num_external_tokens)
             else:
-                # Call with empty blocks for other connectors.
-                c.update_state_after_alloc(request, empty_blocks, 0)
+                # Other connectors still need the real allocated blocks to
+                # track or store newly computed KV cache for the request.
+                connector.update_state_after_alloc(request, blocks, 0)
 
     def get_num_new_matched_tokens(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?
refer to: https://github.com/vllm-project/vllm/pull/46865 , MultiConnector does not need to know whether each connector needs to perform store tracking, but rather ensures that:
-Blocks are always real;
-Whether to load is determined by the num_external_tokens.

### How was this patch tested?
todo

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
