### PR TITLE
[BugFix] Fixed an error that occurred when loading heavy permission sets with DeepSeek Overlay C8 and MTP enabled.

### DIFF
--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -606,7 +606,17 @@
 #       Rotary quant is a unique feature of vllm-ascend.
 #    Future Plan:
 #       Remove this patch when vllm supports rotary quant or pluggable `MultiTokenPredictorLayer`.
-#   4. `vllm.model_executor.models.deepseek_v2.GlmMoeDsaForCausalLM.load_weights`
+#   4. `vllm.model_executor.models.deepseek_mtp.DeepSeekMTP.load_weights`
+#    Why:
+#       The `load_weights` method of the DeepSeekMTP model does not apply the `cache_scale_mapper`.
+#    How：
+#       If the weight name is `fa_k.offset`, rename it to `mla_attn.mla_attn.fa_k.offset`.
+#    Related PR (if no, explain why):
+#       ModelSlim quantization (kvcache quantization) is a unique feature of vllm-ascend.
+#    Future Plan:
+#       Remove this patch when vllm supports pluggable weight preprocessing in `load_weights`
+#       or when ModelSlim cache scale naming aligns with upstream conventions.
+#   5. `vllm.model_executor.models.deepseek_v2.GlmMoeDsaForCausalLM.load_weights`
 #    Why:
 #       After vllm PR #41706, GlmMoeDsaForCausalLM.load_weights uses `AutoWeightsLoader` which
 #       does not skip `rot.weight`, and will cause ValueError while loading weights.

--- a/vllm_ascend/patch/worker/patch_deepseek_mtp.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_mtp.py
@@ -66,6 +66,11 @@ class AscendDeepSeekMTP(DeepSeekMTP):
         else:
             return f"model.layers.{spec_layer}.rot.weight"
 
+    def load_weights(self, weights):
+        if self.quant_config is not None and (cache_scale_mapper := self.quant_config.get_cache_scale_mapper()):
+            weights = cache_scale_mapper.apply(weights)
+        return super().load_weights(weights)
+
 
 class AscendGlmMoeDsaForCausalLM(GlmMoeDsaForCausalLM):
     def load_weights(self, weights):

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -330,9 +330,6 @@ def _reshape_kv_cache_v2(
     kv_cache_config: "KVCacheConfig | None" = None,
 ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
     vllm_config = get_current_vllm_config()
-    is_kv_consumer = (
-        vllm_config.kv_transfer_config.is_kv_consumer if vllm_config.kv_transfer_config is not None else False
-    )
 
     kv_caches: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
     for group in attn_groups:
@@ -382,7 +379,7 @@ def _reshape_kv_cache_v2(
                 v_shape = (mla_num_blocks, mla_block_size, num_kv_heads, v_dim)
 
             k_cache_dtype = v_cache_dtype = kv_cache_spec.dtype
-            if is_kv_consumer and enable_fa_quant(vllm_config):
+            if enable_fa_quant(vllm_config):
                 k_cache_dtype, v_cache_dtype = vllm_config.quant_config.get_kv_quant_dtype(
                     layer_name, kv_cache_spec.dtype, vllm_config.model_config
                 )


### PR DESCRIPTION
### What this PR does / why we need it?
The `load_weights` method of the Deepseek-MTP model failed to apply `cache_scale_mapper`. Consequently, checkpoint weight names (e.g., `model.layers.61.self_attn.fa_k.offset`)—after being rewritten by `_rewrite_spec_layer_name` to `model.layers.61.mtp_block.self_attn.fa_k.offset`—did not match the actual model parameter paths (e.g., `model.layers.61.mtp_block.self_attn.mla_attn.mla_attn.fa_k.offset`). This PR fixes the issue.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
