### PR TITLE
[Refactor][device][1/N] Refactor Ascend hardware configuration and discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,10 @@ def get_chip_type() -> str:
 
 
 envs = load_module_from_path("envs", os.path.join(ROOT_DIR, "vllm_ascend", "envs.py"))
+hardware = load_module_from_path(
+    "vllm_ascend_hardware",
+    os.path.join(ROOT_DIR, "vllm_ascend", "device", "hardware.py"),
+)
 
 if not envs.SOC_VERSION:
     soc_version = get_chip_type()
@@ -152,39 +156,7 @@ if not envs.SOC_VERSION:
 
 def gen_build_info():
     soc_version = envs.SOC_VERSION
-
-    soc_to_device = {
-        "910b": "A2",
-        "910c": "A3",
-        "310p": "_310P",
-        "ascend910b1": "A2",
-        "ascend910b2": "A2",
-        "ascend910b2c": "A2",
-        "ascend910b3": "A2",
-        "ascend910b4": "A2",
-        "ascend910b4-1": "A2",
-        "ascend910_9391": "A3",
-        "ascend910_9381": "A3",
-        "ascend910_9372": "A3",
-        "ascend910_9392": "A3",
-        "ascend910_9382": "A3",
-        "ascend910_9362": "A3",
-        "ascend310p1": "_310P",
-        "ascend310p3": "_310P",
-        "ascend310p5": "_310P",
-        "ascend310p7": "_310P",
-        "ascend310p3vir01": "_310P",
-        "ascend310p3vir02": "_310P",
-        "ascend310p3vir04": "_310P",
-        "ascend310p3vir08": "_310P",
-    }
-    if "ascend950" in soc_version:
-        device_type = "A5"
-    else:
-        assert soc_version in soc_to_device, (
-            f"Undefined soc_version: {soc_version}. Please file an issue to vllm-ascend."
-        )
-        device_type = soc_to_device[soc_version]
+    device_type = hardware.device_type_from_soc_version(soc_version).name
 
     package_dir = os.path.join(ROOT_DIR, "vllm_ascend", "_build_info.py")
     with open(package_dir, "w+") as f:

--- a/tests/ut/device/test_device_config.py
+++ b/tests/ut/device/test_device_config.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_ascend import _build_info
+from vllm_ascend.device.device_config import (
+    check_ascend_device_type,
+    get_ascend_device_type,
+    get_device_config,
+)
+from vllm_ascend.device.hardware import (
+    AscendDeviceType,
+    device_type_from_runtime_soc,
+    device_type_from_soc_version,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_device_config_cache():
+    get_device_config.cache_clear()
+    yield
+    get_device_config.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("soc_version", "expected"),
+    [
+        ("ascend910b1", AscendDeviceType.A2),
+        ("ASCEND910_9391", AscendDeviceType.A3),
+        ("ascend310p3vir08", AscendDeviceType._310P),
+        ("ascend950_9599", AscendDeviceType.A5),
+    ],
+)
+def test_device_type_from_soc_version(soc_version, expected):
+    assert device_type_from_soc_version(soc_version) is expected
+
+
+@pytest.mark.parametrize(
+    ("soc_version", "expected"),
+    [
+        (220, AscendDeviceType.A2),
+        (255, AscendDeviceType.A3),
+        (203, AscendDeviceType._310P),
+        (260, AscendDeviceType.A5),
+    ],
+)
+def test_device_type_from_runtime_soc(soc_version, expected):
+    assert device_type_from_runtime_soc(soc_version) is expected
+
+
+def test_device_config_uses_build_info(monkeypatch):
+    monkeypatch.setattr(_build_info, "__device_type__", "A3")
+
+    assert get_ascend_device_type() is AscendDeviceType.A3
+
+
+def test_device_config_supports_legacy_soc_build_info(monkeypatch):
+    monkeypatch.delattr(_build_info, "__device_type__", raising=False)
+    monkeypatch.setattr(_build_info, "__soc_version__", "Ascend310P3", raising=False)
+
+    assert get_ascend_device_type() is AscendDeviceType._310P
+
+
+def test_import_time_config_does_not_probe_runtime(monkeypatch):
+    import torch_npu
+
+    get_soc_version = MagicMock(side_effect=AssertionError("runtime probe is not import-safe"))
+    monkeypatch.setattr(torch_npu.npu, "get_soc_version", get_soc_version)
+
+    assert get_ascend_device_type() is AscendDeviceType.A2
+    get_soc_version.assert_not_called()
+
+
+def test_runtime_device_match_succeeds(monkeypatch):
+    import torch_npu
+
+    monkeypatch.setattr(torch_npu.npu, "get_soc_version", lambda: 220)
+
+    check_ascend_device_type()
+
+
+def test_runtime_device_mismatch_raises_runtime_error(monkeypatch):
+    import torch_npu
+
+    monkeypatch.setattr(torch_npu.npu, "get_soc_version", lambda: 250)
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        check_ascend_device_type()
+
+
+@pytest.mark.parametrize("soc_version", ["unknown", "ascend910x"])
+def test_unknown_build_soc_version_is_rejected(soc_version):
+    with pytest.raises(RuntimeError, match="Undefined soc_version"):
+        device_type_from_soc_version(soc_version)
+
+
+def test_unknown_runtime_soc_version_is_rejected():
+    with pytest.raises(RuntimeError, match="Cannot support runtime soc_version"):
+        device_type_from_runtime_soc(999)

