### PR TITLE
[Feature] Add sparse HCCL weight transfer

### DIFF
--- a/examples/rl/rlhf_sparse_hccl.py
+++ b/examples/rl/rlhf_sparse_hccl.py
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Demonstrates dense-vs-sparse HCCL weight syncing with a real model.
+
+This example mirrors the validation story used for the sparse HCCL MVP:
+both the dense update path and the sparse patch path start from the same real
+checkpoint and apply the same deterministic trainer-side patch. The script then
+checks that greedy 1-token outputs match between the dense and sparse vLLM
+engines after the update.
+
+The example performs the following steps:
+* Load a training model on one NPU via a Ray actor.
+* Launch a vLLM engine with the same real model on a second NPU.
+* Verify trainer vs vLLM baseline agreement before any update.
+* Apply a deterministic patch to ``model.embed_tokens.weight`` on the trainer.
+* Run a dense HCCL update into a fresh vLLM engine and collect post-update
+  outputs.
+* Reset the trainer back to the baseline checkpoint.
+* Apply the same deterministic patch again.
+* Run a sparse HCCL update into another fresh vLLM engine and collect
+  post-update outputs.
+* Compare dense vs sparse baseline outputs, dense vs sparse post-update
+  outputs, estimated payload sizes, and trainer-side send times.
+
+Current sparse weight transfer MVP limitations:
+* ``TP=1`` and ``PP=1`` only
+* sparse updates use runtime/kernel-format parameter names
+* sparse updates are not composable with checkpoint-format or packed updates
+
+This example assumes a single-node cluster with two NPUs and requires
+``VLLM_ASCEND_ENABLE_NZ=0``.
+"""
+
+import hashlib
+import os
+import time
+from collections.abc import Sequence
+from dataclasses import asdict
+
+import ray
+import torch
+import vllm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from vllm import SamplingParams
+from vllm.config import WeightTransferConfig
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferInitRequest,
+    WeightTransferUpdateRequest,
+)
+from vllm.utils.network_utils import get_ip, get_open_port
+from vllm.v1.executor import Executor
+from vllm_ascend.distributed.weight_transfer.hccl_common import (
+    HCCLWeightTransferInitInfo,
+)
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLTrainerSendWeightsArgs,
+    HCCLWeightTransferEngine,
+)
+from vllm_ascend.distributed.weight_transfer.sparse_hccl_engine import (
+    SparseHCCLWeightTransferEngine,
+)
+from vllm_ascend.distributed.weight_transfer.sparse_weight_patch import (
+    SparseWeightPatch,
+)
+
+# Override this with a local checkpoint path when the default Hugging Face
+# model is not available on the test host.
+MODEL_NAME = os.environ.get("MODEL_NAME", "Qwen/Qwen3-1.7B")
+PATCHED_PARAM_NAME = "model.embed_tokens.weight"
+MAX_PATCH_ROWS = 32
+HCCL_WORLD_SIZE = 2  # One trainer plus one TP=1/PP=1 vLLM worker.
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+SAMPLING_PARAMS = SamplingParams(temperature=0.0, max_tokens=1)
+
+
+class MyLLM(vllm.AsyncLLMEngine):
+    """Async engine wrapper following the Ascend Ray RL example."""
+
+    def __init__(self, **kwargs):
+        engine_args = vllm.AsyncEngineArgs(**kwargs)
+        config = engine_args.create_engine_config()
+        super().__init__(
+            vllm_config=config,
+            executor_class=Executor.get_class(config),
+            log_requests=engine_args.enable_log_requests,
+            log_stats=not engine_args.disable_log_stats,
+        )
+
+    async def generate_prompts(
+        self,
+        prompts: Sequence[str],
+        sampling_params: SamplingParams,
+    ) -> list[dict[str, object]]:
+        """Generate each prompt and return the final token IDs and text."""
+        generations = []
+        for prompt in prompts:
+            output = None
+            async for output in self.generate(
+                prompt,
+                sampling_params,
+                request_id=str(time.time_ns()),
+            ):
+                pass
+            assert output is not None
+            generations.append(
+                {
+                    "token_ids": output.outputs[0].token_ids,
+                    "text": output.outputs[0].text,
+                }
+            )
+        return generations
+
+    async def pause_for_update(self) -> None:
+        """Pause generation while keeping the engine ready for an update."""
+        await self.pause_generation(mode="keep")
+
+
+@ray.remote(resources={"NPU": 1})
+class TrainModel:
+    """Ray actor that owns the trainer-side model and deterministic patch state."""
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        self.model = None
+        self.patched_param = None
+        self.pending_sparse_patches: list[SparseWeightPatch] | None = None
+        self.model_update_group = None
+        self.master_address = get_ip()
+        self.port = get_open_port()
+        self.reset_model()
+
+    def reset_model(self) -> None:
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            torch_dtype=torch.bfloat16,
+        ).to("npu:0")
+        self.model.eval()
+
+        try:
+            self.patched_param = self.model.get_parameter(PATCHED_PARAM_NAME)
+        except AttributeError as exc:
+            raise RuntimeError(
+                f"Expected trainer model to expose `{PATCHED_PARAM_NAME}`"
+            ) from exc
+
+        self.pending_sparse_patches = None
+
+    def create_rendezvous(self) -> tuple[str, int]:
+        self.port = get_open_port()
+        return self.master_address, self.port
+
+    def init_weight_transfer_group(self, world_size: int) -> None:
+        self.model_update_group = HCCLWeightTransferEngine.trainer_init(
+            dict(
+                master_address=self.master_address,
+                master_port=self.port,
+                world_size=world_size,
+            )
+        )
+
+    def get_dense_update_info(self, packed: bool = False) -> tuple[dict, int]:
+        names = []
+        dtype_names = []
+        shapes = []
+        payload_bytes = 0
+        for name, param in self.model.named_parameters():
+            names.append(name)
+            dtype_names.append(str(param.dtype).split(".")[-1])
+            shapes.append(list(param.shape))
+            payload_bytes += param.numel() * param.element_size()
+
+        return (
+            dict(
+                names=names,
+                dtype_names=dtype_names,
+                shapes=shapes,
+                packed=packed,
+            ),
+            payload_bytes,
+        )
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        prompts: Sequence[str],
+        max_new_tokens: int = 1,
+    ) -> list[dict[str, object]]:
+        generations = []
+        for prompt in prompts:
+            model_inputs = self.tokenizer(prompt, return_tensors="pt").to("npu:0")
+            output = self.model.generate(
+                **model_inputs,
+                max_new_tokens=max_new_tokens,
+                do_sample=False,
+                pad_token_id=self.tokenizer.pad_token_id,
+            )
+            new_token_ids = output[0, model_inputs["input_ids"].shape[1] :].tolist()
+            generations.append(
+                {
+                    "token_ids": new_token_ids,
+                    "text": self.tokenizer.decode(
+                        new_token_ids,
+                        skip_special_tokens=False,
+                    ),
+                }
+            )
+        return generations
+
+    def prepare_sparse_patch(
+        self,
+        prompts: Sequence[str],
+        max_patch_rows: int = MAX_PATCH_ROWS,
+    ) -> tuple[dict[str, object], list[int], str, int]:
+        selected_token_ids: list[int] = []
+        special_ids = set(self.tokenizer.all_special_ids)
+        for prompt in prompts:
+            token_ids = self.tokenizer(prompt, add_special_tokens=False)["input_ids"]
+            for token_id in token_ids:
+                if token_id in special_ids or token_id in selected_token_ids:
+                    continue
+                selected_token_ids.append(token_id)
+                if len(selected_token_ids) == max_patch_rows:
+                    break
+            if len(selected_token_ids) == max_patch_rows:
+                break
+
+        if not selected_token_ids:
+            raise ValueError("Could not derive any non-special token IDs to patch")
+
+        vocab_size = self.patched_param.shape[0]
+        next_token_id = selected_token_ids[-1]
+        while len(selected_token_ids) < max_patch_rows:
+            next_token_id = (next_token_id + 1) % vocab_size
+            if next_token_id in special_ids or next_token_id in selected_token_ids:
+                continue
+            selected_token_ids.append(next_token_id)
+
+        row_ids = torch.tensor(
+            selected_token_ids,
+            device=self.patched_param.device,
+            dtype=torch.long,
+        )
+        hidden_size = self.patched_param.shape[1]
+        column_offsets = torch.arange(
+            hidden_size,
+            device=self.patched_param.device,
+            dtype=torch.long,
+        )
+
+        with torch.no_grad():
+            # Rotate the selected embedding rows instead of zeroing them so the
+            # patch remains deterministic while avoiding a degenerate collapse
+            # to the same special token after the update.
+            replacement_rows = self.patched_param[row_ids].roll(shifts=1, dims=0)
+            self.patched_param[row_ids] = replacement_rows
+
+        flat_indices = (
+            row_ids.unsqueeze(1).mul(hidden_size).add(column_offsets).reshape(-1)
+        )
+        flat_values = self.patched_param[row_ids].reshape(-1).contiguous()
+        self.pending_sparse_patches = [
+            SparseWeightPatch(
+                name=PATCHED_PARAM_NAME,
+                indices=flat_indices.to(torch.int32),
+                values=flat_values,
+            )
+        ]
+        patch_digest = hashlib.sha256(
+            self.pending_sparse_patches[0].indices.cpu().numpy().tobytes()
+            + self.pending_sparse_patches[0]
+            .values.detach()
+            .float()
+            .cpu()
+            .numpy()
+            .tobytes()
+        ).hexdigest()
+
+        sparse_payload_bytes = (
+            flat_indices.numel() * torch.tensor([], dtype=torch.int32).element_size()
+            + flat_values.numel() * flat_values.element_size()
+        )
+        update_info = dict(
+            names=[PATCHED_PARAM_NAME],
+            dtype_names=[str(self.patched_param.dtype).split(".")[-1]],
+            shapes=[list(self.patched_param.shape)],
+            num_updates_list=[flat_indices.numel()],
+        )
+        return update_info, selected_token_ids, patch_digest, sparse_payload_bytes
+
+    def broadcast_weights(self, packed: bool = False) -> float:
+        if self.model_update_group is None:
+            raise RuntimeError("Weight transfer group is not initialized")
+
+        trainer_args = HCCLTrainerSendWeightsArgs(
+            group=self.model_update_group,
+            packed=packed,
+        )
+        start = time.perf_counter()
+        HCCLWeightTransferEngine.trainer_send_weights(
+            iterator=self.model.named_parameters(),
+            trainer_args=trainer_args,
+        )
+        torch.accelerator.synchronize()
+        return (time.perf_counter() - start) * 1000.0
+
+    def broadcast_pending_sparse_patch(self) -> float:
+        if self.model_update_group is None:
+            raise RuntimeError("Weight transfer group is not initialized")
+        if self.pending_sparse_patches is None:
+            raise RuntimeError("Sparse patch has not been prepared")
+
+        start = time.perf_counter()
+        SparseHCCLWeightTransferEngine.trainer_send_weights(
+            iter(self.pending_sparse_patches),
+            HCCLTrainerSendWeightsArgs(group=self.model_update_group),
+        )
+        torch.accelerator.synchronize()
+        self.pending_sparse_patches = None
+        return (time.perf_counter() - start) * 1000.0
+
+
+def launch_llm(backend: str = "hccl"):
+    # Do not create an outer placement group. The Ray executor creates its own
+    # groups and performs the NPU resource checks internally.
+    return ray.remote(
+        num_cpus=0,
+    )(MyLLM).remote(
+        model=MODEL_NAME,
+        enforce_eager=True,
+        tensor_parallel_size=1,
+        distributed_executor_backend="ray",
+        gpu_memory_utilization=0.6,
+        additional_config={"weight_nz_mode": 0},
+        weight_transfer_config=WeightTransferConfig(backend=backend),
+    )
+
+
+def collect_vllm_generations(llm_handle) -> list[dict[str, object]]:
+    return ray.get(llm_handle.generate_prompts.remote(PROMPTS, SAMPLING_PARAMS))
+
+
+def token_sequences_match(
+    left: Sequence[dict[str, object]],
+    right: Sequence[dict[str, object]],
+) -> bool:
+    return [item["token_ids"] for item in left] == [item["token_ids"] for item in right]
+
+
+def print_generations(label: str, prompts: Sequence[str], generations) -> None:
+    print(f"\n{label}")
+    print("-" * 50)
+    for prompt, generation in zip(prompts, generations):
+        print(f"Prompt: {prompt!r}")
+        print(f"Token IDs: {generation['token_ids']}")
+        print(f"Text: {generation['text']!r}")
+        print("-" * 50)
+
+
+def run_dense_phase(
+    train_model,
+) -> dict[str, object]:
+    ray.get(train_model.reset_model.remote())
+    llm = launch_llm(backend="hccl")
+    try:
+        dense_before = collect_vllm_generations(llm)
+
+        ray.get(llm.pause_for_update.remote())
+        master_address, master_port = ray.get(train_model.create_rendezvous.remote())
+        world_size = HCCL_WORLD_SIZE
+        inference_init = llm.init_weight_transfer_engine.remote(
+            WeightTransferInitRequest(
+                init_info=asdict(
+                    HCCLWeightTransferInitInfo(
+                        master_address=master_address,
+                        master_port=master_port,
+                        rank_offset=1,
+                        world_size=world_size,
+                    )
+                )
+            )
+        )
+        trainer_init = train_model.init_weight_transfer_group.remote(world_size)
+        ray.get([trainer_init, inference_init])
+        ray.get(llm.start_weight_update.remote())
+
+        dense_update_info, dense_payload_bytes = ray.get(
+            train_model.get_dense_update_info.remote()
+        )
+        _, selected_token_ids, patch_digest, _ = ray.get(
+            train_model.prepare_sparse_patch.remote(PROMPTS)
+        )
+
+        inference_update = llm.update_weights.remote(
+            WeightTransferUpdateRequest(update_info=dense_update_info)
+        )
+        dense_send_ms, _ = ray.get(
+            [
+                train_model.broadcast_weights.remote(packed=False),
+                inference_update,
+            ]
+        )
+        ray.get(llm.finish_weight_update.remote())
+        ray.get(llm.resume_generation.remote())
+
+        dense_after = collect_vllm_generations(llm)
+
+        return {
+            "dense_before": dense_before,
+            "dense_after": dense_after,
+            "selected_token_ids": selected_token_ids,
+            "patch_digest": patch_digest,
+            "dense_payload_bytes": dense_payload_bytes,
+            "dense_send_ms": dense_send_ms,
+        }
+    finally:
+        ray.kill(llm)
+
+
+def run_sparse_phase(
+    train_model,
+) -> dict[str, object]:
+    ray.get(train_model.reset_model.remote())
+    llm = launch_llm(backend="sparse_hccl")
+    try:
+        sparse_before = collect_vllm_generations(llm)
+
+        ray.get(llm.pause_for_update.remote())
+        master_address, master_port = ray.get(train_model.create_rendezvous.remote())
+        world_size = HCCL_WORLD_SIZE
+        inference_init = llm.init_weight_transfer_engine.remote(
+            WeightTransferInitRequest(
+                init_info=asdict(
+                    HCCLWeightTransferInitInfo(
+                        master_address=master_address,
+                        master_port=master_port,
+                        rank_offset=1,
+                        world_size=world_size,
+                    )
+                )
+            )
+        )
+        trainer_init = train_model.init_weight_transfer_group.remote(world_size)
+        ray.get([trainer_init, inference_init])
+        ray.get(llm.start_weight_update.remote())
+
+        sparse_update_info, selected_token_ids, patch_digest, sparse_payload_bytes = (
+            ray.get(train_model.prepare_sparse_patch.remote(PROMPTS))
+        )
+
+        inference_update = llm.update_weights.remote(
+            WeightTransferUpdateRequest(update_info=sparse_update_info)
+        )
+        sparse_send_ms, _ = ray.get(
+            [
+                train_model.broadcast_pending_sparse_patch.remote(),
+                inference_update,
+            ]
+        )
+        ray.get(llm.finish_weight_update.remote())
+        ray.get(llm.resume_generation.remote())
+
+        sparse_after = collect_vllm_generations(llm)
+
+        return {
+            "sparse_before": sparse_before,
+            "sparse_after": sparse_after,
+            "selected_token_ids": selected_token_ids,
+            "patch_digest": patch_digest,
+            "sparse_payload_bytes": sparse_payload_bytes,
+            "sparse_send_ms": sparse_send_ms,
+        }
+    finally:
+        ray.kill(llm)
+
+
+ray.init(
+    runtime_env={"env_vars": {"VLLM_ASCEND_ENABLE_NZ": "0"}},
+)
+
+try:
+    train_model = TrainModel.remote(MODEL_NAME)
+
+    dense_results = run_dense_phase(train_model)
+    sparse_results = run_sparse_phase(train_model)
+
+    baseline_equal = token_sequences_match(
+        dense_results["dense_before"],
+        sparse_results["sparse_before"],
+    )
+    patch_selection_equal = (
+        dense_results["selected_token_ids"] == sparse_results["selected_token_ids"]
+    )
+    patch_digest_equal = (
+        dense_results["patch_digest"] == sparse_results["patch_digest"]
+    )
+    after_equal = token_sequences_match(
+        dense_results["dense_after"],
+        sparse_results["sparse_after"],
+    )
+    any_output_changed = any(
+        before["token_ids"] != after["token_ids"]
+        for before, after in zip(
+            dense_results["dense_before"],
+            dense_results["dense_after"],
+        )
+    )
+    dense_payload_mb = dense_results["dense_payload_bytes"] / (1024 * 1024)
+    sparse_payload_mb = sparse_results["sparse_payload_bytes"] / (1024 * 1024)
+
+    print_generations(
+        "Dense baseline outputs",
+        PROMPTS,
+        dense_results["dense_before"],
+    )
+    print_generations(
+        "Sparse baseline outputs", PROMPTS, sparse_results["sparse_before"]
+    )
+    print_generations(
+        "Dense outputs after update", PROMPTS, dense_results["dense_after"]
+    )
+    print_generations(
+        "Sparse outputs after update",
+        PROMPTS,
+        sparse_results["sparse_after"],
+    )
+
+    print(f"patched_token_ids = {dense_results['selected_token_ids']}")
+    print(f"patch_selection_equal = {patch_selection_equal}")
+    print(f"dense_patch_digest = {dense_results['patch_digest']}")
+    print(f"sparse_patch_digest = {sparse_results['patch_digest']}")
+    print(f"patch_digest_equal = {patch_digest_equal}")
+    print(f"baseline_equal = {baseline_equal}")
+    print(f"after_equal = {after_equal}")
+    print(f"any_output_changed = {any_output_changed}")
+    print(f"dense_payload_mb = {dense_payload_mb:.2f}")
+    print(f"sparse_payload_mb = {sparse_payload_mb:.2f}")
+    print(f"dense_send_ms = {dense_results['dense_send_ms']:.2f}")
+    print(f"sparse_send_ms = {sparse_results['sparse_send_ms']:.2f}")
+
+    if not baseline_equal:
+        raise RuntimeError(
+            "Dense and sparse phases did not start from the same baseline"
+        )
+    if not patch_selection_equal:
+        raise RuntimeError("Dense and sparse phases used different sparse patches")
+    if not patch_digest_equal:
+        raise RuntimeError("Dense and sparse phases produced different patch values")
+    if not after_equal:
+        raise RuntimeError("Dense and sparse updates produced different outputs")
+    if not any_output_changed:
+        raise RuntimeError("Patch did not change the observed outputs")
+finally:
+    ray.shutdown()

--- a/tests/e2e/pull_request/two_card/test_sparse_hccl_weight_transfer.py
+++ b/tests/e2e/pull_request/two_card/test_sparse_hccl_weight_transfer.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end test for sparse HCCL weight transfer.
+
+This follows the dense HCCL E2E workflow: a vLLM server with dummy weights
+runs on NPU 0 while a trainer model built from the same config runs on NPU 1.
+Only selected embedding rows are sent as sparse ``indices + values`` patches.
+"""
+
+import os
+import threading
+
+import pytest
+import requests
+import torch
+import torch_npu  # noqa: F401
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from vllm.utils.network_utils import get_ip, get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+
+MODEL_NAME = os.environ.get(
+    "VLLM_SPARSE_HCCL_TEST_MODEL", "Qwen/Qwen3-0.6B"
+)
+PARAMETER_NAME = "model.embed_tokens.weight"
+INFERENCE_WORLD_SIZE = 1
+TRAINER_DEVICE_INDEX = INFERENCE_WORLD_SIZE
+PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+]
+INIT_TIMEOUT = 120
+UPDATE_TIMEOUT = 300
+CONTROL_TIMEOUT = 60
+
+
+def _log(message: str) -> None:
+    print(f"[trainer] {message}", flush=True)
+
+
+def _build_trainer_model(device_index: int):
+    device = f"npu:{device_index}"
+    override_path = os.getenv("WEIGHT_TRANSFER_TEST_MODEL")
+    if override_path:
+        model = AutoModelForCausalLM.from_pretrained(
+            override_path, dtype=torch.bfloat16
+        )
+    else:
+        config = AutoConfig.from_pretrained(
+            MODEL_NAME, trust_remote_code=True
+        )
+        model = AutoModelForCausalLM.from_config(config)
+    model = model.to(device=device, dtype=torch.bfloat16)
+    model.eval()
+    return model
+
+
+def _post(
+    server: RemoteOpenAIServer,
+    route: str,
+    *,
+    json=None,
+    timeout=CONTROL_TIMEOUT,
+):
+    response = requests.post(
+        server.url_for(route), json=json, timeout=timeout
+    )
+    response.raise_for_status()
+    return response
+
+
+class _BackgroundPost(threading.Thread):
+    def __init__(
+        self,
+        server: RemoteOpenAIServer,
+        route: str,
+        *,
+        json=None,
+        timeout=CONTROL_TIMEOUT,
+    ):
+        super().__init__(daemon=True)
+        self._server = server
+        self._route = route
+        self._json = json
+        self._timeout = timeout
+        self.error: BaseException | None = None
+
+    def run(self) -> None:
+        try:
+            _post(
+                self._server,
+                self._route,
+                json=self._json,
+                timeout=self._timeout,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            self.error = exc
+
+    def raise_if_failed(self) -> None:
+        if self.error is not None:
+            raise RuntimeError(
+                f"server-side /{self._route} failed"
+            ) from self.error
+
+
+def _generate(client):
+    outputs = []
+    for prompt in PROMPTS:
+        response = client.completions.create(
+            model=MODEL_NAME,
+            prompt=prompt,
+            max_tokens=16,
+            temperature=0,
+        )
+        outputs.append(response.choices[0].text)
+    return outputs
+
+
+def _build_sparse_patch(model, tokenizer):
+    from vllm_ascend.distributed.weight_transfer.sparse_weight_patch import (
+        SparseWeightPatch,
+    )
+
+    parameter = model.get_parameter(PARAMETER_NAME)
+    token_ids = []
+    for prompt in PROMPTS:
+        token_ids.extend(
+            tokenizer(prompt, add_special_tokens=False)["input_ids"]
+        )
+    rows = torch.tensor(
+        sorted(set(token_ids)),
+        device=parameter.device,
+        dtype=torch.long,
+    )
+    hidden_size = parameter.shape[1]
+    columns = torch.arange(hidden_size, device=parameter.device)
+    indices = (rows.unsqueeze(1) * hidden_size + columns).reshape(-1)
+    values = parameter.index_select(0, rows).reshape(-1).contiguous()
+    return SparseWeightPatch(
+        name=PARAMETER_NAME,
+        indices=indices.to(torch.int32),
+        values=values,
+    ), parameter
+
+
+@pytest.mark.skipif(
+    torch.npu.device_count() < 2,
+    reason="Sparse HCCL weight transfer E2E requires at least 2 NPUs.",
+)
+def test_sparse_hccl_weight_transfer_updates_server_weights():
+    port = get_open_port()
+    server_args = [
+        "--enforce-eager",
+        "--load-format",
+        "dummy",
+        "--weight-transfer-config",
+        '{"backend":"sparse_hccl"}',
+        "--additional-config",
+        '{"weight_nz_mode": 0}',
+        "--tensor-parallel-size",
+        str(INFERENCE_WORLD_SIZE),
+        "--max-model-len",
+        "1024",
+        "--gpu-memory-utilization",
+        "0.6",
+        "--port",
+        str(port),
+        "--trust-remote-code",
+    ]
+    env_dict = {
+        "VLLM_SERVER_DEV_MODE": "1",
+        "ASCEND_RT_VISIBLE_DEVICES": "0",
+        "VLLM_ASCEND_ENABLE_NZ": "0",
+    }
+
+    with RemoteOpenAIServer(
+        MODEL_NAME,
+        vllm_serve_args=server_args,
+        server_host="127.0.0.1",
+        server_port=port,
+        env_dict=env_dict,
+        auto_port=False,
+    ) as server:
+        client = server.get_client()
+        outputs_before = _generate(client)
+
+        torch.npu.set_device(TRAINER_DEVICE_INDEX)
+        train_model = _build_trainer_model(TRAINER_DEVICE_INDEX)
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+        patch, parameter = _build_sparse_patch(train_model, tokenizer)
+
+        from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+            HCCLTrainerSendWeightsArgs,
+        )
+        from vllm_ascend.distributed.weight_transfer.sparse_hccl_engine import (
+            SparseHCCLWeightTransferEngine,
+        )
+
+        master_address = get_ip()
+        master_port = get_open_port()
+        world_size = INFERENCE_WORLD_SIZE + 1
+        init_info = {
+            "master_address": master_address,
+            "master_port": master_port,
+            "rank_offset": 1,
+            "world_size": world_size,
+        }
+        init_thread = _BackgroundPost(
+            server,
+            "init_weight_transfer_engine",
+            json={"init_info": init_info},
+            timeout=INIT_TIMEOUT,
+        )
+        init_thread.start()
+        group = SparseHCCLWeightTransferEngine.trainer_init(
+            {
+                "master_address": master_address,
+                "master_port": master_port,
+                "world_size": world_size,
+            }
+        )
+        init_thread.join()
+        init_thread.raise_if_failed()
+
+        _post(server, "pause")
+        _post(server, "start_weight_update")
+        update_info = {
+            "names": [PARAMETER_NAME],
+            "dtype_names": [str(patch.values.dtype).split(".")[-1]],
+            "shapes": [list(parameter.shape)],
+            "num_updates_list": [patch.indices.numel()],
+        }
+        update_thread = _BackgroundPost(
+            server,
+            "update_weights",
+            json={"update_info": update_info},
+            timeout=UPDATE_TIMEOUT,
+        )
+        update_thread.start()
+        SparseHCCLWeightTransferEngine.trainer_send_weights(
+            iter([patch]),
+            HCCLTrainerSendWeightsArgs(group=group),
+        )
+        torch.npu.synchronize()
+        update_thread.join()
+        update_thread.raise_if_failed()
+
+        _post(server, "finish_weight_update")
+        _post(server, "resume")
+        outputs_after = _generate(client)
+        _log(f"outputs before update: {outputs_before}")
+        _log(f"outputs after update: {outputs_after}")
+
+    assert outputs_after != outputs_before, (
+        "server weights did not change after sparse HCCL transfer"
+    )

