### PR TITLE
[BugFix][AscendStore] Fix DSV4 Phase-1 offload KV events for conductor

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -166,19 +166,64 @@ _events_mod.KVConnectorKVEvents = type("KVConnectorKVEvents", (), {})  # type: i
 
 
 class _FakeAggregator:
-    def __init__(self, *args, **kwargs):
-        self._mock = MagicMock()
+    """Minimal Counter-based stand-in for KVEventAggregator."""
 
-    def __getattr__(self, name):
-        return getattr(self._mock, name)
+    def __init__(self, num_workers: int = 1, *args, **kwargs):
+        from collections import Counter
+
+        self._event_counter: Counter = Counter()
+        self._num_workers = max(int(num_workers) if num_workers else 1, 1)
+
+    def add_events(self, events):
+        self._event_counter.update(events)
+
+    def get_common_events(self):
+        return [event for event, count in self._event_counter.items() if count == self._num_workers]
+
+    def get_all_events(self):
+        return list(self._event_counter.elements())
+
+    def clear_events(self):
+        self._event_counter.clear()
+
+    def increment_workers(self, count: int = 1):
+        self._num_workers += count
+
+    def reset_workers(self):
+        self._num_workers = 1
+
+    def get_number_of_workers(self):
+        return self._num_workers
 
 
 _events_mod.KVEventAggregator = _FakeAggregator  # type: ignore[attr-defined]
-_events_mod.BlockStored = type(  # type: ignore[attr-defined]
-    "BlockStored",
-    (),
-    {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
-)
+
+
+class _FakeBlockStored:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __hash__(self):
+        return hash(
+            (
+                tuple(getattr(self, "block_hashes", ()) or ()),
+                getattr(self, "parent_block_hash", None),
+                tuple(getattr(self, "token_ids", ()) or ()),
+                getattr(self, "block_size", None),
+                getattr(self, "lora_id", None),
+                getattr(self, "medium", None),
+                getattr(self, "group_idx", None),
+                getattr(self, "kv_cache_spec_kind", None),
+            )
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, _FakeBlockStored):
+            return NotImplemented
+        return self.__dict__ == other.__dict__
+
+
+_events_mod.BlockStored = _FakeBlockStored  # type: ignore[attr-defined]
 
 _kv_cache_utils_mod: Any = sys.modules["vllm.v1.core.kv_cache_utils"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
 _kv_cache_utils_mod.BlockHash = bytes  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 # isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
-from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_events import KVCacheEvent, BlockStored
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector import (
     AscendStoreConnector,
     AscendStoreKVEvents,
@@ -49,6 +49,65 @@ class TestAscendStoreKVEvents(unittest.TestCase):
         ev._aggregator.clear_events.assert_called_once()
         ev._aggregator.reset_workers.assert_called_once()
 
+    def test_aggregate(self):
+        # Union semantics: aggregate keeps unique events from get_all_events,
+        # not the intersection from get_common_events.
+        ev = _mock_events()
+        unique = [MagicMock(), MagicMock()]
+        ev._aggregator.get_all_events.return_value = unique
+        result = ev.aggregate()
+        self.assertIs(result, ev)
+        ev._aggregator.clear_events.assert_called()
+        ev._aggregator.add_events.assert_called_with(unique)
+        ev._aggregator.reset_workers.assert_called()
+        ev._aggregator.get_common_events.assert_not_called()
+
+    def test_aggregate_union_across_workers(self):
+        """MLA put_step shards events: each worker emits a disjoint subset."""
+        ev = AscendStoreKVEvents(num_workers=1)
+
+        def _evt(h):
+            return BlockStored(
+                block_hashes=[h],
+                parent_block_hash=None,
+                token_ids=[1],
+                block_size=16,
+                lora_id=None,
+                medium="cpu",
+                lora_name=None,
+            )
+
+        # Simulate 4 TP ranks each contributing one unique event.
+        for i in range(4):
+            if i > 0:
+                ev.increment_workers(1)
+            ev.add_events([_evt(f"h{i}")])
+
+        # Intersection would drop all (count==1 < num_workers==4).
+        self.assertEqual(len(ev._aggregator.get_common_events()), 0)
+
+        ev.aggregate()
+        events = ev.get_all_events()
+        self.assertEqual(len(events), 4)
+        self.assertEqual(ev.get_number_of_workers(), 1)
+
+    def test_aggregate_dedupes_duplicate_events(self):
+        ev = AscendStoreKVEvents(num_workers=1)
+        evt = BlockStored(
+            block_hashes=["h0"],
+            parent_block_hash=None,
+            token_ids=[1, 2],
+            block_size=16,
+            lora_id=None,
+            medium="cpu",
+            lora_name=None,
+        )
+        ev.add_events([evt, evt])
+        ev.increment_workers(1)
+        ev.add_events([evt])
+        ev.aggregate()
+        self.assertEqual(len(ev.get_all_events()), 1)
+
     def test_worker_aggregation(self):
         ev = _mock_events()
         ev.increment_workers(3)
@@ -56,11 +115,11 @@ class TestAscendStoreKVEvents(unittest.TestCase):
         ev._aggregator.get_number_of_workers.return_value = 5
         self.assertEqual(ev.get_number_of_workers(), 5)
 
-        common = [MagicMock()]
-        ev._aggregator.get_common_events.return_value = common
+        unique = [MagicMock()]
+        ev._aggregator.get_all_events.return_value = unique
         self.assertIs(ev.aggregate(), ev)
         ev._aggregator.clear_events.assert_called_once()
-        ev._aggregator.add_events.assert_called_once_with(common)
+        ev._aggregator.add_events.assert_called_once_with(unique)
         ev._aggregator.reset_workers.assert_called_once()
 
 
@@ -188,7 +247,6 @@ class TestAscendStoreConnector(unittest.TestCase):
         # With events
         events = _mock_events(num_workers=1)
         mock_event = MagicMock()
-        events._aggregator.get_common_events.return_value = [mock_event]
         events._aggregator.get_all_events.return_value = [mock_event]
         connector._kv_cache_events = events
         result = list(connector.take_events())

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -540,12 +540,66 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
             current_event=None,
             token_ids=list(range(16)),
             original_block_size=16,
+            kv_cache_spec_kinds=["mla_attention"],
         )
         t.add_stored_request("r1")
         t.request_queue.put(req)
         t._handle_request(req)
         events = t.get_kv_events()
         self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].medium, "cpu")
