### PR TITLE
[Feature][Model] Use SparseFlashMla for DSV4 A5 BF16 KV

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -118,8 +118,13 @@
   base: attention_common
   source_file_dependencies:
     - vllm_ascend/attention/dsa_v1.py
+    - vllm_ascend/attention/dsa_attn_kv_plan.py
+    - vllm_ascend/attention/sparse_flash_mla.py
   tests:
     - tests/e2e/pull_request/four_card/test_deepseek_v4.py
+    - tests/ut/attention/test_dsa_attn_kv_plan.py
+    - tests/ut/attention/test_dsa_v1.py
+    - tests/ut/attention/test_sparse_flash_mla.py
 
 - name: attention_cp
   optional: false

--- a/tests/ut/attention/test_dsa_attn_kv_plan.py
+++ b/tests/ut/attention/test_dsa_attn_kv_plan.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+from contextlib import ExitStack
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm_ascend.attention.dsa_attn_kv_plan import (
+    DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET,
+    DSA_COMPRESSOR_SLOT_MAPPING_FLAT,
+    get_dsa_attn_kv_plan,
+    get_dsv4_attn_kv_dtype,
+    is_a5_bf16_kv_enabled,
+    resolve_dsv4_cache_dtype,
+)
+from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla
+from vllm_ascend.utils import AscendDeviceType
+
+_DSA_C_ASCEND_OPS = (
+    "npu_sparse_attn_sharedkv",
+    "npu_sparse_attn_sharedkv_metadata",
+    "npu_kv_quant_sparse_attn_sharedkv",
+    "npu_kv_quant_sparse_attn_sharedkv_metadata",
+    "kv_compress_epilog",
+    "npu_scatter_nd_update_v2",
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_dsa_c_ascend_ops():
+    # CPU images do not register these custom ops on torch.ops._C_ascend.
+    with ExitStack() as stack:
+        for name in _DSA_C_ASCEND_OPS:
+            stack.enter_context(mock.patch.object(torch.ops._C_ascend, name, create=True, new=MagicMock()))
+        yield
+
+
+def _config(use_bf16: bool):
+    return SimpleNamespace(cache_config=SimpleNamespace(cache_dtype="bfloat16" if use_bf16 else "auto"))
+
+
+def _cache_config(cache_dtype: str = "auto"):
+    return SimpleNamespace(cache_config=SimpleNamespace(cache_dtype=cache_dtype))
+
+
+def _on(device_type):
+    return mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=device_type)
+
+
+def test_get_dsa_attn_kv_plan_requires_vllm_config():
+    with pytest.raises(TypeError):
+        get_dsa_attn_kv_plan()
+
+
+def test_a5_fp8_plan_uses_flat_shared_kv():
+    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A5):
+        plan = get_dsa_attn_kv_plan(_config(False))
+        assert plan.get_dsa_compressor_slot_mapping_format() == DSA_COMPRESSOR_SLOT_MAPPING_FLAT
+        assert plan.get_dsa_sparse_attn_metadata_kwargs("npu:0") == {"kv_quant_mode": 1}
+
+
+def test_a5_bf16_plan_uses_sparse_flash_mla():
+    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A5):
+        plan = get_dsa_attn_kv_plan(_config(True))
+        assert plan.get_dsa_sparse_attn_op() is sparse_flash_mla
+        assert plan.get_dsa_compressor_slot_mapping_format() == DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET
+        torch.testing.assert_close(
+            plan.format_dsa_slot_mapping(torch.tensor([5, -1], dtype=torch.int32), 128),
+            torch.tensor([[0, 5], [-1, -1]], dtype=torch.int32),
+        )
+
+
+def test_non_a5_plan_preserves_shared_kv_runtime_kwargs():
+    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A3):
+        plan = get_dsa_attn_kv_plan(_config(True))
+        assert plan.get_dsa_compressor_slot_mapping_format() == DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET
+        kwargs: dict[str, Any] = {}
+        plan.add_dsa_sparse_attn_extra_kwargs(kwargs, cu_seqlens_ori_kv=torch.tensor([0, 1]))
+        assert "cu_seqlens_ori_kv" in kwargs
+
+
+def test_scatter_skips_none_updates():
+    with mock.patch("vllm_ascend.attention.dsa_attn_kv_plan.get_ascend_device_type", return_value=AscendDeviceType.A5):
+        plan = get_dsa_attn_kv_plan(_config(False))
+        cache = torch.zeros(2, 1, 4)
+        with mock.patch.object(torch.ops._C_ascend, "kv_compress_epilog") as epilog:
+            plan.dsa_kv_compress_scatter(cache, None, torch.tensor([0], dtype=torch.int32))
+            epilog.assert_not_called()
+
+
+def test_is_a5_bf16_kv_enabled_requires_vllm_config():
+    with _on(AscendDeviceType.A5), pytest.raises(TypeError):
+        is_a5_bf16_kv_enabled()
+
+
+def test_only_explicit_bfloat16_selects_bf16_kv_on_a5():
+    with _on(AscendDeviceType.A5):
+        assert is_a5_bf16_kv_enabled(_cache_config("bfloat16"))
+        assert not is_a5_bf16_kv_enabled(_cache_config())
+        assert not is_a5_bf16_kv_enabled(_cache_config("fp8"))
+        # The A5 spec path rewrites cache_dtype once FP8 KV is chosen.
+        assert not is_a5_bf16_kv_enabled(_cache_config("float8_e4m3fn"))
+
+
+def test_a5_bf16_kv_is_disabled_on_non_a5():
+    with _on(AscendDeviceType.A3):
+        assert not is_a5_bf16_kv_enabled(_cache_config("bfloat16"))
+
+
+@pytest.mark.parametrize(
+    ("device_type", "cache_dtype", "expected_dtype"),
+    [
+        (AscendDeviceType.A3, "auto", torch.bfloat16),
+        (AscendDeviceType.A5, "bfloat16", torch.bfloat16),
+        (AscendDeviceType.A5, "auto", torch.float8_e4m3fn),
+    ],
+)
+def test_dsv4_attn_kv_dtype_preserves_device_modes(device_type, cache_dtype, expected_dtype):
+    with _on(device_type):
+        assert get_dsv4_attn_kv_dtype(_cache_config(cache_dtype)) == expected_dtype
+
+
+def test_non_a5_pins_cache_dtype_to_the_model_dtype():
+    with _on(AscendDeviceType.A3):
+        for launch in ("auto", "bfloat16", "fp8"):
+            assert resolve_dsv4_cache_dtype(launch, "bfloat16") == "bfloat16"
+
+
+def test_a5_collapses_non_bfloat16_requests_to_auto():
+    # "auto" resolves to the model dtype everywhere downstream, so it carries
+    # the FP8 mode without changing any value upstream would have computed.
+    with _on(AscendDeviceType.A5):
+        assert resolve_dsv4_cache_dtype("bfloat16", "bfloat16") == "bfloat16"
+        assert resolve_dsv4_cache_dtype("auto", "bfloat16") == "auto"
+        assert resolve_dsv4_cache_dtype("fp8", "bfloat16") == "auto"
+
+
+def test_a5_mode_survives_the_spec_path_rewrite():
+    with _on(AscendDeviceType.A5):
+        for launch in ("auto", "fp8"):
+            pinned = resolve_dsv4_cache_dtype(launch, "bfloat16")
+            assert not is_a5_bf16_kv_enabled(_cache_config(pinned))
+            # layer.get_kv_cache_spec pins FP8 once it has picked the mode.
+            assert not is_a5_bf16_kv_enabled(_cache_config("float8_e4m3fn"))
+
+        pinned = resolve_dsv4_cache_dtype("bfloat16", "bfloat16")
+        assert is_a5_bf16_kv_enabled(_cache_config(pinned))

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -44,6 +44,14 @@ from vllm_ascend.models.deepseek_v4.indexer import (
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 
+def _mock_dsa_kv_plan(**method_returns) -> MagicMock:
+    plan = MagicMock()
+    plan.layout_kv = "PA_ND"
+    for name, value in method_returns.items():
+        getattr(plan, name).return_value = value
+    return plan
+
+
 def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
     model_config = SimpleNamespace(
         hf_config=SimpleNamespace(
@@ -130,22 +138,17 @@ def test_build_sas_metadata_parameters_cache_and_builder_buffer(
     cu_seqlens_cmp_kv = torch.tensor([0, 2, 4], dtype=torch.int32)
     generated_metadata = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
     metadata_op = MagicMock(return_value=generated_metadata)
+    plan = _mock_dsa_kv_plan(
+        get_dsa_sparse_attn_metadata_op=metadata_op,
+        get_dsa_sparse_attn_metadata_kwargs={"device": "cpu"},
+    )
 
     with (
         patch(
             "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
             return_value=2,
         ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_metadata_op",
-            return_value=metadata_op,
-        ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_metadata_kwargs",
-            return_value={"device": "cpu"},
-        ),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
     ):
         result = builder._build_sas_metadata(
             metadata_cache=metadata_cache,
@@ -264,10 +267,11 @@ def test_build_req_metadata_uses_for_prefill_and_decode(
             "vllm_ascend.attention.dsa_v1.split_decodes_and_prefills",
             return_value=(2, 0, 3, 0) if num_prefills == 0 else (1, 1, 1, 2),
         ),
-        patch.object(
-            DeviceOperator,
-            "format_dsa_slot_mapping",
-            return_value=torch.zeros((3, 2), dtype=torch.int32),
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan",
+            return_value=_mock_dsa_kv_plan(
+                format_dsa_slot_mapping=torch.zeros((3, 2), dtype=torch.int32),
+            ),
         ),
         patch.object(
             DeviceOperator,
@@ -376,10 +380,11 @@ def test_build_classifies_short_speculative_extends_as_decodes(
             "vllm_ascend.attention.utils.is_pd_decode_recompute_scheduler_enabled",
             return_value=False,
         ),
-        patch.object(
-            DeviceOperator,
-            "format_dsa_slot_mapping",
-            return_value=torch.zeros((14, 2), dtype=torch.int32),
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan",
+            return_value=_mock_dsa_kv_plan(
+                format_dsa_slot_mapping=torch.zeros((14, 2), dtype=torch.int32),
+            ),
         ),
         patch(
             "vllm_ascend.attention.dsa_v1.get_cos_and_sin_dsa",
@@ -500,6 +505,10 @@ def test_build_req_metadata_for_drafting_uses_decode_buffer_and_cpu_lengths():
     decode_cu_seqlens_cmp_kv = torch.tensor([0, 2, 4], dtype=torch.int32)
     generated_metadata = torch.arange(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32)
     metadata_op = MagicMock(return_value=generated_metadata)
+    plan = _mock_dsa_kv_plan(
+        get_dsa_sparse_attn_metadata_op=metadata_op,
+        get_dsa_sparse_attn_metadata_kwargs={"device": "cpu"},
+    )
     cos = torch.ones((3, 1, 1, 2))
     sin = torch.zeros((3, 1, 1, 2))
 
@@ -514,16 +523,7 @@ def test_build_req_metadata_for_drafting_uses_decode_buffer_and_cpu_lengths():
             "get_dsa_decode_cu_seqlens_cmp_kv",
             return_value=decode_cu_seqlens_cmp_kv,
         ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_metadata_op",
-            return_value=metadata_op,
-        ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_metadata_kwargs",
-            return_value={"device": "cpu"},
-        ),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
     ):
         metadata = builder.build_req_metadata_for_drafting(
             draft_index=1,
@@ -592,6 +592,7 @@ def _make_impl(
             n_local_groups=1,
             window_size=16,
             compress_ratio=1,
+            vllm_config=SimpleNamespace(cache_config=SimpleNamespace(cache_dtype="auto")),
             wq_a=linear,
             wq_b=linear,
             wkv=linear,
@@ -723,6 +724,12 @@ def test_forward_attention_routes_unified_req_metadata(
     def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
         extra_kwargs.update(kwargs)
 
+    plan = _mock_dsa_kv_plan(
+        get_dsa_sparse_attn_op=sparse_attn_op,
+        get_dsa_sparse_attn_base_kwargs={},
+    )
+    plan.add_dsa_sparse_attn_extra_kwargs.side_effect = add_extra_kwargs
+
     with (
         patch.object(
             DeviceOperator,
@@ -741,21 +748,7 @@ def test_forward_attention_routes_unified_req_metadata(
             "_mla_prolog_multistream",
             return_value=(q, torch.empty(0), None),
         ) as mla_prolog,
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_op",
-            return_value=sparse_attn_op,
-        ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_base_kwargs",
-            return_value={},
-        ),
-        patch.object(
-            DeviceOperator,
-            "add_dsa_sparse_attn_extra_kwargs",
-            side_effect=add_extra_kwargs,
-        ),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
         patch("vllm_ascend.attention.dsa_v1.record_attention_compute_start"),
     ):
@@ -853,8 +846,9 @@ class TestAscendDSACompressedCacheRouting:
         kv_cache = (torch.empty(0),)
         compress_kv_cache = torch.empty(0)
         state_cache = torch.empty(0)
+        plan = _mock_dsa_kv_plan()
 
-        with patch.object(DeviceOperator, "dsa_kv_compress_scatter") as scatter:
+        with patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan):
             actual = impl._maybe_update_compressed_caches_and_select_topk(
                 layer_name="model.layers.0.self_attn.attn",
                 hidden_states=hidden_states,
@@ -884,7 +878,7 @@ class TestAscendDSACompressedCacheRouting:
             state_cache=state_cache,
             metadata=compressor_metadata,
         )
-        scatter.assert_called_once_with(
+        plan.dsa_kv_compress_scatter.assert_called_once_with(
             compress_kv_cache,
             compressed_kv,
             compress_slot_mapping,
@@ -909,8 +903,9 @@ class TestAscendDSACompressedCacheRouting:
         hidden_states = torch.ones((1, 4))
         state_cache = torch.empty(0)
         compress_kv_cache = torch.empty(0)
+        plan = _mock_dsa_kv_plan()
 
-        with patch.object(DeviceOperator, "dsa_kv_compress_scatter") as scatter:
+        with patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan):
             actual = impl._maybe_update_compressed_caches_and_select_topk(
                 layer_name="layer",
                 hidden_states=hidden_states,
@@ -930,14 +925,14 @@ class TestAscendDSACompressedCacheRouting:
                 state_cache=state_cache,
                 metadata=compressor_metadata,
             )
-            scatter.assert_called_once_with(
+            plan.dsa_kv_compress_scatter.assert_called_once_with(
                 compress_kv_cache,
                 compressed_kv,
                 compress_slot_mapping,
             )
         else:
             impl.compressor.assert_not_called()
-            scatter.assert_not_called()
+            plan.dsa_kv_compress_scatter.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -997,6 +992,12 @@ def test_forward_attention_sets_compressed_kv_args(
     def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
         extra_kwargs.update(kwargs)
 
+    plan = _mock_dsa_kv_plan(
+        get_dsa_sparse_attn_op=sparse_attn_op,
+        get_dsa_sparse_attn_base_kwargs={},
+    )
+    plan.add_dsa_sparse_attn_extra_kwargs.side_effect = add_extra_kwargs
+
     with (
         patch.object(
             DeviceOperator,
@@ -1020,21 +1021,7 @@ def test_forward_attention_sets_compressed_kv_args(
             "_maybe_update_compressed_caches_and_select_topk",
             return_value=topk_indices,
         ) as update_compressed_caches,
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_op",
-            return_value=sparse_attn_op,
-        ),
-        patch.object(
-            DeviceOperator,
-            "get_dsa_sparse_attn_base_kwargs",
-            return_value={},
-        ),
-        patch.object(
-            DeviceOperator,
-            "add_dsa_sparse_attn_extra_kwargs",
-            side_effect=add_extra_kwargs,
-        ),
+        patch("vllm_ascend.attention.dsa_v1.get_dsa_attn_kv_plan", return_value=plan),
         patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
         patch("vllm_ascend.attention.dsa_v1.record_attention_compute_start"),
     ):
@@ -1065,6 +1052,28 @@ def test_forward_attention_sets_compressed_kv_args(
         assert sparse_kwargs["cmp_sparse_indices"] is topk_indices
     else:
         assert "cmp_sparse_indices" not in sparse_kwargs
+
+
+def test_a5_bf16_o_proj_uses_transpose_batchmatmul():
+    impl = _make_impl()
+    impl.support_fp8_attention = True
+    impl.wo_a = SimpleNamespace(weight=torch.randn(1, 2, 2), weight_scale=None)
+    impl.wo_b = lambda x: x
+    o_proj_input = torch.randn(4, 1, 2)
+    output = torch.empty(4, 2)
+    projected = torch.randn(4, 1, 2)
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.oproj_tp_enable", return_value=False),
+        patch("vllm_ascend.attention.dsa_v1.olora_tp_enable", return_value=False),
+        patch("vllm_ascend.attention.dsa_v1.torch_npu.npu_transpose_batchmatmul", return_value=projected) as batched,
+        patch("vllm_ascend.attention.dsa_v1.torch_npu.npu_dynamic_mx_quant") as quant,
+    ):
+        impl._forward_o_proj(o_proj_input, output)
+
+    batched.assert_called_once()
+    quant.assert_not_called()
+    torch.testing.assert_close(output, projected.reshape(4, -1))
 
 
 def test_prepared_cache_rejects_multistream_before_cache_access():

--- a/tests/ut/attention/test_dsv4_block_geometry.py
+++ b/tests/ut/attention/test_dsv4_block_geometry.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
-from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import Compressor
 
 
@@ -48,10 +47,14 @@ def test_compressor_metadata_uses_physical_storage_geometry(
         captured["args"] = args
         return expected
 
+    plan = SimpleNamespace(get_dsa_compressor_slot_mapping_format=lambda: 2)
     monkeypatch.setattr(
-        DeviceOperator,
-        "get_dsa_compressor_slot_mapping_format",
-        staticmethod(lambda: 2),
+        "vllm_ascend.attention.dsa_attn_kv_plan.get_dsa_attn_kv_plan",
+        lambda vllm_config: plan,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.attention.context_parallel.dsa_cp.get_dsa_attn_kv_plan",
+        lambda vllm_config: plan,
     )
     monkeypatch.setattr(
         torch.ops._C_ascend,
@@ -61,6 +64,7 @@ def test_compressor_metadata_uses_physical_storage_geometry(
     )
     owner = owner_cls.__new__(owner_cls)
     owner.compress_ratio = compress_ratio
+    owner.vllm_config = SimpleNamespace()
 
     result = getattr(owner, method_name)(metadata)
 

--- a/tests/ut/attention/test_sparse_flash_mla.py
+++ b/tests/ut/attention/test_sparse_flash_mla.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+from unittest import mock
+
+import torch
+
+from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla, sparse_flash_mla_metadata
+
+
+def test_adapter_enforces_bf16_paged_layout():
+    metadata_op = mock.Mock(return_value=torch.empty(0))
+    attention_op = mock.Mock(return_value=torch.empty(0))
+    with mock.patch(
+        "vllm_ascend.attention.sparse_flash_mla._get_sparse_flash_mla_ops",
+        return_value=(attention_op, metadata_op),
+    ):
+        sparse_flash_mla_metadata(layout_kv="PA_ND")
+        sparse_flash_mla(torch.empty(0), layout_kv="PA_ND")
+
+    assert metadata_op.call_args.kwargs["layout_kv"] == "PA_BBND"
+    assert attention_op.call_args.kwargs["layout_kv"] == "PA_BBND"

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -124,6 +124,9 @@ if not _npu_available:
     sys.modules["torch_npu"].npu_rms_norm = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_swiglu = MagicMock()  # type: ignore[attr-defined]
     sys.modules["torch_npu"].npu_convert_weight_to_int4pack = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_transpose_batchmatmul = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_scatter_nd_update_ = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch_npu"].npu_dynamic_mx_quant = MagicMock()  # type: ignore[attr-defined]
 
 adapt_patch()
 adapt_patch(True)

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.attention import dsa_attn_kv_plan
 from vllm_ascend.models.deepseek_v4.compressor import (
     AscendCompressorMetadata,
     AscendCompressorStateCache,
@@ -20,6 +20,7 @@ class TestCompressorMetadata:
         compressor = Compressor.__new__(Compressor)
         torch.nn.Module.__init__(compressor)
         compressor.compress_ratio = 4
+        compressor.vllm_config = SimpleNamespace()
         full_cos = torch.arange(8).view(2, 1, 1, 4)
         full_sin = -full_cos
         query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
@@ -38,13 +39,14 @@ class TestCompressorMetadata:
         result_cos = torch.ones((3, 4))
         result_sin = torch.zeros((3, 4))
         slot_mapping = torch.tensor([[0, 1]], dtype=torch.int32)
+        plan = SimpleNamespace(get_dsa_compressor_slot_mapping_format=MagicMock(return_value=7))
 
         with (
             patch.object(
-                DeviceOperator,
-                "get_dsa_compressor_slot_mapping_format",
-                return_value=7,
-            ) as get_slot_format,
+                dsa_attn_kv_plan,
+                "get_dsa_attn_kv_plan",
+                return_value=plan,
+            ),
             patch.object(
                 torch.ops._C_ascend,
                 "compressor_metadata",
@@ -57,7 +59,7 @@ class TestCompressorMetadata:
         assert actual[0] is result_cos
         assert actual[1] is result_sin
         assert actual[2] is slot_mapping
-        get_slot_format.assert_called_once_with()
+        plan.get_dsa_compressor_slot_mapping_format.assert_called_once_with()
         args = metadata_op.call_args.args
         assert torch.equal(args[0], full_cos.view(2, 4))
         assert torch.equal(args[1], full_sin.view(2, 4))
@@ -150,7 +152,9 @@ class TestCompressorStateCache:
         cache.block_size = 8
         cache.dtype = torch.float32
         cache.sliding_window = 64
-        vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=128))
+        vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=128, cache_dtype="auto"),
+        )
 
         spec = cache.get_kv_cache_spec(vllm_config)
 

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -1,3 +1,5 @@
+import sys
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -398,3 +400,44 @@ def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
     )
 
     assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER
+
+
+def test_set_ascend_forward_context_pins_current_vllm_config(monkeypatch):
+    vllm_config = _make_vllm_config()
+    seen: dict[str, object] = {"config": None, "inside": False}
+
+    @contextmanager
+    def fake_set_current(config):
+        seen["config"] = config
+        seen["inside"] = True
+        try:
+            yield
+        finally:
+            seen["inside"] = False
+
+    @contextmanager
+    def fake_set_forward_context(**_kwargs):
+        yield
+
+    forward_context = SimpleNamespace(dp_metadata=None)
+
+    monkeypatch.setattr(afc, "set_current_vllm_config", fake_set_current)
+    monkeypatch.setattr(afc, "set_forward_context", fake_set_forward_context)
+    monkeypatch.setattr(afc, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(afc, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(afc, "get_dp_group", lambda: SimpleNamespace(world_size=1))
+    monkeypatch.setattr(afc, "has_layer_idx", lambda _model: False)
+    monkeypatch.setattr(afc, "select_moe_comm_method", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(afc, "get_mc2_mask", lambda: None)
+
+    moe_mod_name = "vllm_ascend.ops.fused_moe.moe_comm_method"
+    if moe_mod_name in sys.modules:
+        monkeypatch.setattr(sys.modules[moe_mod_name], "get_moe_comm_method", lambda _t: None)
+    else:
+        monkeypatch.setitem(sys.modules, moe_mod_name, SimpleNamespace(get_moe_comm_method=lambda _t: None))
+
+    with afc.set_ascend_forward_context(None, vllm_config, num_tokens=4):
+        assert seen["inside"] is True
+        assert seen["config"] is vllm_config
+
+    assert seen["inside"] is False

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 import vllm.envs as envs_vllm
-from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import BatchDescriptor, get_forward_context, set_forward_context
 from vllm.logger import logger
@@ -76,6 +76,13 @@ def set_ascend_forward_context(
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
     We add some additional param into forward_context.
+
+    Also publish the process-global current vLLM config for this forward so
+    CustomOps (RMSNorm, rotary, Linear, MoE) can call get_current_vllm_config()
+    from ``__init__`` when they are first created during eager prefill.
+    ``set_current_vllm_config`` is a context manager and restores ``None`` on
+    exit, so wrapping only ``load_model`` is not enough; pin it here instead of
+    in the Worker.
     """
     forward_context_kwargs = {
         "attn_metadata": attn_metadata,
@@ -86,7 +93,7 @@ def set_ascend_forward_context(
         "batch_descriptor": batch_descriptor,
         "skip_compiled": skip_compiled,
     }
-    with set_forward_context(**forward_context_kwargs):
+    with set_current_vllm_config(vllm_config), set_forward_context(**forward_context_kwargs):
         forward_context = get_forward_context()
         forward_context.draft_attn_metadatas = draft_attn_metadatas
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -14,7 +14,14 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 from vllm_ascend.attention import dsa_v1
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_attn_kv_plan import (
+    get_dsa_attn_kv_plan,
+    is_a5_bf16_kv_enabled,
+)
 from vllm_ascend.attention.dsa_v1 import (
+    _dsa_layout_kv,
+    _dsa_swa_only_cmp_ratio,
+    _has_weight_scale,
     build_dspark_swa_indices,
     get_dspark_sparse_sas_window,
 )
@@ -238,7 +245,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION) and not is_a5_bf16_kv_enabled(
+            vllm_config
+        ):
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
@@ -342,7 +351,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # are generated later from the logical block table by compressor_metadata.
         if self.compressor_ratio <= 1:
             slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-            self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(
+            self.slot_mapping[:num_input_tokens] = get_dsa_attn_kv_plan(self.vllm_config).format_dsa_slot_mapping(
                 slot_mapping, self.storage_block_size
             )
 
@@ -411,9 +420,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
 
         assert self.spec_slot_mapping is not None
-        self.spec_slot_mapping[draft_index - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(
-            slot_mapping, self.storage_block_size
-        )
+        self.spec_slot_mapping[draft_index - 1][:num_input_tokens] = get_dsa_attn_kv_plan(
+            self.vllm_config
+        ).format_dsa_slot_mapping(slot_mapping, self.storage_block_size)
 
         self.block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         req_metadata = self.build_req_metadata_for_drafting(
@@ -522,9 +531,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         slot_mapping = self.spec_slot_mapping[draft_index - 1][: self.num_actual_tokens]
 
         num_heads = self.model_config.hf_config.num_attention_heads
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        metadata_kwargs.setdefault("device", str(self.seqused_q.device))
+        kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
+        metadata_op = kv_plan.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = kv_plan.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         cu_seqlens_ori_kv = (
             local_query_start_loc
             if has_prefill
@@ -558,7 +567,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             ori_win_left=ori_win_left,
             ori_win_right=ori_win_right,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv=_dsa_layout_kv(self.vllm_config),
             has_ori_kv=True,
             has_cmp_kv=False,
         )
@@ -953,9 +962,9 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cu_seqlens_cmp_kv = (
                 None if has_prefill else DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
             )
-            metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-            metadata_kwargs.setdefault("device", str(self.seqused_q.device))
+            kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
+            metadata_op = kv_plan.get_dsa_sparse_attn_metadata_op()
+            metadata_kwargs = kv_plan.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
             kw = dict(
                 **metadata_kwargs,
                 num_heads_q=num_heads,
@@ -973,7 +982,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 ori_win_left=self.model_config.hf_config.sliding_window - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
+                layout_kv=_dsa_layout_kv(self.vllm_config),
                 has_ori_kv=True,
             )
 
@@ -1118,7 +1127,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
         self.attn_sink = kwargs["attn_sink"]
 
-        self.vllm_config = get_current_vllm_config()
+        self.vllm_config = kwargs.get("vllm_config", get_current_vllm_config())
 
         # indexer param
         if self.indexer is not None:
@@ -1201,7 +1210,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             metadata.start_pos,
             metadata.block_table,
             metadata.storage_block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+            get_dsa_attn_kv_plan(self.vllm_config).get_dsa_compressor_slot_mapping_format(),
             self.compress_ratio,
             metadata.num_compressed_tokens,
             metadata.num_actual_reqs,
@@ -1463,7 +1472,8 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             self._switch_o_proj_to_full_weight()
         o_proj_groups = self.n_group if full_gather_wo_a_enabled else self.n_local_groups
         try:
-            if self.support_fp8_attention:
+            use_a5_quant_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
+            if use_a5_quant_o_proj:
                 o = o_proj_input.view(num_tokens, o_proj_groups, -1)
                 wo_a_method = getattr(self.wo_a.quant_method, "quant_method", self.wo_a.quant_method)
                 if isinstance(wo_a_method, AscendUnquantizedLinearMethod):
@@ -1491,6 +1501,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 else:
                     # wo_a = self.wo_a.weight.view(o_proj_groups, self.o_lora_rank, -1)
                     # o = torch.einsum("tgd,grd->tgr", o, wo_a)
+                    # A5 BF16 uses the same 3D [groups, hidden, rank] layout.
                     o_proj_input = torch_npu.npu_transpose_batchmatmul(
                         o_proj_input,
                         self._get_batched_wo_a_weight(o_proj_groups),
@@ -1620,7 +1631,9 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, swa_metadata.req_metadata.slot_mapping)
+        get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
+            swa_kv_cache, kv, swa_metadata.req_metadata.slot_mapping
+        )
 
         compress_topk_idxs = None
         if self.compress_ratio > 1:
@@ -1678,16 +1691,17 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
             if compressed_kv.numel() == 0:
                 compressed_kv = None
-            DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
+            get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
+                compress_kv_cache, compressed_kv, compress_slot_mapping
+            )
 
         notify_kv_cache_written(layer_name)
         record_attention_compute_start()
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
+        attn_op = kv_plan.get_dsa_sparse_attn_op()
+        extra_attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()
         if has_prefill:
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query
-            )
+            kv_plan.add_dsa_sparse_attn_extra_kwargs(extra_attn_kwargs, cu_seqlens_ori_kv=local_seq_lengths_query)
         if swa_req_metadata.dspark_swa_indices is not None:
             extra_attn_kwargs["ori_sparse_indices"] = swa_req_metadata.dspark_swa_indices
 
@@ -1699,12 +1713,12 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             seqused_kv=local_seq_lengths_key,
             sinks=self.attn_sink,
             softmax_scale=self.softmax_scale,
-            cmp_ratio=max(self.compress_ratio, 1),
+            cmp_ratio=_dsa_swa_only_cmp_ratio(self.compress_ratio, self.vllm_config),
             ori_mask_mode=4,
             ori_win_left=ori_win_left,
             ori_win_right=ori_win_right,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv=_dsa_layout_kv(self.vllm_config),
             **extra_attn_kwargs,
         )
 
@@ -1720,7 +1734,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             assert compressor_attn_metadata is not None
             compressor_req_metadata = compressor_attn_metadata.req_metadata
             assert compressor_req_metadata is not None
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+            kv_plan.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             attn_output = attn_op(
@@ -1738,7 +1752,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             assert compressor_attn_metadata is not None
             compressor_req_metadata = compressor_attn_metadata.req_metadata
             assert compressor_req_metadata is not None
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
+            kv_plan.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             attn_output = attn_op(
@@ -2182,7 +2196,7 @@ class AscendDSAPCPImpl(dsa_v1.AscendDSAImpl):
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
-        DeviceOperator.dsa_kv_compress_scatter(
+        get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
             swa_kv_cache,
             kv,
             req_metadata.slot_mapping,
@@ -2203,7 +2217,7 @@ class AscendDSAPCPImpl(dsa_v1.AscendDSAImpl):
             metadata=metadata,
         )
         if compressed_kv.shape[0] > 0:
-            DeviceOperator.dsa_kv_compress_scatter(
+            get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
                 compress_kv_cache,
                 compressed_kv,
                 compress_slot_mapping,

--- a/vllm_ascend/attention/dsa_attn_kv_plan.py
+++ b/vllm_ascend/attention/dsa_attn_kv_plan.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Centralized DeepSeek-V4 attention-KV execution choices."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch_npu
+
+from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla, sparse_flash_mla_metadata
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+_BF16_KV_CACHE_DTYPES = frozenset({"bfloat16", "bf16"})
+
+
+def resolve_dsv4_cache_dtype(cache_dtype, model_dtype: str) -> str:
+    """Return the KV cache dtype the platform should pin for DeepSeek-V4.
+
+    On A5 the launch request has to stay readable afterwards, because it is the
+    only thing that separates an explicit bfloat16 KV request from ``auto``.
+    ``auto`` and the model dtype resolve identically everywhere downstream, so
+    collapsing every non-bfloat16 request to ``auto`` preserves the upstream
+    values while keeping the mode recoverable.
+    """
+    if get_ascend_device_type() != AscendDeviceType.A5:
+        return model_dtype
+    return "bfloat16" if str(cache_dtype).lower() in _BF16_KV_CACHE_DTYPES else "auto"
+
+
+def is_a5_bf16_kv_enabled(vllm_config) -> bool:
+    """Return whether BF16 SparseFlashMla KV is enabled on A5.
+
+    Callers must pass the engine ``vllm_config``. Do not look it up from the
+    process-global current config: that context is only set during
+    ``load_model()`` and a missing lookup would silently pick the FP8 plan.
+    """
+    if get_ascend_device_type() != AscendDeviceType.A5:
+        return False
+    cache_config = getattr(vllm_config, "cache_config", None)
+    if cache_config is None:
+        return False
+    return str(cache_config.cache_dtype).lower() in _BF16_KV_CACHE_DTYPES
+
+
+def get_dsv4_attn_kv_dtype(vllm_config) -> torch.dtype:
+    """Return the attention KV dtype while preserving non-A5 behavior."""
+    return (
+        torch.bfloat16
+        if get_ascend_device_type() != AscendDeviceType.A5 or is_a5_bf16_kv_enabled(vllm_config)
+        else torch.float8_e4m3fn
+    )
+
+
+DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
+DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
+
+
+@dataclass(frozen=True)
+class DsaAttnKvPlan:
+    """The attention-KV plan only; indexer KV remains independently FP8."""
+
+    uses_sparse_flash_mla: bool
+    uses_kv_compress_epilog: bool
+    layout_kv: str
+    compressor_slot_mapping_format: int
+    requires_block_offset_slots: bool
+    sparse_attn_op: Callable[..., Any]
+    sparse_attn_metadata_op: Callable[..., Any]
+    sparse_attn_base_kwargs: dict[str, Any]
+    sparse_attn_metadata_kwargs: dict[str, Any]
+    include_metadata_device: bool
+    applies_sparse_attn_runtime_kwargs: bool
+
+    def get_dsa_sparse_attn_metadata_op(self):
+        return self.sparse_attn_metadata_op
+
+    def get_dsa_sparse_attn_metadata_kwargs(self, device) -> dict[str, Any]:
+        kwargs = dict(self.sparse_attn_metadata_kwargs)
+        if self.include_metadata_device:
+            kwargs["device"] = str(device)
+        return kwargs
+
+    def get_dsa_sparse_attn_op(self):
+        return self.sparse_attn_op
+
+    def get_dsa_sparse_attn_base_kwargs(self) -> dict[str, Any]:
+        return dict(self.sparse_attn_base_kwargs)
+
+    def add_dsa_sparse_attn_extra_kwargs(self, extra_kwargs: dict[str, Any], **kwargs_to_add) -> None:
+        if self.applies_sparse_attn_runtime_kwargs:
+            extra_kwargs.update(kwargs_to_add)
+
+    def get_dsa_compressor_slot_mapping_format(self) -> int:
+        return self.compressor_slot_mapping_format
+
+    def format_dsa_slot_mapping(self, slot_mapping: torch.Tensor, block_size: int) -> torch.Tensor:
+        if not self.requires_block_offset_slots:
+            return slot_mapping
+        valid = slot_mapping >= 0
+        invalid = torch.full_like(slot_mapping, -1)
+        block_idx = torch.where(valid, torch.div(slot_mapping, block_size, rounding_mode="floor"), invalid)
+        offset = torch.where(valid, slot_mapping % block_size, invalid)
+        return torch.stack([block_idx, offset], dim=-1).to(torch.int32)
+
+    def dsa_kv_compress_scatter(self, cache: torch.Tensor, x: torch.Tensor | None, slot_mapping: torch.Tensor) -> None:
+        if x is None:
+            return
+        if self.uses_sparse_flash_mla:
+            if slot_mapping.ndim != 2 or slot_mapping.shape[-1] != 2:
+                raise ValueError(f"BF16 DSA slot_mapping must be [num_tokens, 2], got {tuple(slot_mapping.shape)}.")
+            # Keep fixed [T, 2] shape under ACLGraph. SparseFlashMla's
+            # scatter path receives padded [-1, -1] rows directly; do not
+            # introduce a data-dependent Nonzero/gather operation here.
+            indices = slot_mapping.to(torch.int64).contiguous()
+            updates = x.reshape((slot_mapping.shape[0],) + tuple(cache.shape[2:])).contiguous()
+            torch_npu.npu_scatter_nd_update_(cache, indices, updates)
+            return
+        if not self.uses_kv_compress_epilog:
+            torch.ops._C_ascend.npu_scatter_nd_update_v2(cache, slot_mapping, x)
+            return
+        torch.ops._C_ascend.kv_compress_epilog(
+            kv_compress_cache=cache.view(-1, 1, cache.shape[-1]),
+            x=x.view(-1, x.shape[-1]),
+            slot_mapping=slot_mapping,
+            quant_group_size=64,
+            quant_mode=2,
+            round_scale_flag=True,
+            layout=1,
+        )
+
+
+def get_dsa_attn_kv_plan(vllm_config) -> DsaAttnKvPlan:
+    """Return the explicit A5 BF16 or upstream-compatible FP8 DSA plan."""
+    if get_ascend_device_type() != AscendDeviceType.A5:
+        return DsaAttnKvPlan(
+            uses_sparse_flash_mla=False,
+            uses_kv_compress_epilog=False,
+            layout_kv="PA_ND",
+            compressor_slot_mapping_format=DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET,
+            requires_block_offset_slots=True,
+            sparse_attn_op=torch.ops._C_ascend.npu_sparse_attn_sharedkv,
+            sparse_attn_metadata_op=torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata,
+            sparse_attn_base_kwargs={},
+            sparse_attn_metadata_kwargs={},
+            include_metadata_device=True,
+            applies_sparse_attn_runtime_kwargs=True,
+        )
+
+    use_bf16 = is_a5_bf16_kv_enabled(vllm_config)
+    if use_bf16:
+        return DsaAttnKvPlan(
+            uses_sparse_flash_mla=True,
+            uses_kv_compress_epilog=False,
+            layout_kv="PA_BBND",
+            compressor_slot_mapping_format=DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET,
+            requires_block_offset_slots=True,
+            sparse_attn_op=sparse_flash_mla,
+            sparse_attn_metadata_op=sparse_flash_mla_metadata,
+            sparse_attn_base_kwargs={},
+            sparse_attn_metadata_kwargs={},
+            include_metadata_device=True,
+            applies_sparse_attn_runtime_kwargs=True,
+        )
+    return DsaAttnKvPlan(
+        uses_sparse_flash_mla=False,
+        uses_kv_compress_epilog=True,
+        layout_kv="PA_ND",
+        compressor_slot_mapping_format=DSA_COMPRESSOR_SLOT_MAPPING_FLAT,
+        requires_block_offset_slots=False,
+        sparse_attn_op=torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv,
+        sparse_attn_metadata_op=torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata,
+        sparse_attn_base_kwargs={"kv_quant_mode": 1, "tile_size": 64, "rope_head_dim": 64},
+        sparse_attn_metadata_kwargs={"kv_quant_mode": 1},
+        include_metadata_device=False,
+        applies_sparse_attn_runtime_kwargs=False,
+    )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -19,6 +19,10 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.dsa_attn_kv_plan import (
+    get_dsa_attn_kv_plan,
+    is_a5_bf16_kv_enabled,
+)
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     enable_pcp,
@@ -78,6 +82,21 @@ def _is_w8a8_dynamic(linear) -> bool:
         return False
     inner_method = getattr(quant_method, "quant_method", None)
     return isinstance(inner_method, AscendW8A8DynamicLinearMethod)
+
+
+def _has_weight_scale(linear) -> bool:
+    return getattr(linear, "weight_scale", None) is not None
+
+
+def _dsa_layout_kv(vllm_config: VllmConfig) -> str:
+    return get_dsa_attn_kv_plan(vllm_config).layout_kv
+
+
+def _dsa_swa_only_cmp_ratio(compress_ratio: int, vllm_config: VllmConfig) -> int:
+    """BF16 SWA-only attention takes no compressed stream; otherwise keep main's value."""
+    if is_a5_bf16_kv_enabled(vllm_config) and compress_ratio <= 1:
+        return 0
+    return max(compress_ratio, 1)
 
 
 class AscendDSABackend(AttentionBackend):
@@ -354,7 +373,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION) and not is_a5_bf16_kv_enabled(
+            vllm_config
+        ):
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
@@ -569,7 +590,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # are generated later from the logical block table by compressor_metadata.
         if self.compressor_ratio <= 1:
             slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
-            self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(
+            self.slot_mapping[:num_input_tokens] = get_dsa_attn_kv_plan(self.vllm_config).format_dsa_slot_mapping(
                 slot_mapping, self.storage_block_size
             )
 
@@ -609,9 +630,16 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             tp_size = get_tensor_model_parallel_world_size()
             n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
             index_topk = self.model_config.hf_config.index_topk
-            cmp_ratio = 1 if self.compressor_ratio <= 1 else 4 if self.compressor_ratio == 4 else 128
-            metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+            cmp_ratio = (
+                _dsa_swa_only_cmp_ratio(self.compressor_ratio, self.vllm_config)
+                if self.compressor_ratio <= 1
+                else 4
+                if self.compressor_ratio == 4
+                else 128
+            )
+            kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
+            metadata_op = kv_plan.get_dsa_sparse_attn_metadata_op()
+            metadata_kwargs = kv_plan.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
             sas_metadata = metadata_op(
                 **metadata_kwargs,
                 num_heads_q=n_local_heads,
@@ -632,7 +660,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 ori_win_left=self.model_config.hf_config.sliding_window - 1,
                 ori_win_right=0,
                 layout_q="TND",
-                layout_kv="PA_ND",
+                layout_kv=_dsa_layout_kv(self.vllm_config),
                 has_ori_kv=True,
                 has_cmp_kv=self.compressor_ratio > 1,
             )
@@ -817,9 +845,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_index)
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
         assert self.spec_slot_mapping is not None
-        self.spec_slot_mapping[draft_index - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(
-            slot_mapping, self.storage_block_size
-        )
+        self.spec_slot_mapping[draft_index - 1][:num_input_tokens] = get_dsa_attn_kv_plan(
+            self.vllm_config
+        ).format_dsa_slot_mapping(slot_mapping, self.storage_block_size)
         req_metadata = self.build_req_metadata_for_drafting(
             draft_index=draft_index,
             common_attn_metadata=common_attn_metadata,
@@ -892,8 +920,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         cu_seqlens_cmp_kv = (
             None if has_prefill else DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
         )
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
+        kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
+        metadata_op = kv_plan.get_dsa_sparse_attn_metadata_op()
+        metadata_kwargs = kv_plan.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
         n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
         sas_metadata = metadata_op(
@@ -915,7 +944,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             ori_win_left=ori_win_left,
             ori_win_right=ori_win_right,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv=_dsa_layout_kv(self.vllm_config),
             has_ori_kv=True,
             has_cmp_kv=False,
         )
@@ -992,6 +1021,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         compress_ratio: int,
         **kwargs,
     ):
+        self.vllm_config = kwargs["vllm_config"]
         self.num_heads = n_heads
         self.n_local_heads = n_local_heads
         self.scale = scale
@@ -1034,6 +1064,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         ascend_config = get_ascend_config()
         self.multistream_dsv4_dsa_overlap = ascend_config.multistream_dsv4_dsa_overlap
+        if self.multistream_dsv4_dsa_overlap and is_a5_bf16_kv_enabled(self.vllm_config):
+            self.multistream_dsv4_dsa_overlap = False
 
     def _get_layer_metadata(
         self,
@@ -1097,7 +1129,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
         # + quantized batch matmul). Preserve it as-is: it predates and is
         # orthogonal to the OTP / olora_tp paths below, so it must win first.
-        if self.support_fp8_attention:
+        use_a5_quant_o_proj = self.support_fp8_attention and _has_weight_scale(self.wo_a)
+        if use_a5_quant_o_proj:
             o = o_proj_input
             o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(
@@ -1185,6 +1218,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             o_proj_input = self.wo_a(o_proj_input)
             output[...] = self.wo_b(o_proj_input)
         else:
+            # A5 BF16 wo_a is reshaped to [groups, hidden, rank] at load time,
+            # matching the A3 layout expected by npu_transpose_batchmatmul.
             o_proj_input = torch_npu.npu_transpose_batchmatmul(
                 o_proj_input,
                 self.wo_a.weight,
@@ -1362,7 +1397,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             )
 
             # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(
+            get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
                 swa_kv_cache,
                 kv,
                 slot_mapping,
@@ -1437,7 +1472,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 rotary_mode="interleave",
                 partial_slice=[self.nope_head_dim, self.head_dim],
             )
-            DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+            get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
 
         if is_prefill:
             q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
@@ -1500,7 +1535,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 compress_slot_mapping: torch.Tensor,
             ) -> None:
                 if compressed_kv.shape[0] > 0:
-                    DeviceOperator.dsa_kv_compress_scatter(
+                    get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
                         compress_kv_cache,
                         compressed_kv,
                         compress_slot_mapping,
@@ -1530,7 +1565,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             metadata=layer_metadata.compressor,
         )
         if compressed_kv.shape[0] > 0:
-            DeviceOperator.dsa_kv_compress_scatter(
+            get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(
                 compress_kv_cache,
                 compressed_kv,
                 compress_slot_mapping,
@@ -1613,18 +1648,13 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         notify_kv_cache_written(layer_name)
         record_attention_compute_start()
-        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
+        attn_op = kv_plan.get_dsa_sparse_attn_op()
+        attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()
         if has_prefill:
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                attn_kwargs,
-                cu_seqlens_ori_kv=actual_seq_lengths_query,
-            )
+            kv_plan.add_dsa_sparse_attn_extra_kwargs(attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query)
         if self.compress_ratio > 1:
-            DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                attn_kwargs,
-                cu_seqlens_cmp_kv=common_metadata.cu_cmp_seqlen_list,
-            )
+            kv_plan.add_dsa_sparse_attn_extra_kwargs(attn_kwargs, cu_seqlens_cmp_kv=common_metadata.cu_cmp_seqlen_list)
 
         attn_kwargs.update(
             ori_kv=swa_kv_cache,
@@ -1634,12 +1664,12 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             sinks=self.attn_sink,
             metadata=common_metadata.sas_metadata,
             softmax_scale=self.softmax_scale,
-            cmp_ratio=max(self.compress_ratio, 1),
+            cmp_ratio=_dsa_swa_only_cmp_ratio(self.compress_ratio, self.vllm_config),
             ori_mask_mode=4,
             ori_win_left=ori_win_left,
             ori_win_right=ori_win_right,
             layout_q="TND",
-            layout_kv="PA_ND",
+            layout_kv=_dsa_layout_kv(self.vllm_config),
         )
 
         if self.compress_ratio <= 1:

--- a/vllm_ascend/attention/sparse_flash_mla.py
+++ b/vllm_ascend/attention/sparse_flash_mla.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from functools import lru_cache
+from importlib import import_module
+from typing import Any
+
+import torch
+
+
+@lru_cache
+def _get_sparse_flash_mla_ops() -> tuple[Callable, Callable]:
+    """Load SparseFlashMla operators without importing vllm_ascend.ops."""
+    try:
+        import_module("cann_ops_transformer")
+        namespace = torch.ops.cann_ops_transformer
+        return namespace.sparse_flash_mla, namespace.sparse_flash_mla_metadata
+    except (ImportError, AttributeError) as exc:
+        raise RuntimeError(
+            "DeepSeek-V4 BF16 KV on Ascend A5 requires SparseFlashMla from a matching CANN 9.2 toolkit."
+        ) from exc
+
+
+def _add_compressed_kv_lengths(kwargs: dict[str, Any]) -> None:
+    cmp_ratio = kwargs.get("cmp_ratio") or 0
+    seqused_ori_kv = kwargs.get("seqused_ori_kv")
+    if cmp_ratio <= 1 or seqused_ori_kv is None:
+        return
+    kwargs.setdefault("seqused_cmp_kv", seqused_ori_kv // cmp_ratio)
+    kwargs.setdefault("cmp_residual_kv", seqused_ori_kv % cmp_ratio)
+    if kwargs.get("max_seqlen_cmp_kv") is None and kwargs.get("max_seqlen_ori_kv") is not None:
+        kwargs["max_seqlen_cmp_kv"] = kwargs["max_seqlen_ori_kv"] // cmp_ratio
+
+
+def sparse_flash_mla_metadata(**kwargs):
+    """Adapt existing DSA metadata kwargs to SparseFlashMla BF16 KV."""
+    kwargs.pop("device", None)
+    kwargs.pop("kv_quant_mode", None)
+    # This adapter is only selected for the BF16 paged-KV path. SparseFlashMla
+    # accepts PA_BBND for this cache; PA_ND belongs to the FP8 quantized op.
+    kwargs["layout_kv"] = "PA_BBND"
+    if "seqused_kv" in kwargs:
+        kwargs["seqused_ori_kv"] = kwargs.pop("seqused_kv")
+    if "max_seqlen_kv" in kwargs:
+        kwargs["max_seqlen_ori_kv"] = kwargs.pop("max_seqlen_kv")
+    _add_compressed_kv_lengths(kwargs)
+    _, metadata_op = _get_sparse_flash_mla_ops()
+    return metadata_op(**kwargs)
+
+
+def sparse_flash_mla(q: torch.Tensor, **kwargs):
+    """Adapt existing DSA attention kwargs to SparseFlashMla BF16 KV."""
+    kwargs.pop("kv_quant_mode", None)
+    kwargs.pop("tile_size", None)
+    kwargs.pop("rope_head_dim", None)
+    kwargs["layout_kv"] = "PA_BBND"
+    if "seqused_kv" in kwargs:
+        kwargs["seqused_ori_kv"] = kwargs.pop("seqused_kv")
+    _add_compressed_kv_lengths(kwargs)
+    attention_op, _ = _get_sparse_flash_mla_ops()
+    return attention_op(q, **kwargs)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -31,9 +31,6 @@ from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.quantization.utils import QUANT_DTYPES, SCALE_DTYPES, get_dynamic_mx_quant_scale_alg
 
-DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
-DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
-
 if HAS_TRITON:
     from vllm_ascend.ops.triton.rms_norm import triton_q_rms  # noqa: F811
 else:
@@ -510,40 +507,6 @@ class BaseDeviceAdaptor:
 
         return context_layer
 
-    # ===== Sparse Attention Metadata & Op Selectors =====
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_op():
-        """Returns the metadata-building operator for sparse attention."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_kwargs(device):
-        """Returns kwargs for sparse attention metadata builder."""
-        return {"device": str(device)}
-
-    @staticmethod
-    def get_dsa_sparse_attn_op():
-        """Returns the sparse attention operator."""
-        return torch.ops._C_ascend.npu_sparse_attn_sharedkv
-
-    @staticmethod
-    def get_dsa_sparse_attn_base_kwargs():
-        """Returns base kwargs for sparse attention (extended by caller)."""
-        return {}
-
-    @staticmethod
-    def get_dsa_compressor_slot_mapping_format():
-        """Slot mapping side output format consumed by the DSA scatter op."""
-        return DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET
-
-    # ===== SWA / Compressor KV Scatter =====
-
-    @staticmethod
-    def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache. Non-A5: simple scatter of pre-quantized tensor."""
-        torch.ops._C_ascend.npu_scatter_nd_update_v2(cache, slot_mapping, x)
-
     # ===== Indexer Quant + Scatter =====
 
     @staticmethod
@@ -674,21 +637,10 @@ class BaseDeviceAdaptor:
         return slot_mapping
 
     @staticmethod
-    def format_dsa_slot_mapping(slot_mapping, block_size):
-        """Format slot_mapping for metadata storage.
-        Non-A5: 2D [block_idx, offset]; A5: 1D pass-through."""
-        return torch.stack([slot_mapping // block_size, slot_mapping % block_size], axis=-1)
-
-    @staticmethod
     def get_dsa_decode_cu_seqlens_cmp_kv(cmp_kv_tensor):
         """Non-A5: return the cached cu_seqlens_cmp_kv tensor.
         A5 override always returns None."""
         return cmp_kv_tensor
-
-    @staticmethod
-    def add_dsa_sparse_attn_extra_kwargs(extra_kwargs, **kwargs_to_add):
-        """Non-A5: add extra kwargs for sparse attention. A5: no-op."""
-        extra_kwargs.update(kwargs_to_add)
 
     @staticmethod
     def get_dsa_decode_cu_seqlens_ori_kv(
@@ -1247,46 +1199,6 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             value=value,
         )
 
-    # ===== Sparse Attention Metadata & Op Selectors =====
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv_metadata
-
-    @staticmethod
-    def get_dsa_sparse_attn_metadata_kwargs(device):
-        return {"kv_quant_mode": 1}
-
-    @staticmethod
-    def get_dsa_sparse_attn_op():
-        return torch.ops._C_ascend.npu_kv_quant_sparse_attn_sharedkv
-
-    @staticmethod
-    def get_dsa_sparse_attn_base_kwargs():
-        return {"kv_quant_mode": 1, "tile_size": 64, "rope_head_dim": 64}
-
-    @staticmethod
-    def get_dsa_compressor_slot_mapping_format():
-        """A5 kv_compress_epilog consumes flat slot ids."""
-        return DSA_COMPRESSOR_SLOT_MAPPING_FLAT
-
-    # ===== SWA / Compressor KV Scatter =====
-
-    @staticmethod
-    def dsa_kv_compress_scatter(cache, x, slot_mapping):
-        """Scatter KV into cache with fused quantization+compression.
-        A5: kv_compress_epilog handles quant/compress/scatter internally.
-        Input x is unquantized bf16; cache shape is [..., head_dim]."""
-        torch.ops._C_ascend.kv_compress_epilog(
-            kv_compress_cache=cache.view(-1, 1, cache.shape[-1]),
-            x=x.view(-1, x.shape[-1]),
-            slot_mapping=slot_mapping,
-            quant_group_size=64,
-            quant_mode=2,
-            round_scale_flag=True,
-            layout=1,
-        )
-
     # ===== Indexer Quant + Scatter =====
 
     @staticmethod
@@ -1421,19 +1333,9 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         return slot_mapping
 
     @staticmethod
-    def format_dsa_slot_mapping(slot_mapping, block_size):
-        """A5: 1D pass-through."""
-        return slot_mapping
-
-    @staticmethod
     def get_dsa_decode_cu_seqlens_cmp_kv(cmp_kv_tensor):
         """A5: cu_seqlens_cmp_kv is always None."""
         return None
-
-    @staticmethod
-    def add_dsa_sparse_attn_extra_kwargs(extra_kwargs, **kwargs_to_add):
-        """A5: no-op — A5 ops do not need extra kwargs from this path."""
-        pass
 
     @staticmethod
     def get_dsa_decode_cu_seqlens_ori_kv(

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -55,9 +55,9 @@ class AscendCompressorStateCache(CompressorStateCache):
         self.block_size = block_size
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+        from vllm_ascend.models.layer.attention.layer import dsv4_block_sizes
 
-        pads = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1]
+        pads = dsv4_block_sizes(vllm_config)[vllm_config.cache_config.block_size][1]
         page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
 
         return AscendSlidingWindowMLASpec(
@@ -170,7 +170,7 @@ class Compressor(nn.Module):
         self,
         metadata: typing.Any,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        from vllm_ascend.device.device_op import DeviceOperator
+        from vllm_ascend.attention.dsa_attn_kv_plan import get_dsa_attn_kv_plan
 
         assert metadata.full_compress_cos is not None
         assert metadata.full_compress_sin is not None
@@ -192,7 +192,7 @@ class Compressor(nn.Module):
             metadata.start_pos,
             metadata.block_table,
             metadata.storage_block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+            get_dsa_attn_kv_plan(self.vllm_config).get_dsa_compressor_slot_mapping_format(),
             self.compress_ratio,
             metadata.num_compressed_tokens,
             metadata.num_actual_reqs,

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -119,6 +119,7 @@ class DeepseekV4DSparkModel(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         assert vllm_config.speculative_config is not None
+        self.vllm_config = vllm_config
         config = vllm_config.speculative_config.draft_model_config.hf_config
         self.config = config
         self.hc_mult = config.hc_mult
@@ -230,11 +231,13 @@ class DeepseekV4DSparkModel(nn.Module):
         while isinstance(swa_kv_cache, (list, tuple)) and len(swa_kv_cache) == 1:
             swa_kv_cache = swa_kv_cache[0]
 
-        from vllm_ascend.device.device_op import DeviceOperator
+        from vllm_ascend.attention.dsa_attn_kv_plan import get_dsa_attn_kv_plan
 
         if slot_mapping.ndim == 1:
-            slot_mapping = DeviceOperator.format_dsa_slot_mapping(slot_mapping, swa_cache_layer.block_size)
-        DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, shared_kv, slot_mapping)
+            slot_mapping = get_dsa_attn_kv_plan(self.vllm_config).format_dsa_slot_mapping(
+                slot_mapping, swa_cache_layer.block_size
+            )
+        get_dsa_attn_kv_plan(self.vllm_config).dsa_kv_compress_scatter(swa_kv_cache, shared_kv, slot_mapping)
 
     def precompute_and_store_context_kv(
         self,

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -39,6 +39,7 @@ from vllm.models.deepseek_v4.attention import DeepseekV4IndexerCache
 from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
+from vllm_ascend.attention.dsa_attn_kv_plan import is_a5_bf16_kv_enabled
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata, Compressor
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
@@ -95,7 +96,8 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         if get_ascend_device_type() in {AscendDeviceType.A5}:
             self.dtype = torch.float8_e4m3fn
-            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
+            if not is_a5_bf16_kv_enabled(vllm_config):
+                vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
         from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
         from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -76,6 +76,7 @@ from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache as Vllm
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.attention.dsa_attn_kv_plan import get_dsv4_attn_kv_dtype
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.models.deepseek_v4.compressor import Compressor
 from vllm_ascend.models.deepseek_v4.indexer import DeepseekV4Indexer
@@ -83,10 +84,8 @@ from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_dsa_cp,
     extract_dsv4_layer_index,
-    get_ascend_device_type,
     get_dsv4_compress_ratio,
 )
 
@@ -108,10 +107,10 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.dtype = torch.float8_e4m3fn
+        self.dtype = get_dsv4_attn_kv_dtype(vllm_config)
+        if self.dtype == torch.float8_e4m3fn:
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-        cached_head_size = self.head_dim + 128 if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_dim
+        cached_head_size = self.head_dim + 128 if self.dtype == torch.float8_e4m3fn else self.head_dim
         return AscendSlidingWindowMLASpec(
             block_size=self.block_size,
             num_kv_heads=1,
@@ -586,8 +585,7 @@ class DeepseekV4Attention(nn.Module):
                     topk_indices_buffer=topk_indices_buffer,
                 )
 
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.bfloat16
+        k_dtype = get_dsv4_attn_kv_dtype(vllm_config)
         swa_cache_layer = AscendDeepseekV4SWACache(
             head_dim=self.head_dim,
             window_size=self.window_size,

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -19,6 +19,7 @@ from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
+from vllm_ascend.attention.dsa_attn_kv_plan import is_a5_bf16_kv_enabled
 from vllm_ascend.attention.dsa_v1 import (
     AscendDSAC4Backend,
     AscendDSAC128Backend,
@@ -31,7 +32,7 @@ from vllm_ascend.utils import (
 )
 
 
-def get_dsv4_block_sizes():
+def get_dsv4_block_sizes(use_a5_bf16_kv: bool = False):
     # cache_config.block_size: [mla, swa, c4 state, c128 state], [page_size_padded_t1, page_size_padded_t2]
     _DSV4_BLOCK_SIZES = {
         128: [[128, 128, 8, 32], [16640, 131072]],
@@ -43,13 +44,29 @@ def get_dsv4_block_sizes():
         64: [[64, 64, 4, 8], [8448, 40960]],
         32: [[32, 32, 2, 4], [4224, 20480]],
     }
+    _DSV4_BLOCK_SIZES_A5_BF16 = {
+        128: [[128, 128, 8, 16], [16896, 131072]],
+        64: [[64, 64, 4, 8], [8448, 65536]],
+        32: [[32, 32, 2, 4], [4224, 32768]],
+    }
     if get_ascend_device_type() in {AscendDeviceType.A5}:
-        return _DSV4_BLOCK_SIZES_A5
+        if use_a5_bf16_kv:
+            return _DSV4_BLOCK_SIZES_A5_BF16
+        else:
+            return _DSV4_BLOCK_SIZES_A5
     else:
         return _DSV4_BLOCK_SIZES
 
 
 DSV4_BLOCK_SIZES = get_dsv4_block_sizes()
+DSV4_BLOCK_SIZES_A5_BF16 = get_dsv4_block_sizes(use_a5_bf16_kv=True)
+
+
+def dsv4_block_sizes(vllm_config: VllmConfig):
+    """Return the A5 BF16 KV table when explicitly requested, else the upstream table."""
+    if is_a5_bf16_kv_enabled(vllm_config):
+        return DSV4_BLOCK_SIZES_A5_BF16
+    return DSV4_BLOCK_SIZES
 
 
 class DSAAttention(nn.Module, AttentionLayerBase):
@@ -141,6 +158,7 @@ class DSAAttention(nn.Module, AttentionLayerBase):
             n_local_groups=self.n_local_groups,
             window_size=self.window_size,
             compress_ratio=self.compress_ratio,
+            vllm_config=get_current_vllm_config(),
             **extra_impl_args,
         )
 
@@ -178,14 +196,19 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         if self.compress_ratio <= 1:  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        use_bf16_kv = is_a5_bf16_kv_enabled(vllm_config)
+        if use_bf16_kv:
+            kv_cache_dtype = torch.bfloat16
+        elif get_ascend_device_type() in {AscendDeviceType.A5}:
             kv_cache_dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
         cached_head_size = (
-            (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
+            self.head_size + 128
+            if not use_bf16_kv and get_ascend_device_type() == AscendDeviceType.A5
+            else self.head_size
         )
-        storage_block_size = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0]
+        storage_block_size = dsv4_block_sizes(vllm_config)[vllm_config.cache_config.block_size][0][0]
         return AscendMLAAttentionSpec(
             # The scheduler operates in raw-token units. Ascend kernels keep
             # using the compressed page exposed by storage_block_size.

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -458,9 +458,16 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        if "wo_a" in self.prefix and not get_current_hardware_profile().supports(
+        supports_dynamic_mx_quant_fusion = get_current_hardware_profile().supports(
             HardwareCapability.DYNAMIC_MX_QUANT_FUSION
-        ):
+        )
+        reshape_bf16_wo_a = (
+            "wo_a" in self.prefix
+            and supports_dynamic_mx_quant_fusion
+            and self.quant_config is None
+            and loaded_weight.dtype == torch.bfloat16
+        )
+        if "wo_a" in self.prefix and (not supports_dynamic_mx_quant_fusion or reshape_bf16_wo_a):
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
                 self.weight.data = (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1031,7 +1031,12 @@ def _update_compilation_modes(vllm_config: VllmConfig, ascend_config) -> None:
         )
 
     if model_config and hasattr(model_config.hf_text_config, "index_topk"):
-        vllm_config.cache_config.cache_dtype = str(model_config.dtype).replace("torch.", "")
+        from vllm_ascend.attention.dsa_attn_kv_plan import resolve_dsv4_cache_dtype
+
+        vllm_config.cache_config.cache_dtype = resolve_dsv4_cache_dtype(
+            vllm_config.cache_config.cache_dtype,
+            str(model_config.dtype).replace("torch.", ""),
+        )
 
     # Update compilation mode in some cases
     enforce_eager = getattr(model_config, "enforce_eager", False)


### PR DESCRIPTION
### What this PR does / why we need it?

Enable DeepSeek-V4 BF16 KV sparse attention on Ascend A5 (950) via SparseFlashMla.

- Route A5 BF16 DSA to the SparseFlashMla path via device adaptor (`device_op.py` + `ops/sparse_flash_mla.py`)
- Adapt DSA kwargs (`seqused_kv` → `seqused_ori_kv`, compressed KV lengths, etc.) to SparseFlashMla IR
- Fix A5 BF16 o_proj / weight layout (`npu_transpose_batchmatmul`, `wo_a` reshape to `[G,D,R]`)
- Keep A3 FP8 DSA path unchanged

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-V4 on Ascend A5 can use BF16 KV sparse attention through the A5 SparseFlashMla path.

### How was this patch tested?

- Unit tests added/updated:
  - `tests/ut/device/test_device_op.py` (BF16 vs FP8 routing, kwargs adaptation)
  - `tests/ut/attention/test_dsa_v1.py` (BF16 projection / DSA path)
- Manual validation on Ascend A5 BF16 serve path
- Accuracy:
<img width="926" height="322" alt="image" src="https://github.com/user-attachments/assets/5bb65c42-6256-458a-b0d1-757f70f9a8c5" />


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
