### PR TITLE
[BugFix][MRV2] Add potential max tokens setting in NPUModelRunner

### DIFF
--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -51,7 +51,7 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_tokens_capacity,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
-from vllm_ascend.utils import enable_sp
+from vllm_ascend.utils import enable_sp, set_potential_max_tokens
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
@@ -193,6 +193,7 @@ class NPUModelRunner(GPUModelRunner):
         set_cos_and_sin(vllm_config, self.max_num_reqs, self.decode_query_len, self.dtype, self.device)
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
+        set_potential_max_tokens(vllm_config)
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         with graph_manager_wrapper(self):


### PR DESCRIPTION
[Enhancement][MRV2] Add potential max tokens setting in NPUModelRunner

### What this commit does / why we need it?
This commit enhances the NPUModelRunner by introducing a new utility function, `set_potential_max_tokens`, which is now called during the model initialization process. This addition allows for better management of token capacity during model execution.

### Does this commit introduce any user-facing change?
No.

### How was this patch tested?
- Verified that the new function integrates correctly with existing model initialization routines.
- Conducted unit tests to ensure no regressions in model performance.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