+        self.assertEqual(events[0].kv_cache_spec_kind, "mla_attention")
+        self.assertEqual(events[0].group_idx, 0)
+        self.assertEqual(events[0].block_size, 16)
+        self.assertEqual(events[0].token_ids, list(range(16)))
+
+    def test_handle_request_kv_event_uses_effective_block_size(self):
+        """DSV4 MLA compress_ratio: storage start/end is shrunk, Phase-1 must
+        emit conductor/HBM-aligned effective block_size and token window."""
+        t, store = self._make_thread([0, 0], enable_kv_event=True)
+        t.token_database.group_cache_families = {"kv": {0: "c4"}, "state": {}}
+        # Fine-grained hashes so get_block_hashes(..., 64, ...) can combine.
+        fine_hashes = [f"h{i}".encode() for i in range(8)]
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=128,
+            block_ids=[0, 1],
+            block_hashes=fine_hashes,  # type: ignore[arg-type]
+            current_event=None,
+            token_ids=list(range(128)),
+            original_block_size=16,
+            kv_cache_spec_kinds=["mla_attention"],
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        events = t.get_kv_events()
+        self.assertEqual(len(store.put_calls), 1)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].block_size, 64)
+        self.assertEqual(events[0].token_ids, list(range(64)))
+        self.assertEqual(events[1].block_size, 64)
+        self.assertEqual(events[1].token_ids, list(range(64, 128)))
+
+    def test_handle_request_emits_kv_event_for_non_main_group(self):
+        t, store = self._make_thread([0], enable_kv_event=True)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+            current_event=None,
+            token_ids=list(range(16)),
+            original_block_size=16,
+            kv_cache_spec_kinds=["sliding_window_mla"],
+        )
+        t.add_stored_request("r1")
+        t.request_queue.put(req)
+        t._handle_request(req)
+        self.assertEqual(len(store.put_calls), 1)
+        events = t.get_kv_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].kv_cache_spec_kind, "sliding_window_mla")
 
     def test_add_dec_delete_stored_request(self):
         t, _ = self._make_thread()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -59,11 +59,16 @@ class AscendStoreKVEvents(KVConnectorKVEvents):
 
     def aggregate(self) -> "AscendStoreKVEvents":
         """
-        Aggregate KV events and retain only common events.
+        Aggregate KV events across TP workers.
+
+        AscendStore shards puts via ``put_step`` (especially MLA where
+        ``put_step == tp_size``), so each ``BlockStored`` is emitted by
+        exactly one worker. Retain the unique union rather than the
+        intersection required by ``get_common_events``.
         """
