### PR TITLE
[Test] Add regression guard for MoE final-output all-reduce in non-SP graph mode

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -458,6 +458,64 @@ def test_local_shared_expert_dp_reduces_partial_routed_output(
         all_reduce.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("output_is_reduced", "moe_comm_type", "flash_comm_v1_enabled", "should_call_op"),
+    [
+        # No explicit flag: falls back to _fused_output_is_reduced, which
+        # resolves from the runtime moe_comm_type.
+        (None, MoECommType.ALLGATHER, False, True),
+        (None, MoECommType.MC2, False, False),
+        # Explicit flag must win over the property: an un-reduced output has
+        # to reach the graph-opaque custom op no matter what the context says.
+        (False, MoECommType.MC2, False, True),
+        # Already-reduced output (finalize() reduced it upstream) is skipped
+        # by design.
+        (True, MoECommType.ALLGATHER, False, False),
+    ],
+)
+def test_runner_maybe_reduce_final_output_routes_via_custom_op_when_unreduced(
+    monkeypatch,
+    output_is_reduced,
+    moe_comm_type,
+    flash_comm_v1_enabled,
+    should_call_op,
+):
+    """Regression guard for A00282 / upstream #10557.
+
+    When the combined MoE output is not reduced yet, the final TP reduction
+    must go through the graph-opaque custom op
+    ``maybe_all_reduce_tensor_model_parallel`` instead of a Python-level
+    branch that a captured graph could bake in with a stale value. Before
+    upstream #10557 the decision lived in a Python ``@property`` evaluated
+    during graph capture and baked into the replay graph, so the all-reduce
+    was skipped at runtime and multi-concurrency output was garbled on A2.
+    """
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(moe_comm_type=moe_comm_type, flash_comm_v1_enabled=flash_comm_v1_enabled),
+    )
+    states = torch.randn(4, 8)
+
+    with patch(
+        "torch.ops.vllm.maybe_all_reduce_tensor_model_parallel",
+        side_effect=lambda x: x,
+    ) as mock_reduce:
+        result = runner._maybe_reduce_final_output(
+            states,
+            5,
+            output_is_reduced,
+        )
+
+    assert result.shape == (4, 5)
+    torch.testing.assert_close(result, states[..., :5])
+    if should_call_op:
+        mock_reduce.assert_called_once_with(states)
+    else:
+        mock_reduce.assert_not_called()
+
+
 def test_routed_experts_select_experts_validates_router_logits(monkeypatch):
     routed_experts = AscendRoutedExperts.__new__(AscendRoutedExperts)
     hidden_states = torch.randn(2, 4)


### PR DESCRIPTION
### What this PR does / why we need it?

Adds a regression unit test for the MoE final-output reduction contract fixed
by upstream #10557 (internal issue A00282 / DTS2026060451978).

For the ALLGATHER (non-SP) MoE path, the final TP all-reduce is required.
Before #10557, the "is the fused output already reduced" decision was a Python
`@property` (`_fused_output_is_reduced`) evaluated during graph capture. With a
small capture batch the MC2 path is selected (property = True, skip the final
all-reduce), and that branch was baked into the replay graph. At replay time a
large concurrent batch switches to the ALLGATHER path, which needs the
all-reduce — but the graph had already frozen "skip". Hidden states were then
not reduced across TP/EP ranks and multi-concurrency output was garbled (GSM8K
accuracy dropped to 0% in the A2 nightly case).

The fix (#10557) routes the final reduction through the graph-opaque custom op
`maybe_all_reduce_tensor_model_parallel`, which decides at execution time
whether the reduction is needed.

This test locks that contract so the regression is caught at PR/UT level
instead of relying only on the A2 nightly accuracy case.

### Rebase note (adapted to #13158)

This PR was rebased after #13158 reworked the shared-expert reduction
contracts. `_maybe_reduce_final_output` now takes an explicit
`output_is_reduced` flag (falling back to `_fused_output_is_reduced` when
None) and only invokes the custom op when the output is not reduced yet. The
guard was therefore parametrized:

- explicit `output_is_reduced=False` must reach the custom op regardless of
  the runtime `moe_comm_type` (the regression we never want to see again);
- `None` falls back to the property: ALLGATHER calls the op, MC2 skips it
  (`finalize()` already reduced the routed output);
- explicit `True` is skipped by design (upstream reduced it early).

### Test

- New test:
  `tests/ut/ops/test_fused_moe.py::test_runner_maybe_reduce_final_output_routes_via_custom_op_when_unreduced`
- Runs in the default CPU UT module on every PR (`tests/ut`, CPU-only).
- Locally validated with `ruff check` / `ruff format --check` and a pure-Python
  simulation of the current main implementation against all four parametrized
  cases; the test itself is executed by PR CI (no local NPU/vllm environment).

### Notes

- Test-only PR, no user-facing change.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
