### PR TITLE
[feature][KV Offload][v0.26.0rc] Support Sparse KV Cache Offload

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -100,8 +100,10 @@
   source_file_dependencies:
     - vllm_ascend/attention/indexer.py
     - vllm_ascend/attention/sfa_v1.py
+    - vllm_ascend/attention/sfa_kv_offload.py
   tests:
     - tests/ut/attention/test_indexer.py
+    - tests/ut/attention/test_sfa_kv_offload.py
     - tests/ut/attention/a2/test_sfa_v1.py
     - tests/ut/attention/a2/test_sfa_v1_precision.py
     - tests/e2e/pull_request/four_card/test_deepseek_v3_2_w8a8_pruning.py

--- a/docs/source/user_guide/feature_guide/sparse_kv_cache_offload.md
+++ b/docs/source/user_guide/feature_guide/sparse_kv_cache_offload.md
@@ -1,0 +1,113 @@
+# Sparse KV Cache Offload Guide
+
+## Overview
+
+This guide shows how to use Sparse KV Cache Offload, a long sequence inference optimization technique.
+
+In long sequence inference scenario, KV cache size has become one of the inference bottlenecks. Although Layerwise KV Cache Offload proposed in RFC ([#33398](https://github.com/vllm-project/vllm/issues/33398)) can save KV cache NPU memory usage during prefill, we found out that Layerwise KV Cache Offload is not suitable for decode: time consumption of loading full KV Cache is too long to be overlapped by decoding, leads to a significant increase in TPOT.
+
+To solve the problems above, we propose sparse KV cache offload, a sparse attention based long sequence inference optimization technique. Take [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) as an example, although we still need to store full KV cache, only topk (2048) of them are needed in sparse attention. By offloading the full KV cache to host, we are able to save most of the KV Cache NPU memory usage. And since we only need to onload the needed topk KV cache in each decode step, the h2d data transmission size is small (about ~2MB for each batch), thus h2d loading time is relatively low and make it available in decode phase.
+
+For more information about Layerwise KV Cache Offload and Sparse KV Cache Offload, please refer to our RFC ([#48203](https://github.com/vllm-project/vllm/issues/48203)).
+
+## Supported Scenarios
+
+- Sparse KV Cache Offload only support sparse attention based model, such as [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2) and [DeepSeek-V3.2](https://huggingface.co/deepseek-ai/DeepSeek-V3.2).
+- Currently Sparse KV Cache Offload only support PD disagregate scenario, and it can be only used in D node.
+- Currently Sparse KV Cache Offload only support Tensor Parallel (TP). Context Parallel (CP) and Pipeline Parallel (PP) are not supported now.
+- Currently Sparse KV Cache Offload only support model_runner_v1, we will support model_runner_v2 in the future.
+
+Some other features that can be used together with Sparse KV Cache Offload are as follows:
+
+| Eager | Graph | SpecDecode <br> (MTP) | Li C8 |
+| ----- | ------| -----                 | ----- |
+| ✅    | ✅   | ✅                   | ✅      |
+
+## How to use Sparse KV Cache offload
+
+### Environment setup
+
+Since some third party dependencies needed by sparse KV Cache offload are not included in published images yet, you may need to install them manually before using sparse KV Cache offload:
+
+- Update memfabric-hybrid
+
+    ```bash
+    # uninstall old memfabric_hybrid in your image
+    pip uninstall -y memfabric_hybrid
+    # clone and build from src
+    git clone https://gitcode.com/Ascend/memfabric_hybrid.git -b release/1.2
+    cd memfabric_hybrid
+    bash script/build_and_pack_run.sh
+    # install new version memfabric_hybrid
+    bash output/memfabric_hybrid-1.2.0_linux_aarch64.run
+    # set library path env
+    export MEMFABRIC_HYBRID_EXTEND_LIB_PATH=/usr/local/memfabric_hybrid/1.2.0/aarch64-linux/lib64
+    ```
+
+    You can refer to the [memfabric installation doc](https://gitcode.com/Ascend/memfabric_hybrid/blob/master/doc/installation.md) for more information if you encounter any problems.
+
+    This dependency will be removed after sparse KV cache offload related code is merged to memfabric master branch.
+
+    **NOTE:** Current memfabric_hybrid version requires NPU driver version >= `25.5.1`. Use `npu-smi info` to check your driver version, you may need to update it if it's version is too low.
+
+- Install CPP compilation dependencies (optional)
+
+    If your image doesn't have clang installed, install clang and openmp library.
+
+    ```bash
+    # check whether clang is installed
+    clang --version
+    # install clang and openmp
+    apt install clang
+    apt-get install libomp-dev
+    ```
+
+    If your image has already installed clang, check whether openmp library is already installed too. If not, install the specific version according to your clang version.
+    ```bash
+    # check whether openmp is already installed by finding omp.h
+    ls $(clang --print-resource-dir)/include/omp.h
+    # install the specific version openmp,
+    # for example your image already have clang17, then you need to install omp-17
+    apt-get install libomp-17-dev
+    ```
+
+    If your image already have clang and openmp library installed, you can skip this step.
+
+    This dependency will be removed after we use custom NPU operator to replace current `lru_resident_compact` and `compute_lru_resident_addrs` written by cpp.
+
+### Configuration
+
+You can enable Sparse KV Cache Offload by setting `sparse_kv_offload_config` in `additional-config`. You also need to specify `SFAPDCpuOffloadConnector` in `kv-transfer-config` for PD KV transfer. Refer to the following example:
+
+```bash
+vllm serve zai-org/GLM-5.2 \
+    --host 0.0.0.0 \
+    --port 8005 \
+    --served-model-name model \
+    --tensor-parallel-size 16 \
+    --max-num-seqs 4 \
+    --max-model-len 4096 \
+    --max-num-batched-tokens 4096 \
+    --trust-remote-code \
+    --enforce-eager \
+    --gpu-memory-utilization 0.7 \
+    --quantization ascend \
+    --no-enable-prefix-caching \
+    --additional-config '{"sparse_kv_offload_config": {"enabled": true, "topk_buffer_size": 4096, "dram_size_per_dp_GB": 128}}' \
+    --kv-transfer-config "{
+        \"kv_connector\": \"SFAPDCpuOffloadConnector\",
+        \"kv_buffer_device\": \"npu\",
+        \"kv_role\": \"kv_consumer\",
+        \"kv_parallel_size\": 1,
+        \"kv_port\": 20050,
+        \"kv_rank\": 1,
+        \"kv_connector_extra_config\": {\"use_layerwise\": true}
+    }"
+```
+
+`sparse_kv_offload_config` parameters meaning and usage:
+
+- `enabled` (bool, default: `False`): Whether to enable sparse KV Cache offload.
+- `topk_buffer_size` (int, default: `4096`): Size of the device hot KV buffer, should be greater than the model's `index_topk`. Increase this size will increase topk KV hit rate thus reduce tpot, but will bring higher device memory usage. Normally we set it to 2 * `index_topk` to achieve a balance between topk KV hit rate and device memory usage.
+- `dram_size_per_dp_GB` (bool, default: `128`): Reserved host memory size in Gigabyte per DP group. An error will be raised if this reserved size is not enough to contain the whole host KV cache buffer. All ranks in one TP group will share one host KV cache buffer, so the total host memory usage will be `dram_size_per_dp_GB` * `data_parallel_size`.
+- `keep_device_kv_cache` (bool, optional, default: `False`): Whether to allocate the device KV Cache buffer. If enabled, we will still allocate device KV Cache, thus we can't save KV cache device memory usage, and can not improve sequence length or batch_size. Only reserved for PD-colocate debugging, you **SHOULD NOT** enable it in actual production environment.

--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -15,6 +15,10 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
+from vllm_ascend.attention.sfa_kv_offload import (
+    AscendSFAKVOffloadImpl,
+    AscendSFAKVOffloadMetadataBuilder,
+)
 from vllm_ascend.attention.sfa_v1 import (
     AscendSFABackend,
     AscendSFAImpl,
@@ -54,28 +58,48 @@ class TestAscendSFABackend(TestBase):
     def test_get_name(self):
         self.assertEqual(AscendSFABackend.get_name(), "ASCEND_SFA")
 
-    def test_get_builder_cls(self):
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_get_builder_cls(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         self.assertEqual(AscendSFABackend.get_builder_cls(), AscendSFAMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
         result = AscendSFABackend.get_kv_cache_shape(2, 4, 8, 128)
         self.assertEqual(result, (2, 4, 8, 128))
 
-    def test_get_impl_cls(self):
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_get_impl_cls(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         result = AscendSFABackend.get_impl_cls()
         self.assertEqual(result, AscendSFAImpl)
 
     @patch("vllm_ascend.attention.sfa_v1.enable_sfa_dcp_replicated_indexer")
-    def test_get_builder_cls_with_dcp(self, mock_enable_dcp):
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_get_builder_cls_with_dcp(self, mock_get_ascend_config, mock_enable_dcp):
         mock_enable_dcp.return_value = True
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         builder_cls = AscendSFABackend.get_builder_cls()
         self.assertIsNotNone(builder_cls)
 
     @patch("vllm_ascend.attention.sfa_v1.enable_sfa_dcp_replicated_indexer")
-    def test_get_impl_cls_with_dcp(self, mock_enable_dcp):
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_get_impl_cls_with_dcp(self, mock_get_ascend_config, mock_enable_dcp):
         mock_enable_dcp.return_value = True
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         impl_cls = AscendSFABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_get_builder_cls_with_sparse_kv_offload(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = True
+        result = AscendSFABackend.get_builder_cls()
+        self.assertEqual(result, AscendSFAKVOffloadMetadataBuilder)
+
+    @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
+    def test_get_impl_cls_with_sparse_kv_offload(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = True
+        result = AscendSFABackend.get_impl_cls()
+        self.assertEqual(result, AscendSFAKVOffloadImpl)
 
 
 class TestAscendSFADeviceOperator(TestBase):

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -1,0 +1,103 @@
+"""Regression tests for SFA KV-offload attention metadata."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+
+from vllm_ascend.attention.attention_v1 import AscendAttentionState  # noqa: E402
+from vllm_ascend.attention.sfa_kv_offload import (  # noqa: E402
+    AscendSFAKVOffloadImpl,
+    AscendSFAKVOffloadMetadataBuilder,
+)
+from vllm_ascend.attention.sfa_v1 import AscendSFAMetadataBuilder  # noqa: E402
+
+
+def _make_boundary_decode_metadata():
+    return SimpleNamespace(
+        context_parallel_metadata=None,
+        max_query_len=1,
+        num_reqs=1,
+        num_actual_tokens=1,
+        query_start_loc_cpu=torch.tensor([0, 1]),
+        is_prefilling=torch.tensor([True]),
+        req_ids_tensor=torch.tensor([7]),
+        token_to_req=torch.tensor([0]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("kv_transfer_config", "expected"),
+    [
+        (None, False),
+        (SimpleNamespace(is_kv_consumer=False, is_kv_producer=True), False),
+        (SimpleNamespace(is_kv_consumer=True, is_kv_producer=True), False),
+        (SimpleNamespace(is_kv_consumer=True, is_kv_producer=False), True),
+    ],
+)
+def test_pd_decode_consumer_is_derived_from_kv_role(kv_transfer_config, expected):
+    vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+    with patch.object(AscendSFAMetadataBuilder, "__init__", return_value=None):
+        builder = AscendSFAKVOffloadMetadataBuilder(
+            kv_cache_spec=None,
+            layer_names=[],
+            vllm_config=vllm_config,
+            device=torch.device("cpu"),
+        )
+
+    assert builder.is_pd_decode_consumer is expected
+
+
+@pytest.mark.parametrize(
+    ("is_pd_decode_consumer", "expected_decodes", "expected_prefills"),
+    [
+        (True, 1, 0),
+        (False, 0, 1),
+    ],
+)
+def test_boundary_token_classification_depends_on_pd_decode_role(
+    is_pd_decode_consumer,
+    expected_decodes,
+    expected_prefills,
+):
+    builder = AscendSFAKVOffloadMetadataBuilder.__new__(AscendSFAKVOffloadMetadataBuilder)
+    builder.decode_threshold = 1
+    builder.is_pd_decode_consumer = is_pd_decode_consumer
+    metadata = SimpleNamespace(attn_state=AscendAttentionState.DecodeOnly)
+
+    with patch(
+        "vllm_ascend.attention.utils.is_pd_decode_recompute_scheduler_enabled",
+        return_value=False,
+    ):
+        builder._populate_offload_metadata(metadata, _make_boundary_decode_metadata())
+
+    assert metadata.num_decodes == expected_decodes
+    assert metadata.num_prefills == expected_prefills
+    assert metadata.num_decode_tokens == expected_decodes
+    assert metadata.req_ids_tensor.tolist() == [7]
+    assert metadata.token_to_req.tolist() == [0]
+    assert AscendSFAKVOffloadImpl._is_decode_only(metadata) is is_pd_decode_consumer
+
+
+def test_pd_decode_consumer_still_rejects_long_prefill_classification():
+    builder = AscendSFAKVOffloadMetadataBuilder.__new__(AscendSFAKVOffloadMetadataBuilder)
+    builder.decode_threshold = 1
+    builder.is_pd_decode_consumer = True
+    metadata = SimpleNamespace()
+    common_metadata = _make_boundary_decode_metadata()
+    common_metadata.max_query_len = 2
+    common_metadata.num_actual_tokens = 2
+    common_metadata.query_start_loc_cpu = torch.tensor([0, 2])
+
+    with patch(
+        "vllm_ascend.attention.utils.is_pd_decode_recompute_scheduler_enabled",
+        return_value=False,
+    ):
+        builder._populate_offload_metadata(metadata, common_metadata)
+
+    assert metadata.num_decodes == 0
+    assert metadata.num_prefills == 1
+    assert metadata.num_decode_tokens == 0

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -1,0 +1,174 @@
+import unittest
+
+import torch
+from vllm.v1.kv_cache_interface import KVCacheSpec
+
+from vllm_ascend.core.kv_cache_interface import (
+    AscendMLAAttentionSpec,
+    AscendSFAIndexerCacheSpec,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    get_host_device_memory_usage_ratio,
+)
+
+
+class TestHostDeviceMemoryRatio(unittest.TestCase):
+    def gen_kv_cache_specs(
+        self,
+        spec_type: type[KVCacheSpec],
+        num: int,
+        name_suffix: str,
+        **kwargs,
+    ):
+        kv_cache_specs = {}
+        for layer_id in range(num):
+            name = f"model.layers.{layer_id}.{name_suffix}"
+            spec = spec_type(**kwargs)
+            kv_cache_specs[name] = spec
+        return kv_cache_specs
+
+    def test_normal_case(self):
+        # same number of mla & indexer cache, no c8
+        # gold = kv_dim / idx_dim
+        #      = 576 / 128
+        #      = 4.5
+        hd_memory_ratio_gold = 4.5
+        mla_specs = self.gen_kv_cache_specs(
+            AscendMLAAttentionSpec,
+            4,
+            "self_attn.attn",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            cache_sparse_sfa_c8=False,
+            store_on_host=True,
+        )
+        indexer_specs = self.gen_kv_cache_specs(
+            AscendSFAIndexerCacheSpec,
+            4,
+            "self_attn.indexer.k_cache",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            scale_dim=0,
+            scale_dtype=torch.int8,
+            cache_sparse_li_c8=False,
+        )
+        all_specs = {}
+        all_specs.update(mla_specs)
+        all_specs.update(indexer_specs)
+        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
+
+    def test_indexer_share(self):
+        # multi layer share one indexer (GLM5.2), no c8
+        # gold = (kv_num * kv_dim) / (idx_num * idx_dim)
+        #      = (4 * 576) / (1 * 128)
+        #      = 18
+        hd_memory_ratio_gold = 18
+        mla_specs = self.gen_kv_cache_specs(
+            AscendMLAAttentionSpec,
+            4,
+            "self_attn.attn",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            cache_sparse_sfa_c8=False,
+            store_on_host=True,
+        )
+        indexer_specs = self.gen_kv_cache_specs(
+            AscendSFAIndexerCacheSpec,
+            1,
+            "self_attn.indexer.k_cache",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            scale_dim=0,
+            scale_dtype=torch.int8,
+            cache_sparse_li_c8=False,
+        )
+        all_specs = {}
+        all_specs.update(mla_specs)
+        all_specs.update(indexer_specs)
+        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
+
+    def test_li_c8(self):
+        # indxer c8 cache
+        # gold = (kv_num * kv_dim * bf16) / (idx_num * (idx_dim * int8 + scale_dim * fp16))
+        #      = (4 * 576 * 2) / (1 * (128 * 1 + 1 * 2))
+        #      = 35.44615384615385
+        hd_memory_ratio_gold = 35.44615384615385
+        mla_specs = self.gen_kv_cache_specs(
+            AscendMLAAttentionSpec,
+            4,
+            "self_attn.attn",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            cache_sparse_sfa_c8=False,
+            store_on_host=True,
+        )
+        indexer_specs = self.gen_kv_cache_specs(
+            AscendSFAIndexerCacheSpec,
+            1,
+            "self_attn.indexer.k_cache",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.int8,
+            cache_dtype_str="bfloat16",
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_li_c8=True,
+        )
+        all_specs = {}
+        all_specs.update(mla_specs)
+        all_specs.update(indexer_specs)
+        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
+
+    def test_no_offload(self):
+        # no store_on_host specs
+        # gold = 0 (don't need host memory)
+        hd_memory_ratio_gold = 0
+        mla_specs = self.gen_kv_cache_specs(
+            AscendMLAAttentionSpec,
+            4,
+            "self_attn.attn",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            cache_sparse_sfa_c8=False,
+            store_on_host=False,
+        )
+        indexer_specs = self.gen_kv_cache_specs(
+            AscendSFAIndexerCacheSpec,
+            1,
+            "self_attn.indexer.k_cache",
+            block_size=128,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            cache_dtype_str="bfloat16",
+            scale_dim=0,
+            scale_dtype=torch.int8,
+            cache_sparse_li_c8=False,
+        )
+        all_specs = {}
+        all_specs.update(mla_specs)
+        all_specs.update(indexer_specs)
+        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -96,6 +96,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
     def test_allocate_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()
+        runner.sparse_kv_offload_enabled = False
         kv_cache_spec = FullAttentionSpec(
             block_size=16,
             num_kv_heads=8,
@@ -117,6 +118,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
     def test_reshape_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()
+        runner.sparse_kv_offload_enabled = False
         kv_cache_spec = FullAttentionSpec(
             block_size=16,
             num_kv_heads=8,
@@ -162,6 +164,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             qk_rope_head_dim=64,
         )
         runner.vllm_config.cache_config.cache_dtype = "auto"
+        runner.sparse_kv_offload_enabled = False
 
         attn_module = MLAAttention.__new__(MLAAttention)
         torch.nn.Module.__init__(attn_module)
@@ -224,6 +227,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             index_head_dim=128,
         )
         runner.vllm_config.cache_config.cache_dtype = "auto"
+        runner.sparse_kv_offload_enabled = False
 
         attn_module = MLAAttention.__new__(MLAAttention)
         torch.nn.Module.__init__(attn_module)
@@ -338,6 +342,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.c8_k_cache_dtype = torch.int8
         runner.c8_k_scale_cache_dtype = torch.float16
         runner._get_attention_kv_cache_dims = lambda _layer_name, _spec: (512, 64)
+        runner.sparse_kv_offload_enabled = False
 
         attn_layer_name = "model.layers.1.self_attn.attn"
         indexer_layer_name = "model.layers.1.self_attn.indexer.k_cache"
@@ -467,6 +472,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             index_head_dim=128,
         )
         runner.vllm_config.cache_config.cache_dtype = "auto"
+        runner.sparse_kv_offload_enabled = False
 
         attn_module = MLAAttention.__new__(MLAAttention)
         torch.nn.Module.__init__(attn_module)

--- a/tests/ut/worker/a2/test_worker_multi_instance.py
+++ b/tests/ut/worker/a2/test_worker_multi_instance.py
@@ -112,9 +112,11 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
     # Tests
     # ------------------------------------------------------------------ #
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
-    def test_single_instance_positive_kv_cache(self, mock_logger):
+    def test_single_instance_positive_kv_cache(self, mock_logger, mock_get_ascend_config):
         """Baseline: single instance on an empty card yields positive KV cache."""
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         total = int(64 * GiB_bytes)
         gpu_util = 0.9
         requested_memory = int(total * gpu_util)  # 57.6 GiB
@@ -134,8 +136,10 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         self.assertEqual(result, expected)
         self.assertGreater(result, 0)
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
-    def test_determine_available_memory_does_not_profile_npugraph_memory(self, mock_logger):
+    def test_determine_available_memory_does_not_profile_npugraph_memory(self, mock_logger, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         total = int(64 * GiB_bytes)
         requested_memory = int(total * 0.9)
         init_free = int(60 * GiB_bytes)
@@ -156,8 +160,9 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         self.assertFalse(hasattr(worker, "npugraph_memory_estimate"))
         self.assertEqual(result, requested_memory - non_kv_cache)
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
-    def test_second_instance_on_same_card_positive_kv_cache(self, mock_logger):
+    def test_second_instance_on_same_card_positive_kv_cache(self, mock_logger, mock_get_ascend_config):
         """
         Regression test for PR #7427.
 
@@ -176,6 +181,7 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         Before the fix, non_kv_cache_memory was inflated to include first
         instance memory (~25.6 GiB), yielding available ≈ -1.32 GiB (OOM).
         """
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         total = int(64 * GiB_bytes)
         gpu_util = 0.4
         requested_memory = int(total * gpu_util)  # 25.6 GiB
@@ -209,8 +215,9 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         # Verify model_runner.profile_run() was called during profiling
         worker.model_runner.profile_run.assert_called_once()
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
-    def test_second_instance_buggy_non_kv_cache_gives_negative(self, mock_logger):
+    def test_second_instance_buggy_non_kv_cache_gives_negative(self, mock_logger, mock_get_ascend_config):
         """
         Documents the *pre-fix* buggy behaviour that PR #7427 addresses.
 
@@ -222,6 +229,7 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         This test is intentionally asserting the *negative* outcome to
         document the regressed state; it is NOT testing the fix itself.
         """
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         total = int(64 * GiB_bytes)
         gpu_util = 0.4
         requested_memory = int(total * gpu_util)  # 25.6 GiB
@@ -273,8 +281,9 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
 
         self.assertIn("Error in memory profiling", str(ctx.exception))
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
-    def test_second_instance_tight_memory_still_positive(self, mock_logger):
+    def test_second_instance_tight_memory_still_positive(self, mock_logger, mock_get_ascend_config):
         """
         Edge case: card is almost full when second instance starts.
 
@@ -282,6 +291,7 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         non_kv_cache_memory (i.e. there is room for at least some KV blocks),
         the result must be positive.
         """
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         total = int(32 * GiB_bytes)  # smaller card (e.g. 910B1)
         gpu_util = 0.3
         requested_memory = int(total * gpu_util)  # 9.6 GiB

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -489,11 +489,13 @@ class TestNPUWorker(TestBase):
             self.assertTrue(worker.pin_lora(2))
             mock_model_runner.pin_lora.assert_called_once_with(2)
 
-    def test_get_methods(self):
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_get_methods(self, mock_get_ascend_config):
         """Test various get methods"""
         from vllm_ascend.worker.worker import NPUWorker
 
         # Create worker mock
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
             worker = NPUWorker()
             mock_model_runner = MagicMock()
@@ -535,6 +537,7 @@ class TestNPUWorker(TestBase):
             # Verify call
             mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("torch.npu.reset_peak_memory_stats")
     @patch("torch.npu.empty_cache")
@@ -549,6 +552,7 @@ class TestNPUWorker(TestBase):
         mock_torch_empty_cache,
         mock_torch_reset_peak_memory_stats,
         mock_memory_profiling,
+        mock_get_ascend_config,
     ):
         """Test determine_available_memory normal case (no non-torch memory allocation)"""
         from vllm_ascend.worker.worker import NPUWorker
@@ -567,6 +571,7 @@ class TestNPUWorker(TestBase):
         mock_context.__enter__ = MagicMock(return_value=mock_profile_result)
         mock_context.__exit__ = MagicMock(return_value=False)
         mock_memory_profiling.return_value = mock_context
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
 
         # Mock init_snapshot
         mock_init_snapshot = MagicMock()
@@ -598,6 +603,7 @@ class TestNPUWorker(TestBase):
             expected_result = int(10000 * 0.8 - 3500)
             self.assertEqual(result, expected_result)
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("torch.npu.reset_peak_memory_stats")
     @patch("torch.npu.empty_cache")
@@ -610,6 +616,7 @@ class TestNPUWorker(TestBase):
         mock_torch_empty_cache,
         mock_torch_reset_peak_memory_stats,
         mock_memory_profiling,
+        mock_get_ascend_config,
     ):
         """Test determine_available_memory with significant non-torch memory allocation"""
         from vllm_ascend.worker.worker import NPUWorker
@@ -628,6 +635,7 @@ class TestNPUWorker(TestBase):
         mock_context.__enter__ = MagicMock(return_value=mock_profile_result)
         mock_context.__exit__ = MagicMock(return_value=False)
         mock_memory_profiling.return_value = mock_context
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
 
         # Mock init_snapshot
         mock_init_snapshot = MagicMock()
@@ -700,6 +708,7 @@ class TestNPUWorker(TestBase):
 
             self.assertIn("Error in memory profiling", str(cm.exception))
 
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("torch.npu.reset_peak_memory_stats")
     @patch("torch.npu.empty_cache")
@@ -712,6 +721,7 @@ class TestNPUWorker(TestBase):
         mock_torch_empty_cache,
         mock_torch_reset_peak_memory_stats,
         mock_memory_profiling,
+        mock_get_ascend_config,
     ):
         """Test determine_available_memory returns 0 when result is negative"""
         from vllm_ascend.worker.worker import NPUWorker
@@ -730,6 +740,7 @@ class TestNPUWorker(TestBase):
         mock_context.__enter__ = MagicMock(return_value=mock_profile_result)
         mock_context.__exit__ = MagicMock(return_value=False)
         mock_memory_profiling.return_value = mock_context
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
 
         # Mock init_snapshot
         mock_init_snapshot = MagicMock()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -288,6 +288,20 @@ class AscendConfig:
         rejection_sampler_config = additional_config.get("rejection_sampler_config", {})
         self.rejection_sampler_config = RejectionSamplerConfig(rejection_sampler_config)
 
+        self.sparse_kv_offload_config = SparseKVOffloadConfig(
+            self.vllm_config,
+            additional_config.get("sparse_kv_offload_config", {}),
+        )
+        self._validate_sparse_c8_kv_offload_compatibility()
+
+    def _validate_sparse_c8_kv_offload_compatibility(self) -> None:
+        if self.sparse_kv_offload_config.enabled and self.enable_sparse_sfa_c8:
+            raise NotImplementedError(
+                "Sparse KV offload does not support the sparse SFA C8 main "
+                "cache. Disable enable_sparse_sfa_c8; enable_sparse_li_c8 is "
+                "supported because the indexer cache remains device-resident."
+            )
+
     @staticmethod
     def _get_config_value(additional_config: dict[str, Any], config_key: str, env_key: str, env_value: Any) -> Any:
         if config_key in additional_config:
@@ -936,6 +950,56 @@ class SchedulerConfig:
                 env_key,
             )
         return default
+
+
+class SparseKVOffloadConfig:
+    """
+    Configuration for the Sparse KV cache offloading.
+    """
+
+    def __init__(self, vllm_config: "VllmConfig", user_config: dict[str, Any]):
+        self.enabled = bool(user_config.get("enabled", False))
+        if not self.enabled:
+            return
+
+        self.topk_buffer_size = int(user_config.get("topk_buffer_size", 4096))
+        self.dram_size_per_dp_GB = int(user_config.get("dram_size_per_dp_GB", 128))
+        self.keep_device_kv_cache = bool(user_config.get("keep_device_kv_cache", False))
+
+        if hasattr(vllm_config.model_config.hf_text_config, "compress_ratios"):
+            raise ValueError("Sparse KV offload don't support compress now.")
+        if not hasattr(vllm_config.model_config.hf_text_config, "index_topk"):
+            raise ValueError("Sparse KV offload only support sparse attention model.")
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.prefill_context_parallel_size * parallel_config.decode_context_parallel_size > 1:
+            raise ValueError("Sparse KV offload don't support context parallel now.")
+        if parallel_config.pipeline_parallel_size > 1:
+            raise ValueError("Sparse KV offload don't support pipeline parallel now.")
+        if self.keep_device_kv_cache:
+            logger.warning_once(
+                "Init sparse KV offload with keep_device_kv_cache enabled, "
+                "in this case we will still allocate device kv cache "
+                "and can not improve sequence length or batch_size. "
+                "You should only use it for debugging in PD colocate scenario."
+            )
+        else:
+            if vllm_config.kv_transfer_config is None or not vllm_config.kv_transfer_config.is_kv_consumer:
+                raise AssertionError(
+                    "Sparse KV offload is only supported in PD disaggregate scenario "
+                    "and can only be used in D node. For debugging in PD colocate scenario, "
+                    "you can enable keep_device_kv_cache."
+                )
+        if vllm_config.use_v2_model_runner:
+            raise ValueError("Sparse KV offload doesn't support model_runner_v2 now.")
+
+        self.topk = vllm_config.model_config.hf_text_config.index_topk
+        if self.topk_buffer_size <= 0:
+            raise ValueError("sparse_kv_offload_config.topk_buffer_size must be positive")
+        if self.topk_buffer_size < self.topk:
+            raise ValueError(
+                "sparse_kv_offload_config.topk_buffer_size must be >= topk, "
+                f"got topk_buffer_size={self.topk_buffer_size}, topk={self.topk}"
+            )
 
 
 _ASCEND_CONFIG: AscendConfig | None = None

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -739,6 +739,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         attn_metadata,
         actual_seq_lengths_query,
         actual_seq_lengths_key,
+        block_table=None,
     ):
         assert attn_metadata.dcp_context is not None, "DCP SFA requires attn_metadata.dcp_context."
         assert self.dcp_group is not None, "DCP SFA requires dcp_group when dcp_size > 1."

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -1,0 +1,470 @@
+"""Standalone SFA backend for Sparse KV offload.
+
+All Sparse KV offload related attention logic lives in this module and is selected by
+``AscendSFABackend.get_impl_cls()`` / ``get_builder_cls()`` when
+``sparse_kv_offload_config.enabled`` is set, keeping ``sfa_v1.py`` clean.
+
+Data plane (see zsc-sfa-kv-offload-merge-plan.md):
+
+- prefill (debug intermediate state, only reachable with
+  ``keep_device_kv_cache=True``): ``exec_kv`` writes the NPU paged main
+  cache as usual, then the layer's cache rows are committed D2H
+  (``cache_cpu[slot] = cache_npu[slot]``) through the manager;
+- decode: no NPU main K/V cache at all (indexer K cache only). The current
+  token's K/V is produced compute-only and committed D2H directly; top-k
+  misses are loaded H2D into the resident (topk) buffer and a single
+  resident SFA attention runs.
+"""
+
+from typing import Any, TypeVar
+
+import torch
+import torch_npu
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
+)
+from vllm.logger import logger
+
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.sfa_v1 import (
+    AscendSFAImpl,
+    AscendSFAMetadata,
+    AscendSFAMetadataBuilder,
+    PreprocessType,
+)
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    build_valid_topk_mask,
+    split_decodes_and_prefills,
+)
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    get_sparse_kv_offload_manager,
+)
+
+M = TypeVar("M", bound=AscendSFAMetadata)
+
+
+def _check_device_kv_cache_exist() -> None:
+    # prefill/mixed handling only exists for single-node PD-colocate debug;
+    # a PD-disaggregated decode node never receives prefill batches.
+    if not get_ascend_config().sparse_kv_offload_config.keep_device_kv_cache:
+        raise RuntimeError(
+            "Sparse KV offload received a prefill/mixed batch without "
+            "keep_device_kv_cache=True; a PD-disaggregated decode node "
+            "only accepts decode requests"
+        )
+
+
+class AscendSFAKVOffloadMetadataBuilder(AscendSFAMetadataBuilder):
+    """Fills the offload-specific SFA metadata (decode split + request ids)."""
+
+    def __init__(
+        self,
+        kv_cache_spec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+        metadata_cls: type[AscendSFAMetadata] | None = None,
+        supports_dcp_with_varlen: bool = False,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls,
+            supports_dcp_with_varlen,
+        )
+        kv_transfer_config = vllm_config.kv_transfer_config
+        self.is_pd_decode_consumer = (
+            kv_transfer_config is not None
+            and kv_transfer_config.is_kv_consumer
+            and not kv_transfer_config.is_kv_producer
+        )
+
+    def _populate_offload_metadata(
+        self,
+        metadata: AscendSFAMetadata,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+    ) -> AscendSFAMetadata:
+        num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.decode_threshold,
+            # The D node has already loaded the prompt KV from P. vLLM still
+            # marks the one-token boundary step as prefilling because its
+            # computed-token count is N - 1, but SFA must execute it through
+            # the decode-offload path. Keep colocated producer/debug behavior
+            # unchanged so genuine short prefills still populate the cache.
+            treat_short_extends_as_decodes=self.is_pd_decode_consumer,
+        )
+        metadata.num_decodes = num_decodes
+        metadata.num_prefills = num_prefills
+        metadata.num_decode_tokens = num_decode_tokens
+        metadata.req_ids_tensor = common_attn_metadata.req_ids_tensor
+        metadata.token_to_req = common_attn_metadata.token_to_req
+        return metadata
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+        **kwargs: Any,
+    ) -> AscendSFAMetadata:
+        metadata = super().build(common_prefix_len, common_attn_metadata, fast_build, **kwargs)
+        return self._populate_offload_metadata(metadata, common_attn_metadata)
+
+    def build_for_drafting(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        draft_index: int,
+        **kwargs: Any,
+    ) -> AscendSFAMetadata:
+        metadata = super().build_for_drafting(
+            common_attn_metadata,
+            draft_index,
+            **kwargs,
+        )
+        return self._populate_offload_metadata(metadata, common_attn_metadata)
+
+
+class AscendSFAKVOffloadImpl(AscendSFAImpl):
+    """SFA implementation that routes main MLA K/V through the CPU pool."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None,
+        attn_type: str,
+        kv_sharing_target_layer_name: str | None,
+        **kwargs,
+    ):
+        super().__init__(
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,
+            alibi_slopes,
+            sliding_window,
+            kv_cache_dtype,
+            logits_soft_cap,
+            attn_type,
+            kv_sharing_target_layer_name,
+            **kwargs,
+        )
+        if self.enable_dsa_cp:
+            raise NotImplementedError("Sparse KV offload currently requires TP without context parallelism")
+        if self.enable_sparse_sfa_c8:
+            raise NotImplementedError(
+                "Sparse KV offload does not support the sparse SFA C8 main "
+                "cache; sparse LI C8 is supported for the device-resident "
+                "indexer cache."
+            )
+        self._current_layer_name: str | None = None
+
+    def _resolve_preprocess_type(self, act_dtype: torch.dtype) -> PreprocessType:
+        logger.warning_once(
+            "Sparse KV offload requires the native SFA preprocessing path; sfa_prolog_v3/mlapo is disabled."
+        )
+        return PreprocessType.NATIVE
+
+    @staticmethod
+    def _cpu_cache_pair(manager, layer_name: str):
+        layer_id = manager._get_offload_layer_id(layer_name)
+        if manager.tp_rank != 0:
+            return None, None
+        return manager.k_caches_cpu[layer_id], manager.v_caches_cpu[layer_id]
+
+    @staticmethod
+    def _resident_views(manager, layer_name: str, rows: int):
+        layer_id = manager._get_offload_layer_id(layer_name)
+        buffer_k = manager.topk_buffers_k[layer_id]
+        buffer_v = manager.topk_buffers_v[layer_id]
+        pages_per_row = manager.topk_buffer_size // manager.block_size
+        resident_pages = rows * pages_per_row
+        resident_k = buffer_k[:rows].view(
+            resident_pages,
+            manager.block_size,
+            buffer_k.shape[-2],
+            buffer_k.shape[-1],
+        )
+        resident_v = buffer_v[:rows].view(
+            resident_pages,
+            manager.block_size,
+            buffer_v.shape[-2],
+            buffer_v.shape[-1],
+        )
+        return (
+            resident_k,
+            resident_v,
+            manager.current_slots_npu[:rows],
+            manager.resident_block_table_npu[:rows],
+            manager.resident_query_lens_npu[:rows],
+            manager.resident_seq_lens_npu[:rows],
+        )
+
+    def _offload_layer_name(self) -> str:
+        layer_name = self.layer_name or self._current_layer_name
+        if layer_name is None:
+            raise RuntimeError("Sparse KV offload requires a bound attention layer name")
+        return layer_name
+
+    @staticmethod
+    def _is_decode_only(attn_metadata: M) -> bool:
+        return (
+            attn_metadata.attn_state in (AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding)
+            and int(getattr(attn_metadata, "num_prefills", 0) or 0) == 0
+            and int(getattr(attn_metadata, "num_decodes", 0) or 0) > 0
+        )
+
+    @staticmethod
+    def _pad_to_input_tokens(
+        attn_output: torch.Tensor,
+        num_input_tokens: int,
+    ) -> torch.Tensor:
+        if attn_output.shape[0] >= num_input_tokens:
+            return attn_output
+        padded = attn_output.new_zeros(num_input_tokens, *attn_output.shape[1:])
+        padded[: attn_output.shape[0]] = attn_output
+        return padded
+
+    @staticmethod
+    def _in_graph_runtime() -> bool:
+        if not is_forward_context_available():
+            return False
+        forward_context = get_forward_context()
+        runtime_mode = getattr(
+            forward_context,
+            "cudagraph_runtime_mode",
+            CUDAGraphMode.NONE,
+        )
+        return forward_context.capturing or runtime_mode not in (
+            None,
+            CUDAGraphMode.NONE,
+        )
+
+    def forward(
+        self,
+        layer_name,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: M,
+        need_gather_q_kv: bool = False,
+        output: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        self._current_layer_name = layer_name
+        try:
+            return super().forward(layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv, output)
+        finally:
+            self._current_layer_name = None
+
+    def _compute_kv_only(
+        self,
+        kv_no_split: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Decode-only KV generation that never touches an NPU paged cache."""
+        B = kv_no_split.shape[0]
+        N = self.num_kv_heads
+        S = 1
+        assert self.kv_a_layernorm is not None, "kv_a_layernorm must be initialized"
+        kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
+        rms_in, rope_in = kv_no_split.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        k_nope_flat, _ = torch_npu.npu_rms_norm(
+            rms_in.view(-1, self.kv_lora_rank),
+            self.kv_a_layernorm.weight,
+            epsilon=self.kv_a_layernorm.variance_epsilon,
+        )
+        k_nope = k_nope_flat.view(B, N, S, self.kv_lora_rank)
+        k_pe = torch_npu.npu_interleave_rope(
+            rope_in,
+            cos,
+            sin,
+        )
+        return k_nope, k_pe
+
+    def exec_kv(
+        self,
+        kv_no_split: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        kv_cache: tuple,
+        slots: torch.Tensor,
+        attn_metadata: M,
+    ):
+        if self._is_decode_only(attn_metadata):
+            k_nope, k_pe = self._compute_kv_only(kv_no_split, cos, sin)
+            manager = get_sparse_kv_offload_manager()
+            layer_name = self._offload_layer_name()
+            k_cache_cpu, v_cache_cpu = self._cpu_cache_pair(manager, layer_name)
+            manager.offload_new_kv(
+                slot_mapping=slots,
+                k_cache_cpu=k_cache_cpu,
+                v_cache_cpu=v_cache_cpu,
+                k_cache_npu=None,
+                v_cache_npu=None,
+                k=k_nope,
+                v=k_pe,
+                has_prefill=False,
+                capturing=self._in_graph_runtime(),
+            )
+            return k_pe, k_nope
+
+        # Prefill / mixed batch (colocate debug only): stage in the NPU paged
+        # main cache as usual, then commit the written rows D2H into the
+        # shared CPU pool.
+        _check_device_kv_cache_exist()
+        result = super().exec_kv(kv_no_split, cos, sin, kv_cache, slots, attn_metadata)
+        manager = get_sparse_kv_offload_manager()
+        layer_name = self._offload_layer_name()
+        k_cache_cpu, v_cache_cpu = self._cpu_cache_pair(manager, layer_name)
+        manager.offload_new_kv(
+            slot_mapping=slots,
+            k_cache_cpu=k_cache_cpu,
+            v_cache_cpu=v_cache_cpu,
+            k_cache_npu=kv_cache[0],
+            v_cache_npu=kv_cache[1],
+            k=None,
+            v=None,
+            has_prefill=True,
+            capturing=self._in_graph_runtime(),
+        )
+        return result
+
+    def _execute_sparse_flash_attention_process(
+        self,
+        ql_nope,
+        q_pe,
+        kv_cache,
+        topk_indices,
+        attn_metadata,
+        actual_seq_lengths_query,
+        actual_seq_lengths_key,
+        block_table=None,
+    ):
+        num_decodes = int(getattr(attn_metadata, "num_decodes", 0) or 0)
+        num_decode_tokens = int(getattr(attn_metadata, "num_decode_tokens", 0) or 0)
+        num_prefills = int(getattr(attn_metadata, "num_prefills", 0) or 0)
+        manager = get_sparse_kv_offload_manager()
+        layer_name = self._offload_layer_name()
+
+        if num_decode_tokens == 0:
+            # Pure prefill batch (colocate debug only).
+            _check_device_kv_cache_exist()
+            return super()._execute_sparse_flash_attention_process(
+                ql_nope,
+                q_pe,
+                kv_cache,
+                topk_indices,
+                attn_metadata,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+                block_table=block_table,
+            )
+
+        if attn_metadata.req_ids_tensor is None or attn_metadata.token_to_req is None:
+            raise RuntimeError("Sparse KV offload requires req_ids_tensor/token_to_req metadata")
+        token_to_req = attn_metadata.token_to_req[:num_decode_tokens]
+        row_to_req = token_to_req.to(dtype=torch.int64)
+        decode_seq_lens = torch.index_select(
+            actual_seq_lengths_key[:num_decodes],
+            0,
+            row_to_req,
+        )
+        decode_cum_query_lens = actual_seq_lengths_query[:num_decodes]
+        decode_query_lens = decode_cum_query_lens.clone()
+        if num_decodes > 1:
+            decode_query_lens[1:] -= decode_cum_query_lens[:-1]
+        # Only the query span can be rewritten by the next MTP step.
+        stable_prefix_lens = (actual_seq_lengths_key[:num_decodes] - decode_query_lens).clamp_min_(0)
+        decode_stable_prefix_lens = torch.index_select(
+            stable_prefix_lens,
+            0,
+            row_to_req,
+        )
+        decode_topk = topk_indices[:num_decode_tokens]
+        seq_len_thresholds = decode_seq_lens.view(
+            decode_seq_lens.shape[0],
+            *([1] * (decode_topk.ndim - 1)),
+        )
+        valid_topk = build_valid_topk_mask(decode_topk, seq_len_thresholds)
+        decode_topk = torch.where(
+            valid_topk,
+            decode_topk,
+            torch.full_like(decode_topk, -1),
+        )
+        if decode_topk.ndim == 3 and decode_topk.shape[1] == 1:
+            decode_topk = decode_topk.squeeze(1)
+        if decode_topk.ndim != 2:
+            raise ValueError("Sparse KV offload top-k must have [tokens, topk] shape")
+
+        (
+            resident_k,
+            resident_v,
+            resident_slot_indices,
+            resident_block_table,
+            resident_query_lens,
+            resident_seq_lens,
+        ) = self._resident_views(manager, layer_name, num_decode_tokens)
+        decode_req_ids = torch.index_select(
+            attn_metadata.req_ids_tensor[:num_decodes],
+            0,
+            row_to_req,
+        )
+        manager.onload_topk_kv(
+            layer_name,
+            num_decode_tokens,
+            num_decodes,
+            attn_metadata.block_table[:num_decodes],
+            decode_topk,
+            resident_slot_indices,
+            decode_req_ids,
+            decode_stable_prefix_lens,
+            token_to_req,
+            capturing=self._in_graph_runtime(),
+            skip_topk=self.skip_topk,
+        )
+        decode_attn_output = DeviceOperator.execute_sparse_flash_attention_process(
+            self,
+            ql_nope[:num_decode_tokens],
+            q_pe[:num_decode_tokens],
+            (resident_k, resident_v),
+            resident_slot_indices.unsqueeze(1),
+            attn_metadata,
+            resident_query_lens,
+            resident_seq_lens,
+            block_table=resident_block_table,
+        )
+        if num_prefills == 0:
+            return self._pad_to_input_tokens(decode_attn_output, ql_nope.shape[0])
+
+        # Mixed batch (colocate debug only): prefill rows still attend the NPU
+        # paged cache. The cumulative query lengths are rebased to the first
+        # prefill request.
+        _check_device_kv_cache_exist()
+        prefill_query_offset = actual_seq_lengths_query[num_decodes - 1]
+        prefill_query_lens = actual_seq_lengths_query[num_decodes:] - prefill_query_offset
+        prefill_block_table = attn_metadata.block_table[num_decodes : num_decodes + num_prefills]
+        prefill_attn_output = super()._execute_sparse_flash_attention_process(
+            ql_nope[num_decode_tokens:],
+            q_pe[num_decode_tokens:],
+            kv_cache,
+            topk_indices[num_decode_tokens:],
+            attn_metadata,
+            prefill_query_lens,
+            actual_seq_lengths_key[num_decodes:],
+            block_table=prefill_block_table,
+        )
+        attn_output = torch.cat([decode_attn_output, prefill_attn_output], dim=0)
+        return self._pad_to_input_tokens(attn_output, ql_nope.shape[0])

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -39,6 +39,11 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.mxfp_compat import FLOAT8_E8M0FNU_DTYPE
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    OFFLOAD_K_CACHE_NPU_INDEX,
+    OFFLOAD_KV_CACHE_TUPLE_LEN,
+    OFFLOAD_V_CACHE_NPU_INDEX,
+)
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.memcache_comm_fence import (
     record_attention_compute_start,
@@ -121,6 +126,10 @@ class AscendSFABackend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls():
+        if get_ascend_config().sparse_kv_offload_config.enabled:
+            from vllm_ascend.attention.sfa_kv_offload import AscendSFAKVOffloadMetadataBuilder
+
+            return AscendSFAKVOffloadMetadataBuilder
         if enable_sfa_dcp_replicated_indexer():
             from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
 
@@ -139,6 +148,10 @@ class AscendSFABackend(AttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["AscendSFAImpl"]:
+        if get_ascend_config().sparse_kv_offload_config.enabled:
+            from vllm_ascend.attention.sfa_kv_offload import AscendSFAKVOffloadImpl
+
+            return AscendSFAKVOffloadImpl
         if enable_sfa_dcp_replicated_indexer():
             from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPImpl
 
@@ -202,6 +215,10 @@ class AscendSFAMetadata:
     group_len: torch.Tensor | None = None
     group_key_idx: torch.Tensor | None = None
     group_key_cache_idx: torch.Tensor | None = None
+    # Request identity for the Sparse KV offload resident LRU; only populated
+    # by AscendSFAKVOffloadMetadataBuilder.
+    req_ids_tensor: torch.Tensor | None = None
+    token_to_req: torch.Tensor | None = None
 
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -1530,7 +1547,15 @@ class AscendSFAImpl(MLAAttentionImpl):
         return self.enable_sparse_li_c8 and get_ascend_config().c8_enable_reshape_optim
 
     def _execute_sparse_flash_attention_process(
-        self, ql_nope, q_pe, kv_cache, topk_indices, attn_metadata, actual_seq_lengths_query, actual_seq_lengths_key
+        self,
+        ql_nope,
+        q_pe,
+        kv_cache,
+        topk_indices,
+        attn_metadata,
+        actual_seq_lengths_query,
+        actual_seq_lengths_key,
+        block_table=None,
     ):
         return DeviceOperator.execute_sparse_flash_attention_process(
             self,
@@ -1541,6 +1566,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             attn_metadata,
             actual_seq_lengths_query,
             actual_seq_lengths_key,
+            block_table=block_table,
         )
 
     def _record_query_gather_context(
@@ -1762,6 +1788,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         main_cache = kv_cache
         if main_cache is None or not self.has_indexer:
             return main_cache
+
+        # Sparse KV offload registers the main MLA cache as a 6-tuple
+        # (k_npu, v_npu, k_cpu, v_cpu, topk_buffer_k, topk_buffer_v); the
+        # attention kernels only consume the leading NPU pair.
+        if len(main_cache) == OFFLOAD_KV_CACHE_TUPLE_LEN:
+            main_cache = (main_cache[OFFLOAD_K_CACHE_NPU_INDEX], main_cache[OFFLOAD_V_CACHE_NPU_INDEX])
 
         indexer_cache = self.indexer.k_cache.kv_cache
         if indexer_cache is None:

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -22,6 +22,14 @@ from vllm_ascend.utils import (
 SFA_QSFA_TILE_SIZE = 128
 
 
+def build_valid_topk_mask(
+    topk_indices: torch.Tensor,
+    seq_len_thresholds: torch.Tensor,
+) -> torch.Tensor:
+    """Mask padding and unwritten tail-block positions in SFA top-k rows."""
+    return (topk_indices >= 0) & (topk_indices < seq_len_thresholds)
+
+
 def get_sfa_qsfa_packed_head_dim(
     kv_lora_rank: int,
     qk_rope_head_dim: int,
@@ -240,6 +248,10 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
     group_len: torch.Tensor = None
     group_key_idx: torch.Tensor = None
     group_key_cache_idx: torch.Tensor = None
+    # Per-request / per-token request identity used by the Sparse KV offload
+    # resident LRU (adler32-hashed request ids and token->request mapping).
+    req_ids_tensor: torch.Tensor | None = None
+    token_to_req: torch.Tensor | None = None
 
     # TODO: Remove it when vLLM no longer uses this function.
     def unpadded(self, num_actual_tokens: int, num_actual_reqs: int) -> "AscendCommonAttentionMetadata":
@@ -295,6 +307,8 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
             group_len=self.group_len,
             group_key_idx=self.group_key_idx,
             group_key_cache_idx=self.group_key_cache_idx,
+            req_ids_tensor=_slice_reqs(self.req_ids_tensor),
+            token_to_req=(self.token_to_req[:num_actual_tokens] if self.token_to_req is not None else None),
         )
 
 

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -30,6 +30,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
     # main-cache property here; indexer-specific C8 properties belong to the
     # indexer spec.
     cache_sparse_sfa_c8: bool = False
+    store_on_host: bool = False
 
     @property
     def real_page_size_bytes(self) -> int:
@@ -67,6 +68,10 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             "All attention layers in the same KV cache group must use the same sparse SFA C8 setting."
         )
         first_spec = specs[0]
+        store_on_host_set = set(spec.store_on_host for spec in specs)
+        assert len(store_on_host_set) == 1, (
+            "All attention layers in the same KV cache group must use the same host storage setting."
+        )
         return cls(
             block_size=first_spec.block_size,
             num_kv_heads=first_spec.num_kv_heads,
@@ -82,6 +87,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             compress_ratio=first_spec.compress_ratio,
             model_version=first_spec.model_version,
             cache_sparse_sfa_c8=first_spec.cache_sparse_sfa_c8,
+            store_on_host=store_on_host_set.pop(),
         )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload.cpp
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload.cpp
@@ -1,0 +1,336 @@
+#include <torch/extension.h>
+#include <limits>
+#include <optional>
+#include <iostream>
+#include <chrono>
+#include <string>
+#include <stdexcept>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <ATen/Parallel.h>
+#include <torch/script.h>
+
+#include <acl/acl.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+
+#include <omp.h>
+#include <assert.h>
+#include <torch/torch.h>
+#include <pthread.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+  #define HOT_FUNCTION __attribute__((hot))
+  #define FORCE_INLINE inline __attribute__((always_inline))
+  #define LIKELY(x) __builtin_expect(!!(x), 1)
+  #define UNLIKELY(x) __builtin_expect(!!(x), 0)
+  #define RESTRICT __restrict__
+#else
+  #define HOT_FUNCTION
+  #define FORCE_INLINE inline
+  #define LIKELY(x) (x)
+  #define UNLIKELY(x) (x)
+  #define RESTRICT
+#endif
+
+constexpr int32_t EPOCH_RESET_THRESHOLD = 1 << 30;
+
+FORCE_INLINE int choose_lru_resident_threads(const int num_reqs, const int workspace_threads,
+                                             const int requested_threads) {
+  if (num_reqs <= 1) {
+    return 1;
+  }
+  int active_threads = num_reqs;
+  if (workspace_threads > 0) {
+    active_threads = std::min(active_threads, workspace_threads);
+  }
+  if (requested_threads > 0) {
+    active_threads = std::min(active_threads, requested_threads);
+  }
+  return std::max(active_threads, 1);
+}
+
+FORCE_INLINE bool is_valid_lru_resident_token(const int32_t token, const int32_t max_token) {
+  return token >= 0 && token < max_token;
+}
+
+FORCE_INLINE void reset_lru_resident_row(int32_t* RESTRICT slot_to_token_row, int32_t* RESTRICT lru_slots_row,
+                                         const int32_t capacity) {
+  std::fill(slot_to_token_row, slot_to_token_row + capacity, -1);
+  for (int32_t slot = 0; slot < capacity; ++slot) {
+    lru_slots_row[slot] = slot;
+  }
+}
+
+FORCE_INLINE int32_t next_lru_resident_epoch(int32_t* RESTRICT token_mark, int32_t* RESTRICT token_pos,
+                                             int32_t* RESTRICT epoch, const int32_t max_token) {
+  int32_t base = epoch[0] + 1;
+  if (UNLIKELY(base >= EPOCH_RESET_THRESHOLD)) {
+    std::fill(token_mark, token_mark + max_token, 0);
+    std::fill(token_pos, token_pos + max_token, -1);
+    base = 1;
+  }
+  epoch[0] = base;
+  return base;
+}
+
+FORCE_INLINE void process_one_lru_resident_row(
+    const int row, const int32_t topk, const int32_t capacity, const int32_t max_token, const int64_t* RESTRICT req_ids,
+    int64_t* RESTRICT last_req_ids, const int32_t* RESTRICT topk_indices, const int32_t* RESTRICT stable_prefix_lens,
+    int32_t* RESTRICT slot_to_token, int32_t* RESTRICT lru_slots, int32_t* RESTRICT current_slots,
+    int32_t* RESTRICT miss_count, int32_t* RESTRICT miss_tokens_out, int32_t* RESTRICT miss_slots_out,
+    int32_t* RESTRICT token_mark, int32_t* RESTRICT token_pos, int32_t* RESTRICT slot_workspace,
+    int32_t* RESTRICT miss_positions, int32_t* RESTRICT epoch) {
+  int32_t* RESTRICT slot_to_token_row = slot_to_token + static_cast<int64_t>(row) * capacity;
+  int32_t* RESTRICT lru_slots_row = lru_slots + static_cast<int64_t>(row) * capacity;
+  int32_t* RESTRICT current_slots_row = current_slots + static_cast<int64_t>(row) * topk;
+  int32_t* RESTRICT miss_tokens_row = miss_tokens_out + static_cast<int64_t>(row) * topk;
+  int32_t* RESTRICT miss_slots_row = miss_slots_out + static_cast<int64_t>(row) * topk;
+  const int32_t* RESTRICT topk_row = topk_indices + static_cast<int64_t>(row) * topk;
+  int32_t* RESTRICT hit_slots = slot_workspace;
+  int32_t* RESTRICT evictable_slots = slot_workspace + capacity;
+  int32_t* RESTRICT assigned_miss_slots = slot_workspace + static_cast<int64_t>(capacity) * 2;
+
+  std::fill(current_slots_row, current_slots_row + topk, -1);
+  std::fill(miss_tokens_row, miss_tokens_row + topk, -1);
+  std::fill(miss_slots_row, miss_slots_row + topk, -1);
+  miss_count[row] = 0;
+
+  const int64_t req_id = req_ids[row];
+  if (UNLIKELY(last_req_ids[row] != req_id)) {
+    reset_lru_resident_row(slot_to_token_row, lru_slots_row, capacity);
+    last_req_ids[row] = req_id;
+  }
+  const int32_t stable_prefix_len = std::clamp(stable_prefix_lens[row], 0, max_token);
+
+  const int32_t base = next_lru_resident_epoch(token_mark, token_pos, epoch, max_token);
+  for (int32_t pos = 0; pos < topk; ++pos) {
+    const int32_t token = topk_row[pos];
+    if (LIKELY(is_valid_lru_resident_token(token, max_token)) && token_mark[token] != base) {
+      token_mark[token] = base;
+      token_pos[token] = pos;
+    }
+  }
+
+  int32_t hit_count = 0;
+  int32_t evictable_count = 0;
+  for (int32_t order = 0; order < capacity; ++order) {
+    const int32_t slot = lru_slots_row[order];
+    if (UNLIKELY(slot < 0 || slot >= capacity)) {
+      continue;
+    }
+    int32_t token = slot_to_token_row[slot];
+    // The speculative suffix may have been overwritten in the CPU KV pool.
+    if (LIKELY(is_valid_lru_resident_token(token, max_token)) && UNLIKELY(token >= stable_prefix_len)) {
+      slot_to_token_row[slot] = -1;
+      token = -1;
+    }
+    if (LIKELY(is_valid_lru_resident_token(token, max_token)) && token_mark[token] == base) {
+      const int32_t pos = token_pos[token];
+      current_slots_row[pos] = slot;
+      hit_slots[hit_count] = slot;
+      ++hit_count;
+    } else {
+      evictable_slots[evictable_count] = slot;
+      ++evictable_count;
+    }
+  }
+
+  int32_t local_miss_count = 0;
+  for (int32_t pos = 0; pos < topk; ++pos) {
+    const int32_t token = topk_row[pos];
+    if (LIKELY(is_valid_lru_resident_token(token, max_token)) && current_slots_row[pos] < 0) {
+      miss_tokens_row[local_miss_count] = token;
+      miss_positions[local_miss_count] = pos;
+      ++local_miss_count;
+    }
+  }
+
+  const int32_t assign_count = std::min(local_miss_count, evictable_count);
+  for (int32_t miss_idx = 0; miss_idx < assign_count; ++miss_idx) {
+    const int32_t slot = evictable_slots[miss_idx];
+    const int32_t token = miss_tokens_row[miss_idx];
+    const int32_t pos = miss_positions[miss_idx];
+    slot_to_token_row[slot] = token;
+    current_slots_row[pos] = slot;
+    miss_slots_row[miss_idx] = slot;
+    assigned_miss_slots[miss_idx] = slot;
+    miss_count[row] = miss_idx + 1;
+  }
+
+  int32_t write_pos = 0;
+  for (int32_t idx = assign_count; idx < evictable_count; ++idx) {
+    lru_slots_row[write_pos] = evictable_slots[idx];
+    ++write_pos;
+  }
+  for (int32_t idx = 0; idx < assign_count; ++idx) {
+    lru_slots_row[write_pos] = assigned_miss_slots[idx];
+    ++write_pos;
+  }
+  for (int32_t idx = 0; idx < hit_count; ++idx) {
+    lru_slots_row[write_pos] = hit_slots[idx];
+    ++write_pos;
+  }
+}
+
+HOT_FUNCTION void lru_resident_compact(uintptr_t req_ids_ptr, uintptr_t last_req_ids_ptr, uintptr_t topk_indices_ptr,
+                                       uintptr_t stable_prefix_lens_ptr, uintptr_t slot_to_token_ptr,
+                                       uintptr_t lru_slots_ptr, uintptr_t current_slots_ptr, uintptr_t miss_count_ptr,
+                                       uintptr_t miss_tokens_ptr, uintptr_t miss_slots_ptr,
+                                       uintptr_t token_mark_workspace_ptr, uintptr_t token_pos_workspace_ptr,
+                                       uintptr_t slot_workspace_ptr, uintptr_t miss_position_workspace_ptr,
+                                       uintptr_t epochs_ptr, int64_t num_reqs, int64_t topk, int64_t capacity,
+                                       int64_t max_token, int64_t workspace_threads, int64_t requested_threads) {
+  if (num_reqs <= 0 || topk <= 0 || capacity <= 0 || max_token <= 0) {
+    return;
+  }
+
+  auto* RESTRICT req_ids = reinterpret_cast<int64_t*>(req_ids_ptr);
+  auto* RESTRICT last_req_ids = reinterpret_cast<int64_t*>(last_req_ids_ptr);
+  auto* RESTRICT topk_indices = reinterpret_cast<int32_t*>(topk_indices_ptr);
+  auto* RESTRICT stable_prefix_lens = reinterpret_cast<int32_t*>(stable_prefix_lens_ptr);
+  auto* RESTRICT slot_to_token = reinterpret_cast<int32_t*>(slot_to_token_ptr);
+  auto* RESTRICT lru_slots = reinterpret_cast<int32_t*>(lru_slots_ptr);
+  auto* RESTRICT current_slots = reinterpret_cast<int32_t*>(current_slots_ptr);
+  auto* RESTRICT miss_count = reinterpret_cast<int32_t*>(miss_count_ptr);
+  auto* RESTRICT miss_tokens = reinterpret_cast<int32_t*>(miss_tokens_ptr);
+  auto* RESTRICT miss_slots = reinterpret_cast<int32_t*>(miss_slots_ptr);
+  auto* RESTRICT token_mark_workspace = reinterpret_cast<int32_t*>(token_mark_workspace_ptr);
+  auto* RESTRICT token_pos_workspace = reinterpret_cast<int32_t*>(token_pos_workspace_ptr);
+  auto* RESTRICT slot_workspace = reinterpret_cast<int32_t*>(slot_workspace_ptr);
+  auto* RESTRICT miss_position_workspace = reinterpret_cast<int32_t*>(miss_position_workspace_ptr);
+  auto* RESTRICT epochs = reinterpret_cast<int32_t*>(epochs_ptr);
+
+  const int num_reqs_int = static_cast<int>(num_reqs);
+  const int topk_int = static_cast<int>(topk);
+  const int capacity_int = static_cast<int>(capacity);
+  const int max_token_int = static_cast<int>(max_token);
+  const int active_threads = choose_lru_resident_threads(num_reqs_int, static_cast<int>(workspace_threads),
+                                                         static_cast<int>(requested_threads));
+
+  if (active_threads == 1) {
+    for (int row = 0; row < num_reqs_int; ++row) {
+      process_one_lru_resident_row(row, topk_int, capacity_int, max_token_int, req_ids, last_req_ids, topk_indices,
+                                   stable_prefix_lens, slot_to_token, lru_slots, current_slots, miss_count, miss_tokens,
+                                   miss_slots, token_mark_workspace, token_pos_workspace, slot_workspace,
+                                   miss_position_workspace, epochs);
+    }
+    return;
+  }
+
+#pragma omp parallel num_threads(active_threads)
+  {
+    const int thread_id = omp_get_thread_num();
+    int32_t* RESTRICT token_mark = token_mark_workspace + static_cast<int64_t>(thread_id) * max_token_int;
+    int32_t* RESTRICT token_pos = token_pos_workspace + static_cast<int64_t>(thread_id) * max_token_int;
+    int32_t* RESTRICT slots = slot_workspace + static_cast<int64_t>(thread_id) * capacity_int * 3;
+    int32_t* RESTRICT miss_positions = miss_position_workspace + static_cast<int64_t>(thread_id) * topk_int;
+    int32_t* RESTRICT epoch = epochs + thread_id;
+    for (int row = thread_id; row < num_reqs_int; row += active_threads) {
+      process_one_lru_resident_row(row, topk_int, capacity_int, max_token_int, req_ids, last_req_ids, topk_indices,
+                                   stable_prefix_lens, slot_to_token, lru_slots, current_slots, miss_count, miss_tokens,
+                                   miss_slots, token_mark, token_pos, slots, miss_positions, epoch);
+    }
+  }
+}
+
+int32_t compute_lru_resident_addrs(const at::Tensor& miss_count, const at::Tensor& miss_tokens,
+                                   const at::Tensor& miss_slots, const at::Tensor& block_table,
+                                   const int32_t block_size, const int32_t token_size_bytes_k,
+                                   const int32_t token_size_bytes_v, const int64_t gvas_k_base,
+                                   const int64_t gvas_v_base, const int64_t addr_k_base, const int64_t addr_v_base,
+                                   const int32_t resident_capacity, const int32_t max_num_threads,
+                                   at::Tensor& gvas_buffer, at::Tensor& addr_buffer, at::Tensor& size_buffer,
+                                   at::Tensor& num_tokens_buffer) {
+  const int32_t num_reqs = miss_tokens.size(0);
+  const int32_t topk = miss_tokens.size(1);
+  const int32_t max_num_tokens_to_load = num_reqs * topk;
+  const int32_t max_num_blocks = block_table.size(1);
+  const int32_t block_size_bytes_k = block_size * token_size_bytes_k;
+  const int32_t block_size_bytes_v = block_size * token_size_bytes_v;
+  TORCH_CHECK(miss_count.size(0) >= num_reqs, "miss_count size not enough for loading.");
+  TORCH_CHECK(miss_slots.size(0) == num_reqs && miss_slots.size(1) == topk,
+              "miss_slots shape should match miss_tokens.");
+  TORCH_CHECK(gvas_buffer.size(0) >= max_num_tokens_to_load * 2, "gvas_buffer size not enough for loading.");
+  TORCH_CHECK(addr_buffer.size(0) >= max_num_tokens_to_load * 2, "addr_buffer size not enough for loading.");
+  TORCH_CHECK(size_buffer.size(0) >= max_num_tokens_to_load * 2, "size_buffer size not enough for loading.");
+  TORCH_CHECK(miss_count.scalar_type() == at::kInt, "miss_count wrong dtype, should be int32.");
+  TORCH_CHECK(miss_tokens.scalar_type() == at::kInt, "miss_tokens wrong dtype, should be int32.");
+  TORCH_CHECK(miss_slots.scalar_type() == at::kInt, "miss_slots wrong dtype, should be int32.");
+  TORCH_CHECK(block_table.scalar_type() == at::kInt, "block_table wrong dtype, should be int32.");
+  TORCH_CHECK(gvas_buffer.scalar_type() == at::kLong, "gvas_buffer wrong dtype, should be int64.");
+  TORCH_CHECK(addr_buffer.scalar_type() == at::kLong, "addr_buffer wrong dtype, should be int64.");
+  TORCH_CHECK(size_buffer.scalar_type() == at::kInt, "size_buffer wrong dtype, should be int32.");
+
+  const int32_t* miss_count_ptr = static_cast<int32_t*>(miss_count.data_ptr());
+  const int32_t* miss_tokens_ptr = static_cast<int32_t*>(miss_tokens.data_ptr());
+  const int32_t* miss_slots_ptr = static_cast<int32_t*>(miss_slots.data_ptr());
+  const int32_t* block_table_ptr = static_cast<int32_t*>(block_table.data_ptr());
+  int64_t* gvas_buffer_ptr = static_cast<int64_t*>(gvas_buffer.data_ptr());
+  int64_t* addr_buffer_ptr = static_cast<int64_t*>(addr_buffer.data_ptr());
+  int32_t* size_buffer_ptr = static_cast<int32_t*>(size_buffer.data_ptr());
+  int32_t* num_tokens_buffer_ptr = static_cast<int32_t*>(num_tokens_buffer.data_ptr());
+
+  int n_threads = std::min(num_reqs, max_num_threads);
+  n_threads = std::max(n_threads, 1);
+
+  std::vector<int32_t> num_tokens_to_load_req(num_reqs);
+#pragma omp parallel for num_threads(n_threads)
+  for (size_t req_idx = 0; req_idx < num_reqs; ++req_idx) {
+    int32_t count = miss_count_ptr[req_idx];
+    count = std::max(count, 0);
+    count = std::min(count, topk);
+    num_tokens_to_load_req[req_idx] = count;
+  }
+  int32_t num_tokens_to_load_sum = std::accumulate(num_tokens_to_load_req.begin(), num_tokens_to_load_req.end(), 0);
+  std::vector<int32_t> req_start_locs(num_reqs);
+  int32_t cumsum = 0;
+  for (size_t req_idx = 0; req_idx < num_reqs; ++req_idx) {
+    req_start_locs[req_idx] = cumsum;
+    cumsum += num_tokens_to_load_req[req_idx];
+  }
+
+#pragma omp parallel for num_threads(n_threads)
+  for (size_t req_idx = 0; req_idx < num_reqs; ++req_idx) {
+    int32_t req_start_loc_k = req_start_locs[req_idx];
+    int32_t req_start_loc_v = num_tokens_to_load_sum + req_start_loc_k;
+    for (int32_t idx = 0; idx < num_tokens_to_load_req[req_idx]; ++idx) {
+      const int32_t token = miss_tokens_ptr[req_idx * topk + idx];
+      const int32_t slot = miss_slots_ptr[req_idx * topk + idx];
+      if (token < 0 || slot < 0 || slot >= resident_capacity) {
+        continue;
+      }
+      const int32_t block_id = token / block_size;
+      if (block_id < 0 || block_id >= max_num_blocks) {
+        continue;
+      }
+      const int32_t offset_in_block = token % block_size;
+      const int32_t block_indice = block_table_ptr[req_idx * max_num_blocks + block_id];
+      if (block_indice < 0) {
+        continue;
+      }
+      const int64_t gvas_k = gvas_k_base + block_indice * block_size_bytes_k + offset_in_block * token_size_bytes_k;
+      const int64_t gvas_v = gvas_v_base + block_indice * block_size_bytes_v + offset_in_block * token_size_bytes_v;
+      const int64_t addr_k = addr_k_base + (req_idx * resident_capacity + slot) * token_size_bytes_k;
+      const int64_t addr_v = addr_v_base + (req_idx * resident_capacity + slot) * token_size_bytes_v;
+      gvas_buffer_ptr[req_start_loc_k + idx] = gvas_k;
+      gvas_buffer_ptr[req_start_loc_v + idx] = gvas_v;
+      addr_buffer_ptr[req_start_loc_k + idx] = addr_k;
+      addr_buffer_ptr[req_start_loc_v + idx] = addr_v;
+    }
+  }
+
+  std::fill_n(size_buffer_ptr, num_tokens_to_load_sum, token_size_bytes_k);
+  std::fill_n(&(size_buffer_ptr[num_tokens_to_load_sum]), num_tokens_to_load_sum, token_size_bytes_v);
+
+  num_tokens_buffer_ptr[0] = num_tokens_to_load_sum * 2;
+  return num_tokens_to_load_sum;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  namespace py = pybind11;
+  m.def("lru_resident_compact", &lru_resident_compact,
+        "CPU LRU resident compact miss prepare with OpenMP row-level parallelism");
+  m.def("compute_lru_resident_addrs", &compute_lru_resident_addrs,
+        "Compute sparse H2D metadata for compact LRU resident miss loads");
+}

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -1,0 +1,1081 @@
+import contextlib
+import os
+import typing
+from zlib import adler32
+
+import numpy as np
+import torch
+import torch_npu
+
+with contextlib.suppress(ImportError):
+    # we should remove this after memfabric.offload is merged to master and available in ci machine.
+    from memfabric_hybrid import offload  # type: ignore
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+)
+from vllm.logger import logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.utils import CpuGpuBuffer
+
+from vllm_ascend.ascend_config import SparseKVOffloadConfig, get_ascend_config
+
+# Main BF16 cache:
+# [k_cache, v_cache, k_cache_cpu, v_cache_cpu, topk_buffer_k, topk_buffer_v].
+# Sparse LI C8 indexer caches are separate and
+# remain device-resident, so they are not registered with this manager.
+OFFLOAD_KV_CACHE_TUPLE_LEN = 6
+OFFLOAD_K_CACHE_NPU_INDEX = 0
+OFFLOAD_V_CACHE_NPU_INDEX = 1
+OFFLOAD_K_CACHE_CPU_INDEX = 2
+OFFLOAD_V_CACHE_CPU_INDEX = 3
+OFFLOAD_TOPK_BUFFER_K_INDEX = 4
+OFFLOAD_TOPK_BUFFER_V_INDEX = 5
+
+
+_SUBSCRIBED_COMPUTE_STREAMS: set[object] = set()
+
+
+def get_subscribed_compute_streams() -> set:
+    return _SUBSCRIBED_COMPUTE_STREAMS
+
+
+def get_host_device_memory_usage_ratio(kv_cache_specs: dict[str, KVCacheSpec]) -> float:
+    page_size_bytes_host = 0
+    page_size_bytes_device = 0
+    for kv_cache_spec in kv_cache_specs.values():
+        assert isinstance(kv_cache_spec, KVCacheSpec)
+        if getattr(kv_cache_spec, "store_on_host", False):
+            page_size_bytes_host += kv_cache_spec.page_size_bytes
+        else:
+            page_size_bytes_device += kv_cache_spec.page_size_bytes
+
+    assert page_size_bytes_device > 0, "Case of no device kv cache is not considered."
+    return page_size_bytes_host / page_size_bytes_device
+
+
+def allocate_kv_offload_topk_buffer_pair(
+    vllm_config: VllmConfig,
+    sparse_kv_offload_config: SparseKVOffloadConfig,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    decode_width = 1
+    if vllm_config.speculative_config is not None:
+        decode_width += vllm_config.speculative_config.num_speculative_tokens
+
+    topk_buffer_size = sparse_kv_offload_config.topk_buffer_size
+    num_kv_heads = 1  # sparse kv offload only support sfa(mla) now.
+    k_dim = vllm_config.model_config.hf_text_config.kv_lora_rank
+    v_dim = vllm_config.model_config.hf_text_config.qk_rope_head_dim
+    max_num_topk_rows = min(
+        vllm_config.scheduler_config.max_num_batched_tokens,
+        vllm_config.scheduler_config.max_num_seqs * decode_width,
+    )
+    topk_buffer_k_size_bytes = max_num_topk_rows * topk_buffer_size * num_kv_heads * k_dim * torch.bfloat16.itemsize
+    topk_buffer_v_size_bytes = max_num_topk_rows * topk_buffer_size * num_kv_heads * v_dim * torch.bfloat16.itemsize
+    # NOTE make sure to allocate k+v together and split them after allocate.
+    # Refer to the comment in empty_aligned_int8_cpu_tensors for reason.
+    topk_buffer_raw = torch.empty([topk_buffer_k_size_bytes + topk_buffer_v_size_bytes], dtype=torch.int8, device="npu")
+    topk_buffer_k = (
+        topk_buffer_raw[:topk_buffer_k_size_bytes]
+        .view(torch.bfloat16)
+        .view([max_num_topk_rows, topk_buffer_size, num_kv_heads, k_dim])
+    )
+    topk_buffer_v = (
+        topk_buffer_raw[topk_buffer_k_size_bytes : topk_buffer_k_size_bytes + topk_buffer_v_size_bytes]
+        .view(torch.bfloat16)
+        .view([max_num_topk_rows, topk_buffer_size, num_kv_heads, v_dim])
+    )
+    return (topk_buffer_k, topk_buffer_v)
+
+
+def allocate_kv_offload_topk_profile_buffers(
+    kv_cache_spec: dict[str, KVCacheSpec],
+    vllm_config: VllmConfig,
+    sparse_kv_offload_config: SparseKVOffloadConfig,
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    num_offload_layers = sum(bool(getattr(spec, "store_on_host", False)) for spec in kv_cache_spec.values())
+    if num_offload_layers == 0:
+        raise RuntimeError("Sparse KV offload profile did not find any host-resident SFA KV cache layers.")
+
+    buffers = [
+        allocate_kv_offload_topk_buffer_pair(vllm_config, sparse_kv_offload_config) for _ in range(num_offload_layers)
+    ]
+    buffer_bytes = sum(tensor.numel() * tensor.element_size() for buffer_pair in buffers for tensor in buffer_pair)
+    logger.info_once(
+        "Sparse KV offload reserved %.2f GiB of KV offload topk buffers across %d layers for profile run.",
+        buffer_bytes / (1 << 30),
+        num_offload_layers,
+    )
+    return buffers
+
+
+_CPU_CACHE_ALIGNMENT = 2 * 1024 * 1024
+
+
+def empty_aligned_int8_cpu_tensors(
+    sizes: list[int],
+    alignment: int = _CPU_CACHE_ALIGNMENT,
+) -> list[torch.Tensor]:
+    """
+    Allocate multiple int8 tensors with specified sizes,
+    each aligned to specified alignment,
+    and minimize the gap between each tensor's data_ptr.
+    This is used for GLM-5.2 indexer reuse optimize:
+    make sure that delta_k_cache_addrs and delta_v_cache_addrs
+    between each two layers are the same,
+    so we only need to add one delta_addr to the addr tensor of sparse_copy
+    without need to mask k and v separately.
+    Same reason that we allocate topk_buffer_k & topk_buffer_v together.
+    """
+    chunk_nums = [cdiv(size, alignment) for size in sizes]
+    total_chunk_num = 1 + sum(chunk_nums)
+    raw_tensor = offload.empty([total_chunk_num * alignment], dtype=torch.int8, pin_memory=True)
+    base_addr = raw_tensor.data_ptr()
+    if base_addr % alignment:
+        base_addr = (base_addr // alignment + 1) * alignment
+    base_offset = base_addr - raw_tensor.data_ptr()
+    allocate_tensors = []
+    for size, chunk_num in zip(sizes, chunk_nums):
+        allocate_tensors.append(raw_tensor[base_offset : base_offset + size])
+        base_offset += chunk_num * alignment
+    return allocate_tensors
+
+
+def allocate_kv_cache_tensors_for_sparse_kv_offload(
+    k_tensor_size: int,
+    v_tensor_size: int,
+    alignment: int,
+    tp_rank: int,
+    keep_device_kv_cache: bool,
+    npu_kv_cache_allocate_func: typing.Callable,
+):
+    if tp_rank == 0:
+        [k_tensor_cpu, v_tensor_cpu] = empty_aligned_int8_cpu_tensors(
+            [k_tensor_size, v_tensor_size],
+            alignment,
+        )
+    else:
+        k_tensor_cpu = None
+        v_tensor_cpu = None
+
+    if keep_device_kv_cache:
+        k_tensor = npu_kv_cache_allocate_func(
+            k_tensor_size,
+            alignment,
+        )
+        v_tensor = npu_kv_cache_allocate_func(
+            v_tensor_size,
+            alignment,
+        )
+    else:
+        k_tensor = None
+        v_tensor = None
+
+    return (k_tensor, v_tensor, k_tensor_cpu, v_tensor_cpu, k_tensor_size + v_tensor_size)
+
+
+def reshape_kv_cache_tensors_for_sparse_kv_offload(
+    raw_cache_tensors: tuple,
+    current_kv_cache_spec: AttentionSpec,
+    attn_backend: type[AttentionBackend],
+    tp_rank: int,
+    vllm_config: VllmConfig,
+    sparse_kv_offload_config: SparseKVOffloadConfig,
+):
+    raw_k_tensor, raw_v_tensor, raw_k_tensor_cpu, raw_v_tensor_cpu, sum_page_size_bytes = raw_cache_tensors
+    assert sum_page_size_bytes % current_kv_cache_spec.page_size_bytes == 0
+    num_blocks = sum_page_size_bytes // current_kv_cache_spec.page_size_bytes
+    kv_cache_shape = attn_backend.get_kv_cache_shape(
+        num_blocks,
+        current_kv_cache_spec.block_size,
+        current_kv_cache_spec.num_kv_heads,
+        current_kv_cache_spec.head_size,
+    )
+    mla_num_blocks, mla_block_size, num_kv_heads, _ = kv_cache_shape
+    k_dim = vllm_config.model_config.hf_text_config.kv_lora_rank
+    v_dim = vllm_config.model_config.hf_text_config.qk_rope_head_dim
+    k_shape = (
+        mla_num_blocks,
+        mla_block_size,
+        num_kv_heads,
+        k_dim,
+    )
+    v_shape = (
+        mla_num_blocks,
+        mla_block_size,
+        num_kv_heads,
+        v_dim,
+    )
+    k_cache_dtype = v_cache_dtype = current_kv_cache_spec.dtype
+
+    k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape) if raw_k_tensor is not None else None
+    v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape) if raw_v_tensor is not None else None
+
+    if tp_rank == 0:
+        k_cache_cpu = raw_k_tensor_cpu.view(k_cache_dtype).view(k_shape)
+        v_cache_cpu = raw_v_tensor_cpu.view(v_cache_dtype).view(v_shape)
+    else:
+        k_cache_cpu = None
+        v_cache_cpu = None
+
+    topk_buffer_k, topk_buffer_v = allocate_kv_offload_topk_buffer_pair(vllm_config, sparse_kv_offload_config)
+    return (k_cache, v_cache, k_cache_cpu, v_cache_cpu, topk_buffer_k, topk_buffer_v)
+
+
+def update_sparse_kv_offload_metadata(
+    num_tokens: int,
+    num_reqs: int,
+    num_tokens_padded: int,
+    num_reqs_padded: int,
+    req_ids: list[str],
+    query_start_loc: CpuGpuBuffer,
+    offload_req_ids_tensor: CpuGpuBuffer,
+    offload_token_to_req: CpuGpuBuffer,
+) -> None:
+    """Populate per-request identity tensors for the Sparse KV offload LRU.
+
+    Request ids are adler32 hashes of the scheduler request id,
+    rows are reset whenever the occupying request changes.
+    """
+    offload_req_ids_tensor.np[:num_reqs_padded].fill(0)
+    effective_num_reqs = min(num_reqs, len(req_ids))
+    req_id_values = np.asarray(
+        [
+            adler32(req_id.encode("utf-8")) if isinstance(req_id, str) else row + 1
+            for row, req_id in enumerate(req_ids[:effective_num_reqs])
+        ],
+        dtype=np.int64,
+    )
+    offload_req_ids_tensor.np[:effective_num_reqs] = req_id_values
+    offload_req_ids_tensor.copy_to_gpu(num_reqs_padded)
+
+    query_start_loc_cpu = query_start_loc.cpu[: num_reqs + 1]
+    query_lens = np.diff(query_start_loc_cpu.numpy()).astype(np.int32, copy=False)
+    token_to_req = np.repeat(np.arange(num_reqs, dtype=np.int32), query_lens)
+    if token_to_req.shape[0] < num_tokens:
+        raise RuntimeError(
+            "KV offload token_to_req metadata is shorter than the scheduled token batch: "
+            f"metadata={token_to_req.shape[0]}, tokens={num_tokens}"
+        )
+    offload_token_to_req.np[:num_tokens] = token_to_req[:num_tokens]
+    if num_tokens_padded > num_tokens:
+        offload_token_to_req.np[num_tokens:num_tokens_padded].fill(0)
+    offload_token_to_req.copy_to_gpu(num_tokens_padded)
+
+
+def prepare_sparse_kv_offload_mtp_dummy_metadata(
+    num_tokens: int,
+    num_reqs: int,
+    query_start_loc_cpu: torch.Tensor,
+    req_ids_buffer: CpuGpuBuffer,
+    token_to_req_buffer: CpuGpuBuffer,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    if not get_ascend_config().sparse_kv_offload_config.enabled:
+        return None, None
+    if req_ids_buffer is None or token_to_req_buffer is None:
+        raise RuntimeError("Sparse KV offload metadata buffers are not initialized")
+
+    query_lens = np.diff(query_start_loc_cpu[: num_reqs + 1].numpy()).astype(np.int32, copy=False)
+    token_to_req = np.repeat(np.arange(num_reqs, dtype=np.int32), query_lens)
+    if token_to_req.shape[0] < num_tokens:
+        token_to_req = np.pad(token_to_req, (0, num_tokens - token_to_req.shape[0]))
+
+    req_ids_buffer.np[:num_reqs] = np.arange(1, num_reqs + 1, dtype=np.int64)
+    req_ids_buffer.copy_to_gpu(num_reqs)
+    token_to_req_buffer.np[:num_tokens] = token_to_req[:num_tokens]
+    token_to_req_buffer.copy_to_gpu(num_tokens)
+    return (
+        req_ids_buffer.gpu[:num_reqs],
+        token_to_req_buffer.gpu[:num_tokens],
+    )
+
+
+class SparseKVOffloadManager:
+    """
+    A manager responsible to the Sparse KV cache Offload.
+    It enlarge the available memory that scheduler can see,
+    so we can schedule longer max_model_len or larger decode batch size.
+    No more scheduling logic: we reuse the original block_table/slot_mapping.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        sparse_kv_offload_config: SparseKVOffloadConfig,
+    ):
+        self.vllm_config = vllm_config
+        self.kv_cache_config = kv_cache_config
+        self.sparse_kv_offload_config = sparse_kv_offload_config
+
+        model_config = vllm_config.model_config
+        parallel_config = vllm_config.parallel_config
+
+        self.num_target_layers = model_config.get_num_layers(parallel_config)
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_group = get_tp_group()
+        self.block_size = self._infer_group_block_sizes(self.kv_cache_config)
+        self.topk_buffer_size = sparse_kv_offload_config.topk_buffer_size
+        self.topk = sparse_kv_offload_config.topk
+
+        self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.max_model_len = vllm_config.model_config.max_model_len
+        decode_width = 1
+        if vllm_config.speculative_config is not None:
+            decode_width += vllm_config.speculative_config.num_speculative_tokens
+        self.max_num_topk_rows = min(
+            self.max_num_tokens,
+            self.max_num_reqs * decode_width,
+        )
+        max_block_num = cdiv(self.max_model_len, self.block_size)
+        self.block_table_cpu = torch.zeros(
+            [self.max_num_reqs, max_block_num],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.block_table_expanded_cpu = torch.empty(
+            [self.max_num_topk_rows, max_block_num],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self._npu_runtime = torch_npu.npu
+
+        self._build_cpp()
+
+        logger.info(
+            "SparseKVOffloadManager start init CPU KV pool with %s "
+            "GB dram per dp group, it might be time consuming, please wait.",
+            sparse_kv_offload_config.dram_size_per_dp_GB,
+        )
+        config = offload.OffloadConfig()
+        config.device_id = torch_npu.npu.current_device()
+        config.reserve_size = sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30)
+        config.alloc_size = sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30) if self.tp_rank == 0 else 0
+        config.world_size = self.tp_size
+        config.rank_id = self.tp_rank
+        config.scene = offload.Scene.SHARED
+        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
+        self.tp_group.barrier()
+
+    def _build_cpp(self):
+        os.environ["TORCH_EXTENSIONS_ALWAYS_BUILD"] = "1"
+        ascend_home = os.environ.get("ASCEND_HOME_PATH", "/usr/local/Ascend/ascend-toolkit/latest")
+        npu_include_path = os.path.join(ascend_home, "include")
+        npu_lib_path = os.path.join(ascend_home, "lib64")
+        if not os.path.exists(npu_lib_path):
+            npu_lib_path = os.path.join(ascend_home, "lib")
+        torch_npu_path = os.path.dirname(torch_npu.__file__)
+        torch_npu_include = os.path.join(torch_npu_path, "include")
+        torch_npu_lib_path = os.path.join(torch_npu_path, "lib")
+        os.environ["TORCH_EXTENSIONS_ALWAYS_BUILD"] = "1"
+        os.environ["CXX"] = "clang++"
+        os.environ["CC"] = "clang"
+        abs_path = os.path.dirname(os.path.abspath(__file__))
+        src_path = os.path.join(abs_path, "sparse_kv_offload.cpp")
+        logger.info_once(f"Sparse KV offload build cpp utils from src: {src_path}")
+        self.sparse_kv_offload_cpp = torch.utils.cpp_extension.load(
+            name="sparse_kv_offload",
+            sources=[src_path],
+            extra_cflags=[
+                "-O3",
+                "-std=c++20",
+                "-fopenmp",
+                "-march=armv8.2-a+sve+fp16+bf16",
+                "-fPIC",
+                f"-I{npu_include_path}",
+                f"-I{torch_npu_include}",
+            ],
+            extra_ldflags=[
+                "-fopenmp",
+                f"-L{npu_lib_path}",
+                "-lascendcl",
+                f"-L{torch_npu_lib_path}",
+                "-ltorch_npu",
+            ],
+            verbose=True,
+        )
+
+    def _infer_group_block_sizes(
+        self,
+        kv_cache_config: KVCacheConfig,
+    ) -> int:
+        assert len(kv_cache_config.kv_cache_groups) == 1, "Hybrid KV is not supported."
+        kv_cache_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+            kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
+        return kv_cache_spec.block_size
+
+    @staticmethod
+    def _as_cache_tuple(cache_or_caches) -> tuple[torch.Tensor, ...]:
+        if isinstance(cache_or_caches, torch.Tensor):
+            return (cache_or_caches,)
+        return tuple(cache_or_caches)
+
+    def _register_offload_layers(self, kv_caches: dict[str, torch.Tensor]) -> None:
+        self.offload_layer_names = [layer_name for layer_name in kv_caches if "indexer" not in layer_name]
+        if not self.offload_layer_names:
+            raise ValueError("Sparse KV offload did not find SFA KV cache layers.")
+
+        self.num_layers = len(self.offload_layer_names)
+        self.layer_name_to_offload_id = {
+            layer_name: layer_id for layer_id, layer_name in enumerate(self.offload_layer_names)
+        }
+
+        logger.info_once(
+            "Sparse KV offload registered %s layers (%s target layers).",
+            self.num_layers,
+            self.num_target_layers,
+        )
+        self.mtp_layer_id = self.num_layers - 1 if self.num_layers != self.num_target_layers else -1
+        if self.tp_rank == 0:
+            preview_layer_names = self.offload_layer_names[:4]
+            if len(self.offload_layer_names) > 4:
+                preview_layer_names += ["..."] + self.offload_layer_names[-4:]
+            logger.info("Sparse KV offload layer names: %s", preview_layer_names)
+
+    def _get_offload_layer_id(self, layer_name: str) -> int:
+        layer_id = self.layer_name_to_offload_id.get(layer_name)
+        if layer_id is None:
+            registered_layers = ", ".join(self.offload_layer_names[:8])
+            if len(self.offload_layer_names) > 8:
+                registered_layers += ", ..."
+            raise KeyError(
+                "Sparse KV offload layer is not registered, "
+                f"layer_name={layer_name}, registered_layers=[{registered_layers}]"
+            )
+        return layer_id
+
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+    ):
+        self._register_offload_layers(kv_caches)
+
+        # register topk_buffer and cpu kv_cache
+        self.topk_buffers_k: list[torch.Tensor] = []
+        self.topk_buffers_v: list[torch.Tensor] = []
+        self.k_caches_cpu: list[torch.Tensor] = []
+        self.v_caches_cpu: list[torch.Tensor] = []
+        for layer_name in self.offload_layer_names:
+            cache_or_caches = self._as_cache_tuple(kv_caches[layer_name])
+            tuple_len = len(cache_or_caches)
+            if tuple_len not in [OFFLOAD_KV_CACHE_TUPLE_LEN]:
+                raise ValueError(
+                    f"Sparse KV offload layer {layer_name}: expected tuple length "
+                    f"{OFFLOAD_KV_CACHE_TUPLE_LEN}, got {tuple_len}"
+                )
+            self.topk_buffers_k.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_K_INDEX])
+            self.topk_buffers_v.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_V_INDEX])
+            if self.tp_rank == 0:
+                self.k_caches_cpu.append(cache_or_caches[OFFLOAD_K_CACHE_CPU_INDEX])
+                self.v_caches_cpu.append(cache_or_caches[OFFLOAD_V_CACHE_CPU_INDEX])
+
+        kv_head_num = self.topk_buffers_k[0].size(-2)
+        head_dim_k = self.topk_buffers_k[0].size(-1)
+        head_dim_v = self.topk_buffers_v[0].size(-1)
+        dtype = self.topk_buffers_k[0].dtype
+        assert kv_head_num == 1, "Sparse KV offload only support sfa(mla)"
+        if dtype != torch.bfloat16:
+            raise ValueError(
+                "Sparse KV offload requires a BF16 main SFA cache; sparse LI "
+                "C8 is supported only for the device-resident indexer cache."
+            )
+        self.token_size_bytes_k = kv_head_num * head_dim_k * dtype.itemsize
+        self.token_size_bytes_v = kv_head_num * head_dim_v * dtype.itemsize
+        if self.topk_buffer_size % self.block_size != 0:
+            raise ValueError(
+                "Sparse KV offload topk_buffer_size must be divisible by "
+                f"block_size, got {self.topk_buffer_size} and {self.block_size}"
+            )
+
+        # D2H uses a separate descriptor set from the shared H2D buffers below.
+        # Both prefill (colocate debug only, gated by keep_device_kv_cache)
+        # and decode can produce up to max_num_tokens rows.
+        d2h_descriptor_rows = self.max_num_tokens * 2
+        device = self.topk_buffers_k[0].device
+        self.d2h_src_ptrs_npu = torch.empty(d2h_descriptor_rows, dtype=torch.int64, device=device)
+        self.d2h_dst_ptrs_npu = torch.empty(d2h_descriptor_rows, dtype=torch.int64, device=device)
+        self.d2h_lengths_npu = torch.empty(d2h_descriptor_rows, dtype=torch.int32, device=device)
+        self.d2h_size_npu = torch.empty(1, dtype=torch.int32, device=device)
+        self.d2h_token_indices_npu = torch.arange(self.max_num_tokens, dtype=torch.int64, device=device)
+
+        pages_per_row = self.topk_buffer_size // self.block_size
+        self.current_slots_npu = torch.empty(
+            (self.max_num_topk_rows, self.topk),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.resident_block_table_npu = torch.arange(
+            self.max_num_topk_rows * pages_per_row,
+            dtype=torch.int32,
+            device=device,
+        ).view(self.max_num_topk_rows, pages_per_row)
+        self.resident_query_lens_npu = torch.arange(1, self.max_num_topk_rows + 1, dtype=torch.int32, device=device)
+        self.resident_seq_lens_npu = torch.full(
+            (self.max_num_topk_rows,),
+            self.topk_buffer_size,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # sparse_copy related addrs and buffers
+        self.addr_k_bases: list[int] = [t.data_ptr() for t in self.topk_buffers_k]
+        self.addr_v_bases: list[int] = [t.data_ptr() for t in self.topk_buffers_v]
+        self.gvas_k_bases: list[int] = []
+        self.gvas_v_bases: list[int] = []
+        self.cpu_block_lens: list[tuple[int, int]] = []
+        gvas_k_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
+        gvas_v_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
+        cpu_block_lens_tensor = torch.zeros([self.num_layers, 2], dtype=torch.int64, device="npu")
+        if self.tp_rank == 0:
+            for layer_id in range(self.num_layers):
+                k_cpu = self.k_caches_cpu[layer_id]
+                v_cpu = self.v_caches_cpu[layer_id]
+                gvas_k_tensor[layer_id] = k_cpu.data_ptr()
+                gvas_v_tensor[layer_id] = v_cpu.data_ptr()
+                cpu_block_lens_tensor[layer_id, 0] = (
+                    k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks
+                )
+                cpu_block_lens_tensor[layer_id, 1] = (
+                    v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks
+                )
+        self.tp_group.broadcast(gvas_k_tensor, src=0)
+        self.tp_group.broadcast(gvas_v_tensor, src=0)
+        self.tp_group.broadcast(cpu_block_lens_tensor, src=0)
+        for layer_id in range(self.num_layers):
+            self.gvas_k_bases.append(gvas_k_tensor[layer_id].item())
+            self.gvas_v_bases.append(gvas_v_tensor[layer_id].item())
+            self.cpu_block_lens.append(
+                (
+                    cpu_block_lens_tensor[layer_id, 0].item(),
+                    cpu_block_lens_tensor[layer_id, 1].item(),
+                )
+            )
+
+        gvas_buffer_offset = 0
+        gvas_buffer_size_bytes = self.max_num_topk_rows * self.topk * 2 * 8  # 2: k+v, 8: int64
+        addr_buffer_offset = gvas_buffer_offset + gvas_buffer_size_bytes
+        addr_buffer_size_bytes = self.max_num_topk_rows * self.topk * 2 * 8
+        size_buffer_offset = addr_buffer_offset + addr_buffer_size_bytes
+        size_buffer_size_bytes = self.max_num_topk_rows * self.topk * 2 * 4  # 2: k+v, 4: int32
+        num_tokens_buffer_offset = size_buffer_offset + size_buffer_size_bytes
+        num_tokens_buffer_size_bytes = 4  # 1 * int32
+        sparse_copy_args_buffer_size_bytes = (
+            gvas_buffer_size_bytes + addr_buffer_size_bytes + size_buffer_size_bytes + num_tokens_buffer_size_bytes
+        )
+        self.sparse_copy_args_buffer_cpu = torch.zeros(
+            [sparse_copy_args_buffer_size_bytes], dtype=torch.int8, device="cpu", pin_memory=True
+        )
+        self.sparse_copy_args_buffer_npu = torch.zeros(
+            [sparse_copy_args_buffer_size_bytes], dtype=torch.int8, device="npu"
+        )
+
+        self.gvas_buffer_cpu = self.sparse_copy_args_buffer_cpu[
+            gvas_buffer_offset : gvas_buffer_offset + gvas_buffer_size_bytes
+        ].view(torch.int64)
+        self.addr_buffer_cpu = self.sparse_copy_args_buffer_cpu[
+            addr_buffer_offset : addr_buffer_offset + addr_buffer_size_bytes
+        ].view(torch.int64)
+        self.size_buffer_cpu = self.sparse_copy_args_buffer_cpu[
+            size_buffer_offset : size_buffer_offset + size_buffer_size_bytes
+        ].view(torch.int32)
+        self.num_tokens_buffer_cpu = self.sparse_copy_args_buffer_cpu[
+            num_tokens_buffer_offset : num_tokens_buffer_offset + num_tokens_buffer_size_bytes
+        ].view(torch.int32)
+        assert self.gvas_buffer_cpu.shape == torch.Size([self.max_num_topk_rows * self.topk * 2])
+        assert self.addr_buffer_cpu.shape == torch.Size([self.max_num_topk_rows * self.topk * 2])
+        assert self.size_buffer_cpu.shape == torch.Size([self.max_num_topk_rows * self.topk * 2])
+        assert self.num_tokens_buffer_cpu.shape == torch.Size([1])
+
+        self.gvas_buffer_npu = self.sparse_copy_args_buffer_npu[
+            gvas_buffer_offset : gvas_buffer_offset + gvas_buffer_size_bytes
+        ].view(torch.int64)
+        self.addr_buffer_npu = self.sparse_copy_args_buffer_npu[
+            addr_buffer_offset : addr_buffer_offset + addr_buffer_size_bytes
+        ].view(torch.int64)
+        self.size_buffer_npu = self.sparse_copy_args_buffer_npu[
+            size_buffer_offset : size_buffer_offset + size_buffer_size_bytes
+        ].view(torch.int32)
+        self.num_tokens_buffer_npu = self.sparse_copy_args_buffer_npu[
+            num_tokens_buffer_offset : num_tokens_buffer_offset + num_tokens_buffer_size_bytes
+        ].view(torch.int32)
+        assert self.gvas_buffer_npu.shape == torch.Size([self.max_num_topk_rows * self.topk * 2])
+        assert self.addr_buffer_npu.shape == torch.Size([self.max_num_topk_rows * self.topk * 2])
+        assert self.size_buffer_npu.shape == torch.Size([self.max_num_topk_rows * self.topk * 2])
+        assert self.num_tokens_buffer_npu.shape == torch.Size([1])
+
+        # topk cache reuse related
+        self.lru_workspace_threads = 8
+        self.lru_topk_indices_cpu = torch.empty(
+            [self.max_num_topk_rows, self.topk],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_token_to_req_cpu = torch.empty(
+            [self.max_num_topk_rows],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_slot_to_token_cpu_list = [
+            torch.full(
+                [self.max_num_topk_rows, self.topk_buffer_size],
+                -1,
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=True,
+            )
+            for _ in range(self.num_layers)
+        ]
+        self.lru_slots_cpu_list = [
+            torch.arange(
+                self.topk_buffer_size,
+                dtype=torch.int32,
+                device="cpu",
+            )
+            .view(1, -1)
+            .repeat(self.max_num_topk_rows, 1)
+            .pin_memory()
+            for _ in range(self.num_layers)
+        ]
+        self.lru_current_slots_cpu = torch.empty(
+            [self.max_num_topk_rows, self.topk],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_miss_count_cpu_list = [
+            torch.empty(
+                [self.max_num_topk_rows],
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=True,
+            )
+            for _ in range(self.num_layers)
+        ]
+        self.lru_miss_tokens_cpu_list = [
+            torch.empty(
+                [self.max_num_topk_rows, self.topk],
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=True,
+            )
+            for _ in range(self.num_layers)
+        ]
+        self.lru_miss_slots_cpu_list = [
+            torch.empty(
+                [self.max_num_topk_rows, self.topk],
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=True,
+            )
+            for _ in range(self.num_layers)
+        ]
+        self.lru_req_ids_cpu = torch.empty([self.max_num_topk_rows], dtype=torch.int64, device="cpu", pin_memory=True)
+        self.lru_stable_prefix_lens_cpu = torch.empty(
+            [self.max_num_topk_rows],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_last_req_ids_cpu_list = [
+            torch.full(
+                [self.max_num_topk_rows],
+                -1,
+                dtype=torch.int64,
+                device="cpu",
+                pin_memory=True,
+            )
+            for _ in range(self.num_layers)
+        ]
+        self.lru_token_mark_workspace = torch.zeros(
+            [self.lru_workspace_threads, self.max_model_len],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_token_pos_workspace = torch.full(
+            [self.lru_workspace_threads, self.max_model_len],
+            -1,
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_slot_workspace = torch.empty(
+            [self.lru_workspace_threads, self.topk_buffer_size * 3],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_miss_position_workspace = torch.empty(
+            [self.lru_workspace_threads, self.topk],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+        self.lru_epochs = torch.zeros(
+            [self.lru_workspace_threads],
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=True,
+        )
+
+        self.lru_req_ids_ptr = self.lru_req_ids_cpu.data_ptr()
+        self.lru_stable_prefix_lens_ptr = self.lru_stable_prefix_lens_cpu.data_ptr()
+        self.lru_last_req_ids_ptrs = [
+            lru_last_req_ids_cpu.data_ptr() for lru_last_req_ids_cpu in self.lru_last_req_ids_cpu_list
+        ]
+        self.lru_topk_indices_ptr = self.lru_topk_indices_cpu.data_ptr()
+        self.lru_token_to_req_ptr = self.lru_token_to_req_cpu.data_ptr()
+        self.lru_slot_to_token_ptrs = [
+            lru_slot_to_token_cpu.data_ptr() for lru_slot_to_token_cpu in self.lru_slot_to_token_cpu_list
+        ]
+        self.lru_slots_ptrs = [lru_slots_cpu.data_ptr() for lru_slots_cpu in self.lru_slots_cpu_list]
+        self.lru_current_slots_ptr = self.lru_current_slots_cpu.data_ptr()
+        self.lru_miss_count_ptrs = [
+            lru_miss_count_cpu.data_ptr() for lru_miss_count_cpu in self.lru_miss_count_cpu_list
+        ]
+        self.lru_miss_tokens_ptrs = [
+            lru_miss_tokens_cpu.data_ptr() for lru_miss_tokens_cpu in self.lru_miss_tokens_cpu_list
+        ]
+        self.lru_miss_slots_ptrs = [
+            lru_miss_slots_cpu.data_ptr() for lru_miss_slots_cpu in self.lru_miss_slots_cpu_list
+        ]
+        self.lru_token_mark_workspace_ptr = self.lru_token_mark_workspace.data_ptr()
+        self.lru_token_pos_workspace_ptr = self.lru_token_pos_workspace.data_ptr()
+        self.lru_slot_workspace_ptr = self.lru_slot_workspace.data_ptr()
+        self.lru_miss_position_workspace_ptr = self.lru_miss_position_workspace.data_ptr()
+        self.lru_epochs_ptr = self.lru_epochs.data_ptr()
+
+    def offload_new_kv(
+        self,
+        slot_mapping: torch.Tensor,
+        k_cache_cpu: torch.Tensor | None,
+        v_cache_cpu: torch.Tensor | None,
+        k_cache_npu: torch.Tensor | None,  # prefill (colocate debug only): cache_npu[slot] -> cache_cpu[slot]
+        v_cache_npu: torch.Tensor | None,  # prefill (colocate debug only): cache_npu[slot] -> cache_cpu[slot]
+        k: torch.Tensor | None,  # decode: k/v -> cache_cpu[slot]
+        v: torch.Tensor | None,  # decode: k/v -> cache_cpu[slot]
+        has_prefill: bool = False,
+        capturing: bool = False,
+    ) -> None:
+        # the has_prefill path (NPU paged cache -> CPU pool D2H) only exists
+        # for single-node PD-colocate debug.
+        if self.tp_rank != 0:
+            # Decode-produced K/V is replicated across TP ranks, so TP0 alone
+            # writes new decode tokens. PD pull fills disjoint parts of this
+            # shared pool from all TP ranks through the broadcast GVA.
+            return
+        if k_cache_cpu is None or v_cache_cpu is None:
+            raise RuntimeError("Sparse KV offload TP0 CPU cache is not registered")
+        if has_prefill and not self.sparse_kv_offload_config.keep_device_kv_cache:
+            raise RuntimeError(
+                "Sparse KV offload prefill offload requires "
+                "keep_device_kv_cache=True; a PD-disaggregated decode node "
+                "never stages prefill KV in an NPU paged cache"
+            )
+
+        if has_prefill:
+            if k_cache_npu is None or v_cache_npu is None:
+                raise ValueError("prefill offload requires NPU paged K/V caches")
+            device = k_cache_npu.device
+        else:
+            if k is None or v is None:
+                raise ValueError("decode offload requires current-token K/V")
+            device = k.device
+
+        slots = slot_mapping.reshape(-1).to(device=device, dtype=torch.int64)
+        token_count = slots.numel()
+        if token_count > self.max_num_tokens:
+            raise ValueError(
+                "Sparse KV offload rows exceed D2H descriptor capacity, "
+                f"got {token_count}, capacity={self.max_num_tokens}"
+            )
+
+        num_k_slots = k_cache_cpu.numel() * k_cache_cpu.element_size() // self.token_size_bytes_k
+        num_v_slots = v_cache_cpu.numel() * v_cache_cpu.element_size() // self.token_size_bytes_v
+        if num_k_slots != num_v_slots or num_k_slots <= 0:
+            raise ValueError(
+                f"Sparse KV offload CPU K/V pools have incompatible token capacities: k={num_k_slots}, v={num_v_slots}"
+            )
+        valid = (slots >= 0) & (slots < num_k_slots)
+        safe_slots = slots.clamp(min=0, max=num_k_slots - 1)
+
+        if has_prefill:
+            assert k_cache_npu is not None and v_cache_npu is not None
+            src_k = int(k_cache_npu.data_ptr()) + safe_slots * self.token_size_bytes_k
+            src_v = int(v_cache_npu.data_ptr()) + safe_slots * self.token_size_bytes_v
+        else:
+            assert k is not None and v is not None
+            k_rows = k.reshape(-1, self.token_size_bytes_k // k.element_size())
+            v_rows = v.reshape(-1, self.token_size_bytes_v // v.element_size())
+            if k_rows.shape[0] != token_count or v_rows.shape[0] != token_count:
+                raise ValueError("decode K/V row counts must match slot_mapping")
+            if not k_rows.is_contiguous():
+                k_rows = k_rows.contiguous()
+            if not v_rows.is_contiguous():
+                v_rows = v_rows.contiguous()
+            token_indices = self.d2h_token_indices_npu[:token_count]
+            src_k = int(k_rows.data_ptr()) + token_indices * self.token_size_bytes_k
+            src_v = int(v_rows.data_ptr()) + token_indices * self.token_size_bytes_v
+
+        dst_k = int(k_cache_cpu.data_ptr()) + safe_slots * self.token_size_bytes_k
+        dst_v = int(v_cache_cpu.data_ptr()) + safe_slots * self.token_size_bytes_v
+        self.d2h_src_ptrs_npu[:token_count].copy_(src_k)
+        self.d2h_src_ptrs_npu[token_count : 2 * token_count].copy_(src_v)
+        self.d2h_dst_ptrs_npu[:token_count].copy_(dst_k)
+        self.d2h_dst_ptrs_npu[token_count : 2 * token_count].copy_(dst_v)
+        self.d2h_lengths_npu[:token_count].fill_(self.token_size_bytes_k)
+        self.d2h_lengths_npu[token_count : 2 * token_count].fill_(self.token_size_bytes_v)
+        self.d2h_lengths_npu[:token_count].masked_fill_(~valid, 0)
+        self.d2h_lengths_npu[token_count : 2 * token_count].masked_fill_(~valid, 0)
+        self.d2h_size_npu.fill_(2 * token_count)
+
+        result = offload.sparse_copy(
+            self.d2h_src_ptrs_npu,
+            self.d2h_dst_ptrs_npu,
+            self.d2h_lengths_npu,
+            self.d2h_size_npu,
+            device,
+        )
+        if result not in (None, 0):
+            raise RuntimeError(f"memfabric D2H sparse_copy failed with result={result}")
+
+    def onload_topk_kv(
+        self,
+        layer_name: str,
+        num_tokens: int,
+        num_reqs: int,
+        block_table: torch.Tensor,
+        topk_indices_npu: torch.Tensor,
+        current_slots_npu: torch.Tensor,
+        req_ids_npu: torch.Tensor,
+        stable_prefix_lens_npu: torch.Tensor,
+        token_to_req_npu: torch.Tensor | None = None,
+        capturing: bool = False,
+        skip_topk: bool = False,
+    ):
+        layer_id = self._get_offload_layer_id(layer_name)
+        if num_tokens > self.max_num_topk_rows:
+            raise ValueError(
+                "Sparse KV offload topk rows exceed configured workspace, "
+                f"num_tokens={num_tokens}, max_num_topk_rows={self.max_num_topk_rows}"
+            )
+        if layer_id in [0, self.mtp_layer_id]:
+            # metadata which are same across all layers, only compute/copy once in first layer.
+            # last layer (mtp layer) may have different metadata, do not skip.
+            if token_to_req_npu is not None:
+                # spec decode case, expand block_table to actual num decode tokens.
+                token_to_req_cpu = self.lru_token_to_req_cpu[:num_tokens]
+                token_to_req_cpu.copy_(token_to_req_npu[:num_tokens], non_blocking=capturing)
+                block_table_expanded = torch.index_select(block_table, 0, token_to_req_npu[:num_tokens].to(torch.int64))
+                self.block_table_expanded_cpu[:num_tokens].copy_(block_table_expanded, non_blocking=capturing)
+            else:
+                self.block_table_cpu[:num_reqs].copy_(block_table, non_blocking=capturing)
+            self.lru_req_ids_cpu[:num_tokens].copy_(req_ids_npu[:num_tokens], non_blocking=capturing)
+            self.lru_stable_prefix_lens_cpu[:num_tokens].copy_(
+                stable_prefix_lens_npu[:num_tokens],
+                non_blocking=capturing,
+            )
+
+        if skip_topk:
+            assert layer_id > 0, "No previous layer to reuse."
+            gvas_offset = self.gvas_k_bases[layer_id] - self.gvas_k_bases[layer_id - 1]
+            addr_offset = self.addr_k_bases[layer_id] - self.addr_k_bases[layer_id - 1]
+            assert self.gvas_v_bases[layer_id] - self.gvas_v_bases[layer_id - 1] == gvas_offset, (
+                "k/v gvas base delta mismatch."
+            )
+            assert self.addr_v_bases[layer_id] - self.addr_v_bases[layer_id - 1] == addr_offset, (
+                "k/v addr base delta mismatch."
+            )
+            self.gvas_buffer_npu += gvas_offset
+            self.addr_buffer_npu += addr_offset
+        else:
+            if token_to_req_npu is not None:
+                block_table_cpu = self.block_table_expanded_cpu[:num_tokens]
+            else:
+                block_table_cpu = self.block_table_cpu[:num_reqs]
+            topk_indices_cpu = self.lru_topk_indices_cpu[:num_tokens]
+            topk_indices_cpu.copy_(topk_indices_npu[:num_tokens], non_blocking=capturing)
+
+            args = (
+                num_tokens,
+                self.lru_miss_count_cpu_list[layer_id][:num_tokens],
+                self.lru_miss_tokens_cpu_list[layer_id][:num_tokens],
+                self.lru_miss_slots_cpu_list[layer_id][:num_tokens],
+                self.lru_req_ids_ptr,
+                self.lru_last_req_ids_ptrs[layer_id],
+                self.lru_topk_indices_ptr,
+                self.lru_stable_prefix_lens_ptr,
+                self.lru_slot_to_token_ptrs[layer_id],
+                self.lru_slots_ptrs[layer_id],
+                self.lru_current_slots_ptr,
+                self.lru_miss_count_ptrs[layer_id],
+                self.lru_miss_tokens_ptrs[layer_id],
+                self.lru_miss_slots_ptrs[layer_id],
+                block_table_cpu,
+                self.block_size,
+                self.token_size_bytes_k,
+                self.token_size_bytes_v,
+                self.gvas_k_bases[layer_id],
+                self.gvas_v_bases[layer_id],
+                self.addr_k_bases[layer_id],
+                self.addr_v_bases[layer_id],
+                self.lru_token_mark_workspace_ptr,
+                self.lru_token_pos_workspace_ptr,
+                self.lru_slot_workspace_ptr,
+                self.lru_miss_position_workspace_ptr,
+                self.lru_epochs_ptr,
+                self.gvas_buffer_cpu,
+                self.addr_buffer_cpu,
+                self.size_buffer_cpu,
+                self.num_tokens_buffer_cpu,
+                layer_id,
+            )
+
+            if capturing:
+                current_compute_stream = torch_npu.npu.current_stream()
+                subscribed_compute_streams = get_subscribed_compute_streams()
+                if current_compute_stream not in subscribed_compute_streams:
+                    torch_npu.npu._subscribe_report(current_compute_stream)
+                    subscribed_compute_streams.add(current_compute_stream)
+                torch_npu.npu._launch_host_func(
+                    current_compute_stream,
+                    self._onload_topk_kv_cpu,
+                    args,
+                )
+            else:
+                self._onload_topk_kv_cpu(args)
+
+            self.sparse_copy_args_buffer_npu.copy_(self.sparse_copy_args_buffer_cpu, non_blocking=capturing)
+
+        if self.tp_size > 1:
+            # Make sure that tp0 d2h is finished before other tp's h2d.
+            # NOTE we can't use barrier since it can't be captured in graph.
+            self.tp_group.broadcast(torch.empty([], dtype=torch.int8, device="npu"), src=0)
+        offload.sparse_copy(
+            self.gvas_buffer_npu,
+            self.addr_buffer_npu,
+            self.size_buffer_npu,
+            self.num_tokens_buffer_npu,
+            self.topk_buffers_k[0].device,
+        )
+
+        current_slots_cpu = self.lru_current_slots_cpu[:num_tokens]
+        current_slots_npu[:num_tokens].copy_(current_slots_cpu, non_blocking=capturing)
+
+    def _onload_topk_kv_cpu(self, args):
+        # code that is incompatible with graph mode, compute here outside graph
+        (
+            num_reqs,
+            miss_count,
+            miss_tokens,
+            miss_slots,
+            lru_req_ids_ptr,
+            lru_last_req_ids_ptr,
+            lru_topk_indices_ptr,
+            lru_stable_prefix_lens_ptr,
+            lru_slot_to_token_ptr,
+            lru_slots_ptr,
+            lru_current_slots_ptr,
+            lru_miss_count_ptr,
+            lru_miss_tokens_ptr,
+            lru_miss_slots_ptr,
+            block_table,
+            block_size,
+            token_size_bytes_k,
+            token_size_bytes_v,
+            gvas_k_bases,
+            gvas_v_bases,
+            addr_k_bases,
+            addr_v_bases,
+            lru_token_mark_workspace_ptr,
+            lru_token_pos_workspace_ptr,
+            lru_slot_workspace_ptr,
+            lru_miss_position_workspace_ptr,
+            lru_epochs_ptr,
+            gvas_buffer,
+            addr_buffer,
+            size_buffer,
+            num_tokens_buffer,
+            layer_id,
+        ) = args
+        self.sparse_kv_offload_cpp.lru_resident_compact(
+            lru_req_ids_ptr,
+            lru_last_req_ids_ptr,
+            lru_topk_indices_ptr,
+            lru_stable_prefix_lens_ptr,
+            lru_slot_to_token_ptr,
+            lru_slots_ptr,
+            lru_current_slots_ptr,
+            lru_miss_count_ptr,
+            lru_miss_tokens_ptr,
+            lru_miss_slots_ptr,
+            lru_token_mark_workspace_ptr,
+            lru_token_pos_workspace_ptr,
+            lru_slot_workspace_ptr,
+            lru_miss_position_workspace_ptr,
+            lru_epochs_ptr,
+            num_reqs,
+            self.topk,
+            self.topk_buffer_size,
+            self.max_model_len,
+            self.lru_workspace_threads,
+            self.lru_workspace_threads,
+        )
+        self.sparse_kv_offload_cpp.compute_lru_resident_addrs(
+            miss_count,
+            miss_tokens,
+            miss_slots,
+            block_table,
+            block_size,
+            token_size_bytes_k,
+            token_size_bytes_v,
+            gvas_k_bases,
+            gvas_v_bases,
+            addr_k_bases,
+            addr_v_bases,
+            self.topk_buffer_size,
+            self.lru_workspace_threads,
+            gvas_buffer,
+            addr_buffer,
+            size_buffer,
+            num_tokens_buffer,
+        )
+
+
+_SPARSE_KV_OFFLOAD_MANAGER: SparseKVOffloadManager | None = None
+
+
+def init_sparse_kv_offload_manager(
+    vllm_config: VllmConfig,
+    kv_cache_config: KVCacheConfig,
+    sparse_kv_offload_config: SparseKVOffloadConfig,
+):
+    global _SPARSE_KV_OFFLOAD_MANAGER
+    if _SPARSE_KV_OFFLOAD_MANAGER is None:
+        _SPARSE_KV_OFFLOAD_MANAGER = SparseKVOffloadManager(
+            vllm_config,
+            kv_cache_config,
+            sparse_kv_offload_config,
+        )
+    return _SPARSE_KV_OFFLOAD_MANAGER
+
+
+def get_sparse_kv_offload_manager():
+    assert _SPARSE_KV_OFFLOAD_MANAGER is not None, "KV offload manager is not initialized."
+    return _SPARSE_KV_OFFLOAD_MANAGER

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -47,6 +47,9 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    prepare_sparse_kv_offload_mtp_dummy_metadata,
+)
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.deepseek_v4_dspark import DSparkDeepseekV4ForCausalLM
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
@@ -588,6 +591,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # num_reqs is already the padded version
                 self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
                 self.query_start_loc.copy_to_gpu()
+                req_ids_tensor, token_to_req = prepare_sparse_kv_offload_mtp_dummy_metadata(
+                    num_tokens,
+                    num_reqs,
+                    self.query_start_loc.cpu,
+                    self.runner._offload_req_ids_tensor,
+                    self.runner._offload_token_to_req,
+                )
 
                 common_attn_metadata = AscendCommonAttentionMetadata(
                     query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],
@@ -616,6 +626,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     group_len=self.runner.group_len.gpu[:num_reqs],
                     group_key_idx=self.runner.group_key_idx.gpu[:num_reqs],
                     group_key_cache_idx=self.runner.group_key_cache_idx.gpu[:num_reqs],
+                    req_ids_tensor=req_ids_tensor,
+                    token_to_req=token_to_req,
                 )
                 if dcp_manager is not None:
                     # update long_seq related params and flatten block_table
@@ -1547,6 +1559,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.graph_pad_size = -1
             common_attn_metadata.num_input_tokens = input_batch_size
 
+            if getattr(self.runner, "sparse_kv_offload_enabled", False):
+                # Draft steps run exactly one token per request, while the
+                # inherited token_to_req still describes the verify-step
+                # layout (num_spec + 1 tokens per request). Rebuild it to the
+                # one-token-per-request layout so the Sparse KV offload path
+                # routes every decode row to its own request's CPU-pool
+                # blocks/seq_len; otherwise rows of requests >= 1 are mapped
+                # onto request 0 and attend another request's KV.
+                num_draft_reqs = common_attn_metadata.query_start_loc.shape[0] - 1
+                common_attn_metadata.token_to_req = self.arange[:num_draft_reqs]
+
         # The loop part
         used_update_positions += 1
 
@@ -1850,6 +1873,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.slot_mapping[token_indices]
         )
         common_attn_metadata.slot_mapping[token_indices.shape[0] :].fill_(-1)
+        token_to_req = (
+            common_attn_metadata.token_to_req[token_indices] if common_attn_metadata.token_to_req is not None else None
+        )
 
         # NOTE: Currently positions and seq_lens are not used in attn forward
         # so we do not need to fixed them. But if they are used in the future,
@@ -1884,6 +1910,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             group_len=common_attn_metadata.group_len,
             group_key_idx=common_attn_metadata.group_key_idx,
             group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
+            req_ids_tensor=common_attn_metadata.req_ids_tensor,
+            token_to_req=token_to_req,
         )
         return spec_common_attn_metadata, token_indices
 
@@ -1979,6 +2007,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             group_len=common_attn_metadata.group_len,
             group_key_idx=common_attn_metadata.group_key_idx,
             group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
+            req_ids_tensor=common_attn_metadata.req_ids_tensor,
+            token_to_req=common_attn_metadata.token_to_req,
         )
 
         return spec_common_attn_metadata, token_indices, token_indices_to_sample, num_rejected_tokens_gpu

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -37,10 +37,20 @@ import torch.nn as nn
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import CompilationMode, CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size, tensor_model_parallel_all_gather
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
 from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
-from vllm.distributed.parallel_state import get_dcp_group, get_dp_group, get_pp_group, get_tp_group
+from vllm.distributed.parallel_state import (
+    get_dcp_group,
+    get_dp_group,
+    get_pp_group,
+    get_tp_group,
+    model_parallel_is_initialized,
+)
 from vllm.forward_context import BatchDescriptor, ForwardContext, get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -120,6 +130,13 @@ from vllm_ascend.compilation.acl_graph import (
     set_draft_graph_params,
     set_graph_params,
     update_full_graph_params,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    allocate_kv_cache_tensors_for_sparse_kv_offload,
+    allocate_kv_offload_topk_profile_buffers,
+    init_sparse_kv_offload_manager,
+    reshape_kv_cache_tensors_for_sparse_kv_offload,
+    update_sparse_kv_offload_metadata,
 )
 from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
@@ -548,6 +565,19 @@ class NPUModelRunner(GPUModelRunner):
         self.mamba_state_idx: dict[str, int] = {}
         self._mamba_bufs: Any | None = None
         self._mamba_copy_bufs: Any | None = None
+
+        self.sparse_kv_offload_config = self.ascend_config.sparse_kv_offload_config
+        self.sparse_kv_offload_enabled = self.sparse_kv_offload_config.enabled
+        self.sparse_kv_offload_manager = None
+        self.tp_rank = get_tensor_model_parallel_rank() if model_parallel_is_initialized() else 0
+
+        # Per-request metadata consumed by the Sparse KV offload resident LRU.
+        self._offload_req_ids_tensor = None
+        self._offload_token_to_req = None
+        if self.sparse_kv_offload_enabled:
+            self._offload_req_ids_tensor = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
+            self._offload_token_to_req = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
+
     @property
     def use_dcp(self) -> bool:
         return self.dcp_size > 1
@@ -2798,6 +2828,17 @@ class NPUModelRunner(GPUModelRunner):
             return {}, None
         num_tokens_padded = num_tokens_padded or num_tokens
         num_reqs_padded = num_reqs_padded or num_reqs
+        if self.sparse_kv_offload_enabled:
+            update_sparse_kv_offload_metadata(
+                num_tokens,
+                num_reqs,
+                num_tokens_padded,
+                num_reqs_padded,
+                self.input_batch.req_ids[:num_reqs],
+                self.query_start_loc,
+                self._offload_req_ids_tensor,
+                self._offload_token_to_req,
+            )
         attn_metadata: PerLayerAttnMetadata = {}
         if ubatch_slices is not None:
             attn_metadata = [dict() for _ in range(len(ubatch_slices))]
@@ -2917,6 +2958,16 @@ class NPUModelRunner(GPUModelRunner):
             group_len = self.group_len.gpu[:num_reqs_padded],
             group_key_idx = self.group_key_idx.gpu[:num_reqs_padded],
             group_key_cache_idx = self.group_key_cache_idx.gpu[:num_reqs_padded],
+            req_ids_tensor=(
+                self._offload_req_ids_tensor.gpu[:num_reqs_padded]
+                if self._offload_req_ids_tensor is not None
+                else None
+            ),
+            token_to_req=(
+                self._offload_token_to_req.gpu[:num_tokens_padded]
+                if self._offload_token_to_req is not None
+                else None
+            ),
         )
 
         if logits_indices is not None and self.cache_config.kv_sharing_fast_prefill:
@@ -3413,6 +3464,13 @@ class NPUModelRunner(GPUModelRunner):
 
     def profile_run(self) -> None:
         self.eplb_warmup()
+        if self.sparse_kv_offload_enabled:
+            allocate_kv_offload_topk_profile_buffers(
+                getattr(self, "kv_cache_spec", None) or self.get_kv_cache_spec(),
+                self.vllm_config,
+                self.sparse_kv_offload_config,
+            )
+
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         if self.max_num_tokens > mc2_tokens_capacity and select_moe_comm_method(
             mc2_tokens_capacity, self.vllm_config
@@ -3600,6 +3658,12 @@ class NPUModelRunner(GPUModelRunner):
         )
 
         self.may_reinitialize_input_batch(kv_cache_config)
+        if self.sparse_kv_offload_enabled:
+            self.sparse_kv_offload_manager = init_sparse_kv_offload_manager(
+                self.vllm_config,
+                kv_cache_config,
+                self.sparse_kv_offload_config,
+            )
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
         # TODO: refactor the logic of attention
         if (
@@ -3626,6 +3690,9 @@ class NPUModelRunner(GPUModelRunner):
                 draft_kernel_block_sizes,
             )
 
+        if self.sparse_kv_offload_enabled:
+            assert self.sparse_kv_offload_manager is not None
+            self.sparse_kv_offload_manager.register_kv_caches(kv_caches)
         if has_kv_transfer_group():
             get_kv_transfer_group().register_kv_caches(kv_caches)
 
@@ -3942,6 +4009,21 @@ class NPUModelRunner(GPUModelRunner):
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
                         k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
                         v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
+                    if self.sparse_kv_offload_enabled:
+                        assert self.use_sparse, "Sparse KV offload only support sparse attention."
+                        assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
+                        assert v_tensor_size is not None
+                        raw_tensors = allocate_kv_cache_tensors_for_sparse_kv_offload(
+                            k_tensor_size,
+                            v_tensor_size,
+                            alignment,
+                            self.tp_rank,
+                            self.sparse_kv_offload_config.keep_device_kv_cache,
+                            self._allocate_int8_cache_tensor,
+                        )
+                        assert len(kv_cache_tensor.shared_by) == 1, "Sparse KV offload do not support HMA."
+                        kv_cache_raw_tensors[layer_name] = raw_tensors
+                        continue
                     # Allocate raw int8 tensors. Even bf16/fp16 KV cache entries
                     # are allocated as int8 raw bytes first and then viewed as
                     # the target dtype in _reshape_kv_cache_tensors.
@@ -4136,6 +4218,19 @@ class NPUModelRunner(GPUModelRunner):
                     current_sparse_sfa_c8 = self.use_sparse and kv_cache_spec_uses_sparse_sfa_c8(
                         current_kv_cache_spec
                     )
+                    if self.sparse_kv_offload_enabled:
+                        assert self.use_sparse, "Sparse KV offload only support sparse attention."
+                        assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
+                        reshaped_tensors = reshape_kv_cache_tensors_for_sparse_kv_offload(
+                            kv_cache_raw_tensors[layer_name],
+                            current_kv_cache_spec,
+                            attn_backend,
+                            self.tp_rank,
+                            self.vllm_config,
+                            self.sparse_kv_offload_config,
+                        )
+                        kv_caches[layer_name] = reshaped_tensors
+                        continue
                     if self.use_sparse and "cache_only_layers" not in layer_name:
                         raw_cache = kv_cache_raw_tensors[layer_name]
                         assert isinstance(raw_cache, tuple)
@@ -4548,7 +4643,7 @@ class NPUModelRunner(GPUModelRunner):
         if has_ec_transfer() and get_ec_transfer().is_producer:
             return {}
 
-        kv_cache_spec: dict[str, list[KVCacheSpec]] = defaultdict(list)
+        kv_cache_spec: dict[str, KVCacheSpec] = {}
         attn_layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
         from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 
@@ -4602,6 +4697,7 @@ class NPUModelRunner(GPUModelRunner):
                         dtype=dtype,
                         cache_dtype_str=self.vllm_config.cache_config.cache_dtype,
                         cache_sparse_sfa_c8=cache_sparse_sfa_c8,
+                        store_on_host=self.sparse_kv_offload_enabled,
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     if getattr(attn_module.impl, "fa_quant_layer", False):
@@ -4674,6 +4770,8 @@ class NPUModelRunner(GPUModelRunner):
                 if kv_cache_spec[layer_name].page_size_bytes < mamba_page_size_padded:  # type: ignore[attr-defined]
                     object.__setattr__(kv_cache_spec[layer_name], "page_size_padded", mamba_page_size_padded)
 
+        if self.sparse_kv_offload_enabled:
+            self.kv_cache_spec = kv_cache_spec # reserve for Sparse KV offload usage
         return kv_cache_spec
 
     def _check_and_update_cudagraph_mode(

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -61,6 +61,9 @@ from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    get_host_device_memory_usage_ratio,
+)
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
@@ -545,6 +548,7 @@ class NPUWorker(WorkerBase):
                 GiB(self.init_snapshot.free_memory),
                 GiB(kv_cache_memory_bytes),
             )
+            kv_cache_memory_bytes = self.update_available_memory_for_sparse_kv_offload(kv_cache_memory_bytes)
             return kv_cache_memory_bytes
 
         # Execute a forward pass with dummy inputs to profile the memory usage
@@ -588,8 +592,45 @@ class NPUWorker(WorkerBase):
         logger.info_once(
             "Available KV cache memory: %.2f GiB", GiB(self.available_kv_cache_memory_bytes), scope="local"
         )
+        self.available_kv_cache_memory_bytes = self.update_available_memory_for_sparse_kv_offload(
+            self.available_kv_cache_memory_bytes,
+        )
 
         return int(self.available_kv_cache_memory_bytes)
+
+    def update_available_memory_for_sparse_kv_offload(self, available_memory):
+        """
+        A simple patch for Sparse KV offload: add additional available_memory according to the
+        ratio of host memory (kv) and dev memory (indexer), so we can allocate blocks for indexer cache
+        using all original available device memory without modify original kv_spec or vllm code.
+        For further optimization, consider to merge this logic to vllm kv_cache_utils.py,
+        or reuse hisparse's host pool logic after it's merged to vllm.
+        """
+        GiB = lambda b: b / GiB_bytes
+        sparse_kv_offload_config = get_ascend_config().sparse_kv_offload_config
+        if not sparse_kv_offload_config.enabled:
+            return available_memory
+        keep_device_kv_cache = sparse_kv_offload_config.keep_device_kv_cache
+        if keep_device_kv_cache:
+            needed_dram_size_bytes = available_memory
+        else:
+            kv_cache_spec = getattr(self, "kv_cache_spec", None) or self.get_kv_cache_spec()
+            host_device_memory_usage_ratio = get_host_device_memory_usage_ratio(kv_cache_spec)
+            needed_dram_size_bytes = host_device_memory_usage_ratio * available_memory
+        if needed_dram_size_bytes > sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30):
+            raise ValueError(
+                f"Needed dram size ({GiB(needed_dram_size_bytes)} GB) is larger than "
+                f"user specified dram size ({sparse_kv_offload_config.dram_size_per_dp_GB} GB). "
+                "Please increase sparse_kv_offload_config.dram_size_per_dp_GB if available on your device."
+            )
+        if not keep_device_kv_cache:
+            available_memory += needed_dram_size_bytes
+            logger.info_once(
+                "Sparse KV offload is enabled, enlarge total available memory to %.2f GiB",
+                GiB(available_memory),
+                scope="local",
+            )
+        return int(available_memory)
 
     def log_memory_stats(self) -> None:
         """Profiles the torch reserved memory, torch allocated memory in execute_model()."""
@@ -887,7 +928,11 @@ class NPUWorker(WorkerBase):
         return {(pp_rank, tp_rank): metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
-        return self.model_runner.get_kv_cache_spec()
+        kv_cache_spec = self.model_runner.get_kv_cache_spec()
+        if get_ascend_config().sparse_kv_offload_config.enabled:
+            # reserve kv_cache_spec for sparse kv offload memory profile usage.
+            self.kv_cache_spec = kv_cache_spec
+        return kv_cache_spec
 
     def update_max_model_len(self, max_model_len: int) -> None:
         """Update max_model_len after auto-fit to NPU memory.


### PR DESCRIPTION
### What this PR does / why we need it?
> [!NOTE]
> This PR is part of the implementation of
> [vLLM RFC #48203: Layerwise and Sparse KV cache offloading to support longer sequence length](https://github.com/vllm-project/vllm/issues/48203).
>

This PR implement the Sparse KV Cache Offloading for decode part proposed in [RFC #48203](https://github.com/vllm-project/vllm/issues/48203).
Please refer to our RFC for more detail about the motivation and proposed changes of this PR.

This PR is synchronized from branch main [PR #13026](https://github.com/vllm-project/vllm-ascend/pull/13026).

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
