### PR TITLE
[Refactor][Device][2/N] Introduce capability-oriented hardware profiles

### DIFF
--- a/tests/ut/device/test_device_config.py
+++ b/tests/ut/device/test_device_config.py
@@ -64,6 +64,7 @@ def test_device_config_supports_legacy_soc_build_info(monkeypatch):
 def test_import_time_config_does_not_probe_runtime(monkeypatch):
     import torch_npu
 
+    monkeypatch.setattr(_build_info, "__device_type__", "A2")
     get_soc_version = MagicMock(side_effect=AssertionError("runtime probe is not import-safe"))
     monkeypatch.setattr(torch_npu.npu, "get_soc_version", get_soc_version)
 
@@ -74,6 +75,7 @@ def test_import_time_config_does_not_probe_runtime(monkeypatch):
 def test_runtime_device_match_succeeds(monkeypatch):
     import torch_npu
 
+    monkeypatch.setattr(_build_info, "__device_type__", "A2")
     monkeypatch.setattr(torch_npu.npu, "get_soc_version", lambda: 220)
 
     check_ascend_device_type()
@@ -82,6 +84,7 @@ def test_runtime_device_match_succeeds(monkeypatch):
 def test_runtime_device_mismatch_raises_runtime_error(monkeypatch):
     import torch_npu
 
+    monkeypatch.setattr(_build_info, "__device_type__", "A2")
     monkeypatch.setattr(torch_npu.npu, "get_soc_version", lambda: 250)
 
     with pytest.raises(RuntimeError, match="does not match"):

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from typing import cast
+
+import pytest
+
+from vllm_ascend.device.device_config import DeviceConfig
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    WeightLayoutPolicy,
+    get_current_hardware_profile,
+    get_hardware_profile,
+)
+
+
+@pytest.mark.parametrize(
+    ("device_type", "weight_layout_policy", "capabilities"),
+    [
+        (
+            AscendDeviceType.A2,
+            WeightLayoutPolicy.CONFIGURABLE,
+            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+        ),
+        (
+            AscendDeviceType.A3,
+            WeightLayoutPolicy.CONFIGURABLE,
+            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+        ),
+        (AscendDeviceType._310P, WeightLayoutPolicy.FORCE_NZ, frozenset()),
+        (
+            AscendDeviceType.A5,
+            WeightLayoutPolicy.CONFIGURABLE,
+            frozenset(
+                {
+                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                }
+            ),
+        ),
+    ],
+)
+def test_hardware_profile_matrix(
+    device_type: AscendDeviceType,
+    weight_layout_policy: WeightLayoutPolicy,
+    capabilities: frozenset[HardwareCapability],
+) -> None:
+    profile = get_hardware_profile(device_type)
+
+    assert profile._device_type is device_type
+    assert profile.weight_layout_policy is weight_layout_policy
+    assert profile.capabilities == capabilities
+    for capability in HardwareCapability:
+        assert profile.supports(capability) is (capability in capabilities)
+
+
+def test_current_hardware_profile_uses_device_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import vllm_ascend.device.hardware_profile as profile_module
+
+    monkeypatch.setattr(
+        profile_module,
+        "get_device_config",
+        lambda: DeviceConfig(_device_type=AscendDeviceType.A5),
+    )
+
+    assert get_current_hardware_profile() is get_hardware_profile(AscendDeviceType.A5)
+
+
+def test_unknown_device_type_is_rejected() -> None:
+    unknown_device_type = cast(AscendDeviceType, object())
+
+    with pytest.raises(RuntimeError, match="No hardware profile is registered"):
+        get_hardware_profile(unknown_device_type)
+
+
+def test_every_device_type_has_a_profile() -> None:
+    for device_type in AscendDeviceType:
+        assert get_hardware_profile(device_type)._device_type is device_type

--- a/vllm_ascend/device/__init__.py
+++ b/vllm_ascend/device/__init__.py
@@ -1,3 +1,18 @@
 from vllm_ascend.device.device_config import DeviceConfig, get_device_config
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    HardwareProfile,
+    WeightLayoutPolicy,
+    get_current_hardware_profile,
+    get_hardware_profile,
+)
 
-__all__ = ["DeviceConfig", "get_device_config"]
+__all__ = [
+    "DeviceConfig",
+    "HardwareCapability",
+    "HardwareProfile",
+    "WeightLayoutPolicy",
+    "get_current_hardware_profile",
+    "get_device_config",
+    "get_hardware_profile",
+]

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+"""Capability-oriented profiles for supported Ascend hardware families."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum, auto
+from types import MappingProxyType
+
+from vllm_ascend.device.device_config import get_device_config
+from vllm_ascend.device.hardware import AscendDeviceType
+
+
+class HardwareCapability(Enum):
+    """Independent SoC capabilities consumed by shared business logic."""
+
+    AUTO_ENABLE_CUSTOM_OPS = auto()
+    DYNAMIC_MX_QUANT_FUSION = auto()
+
+
+class WeightLayoutPolicy(Enum):
+    """Weight layout selection policies for supported hardware families."""
+
+    CONFIGURABLE = auto()
+    FORCE_NZ = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareProfile:
+    """Immutable capabilities and implementation choices for one SoC family."""
+
+    _device_type: AscendDeviceType
+    weight_layout_policy: WeightLayoutPolicy
+    capabilities: frozenset[HardwareCapability]
+
+    def supports(self, capability: HardwareCapability) -> bool:
+        """Return whether this hardware family provides ``capability``."""
+
+        return capability in self.capabilities
+
+
+_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES = frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS})
+_HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
+    {
+        AscendDeviceType.A2: HardwareProfile(
+            _device_type=AscendDeviceType.A2,
+            weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+        ),
+        AscendDeviceType.A3: HardwareProfile(
+            _device_type=AscendDeviceType.A3,
+            weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+        ),
+        AscendDeviceType._310P: HardwareProfile(
+            _device_type=AscendDeviceType._310P,
+            weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
+            capabilities=frozenset(),
+        ),
+        AscendDeviceType.A5: HardwareProfile(
+            _device_type=AscendDeviceType.A5,
+            weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            capabilities=frozenset(
+                {
+                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                }
+            ),
+        ),
+    }
+)
+
+
+def get_hardware_profile(device_type: AscendDeviceType) -> HardwareProfile:
+    """Return the immutable profile registered for ``device_type``."""
+
+    try:
+        return _HARDWARE_PROFILES[device_type]
+    except KeyError as exc:
+        raise RuntimeError(f"No hardware profile is registered for device type: {device_type}.") from exc
+
+
+def get_current_hardware_profile() -> HardwareProfile:
+    """Return the profile selected by the current device configuration."""
+
+    return get_hardware_profile(get_device_config()._device_type)


### PR DESCRIPTION
Depends on #13672.

### What this PR does / why we need it?

This PR introduces the capability-oriented hardware profile layer on top of the centralized device detection mechanism.
It adds:
- An immutable HardwareProfile for each supported Ascend device family.
- A HardwareCapability enum for independent SoC capabilities.
- A KVCacheLayout enum for implementation selection.
- Profiles for A2, A3, 310P, and A5.
- An immutable device-to-profile registry.
- get_hardware_profile() and get_current_hardware_profile() lookup APIs.
- Public exports from vllm_ascend.device.
The initial profiles only model hardware differences already present in the codebase:
- Dynamic MX quantization fusion SoC support
- ND or FRACTAL_NZ KV cache layout
This PR intentionally does not migrate Platform, Worker, compilation, attention, quantization, or MoE consumers. Those migrations will be handled in follow-up PRs so this abstraction can be reviewed independently.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