--- a/tests/ut/distributed/weight_transfer/test_hccl_common.py
+++ b/tests/ut/distributed/weight_transfer/test_hccl_common.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_ascend.distributed.weight_transfer.hccl_common import (
+    HCCLWeightTransferInitInfo,
+    trainer_init,
+    worker_init_process_group,
+)
+
+
+def test_worker_init_process_group_uses_global_dp_rank():
+    init_info = HCCLWeightTransferInitInfo(
+        master_address="127.0.0.1",
+        master_port=12345,
+        rank_offset=1,
+        world_size=16,
+    )
+    parallel_config = SimpleNamespace(
+        data_parallel_index=2,
+        world_size=4,
+        rank=3,
+    )
+
+    with (
+        patch(
+            "vllm_ascend.distributed.weight_transfer.hccl_common."
+            "stateless_init_process_group",
+            return_value="group",
+        ) as mock_init,
+        patch("torch.accelerator.current_device_index", return_value=5),
+    ):
+        result = worker_init_process_group(init_info, parallel_config)
+
+    assert result == "group"
+    mock_init.assert_called_once_with("127.0.0.1", 12345, 12, 16, device=5)
+
+
+@pytest.mark.parametrize(
+    "init_info",
+    [
+        {
+            "master_address": "127.0.0.1",
+            "master_port": 23456,
+            "world_size": 2,
+        },
+        HCCLWeightTransferInitInfo(
+            master_address="127.0.0.1",
+            master_port=23456,
+            rank_offset=1,
+            world_size=2,
+        ),
+    ],
+)
+def test_trainer_init_always_uses_rank_zero(init_info):
+    with (
+        patch(
+            "vllm_ascend.distributed.weight_transfer.hccl_common."
+            "stateless_init_process_group",
+            return_value="group",
+        ) as mock_init,
+        patch("torch.accelerator.current_device_index", return_value=3),
+    ):
+        assert trainer_init(init_info) == "group"
+
+    mock_init.assert_called_once_with("127.0.0.1", 23456, 0, 2, 3)

