### PR TITLE
[CI] Make multi-node nightly run.sh compatible with daily CANN image

### DIFF
--- a/tests/e2e/nightly/multi_node/scripts/run.sh
+++ b/tests/e2e/nightly/multi_node/scripts/run.sh
@@ -24,10 +24,25 @@ export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packa
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 # cann and atb environment setup
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
-source /usr/local/Ascend/cann-9.0.1/share/info/ascendnpu-ir/bin/set_env.sh
+
+# The CANN install directory varies between release (cann-9.0.1) and daily
+# (e.g. cann-2026.08.03) images, so discover it dynamically instead of
+# hardcoding a version-specific path. The ascendnpu-ir component is optional;
+# a missing component must not abort the script.
+CANN_DIR=$(ls -d /usr/local/Ascend/cann-* 2>/dev/null | head -1 || true)
+CANN_IR_SET_ENV="${CANN_DIR}/share/info/ascendnpu-ir/bin/set_env.sh"
+if [ -n "${CANN_DIR}" ] && [ -f "${CANN_IR_SET_ENV}" ]; then
+    source "${CANN_IR_SET_ENV}"
+else
+    echo "WARNING: ascendnpu-ir set_env.sh not found (CANN_DIR=${CANN_DIR:-none}), skipping" >&2
+fi
 
 set +eu
-source /usr/local/Ascend/nnal/atb/set_env.sh
+if [ -f /usr/local/Ascend/nnal/atb/set_env.sh ]; then
+    source /usr/local/Ascend/nnal/atb/set_env.sh
+else
+    echo "WARNING: /usr/local/Ascend/nnal/atb/set_env.sh not found, skipping" >&2
+fi
 set -eu
 
 # Home path for aisbench


### PR DESCRIPTION
### What this PR does / why we need it?

fix(ci): make multi-node nightly run.sh compatible with daily CANN image

The main-branch nightly test started running against the daily base image (cann_version=2026.08.03, built from quay.io/atlas_inference/cann), whose CANN install layout differs from the release image (cann-9.0.1). run.sh hardcoded /usr/local/Ascend/cann-9.0.1/share/info/ascendnpu-ir/bin/set_env.sh, so under `set -euo pipefail` every test pod failed on `source` with exit code 1 and entered CrashLoopBackOff before any test could run.

- Discover the CANN install directory dynamically (`/usr/local/Ascend/cann-*`) and source the ascendnpu-ir set_env.sh only when present; otherwise warn and continue instead of aborting
- Source /usr/local/Ascend/nnal/atb/set_env.sh conditionally
- Make show_triton_ascend_info tolerant of missing components (clang/bishengir-compile/triton-ascend) so `set -e` no longer aborts

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