-        common_events = self._aggregator.get_common_events()
+        unique_events = list(dict.fromkeys(self._aggregator.get_all_events()))
         self._aggregator.clear_events()
-        self._aggregator.add_events(common_events)
+        self._aggregator.add_events(unique_events)
         self._aggregator.reset_workers()
         return self
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -821,9 +821,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             effective_block_size = group_block_size * cache_family_ratio
             all_hashes = []
             spec_kinds = req_meta.kv_cache_spec_kinds
-            spec_kind = (
-                spec_kinds[group_id] if spec_kinds is not None and group_id < len(spec_kinds) else None
-            )
+            spec_kind = spec_kinds[group_id] if spec_kinds is not None and group_id < len(spec_kinds) else None
             if self.enable_kv_event:
                 group_block_hashes = get_block_hashes(
                     req_meta.block_hashes,
@@ -864,11 +862,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         # full registered block_size worth of tokens).
                         if token_end - token_start != effective_block_size:
                             continue
-                        token_ids = (
-                            req_meta.token_ids[token_start:token_end]
-                            if req_meta.token_ids is not None
-                            else []
-                        )
+                        token_ids = req_meta.token_ids[token_start:token_end] if req_meta.token_ids is not None else []
                         block_idx = start // group_block_size
                         if block_idx >= len(all_hashes):
                             continue

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -26,6 +26,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     ReqMeta,
     SharedBlockData,
     get_block_hashes,
+    infer_cache_family_ratio,
 )
 # isort: on
 
@@ -727,6 +728,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         for group_id in req_meta.kv_cache_group_ids or [0]:
             group_block_size = self._get_block_size(group_id)
+            cache_family = self.token_database.group_cache_families["kv"].get(group_id)
+            raw_group_block_size = group_block_size * infer_cache_family_ratio(cache_family)
 
             group_store_mask = (
                 list(store_masks[group_id]) if store_masks is not None and group_id < len(store_masks) else None
@@ -734,8 +737,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if group_store_mask is not None:
                 skipped_chunks = 0
                 for chunk_id, allowed in enumerate(group_store_mask):
-                    start = chunk_id * group_block_size
-                    if allowed and should_skip(start, start + group_block_size):
+                    start = chunk_id * raw_group_block_size
+                    if allowed and should_skip(start, start + raw_group_block_size):
                         group_store_mask[chunk_id] = False
                         skipped_chunks += 1
                 if skipped_chunks:
@@ -761,13 +764,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 start: int,
                 group_block_size=group_block_size,
                 group_store_mask=group_store_mask,
+                raw_group_block_size=raw_group_block_size,
             ) -> bool:
                 block_idx = start // group_block_size
                 mask_allows = group_store_mask is None or (
                     block_idx < len(group_store_mask) and group_store_mask[block_idx]
                 )