--- a/tests/ut/distributed/weight_transfer/test_sparse_hccl_engine.py
+++ b/tests/ut/distributed/weight_transfer/test_sparse_hccl_engine.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+import torch
+
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLTrainerSendWeightsArgs,
+)
+from vllm_ascend.distributed.weight_transfer.sparse_hccl_engine import (
+    SparseHCCLWeightTransferEngine,
+    SparseHCCLWeightTransferUpdateInfo,
+    SparseWeightPatch,
+)
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.tensor([10.0, 20.0, 30.0, 40.0])
+        )
+
+
+def make_info(**overrides):
+    values = {
+        "names": ["weight"],
+        "dtype_names": ["float32"],
+        "shapes": [[4]],
+        "num_updates_list": [2],
+    }
+    values.update(overrides)
+    return SparseHCCLWeightTransferUpdateInfo(**values)
+
+
+def make_engine(model=None):
+    engine = object.__new__(SparseHCCLWeightTransferEngine)
+    engine.model = model or DummyModel()
+    return engine
+
+
+def test_update_info_accepts_zero_updates():
+    assert make_info(num_updates_list=[0]).num_updates_list == [0]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"dtype_names": []}, "`dtype_names` should be"),
+        ({"shapes": []}, "`shapes` should be"),
+        ({"num_updates_list": []}, "cannot be empty"),
+        ({"num_updates_list": [1, 2]}, "`num_updates_list` should be"),
+        ({"num_updates_list": [-1]}, "must be non-negative"),
+    ],
+)
+def test_update_info_rejects_invalid_metadata(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        make_info(**overrides)
+
+
+def test_start_requires_tp1_pp1():
+    engine = make_engine()
+    engine.parallel_config = SimpleNamespace(world_size=2)
+    with pytest.raises(NotImplementedError, match="TP=1 and PP=1"):
+        engine.start_weight_update()
+
+
+def test_start_and_finish_are_noops_for_world_size_one():
+    engine = make_engine()
+    engine.parallel_config = SimpleNamespace(world_size=1)
+    engine.start_weight_update()
+    engine.finish_weight_update()
+
+
+def test_sparse_engine_does_not_support_draft_update():
+    assert SparseHCCLWeightTransferEngine.supports_draft_weight_update is False
+
+
+def test_receive_requires_initialized_group():
+    engine = make_engine()
+    engine.model_update_group = None
+    with pytest.raises(RuntimeError, match="not initialized"):
+        engine.receive_weights(make_info())
+
+
+def test_trainer_send_rejects_packed():
+    args = HCCLTrainerSendWeightsArgs(group=MagicMock(), packed=True)
+    with pytest.raises(ValueError, match="cannot be combined"):
+        SparseHCCLWeightTransferEngine.trainer_send_weights(iter(()), args)
+
+
+def test_trainer_send_broadcasts_indices_then_values():
+    group = MagicMock()
+    stream = MagicMock()
+    args = HCCLTrainerSendWeightsArgs(group=group, stream=stream)
+    patch = SparseWeightPatch(
+        "weight",
+        torch.tensor([1, 3], dtype=torch.int32),
+        torch.tensor([2.0, 4.0]),
+    )
+
+    SparseHCCLWeightTransferEngine.trainer_send_weights(iter([patch]), args)
+
+    assert group.broadcast.call_args_list == [
+        call(patch.indices, src=0, stream=stream),
+        call(patch.values, src=0, stream=stream),
+    ]
+
+
+def test_shutdown_clears_group():
+    engine = make_engine()
+    engine.model_update_group = MagicMock()
+    engine.shutdown()
+    assert engine.model_update_group is None

--- a/tests/ut/distributed/weight_transfer/test_sparse_weight_patch.py
+++ b/tests/ut/distributed/weight_transfer/test_sparse_weight_patch.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import inspect
+
+import pytest
+import torch
+
+from vllm_ascend.distributed.weight_transfer.sparse_weight_patch import (
+    SparseWeightPatch,
+    apply_sparse_patch,
+)
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.tensor([10.0, 20.0, 30.0, 40.0])
+        )
+
+
+def test_apply_sparse_patch_matches_upstream_signature():
+    assert "verify" not in inspect.signature(apply_sparse_patch).parameters
+
+
+def test_apply_sparse_patch_updates_only_selected_values():
+    model = DummyModel()
+    apply_sparse_patch(
+        model,
+        SparseWeightPatch(
+            "weight",
+            torch.tensor([1, 3], dtype=torch.int32),
+            torch.tensor([200.0, 400.0]),
+        ),
+        expected_shape=[4],
+    )
+    assert torch.equal(
+        model.weight,
+        torch.tensor([10.0, 200.0, 30.0, 400.0]),
+    )
+
+
+@pytest.mark.parametrize("indices", [[-1], [4]])
+def test_apply_sparse_patch_rejects_out_of_bounds_indices(indices):
+    with pytest.raises((IndexError, RuntimeError)):
+        apply_sparse_patch(
+            DummyModel(),
+            SparseWeightPatch(
+                "weight",
+                torch.tensor(indices, dtype=torch.int32),
+                torch.tensor([1.0]),
+            ),
+        )
+
+
+def test_apply_sparse_patch_rejects_declared_shape_mismatch():
+    with pytest.raises(ValueError, match="declared shape"):
+        apply_sparse_patch(
+            DummyModel(),
+            SparseWeightPatch(
+                "weight",
+                torch.tensor([0], dtype=torch.int32),
+                torch.tensor([1.0]),
+            ),
+            expected_shape=[2, 2],
+        )
+
+
+def test_apply_sparse_patch_empty_update_is_noop():
+    model = DummyModel()
+    before = model.weight.detach().clone()
+    apply_sparse_patch(
+        model,
+        SparseWeightPatch(
+            "weight",
+            torch.empty(0, dtype=torch.int32),
+            torch.empty(0, dtype=torch.float32),
+        ),
+    )
+    assert torch.equal(model.weight, before)
+
+
+@pytest.mark.parametrize(
+    ("indices", "values", "message"),
+    [
+        (
+            torch.tensor([0], dtype=torch.int64),
+            torch.tensor([1.0]),
+            "require int32 indices",
+        ),
+        (
+            torch.tensor([[0]], dtype=torch.int32),
+            torch.tensor([1.0]),
+            "must be 1D flattened updates",
+        ),
+        (
+            torch.tensor([0], dtype=torch.int32),
+            torch.tensor([[1.0]]),
+            "must be 1D flattened updates",
+        ),
+        (
+            torch.tensor([0, 1], dtype=torch.int32),
+            torch.tensor([1.0]),
+            "matching lengths",
+        ),
+        (
+            torch.tensor([0], dtype=torch.int32),
+            torch.tensor([1], dtype=torch.int32),
+            "does not match parameter dtype",
+        ),
+    ],
+)
+def test_apply_sparse_patch_rejects_invalid_patch(indices, values, message):
+    with pytest.raises(ValueError, match=message):
+        apply_sparse_patch(
+            DummyModel(),
+            SparseWeightPatch("weight", indices, values),
+        )
+
+
+def test_apply_sparse_patch_rejects_noncontiguous_parameter():
+    model = torch.nn.Module()
+    model.weight = torch.nn.Parameter(
+        torch.arange(6, dtype=torch.float32).reshape(2, 3).t()
+    )
+    assert not model.weight.is_contiguous()
+
+    with pytest.raises(NotImplementedError, match="require contiguous params"):
+        apply_sparse_patch(
+            model,
+            SparseWeightPatch(
+                "weight",
+                torch.tensor([0], dtype=torch.int32),
+                torch.tensor([1.0]),
+            ),
+        )