--- a/tests/ut/patch/worker/test_patch_kimi_k25.py
+++ b/tests/ut/patch/worker/test_patch_kimi_k25.py
@@ -55,7 +55,11 @@ def test_position_embedding_patch_uses_current_vllm_contract(grid_thws):
 def test_a5_moonvit_to_patch_uses_current_vllm_contract(monkeypatch):
     original_to = MoonViT3dPretrainedModel.to
     original_forward = Learnable2DInterpPosEmbDivided_fixed.forward
-    monkeypatch.setattr(ascend_utils, "_ascend_device_type", ascend_utils.AscendDeviceType.A5)
+    monkeypatch.setattr(
+        ascend_utils,
+        "get_ascend_device_type",
+        lambda: ascend_utils.AscendDeviceType.A5,
+    )
 
     try:
         patch_namespace = runpy.run_path(patch_kimi_k25.__file__)

--- a/vllm_ascend/device/__init__.py
+++ b/vllm_ascend/device/__init__.py
@@ -1,0 +1,3 @@
+from vllm_ascend.device.device_config import DeviceConfig, get_device_config
+
+__all__ = ["DeviceConfig", "get_device_config"]

--- a/vllm_ascend/device/device_config.py
+++ b/vllm_ascend/device/device_config.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+"""Runtime entry point for Ascend hardware configuration.
+
+Hardware discovery is cached, immutable, and import-safe. In particular, this
+module never probes torch-npu while it is being imported. Runtime validation is
+performed explicitly by the worker after the NPU runtime is ready.
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from vllm_ascend.device.hardware import (
+    AscendDeviceType,
+    device_type_from_runtime_soc,
+    device_type_from_soc_version,
+)
+
+
+@dataclass(frozen=True)
+class DeviceConfig:
+    """Immutable configuration selected for the current hardware family."""
+
+    _device_type: AscendDeviceType
+
+
+def _device_type_from_build_info() -> AscendDeviceType:
+    from vllm_ascend import _build_info  # type: ignore
+
+    device_type = getattr(_build_info, "__device_type__", None)
+    if device_type is not None:
+        try:
+            return AscendDeviceType[device_type]
+        except KeyError as exc:
+            raise RuntimeError(f"Unsupported built-in device type: {device_type}.") from exc
+
+    # Compatibility for packages generated before __device_type__ was added.
+    soc_version = getattr(_build_info, "__soc_version__", "ASCEND910B1")
+    return device_type_from_soc_version(soc_version)
+
+
+@lru_cache(maxsize=1)
+def get_device_config() -> DeviceConfig:
+    """Return the immutable hardware configuration for this installation."""
+
+    return DeviceConfig(_device_type=_device_type_from_build_info())
+
+
+# Compatibility API. New business code must consume semantic DeviceConfig
+# capabilities instead of branching on these hardware identities.
+def get_ascend_device_type() -> AscendDeviceType:
+    return get_device_config()._device_type
+
+
+def is_310p() -> bool:
+    return get_ascend_device_type() == AscendDeviceType._310P
+
+
+def is_950() -> bool:
+    return get_ascend_device_type() == AscendDeviceType.A5
+
+
+def check_ascend_device_type() -> None:
+    """Validate that the installed package matches the runtime NPU."""
+
+    import torch_npu
+
+    built_device_type = get_device_config()._device_type
+    runtime_soc_version = torch_npu.npu.get_soc_version()
+    runtime_device_type = device_type_from_runtime_soc(runtime_soc_version)
+    if built_device_type != runtime_device_type:
+        raise RuntimeError(
+            f"Current device type: {runtime_device_type} does not match the installed version's device type: "
+            f"{built_device_type}, please check your installation package."
+        )

--- a/vllm_ascend/device/hardware.py
+++ b/vllm_ascend/device/hardware.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+"""Pure hardware identification helpers.
+
+This module deliberately depends only on the Python standard library so it can
+also be loaded by ``setup.py`` before vllm-ascend is installed. Device identity
+must stay inside the device abstraction package; callers outside this package
+should consume semantic capabilities from ``device_config`` instead.
+"""
+
+from enum import Enum
+
+
+class AscendDeviceType(Enum):
+    """Internal hardware families used to select a device profile."""
+
+    A2 = 0
+    A3 = 1
+    _310P = 2
+    A5 = 3
+
+
+_SOC_VERSION_TO_DEVICE_TYPE = {
+    "910b": AscendDeviceType.A2,
+    "910c": AscendDeviceType.A3,
+    "310p": AscendDeviceType._310P,
+    "ascend910b1": AscendDeviceType.A2,
+    "ascend910b2": AscendDeviceType.A2,
+    "ascend910b2c": AscendDeviceType.A2,
+    "ascend910b3": AscendDeviceType.A2,
+    "ascend910b4": AscendDeviceType.A2,
+    "ascend910b4-1": AscendDeviceType.A2,
+    "ascend910_9391": AscendDeviceType.A3,
+    "ascend910_9381": AscendDeviceType.A3,
+    "ascend910_9372": AscendDeviceType.A3,
+    "ascend910_9392": AscendDeviceType.A3,
+    "ascend910_9382": AscendDeviceType.A3,
+    "ascend910_9362": AscendDeviceType.A3,
+    "ascend310p1": AscendDeviceType._310P,
+    "ascend310p3": AscendDeviceType._310P,
+    "ascend310p5": AscendDeviceType._310P,
+    "ascend310p7": AscendDeviceType._310P,
+    "ascend310p3vir01": AscendDeviceType._310P,
+    "ascend310p3vir02": AscendDeviceType._310P,
+    "ascend310p3vir04": AscendDeviceType._310P,
+    "ascend310p3vir08": AscendDeviceType._310P,
+}
+
+
+def device_type_from_soc_version(soc_version: str) -> AscendDeviceType:
+    """Resolve a build-time SOC_VERSION value to a hardware family."""
+
+    normalized = soc_version.strip().lower()
+    if "ascend950" in normalized:
+        return AscendDeviceType.A5
+    try:
+        return _SOC_VERSION_TO_DEVICE_TYPE[normalized]
+    except KeyError as exc:
+        raise RuntimeError(f"Undefined soc_version: {soc_version}. Please file an issue to vllm-ascend.") from exc
+
+
+def device_type_from_runtime_soc(soc_version: int) -> AscendDeviceType:
+    """Resolve the numeric SOC version reported by torch-npu."""
+
+    if 220 <= soc_version <= 225:
+        return AscendDeviceType.A2
+    if 250 <= soc_version <= 255:
+        return AscendDeviceType.A3
+    if 200 <= soc_version <= 205:
+        return AscendDeviceType._310P
+    if soc_version == 260:
+        return AscendDeviceType.A5
+    raise RuntimeError(f"Cannot support runtime soc_version: {soc_version}.")

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -24,7 +24,6 @@ import json
 import math
 import os
 from contextlib import nullcontext
-from enum import Enum
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -38,6 +37,13 @@ from vllm.sequence import IntermediateTensors
 
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.device_config import (  # noqa: F401
+    AscendDeviceType,
+    check_ascend_device_type,
+    get_ascend_device_type,
+    is_310p,
+    is_950,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -137,10 +143,6 @@ def clear_enable_sp():
     _libc_getenv.cache_clear()
 
 
-def is_310p():
-    return get_ascend_device_type() == AscendDeviceType._310P
-
-
 _IS_RC_DEVICE: bool | None = None
 
 
@@ -165,10 +167,6 @@ def is_rc_device() -> bool:
     except (subprocess.CalledProcessError, FileNotFoundError):
         _IS_RC_DEVICE = False
     return _IS_RC_DEVICE
-
-
-def is_950():
-    return get_ascend_device_type() == AscendDeviceType.A5
 
 
 def _mark_op_side_effectful(op: Any) -> None:
@@ -779,57 +777,6 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
     # NOTE: Keep this at last to ensure all custom actions are registered
     _ASCEND_CUSTOMOP_IS_REIGISTERED = True
-
-
-class AscendDeviceType(Enum):
-    A2 = 0
-    A3 = 1
-    _310P = 2
-    A5 = 3
-
-
-_ascend_device_type = None
-
-
-def _init_ascend_device_type():
-    global _ascend_device_type
-    from vllm_ascend import _build_info  # type: ignore
-
-    device_type = getattr(_build_info, "__device_type__", None)
-    if device_type is None:
-        soc_version = getattr(_build_info, "__soc_version__", "ASCEND910B1").upper()
-        device_type = "_310P" if "310P" in soc_version else "A2"
-    _ascend_device_type = AscendDeviceType[device_type]
-
-
-def check_ascend_device_type():
-    global _ascend_device_type
-    if _ascend_device_type is None:
-        _init_ascend_device_type()
-
-    soc_version = torch_npu.npu.get_soc_version()
-    if 220 <= soc_version <= 225:
-        cur_device_type = AscendDeviceType.A2
-    elif 250 <= soc_version <= 255:
-        cur_device_type = AscendDeviceType.A3
-    elif 200 <= soc_version <= 205:
-        cur_device_type = AscendDeviceType._310P
-    elif soc_version == 260:
-        cur_device_type = AscendDeviceType.A5
-    else:
-        raise RuntimeError(f"Can not support soc_version: {soc_version}.")
-
-    assert _ascend_device_type == cur_device_type, (
-        f"Current device type: {cur_device_type} does not match the installed version's device type: "
-        f"{_ascend_device_type}, please check your installation package."
-    )
-
-
-def get_ascend_device_type():
-    global _ascend_device_type
-    if _ascend_device_type is None:
-        _init_ascend_device_type()
-    return _ascend_device_type
 
 
 def lmhead_tp_enable() -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces the first step of the Ascend hardware abstraction refactoring:

- Centralizes `AscendDeviceType` and SoC mappings in a lightweight module shared by runtime and build-time code.
- Adds a lazily initialized `DeviceConfig` as the unified device detection entry point.
- Removes duplicated device detection state from `utils.py`.
- Keeps `is_310p()`, `is_950()`, and other existing APIs as compatibility wrappers.
- Makes `setup.py` reuse the same SoC mapping instead of maintaining a separate mapping table.

This establishes a single source of truth for hardware identity and prepares for capability-oriented hardware profiles in subsequent PRs.

### Does this PR introduce *any* user-facing change?

No intended user-facing behavior change.

Existing device detection APIs remain available and service startup behavior is unchanged. Device-type mismatch errors now use an explicit `RuntimeError` instead of an assertion.

### How was this patch tested?

- Added unit tests covering:
  - SoC-to-device mappings
  - build information detection
  - legacy `__soc_version__` compatibility
  - runtime device detection
  - unknown and mismatched device types
  - lazy initialization without import-time NPU probing


### Follow-up Plan

This PR only centralizes hardware identity and device detection. The remaining migration will be completed incrementally:

1. **Introduce hardware capabilities and profiles**
   - Define capability-oriented hardware profiles for supported Ascend device families.
   - Keep concrete device identities limited to detection and profile registration.

2. **Migrate platform and worker selection**
   - Move Worker, ModelRunner, and platform implementation selection behind hardware profiles.
   - Remove direct device checks from shared initialization logic.

3. **Migrate compilation and graph behavior**
   - Abstract device-specific graph backends, compilation options, fusion settings, and warm-up behavior.

4. **Migrate operators, quantization, and MoE**
   - Select weight layouts, attention implementations, quantization backends, MoE backends, and hardware-specific kernels through component providers or capabilities.

5. **Remove compatibility helpers**
   - Migrate existing call sites away from `is_310p()`, `is_950()`, and direct `AscendDeviceType` comparisons.
   - Deprecate or remove compatibility re-exports once no downstream users remain.
   - Add a static check to prevent new device-specific branches from being introduced into shared business logic.

The intended end state is that adding a new Ascend device primarily requires registering its SoC mapping and hardware profile, without modifying unrelated business modules.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
