### PR TITLE
[Feature][Spec Decode] Add reduce_sample branch for dspark

### DIFF
--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -44,6 +44,17 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
             {"enable_flashcomm1": False, "enable_dsa_cp": False},
             id="dspark",
         ),
+        # reduce_sample swaps the draft's full-vocab all-gather for a per-rank
+        # local top-1 reduced across TP via greedy_sample; token selection is
+        # unchanged (global argmax), so acceptance must stay on par with the
+        # baseline dspark case above. Verified vs /start_dspark.sh on gsm8k:
+        # both paths match within ~0.005 per position.
+        pytest.param(
+            [0.88, 0.74, 0.58, 0.49, 0.40],
+            5,
+            {"enable_flashcomm1": False, "enable_dsa_cp": False, "enable_reduce_sample": True},
+            id="dspark-reduce-sample",
+        ),
         pytest.param(
             [0.88, 0.74, 0.58, 0.49, 0.40, 0.30, 0.18],
             7,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1131,7 +1131,33 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 
         if get_ascend_config().enable_reduce_sample:
-            if self.method in ("eagle3", "dflash", "mtp"):
+            if self.method == "dspark":
+                # reduce_sample: compute_logits / markov_bias yield per-rank local
+                # vocab logits (AscendLogitsProcessor skips the all-gather);
+                # greedy_sample reduces the local top-1 across TP. markov_embed is
+                # unchanged (VocabParallelEmbedding already all-reduces).
+                with _disable_flash_comm_v1_context():
+                    # lm_head and markov_w2 must shard vocab identically so that
+                    # logits + logits_bias is a per-rank local add over the same
+                    # vocab segment (greedy_sample then reduces to the global top-1).
+                    assert self.model.lm_head.num_embeddings_per_partition == \
+                        self.model.model.markov_head.markov_w2.num_embeddings_per_partition, (
+                        "dspark reduce_sample requires lm_head and markov_w2 to shard "
+                        "vocab identically; otherwise logits + logits_bias is not a "
+                        "valid per-rank local add over the same vocab segment.")
+                    # Per-rank local logits, last dim = vocab/tp (no all-gather).
+                    raw_logits = self.model.compute_logits(sample_hidden_states)
+                    logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
+                    num_blk = logits.shape[0]
+                    draft_token_ids = self._dspark_draft_buffer[:num_blk]
+                    draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
+                    for idx in range(self.num_speculative_tokens):
+                        markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
+                        # Per-rank local bias, last dim = vocab/tp, same shard as logits.
+                        logits_bias = self.model.markov_bias(markov_emb)
+                        logits[:, idx].add_(logits_bias)
+                        draft_token_ids[:, idx + 1].copy_(greedy_sample(logits[:, idx]))
+            elif self.method in ("eagle3", "dflash", "mtp"):
                 draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                 if lmhead_tp_enable():
                     draft_token_ids, token_indices_to_sample = self._align_tensor_and_indices(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1130,34 +1130,56 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 
-        if get_ascend_config().enable_reduce_sample:
-            if self.method == "dspark":
-                # reduce_sample: compute_logits / markov_bias yield per-rank local
-                # vocab logits (AscendLogitsProcessor skips the all-gather);
-                # greedy_sample reduces the local top-1 across TP. markov_embed is
-                # unchanged (VocabParallelEmbedding already all-reduces).
-                with _disable_flash_comm_v1_context():
+        enable_reduce_sample = get_ascend_config().enable_reduce_sample
+        if self.method == "dspark":
+            # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
+            # The MarkovHead performs bias correction on logits.
+            # The ConfidenceHead predicts the expected acceptance length of tokens(Not yet achieved).
+
+            # `sample_hidden_states` has been all-gathered to full.
+            # `markov_emb` should also be full to match it.
+            # We changed `flash_comm_v1_enabled` to avoid `markov_emb` from being split.
+
+            # reduce_sample: compute_logits / markov_bias yield per-rank local
+            # vocab logits (AscendLogitsProcessor skips the all-gather);
+            # greedy_sample reduces the local top-1 across TP. markov_embed is
+            # unchanged (VocabParallelEmbedding already all-reduces).
+            with _disable_flash_comm_v1_context():
+                if enable_reduce_sample:
                     # lm_head and markov_w2 must shard vocab identically so that
                     # logits + logits_bias is a per-rank local add over the same
                     # vocab segment (greedy_sample then reduces to the global top-1).
-                    assert self.model.lm_head.num_embeddings_per_partition == \
-                        self.model.model.markov_head.markov_w2.num_embeddings_per_partition, (
+                    assert (
+                        self.model.lm_head.num_embeddings_per_partition
+                        == self.model.model.markov_head.markov_w2.num_embeddings_per_partition
+                    ), (
                         "dspark reduce_sample requires lm_head and markov_w2 to shard "
                         "vocab identically; otherwise logits + logits_bias is not a "
-                        "valid per-rank local add over the same vocab segment.")
-                    # Per-rank local logits, last dim = vocab/tp (no all-gather).
-                    raw_logits = self.model.compute_logits(sample_hidden_states)
-                    logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
-                    num_blk = logits.shape[0]
-                    draft_token_ids = self._dspark_draft_buffer[:num_blk]
-                    draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
-                    for idx in range(self.num_speculative_tokens):
-                        markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
-                        # Per-rank local bias, last dim = vocab/tp, same shard as logits.
-                        logits_bias = self.model.markov_bias(markov_emb)
-                        logits[:, idx].add_(logits_bias)
+                        "valid per-rank local add over the same vocab segment."
+                    )
+                # Per-rank local logits, last dim = vocab/tp (no all-gather).
+                raw_logits = self.model.compute_logits(sample_hidden_states)
+                logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
+                num_blk = logits.shape[0]
+                draft_token_ids = self._dspark_draft_buffer[:num_blk]
+                draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
+                for idx in range(self.num_speculative_tokens):
+                    markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
+                    # Per-rank local bias, last dim = vocab/tp, same shard as logits.
+                    logits_bias = self.model.markov_bias(markov_emb)
+                    logits[:, idx].add_(logits_bias)
+                    if enable_reduce_sample:
                         draft_token_ids[:, idx + 1].copy_(greedy_sample(logits[:, idx]))
-            elif self.method in ("eagle3", "dflash", "mtp"):
+                    else:
+                        draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
+
+                # Dynamic verify-length path, implemented in AscendDSparkProposer.
+                # Only the dspark method is handled here since it relies on
+                # the DSpark confidence head.
+                if get_ascend_config().dynamic_spec_config.method == "dspark":
+                    self.update_num_verify_tokens(last_hidden_states, draft_token_ids, num_blk)
+        elif enable_reduce_sample:
+            if self.method in ("eagle3", "dflash", "mtp"):
                 draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
                 if lmhead_tp_enable():
                     draft_token_ids, token_indices_to_sample = self._align_tensor_and_indices(
@@ -1183,42 +1205,16 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     )
                 draft_token_ids = logits.argmax(dim=-1)
         else:
-            if self.method == "dspark":
-                # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
-                # The MarkovHead performs bias correction on logits.
-                # The ConfidenceHead predicts the expected acceptance length of tokens(Not yet achieved).
-
-                # `sample_hidden_states` has been all-gathered to full.
-                # `markov_emb` should also be full to match it.
-                # We changed `flash_comm_v1_enabled` to avoid `markov_emb` from being split.
-                with _disable_flash_comm_v1_context():
-                    raw_logits = self.model.compute_logits(sample_hidden_states)
-                    logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
-                    num_blk = logits.shape[0]
-                    draft_token_ids = self._dspark_draft_buffer[:num_blk]
-                    draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
-                    for idx in range(self.num_speculative_tokens):
-                        markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
-                        logits_bias = self.model.markov_bias(markov_emb)
-                        logits[:, idx].add_(logits_bias)
-                        draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
-
-                    # Dynamic verify-length path, implemented in AscendDSparkProposer.
-                    # Only the dspark method is handled here since it relies on
-                    # the DSpark confidence head.
-                    if get_ascend_config().dynamic_spec_config.method == "dspark":
-                        self.update_num_verify_tokens(last_hidden_states, draft_token_ids, num_blk)
-            else:
-                logits = self.model.compute_logits(sample_hidden_states)
-                if lmhead_tp_enable():
-                    logits, token_indices_to_sample = self._align_tensor_and_indices(
-                        logits,
-                        num_indices,
-                        token_indices_to_sample,
-                        ori_token_indices_to_sample,
-                        is_logits=True,
-                    )
-                draft_token_ids = logits.argmax(dim=-1)
+            logits = self.model.compute_logits(sample_hidden_states)
+            if lmhead_tp_enable():
+                logits, token_indices_to_sample = self._align_tensor_and_indices(
+                    logits,
+                    num_indices,
+                    token_indices_to_sample,
+                    ori_token_indices_to_sample,
+                    is_logits=True,
+                )
+            draft_token_ids = logits.argmax(dim=-1)
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:


### PR DESCRIPTION
### What this PR does / why we need it?

Add a dspark-specific branch under enable_reduce_sample that keeps the MarkovHead autoregressive correction loop but runs compute_logits and markov_bias as per-rank local vocab logits (AscendLogitsProcessor skips the all-gather) and uses greedy_sample to reduce the local top-1 across TP. markov_embed is unchanged (VocabParallelEmbedding already all-reduces). Guard the per-rank local add with an assert that lm_head and markov_w2 shard vocab identically.

The markov head runs in 4 steps:
* Compute original logits (no all-reduce).
* Compute logits_bias (with all-reduce).
* Compute final logits (no all-reduce).
* Sample tokens (reduce-sample).

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
