### PR TITLE
[Misc] Always use public npu_mrope API in rope_forward_oot

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -38,8 +38,6 @@ from vllm_ascend.utils import has_rope, is_vl_model
 if HAS_TRITON:
     from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
 
-    from vllm_ascend.ops.triton.rope import rope_forward_triton
-
 # Currently, rope ops used on npu requires detached cos && sin as inputs.
 # However, RotaryEmbedding in vllm use cos_sin_cache as a whole variable.
 # So we have to preprocess cos_sin_cache int cos && sin. In the future,
@@ -164,53 +162,20 @@ def rope_forward_oot(
     query_shape, key_shape = query.shape, key.shape
     if offsets is not None:
         raise NotImplementedError("Batched rotary embedding is currently not supported on NPU.")
-    if HAS_TRITON:
-        num_tokens = query.shape[0]
-        query, key = rope_forward_triton(
-            query.view(num_tokens, -1, head_size),
-            key.view(num_tokens, -1, head_size),
-            cos_sin_cache=cos_sin_cache,
-            positions=positions,
-            rope_dim=rotary_dim,
-            is_neox_style=is_neox_style,
-        )
-    else:
-        if rotary_dim < head_size:
-            num_tokens = query.shape[0]
-            query = query.view(num_tokens, -1, head_size)
-            key = key.view(num_tokens, -1, head_size)
-            q_rot = query[..., :rotary_dim]
-            q_pass = query[..., rotary_dim:]
-            k_rot = key[..., :rotary_dim]
-            k_pass = key[..., rotary_dim:]
-            q_rot = q_rot.contiguous().view(num_tokens, -1)
-            k_rot = k_rot.contiguous().view(num_tokens, -1)
-            # only the rotary part is processed here,
-            # the dimension should be rotary_dim
-            torch_npu._npu_rotary_embedding(
-                positions,
-                q_rot,
-                k_rot,
-                rotary_dim,
-                cos_sin_cache,
-                is_neox_style,
-            )
-            q_rot = q_rot.view(num_tokens, -1, rotary_dim)
-            k_rot = k_rot.view(num_tokens, -1, rotary_dim)
-            query = torch.cat((q_rot, q_pass), dim=-1).reshape(query_shape)
-            key = torch.cat((k_rot, k_pass), dim=-1).reshape(key_shape)
-        else:
-            # TODO: Remove the contiguous in the future.
-            query = query.contiguous().view(query.shape[0], -1)
-            key = key.contiguous().view(key.shape[0], -1)
-            torch_npu._npu_rotary_embedding(
-                positions,
-                query,
-                key,
-                head_size,
-                cos_sin_cache,
-                is_neox_style,
-            )
+    # npu_mrope handles both full and partial rotary internally:
+    # it splits query into queryRot[..., :rotary_dim] and queryPass[..., rotary_dim:],
+    # where rotary_dim is inferred from cos_sin_cache.shape[-1].
+    rotary_mode = "half" if is_neox_style else "interleave"
+    query, key = torch_npu.npu_mrope(
+        positions,
+        query.contiguous().view(query.shape[0], -1),
+        key.contiguous().view(key.shape[0], -1),
+        cos_sin_cache,
+        head_size,
+        mrope_section=[0, 0, 0],
+        rotary_mode=rotary_mode,
+        cache_mode="default",
+    )
     return query.view(query_shape), key.view(key_shape)
 
 


### PR DESCRIPTION
## Motivation

Replace the internal `torch_npu._npu_rotary_embedding` API with the public `torch_npu.npu_mrope` API in `rope_forward_oot`, and always use this path by removing the Triton branch.

## Modifications

- Removed the `HAS_TRITON` / `rope_forward_triton` branch in `rope_forward_oot`
- Replaced `_npu_rotary_embedding` (including partial rotary handling) with a single `torch_npu.npu_mrope` call
- `is_neox_style=True` -> `rotary_mode="half"`, `is_neox_style=False` -> `rotary_mode="interleave"`
- `mrope_section=[0, 0, 0]` keeps standard RoPE mode

## Test

- `py_compile` and `ruff check` passed locally
- NPU validation still required
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
