### PR TITLE
[CI] Rerun selected A3 partitions on 752T

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -275,16 +275,22 @@ jobs:
 
       - name: Select tests based on changed files
         id: scope
-        if: steps.filter.outputs.src == 'true'
+        if: ${{ steps.filter.outputs.src == 'true' || contains(github.event.pull_request.labels.*.name, 'ready') }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install regex
+          RUN_ALL_MODULES_FLAG=""
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'ready') }}" = "true" ]; then
+            RUN_ALL_MODULES_FLAG="--run-all-modules"
+          fi
           python3 .github/workflows/scripts/select_tests.py \
-            --diff-base ${{ steps.source-snapshot.outputs.base_sha }}
+            ${RUN_ALL_MODULES_FLAG} \
+            --diff-base ${{ steps.source-snapshot.outputs.base_sha }} \
+            --only-test-partitions a3_x2:2-3 a3_x4:3-3
 
       - name: Set no-tests output when source paths unchanged
         id: noop
-        if: steps.filter.outputs.src != 'true'
+        if: ${{ steps.filter.outputs.src != 'true' && !contains(github.event.pull_request.labels.*.name, 'ready') }}
         run: |
           {
             echo "has_tests=false"
@@ -361,7 +367,6 @@ jobs:
       matrix:
         vllm_version:
           - ${{ needs.pre-commit.outputs.main_commit }}
-          - ${{ needs.pre-commit.outputs.release_tag }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}
@@ -377,6 +382,7 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
+        false &&
         always() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&

--- a/.github/workflows/scripts/select_tests.py
+++ b/.github/workflows/scripts/select_tests.py
@@ -516,6 +516,29 @@ def _load_partition_config(meta: dict) -> dict[str, int]:
     return {k: int(v) for k, v in meta.get("partition", {}).items()}
 
 
+def _parse_partition_filters(filters: list[str] | None) -> set[tuple[str, str]]:
+    if not filters:
+        return set()
+    result: set[tuple[str, str]] = set()
+    for item in filters:
+        runner_key, separator, partition = item.partition(":")
+        if not separator or not runner_key or not partition:
+            raise ValueError(f"Invalid partition filter: {item!r}; expected <runner_key>:<partition>")
+        result.add((runner_key, partition))
+    return result
+
+
+def _filter_test_groups_by_partition(
+    test_groups: list[dict],
+    filters: set[tuple[str, str]],
+) -> list[dict]:
+    if not filters:
+        return test_groups
+    return [
+        group for group in test_groups if (f"{group['npu_type']}_x{group['num_npus']}", group["partition"]) in filters
+    ]
+
+
 def _lookup_estimated_time(
     test_name: str,
     estimated_times: dict[str, float],
@@ -756,6 +779,11 @@ def main():
         default=None,
         help="Force route all non-CPU tests to the specified runner key (e.g. a5_x4)",
     )
+    parser.add_argument(
+        "--only-test-partitions",
+        nargs="*",
+        help="Only keep selected runner partitions, formatted as <runner_key>:<partition>.",
+    )
     args = parser.parse_args()
     docs = list(yaml.safe_load_all(args.config.read_text()))
     config = _resolve_config_inheritance(docs[0])
@@ -898,6 +926,7 @@ def main():
     estimated_times = _load_estimated_times(meta)
     partition_config = _load_partition_config(meta)
     test_groups = _resolve_to_runners(all_groups, runners, partition_config, estimated_times)
+    test_groups = _filter_test_groups_by_partition(test_groups, _parse_partition_filters(args.only_test_partitions))
 
     _write_output(test_groups, matched_modules)
 


### PR DESCRIPTION
What this PR does / why we need it?

Temporarily limits E2E selected-tests to default A3 runners for comparison with the 560T run:
- a3-2 card-(part 2-3)
- a3-4 card-(part 3-3)

Does this PR introduce any user-facing change?

No.

How was this patch tested?

- python -m py_compile .github/workflows/scripts/select_tests.py
- python .github/workflows/scripts/select_tests.py --changed-files .github/workflows/pr_test.yaml --run-all-modules --only-test-partitions a3_x2:2-3 a3_x4:3-3

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