--- a/vllm_ascend/distributed/weight_transfer/__init__.py
+++ b/vllm_ascend/distributed/weight_transfer/__init__.py
@@ -29,6 +29,11 @@ def register_engine():
         "HCCLWeightTransferEngine",
     )
     WeightTransferEngineFactory.register_engine(
+        "sparse_hccl",
+        "vllm_ascend.distributed.weight_transfer.sparse_hccl_engine",
+        "SparseHCCLWeightTransferEngine",
+    )
+    WeightTransferEngineFactory.register_engine(
         "npu_ipc",
         "vllm_ascend.distributed.weight_transfer.npu_ipc_engine",
         "NPUIPCWeightTransferEngine",

--- a/vllm_ascend/distributed/weight_transfer/hccl_common.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_common.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared HCCL initialization helpers for weight transfer engines."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.distributed.weight_transfer.base import WeightTransferInitInfo
+
+if TYPE_CHECKING:
+    from vllm.config.parallel import ParallelConfig
+
+    from vllm_ascend.distributed.device_communicators.pyhccl import (
+        PyHcclCommunicator,
+    )
+
+
+@dataclass
+class HCCLWeightTransferInitInfo(WeightTransferInitInfo):
+    """Initialization info for HCCL weight transfer backend."""
+
+    master_address: str
+    """IP address of the trainer (rank 0) for HCCL process group setup."""
+    master_port: int
+    """Port on the trainer for HCCL process group setup."""
+    rank_offset: int
+    """Offset added to each vLLM worker's rank within the HCCL group.
+    Typically 1 (trainer is rank 0, workers start at rank 1)."""
+    world_size: int
+    """Total number of participants in the HCCL group (trainer + all workers)."""
+
+
+def stateless_init_process_group(
+    master_address: str,
+    master_port: int,
+    rank: int,
+    world_size: int,
+    device,
+) -> "PyHcclCommunicator":
+    """
+    vLLM provides `StatelessProcessGroup` to create a process group
+    without considering the global process group in torch.distributed.
+    It is recommended to create `StatelessProcessGroup`, and then initialize
+    the data-plane communication (HCCL) between external (train processes)
+    and vLLM workers.
+    """
+    from vllm.distributed.utils import StatelessProcessGroup
+
+    from vllm_ascend.distributed.device_communicators.pyhccl import (
+        PyHcclCommunicator,
+    )
+
+    pg = StatelessProcessGroup.create(
+        host=master_address,
+        port=master_port,
+        rank=rank,
+        world_size=world_size,
+    )
+    return PyHcclCommunicator(pg, device=device)
+
+
+def worker_init_process_group(
+    init_info: HCCLWeightTransferInitInfo,
+    parallel_config: "ParallelConfig",
+) -> "PyHcclCommunicator":
+    """
+    Initialize HCCL process group with the trainer.
+
+    Args:
+        init_info: HCCL initialization info containing master address, port,
+                  rank offset, and world size
+        parallel_config: vLLM parallel configuration used to calculate the
+                         worker's unique rank across data-parallel groups
+    """
+
+    # Calculate the global rank in the trainer-worker process group
+    # Must account for data parallel to get unique ranks across all workers
+    dp_rank = parallel_config.data_parallel_index
+    world_size_per_dp = parallel_config.world_size  # TP * PP
+    rank_within_dp = parallel_config.rank
+
+    # Unique rank across all DP groups
+    worker_rank = dp_rank * world_size_per_dp + rank_within_dp
+    rank = worker_rank + init_info.rank_offset
+    # Create stateless process group
+    device = torch.accelerator.current_device_index()
+    return stateless_init_process_group(
+        init_info.master_address,
+        init_info.master_port,
+        rank,
+        init_info.world_size,
+        device=device,
+    )
+
+
+def trainer_init(
+    init_info: HCCLWeightTransferInitInfo | dict,
+) -> "PyHcclCommunicator":
+    """
+    Initialize HCCL process group for trainer-side weight transfer.
+
+    The trainer is always rank 0 in the process group. Uses the current
+    Ascend device (torch.accelerator.current_device_index()).
+
+    Args:
+        init_info: Either an HCCLWeightTransferInitInfo object or a dict with keys:
+            - master_address: str
+            - master_port: int
+            - world_size: int
+
+    Returns:
+        PyHcclCommunicator for weight transfer.
+
+    Example:
+        >>> from vllm.distributed.weight_transfer.hccl_engine import (
+        ...     HCCLWeightTransferEngine,
+        ... )
+        >>> group = HCCLWeightTransferEngine.trainer_init(
+        ...     dict(
+        ...         master_address=master_address,
+        ...         master_port=master_port,
+        ...         world_size=world_size,
+        ...     ),
+        ... )
+    """
+    if isinstance(init_info, dict):
+        master_address = init_info["master_address"]
+        master_port = init_info["master_port"]
+        world_size = init_info["world_size"]
+    else:
+        # HCCLWeightTransferInitInfo object
+        master_address = init_info.master_address
+        master_port = init_info.master_port
+        world_size = init_info.world_size
+
+    # Trainer is always rank 0
+    device = torch.accelerator.current_device_index()
+    return stateless_init_process_group(
+        master_address,
+        master_port,
+        0,
+        world_size,
+        device,
+    )

--- a/vllm_ascend/distributed/weight_transfer/hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/hccl_engine.py
@@ -15,30 +15,27 @@ from vllm.config import VllmConfig
 from vllm.config.weight_transfer import WeightTransferConfig
 from vllm.distributed.weight_transfer.base import (
     WeightTransferEngine,
-    WeightTransferInitInfo,
     WeightTransferUpdateInfo,
 )
 
+from vllm_ascend.distributed.weight_transfer.hccl_common import (
+    HCCLWeightTransferInitInfo,
+    trainer_init,
+    worker_init_process_group,
+)
 from vllm_ascend.distributed.weight_transfer.packed_tensor import (
     DEFAULT_PACKED_BUFFER_SIZE_BYTES,
     DEFAULT_PACKED_NUM_BUFFERS,
     packed_broadcast_consumer,
 )
 
-
-@dataclass
-class HCCLWeightTransferInitInfo(WeightTransferInitInfo):
-    """Initialization info for HCCL weight transfer backend."""
-
-    master_address: str
-    """IP address of the trainer (rank 0) for HCCL process group setup."""
-    master_port: int
-    """Port on the trainer for HCCL process group setup."""
-    rank_offset: int
-    """Offset added to each vLLM worker's rank within the HCCL group.
-    Typically 1 (trainer is rank 0, workers start at rank 1)."""
-    world_size: int
-    """Total number of participants in the HCCL group (trainer + all workers)."""
+# Re-exported for backward compatibility; canonical home is hccl_common.
+__all__ = [
+    "HCCLWeightTransferInitInfo",
+    "HCCLTrainerSendWeightsArgs",
+    "HCCLWeightTransferUpdateInfo",
+    "HCCLWeightTransferEngine",
+]
 
 
 @dataclass
@@ -147,23 +144,9 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
                       rank offset, and world size
         """
 
-        # Calculate the global rank in the trainer-worker process group
-        # Must account for data parallel to get unique ranks across all workers
-        dp_rank = self.parallel_config.data_parallel_index
-        world_size_per_dp = self.parallel_config.world_size  # TP * PP
-        rank_within_dp = self.parallel_config.rank
-
-        # Unique rank across all DP groups
-        worker_rank = dp_rank * world_size_per_dp + rank_within_dp
-        rank = worker_rank + init_info.rank_offset
-        # Create stateless process group
-        device = torch.accelerator.current_device_index()
-        self.model_update_group = HCCLWeightTransferEngine._stateless_init_process_group(
-            init_info.master_address,
-            init_info.master_port,
-            rank,
-            init_info.world_size,
-            device=device,
+        self.model_update_group = worker_init_process_group(
+            init_info,
+            self.parallel_config,
         )
 
     def receive_weights(
@@ -271,70 +254,6 @@ class HCCLWeightTransferEngine(WeightTransferEngine[HCCLWeightTransferInitInfo, 
                     stream=args.stream or torch.npu.current_stream(),
                 )
 
-    @staticmethod
-    def trainer_init(
-        init_info: HCCLWeightTransferInitInfo | dict,
-    ) -> "PyHcclCommunicator":
-        """
-        Initialize HCCL process group for trainer-side weight transfer.
-
-        The trainer is always rank 0 in the process group. Uses the current
-        Ascend device (torch.accelerator.current_device_index()).
-
-        Args:
-            init_info: Either an HCCLWeightTransferInitInfo object or a dict with keys:
-                - master_address: str
-                - master_port: int
-                - world_size: int
-
-        Returns:
-            PyHcclCommunicator for weight transfer.
-
-        Example:
-            >>> from vllm.distributed.weight_transfer.hccl_engine import (
-            ...     HCCLWeightTransferEngine,
-            ... )
-            >>> group = HCCLWeightTransferEngine.trainer_init(
-            ...     dict(
-            ...         master_address=master_address,
-            ...         master_port=master_port,
-            ...         world_size=world_size,
-            ...     ),
-            ... )
-        """
-        if isinstance(init_info, dict):
-            master_address = init_info["master_address"]
-            master_port = init_info["master_port"]
-            world_size = init_info["world_size"]
-        else:
-            # HCCLWeightTransferInitInfo object
-            master_address = init_info.master_address
-            master_port = init_info.master_port
-            world_size = init_info.world_size
-
-        # Trainer is always rank 0
-        device = torch.accelerator.current_device_index()
-        return HCCLWeightTransferEngine._stateless_init_process_group(
-            master_address,
-            master_port,
-            0,
-            world_size,
-            device,
-        )
-
-    @staticmethod
-    def _stateless_init_process_group(master_address, master_port, rank, world_size, device):
-        """
-        vLLM provides `StatelessProcessGroup` to create a process group
-        without considering the global process group in torch.distributed.
-        It is recommended to create `StatelessProcessGroup`, and then initialize
-        the data-plane communication (HCCL) between external (train processes)
-        and vLLM workers.
-        """
-        from vllm.distributed.utils import StatelessProcessGroup
-
-        from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator
-
-        pg = StatelessProcessGroup.create(host=master_address, port=master_port, rank=rank, world_size=world_size)
-        pyhccl = PyHcclCommunicator(pg, device=device)
-        return pyhccl
+    # Trainer-side process-group setup. Delegates to the shared helper so the
+    # sparse engine can reuse the exact same rendezvous without subclassing.
+    trainer_init = staticmethod(trainer_init)

--- a/vllm_ascend/distributed/weight_transfer/sparse_hccl_engine.py
+++ b/vllm_ascend/distributed/weight_transfer/sparse_hccl_engine.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sparse HCCL weight transfer engine."""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm.config.weight_transfer import WeightTransferConfig
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferEngine,
+    WeightTransferUpdateInfo,
+)
+
+from vllm_ascend.distributed.weight_transfer.hccl_common import (
+    HCCLWeightTransferInitInfo,
+    trainer_init,
+    worker_init_process_group,
+)
+from vllm_ascend.distributed.weight_transfer.hccl_engine import (
+    HCCLTrainerSendWeightsArgs,
+)
+from vllm_ascend.distributed.weight_transfer.sparse_weight_patch import (
+    SparseWeightPatch,
+    apply_sparse_patch,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+    from vllm_ascend.distributed.device_communicators.pyhccl import (
+        PyHcclCommunicator,
+    )
+
+__all__ = [
+    "SparseWeightPatch",
+    "SparseHCCLWeightTransferUpdateInfo",
+    "SparseHCCLWeightTransferEngine",
+]
+
+
+@dataclass
+class SparseHCCLWeightTransferUpdateInfo(WeightTransferUpdateInfo):
+    """Update info for the sparse HCCL weight transfer backend."""
+
+    names: list[str]
+    dtype_names: list[str]
+    shapes: list[list[int]]
+    num_updates_list: list[int]
+    """Number of sparse entries to receive for each parameter in ``names``."""
+
+    def __post_init__(self) -> None:
+        num_params = len(self.names)
+        if len(self.dtype_names) != num_params:
+            raise ValueError(
+                f"`dtype_names` should be of the same size as `names`: "
+                f"got {len(self.dtype_names)} and {len(self.names)}"
+            )
+        if len(self.shapes) != num_params:
+            raise ValueError(
+                f"`shapes` should be of the same size as `names`: "
+                f"got {len(self.shapes)} and {len(self.names)}"
+            )
+        if len(self.num_updates_list) == 0:
+            raise ValueError("`num_updates_list` cannot be empty for sparse updates")
+        if len(self.num_updates_list) != num_params:
+            raise ValueError(
+                f"`num_updates_list` should be of the same size as `names`: "
+                f"got {len(self.num_updates_list)} and {len(self.names)}"
+            )
+        if any(num_updates < 0 for num_updates in self.num_updates_list):
+            raise ValueError("Sparse `num_updates_list` entries must be non-negative")
+
+
+class SparseHCCLWeightTransferEngine(
+    WeightTransferEngine[
+        HCCLWeightTransferInitInfo,
+        SparseHCCLWeightTransferUpdateInfo,
+    ]
+):
+    """Apply sparse, flat-index weight patches received through HCCL."""
+
+    init_info_cls = HCCLWeightTransferInitInfo
+    update_info_cls = SparseHCCLWeightTransferUpdateInfo
+    supports_draft_weight_update = False
+
+    def __init__(
+        self,
+        config: WeightTransferConfig,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        model: torch.nn.Module,
+    ) -> None:
+        super().__init__(config, vllm_config, device, model)
+        self.model_update_group: PyHcclCommunicator | None = None
+
+    def init_transfer_engine(self, init_info: HCCLWeightTransferInitInfo) -> None:
+        """Initialize the HCCL process group with the trainer."""
+        self.model_update_group = worker_init_process_group(
+            init_info,
+            self.parallel_config,
+        )
+
+    def start_weight_update(self) -> None:
+        """Validate the MVP parallelism restriction before applying patches."""
+        if self.parallel_config.world_size != 1:
+            raise NotImplementedError(
+                "Sparse weight updates currently require TP=1 and PP=1"
+            )
+
+    def finish_weight_update(self) -> None:
+        """Sparse runtime-format patches need no layerwise finalization."""
+        pass
+
+    def receive_weights(
+        self,
+        update_info: SparseHCCLWeightTransferUpdateInfo,
+    ) -> None:
+        """Receive sparse flat-index patches and apply them in place."""
+        if self.model_update_group is None:
+            raise RuntimeError(
+                "HCCL weight transfer not initialized. "
+                "Call init_transfer_engine() first."
+            )
+
+        for name, dtype_name, expected_shape, num_updates in zip(
+            update_info.names,
+            update_info.dtype_names,
+            update_info.shapes,
+            update_info.num_updates_list,
+        ):
+            dtype = getattr(torch, dtype_name)
+            indices = torch.empty(
+                num_updates,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            values = torch.empty(
+                num_updates,
+                dtype=dtype,
+                device=self.device,
+            )
+            self.model_update_group.broadcast(
+                indices,
+                src=0,
+                stream=torch.npu.current_stream(),
+            )
+            self.model_update_group.broadcast(
+                values,
+                src=0,
+                stream=torch.npu.current_stream(),
+            )
+            patch = SparseWeightPatch(
+                name=name,
+                indices=indices,
+                values=values,
+            )
+            apply_sparse_patch(
+                self.model,
+                patch,
+                expected_shape=expected_shape,
+            )
+            del indices
+            del values
+
+    def shutdown(self) -> None:
+        if self.model_update_group is not None:
+            self.model_update_group = None
+
+    @staticmethod
+    def trainer_send_weights(
+        iterator: Iterator[SparseWeightPatch],
+        trainer_args: dict[str, Any] | HCCLTrainerSendWeightsArgs,
+    ) -> None:
+        """Broadcast sparse flat-index patches from trainer to workers."""
+        if isinstance(trainer_args, dict):
+            args = HCCLTrainerSendWeightsArgs(**trainer_args)
+        else:
+            args = trainer_args
+        if args.packed:
+            raise ValueError(
+                "Sparse HCCL updates cannot be combined with `packed=True`"
+            )
+
+        stream = args.stream or torch.npu.current_stream()
+        for patch in iterator:
+            args.group.broadcast(patch.indices, src=args.src, stream=stream)
+            args.group.broadcast(patch.values, src=args.src, stream=stream)
+
+    trainer_init = staticmethod(trainer_init)

--- a/vllm_ascend/distributed/weight_transfer/sparse_weight_patch.py
+++ b/vllm_ascend/distributed/weight_transfer/sparse_weight_patch.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Transport-independent sparse runtime weight patch operations."""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class SparseWeightPatch:
+    """A sparse in-place patch for one existing runtime parameter.
+
+    Dense HCCL transfers every complete runtime parameter, whereas sparse HCCL
+    transfers only flattened positions whose values need to change::
+
+        Dense HCCL
+        parameter name --------> full tensor shaped like the runtime parameter
+                                  [v0, v1, v2, v3, v4, v5, ...]
+
+        Sparse HCCL
+        parameter name --------> existing runtime parameter
+        flat int32 indices ----> [ 1,  4, ...]
+                                  |   |
+                                  v   v
+        replacement values ---> [x1, x4, ...]
+
+        receiver update ------> flat_parameter[indices] = values
+
+    ``indices`` and ``values`` are both one-dimensional and have equal length.
+    Indices address the contiguous, flattened runtime parameter rather than its
+    checkpoint layout. The full parameter shape is transported separately as
+    metadata and validated before the patch is applied.
+
+    Attributes:
+        name: vLLM runtime parameter name, not a checkpoint-format alias.
+        indices: One-dimensional ``torch.int32`` flattened element indices.
+        values: Replacement values with the target runtime parameter's dtype.
+    """
+
+    name: str
+    indices: torch.Tensor
+    values: torch.Tensor
+
+
+def validate_sparse_patch(
+    model: torch.nn.Module,
+    patch: SparseWeightPatch,
+    expected_shape: list[int] | None = None,
+) -> torch.nn.Parameter:
+    """Validate a flat-index patch and return its target parameter."""
+    param = model.get_parameter(patch.name)
+    if expected_shape is not None and list(param.shape) != expected_shape:
+        raise ValueError(
+            f"Sparse parameter shape {list(param.shape)} does not match "
+            f"declared shape {expected_shape} for {patch.name}"
+        )
+    if not param.data.is_contiguous():
+        raise NotImplementedError(
+            "Sparse weight updates currently require contiguous params: "
+            f"{patch.name}"
+        )
+    if patch.indices.dtype != torch.int32:
+        raise ValueError(
+            "Sparse weight updates currently require int32 indices: "
+            f"{patch.name}"
+        )
+    if patch.indices.ndim != 1 or patch.values.ndim != 1:
+        raise ValueError(
+            f"Sparse weight patches must be 1D flattened updates: {patch.name}"
+        )
+    if patch.indices.numel() != patch.values.numel():
+        raise ValueError(
+            "`indices` and `values` must have matching lengths for "
+            f"{patch.name}"
+        )
+    if patch.values.dtype != param.dtype:
+        raise ValueError(
+            f"Sparse values dtype {patch.values.dtype} does not match "
+            f"parameter dtype {param.dtype} for {patch.name}"
+        )
+    return param
+
+
+def apply_sparse_patch(
+    model: torch.nn.Module,
+    patch: SparseWeightPatch,
+    expected_shape: list[int] | None = None,
+) -> None:
+    """Apply a validated patch to the selected flattened parameter values."""
+    param = validate_sparse_patch(model, patch, expected_shape)
+    flat_param = param.data.view(-1)
+    flat_param.index_copy_(
+        0,
+        patch.indices.to(dtype=torch.long),
+        patch.values,
+    )


### PR DESCRIPTION
## Summary

- Add the `sparse_hccl` weight-transfer backend for Ascend NPUs.
- Reuse the dense HCCL transport lifecycle and introduce `SparseWeightPatch`, which carries runtime parameter names, flattened `int32` indices, and replacement values.
- Validate parameter name, dtype, shape, index bounds, and update count before applying an in-place sparse update.
- Add a Ray example that compares one dense update with one sparse update and verifies the two post-update outputs are identical.

NPU IPC is intentionally out of scope for this PR.

## Scope

- Supports TP=1 and PP=1.
- Requires runtime-format parameter names and layouts.
- Does not support packed sparse transfer or draft models.
- Uses the standard lifecycle: `init_weight_transfer_engine -> pause -> start_weight_update -> update_weights -> finish_weight_update -> resume`.
- Uses `weight_nz_mode=0` in the Ascend example to avoid NZ-layout differences.

## Validation

- Unit tests: `28 passed`
- Two-NPU E2E test: passed
- Ray example: passed end-to-end, including `baseline_equal`, patch-selection/digest equality, identical dense/sparse post-update output, and an output change after update.
- `git diff --check` passes after rebasing onto the current upstream `main`.

## Sparse HCCL Profile Measurements

Warm profile traces on **x86 A5**, using Qwen3-1.7B BF16 with TP=1/PP=1 and one trainer NPU plus one vLLM worker NPU. Times are Trainer-side complete send windows from warm profile sweep `110230`, not end-to-end update latency.

| Hardware | Updated elements | Dense payload | Sparse payload | Dense HCCL | Sparse HCCL | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| x86 A5 | 1% | 3281.74 MiB | 98.45 MiB | 90.79 ms | 40.55 ms | 55.3% |
| x86 A5 | 10% | 3281.74 MiB | 984.52 MiB | 90.79 ms | 41.46 ms | 54.3% |

Reduction is calculated as `(Dense HCCL - Sparse HCCL) / Dense HCCL`. These measurements are informational, not a performance gate for this rebase, and do not cover TP/PP greater than one.