-                chunk_start = block_idx * group_block_size
-                return mask_allows and not should_skip(chunk_start, chunk_start + group_block_size)
+                chunk_start = block_idx * raw_group_block_size
+                return mask_allows and not should_skip(chunk_start, chunk_start + raw_group_block_size)
 
             pre_shard = self.dcp_size <= 1 and not align_state_group
             iterator = self.token_database.process_token_key_strings_with_block_ids(
@@ -810,11 +814,20 @@ class KVCacheStoreSendingThread(KVTransferThread):
             addrs = []
             sizes = []
             stored_events: list[BlockStored] = []
+            # MLA compress_ratio (cache_family cN) shrinks storage addressing
+            # (start/end) by N while prefix hashes / conductor / HBM events
+            # stay on the effective token window (block_size * N).
+            cache_family_ratio = max(infer_cache_family_ratio(cache_family), 1)
+            effective_block_size = group_block_size * cache_family_ratio
             all_hashes = []
+            spec_kinds = req_meta.kv_cache_spec_kinds
+            spec_kind = (
+                spec_kinds[group_id] if spec_kinds is not None and group_id < len(spec_kinds) else None
+            )
             if self.enable_kv_event:
                 group_block_hashes = get_block_hashes(
                     req_meta.block_hashes,
-                    group_block_size,
+                    effective_block_size,
                     getattr(self.token_database, "hash_block_size", group_block_size),
                 )
                 all_hashes = [maybe_convert_block_hash(bh) for bh in group_block_hashes]
@@ -836,14 +849,26 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 )
                 addrs.append(addr)
                 sizes.append(size)
+                # Map storage (start, end) back to the effective token window so
+                # conductor/HBM block_size and tokens_hash stay aligned.
                 if self.enable_kv_event:
-                    token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
-                    block_size = (
+                    storage_block_size = (
                         req_meta.original_block_size[group_id]
                         if isinstance(req_meta.original_block_size, list)
                         else req_meta.original_block_size
                     )
-                    if block_size is not None:
+                    if storage_block_size is not None:
+                        token_start = start * cache_family_ratio
+                        token_end = ends[index] * cache_family_ratio
+                        # Skip incomplete effective windows (conductor needs a
+                        # full registered block_size worth of tokens).
+                        if token_end - token_start != effective_block_size:
+                            continue
+                        token_ids = (
+                            req_meta.token_ids[token_start:token_end]
+                            if req_meta.token_ids is not None
+                            else []
+                        )
                         block_idx = start // group_block_size
                         if block_idx >= len(all_hashes):
                             continue
@@ -853,10 +878,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                             block_hashes=[current_hash],
                             parent_block_hash=parent_hash,
                             token_ids=token_ids,
-                            block_size=block_size,
+                            block_size=effective_block_size,
                             lora_id=None,
                             medium="cpu",
                             lora_name=None,
+                            group_idx=group_id,
+                            kv_cache_spec_kind=spec_kind,
                         )
                         stored_events.append(stored_event)
                         logger.debug("Added kv cache event '%s' to kv cache events queue", stored_event)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -180,6 +180,17 @@ def infer_cache_family_from_ratio(compress_ratio: int | None) -> str:
     return f"c{compress_ratio}"
 
 
+def infer_cache_family_ratio(cache_family: str | None) -> int:
+    if not cache_family or not cache_family.startswith("c"):
+        return 1
+    ratio = cache_family[1:]
+    return int(ratio) if ratio.isdigit() else 1
+
+
+def get_cache_family_granularity(block_size: int, cache_family: str | None) -> int:
+    return block_size * infer_cache_family_ratio(cache_family)
+
+
 def _get_layer_compress_ratio(
     layer_name: str,
     compress_ratios: Sequence[int] | None,
@@ -886,6 +897,8 @@ class ReqMeta:
     # TODO: add lora_request which used for gen lora_id/lora_name in kv event
     token_ids: list[int] | None = None
     original_block_size: list[int] | int | None = None
+    # Wire-format KVCacheSpecKind names per group for Phase-1 BlockStored events.
+    kv_cache_spec_kinds: list[str] | None = None
 
     event_id: int | None = None
 
@@ -904,6 +917,7 @@ class ReqMeta:
         num_prompt_tokens: int | None = None,
         token_ids: list[int] | None = None,
         original_block_size: list[int] | int | None = None,
+        kv_cache_spec_kinds: list[str] | None = None,
         block_ids: list[int] | list[list[int]] | None = None,
         event_id: int | None = None,
         save_end_token: int | None = None,
@@ -942,6 +956,7 @@ class ReqMeta:
         self.num_prompt_tokens = num_prompt_tokens
         self.token_ids = token_ids
         self.original_block_size = original_block_size
+        self.kv_cache_spec_kinds = kv_cache_spec_kinds
         self.event_id = event_id
         self.last_block_gva = last_block_gva
         self.partial_block_index = partial_block_index
@@ -991,6 +1006,7 @@ class ReqMeta:
         kv_cache_group_families: list[str] | None = None,
         save_partial_block: bool = False,
         hash_block_size: int | None = None,
+        kv_cache_spec_kinds: list[str] | None = None,
     ) -> ReqMeta | None:
         """Create the request metadata from a request tracker."""
         if block_hashes is None:
