### PR TITLE
change state cache block to 16 to opt memory

### DIFF
--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -59,6 +59,12 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
 
     @property
     def page_size_bytes(self) -> int:
+        if self.model_version == "deepseek_v4" and self.page_size_padded is not None:
+            return super().page_size_bytes
+        return self.real_page_size_bytes
+
+    @property
+    def real_page_size_bytes(self) -> int:
         if self.cache_sparse_c8:
             assert self.sparse_head_dim is not None
             assert len(self.sparse_head_dim) == 3
@@ -170,6 +176,14 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         assert len(cache_sparse_c8_set) == 1, (
             "All attention layers in the same KV cache group must use the same sparse C8 setting."
         )
+        page_size_padded_set = set(spec.page_size_padded for spec in specs)
+        assert len(page_size_padded_set) == 1, (
+            "All attention layers in the same KV cache group must use the same padded page size."
+        )
+        model_version_set = set(spec.model_version for spec in specs)
+        assert len(model_version_set) == 1, (
+            "All attention layers in the same KV cache group must use the same model version."
+        )
         return cls(
             block_size=specs[0].block_size,
             num_kv_heads=specs[0].num_kv_heads,
@@ -180,6 +194,8 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             dtype=specs[0].dtype,
             cache_dtype_str=cache_dtype_str_set.pop(),
             cache_sparse_c8=specs[0].cache_sparse_c8,
+            page_size_padded=page_size_padded_set.pop(),
+            model_version=model_version_set.pop(),
         )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -206,6 +206,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
             scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
+            page_size_padded=_dsv4_block_sizes()[vllm_config.cache_config.block_size][1][0],
         )
 
     def forward(self): ...

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -30,11 +30,12 @@ from vllm_ascend.utils import (
 
 
 def get_dsv4_block_sizes():
-    # cache_config.block_size: [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
+    # cache_config.block_size: [mla, swa, c4 state, c128 state],
+    # [page_size_padded_t1, page_size_padded_t2]
     _DSV4_BLOCK_SIZES = {
-        128: [[128, 128, 8, 32], [16640, 131072]],
-        64: [[64, 64, 4, 16], [8320, 65536]],
-        32: [[32, 32, 2, 8], [4160, 32768]],
+        128: [[128, 128, 16, 32], [16640 + 16 * 1024, 131072]],
+        64: [[64, 64, 8, 16], [8320 + 8 * 1024, 65536]],
+        32: [[32, 32, 4, 8], [4160 + 4 * 1024, 32768]],
     }
     _DSV4_BLOCK_SIZES_A5 = {
         128: [[128, 128, 8, 16], [16896, 81920]],


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request updates the block sizes and padded page sizes for DeepSeek-V4 in `vllm_ascend`. Specifically, it increases the `c4 state` block size and adjusts the corresponding padded page sizes in `_DSV4_BLOCK_SIZES`. It also updates `AscendMLAAttentionSpec` to handle `page_size_padded` and `model_version` properties, adding validation assertions during KV cache group merging.

However, a review comment points out a memory allocation inefficiency in `vllm_ascend/models/deepseek_v4.py`. By using the updated `_dsv4_block_sizes()[...][1][0]` for `AscendDeepseekV4IndexerCache`, the code allocates 33024 bytes instead of the required 16640 bytes, introducing a ~2x memory overhead. A dynamic calculation of `page_size_padded` based on the block size is suggested to avoid this overhead.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No testing details were provided in the PR.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
