### PR TITLE
[CI][Test] Update MiniMax-M3 W8A8 model to Eco-Tech/MiniMax-M3-w8a8-0626

### DIFF
--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -277,6 +277,7 @@
       "MiniMax/MiniMax-M2.5",
       "Eco-Tech/Qwen3.5-27B-w8a8-mtp",
       "Eco-Tech/MiniMax-M3-w8a8",
+      "Eco-Tech/MiniMax-M3-w8a8-0626",
       "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot",
       "vllm-ascend/MiniMax-M2.5-eagle-model-0318",
       "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp",

--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-W8A8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-W8A8-A3.yaml
@@ -4,7 +4,7 @@
 
 test_cases:
   - name: "MiniMax-M3-w8a8"
-    model: "Eco-Tech/MiniMax-M3-w8a8"
+    model: "Eco-Tech/MiniMax-M3-w8a8-0626"
     envs:
       HCCL_BUFFSIZE: "512"
       HCCL_OP_EXPANSION_MODE: "AIV"

--- a/tests/e2e/pull_request/eight_card/test_minimax_m3.py
+++ b/tests/e2e/pull_request/eight_card/test_minimax_m3.py
@@ -27,7 +27,7 @@ import regex as re
 
 from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 
-MINIMAX_M3_MODEL_PATH = os.environ.get("MINIMAX_M3_MODEL_PATH", "Eco-Tech/MiniMax-M3-w8a8")
+MINIMAX_M3_MODEL_PATH = os.environ.get("MINIMAX_M3_MODEL_PATH", "Eco-Tech/MiniMax-M3-w8a8-0626")
 GSM8K_QUESTION = "Ali had $21. Leila gave him half of her $100. How much does Ali have now?"
 GSM8K_ANSWER = "71"
 MAX_TOKENS = 512


### PR DESCRIPTION
Switch PR and nightly MiniMax-M3 W8A8 e2e coverage to the new Eco-Tech/MiniMax-M3-w8a8-0626 checkpoint, and add it to model_dataset_list.json for CI downloads.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
