### PR TITLE
[v0.23.0][Misc] Log AscendStore delayed-free backlog

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -134,6 +134,7 @@ class KVPoolScheduler:
         self._unfinished_request_ids: set[str] = set()
         self._loading_req_ids: set[str] = set()
         self._delayed_free_req_ids: set[str] = set()
+        self._last_delayed_free_reqs = 0
 
         self._block_pool: BlockPool | None = None
         self.sending_event_id = 0
@@ -982,9 +983,6 @@ class KVPoolScheduler:
                     self.touch_sending_mamba_blocks(req_meta)
                     meta.add_request(req_meta)
 
-        if delayed_free_reqs := len(self._delayed_free_req_ids):
-            logger.info("KV pool put status: delayed_free_reqs=%d", delayed_free_reqs)
-
         return meta
 
     def get_sending_event_id(self):
@@ -1018,6 +1016,12 @@ class KVPoolScheduler:
         """
         hand the connector_output, free non-null mamba blocks and so on.
         """
+        self.update_finished_sending(connector_output.finished_sending)
+        delayed_free_reqs = len(self._delayed_free_req_ids)
+        if delayed_free_reqs != self._last_delayed_free_reqs:
+            logger.info("KV pool put status: delayed_free_reqs=%d", delayed_free_reqs)
+            self._last_delayed_free_reqs = delayed_free_reqs
+
         meta = connector_output.kv_connector_worker_meta
         if not isinstance(meta, AscendStoreKVConnectorWorkerMetadata) or self._block_pool is None:
             return

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -577,7 +577,7 @@ class KVPoolScheduler:
             can_load=force_layerwise_load,
             kvpool_store_skip_tokens=store_skip_tokens,
         )
-        logger.info(
+        logger.debug(
             "KV pool load spec created req=%s vllm_cached=%d kvpool_cached=%d "
             "need_to_allocate=%d load_async=%s use_layerwise=%s",
             request.request_id,
@@ -981,6 +981,9 @@ class KVPoolScheduler:
                 if req_meta is not None:
                     self.touch_sending_mamba_blocks(req_meta)
                     meta.add_request(req_meta)
+
+        if delayed_free_reqs := len(self._delayed_free_req_ids):
+            logger.info("KV pool put status: delayed_free_reqs=%d", delayed_free_reqs)
 
         return meta
 


### PR DESCRIPTION
### What this PR does / why we need it?

Keep AscendStore's delayed-free request tracking synchronized with the aggregated `finished_sending` output, and log the number of requests whose KV blocks are still retained while waiting for asynchronous put completion:

```text
KV pool put status: delayed_free_reqs=<count>
```

The message is emitted only when the delayed-free request count changes, including when it returns to zero. It is evaluated once per scheduler output after completed sends are removed, so it reflects the current delayed-free backlog. The per-request load-spec detail is moved to DEBUG to keep INFO output focused.

### Does this PR introduce _any_ user-facing change?

Yes. It adds the delayed-free backlog to INFO logs and moves one detailed load-spec message to DEBUG. It also removes completed request IDs from AscendStore's scheduler-side delayed-free tracking; block release timing remains controlled by the existing vLLM scheduler path.

### How was this patch tested?

All pre-commit hooks passed, including ruff, codespell, typos, and repository-specific checks. No unit test was added because the change is limited to connector bookkeeping and logging.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