@@ -1094,6 +1110,7 @@ class ReqMeta:
             else None,
             gva_block_offset=tracker.gva_block_offset,
             kv_cache_group_ids=list(range(len(tracker.allocated_block_ids_by_group))),
+            kv_cache_spec_kinds=kv_cache_spec_kinds,
         )
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -18,6 +18,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
+    get_kv_cache_spec_kind,
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
@@ -119,6 +120,7 @@ class KVPoolScheduler:
         use_eagle_fn = getattr(speculative_config, "use_eagle", None)
         self.use_eagle = use_eagle_fn() is True if callable(use_eagle_fn) else False
         self.original_block_size = infer_group_block_sizes(vllm_config.cache_config.block_size, kv_cache_groups)
+        self.kv_cache_spec_kinds = self._infer_group_spec_kinds(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
         requested_hash_block_size = vllm_config.cache_config.prefix_match_unit
@@ -400,6 +402,23 @@ class KVPoolScheduler:
         )
         return hit_tokens
 
+    def _infer_group_spec_kinds(
+        self,
+        vllm_config: "VllmConfig",
+        kv_cache_config: KVCacheConfig | None,
+    ) -> list[str]:
+        """Wire-format KVCacheSpecKind names per group for Phase-1 events."""
+        if kv_cache_config is None or not self.use_hybrid:
+            # Non-hybrid: single full/MLA group; kind is optional for events.
+            return ["full_attention"]
+
+        kinds: list[str] = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            kind = get_kv_cache_spec_kind(kv_cache_group.kv_cache_spec)
+            kinds.append(kind.value if hasattr(kind, "value") else str(kind))
+        return kinds
+
+
     def _floor_to_cache_transfer_granularity(self, token_len: int) -> int:
         return token_len // self.cache_transfer_granularity * self.cache_transfer_granularity
 
@@ -654,6 +673,7 @@ class KVPoolScheduler:
             discard_partial_chunks=self._discard_partial_chunks,
             original_block_size=self.original_block_size,
             kv_cache_group_families=self.kv_cache_group_families,
+            kv_cache_spec_kinds=self.kv_cache_spec_kinds,
             save_partial_block=self.layerwise_offload,
             hash_block_size=self.hash_block_size,
         )
@@ -820,6 +840,7 @@ class KVPoolScheduler:
             discard_partial_chunks=self._discard_partial_chunks,
             original_block_size=self.original_block_size,
             kv_cache_group_families=self.kv_cache_group_families,
+            kv_cache_spec_kinds=self.kv_cache_spec_kinds,
             hash_block_size=self.hash_block_size,
         )
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -418,7 +418,6 @@ class KVPoolScheduler:
             kinds.append(kind.value if hasattr(kind, "value") else str(kind))
         return kinds
 
-
     def _floor_to_cache_transfer_granularity(self, token_len: int) -> int:
         return token_len // self.cache_transfer_granularity * self.cache_transfer_granularity
 


### PR DESCRIPTION
Aggregate MLA TP-sharded BlockStored events by unique union, emit only main-attention groups with conductor-aligned effective block_size (MLA compress_ratio), so flash non-HBM offload can match pool confirmations.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
