### PR TITLE
fix kimi3 layers configuration

### DIFF
--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -104,6 +104,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Number of Kimi K3 decoder layers to instantiate and load for debugging.
+    # 0 (the default) loads the complete model.
+    "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS": lambda: os.getenv(
+        "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", "0"
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -17,6 +17,7 @@
 """Native multimodal Kimi K3 model for vLLM-Ascend."""
 
 import math
+import os
 from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
 from typing import Annotated, Any, Literal, cast
@@ -110,6 +111,47 @@ from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
 from vllm_ascend.transformers_utils.configs.kimi_k3 import KimiK3Config, KimiK3TextConfig, KimiK3VisionConfig
 from vllm_ascend.transformers_utils.processors.kimi_k3 import KimiK3Processor
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
+
+
+KIMI_K3_MAX_LOADED_LAYERS_ENV = "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS"
+
+
+def _get_kimi_k3_num_loaded_layers(total_num_layers: int) -> int:
+    """Return the requested Kimi K3 decoder-layer count for debug loading."""
+    requested_num_layers_raw = os.getenv(KIMI_K3_MAX_LOADED_LAYERS_ENV, "0")
+    try:
+        requested_num_layers = int(requested_num_layers_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{KIMI_K3_MAX_LOADED_LAYERS_ENV} must be an integer in "
+            f"[0, {total_num_layers}], got {requested_num_layers_raw!r}"
+        ) from exc
+    if requested_num_layers == 0:
+        return total_num_layers
+    if not 1 <= requested_num_layers <= total_num_layers:
+        raise ValueError(
+            f"{KIMI_K3_MAX_LOADED_LAYERS_ENV} must be in "
+            f"[0, {total_num_layers}], got {requested_num_layers}"
+        )
+    return requested_num_layers
+
+
+def _get_decoder_layer_idx_from_weight_name(weight_name: str) -> int | None:
+    """Extract a K3 decoder-layer index from an inner or VL checkpoint key."""
+    # AutoWeightsLoader removes the child-module prefix before delegating to
+    # KimiK3TextModel.load_weights, so a tensor can arrive as either
+    # ``model.layers.<idx>`` or ``layers.<idx>``.
+    layer_prefix = "layers."
+    prefix_idx = weight_name.find(layer_prefix)
+    if prefix_idx < 0:
+        return None
+
+    layer_idx_start = prefix_idx + len(layer_prefix)
+    layer_idx_end = weight_name.find(".", layer_idx_start)
+    if layer_idx_end < 0:
+        return None
+    layer_idx_text = weight_name[layer_idx_start:layer_idx_end]
+    return int(layer_idx_text) if layer_idx_text.isdecimal() else None
 
 
 def _routed_latent_quant_config(
@@ -1048,6 +1090,16 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
         self.config = config
         self.vocab_size = config.vocab_size
 
+        self.num_loaded_layers = _get_kimi_k3_num_loaded_layers(config.num_hidden_layers)
+        if self.num_loaded_layers != config.num_hidden_layers:
+            logger.warning_once(
+                "Kimi K3 layer-reduced debug mode is enabled: loading and "
+                "executing decoder layers [0, %d) out of %d. Generated "
+                "results are not model-quality valid.",
+                self.num_loaded_layers,
+                config.num_hidden_layers,
+            )
+
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
@@ -1061,7 +1113,7 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
             return KimiK3DecoderLayer(config, vllm_config, prefix)
 
         self.start_layer, self.end_layer, self.layers = make_layers(
-            config.num_hidden_layers,
+            self.num_loaded_layers,
             get_layer,
             prefix=f"{prefix}.layers",
         )
@@ -1173,6 +1225,9 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
             name, loaded_weight = args[:2]
             loader_kwargs: dict[str, Any] = args[2] if len(args) == 3 else {}
             if "rotary_emb" in name:
+                continue
+            layer_idx = _get_decoder_layer_idx_from_weight_name(name)
+            if layer_idx is not None and layer_idx >= self.num_loaded_layers:
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds support for running Kimi-K3 models with reduced number of layers.

The main changes include:
- Add layer reduction support in Kimi-K3 model implementation.
- Update model configuration handling to correctly adapt to models with fewer transformer layers.
- Ensure layer indexing and weight loading logic are consistent when using reduced-layer checkpoints.

This change is needed for scenarios where a smaller-depth Kimi-K3 model is used for performance evaluation, debugging, or deployment optimization. It allows users to reduce model depth while keeping the existing vLLM-Ascend inference workflow compatible.

### Does this PR introduce _any_ user-facing change?

Yes.

Users can now run Kimi-K3 models with reduced layers by providing a corresponding reduced-layer model configuration/checkpoint.

There is no change to the existing behavior for standard Kimi-K3 models.

### How was this patch tested?

Tested Kimi-K3 inference with a reduced-layer model configuration.

Validation includes:
- Successfully loading the reduced-layer Kimi-K3 model.
- Running inference with vLLM-Ascend without layer mismatch errors.
- Verifying model initialization and generation results on Ascend NPUs.

Test environment:
- vLLM-Ascend: releases/v0.26.0rc
- Hardware: Ascend NPU
- Model: Kimi-K3 reduced-layer checkpoint
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
