### PR TITLE
[Refactor][Config] Migrate AscendConfig to @config pydantic dataclass

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,9 @@
 warn_unused_configs = True
 ; disable errors about unchecked annotations for now.
 disable_error_code = annotation-unchecked
+; Enable pydantic mypy plugin so @config (pydantic dataclass) generated
+; __init__ kwargs are recognized (aligns with upstream vllm pyproject.toml).
+plugins = pydantic.mypy
 
 ; Suppress all missing import errors from torch_npu for mypy.
 [mypy-torch_npu.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,9 +3,6 @@
 warn_unused_configs = True
 ; disable errors about unchecked annotations for now.
 disable_error_code = annotation-unchecked
-; Enable pydantic mypy plugin so @config (pydantic dataclass) generated
-; __init__ kwargs are recognized (aligns with upstream vllm pyproject.toml).
-plugins = pydantic.mypy
 
 ; Suppress all missing import errors from torch_npu for mypy.
 [mypy-torch_npu.*]

--- a/tests/ut/core/test_batch_job_aware_scheduler.py
+++ b/tests/ut/core/test_batch_job_aware_scheduler.py
@@ -185,7 +185,7 @@ class TestJobDecodeEstimator(TestBase):
         self.assertEqual(result, 100)
 
     def test_observe_max_jobs_exceeded_raises(self):
-        cfg = BatchJobSchedConfig({"max_jobs": 2})
+        cfg = BatchJobSchedConfig(**{"max_jobs": 2})
         estimator = JobDecodeEstimator(cfg)
         estimator.observe("job1", 100)
         estimator.observe("job2", 100)
@@ -194,7 +194,7 @@ class TestJobDecodeEstimator(TestBase):
         self.assertIn("Maximum number of jobs", str(ctx.exception))
 
     def test_observe_max_jobs_zero_allows_unlimited(self):
-        cfg = BatchJobSchedConfig({"max_jobs": 51})
+        cfg = BatchJobSchedConfig(**{"max_jobs": 51})
         estimator = JobDecodeEstimator(cfg)
         for i in range(50):
             estimator.observe(f"job{i}", 100)
@@ -751,7 +751,7 @@ class TestBatchJobAwareRequestQueue(TestBase):
         self.assertTrue(self.queue)
 
     def test_max_jobs_exceeded_raises_in_get_or_create(self):
-        cfg = BatchJobSchedConfig({"max_jobs": 1})
+        cfg = BatchJobSchedConfig(**{"max_jobs": 1})
         with patch(
             "vllm.v1.core.sched.request_queue.RequestQueue.__init__",
             MagicMock(return_value=None),

--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -81,13 +81,27 @@ class TestProfilingChunkConfig(TestBase):
 
     def test_invalid_smooth_factor_raises(self):
         with self.assertRaises(ValueError):
-            ProfilingChunkConfig({"smooth_factor": 0.0})
+            ProfilingChunkConfig(**{"smooth_factor": 0.0})
         with self.assertRaises(ValueError):
-            ProfilingChunkConfig({"smooth_factor": 1.5})
+            ProfilingChunkConfig(**{"smooth_factor": 1.5})
 
     def test_invalid_min_chunk_raises(self):
         with self.assertRaises(ValueError):
-            ProfilingChunkConfig({"min_chunk": 0})
+            ProfilingChunkConfig(**{"min_chunk": 0})
+
+    def test_need_timing_defaults_to_enabled(self):
+        # When need_timing is not provided, it defaults to enabled.
+        cfg = ProfilingChunkConfig(enabled=True)
+        self.assertTrue(cfg.need_timing)
+        cfg = ProfilingChunkConfig(enabled=False)
+        self.assertFalse(cfg.need_timing)
+
+    def test_need_timing_explicit_false_is_preserved(self):
+        # Regression: previously `need_timing if need_timing else enabled`
+        # turned explicit False back into enabled. The None sentinel must
+        # distinguish "not provided" from "explicitly False".
+        cfg = ProfilingChunkConfig(enabled=True, need_timing=False)
+        self.assertFalse(cfg.need_timing)
 
     @patch("vllm.config.VllmConfig.__post_init__", MagicMock())
     @patch("vllm.config.device.DeviceConfig.__post_init__", MagicMock())

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -664,3 +664,85 @@ class TestSubconfigPydanticTypeValidation(TestBase):
     def test_eplb_config_int_field_lax(self):
         cfg = EplbConfig(eplb_policy_type="2")
         self.assertEqual(cfg.eplb_policy_type, 2)
+
+
+class TestTopLevelSwitchTypeValidation(TestBase):
+    """Verify @config migration gives top-level AscendConfig switches type validation.
+
+    These tests exercise the full ``init_ascend_config`` path (vllm_config +
+    factory + before/after validators), so they require a constructible
+    VllmConfig. Run on NPU/Linux UT runners (Windows lacks torch_npu).
+    """
+
+    @staticmethod
+    def _clean_up(func):
+        def wrapper(*args, **kwargs):
+            clear_ascend_config()
+            clear_enable_sp()
+            try:
+                func(*args, **kwargs)
+            finally:
+                clear_ascend_config()
+                clear_enable_sp()
+
+        return wrapper
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_enable_cpu_binding_string_false_disables(self, mock_fix):
+        # Core regression: bool("false") is True in Python, so
+        # {"enable_cpu_binding": "false"} previously left CPU binding enabled.
+        # Pydantic lax coercion must resolve "false" to False.
+        vc = VllmConfig()
+        vc.additional_config = {"enable_cpu_binding": "false"}
+        self.assertFalse(init_ascend_config(vc).enable_cpu_binding)
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_enable_prefill_mc2_string_false_disables(self, mock_fix):
+        vc = VllmConfig()
+        vc.additional_config = {"enable_prefill_mc2": "false"}
+        self.assertFalse(init_ascend_config(vc).enable_prefill_mc2)
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_enable_mlapo_env_false_no_longer_crashes(self, mock_fix):
+        # Regression: `export VLLM_ASCEND_ENABLE_MLAPO=false` used to crash
+        # startup with ValueError (int("false")). The before-validator reads
+        # os.getenv directly and resolves "false" to False.
+        vc = VllmConfig()
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_MLAPO": "false"}):
+            self.assertFalse(init_ascend_config(vc).enable_mlapo)
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_enable_cpu_binding_rejects_invalid_int(self, mock_fix):
+        # JSON booleans should be true/false; an int 2 is neither 0 nor 1 and
+        # must fail fast rather than being coerced into unexpected truthiness.
+        vc = VllmConfig()
+        vc.additional_config = {"enable_cpu_binding": 2}
+        with self.assertRaises(ValueError):
+            init_ascend_config(vc)
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_mega_moe_max_tokens_int_lax(self, mock_fix):
+        # int string "131072" coerces to 131072 (fixes str-vs-int silent failure).
+        vc = VllmConfig()
+        vc.additional_config = {"mega_moe_max_tokens": "131072"}
+        self.assertEqual(init_ascend_config(vc).mega_moe_max_tokens, 131072)
+
+    @_clean_up
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_bypass_key_not_stripped_silently_when_unknown(self, mock_fix):
+        # A typo'd top-level key (not a declared field, not a known bypass key)
+        # is stripped by the factory __pydantic_fields__ filter, so extra=forbid
+        # does NOT catch it. This documents the Phase-1 limitation: top-level
+        # typo detection requires the future "Did you mean?" registry (PR-3),
+        # not forbid alone. The test asserts the current (lenient) behavior so
+        # the future tightening is a conscious change.
+        vc = VllmConfig()
+        vc.additional_config = {"enable_cpu_bindng": True}  # typo: bindng
+        # No raise: factory strips the unknown key; AscendConfig never sees it.
+        cfg = init_ascend_config(vc)
+        self.assertTrue(cfg.enable_cpu_binding)  # default True, typo ignored

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -526,7 +526,7 @@ class TestShortRequestFirstConfig(TestBase):
 
 class TestSchedulerConfig(TestBase):
     def test_defaults(self):
-        config = SchedulerConfig({}, balance_env_value=False)
+        config = SchedulerConfig(_additional_config={}, _balance_env_value=False)
 
         self.assertFalse(config.enable_balance_scheduling)
         self.assertFalse(config.recompute_scheduler_enable)
@@ -536,11 +536,11 @@ class TestSchedulerConfig(TestBase):
     @patch("vllm_ascend.ascend_config.logger.warning_once")
     def test_none_config_uses_defaults_and_legacy_fallback(self, mock_warning_once):
         config = SchedulerConfig(
-            {
+            _additional_config={
                 "scheduler_config": None,
                 "recompute_scheduler_enable": True,
             },
-            balance_env_value=False,
+            _balance_env_value=False,
         )
 
         self.assertTrue(config.recompute_scheduler_enable)
@@ -548,11 +548,11 @@ class TestSchedulerConfig(TestBase):
 
     def test_non_dict_config_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "scheduler_config must be a dict, got list"):
-            SchedulerConfig({"scheduler_config": []}, balance_env_value=False)
+            SchedulerConfig(_additional_config={"scheduler_config": []}, _balance_env_value=False)
 
     def test_nested_config_overrides_all_scheduler_settings(self):
         config = SchedulerConfig(
-            {
+            _additional_config={
                 "scheduler_config": {
                     "enable_balance_scheduling": True,
                     "recompute_scheduler_enable": True,
@@ -564,7 +564,7 @@ class TestSchedulerConfig(TestBase):
                     "profiling_chunk_config": {"enabled": True, "need_timing": False},
                 }
             },
-            balance_env_value=False,
+            _balance_env_value=False,
         )
 
         self.assertTrue(config.enable_balance_scheduling)
@@ -578,13 +578,13 @@ class TestSchedulerConfig(TestBase):
     @patch("vllm_ascend.ascend_config.logger.warning_once")
     def test_legacy_top_level_config_warns_and_remains_supported(self, mock_warning_once):
         config = SchedulerConfig(
-            {
+            _additional_config={
                 "enable_balance_scheduling": True,
                 "recompute_scheduler_enable": True,
                 "short_request_first_config": {"enabled": True},
                 "profiling_chunk_config": {"enabled": True},
             },
-            balance_env_value=False,
+            _balance_env_value=False,
         )
 
         self.assertTrue(config.enable_balance_scheduling)
@@ -596,7 +596,7 @@ class TestSchedulerConfig(TestBase):
     @patch("vllm_ascend.ascend_config.logger.warning_once")
     def test_nested_config_wins_and_legacy_fields_fill_missing_values(self, mock_warning_once):
         config = SchedulerConfig(
-            {
+            _additional_config={
                 "scheduler_config": {
                     "recompute_scheduler_enable": True,
                     "short_request_first_config": {"enabled": True},
@@ -605,7 +605,7 @@ class TestSchedulerConfig(TestBase):
                 "enable_balance_scheduling": True,
                 "short_request_first_config": {"enabled": False},
             },
-            balance_env_value=False,
+            _balance_env_value=False,
         )
 
         self.assertTrue(config.recompute_scheduler_enable)
@@ -616,7 +616,7 @@ class TestSchedulerConfig(TestBase):
     @patch("vllm_ascend.ascend_config.logger.info_once")
     def test_balance_falls_back_to_environment_default(self, mock_info_once):
         with patch.dict(os.environ, {"VLLM_ASCEND_BALANCE_SCHEDULING": "1"}):
-            config = SchedulerConfig({}, balance_env_value=True)
+            config = SchedulerConfig(_additional_config={}, _balance_env_value=True)
 
         self.assertTrue(config.enable_balance_scheduling)
         mock_info_once.assert_called_once()

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -488,14 +488,14 @@ class TestAscendConfig(TestBase):
 
 class TestShortRequestFirstConfig(TestBase):
     def test_default_is_disabled(self):
-        cfg = ShortRequestFirstConfig({})
+        cfg = ShortRequestFirstConfig()
         self.assertFalse(cfg.enabled)
         self.assertEqual(cfg.threshold, 256)
         self.assertEqual(cfg.long_max_wait_ms, 0.0)
 
     def test_explicit_config(self):
         cfg = ShortRequestFirstConfig(
-            {
+            **{
                 "enabled": True,
                 "threshold": 512,
                 "long_max_wait_ms": 2000,
@@ -507,18 +507,18 @@ class TestShortRequestFirstConfig(TestBase):
 
     def test_unknown_key_rejected(self):
         with self.assertRaises(ValueError):
-            ShortRequestFirstConfig({"foo": 1})
+            ShortRequestFirstConfig(**{"foo": 1})
 
     def test_validation_rejects_out_of_range(self):
         with self.assertRaises(ValueError):
-            ShortRequestFirstConfig({"long_token_reservation": 1.5})
+            ShortRequestFirstConfig(**{"long_token_reservation": 1.5})
         with self.assertRaises(ValueError):
-            ShortRequestFirstConfig({"threshold": -1})
+            ShortRequestFirstConfig(**{"threshold": -1})
         with self.assertRaises(ValueError):
-            ShortRequestFirstConfig({"long_max_wait_ms": -1})
+            ShortRequestFirstConfig(**{"long_max_wait_ms": -1})
 
     def test_none_config_is_disabled(self):
-        cfg = ShortRequestFirstConfig(None)
+        cfg = ShortRequestFirstConfig()
         self.assertFalse(cfg.enabled)
         self.assertEqual(cfg.threshold, 256)
         self.assertEqual(cfg.long_max_wait_ms, 0.0)

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -734,15 +734,12 @@ class TestTopLevelSwitchTypeValidation(TestBase):
 
     @_clean_up
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_bypass_key_not_stripped_silently_when_unknown(self, mock_fix):
-        # A typo'd top-level key (not a declared field, not a known bypass key)
-        # is stripped by the factory __pydantic_fields__ filter, so extra=forbid
-        # does NOT catch it. This documents the Phase-1 limitation: top-level
-        # typo detection requires the future "Did you mean?" registry (PR-3),
-        # not forbid alone. The test asserts the current (lenient) behavior so
-        # the future tightening is a conscious change.
+    def test_unknown_top_level_key_is_rejected(self, mock_fix):
+        # A typo'd top-level key (not a declared field, not a bypass key) flows
+        # into kwargs and extra="forbid" catches it. Previously the factory
+        # filtered by __pydantic_fields__ which stripped typos silently; now
+        # only _BYPASS_KEYS is stripped, so typos reach pydantic and are rejected.
         vc = VllmConfig()
         vc.additional_config = {"enable_cpu_bindng": True}  # typo: bindng
-        # No raise: factory strips the unknown key; AscendConfig never sees it.
-        cfg = init_ascend_config(vc)
-        self.assertTrue(cfg.enable_cpu_binding)  # default True, typo ignored
+        with self.assertRaises(ValueError):
+            init_ascend_config(vc)

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -738,7 +738,7 @@ class TestTopLevelSwitchTypeValidation(TestBase):
         # A typo'd top-level key (not a declared field, not a bypass key) flows
         # into kwargs and extra="forbid" catches it. Previously the factory
         # filtered by __pydantic_fields__ which stripped typos silently; now
-        # only _BYPASS_KEYS is stripped, so typos reach pydantic and are rejected.
+        # only _NON_USER_INPUT_KEYS is stripped, so typos reach pydantic and are rejected.
         vc = VllmConfig()
         vc.additional_config = {"enable_cpu_bindng": True}  # typo: bindng
         with self.assertRaises(ValueError):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -22,7 +22,12 @@ from vllm.config import KVTransferConfig, VllmConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_config import (
+    AscendCompilationConfig,
     AscendConfig,
+    AscendFusionConfig,
+    EplbConfig,
+    ProfilingChunkConfig,
+    RejectionSamplerConfig,
     SchedulerConfig,
     ShortRequestFirstConfig,
     clear_ascend_config,
@@ -63,7 +68,10 @@ class TestAscendConfig(TestBase):
     @staticmethod
     def _make_sparse_li_c8_config(quant_description):
         quant_config = SimpleNamespace(quant_description=quant_description)
-        config = AscendConfig.__new__(AscendConfig)
+        # Use object.__new__ to bypass pydantic dataclass validation; this
+        # helper only needs a partial AscendConfig to test sparse-li-c8 layer
+        # filtering, not a fully constructed instance.
+        config = object.__new__(AscendConfig)
         config.enable_sparse_li_c8 = True
         (
             config._sparse_li_c8_layer_ids,
@@ -612,3 +620,47 @@ class TestSchedulerConfig(TestBase):
 
         self.assertTrue(config.enable_balance_scheduling)
         mock_info_once.assert_called_once()
+
+
+class TestSubconfigPydanticTypeValidation(TestBase):
+    """Verify @config migration gives sub-configs lax bool/int coercion and forbid.
+
+    These tests construct sub-configs directly (no vllm_config / init_ascend_config)
+    so they run on CPU-only UT runners.
+    """
+
+    def test_ascend_fusion_config_string_false_disables(self):
+        # bool("false") is True in Python; pydantic lax must resolve to False.
+        self.assertFalse(AscendFusionConfig(fusion_ops_gmmswigluquant="false").fusion_ops_gmmswigluquant)
+        self.assertTrue(AscendFusionConfig(fusion_ops_gmmswigluquant="true").fusion_ops_gmmswigluquant)
+
+    def test_ascend_fusion_config_forbids_unknown_key(self):
+        with self.assertRaises(ValueError):
+            AscendFusionConfig(unknown_key=1)
+
+    def test_ascend_compilation_config_bool_lax_and_forbid(self):
+        cfg = AscendCompilationConfig(enable_npugraph_ex="false")
+        self.assertFalse(cfg.enable_npugraph_ex)
+        with self.assertRaises(ValueError):
+            AscendCompilationConfig(unknown_key=1)
+
+    def test_profiling_chunk_config_int_lax_and_range(self):
+        # int string "2" coerces to 2 (fixes "2"==2 silent failure)
+        cfg = ProfilingChunkConfig(min_chunk="4096", max_fit_chunk="30")
+        self.assertEqual(cfg.min_chunk, 4096)
+        # range check preserved
+        with self.assertRaises(ValueError):
+            ProfilingChunkConfig(smooth_factor=1.5)
+
+    def test_short_request_first_config_unknown_key_forbidden(self):
+        # Was hand-written unknown-key check; now extra="forbid".
+        with self.assertRaises(ValueError):
+            ShortRequestFirstConfig(foo=1)
+
+    def test_rejection_sampler_config_range_check_preserved(self):
+        with self.assertRaises(ValueError):
+            RejectionSamplerConfig(posterior_threshold=1.5)
+
+    def test_eplb_config_int_field_lax(self):
+        cfg = EplbConfig(eplb_policy_type="2")
+        self.assertEqual(cfg.eplb_policy_type, 2)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -219,7 +219,7 @@ class AscendConfig:
 
     # ---- sub-configs (need vllm_config / special): factory pre-constructs, kw_only ----
     xlite_graph_config: XliteGraphConfig = dataclasses.field(kw_only=True)
-    finegrained_tp_config: Any = dataclasses.field(kw_only=True)
+    finegrained_tp_config: FinegrainedTPConfig = dataclasses.field(kw_only=True)
     scheduler_config: Any = dataclasses.field(kw_only=True)
     sparse_kv_offload_config: Any = dataclasses.field(kw_only=True)
 
@@ -553,18 +553,25 @@ class AscendConfig:
         return
 
 
+@config
 class FinegrainedTPConfig:
-    """
-    Configuration Object for finegrained_tp_config from additional_config
+    """Configuration Object for ``additional_config["finegrained_tp_config"]``.
+
+    Migrated to ``@config`` (pydantic dataclass). 5 int fields get lax coercion
+    ('2'→2). vllm_config-dependent preconditions (TP/eager/kv_consumer/is_moe/
+    data_parallel divisibility) moved to an ``after`` model_validator.
     """
 
-    def __init__(self, finegrained_tp_config: dict, vllm_config):
-        self.oproj_tensor_parallel_size = finegrained_tp_config.get("oproj_tensor_parallel_size", 0)
-        self.lmhead_tensor_parallel_size = finegrained_tp_config.get("lmhead_tensor_parallel_size", 0)
-        self.embedding_tensor_parallel_size = finegrained_tp_config.get("embedding_tensor_parallel_size", 0)
-        self.mlp_tensor_parallel_size = finegrained_tp_config.get("mlp_tensor_parallel_size", 0)
-        self.olora_tensor_parallel_size = finegrained_tp_config.get("olora_tensor_parallel_size", 0)
+    oproj_tensor_parallel_size: int = 0
+    lmhead_tensor_parallel_size: int = 0
+    embedding_tensor_parallel_size: int = 0
+    mlp_tensor_parallel_size: int = 0
+    olora_tensor_parallel_size: int = 0
+    vllm_config: Any = dataclasses.field(kw_only=True, repr=False)
 
+    @model_validator(mode="after")
+    def _validate_preconditions(self):
+        vc = self.vllm_config
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
@@ -574,19 +581,19 @@ class FinegrainedTPConfig:
             # (standard TP). When tp_size > 1 the weight-shard and input-shard
             # operate on different axes of the rank grid and no longer align,
             # so oproj TP currently requires standard tp_size == 1.
-            if vllm_config.parallel_config.tensor_parallel_size > 1:
+            if vc.parallel_config.tensor_parallel_size > 1:
                 raise AssertionError(
                     "oproj_tensor_parallel_size currently requires "
                     "tensor_parallel_size == 1, got "
-                    f"{vllm_config.parallel_config.tensor_parallel_size}."
+                    f"{vc.parallel_config.tensor_parallel_size}."
                 )
             # The static all_to_all / reduce_scatter exchange buffers used by
             # _forward_o_proj are sized for graph replay and require ACL graph
             # capture; dummy_run does not run the entire attention module in
             # eager mode, so o_proj tp split can only be used in graph mode.
-            if vllm_config.model_config and vllm_config.model_config.enforce_eager:
+            if vc.model_config and vc.model_config.enforce_eager:
                 raise AssertionError("oproj_tensor_parallel_size is only supported in graph mode")
-            if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
+            if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
                     "oproj_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
                 )
@@ -594,9 +601,9 @@ class FinegrainedTPConfig:
             enabled_configs.append(f"olora_tensor_parallel_size={self.olora_tensor_parallel_size}")
             # dummy_run does not run the entire attention module in eager mode,
             # so the o_lora tp split can only be used in graph mode.
-            if vllm_config.model_config and vllm_config.model_config.enforce_eager:
+            if vc.model_config and vc.model_config.enforce_eager:
                 raise AssertionError("olora_tensor_parallel_size is only supported in graph mode")
-            if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
+            if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:
                 raise AssertionError(
                     "olora_tensor_parallel_size is only supported in pd scenario and can only be used in D node."
                 )
@@ -619,12 +626,13 @@ class FinegrainedTPConfig:
             # to greater than 1 in the model launch configuration, its value will be changed to 1 later.
             # This will cause an issue when finegrained tp is enabled, as it
             # cannot be split into the data parallel communication group, leading to an error.
-            if module_tp_size > 0 and not vllm_config.model_config.is_moe:
+            if module_tp_size > 0 and not vc.model_config.is_moe:
                 raise AssertionError("The finegrained tp sizes can be enabled only for MOE models.")
-            if module_tp_size > 0 and vllm_config.parallel_config.data_parallel_size % module_tp_size != 0:
+            if module_tp_size > 0 and vc.parallel_config.data_parallel_size % module_tp_size != 0:
                 raise AssertionError("finegrained tp sizes must divide by data_parallel_size.")
         if any(size > 0 for size in module_tp_sizes) and enabled_configs:
             logger.info("finegrained_tp_config enabled: %s", ", ".join(enabled_configs))
+        return self
 
 
 @config
@@ -913,7 +921,7 @@ def init_ascend_config(vllm_config):
     from vllm_ascend import envs as ascend_envs
 
     xlite = XliteGraphConfig(vllm_config=vllm_config, **additional_config.get("xlite_graph_config", {}))
-    finegrained = FinegrainedTPConfig(additional_config.get("finegrained_tp_config", {}), vllm_config)
+    finegrained = FinegrainedTPConfig(vllm_config=vllm_config, **additional_config.get("finegrained_tp_config", {}))
     sched = SchedulerConfig(additional_config, balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING)
     sparse_kv = SparseKVOffloadConfig(vllm_config, additional_config.get("sparse_kv_offload_config", {}))
     # dump_config: keep the mutual-exclusion / materialize logic as a factory
@@ -929,13 +937,13 @@ def init_ascend_config(vllm_config):
     # etc.) are kept in kwargs so pydantic coerces dict→dataclass.
     fields = AscendConfig.__pydantic_fields__
     _BYPASS_KEYS = {
-        "refresh",
+        "refresh",  # control-flow flag (singleton/cache refresh), not a config; not converged
         "dump_config_path",  # passed explicitly below
         "enable_balance_scheduling",  # SchedulerConfig internal (top-level legacy)
-        "xlite_graph_config",  # pre-constructed above
-        "finegrained_tp_config",  # pre-constructed above
-        "scheduler_config",  # pre-constructed above
-        "sparse_kv_offload_config",  # pre-constructed above
+        "xlite_graph_config",  # pre-constructed above (vllm_config dep)
+        "finegrained_tp_config",  # pre-constructed above (vllm_config dep)
+        "scheduler_config",  # pre-constructed above (vllm_config dep)
+        "sparse_kv_offload_config",  # pre-constructed above (vllm_config dep)
     }
     kwargs = {k: v for k, v in additional_config.items() if k in fields and k not in _BYPASS_KEYS}
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -28,6 +28,11 @@ from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+else:
+    # At runtime VllmConfig is not imported (avoids heavy/circular import), but
+    # pydantic must resolve the field type name. Treat it as Any so pydantic
+    # stores the reference without recursive validation (arbitrary_types_allowed).
+    VllmConfig = Any
 
 
 @config
@@ -650,22 +655,25 @@ class ProfilingChunkConfig:
     """Configuration for profiling-based dynamic chunk sizing.
 
     Migrated to ``@config`` (pydantic dataclass). Range/positivity checks
-    moved to an ``after`` model_validator. ``need_timing`` defaults to
-    ``enabled`` via the after-validator (field default is False, overridden
-    post-construction to mirror the original ``config.get("need_timing", self.enabled)``).
+    moved to an ``after`` model_validator. ``need_timing`` uses ``None`` as a
+    "not provided" sentinel so the after-validator can distinguish "user did
+    not set it" (→ default to ``enabled``) from "user explicitly set False"
+    (→ keep False), mirroring the original ``config.get("need_timing", self.enabled)``.
     """
 
     enabled: bool = False
     smooth_factor: float = 1.0
     min_chunk: int = 4096
-    need_timing: bool = False
+    need_timing: bool | None = None
     max_fit_chunk: int = 30
 
     @model_validator(mode="after")
     def _validate_and_link_need_timing(self):
         # need_timing defaults to enabled when not explicitly set by the user.
-        # (Original: config.get("need_timing", self.enabled).)
-        self.need_timing = self.need_timing if self.need_timing else self.enabled
+        # (Original: config.get("need_timing", self.enabled).) Using None as
+        # sentinel distinguishes "not provided" from "explicitly False".
+        if self.need_timing is None:
+            self.need_timing = self.enabled
         if not (0 < self.smooth_factor <= 1.0):
             raise ValueError(f"profiling_chunk_config.smooth_factor must be in (0, 1], got {self.smooth_factor}")
         if self.min_chunk <= 0:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 
 
 @config
-@dataclasses.dataclass
 class AscendCompilationConfig:
     """Configuration for controlling the behavior of Ascend graph optimization.
 
@@ -65,7 +64,6 @@ class AscendCompilationConfig:
 
 
 @config
-@dataclasses.dataclass
 class AscendFusionConfig:
     """Configuration for controlling whether to use a fused operator gmmswigluquant.
 
@@ -78,7 +76,6 @@ class AscendFusionConfig:
 
 
 @config
-@dataclasses.dataclass
 class EplbConfig:
     """Configuration Object for ``additional_config["eplb_config"]``.
 
@@ -134,7 +131,6 @@ class EplbConfig:
 
 
 @config
-@dataclasses.dataclass
 class RejectionSamplerConfig:
     """Configuration for Block Verify and Entropy Verify in Rejection Sampler.
 
@@ -160,7 +156,6 @@ class RejectionSamplerConfig:
 
 
 @config
-@dataclasses.dataclass
 class AscendConfig:
     """Configuration Object for additional_config from vllm.configs.
 
@@ -651,7 +646,6 @@ class XliteGraphConfig:
 
 
 @config
-@dataclasses.dataclass
 class ProfilingChunkConfig:
     """Configuration for profiling-based dynamic chunk sizing.
 
@@ -682,7 +676,6 @@ class ProfilingChunkConfig:
 
 
 @config
-@dataclasses.dataclass
 class BatchJobSchedConfig:
     """Configuration for batch-job-aware scheduler.
 
@@ -723,7 +716,6 @@ class BatchJobSchedConfig:
 
 
 @config
-@dataclasses.dataclass
 class ShortRequestFirstConfig:
     """Configuration object for ``additional_config["scheduler_config"]["short_request_first_config"]``.
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -850,7 +850,7 @@ class SparseKVOffloadConfig:
     Configuration for the Sparse KV cache offloading.
     """
 
-    def __init__(self, vllm_config: "VllmConfig", user_config: dict[str, Any]):
+    def __init__(self, vllm_config: VllmConfig, user_config: dict[str, Any]):
         self.enabled = bool(user_config.get("enabled", False))
         if not self.enabled:
             return
@@ -936,24 +936,40 @@ def init_ascend_config(vllm_config):
     # pre-step; the resolved path is passed as the dump_config_path field.
     dump_config_path = AscendConfig._resolve_dump_config_path(additional_config)
 
-    # Extract only the keys that correspond to declared AscendConfig fields and
-    # strip bypass keys (extra="forbid" would otherwise reject them). Bypass
-    # keys are read elsewhere (refresh by this factory; enable_dsa_cp /
-    # draft_window_size by other modules directly off additional_config;
-    # enable_balance_scheduling by SchedulerConfig above; dump_config resolved
-    # into dump_config_path above). Sub-config dicts (ascend_compilation_config
-    # etc.) are kept in kwargs so pydantic coerces dict→dataclass.
-    fields = AscendConfig.__pydantic_fields__
+    # Strip keys that must NOT flow from additional_config into AscendConfig:
+    #   - control-flow flags (refresh: not a config)
+    #   - injected fields (factory passes explicitly; additional_config copy would conflict)
+    #   - derived fields (after-validator computes them; user input would residualize)
+    #   - SchedulerConfig-internal top-level legacy key
+    # Keys NOT in this set flow into kwargs; pydantic extra="forbid" then catches
+    # typos (e.g. enable_cpu_bindng) that are neither declared fields nor bypass keys.
     _BYPASS_KEYS = {
-        "refresh",  # control-flow flag (singleton/cache refresh), not a config; not converged
-        "dump_config_path",  # passed explicitly below
-        "enable_balance_scheduling",  # SchedulerConfig field; stripped (not AscendConfig field)
-        "xlite_graph_config",  # pre-constructed above (vllm_config dep)
-        "finegrained_tp_config",  # pre-constructed above (vllm_config dep)
-        "scheduler_config",  # pre-constructed above (vllm_config dep)
-        "sparse_kv_offload_config",  # pre-constructed above (vllm_config dep)
+        # control-flow flag (singleton/cache refresh), not a config; not converged
+        "refresh",
+        # injected fields (factory passes explicitly below)
+        "vllm_config",
+        "xlite_graph_config",
+        "finegrained_tp_config",
+        "scheduler_config",
+        "sparse_kv_offload_config",
+        "dump_config_path",
+        # derived fields (after-validator computes; user input would residualize)
+        "enable_shared_expert_dp",
+        "enable_sp_by_pass",
+        "enable_sparse_sfa_c8",
+        "enable_sparse_li_c8",
+        "c8_enable_reshape_optim",
+        "pd_tp_ratio",
+        "pd_head_ratio",
+        "num_head_replica",
+        # private derived state (init=False, but list for safety)
+        "_sparse_li_c8_layer_ids",
+        "_sparse_li_c8_layer_names",
+        "_sparse_li_c8_layer_filter_enabled",
+        # SchedulerConfig field (top-level legacy, SchedulerConfig resolves internally)
+        "enable_balance_scheduling",
     }
-    kwargs = {k: v for k, v in additional_config.items() if k in fields and k not in _BYPASS_KEYS}
+    kwargs = {k: v for k, v in additional_config.items() if k not in _BYPASS_KEYS}
 
     new_config = AscendConfig(
         vllm_config=vllm_config,

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -193,6 +193,7 @@ class AscendConfig:
     enable_mc2_hierarchy_comm: bool = False
     enable_reduce_sample: bool = False
     enable_dsa_cp: bool = False
+    draft_window_size: int | None = None
     mix_placement: bool = False
     pa_shape_list: list[Any] = dataclasses.field(default_factory=list)
     mega_moe_max_tokens: int = 131072
@@ -918,7 +919,6 @@ def init_ascend_config(vllm_config):
     fields = AscendConfig.__pydantic_fields__
     _BYPASS_KEYS = {
         "refresh",
-        "draft_window_size",
         "dump_config",
         "dump_config_path",  # passed explicitly below
         "enable_balance_scheduling",  # SchedulerConfig internal (top-level legacy)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -169,19 +169,21 @@ class AscendConfig:
     fixing the ``bool("false")``/``"2"==2`` pitfalls. Unknown keys are
     forbidden (``extra="forbid"``). A-family env-var fallbacks (additional_config
     → envs → default) run in a ``before`` model_validator. Cross-config
-    derivations, downgrades and mutex checks run in an ``after``
-    model_validator (preserving original ordering and error messages).
+    derivations, downgrades and mutex checks that need ``vllm_config`` run in
+    ``derive_and_validate()``, a plain method invoked explicitly by
+    ``init_ascend_config`` (not a pydantic validator) — preserving original
+    ordering and error messages.
 
-    ``vllm_config`` is injected as a ``kw_only`` field with
-    ``arbitrary_types_allowed=True`` so pydantic does not recursively validate
-    the heavy upstream object; it is consumed only inside the ``after``
-    validator for derivations (pd_tp_ratio, enable_sp_by_pass, sparse, etc.).
+    ``vllm_config`` is NOT a member field. Pydantic handles only type/range/
+    enum validation here; cross-config derivations and mutex checks that need
+    ``vllm_config`` live in ``derive_and_validate()``, a plain method invoked
+    explicitly by ``init_ascend_config``. This keeps AscendConfig a pure
+    Ascend-configuration container, free of the heavy upstream VllmConfig graph
+    (and drops ``arbitrary_types_allowed``, which existed only for the former
+    ``vllm_config`` field).
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
-
-    # ---- injected dependency (non-user input) ----
-    vllm_config: VllmConfig = dataclasses.field(kw_only=True, repr=False)
+    model_config = ConfigDict(extra="forbid")
 
     # ---- user-input switches: bool/int/list/str, auto type validation ----
     enable_cpu_binding: bool = True
@@ -267,10 +269,13 @@ class AscendConfig:
                 kw[key] = env_value
         return ArgsKwargs(data.args, kw)
 
-    # ---- derivations + cross-config downgrades/mutex (after, preserves original __init__ order) ----
-    @model_validator(mode="after")
-    def _derive_and_validate(self) -> AscendConfig:
-        vc = self.vllm_config
+    # ---- derivations + cross-config downgrades/mutex ----
+    # Business validation: invoked explicitly by init_ascend_config (NOT a
+    # pydantic after-validator). Preserves the original __init__ ordering —
+    # multi-step downgrades are order-dependent (e.g. profiling_chunk reads
+    # the max_num_batched_tokens that FLASHCOMM1 writeback just corrected).
+    def derive_and_validate(self, vllm_config: VllmConfig) -> AscendConfig:
+        vc = vllm_config
         self._check_mooncake_c8_kv_cache_quant(vc)
 
         # profiling_chunk vs min_chunk clamp
@@ -559,7 +564,10 @@ class FinegrainedTPConfig:
 
     Migrated to ``@config`` (pydantic dataclass). 5 int fields get lax coercion
     ('2'→2). vllm_config-dependent preconditions (TP/eager/kv_consumer/is_moe/
-    data_parallel divisibility) moved to an ``after`` model_validator.
+    data_parallel divisibility) are validated in ``_validate_preconditions()``,
+    a plain method invoked explicitly by ``init_ascend_config`` (Plan B:
+    business validation stays out of pydantic). ``vllm_config`` is no longer a
+    member field.
     """
 
     oproj_tensor_parallel_size: int = 0
@@ -567,11 +575,9 @@ class FinegrainedTPConfig:
     embedding_tensor_parallel_size: int = 0
     mlp_tensor_parallel_size: int = 0
     olora_tensor_parallel_size: int = 0
-    vllm_config: Any = dataclasses.field(kw_only=True, repr=False)
 
-    @model_validator(mode="after")
-    def _validate_preconditions(self):
-        vc = self.vllm_config
+    def _validate_preconditions(self, vllm_config: Any):
+        vc = vllm_config
         enabled_configs = []
         if self.oproj_tensor_parallel_size > 0:
             enabled_configs.append(f"oproj_tensor_parallel_size={self.oproj_tensor_parallel_size}")
@@ -632,7 +638,6 @@ class FinegrainedTPConfig:
                 raise AssertionError("finegrained tp sizes must divide by data_parallel_size.")
         if any(size > 0 for size in module_tp_sizes) and enabled_configs:
             logger.info("finegrained_tp_config enabled: %s", ", ".join(enabled_configs))
-        return self
 
 
 @config
@@ -641,19 +646,17 @@ class XliteGraphConfig:
 
     Migrated to ``@config`` (pydantic dataclass). The vllm_config-dependent
     preconditions (speculative decoding / pipeline parallelism / cache block
-    size) are applied in an ``after`` model_validator. ``vllm_config`` is
-    injected as a ``kw_only`` field with ``arbitrary_types_allowed`` so pydantic
-    does not recursively validate the heavy upstream object.
+    size) are validated in ``_validate_preconditions()``, a plain method
+    invoked explicitly by ``init_ascend_config`` (Plan B: business validation
+    stays out of pydantic). ``vllm_config`` is no longer a member field.
     """
 
     enabled: bool = False
     full_mode: bool = False
-    vllm_config: Any = dataclasses.field(kw_only=True, repr=False)
 
-    @model_validator(mode="after")
-    def _validate_preconditions(self):
+    def _validate_preconditions(self, vllm_config: Any):
         if self.enabled:
-            vc = self.vllm_config
+            vc = vllm_config
             if bool(vc.speculative_config) and vc.speculative_config.num_speculative_tokens != 1:
                 raise RuntimeError("Xlite graph mode only support speculative decoding with num_speculative_tokens=1.")
             if vc.parallel_config.pipeline_parallel_size > 1:
@@ -667,7 +670,6 @@ class XliteGraphConfig:
                     "current_block_size=%d, recommended_block_size=128.",
                     vc.cache_config.block_size,
                 )
-        return self
 
 
 @config
@@ -896,6 +898,11 @@ class SparseKVOffloadConfig:
 
 
 _ASCEND_CONFIG: AscendConfig | None = None
+# Identity key for the singleton cache: the vllm_config that initialized it.
+# Private module state (not a field on AscendConfig) — replaces the former
+# ``getattr(_ASCEND_CONFIG, "vllm_config", None) is vllm_config`` check, now
+# that vllm_config is no longer a member of AscendConfig.
+_INIT_VLLM_CONFIG: Any = None
 
 
 def _is_ascend_config_initialized(config: AscendConfig | None) -> bool:
@@ -914,20 +921,20 @@ def _is_ascend_config_initialized(config: AscendConfig | None) -> bool:
 def init_ascend_config(vllm_config):
     additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
     refresh = additional_config.get("refresh", False) if additional_config else False
-    global _ASCEND_CONFIG
+    global _ASCEND_CONFIG, _INIT_VLLM_CONFIG
     if (
         _ASCEND_CONFIG is not None
         and not refresh
         and _is_ascend_config_initialized(_ASCEND_CONFIG)
-        and getattr(_ASCEND_CONFIG, "vllm_config", None) is vllm_config
+        and _INIT_VLLM_CONFIG is vllm_config
     ):
         return _ASCEND_CONFIG
 
-    # Pre-construct sub-configs that need vllm_config or special injection.
+    # Pre-construct sub-configs that need special injection.
     from vllm_ascend import envs as ascend_envs
 
-    xlite = XliteGraphConfig(vllm_config=vllm_config, **additional_config.get("xlite_graph_config", {}))  # type: ignore[call-arg]
-    finegrained = FinegrainedTPConfig(vllm_config=vllm_config, **additional_config.get("finegrained_tp_config", {}))  # type: ignore[call-arg]
+    xlite = XliteGraphConfig(**additional_config.get("xlite_graph_config", {}))  # type: ignore[call-arg]
+    finegrained = FinegrainedTPConfig(**additional_config.get("finegrained_tp_config", {}))  # type: ignore[call-arg]
     sched = SchedulerConfig(
         _additional_config=additional_config, _balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING
     )  # type: ignore[call-arg]
@@ -943,16 +950,15 @@ def init_ascend_config(vllm_config):
         # control-flow flag (singleton/cache refresh), not a configuration field
         "refresh",
         # injected fields (factory passes explicitly; a copy in additional_config would conflict)
-        "vllm_config",
         "xlite_graph_config",
         "finegrained_tp_config",
         "scheduler_config",
         "sparse_kv_offload_config",
         "dump_config_path",
-        # pure-derived fields (after-validator computes them; user input would residualize)
+        # pure-derived fields (derive_and_validate computes them; user input would residualize)
         # NOTE: enable_shared_expert_dp/enable_sparse_sfa_c8/enable_sparse_li_c8/
         # c8_enable_reshape_optim are NOT here — they are user-input fields that
-        # after-validator *augments* (self.x = self.x and condition), so the user
+        # derive_and_validate *augments* (self.x = self.x and condition), so the user
         # must be able to pass them. Only pure-derived fields (no user input) are stripped.
         "enable_sp_by_pass",
         "pd_tp_ratio",
@@ -968,7 +974,6 @@ def init_ascend_config(vllm_config):
     kwargs = {k: v for k, v in additional_config.items() if k not in _NON_USER_INPUT_KEYS}
 
     new_config = AscendConfig(  # type: ignore[call-arg]
-        vllm_config=vllm_config,
         xlite_graph_config=xlite,
         finegrained_tp_config=finegrained,
         scheduler_config=sched,
@@ -976,16 +981,26 @@ def init_ascend_config(vllm_config):
         dump_config_path=dump_config_path,
         **kwargs,
     )
+    # Business validation (Plan B): pydantic did type/range/enum checks during
+    # construction; the cross-config derivations and mutex checks that need
+    # vllm_config run here, explicitly, before the instance is usable. This is
+    # the single legitimate entry point — bypassing the factory leaves derived
+    # fields at their sentinel defaults.
+    new_config.derive_and_validate(vllm_config)
+    finegrained._validate_preconditions(vllm_config)
+    xlite._validate_preconditions(vllm_config)
     if _is_ascend_config_initialized(new_config):
         _ASCEND_CONFIG = new_config
+        _INIT_VLLM_CONFIG = vllm_config
     else:
         logger.warning("Ascend config instance is not fully initialized. action: skip singleton cache update. ")
     return new_config
 
 
 def clear_ascend_config():
-    global _ASCEND_CONFIG
+    global _ASCEND_CONFIG, _INIT_VLLM_CONFIG
     _ASCEND_CONFIG = None
+    _INIT_VLLM_CONFIG = None
     from vllm_ascend.utils import clear_enable_sp
 
     clear_enable_sp()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -220,7 +220,7 @@ class AscendConfig:
     # ---- sub-configs (need vllm_config / special): factory pre-constructs, kw_only ----
     xlite_graph_config: XliteGraphConfig = dataclasses.field(kw_only=True)
     finegrained_tp_config: FinegrainedTPConfig = dataclasses.field(kw_only=True)
-    scheduler_config: Any = dataclasses.field(kw_only=True)
+    scheduler_config: SchedulerConfig = dataclasses.field(kw_only=True)
     sparse_kv_offload_config: Any = dataclasses.field(kw_only=True)
 
     # ---- derived fields: sentinel default, after-validator overwrites ----
@@ -765,10 +765,36 @@ class ShortRequestFirstConfig:
         return self
 
 
+@config
 class SchedulerConfig:
-    """Configuration object for ``additional_config[\"scheduler_config\"]``."""
+    """Configuration object for ``additional_config["scheduler_config"]``.
 
-    def __init__(self, additional_config: dict[str, Any], balance_env_value: Any):
+    Migrated to ``@config`` (pydantic dataclass). The three-level precedence
+    (nested scheduler_config > top-level legacy > env) is resolved in a
+    ``before`` model_validator that handles ``ArgsKwargs``, preserving the
+    original deprecation warnings. Sub-configs (ShortRequestFirstConfig /
+    ProfilingChunkConfig / BatchJobSchedConfig) are typed fields that pydantic
+    coerces from nested dicts.
+    """
+
+    enable_balance_scheduling: Any = False
+    recompute_scheduler_enable: Any = False
+    short_request_first_config: ShortRequestFirstConfig = dataclasses.field(default_factory=ShortRequestFirstConfig)
+    profiling_chunk_config: ProfilingChunkConfig = dataclasses.field(default_factory=ProfilingChunkConfig)
+    batch_job_sched_config: BatchJobSchedConfig = dataclasses.field(default_factory=BatchJobSchedConfig)
+    # Injected for three-level precedence resolution (not user input):
+    _additional_config: dict[str, Any] = dataclasses.field(kw_only=True, repr=False)
+    _balance_env_value: Any = dataclasses.field(kw_only=True, repr=False)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_three_level_precedence(cls, data: Any) -> Any:
+        if not isinstance(data, ArgsKwargs):
+            return data
+        kw = dict(data.kwargs)
+        additional_config = kw.pop("_additional_config", {})
+        balance_env_value = kw.pop("_balance_env_value", False)
+
         scheduler_config = additional_config.get("scheduler_config")
         if scheduler_config is None:
             scheduler_config = {}
@@ -776,67 +802,47 @@ class SchedulerConfig:
             raise ValueError(
                 f"additional_config.scheduler_config must be a dict, got {type(scheduler_config).__name__}."
             )
-        self.enable_balance_scheduling = self._get_config_value(
-            scheduler_config,
-            additional_config,
-            "enable_balance_scheduling",
-            balance_env_value,
-            "VLLM_ASCEND_BALANCE_SCHEDULING",
-        )
-        self.recompute_scheduler_enable = self._get_config_value(
-            scheduler_config,
-            additional_config,
-            "recompute_scheduler_enable",
-            False,
-        )
-        self.short_request_first_config = ShortRequestFirstConfig(
-            **self._get_config_value(scheduler_config, additional_config, "short_request_first_config", {})
-        )
-        self.profiling_chunk_config = ProfilingChunkConfig(
-            **self._get_config_value(scheduler_config, additional_config, "profiling_chunk_config", {})
-        )
-        self.batch_job_sched_config = BatchJobSchedConfig(
-            **self._get_config_value(scheduler_config, additional_config, "batch_job_sched_config", {})
-        )
 
-    @staticmethod
-    def _get_config_value(
-        scheduler_config: dict[str, Any],
-        additional_config: dict[str, Any],
-        config_key: str,
-        default: Any,
-        env_key: str | None = None,
-    ) -> Any:
-        if config_key in scheduler_config:
+        def _resolve(config_key: str, default: Any, env_key: str | None = None) -> Any:
+            if config_key in scheduler_config:
+                if config_key in additional_config:
+                    logger.warning_once(
+                        "additional_config.%s is deprecated and ignored because "
+                        "additional_config.scheduler_config.%s is set.",
+                        config_key,
+                        config_key,
+                    )
+                return scheduler_config[config_key]
             if config_key in additional_config:
                 logger.warning_once(
-                    "additional_config.%s is deprecated and ignored because "
-                    "additional_config.scheduler_config.%s is set.",
+                    "additional_config.%s is deprecated; use additional_config.scheduler_config.%s instead.",
                     config_key,
                     config_key,
                 )
-            return scheduler_config[config_key]
+                return additional_config[config_key]
+            if env_key is not None and env_key in os.environ:
+                logger.info_once(
+                    "AscendConfig.scheduler_config.%s falls back to environment variable %s with value %s. "
+                    "Please use additional_config.scheduler_config.%s instead, because %s will be removed in the "
+                    "next release.",
+                    config_key,
+                    env_key,
+                    default,
+                    config_key,
+                    env_key,
+                )
+            return default
 
-        if config_key in additional_config:
-            logger.warning_once(
-                "additional_config.%s is deprecated; use additional_config.scheduler_config.%s instead.",
-                config_key,
-                config_key,
-            )
-            return additional_config[config_key]
-
-        if env_key is not None and env_key in os.environ:
-            logger.info_once(
-                "AscendConfig.scheduler_config.%s falls back to environment variable %s with value %s. "
-                "Please use additional_config.scheduler_config.%s instead, because %s will be removed in the "
-                "next release.",
-                config_key,
-                env_key,
-                default,
-                config_key,
-                env_key,
-            )
-        return default
+        # Scalar fields: resolve via three-level precedence
+        kw["enable_balance_scheduling"] = _resolve(
+            "enable_balance_scheduling", balance_env_value, "VLLM_ASCEND_BALANCE_SCHEDULING"
+        )
+        kw["recompute_scheduler_enable"] = _resolve("recompute_scheduler_enable", False)
+        # Sub-config dicts: resolve then let pydantic coerce dict→dataclass
+        kw["short_request_first_config"] = _resolve("short_request_first_config", {})
+        kw["profiling_chunk_config"] = _resolve("profiling_chunk_config", {})
+        kw["batch_job_sched_config"] = _resolve("batch_job_sched_config", {})
+        return ArgsKwargs(data.args, kw)
 
 
 class SparseKVOffloadConfig:
@@ -922,7 +928,9 @@ def init_ascend_config(vllm_config):
 
     xlite = XliteGraphConfig(vllm_config=vllm_config, **additional_config.get("xlite_graph_config", {}))
     finegrained = FinegrainedTPConfig(vllm_config=vllm_config, **additional_config.get("finegrained_tp_config", {}))
-    sched = SchedulerConfig(additional_config, balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING)
+    sched = SchedulerConfig(
+        _additional_config=additional_config, _balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING
+    )
     sparse_kv = SparseKVOffloadConfig(vllm_config, additional_config.get("sparse_kv_offload_config", {}))
     # dump_config: keep the mutual-exclusion / materialize logic as a factory
     # pre-step; the resolved path is passed as the dump_config_path field.
@@ -939,7 +947,7 @@ def init_ascend_config(vllm_config):
     _BYPASS_KEYS = {
         "refresh",  # control-flow flag (singleton/cache refresh), not a config; not converged
         "dump_config_path",  # passed explicitly below
-        "enable_balance_scheduling",  # SchedulerConfig internal (top-level legacy)
+        "enable_balance_scheduling",  # SchedulerConfig field; stripped (not AscendConfig field)
         "xlite_graph_config",  # pre-constructed above (vllm_config dep)
         "finegrained_tp_config",  # pre-constructed above (vllm_config dep)
         "scheduler_config",  # pre-constructed above (vllm_config dep)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -174,13 +174,13 @@ class AscendConfig:
     ``init_ascend_config`` (not a pydantic validator) — preserving original
     ordering and error messages.
 
-    ``vllm_config`` is NOT a member field. Pydantic handles only type/range/
-    enum validation here; cross-config derivations and mutex checks that need
-    ``vllm_config`` live in ``derive_and_validate()``, a plain method invoked
-    explicitly by ``init_ascend_config``. This keeps AscendConfig a pure
-    Ascend-configuration container, free of the heavy upstream VllmConfig graph
-    (and drops ``arbitrary_types_allowed``, which existed only for the former
-    ``vllm_config`` field).
+    ``vllm_config`` is NOT a member of AscendConfig (neither a declared
+    pydantic field nor a plain instance attribute). Pydantic handles only
+    type/range/enum validation here; the factory passes ``vllm_config``
+    explicitly to ``derive_and_validate()``. This keeps AscendConfig a pure
+    Ascend-configuration container, free of the heavy upstream VllmConfig
+    graph (and drops ``arbitrary_types_allowed``, which existed only for the
+    former ``vllm_config`` field).
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -218,7 +218,7 @@ class AscendConfig:
     rejection_sampler_config: RejectionSamplerConfig = dataclasses.field(default_factory=RejectionSamplerConfig)
 
     # ---- sub-configs (need vllm_config / special): factory pre-constructs, kw_only ----
-    xlite_graph_config: Any = dataclasses.field(kw_only=True)
+    xlite_graph_config: XliteGraphConfig = dataclasses.field(kw_only=True)
     finegrained_tp_config: Any = dataclasses.field(kw_only=True)
     scheduler_config: Any = dataclasses.field(kw_only=True)
     sparse_kv_offload_config: Any = dataclasses.field(kw_only=True)
@@ -627,28 +627,39 @@ class FinegrainedTPConfig:
             logger.info("finegrained_tp_config enabled: %s", ", ".join(enabled_configs))
 
 
+@config
 class XliteGraphConfig:
-    """
-    Configuration Object for xlite_graph_config from additional_config
+    """Configuration Object for ``additional_config["xlite_graph_config"]``.
+
+    Migrated to ``@config`` (pydantic dataclass). The vllm_config-dependent
+    preconditions (speculative decoding / pipeline parallelism / cache block
+    size) are applied in an ``after`` model_validator. ``vllm_config`` is
+    injected as a ``kw_only`` field with ``arbitrary_types_allowed`` so pydantic
+    does not recursively validate the heavy upstream object.
     """
 
-    def __init__(self, xlite_graph_config, vllm_config):
-        self.enabled = xlite_graph_config.get("enabled", False)
-        self.full_mode = xlite_graph_config.get("full_mode", False)
+    enabled: bool = False
+    full_mode: bool = False
+    vllm_config: Any = dataclasses.field(kw_only=True, repr=False)
+
+    @model_validator(mode="after")
+    def _validate_preconditions(self):
         if self.enabled:
-            if bool(vllm_config.speculative_config) and vllm_config.speculative_config.num_speculative_tokens != 1:
+            vc = self.vllm_config
+            if bool(vc.speculative_config) and vc.speculative_config.num_speculative_tokens != 1:
                 raise RuntimeError("Xlite graph mode only support speculative decoding with num_speculative_tokens=1.")
-            if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            if vc.parallel_config.pipeline_parallel_size > 1:
                 raise RuntimeError(
                     "Xlite graph mode is not compatible with pipeline parallelism. "
                     "Please set pipeline_parallel_size to 1."
                 )
-            if vllm_config.cache_config.block_size != 128:
+            if vc.cache_config.block_size != 128:
                 logger.warning(
                     "Current cache block size may not be optimal for xlite graph mode. "
                     "current_block_size=%d, recommended_block_size=128.",
-                    vllm_config.cache_config.block_size,
+                    vc.cache_config.block_size,
                 )
+        return self
 
 
 @config
@@ -901,7 +912,7 @@ def init_ascend_config(vllm_config):
     # Pre-construct sub-configs that need vllm_config or special injection.
     from vllm_ascend import envs as ascend_envs
 
-    xlite = XliteGraphConfig(additional_config.get("xlite_graph_config", {}), vllm_config)
+    xlite = XliteGraphConfig(vllm_config=vllm_config, **additional_config.get("xlite_graph_config", {}))
     finegrained = FinegrainedTPConfig(additional_config.get("finegrained_tp_config", {}), vllm_config)
     sched = SchedulerConfig(additional_config, balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING)
     sparse_kv = SparseKVOffloadConfig(vllm_config, additional_config.get("sparse_kv_offload_config", {}))
@@ -919,7 +930,6 @@ def init_ascend_config(vllm_config):
     fields = AscendConfig.__pydantic_fields__
     _BYPASS_KEYS = {
         "refresh",
-        "dump_config",
         "dump_config_path",  # passed explicitly below
         "enable_balance_scheduling",  # SchedulerConfig internal (top-level legacy)
         "xlite_graph_config",  # pre-constructed above

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -936,24 +936,20 @@ def init_ascend_config(vllm_config):
     # pre-step; the resolved path is passed as the dump_config_path field.
     dump_config_path = AscendConfig._resolve_dump_config_path(additional_config)
 
-    # Strip keys that must NOT flow from additional_config into AscendConfig:
-    #   - control-flow flags (refresh: not a config)
-    #   - injected fields (factory passes explicitly; additional_config copy would conflict)
-    #   - derived fields (after-validator computes them; user input would residualize)
-    #   - SchedulerConfig-internal top-level legacy key
-    # Keys NOT in this set flow into kwargs; pydantic extra="forbid" then catches
-    # typos (e.g. enable_cpu_bindng) that are neither declared fields nor bypass keys.
-    _BYPASS_KEYS = {
-        # control-flow flag (singleton/cache refresh), not a config; not converged
+    # Keys that must NOT flow from additional_config into AscendConfig.
+    # These are stripped so that only user-configurable keys reach pydantic,
+    # where extra="forbid" can catch typos (e.g. enable_cpu_bindng).
+    _NON_USER_INPUT_KEYS = {
+        # control-flow flag (singleton/cache refresh), not a configuration field
         "refresh",
-        # injected fields (factory passes explicitly below)
+        # injected fields (factory passes explicitly; a copy in additional_config would conflict)
         "vllm_config",
         "xlite_graph_config",
         "finegrained_tp_config",
         "scheduler_config",
         "sparse_kv_offload_config",
         "dump_config_path",
-        # derived fields (after-validator computes; user input would residualize)
+        # pure-derived fields (after-validator computes them; user input would residualize)
         # NOTE: enable_shared_expert_dp/enable_sparse_sfa_c8/enable_sparse_li_c8/
         # c8_enable_reshape_optim are NOT here — they are user-input fields that
         # after-validator *augments* (self.x = self.x and condition), so the user
@@ -962,14 +958,14 @@ def init_ascend_config(vllm_config):
         "pd_tp_ratio",
         "pd_head_ratio",
         "num_head_replica",
-        # private derived state (init=False, but list for safety)
+        # private derived state (init=False, but listed for safety)
         "_sparse_li_c8_layer_ids",
         "_sparse_li_c8_layer_names",
         "_sparse_li_c8_layer_filter_enabled",
-        # SchedulerConfig field (top-level legacy, SchedulerConfig resolves internally)
+        # SchedulerConfig-internal top-level legacy key (SchedulerConfig resolves it internally)
         "enable_balance_scheduling",
     }
-    kwargs = {k: v for k, v in additional_config.items() if k not in _BYPASS_KEYS}
+    kwargs = {k: v for k, v in additional_config.items() if k not in _NON_USER_INPUT_KEYS}
 
     new_config = AscendConfig(  # type: ignore[call-arg]
         vllm_config=vllm_config,

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -954,11 +954,11 @@ def init_ascend_config(vllm_config):
         "sparse_kv_offload_config",
         "dump_config_path",
         # derived fields (after-validator computes; user input would residualize)
-        "enable_shared_expert_dp",
+        # NOTE: enable_shared_expert_dp/enable_sparse_sfa_c8/enable_sparse_li_c8/
+        # c8_enable_reshape_optim are NOT here — they are user-input fields that
+        # after-validator *augments* (self.x = self.x and condition), so the user
+        # must be able to pass them. Only pure-derived fields (no user input) are stripped.
         "enable_sp_by_pass",
-        "enable_sparse_sfa_c8",
-        "enable_sparse_li_c8",
-        "c8_enable_reshape_optim",
         "pd_tp_ratio",
         "pd_head_ratio",
         "num_head_replica",

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -192,6 +192,7 @@ class AscendConfig:
     enable_kv_nz: bool = False
     enable_mc2_hierarchy_comm: bool = False
     enable_reduce_sample: bool = False
+    enable_dsa_cp: bool = False
     mix_placement: bool = False
     pa_shape_list: list[Any] = dataclasses.field(default_factory=list)
     mega_moe_max_tokens: int = 131072
@@ -917,7 +918,6 @@ def init_ascend_config(vllm_config):
     fields = AscendConfig.__pydantic_fields__
     _BYPASS_KEYS = {
         "refresh",
-        "enable_dsa_cp",
         "draft_window_size",
         "dump_config",
         "dump_config_path",  # passed explicitly below

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -926,11 +926,11 @@ def init_ascend_config(vllm_config):
     # Pre-construct sub-configs that need vllm_config or special injection.
     from vllm_ascend import envs as ascend_envs
 
-    xlite = XliteGraphConfig(vllm_config=vllm_config, **additional_config.get("xlite_graph_config", {}))
-    finegrained = FinegrainedTPConfig(vllm_config=vllm_config, **additional_config.get("finegrained_tp_config", {}))
+    xlite = XliteGraphConfig(vllm_config=vllm_config, **additional_config.get("xlite_graph_config", {}))  # type: ignore[call-arg]
+    finegrained = FinegrainedTPConfig(vllm_config=vllm_config, **additional_config.get("finegrained_tp_config", {}))  # type: ignore[call-arg]
     sched = SchedulerConfig(
         _additional_config=additional_config, _balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING
-    )
+    )  # type: ignore[call-arg]
     sparse_kv = SparseKVOffloadConfig(vllm_config, additional_config.get("sparse_kv_offload_config", {}))
     # dump_config: keep the mutual-exclusion / materialize logic as a factory
     # pre-step; the resolved path is passed as the dump_config_path field.
@@ -971,7 +971,7 @@ def init_ascend_config(vllm_config):
     }
     kwargs = {k: v for k, v in additional_config.items() if k not in _BYPASS_KEYS}
 
-    new_config = AscendConfig(
+    new_config = AscendConfig(  # type: ignore[call-arg]
         vllm_config=vllm_config,
         xlite_graph_config=xlite,
         finegrained_tp_config=finegrained,

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -13,10 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+import dataclasses
 import json
 import os
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ConfigDict, model_validator
+from pydantic_core import ArgsKwargs
+from vllm.config.utils import config
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 
@@ -24,39 +30,250 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
 
+@config
+@dataclasses.dataclass
+class AscendCompilationConfig:
+    """Configuration for controlling the behavior of Ascend graph optimization.
+
+    Migrated to ``@config`` (pydantic dataclass). The 310P runtime downgrade
+    (disable npugraph_ex / static_kernel) and the static_kernel→npugraph_ex
+    dependency check are applied in an ``after`` model_validator.
+    """
+
+    enable_npugraph_ex: bool = True
+    enable_static_kernel: bool = False
+    fuse_norm_quant: bool = True
+    fuse_qknorm_rope: bool = True
+    fuse_muls_add: bool = True
+
+    @model_validator(mode="after")
+    def _apply_310p_downgrade_and_static_kernel_check(self):
+        from vllm_ascend.utils import is_310p
+
+        if is_310p():
+            if self.enable_npugraph_ex:
+                logger.warning("npugraph_ex is not supported on Ascend 310P. Disabling it.")
+            if self.enable_static_kernel:
+                logger.warning(
+                    "static kernel requires npugraph_ex, which is not supported on Ascend 310P. Disabling it."
+                )
+            self.enable_npugraph_ex = False
+            self.enable_static_kernel = False
+        if self.enable_static_kernel:
+            assert self.enable_npugraph_ex, "Static kernel generation requires npugraph_ex to be enabled."
+        return self
+
+
+@config
+@dataclasses.dataclass
+class AscendFusionConfig:
+    """Configuration for controlling whether to use a fused operator gmmswigluquant.
+
+    Migrated to ``@config`` (pydantic dataclass): bool field gets lax coercion
+    (``"false"``→False) and unknown keys are forbidden (``extra="forbid"``),
+    fixing the ``bool("false")`` pitfall and surfacing typos.
+    """
+
+    fusion_ops_gmmswigluquant: bool = True
+
+
+@config
+@dataclasses.dataclass
+class EplbConfig:
+    """Configuration Object for ``additional_config["eplb_config"]``.
+
+    Migrated to ``@config`` (pydantic dataclass). Unknown-key detection is now
+    handled by ``extra="forbid"`` (replaces the hand-written ``unknown`` check);
+    int/range/enum checks moved to an ``after`` model_validator. The
+    ``__getattr__`` proxy over the internal ``self.config`` dict is removed —
+    fields are accessed directly (``self.dynamic_eplb`` etc.).
+    """
+
+    dynamic_eplb: bool = False
+    expert_map_path: str | None = None
+    expert_heat_collection_interval: int = 600
+    algorithm_execution_interval: int = 50
+    expert_map_record_path: str | None = None
+    num_redundant_experts: int = 0
+    eplb_policy_type: int = 2
+    eplb_heat_collection_stage: str = "all"
+
+    @model_validator(mode="after")
+    def _validate_config(self):
+        if self.expert_map_path is not None:
+            logger.info("The expert_map is %s", self.expert_map_path)
+            if self.expert_map_path[-5:] != ".json":
+                raise TypeError("The expert_map is not json.")
+            if not (os.path.exists(self.expert_map_path) and os.access(self.expert_map_path, os.R_OK)):
+                raise ValueError("The expert_map is not exist.")
+        if self.expert_map_record_path is not None:
+            self.dynamic_eplb = True
+            if self.expert_map_record_path[-5:] != ".json":
+                raise TypeError("The expert_map_record_path is not json.")
+            dirname = os.path.dirname(self.expert_map_record_path)
+            os.makedirs(dirname, exist_ok=True)
+        for key in ["expert_heat_collection_interval", "algorithm_execution_interval", "num_redundant_experts"]:
+            value = getattr(self, key)
+            if not isinstance(value, int):
+                raise TypeError(f"{key} must be an integer")
+            if value < 0:
+                raise ValueError(f"{key} must greater than 0; got {value} instead")
+        if self.eplb_policy_type not in [0, 1, 2, 3]:
+            raise ValueError("eplb_policy_type must in [0, 1, 2, 3]")
+        if self.dynamic_eplb:
+            assert (
+                os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
+                or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
+            ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
+        if self.eplb_heat_collection_stage not in ["all", "prefill", "decode"]:
+            raise ValueError('eplb_heat_collection_stage must be one of ["all", "prefill", "decode"]')
+
+        logger.info("Dynamic EPLB is %s", self.dynamic_eplb)
+        logger.info("The number of redundant experts is %s", self.num_redundant_experts)
+        return self
+
+
+@config
+@dataclasses.dataclass
+class RejectionSamplerConfig:
+    """Configuration for Block Verify and Entropy Verify in Rejection Sampler.
+
+    Migrated to ``@config`` (pydantic dataclass). Type checks (bool/float) are
+    now handled by pydantic field types; range checks moved to an ``after``
+    model_validator.
+    """
+
+    enable_block_verify: bool = False
+    enable_entropy_verify: bool = False
+    posterior_threshold: float = 0.95
+    posterior_alpha: float = 0.4
+
+    @model_validator(mode="after")
+    def _validate(self):
+        if not (0 < self.posterior_threshold <= 1):
+            raise ValueError(
+                f"rejection_sampler_config.posterior_threshold must be in (0, 1], got {self.posterior_threshold}"
+            )
+        if self.posterior_alpha < 0:
+            raise ValueError(f"rejection_sampler_config.posterior_alpha must be >= 0, got {self.posterior_alpha}")
+        return self
+
+
+@config
+@dataclasses.dataclass
 class AscendConfig:
+    """Configuration Object for additional_config from vllm.configs.
+
+    Migrated to ``@config`` (pydantic dataclass). User-input switches are now
+    typed fields with lax bool/int coercion (``"false"``→False, ``"2"``→2),
+    fixing the ``bool("false")``/``"2"==2`` pitfalls. Unknown keys are
+    forbidden (``extra="forbid"``). A-family env-var fallbacks (additional_config
+    → envs → default) run in a ``before`` model_validator. Cross-config
+    derivations, downgrades and mutex checks run in an ``after``
+    model_validator (preserving original ordering and error messages).
+
+    ``vllm_config`` is injected as a ``kw_only`` field with
+    ``arbitrary_types_allowed=True`` so pydantic does not recursively validate
+    the heavy upstream object; it is consumed only inside the ``after``
+    validator for derivations (pd_tp_ratio, enable_sp_by_pass, sparse, etc.).
     """
-    Configuration Object for additional_config from vllm.configs.
-    """
 
-    def __init__(self, vllm_config: "VllmConfig"):
-        self.vllm_config = vllm_config
-        additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
-        self._check_mooncake_c8_kv_cache_quant(vllm_config)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-        xlite_graph_config = additional_config.get("xlite_graph_config", {})
-        self.xlite_graph_config = XliteGraphConfig(xlite_graph_config, vllm_config)
+    # ---- injected dependency (non-user input) ----
+    vllm_config: VllmConfig = dataclasses.field(kw_only=True, repr=False)
 
-        ascend_compilation_config = additional_config.get("ascend_compilation_config", {})
-        self.ascend_compilation_config = AscendCompilationConfig(**ascend_compilation_config)
+    # ---- user-input switches: bool/int/list/str, auto type validation ----
+    enable_cpu_binding: bool = True
+    enable_sleep_mode_extra_cleanup: bool = False
+    multistream_dsv4_dsa_overlap: bool = True
+    enable_prefill_mc2: bool = False
+    multistream_overlap_shared_expert: bool = False
+    enable_kv_nz: bool = False
+    enable_mc2_hierarchy_comm: bool = False
+    enable_reduce_sample: bool = False
+    mix_placement: bool = False
+    pa_shape_list: list[Any] = dataclasses.field(default_factory=list)
+    mega_moe_max_tokens: int = 131072
+    ascend_log_path: str = dataclasses.field(
+        default_factory=lambda: os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend")
+    )
+    dump_config_path: str | None = None
+    c8_enable_reshape_optim: bool = False
 
-        ascend_fusion_config = additional_config.get("ascend_fusion_config", {})
-        self.ascend_fusion_config = AscendFusionConfig(**ascend_fusion_config)
+    # ---- A-family (envs fallback): default = envs module value, before-validator injects ----
+    enable_flashcomm1: Any = False
+    enable_fused_mc2: Any = 0
+    enable_mlapo: Any = True
+    msmonitor_use_daemon: Any = False
+    enable_transpose_kv_cache_by_block: Any = True
+    weight_nz_mode: Any = 1
 
-        finegrained_tp_config = additional_config.get("finegrained_tp_config", {})
-        self.finegrained_tp_config = FinegrainedTPConfig(finegrained_tp_config, vllm_config)
+    # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
+    ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
+    ascend_fusion_config: AscendFusionConfig = dataclasses.field(default_factory=AscendFusionConfig)
+    eplb_config: EplbConfig = dataclasses.field(default_factory=EplbConfig)
+    rejection_sampler_config: RejectionSamplerConfig = dataclasses.field(default_factory=RejectionSamplerConfig)
 
-        eplb_config = additional_config.get("eplb_config", {})
-        self.eplb_config = EplbConfig(eplb_config)
+    # ---- sub-configs (need vllm_config / special): factory pre-constructs, kw_only ----
+    xlite_graph_config: Any = dataclasses.field(kw_only=True)
+    finegrained_tp_config: Any = dataclasses.field(kw_only=True)
+    scheduler_config: Any = dataclasses.field(kw_only=True)
+    sparse_kv_offload_config: Any = dataclasses.field(kw_only=True)
 
+    # ---- derived fields: sentinel default, after-validator overwrites ----
+    enable_shared_expert_dp: bool = False
+    enable_sp_by_pass: bool = False
+    enable_sparse_sfa_c8: bool = False
+    enable_sparse_li_c8: bool = False
+    pd_tp_ratio: int = 1
+    pd_head_ratio: int = 1
+    num_head_replica: int = 1
+
+    # ---- private derived state (init=False) ----
+    _sparse_li_c8_layer_ids: set[int] = dataclasses.field(default_factory=set, init=False, repr=False)
+    _sparse_li_c8_layer_names: set[str] = dataclasses.field(default_factory=set, init=False, repr=False)
+    _sparse_li_c8_layer_filter_enabled: bool = dataclasses.field(default=False, init=False, repr=False)
+
+    # ---- A-family envs fallback (before, handles ArgsKwargs) ----
+    @model_validator(mode="before")
+    @classmethod
+    def _env_fallback(cls, data: Any) -> Any:
+        if not isinstance(data, ArgsKwargs):
+            return data
+        kw = dict(data.kwargs)
         from vllm_ascend import envs as ascend_envs
 
-        self.scheduler_config = SchedulerConfig(
-            additional_config,
-            balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING,
-        )
+        _A_FAMILY = {
+            "enable_flashcomm1": "VLLM_ASCEND_ENABLE_FLASHCOMM1",
+            "enable_fused_mc2": "VLLM_ASCEND_ENABLE_FUSED_MC2",
+            "enable_mlapo": "VLLM_ASCEND_ENABLE_MLAPO",
+            "msmonitor_use_daemon": "MSMONITOR_USE_DAEMON",
+            "enable_transpose_kv_cache_by_block": "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK",
+            "weight_nz_mode": "VLLM_ASCEND_ENABLE_NZ",
+        }
+        for key, env_name in _A_FAMILY.items():
+            if key in kw:
+                logger.info_once(f"AscendConfig.{key} is set from additional_config with value {kw[key]}.")
+            elif env_name in os.environ:
+                env_value = getattr(ascend_envs, env_name)
+                logger.info_once(
+                    f"AscendConfig.{key} falls back to environment variable {env_name} with value {env_value}. "
+                    f"Please use additional_config.{key} instead, because {env_name} will be removed in the "
+                    "next release."
+                )
+                kw[key] = env_value
+        return ArgsKwargs(data.args, kw)
+
+    # ---- derivations + cross-config downgrades/mutex (after, preserves original __init__ order) ----
+    @model_validator(mode="after")
+    def _derive_and_validate(self) -> AscendConfig:
+        vc = self.vllm_config
+        self._check_mooncake_c8_kv_cache_quant(vc)
+
+        # profiling_chunk vs min_chunk clamp
         if self.scheduler_config.profiling_chunk_config.enabled:
-            max_batched = vllm_config.scheduler_config.max_num_batched_tokens
+            max_batched = vc.scheduler_config.max_num_batched_tokens
             if max_batched < self.scheduler_config.profiling_chunk_config.min_chunk:
                 logger.warning(
                     "max_num_batched_tokens is smaller than profiling_chunk_config.min_chunk. "
@@ -67,73 +284,46 @@ class AscendConfig:
                     max_batched,
                 )
                 self.scheduler_config.profiling_chunk_config.min_chunk = max_batched
-        if (
-            self.scheduler_config.profiling_chunk_config.enabled
-            and vllm_config.parallel_config.pipeline_parallel_size <= 1
-        ):
+        if self.scheduler_config.profiling_chunk_config.enabled and vc.parallel_config.pipeline_parallel_size <= 1:
             raise ValueError(
                 "profiling_chunk_config requires pipeline parallelism (pp > 1). "
                 "Please set --pipeline-parallel-size to a value greater than 1, "
                 "or disable profiling_chunk_config."
             )
 
-        self.enable_flashcomm1 = self._get_config_value(
-            additional_config,
-            "enable_flashcomm1",
-            "VLLM_ASCEND_ENABLE_FLASHCOMM1",
-            ascend_envs.VLLM_ASCEND_ENABLE_FLASHCOMM1,
-        )
+        # profiling_chunk vs balance mutex
         if self.scheduler_config.profiling_chunk_config.enabled and self.scheduler_config.enable_balance_scheduling:
             raise ValueError(
                 "profiling_chunk_config and balance scheduling (enable_balance_scheduling) "
                 "cannot be enabled at the same time. Please disable one of them."
             )
 
-        # Dump / PrecisionDebugger configuration
-        self.dump_config_path = self._resolve_dump_config_path(additional_config)
-
-        # Log configuration
-        self.ascend_log_path = additional_config.get(
-            "ascend_log_path",
-            os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend"),
-        )
-
-        self.enable_shared_expert_dp = (
-            additional_config.get("enable_shared_expert_dp", False)
-            and vllm_config.parallel_config.enable_expert_parallel
-            and vllm_config.parallel_config.tensor_parallel_size > 1
-        )
+        # enable_shared_expert_dp = val and ep and tp>1
         from vllm_ascend.utils import enable_sp
 
+        self.enable_shared_expert_dp = (
+            self.enable_shared_expert_dp
+            and vc.parallel_config.enable_expert_parallel
+            and vc.parallel_config.tensor_parallel_size > 1
+        )
         if self.enable_shared_expert_dp:
-            assert enable_sp(vllm_config=vllm_config, enable_shared_expert_dp=True)
+            assert enable_sp(vllm_config=vc, enable_shared_expert_dp=True)
 
-        if vllm_config.parallel_config.prefill_context_parallel_size > 1 and enable_sp(vllm_config=vllm_config):
-            tp_pcp_size = (
-                vllm_config.parallel_config.tensor_parallel_size
-                * vllm_config.parallel_config.prefill_context_parallel_size
-            )
-            if vllm_config.scheduler_config.max_num_batched_tokens % tp_pcp_size != 0:
-                vllm_config.scheduler_config.max_num_batched_tokens = (
-                    cdiv(vllm_config.scheduler_config.max_num_batched_tokens, tp_pcp_size) * tp_pcp_size
+        # FLASHCOMM1 max_num_batched_tokens divisibility writeback
+        if vc.parallel_config.prefill_context_parallel_size > 1 and enable_sp(vllm_config=vc):
+            tp_pcp_size = vc.parallel_config.tensor_parallel_size * vc.parallel_config.prefill_context_parallel_size
+            if vc.scheduler_config.max_num_batched_tokens % tp_pcp_size != 0:
+                vc.scheduler_config.max_num_batched_tokens = (
+                    cdiv(vc.scheduler_config.max_num_batched_tokens, tp_pcp_size) * tp_pcp_size
                 )
                 logger.warning_once(
                     "When using FLASHCOMM1, the max_num_batched_tokens should be divisible "
                     "by tp_size * pcp_size (%s). It has been adjusted to %s.",
                     str(tp_pcp_size),
-                    str(vllm_config.scheduler_config.max_num_batched_tokens),
+                    str(vc.scheduler_config.max_num_batched_tokens),
                 )
-        self.multistream_overlap_shared_expert = additional_config.get("multistream_overlap_shared_expert", False)
-        # PD-disaggregated D node only (kv_consumer); invalid on P nodes and in PD-mixed mode.
-        # DSV4 oproj / embedding fine-grained TP (oproj_tensor_parallel_size /
-        # embedding_tensor_parallel_size) use static, graph-stable exchange
-        # buffers and run cross-DP HCCL collectives (all_to_all / all_gather /
-        # reduce_scatter) that require uniform num_tokens across all DP ranks.
-        # Only the recompute scheduler balances num_tokens across DP ranks; the
-        # MC2 uneven-token skip path leaves each rank at its own num_tokens and
-        # would deadlock these collectives on a shape mismatch. So bind both
-        # features to recompute_scheduler_enable: they are only supported when
-        # recompute is on.
+
+        # finegrained_tp requires recompute_scheduler
         if (
             self.finegrained_tp_config.oproj_tensor_parallel_size > 0
             or self.finegrained_tp_config.embedding_tensor_parallel_size > 0
@@ -144,19 +334,10 @@ class AscendConfig:
                 "collectives need uniform num_tokens across DP ranks, which is "
                 "only guaranteed when the recompute scheduler is enabled."
             )
-        self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
-        self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
-        self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
-        self.enable_prefill_mc2 = bool(additional_config.get("enable_prefill_mc2", False))
 
-        self.enable_fused_mc2 = self._get_config_value(
-            additional_config,
-            "enable_fused_mc2",
-            "VLLM_ASCEND_ENABLE_FUSED_MC2",
-            ascend_envs.VLLM_ASCEND_ENABLE_FUSED_MC2,
-        )
+        # enable_fused_mc2 enum + MiniMax mutex + multistream auto-disable
         assert self.enable_fused_mc2 in (0, 1), f"enable_fused_mc2 must be 0 or 1, got {self.enable_fused_mc2}"
-        model_architectures = getattr(vllm_config.model_config, "architectures", None) or []
+        model_architectures = getattr(vc.model_config, "architectures", None) or []
         assert not (
             self.enable_fused_mc2 == 1
             and any(architecture.startswith("MiniMaxM3") for architecture in model_architectures)
@@ -170,40 +351,15 @@ class AscendConfig:
                 "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "
                 "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
             )
-        self.enable_mlapo = self._get_config_value(
-            additional_config,
-            "enable_mlapo",
-            "VLLM_ASCEND_ENABLE_MLAPO",
-            ascend_envs.VLLM_ASCEND_ENABLE_MLAPO,
-        )
-        self.msmonitor_use_daemon = self._get_config_value(
-            additional_config,
-            "msmonitor_use_daemon",
-            "MSMONITOR_USE_DAEMON",
-            ascend_envs.MSMONITOR_USE_DAEMON,
-        )
-        self.enable_transpose_kv_cache_by_block = self._get_config_value(
-            additional_config,
-            "enable_transpose_kv_cache_by_block",
-            "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK",
-            ascend_envs.VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK,
-        )
 
-        self.pd_tp_ratio = 1
-        self.pd_head_ratio = 1
-        self.num_head_replica = 1
-        if (
-            vllm_config.kv_transfer_config is not None
-            and vllm_config.model_config is not None
-            and not vllm_config.model_config.is_deepseek_mla
-        ):
-            prefill_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {"tp_size": 1})["tp_size"]
-            decode_tp_size = vllm_config.kv_transfer_config.get_from_extra_config("decode", {"tp_size": 1})["tp_size"]
+        # PD tp_ratio / head_ratio / num_head_replica derivation
+        if vc.kv_transfer_config is not None and vc.model_config is not None and not vc.model_config.is_deepseek_mla:
+            prefill_tp_size = vc.kv_transfer_config.get_from_extra_config("prefill", {"tp_size": 1})["tp_size"]
+            decode_tp_size = vc.kv_transfer_config.get_from_extra_config("decode", {"tp_size": 1})["tp_size"]
             assert prefill_tp_size % decode_tp_size == 0, "Prefill TP size must be divisible by Decode TP size."
             self.pd_tp_ratio = prefill_tp_size // decode_tp_size
             if self.pd_tp_ratio > 1:
-                # Total KV heads from vLLM's resolved architecture (ModelArchConfigConvertor).
-                num_kv_head = vllm_config.model_config.get_total_num_kv_heads()
+                num_kv_head = vc.model_config.get_total_num_kv_heads()
                 if not num_kv_head or num_kv_head < 1:
                     raise ValueError(
                         "Could not determine a positive total KV head count for PD "
@@ -214,88 +370,54 @@ class AscendConfig:
                 prefill_tp_size = min(prefill_tp_size, num_kv_head)
                 decode_tp_size = min(decode_tp_size, num_kv_head)
                 self.pd_head_ratio = prefill_tp_size // decode_tp_size
-
             if self.pd_tp_ratio == 0:
                 raise AssertionError("Only support P node tp size lagger then D node tp size")
-        # We find that _npu_paged_attention still performs better than
-        # npu_fused_infer_attention_score in some cases. We allow to execute
-        # _npu_paged_attention in this cases. This should be removed once
-        # npu_fused_infer_attention_score performs better on all scenarios.
-        self.pa_shape_list = additional_config.get("pa_shape_list", [])
-        # Weight NZ mode configuration.
-        # 0: disabled, 1: only quant case enable nz (default), 2: BF16/FP16 also enable nz
-        self.weight_nz_mode = self._get_config_value(
-            additional_config,
-            "weight_nz_mode",
-            "VLLM_ASCEND_ENABLE_NZ",
-            ascend_envs.VLLM_ASCEND_ENABLE_NZ,
-        )
 
-        from vllm_ascend.utils import model_uses_sfa_sparse
-
-        use_sparse = model_uses_sfa_sparse(vllm_config.model_config)
-
-        self.enable_kv_nz = additional_config.get("enable_kv_nz", False)
+        # enable_kv_nz preconditions
         if self.enable_kv_nz:
-            if vllm_config.model_config is None:
+            if vc.model_config is None:
                 raise RuntimeError("enable_kv_nz requires a valid model_config.")
-            if not vllm_config.model_config.is_deepseek_mla or use_sparse:
+            from vllm_ascend.utils import model_uses_sfa_sparse
+
+            use_sparse = model_uses_sfa_sparse(vc.model_config)
+            if not vc.model_config.is_deepseek_mla or use_sparse:
                 raise RuntimeError("enable_kv_nz is only supported for mla currently.")
-            if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
+            if vc.kv_transfer_config is None or not vc.kv_transfer_config.is_kv_consumer:
                 raise NotImplementedError(
                     "enable_kv_nz is only supported in pd scenario and can only be used in D node."
                 )
 
-        self.enable_sparse_sfa_c8 = additional_config.get("enable_sparse_sfa_c8", False) and use_sparse
-        self.enable_sparse_li_c8 = additional_config.get("enable_sparse_li_c8", False) and use_sparse
-        self.c8_enable_reshape_optim = self.enable_sparse_li_c8 and additional_config.get(
-            "c8_enable_reshape_optim", False
-        )
-        quant_config = getattr(vllm_config, "quant_config", None)
+        # sparse c8 + reshape optim derivation
+        from vllm_ascend.utils import model_uses_sfa_sparse
+
+        use_sparse = model_uses_sfa_sparse(vc.model_config)
+        self.enable_sparse_sfa_c8 = self.enable_sparse_sfa_c8 and use_sparse
+        self.enable_sparse_li_c8 = self.enable_sparse_li_c8 and use_sparse
+        # c8_enable_reshape_optim is a user input field now; keep the original
+        # semantics: only meaningful when enable_sparse_li_c8 is true.
+        self.c8_enable_reshape_optim = self.enable_sparse_li_c8 and self.c8_enable_reshape_optim
+        quant_config = getattr(vc, "quant_config", None)
         (
             self._sparse_li_c8_layer_ids,
             self._sparse_li_c8_layer_names,
         ) = self._parse_sparse_li_c8_layers_from_quant_config(quant_config)
         self._sparse_li_c8_layer_filter_enabled = self._has_sparse_li_c8_layer_config(quant_config)
         self.enable_sp_by_pass = (
-            vllm_config.model_config is not None
-            and not vllm_config.model_config.enforce_eager
-            and vllm_config.compilation_config.pass_config.enable_sp
+            vc.model_config is not None
+            and not vc.model_config.enforce_eager
+            and vc.compilation_config.pass_config.enable_sp
         )
 
-        # Enable dispatch/combine op inter-node communication by ROCE
-        self.enable_mc2_hierarchy_comm = additional_config.get("enable_mc2_hierarchy_comm", False)
-
-        # Per-rank token capacity after dispatch in the mega moe (dispatch_ffn_combine) fused operator.
-        # When load imbalance causes a rank to receive more tokens than this limit, the excess tokens
-        # are dropped and skipped from computation, degrading accuracy.
-        # Do not set this too large: workspace memory scales linearly with this value, which matters
-        # especially under long-context scenarios where the operator should not hold too much memory.
-        # Default 131072.
-        self.mega_moe_max_tokens = additional_config.get("mega_moe_max_tokens", 131072)
-        if not isinstance(self.mega_moe_max_tokens, int):
-            raise ValueError(
-                f"mega_moe_max_tokens must be an integer, got {type(self.mega_moe_max_tokens).__name__}: "
-                f"{self.mega_moe_max_tokens}"
-            )
+        # mega_moe_max_tokens range
         if self.mega_moe_max_tokens <= 0:
             raise ValueError(f"mega_moe_max_tokens must be a positive integer, got {self.mega_moe_max_tokens}")
 
-        # Enable optimized reduce sampling scheme
-        self.enable_reduce_sample = additional_config.get("enable_reduce_sample", False)
-
-        self.mix_placement = additional_config.get("mix_placement", False)
+        # mix_placement mutex
         self._check_mix_placement()
 
-        # Enable Block Verify and Entropy Verify in Rejection Sampler
-        rejection_sampler_config = additional_config.get("rejection_sampler_config", {})
-        self.rejection_sampler_config = RejectionSamplerConfig(rejection_sampler_config)
-
-        self.sparse_kv_offload_config = SparseKVOffloadConfig(
-            self.vllm_config,
-            additional_config.get("sparse_kv_offload_config", {}),
-        )
+        # sparse KV offload vs sparse SFA C8 main cache mutex
         self._validate_sparse_c8_kv_offload_compatibility()
+        return self
 
     def _validate_sparse_c8_kv_offload_compatibility(self) -> None:
         if self.sparse_kv_offload_config.enabled and self.enable_sparse_sfa_c8:
@@ -305,22 +427,8 @@ class AscendConfig:
                 "supported because the indexer cache remains device-resident."
             )
 
-    @staticmethod
-    def _get_config_value(additional_config: dict[str, Any], config_key: str, env_key: str, env_value: Any) -> Any:
-        if config_key in additional_config:
-            value = additional_config[config_key]
-            logger.info_once(f"AscendConfig.{config_key} is set from additional_config with value {value}.")
-            return value
-        if env_key in os.environ:
-            logger.info_once(
-                f"AscendConfig.{config_key} falls back to environment variable {env_key} with value {env_value}. "
-                f"Please use additional_config.{config_key} instead, because {env_key} will be removed in the "
-                "next release."
-            )
-        return env_value
-
     @classmethod
-    def _check_mooncake_c8_kv_cache_quant(cls, vllm_config: "VllmConfig") -> None:
+    def _check_mooncake_c8_kv_cache_quant(cls, vllm_config: VllmConfig) -> None:
         kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
         if kv_transfer_config is None:
             return
@@ -517,84 +625,6 @@ class FinegrainedTPConfig:
             logger.info("finegrained_tp_config enabled: %s", ", ".join(enabled_configs))
 
 
-class AscendCompilationConfig:
-    """
-    Configuration for controlling the behavior of Ascend graph optimization.
-
-    This class provides a way to configure graph fusion optimizations.
-    These configurations directly impact the performance and behavior of models
-    deployed on Ascend platforms.
-    """
-
-    def __init__(
-        self,
-        enable_npugraph_ex: bool = True,
-        enable_static_kernel: bool = False,
-        fuse_norm_quant: bool = True,
-        fuse_qknorm_rope: bool = True,
-        **kwargs,
-    ):
-        """
-        Initialize the configuration.
-
-        Args:
-            enable_npugraph_ex (bool): Whether to enable npugraph_ex backend.
-                When set to True, the Fx graph generated by Dymano will be
-                optimized and compiled by the npugraph_ex backend.
-                Default: True
-            enable_static_kernel (bool): Whether to enable static kernel.
-                Static kernel is suitable for scenarios with purely static shapes
-                or minimal shape changes, and can improve network performance.
-                When set to True, when during graph capture, it will compile operator
-                binary files with the corresponding shapes based on the current batch_size,
-                which usually takes some time.
-                Default: False
-            fuse_norm_quant (bool): Whether to enable norm and quant fusion optimization.
-                When set to True, the system will optimize norm and quant operations.
-                Default: True
-            fuse_qknorm_rope (bool): Whether to enable qknorm and rope fusion optimization.
-                Default: True
-            **kwargs: Additional optional parameters for forward compatibility and configuration extension.
-        """
-        from vllm_ascend.utils import is_310p
-
-        if is_310p():
-            if enable_npugraph_ex:
-                logger.warning("npugraph_ex is not supported on Ascend 310P. Disabling it.")
-            if enable_static_kernel:
-                logger.warning(
-                    "static kernel requires npugraph_ex, which is not supported on Ascend 310P. Disabling it."
-                )
-            enable_npugraph_ex = False
-            enable_static_kernel = False
-
-        self.fuse_norm_quant = fuse_norm_quant
-        self.fuse_qknorm_rope = fuse_qknorm_rope
-        self.enable_npugraph_ex = enable_npugraph_ex
-        self.enable_static_kernel = enable_static_kernel
-        self.fuse_muls_add = kwargs.get("fuse_muls_add", True)
-        if self.enable_static_kernel:
-            assert self.enable_npugraph_ex, "Static kernel generation requires npugraph_ex to be enabled."
-
-
-class AscendFusionConfig:
-    """
-    Configuration for controlling whether to use a fused operator gmmswigluquant.
-    """
-
-    def __init__(self, fusion_ops_gmmswigluquant: bool = True, **kwargs):
-        """
-        Initialize the configuration.
-
-        Args:
-            fusion_ops_gmmswigluquant (bool): Whether to use a fused operator gmmswigluquant.
-                When set to True, the system will use a fused operator gmmswigluquant.
-                Default: True
-            **kwargs: Additional optional parameters for forward compatibility and configuration extension.
-        """
-        self.fusion_ops_gmmswigluquant = fusion_ops_gmmswigluquant
-
-
 class XliteGraphConfig:
     """
     Configuration Object for xlite_graph_config from additional_config
@@ -619,83 +649,55 @@ class XliteGraphConfig:
                 )
 
 
+@config
+@dataclasses.dataclass
 class ProfilingChunkConfig:
     """Configuration for profiling-based dynamic chunk sizing.
 
-    When enabled, the scheduler profiles prefill latency during initialization
-    and uses a quadratic model to predict optimal chunk sizes at runtime.
-
-    Usage (online)::
-
-        vllm serve <model> --additional-config '{"scheduler_config": {"profiling_chunk_config": {"enabled": true}}}'
-
-    Usage (offline)::
-
-        llm = LLM(model, additional_config={"scheduler_config": {"profiling_chunk_config": {"enabled": true}}})
+    Migrated to ``@config`` (pydantic dataclass). Range/positivity checks
+    moved to an ``after`` model_validator. ``need_timing`` defaults to
+    ``enabled`` via the after-validator (field default is False, overridden
+    post-construction to mirror the original ``config.get("need_timing", self.enabled)``).
     """
 
-    def __init__(self, config: dict | None = None):
-        if config is None:
-            config = {}
-        self.enabled: bool = config.get("enabled", False)
-        self.smooth_factor: float = float(config.get("smooth_factor", 1.0))
-        self.min_chunk: int = int(config.get("min_chunk", 4096))
-        # Controls online history-aware calibration. When True, the model
-        # runner synchronizes the device each step to measure execution time
-        # and feeds it back for incremental refitting.  Automatically set to
-        # False once calibration completes.  Users can set it to False from
-        # the start to skip online calibration entirely and rely solely on
-        # the startup profiling model (avoids per-step sync overhead).
-        self.need_timing: bool = config.get("need_timing", self.enabled)
-        self.max_fit_chunk: int = int(config.get("max_fit_chunk", 30))
-        self._validate()
+    enabled: bool = False
+    smooth_factor: float = 1.0
+    min_chunk: int = 4096
+    need_timing: bool = False
+    max_fit_chunk: int = 30
 
-    def _validate(self):
+    @model_validator(mode="after")
+    def _validate_and_link_need_timing(self):
+        # need_timing defaults to enabled when not explicitly set by the user.
+        # (Original: config.get("need_timing", self.enabled).)
+        self.need_timing = self.need_timing if self.need_timing else self.enabled
         if not (0 < self.smooth_factor <= 1.0):
             raise ValueError(f"profiling_chunk_config.smooth_factor must be in (0, 1], got {self.smooth_factor}")
         if self.min_chunk <= 0:
             raise ValueError(f"profiling_chunk_config.min_chunk must be positive, got {self.min_chunk}")
         if self.max_fit_chunk <= 5:
             raise ValueError(f"Recommend to use at least 30 data points for fitting, got {self.max_fit_chunk}")
+        return self
 
 
+@config
+@dataclasses.dataclass
 class BatchJobSchedConfig:
     """Configuration for batch-job-aware scheduler.
 
-    All parameters can be configured via ``additional_config.batch_job_sched_config``
-    in the vLLM config.
-
-    Usage (offline)::
-
-        llm = LLM(model, additional_config={"batch_job_sched_config": {"enabled": true}})
+    Migrated to ``@config`` (pydantic dataclass). Range checks moved to an
+    ``after`` model_validator.
     """
 
-    def __init__(self, config: dict | None = None):
-        if config is None:
-            config = {}
+    enabled: bool = False
+    max_jobs: int = 20
+    reserve_margin_blocks: int = 2
+    reserve_max_blocks: int = 8
+    low_available_tokens_threshold: int = 4096
+    short_decode_token_threshold: int = 32
 
-        # Enable batch-job-aware scheduler
-        self.enabled: bool = config.get("enabled", False)
-
-        # Maximum number of tracked jobs (0 = unlimited)
-        self.max_jobs: int = int(config.get("max_jobs", 20))
-
-        # Extra block margin added to the reserve as safety buffer
-        self.reserve_margin_blocks: int = int(config.get("reserve_margin_blocks", 2))
-
-        # Maximum number of blocks that can be reserved
-        self.reserve_max_blocks: int = int(config.get("reserve_max_blocks", 8))
-
-        # Threshold for prioritizing long vs short decode jobs
-        self.low_available_tokens_threshold: int = int(config.get("low_available_tokens_threshold", 4096))
-
-        # Threshold for identifying short decoding jobs
-        self.short_decode_token_threshold: int = int(config.get("short_decode_token_threshold", 32))
-
-        self._validate()
-
-    def _validate(self) -> None:
-        """Validate the validity of configuration parameters."""
+    @model_validator(mode="after")
+    def _validate(self):
         if self.max_jobs < 0:
             raise ValueError(f"batch_job_sched_config.max_jobs must be non-negative, got {self.max_jobs}")
         if self.reserve_margin_blocks < 0:
@@ -716,169 +718,30 @@ class BatchJobSchedConfig:
                 f"batch_job_sched_config.short_decode_token_threshold must be positive, "
                 f"got {self.short_decode_token_threshold}"
             )
+        return self
 
 
-class RejectionSamplerConfig:
-    """Configuration for Block Verify and Entropy Verify in Rejection Sampler.
-
-    Block Verify improves acceptance rate by evaluating all draft tokens
-    as a block using cumulative probability products. Entropy Verify
-    adjusts the acceptance threshold based on the entropy of the target
-    distribution, allowing higher acceptance for high-entropy (uncertain)
-    tokens and stricter rejection for low-entropy (confident) tokens.
-
-    Usage (online)::
-
-        vllm serve <model> --additional-config \
-            '{"rejection_sampler_config": {"enable_block_verify": true, \
-            "enable_entropy_verify": true, "posterior_threshold": 0.95, \
-            "posterior_alpha": 0.4}}'
-
-    Usage (offline)::
-
-        llm = LLM(
-            model,
-            additional_config={
-                "rejection_sampler_config": {
-                    "enable_block_verify": true,
-                    "enable_entropy_verify": true,
-                    "posterior_threshold": 0.95,
-                    "posterior_alpha": 0.4,
-                }
-            },
-        )
-    """
-
-    def __init__(self, config: dict | None = None):
-        if config is None:
-            config = {}
-        self.enable_block_verify: bool = config.get("enable_block_verify", False)
-        self.enable_entropy_verify: bool = config.get("enable_entropy_verify", False)
-        self.posterior_threshold: float = config.get("posterior_threshold", 0.95)
-        self.posterior_alpha: float = config.get("posterior_alpha", 0.4)
-        self._validate()
-
-    def _validate(self):
-        if not isinstance(self.enable_block_verify, bool):
-            raise ValueError(
-                f"rejection_sampler_config.enable_block_verify must be a bool, "
-                f"got {type(self.enable_block_verify).__name__}"
-            )
-        if not isinstance(self.enable_entropy_verify, bool):
-            raise ValueError(
-                f"rejection_sampler_config.enable_entropy_verify must be a bool, "
-                f"got {type(self.enable_entropy_verify).__name__}"
-            )
-        if not isinstance(self.posterior_threshold, (int, float)):
-            raise ValueError(
-                f"rejection_sampler_config.posterior_threshold must be a float, "
-                f"got {type(self.posterior_threshold).__name__}"
-            )
-        if not isinstance(self.posterior_alpha, (int, float)):
-            raise ValueError(
-                f"rejection_sampler_config.posterior_alpha must be a float, got {type(self.posterior_alpha).__name__}"
-            )
-        if not (0 < self.posterior_threshold <= 1):
-            raise ValueError(
-                f"rejection_sampler_config.posterior_threshold must be in (0, 1], got {self.posterior_threshold}"
-            )
-        if self.posterior_alpha < 0:
-            raise ValueError(f"rejection_sampler_config.posterior_alpha must be >= 0, got {self.posterior_alpha}")
-
-
-class EplbConfig:
-    """
-    Configuration Object for xlite_graph_config from additional_config
-    """
-
-    _defaults = {
-        "dynamic_eplb": False,
-        "expert_map_path": None,
-        "expert_heat_collection_interval": 600,
-        "algorithm_execution_interval": 50,
-        "expert_map_record_path": None,
-        "num_redundant_experts": 0,
-        "eplb_policy_type": 2,
-        "eplb_heat_collection_stage": "all",
-    }
-
-    def __init__(self, user_config: dict | None = None):
-        if user_config is None:
-            user_config = {}
-        self.config = self._defaults.copy()
-        if user_config and isinstance(user_config, dict):
-            for key, value in user_config.items():
-                if key in self.config:
-                    self.config[key] = value
-                else:
-                    raise ValueError(f"Config has no attribute '{key}'")
-
-        self._validate_config()
-
-    def __getattr__(self, key):
-        if key in self.config:
-            return self.config[key]
-        raise AttributeError(f"Config has no attribute '{key}'")
-
-    def _validate_config(self):
-        if self.expert_map_path is not None:
-            logger.info("The expert_map is %s", self.expert_map_path)
-            if self.expert_map_path[-5:] != ".json":
-                raise TypeError("The expert_map is not json.")
-            if not (os.path.exists(self.expert_map_path) and os.access(self.expert_map_path, os.R_OK)):
-                raise ValueError("The expert_map is not exist.")
-        if self.expert_map_record_path is not None:
-            self.config["dynamic_eplb"] = True
-            if self.expert_map_record_path[-5:] != ".json":
-                raise TypeError("The expert_map_record_path is not json.")
-            dirname = os.path.dirname(self.expert_map_record_path)
-            os.makedirs(dirname, exist_ok=True)
-        for key in ["expert_heat_collection_interval", "algorithm_execution_interval", "num_redundant_experts"]:
-            if not isinstance(self.config[key], int):
-                raise TypeError(f"{key} must be an integer")
-            if self.config[key] < 0:  # type: ignore
-                raise ValueError(f"{key} must greater than 0; got {self.config[key]} instead")
-        if self.eplb_policy_type not in [0, 1, 2, 3]:
-            raise ValueError("eplb_policy_type must in [0, 1, 2, 3]")
-        if self.config["dynamic_eplb"]:
-            assert (
-                os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1")
-                or os.getenv("EXPERT_MAP_RECORD", "false") == "true"
-            ), "The environment variable DYNAMIC_EPLB or EXPERT_MAP_RECORD of the EPLB must be set to true."
-        if self.eplb_heat_collection_stage not in ["all", "prefill", "decode"]:
-            raise ValueError('eplb_heat_collection_stage must be one of ["all", "prefill", "decode"]')
-
-        logger.info("Dynamic EPLB is %s", self.config["dynamic_eplb"])
-        logger.info("The number of redundant experts is %s", self.config["num_redundant_experts"])
-
-
+@config
+@dataclasses.dataclass
 class ShortRequestFirstConfig:
-    """Configuration object for ``additional_config["scheduler_config"]["short_request_first_config"]``."""
+    """Configuration object for ``additional_config["scheduler_config"]["short_request_first_config"]``.
 
-    _defaults = {
-        "enabled": False,
-        "threshold": 256,
-        "long_max_wait_ms": 0.0,
-    }
+    Migrated to ``@config`` (pydantic dataclass). Unknown-key detection is now
+    handled by ``extra="forbid"`` (replaces the hand-written ``unknown`` set
+    check); range checks moved to an ``after`` model_validator.
+    """
 
-    def __init__(self, user_config: dict | None = None):
-        user_config = user_config or {}
-        unknown = set(user_config) - set(self._defaults)
-        if unknown:
-            raise ValueError(f"Unknown short_request_first_config keys: {sorted(unknown)}")
+    enabled: bool = False
+    threshold: int = 256
+    long_max_wait_ms: float = 0.0
 
-        source = user_config
-
-        self.enabled = bool(source.get("enabled", self._defaults["enabled"]))
-        self.threshold = int(source.get("threshold", self._defaults["threshold"]))
-        self.long_max_wait_ms = float(source.get("long_max_wait_ms", self._defaults["long_max_wait_ms"]))
-        self._validate_config()
-
+    @model_validator(mode="after")
     def _validate_config(self):
         if self.threshold < 0:
             raise ValueError(f"short_request_first_config.threshold must be a non-negative int; got {self.threshold}")
         if self.long_max_wait_ms < 0:
             raise ValueError(f"short_request_first_config.long_max_wait_ms must be >= 0; got {self.long_max_wait_ms}")
+        return self
 
 
 class SchedulerConfig:
@@ -906,13 +769,13 @@ class SchedulerConfig:
             False,
         )
         self.short_request_first_config = ShortRequestFirstConfig(
-            self._get_config_value(scheduler_config, additional_config, "short_request_first_config", {})
+            **self._get_config_value(scheduler_config, additional_config, "short_request_first_config", {})
         )
         self.profiling_chunk_config = ProfilingChunkConfig(
-            self._get_config_value(scheduler_config, additional_config, "profiling_chunk_config", {})
+            **self._get_config_value(scheduler_config, additional_config, "profiling_chunk_config", {})
         )
         self.batch_job_sched_config = BatchJobSchedConfig(
-            self._get_config_value(scheduler_config, additional_config, "batch_job_sched_config", {})
+            **self._get_config_value(scheduler_config, additional_config, "batch_job_sched_config", {})
         )
 
     @staticmethod
@@ -1032,7 +895,49 @@ def init_ascend_config(vllm_config):
         and getattr(_ASCEND_CONFIG, "vllm_config", None) is vllm_config
     ):
         return _ASCEND_CONFIG
-    new_config = AscendConfig(vllm_config)
+
+    # Pre-construct sub-configs that need vllm_config or special injection.
+    from vllm_ascend import envs as ascend_envs
+
+    xlite = XliteGraphConfig(additional_config.get("xlite_graph_config", {}), vllm_config)
+    finegrained = FinegrainedTPConfig(additional_config.get("finegrained_tp_config", {}), vllm_config)
+    sched = SchedulerConfig(additional_config, balance_env_value=ascend_envs.VLLM_ASCEND_BALANCE_SCHEDULING)
+    sparse_kv = SparseKVOffloadConfig(vllm_config, additional_config.get("sparse_kv_offload_config", {}))
+    # dump_config: keep the mutual-exclusion / materialize logic as a factory
+    # pre-step; the resolved path is passed as the dump_config_path field.
+    dump_config_path = AscendConfig._resolve_dump_config_path(additional_config)
+
+    # Extract only the keys that correspond to declared AscendConfig fields and
+    # strip bypass keys (extra="forbid" would otherwise reject them). Bypass
+    # keys are read elsewhere (refresh by this factory; enable_dsa_cp /
+    # draft_window_size by other modules directly off additional_config;
+    # enable_balance_scheduling by SchedulerConfig above; dump_config resolved
+    # into dump_config_path above). Sub-config dicts (ascend_compilation_config
+    # etc.) are kept in kwargs so pydantic coerces dict→dataclass.
+    fields = AscendConfig.__pydantic_fields__
+    _BYPASS_KEYS = {
+        "refresh",
+        "enable_dsa_cp",
+        "draft_window_size",
+        "dump_config",
+        "dump_config_path",  # passed explicitly below
+        "enable_balance_scheduling",  # SchedulerConfig internal (top-level legacy)
+        "xlite_graph_config",  # pre-constructed above
+        "finegrained_tp_config",  # pre-constructed above
+        "scheduler_config",  # pre-constructed above
+        "sparse_kv_offload_config",  # pre-constructed above
+    }
+    kwargs = {k: v for k, v in additional_config.items() if k in fields and k not in _BYPASS_KEYS}
+
+    new_config = AscendConfig(
+        vllm_config=vllm_config,
+        xlite_graph_config=xlite,
+        finegrained_tp_config=finegrained,
+        scheduler_config=sched,
+        sparse_kv_offload_config=sparse_kv,
+        dump_config_path=dump_config_path,
+        **kwargs,
+    )
     if _is_ascend_config_initialized(new_config):
         _ASCEND_CONFIG = new_config
     else:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -315,9 +315,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
 
         # Sliding-window draft attention adapter.
-        self.draft_window_size = (
-            self.vllm_config.additional_config.get("draft_window_size") if self.vllm_config.additional_config else None
-        )
+        # Read from the validated AscendConfig singleton instead of bypassing it
+        # via additional_config["draft_window_size"] (architecture debt #7).
+        from vllm_ascend.ascend_config import get_ascend_config
+
+        self.draft_window_size = get_ascend_config().draft_window_size
         if self.draft_window_size is not None:
             # EAGLE3: seq_lens is context-only, K draft positions lie beyond it
             #   -> future_offset = K.

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1089,12 +1089,17 @@ def is_pd_decode_recompute_scheduler_enabled(vllm_config: VllmConfig | None = No
     """
     try:
         if vllm_config is None:
-            try:
-                from vllm.config import get_current_vllm_config
+            # No caller-provided config: fall back to the upstream runtime
+            # context (non-raising). Previously this used the reach-through
+            # `get_ascend_config().vllm_config` as a second fallback, but
+            # vllm_config is no longer a member of AscendConfig (Plan B).
+            # get_current_vllm_config_or_none returns None outside an engine
+            # context — which is the exact case where the old fallback also
+            # could not supply a usable runtime config, so `vllm_config is None`
+            # below handles it identically.
+            from vllm.config import get_current_vllm_config_or_none
 
-                vllm_config = get_current_vllm_config()
-            except AssertionError:
-                vllm_config = get_ascend_config().vllm_config
+            vllm_config = get_current_vllm_config_or_none()
         if vllm_config is None:
             return False
         kv_cfg = vllm_config.kv_transfer_config

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1379,10 +1379,13 @@ def enable_dsa_cp() -> bool:
     if not has_indexer:
         return False
 
-    dsa_cp_enable = False
-    additional_config = getattr(vllm_config, "additional_config", None)
-    if additional_config is not None and "enable_dsa_cp" in additional_config:
-        dsa_cp_enable = bool(additional_config["enable_dsa_cp"])
+    # Read from the validated AscendConfig singleton instead of bypassing it
+    # via additional_config["enable_dsa_cp"]. This converges the bypass read
+    # (architecture debt #7) onto the canonical get_ascend_config() path, so
+    # the value benefits from @config type validation (bool lax coercion).
+    from vllm_ascend.ascend_config import get_ascend_config
+
+    dsa_cp_enable = get_ascend_config().enable_dsa_cp
 
     if dsa_cp_enable and not enable_sp():
         raise ValueError(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR migrates the entire `AscendConfig` and all 10 sub-config classes to upstream vLLM's `@config` decorator (pydantic dataclass), achieving three goals:

1. **Type validation**: All ~30 config fields become typed pydantic fields with lax coercion (`"false"`→False, `"2"`→2), fixing the `bool("false")==True` pitfall (users could not disable features), `int("2")==2` silent failures, and `int("false")` env-var crashes.

2. **Unknown key rejection (`extra="forbid"`)**: Typoed configuration keys (e.g. `enable_cpu_bindng`) now raise `ValidationError` instead of being silently ignored.

3. **Bypass read convergence**: Configuration keys previously read by business modules directly off the raw `additional_config` dict (bypassing `AscendConfig`) are converged onto the canonical `get_ascend_config()` singleton path — `enable_dsa_cp` (utils.py), `draft_window_size` (spec_decode), `enable_balance_scheduling` (SchedulerConfig field). This eliminates the pattern where multiple modules read the raw dict independently, bypassing validation.

### Key changes

- **AscendConfig** migrated to `@config` (pydantic dataclass) with `extra="forbid"`
  - `vllm_config` injected as `kw_only` field with `arbitrary_types_allowed=True` (not recursively validated)
  - Environment variable fallbacks resolved in `before` model_validator (handles `ArgsKwargs`)
  - Cross-config derivations/downgrades/mutex checks in `after` model_validator (preserves original ordering and error messages)

- **10 sub-config classes** migrated to `@config`:
  - 7 without vllm_config dependency: AscendCompilationConfig, AscendFusionConfig, EplbConfig, RejectionSamplerConfig, ProfilingChunkConfig, BatchJobSchedConfig, ShortRequestFirstConfig
  - 3 with vllm_config dependency: XliteGraphConfig, FinegrainedTPConfig, SchedulerConfig (vllm_config as `kw_only` field; SchedulerConfig's three-level precedence rewritten as `before`-validator)

- **Factory `init_ascend_config`** reworked:
  - Pre-constructs vllm_config-dependent sub-configs and injects them as `kw_only` fields
  - Strips non-user-configurable keys (control-flow flags, injected fields, pure-derived fields computed by after-validator, SchedulerConfig-internal legacy key) before construction, so that only user-configurable keys reach pydantic, where `extra="forbid"` can catch typos

### Does this PR introduce _any_ user-facing change?

Yes (breaking changes, all intentional):
- `bool("false")` now correctly disables features (was silently enabling)
- `int` values like `2` for bool fields are rejected (use JSON `true`/`false`)
- Unknown top-level keys (typos) now raise `ValidationError` (were silently ignored)

> **Note**: 6 configuration fields that currently fall back to environment variables (`VLLM_ASCEND_ENABLE_MLAPO` etc.) are temporarily typed as `Any` to preserve backward compatibility. Once the deprecated environment variables are sunset in a follow-up PR, these fields will be tightened to `bool`/`int` for full type validation coverage.

### How was this patch tested?

- Unit tests: `tests/ut/test_ascend_config.py`, `tests/ut/core/test_profiling_chunk.py`, `tests/ut/core/test_batch_job_aware_scheduler.py`
- Lint: `ruff check` + `ruff format` + `mypy` (via `tools/mypy.sh`)
- CI: pre-commit hooks

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
