### PR TITLE
[Ops][Feature] Unified RL Configuration via additional_config.rl_config

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -244,7 +244,7 @@ ShortRequestFirst is a waiting-queue policy for FCFS synchronous or asynchronous
 
 **rl_config**
 
-`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it refreshes the global Ascend configuration on every initialization, forces `AscendConfig.weight_nz_mode=0`, synchronizes `VLLM_ASCEND_ENABLE_NZ=0`, and sets `VLLM_SERVER_DEV_MODE=1`. These fixed RL behaviors are not configurable as `rl_config` sub-fields. When `enabled` is `false`, all other sub-fields are ignored.
+`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it refreshes the global Ascend configuration on every initialization, forces `AscendConfig.weight_nz_mode=0`, synchronizes `VLLM_ASCEND_ENABLE_NZ=0`, sets `VLLM_SERVER_DEV_MODE=1`, and removes the `expandable_segments` entry from `PYTORCH_NPU_ALLOC_CONF` with an informational log. These fixed RL behaviors are not configurable as `rl_config` sub-fields. When `enabled` is `false`, all other sub-fields are ignored.
 
 When RL mode is enabled, its fixed NZ and developer-endpoint settings take precedence over top-level configuration and environment variables. `VLLM_BATCH_INVARIANT=1` remains enabled when `rl_config.enable_batch_invariant` is false.
 
@@ -252,9 +252,8 @@ When RL mode is enabled, its fixed NZ and developer-endpoint settings take prece
 | ---- | ---- | ------- | ----------- |
 | `enabled` | bool | `false` | Master switch for RL mode. When `true`, all RL best-practice defaults below are applied. |
 | `sleep_mode_extra_cleanup` | bool | `false` | Same-device mode. Enables HCCL process-group release + ACL graph workspace cleanup during sleep, returning more NPU memory to the trainer at the cost of increased wakeup latency. This option is available only under `rl_config`; the former top-level `enable_sleep_mode_extra_cleanup` key has been removed. |
-| `disable_expandable_segments` | bool | `true` | Same-device mode. Removes `expandable_segments` from `PYTORCH_NPU_ALLOC_CONF`, which is mutually exclusive with the CaMemAllocator pool used by sleep mode. No effect in cross-device mode. |
 | `enable_training_consistency` | bool | `false` | Both modes. Enables the FA3 attention backend used for training-inference consistency. Requires the `flash_attn_npu_v3` package and does not implicitly enable batch invariance. |
-| `enable_batch_invariant` | bool | `false` | Both modes. Provides an additional way to enable batch-invariant deterministic computation: when `true`, sets `VLLM_BATCH_INVARIANT=1`, `HCCL_DETERMINISTIC=strict`, and `LCCL_DETERMINISTIC=1` before workers are started. When `false`, an existing `VLLM_BATCH_INVARIANT` environment setting is preserved. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1`; RL mode already forces `weight_nz_mode=0`. |
+| `enable_batch_invariant` | bool | `false` | Both modes. Provides an additional way to enable batch-invariant deterministic computation: when `true`, sets `VLLM_BATCH_INVARIANT=1` before workers are started. Worker-side batch-invariant initialization then sets `HCCL_DETERMINISTIC=strict` and `LCCL_DETERMINISTIC=1`. When `false`, an existing `VLLM_BATCH_INVARIANT` environment setting is preserved. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1`; RL mode already forces `weight_nz_mode=0`. |
 
 **Deployment modes**
 

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -93,6 +93,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
 | `dynamic_spec_config`               | dict | `{}`    | Configuration options for Dynamic Speculative Decoding. See [Dynamic Speculative Decoding](../feature_guide/speculative_decoding.md#dynamic-speculative-decoding). |
 | `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
+| `rl_config`                        | dict | `{}`    | One-click RL mode configuration. See [rl_config](#rl_config) for all fields, the two deployment modes, usage examples, and the migration guide. |
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. **Note**: This is an experimental feature. **Limitations**: (1) Not supported on PD-disaggregated scenario. (2) Must be disabled when sampling logprobs are requested. When reduce sample is enabled, logprobs are silently computed over partitioned logits instead of the full vocabulary, producing incorrect logprob values and top-k rankings. (3) Cannot be enabled together with lmhead TP.|
 
 The details of each configuration option are as follows:
@@ -241,6 +242,73 @@ ShortRequestFirst is a waiting-queue policy for FCFS synchronous or asynchronous
 | `reserve_max_blocks` | int | `8` | Maximum number of blocks that can be reserved. |
 | `low_available_tokens_threshold` | int | `4096` | Threshold for prioritising long vs short decode jobs. When available tokens > threshold, long decode jobs are prioritised; when ≤ threshold, short decode jobs are prioritised. |
 | `short_decode_token_threshold` | int | `32` | Threshold for classifying a job as "short decode". |
+
+**rl_config**
+
+`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it applies RL best-practice defaults automatically. When `enabled` is `false`, all other sub-fields are ignored.
+
+Priority: `rl_config` sub-fields > `additional_config` top-level keys > environment variables > code defaults. The only exception is an explicit `VLLM_SERVER_DEV_MODE=0`, which is retained as a security opt-out and produces a warning.
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `enabled` | bool | `false` | Master switch for RL mode. When `true`, all RL best-practice defaults below are applied. |
+| `sleep_mode_extra_cleanup` | bool | `false` | Same-device mode. Enables HCCL process-group release + ACL graph workspace cleanup during sleep, returning more NPU memory to the trainer at the cost of increased wakeup latency. Overrides the top-level `enable_sleep_mode_extra_cleanup`. |
+| `weight_nz_mode` | int | `0` | Both modes. Disables the FRACTAL_NZ weight layout conversion (`0`=disable, `1`=quant only, `2`=all). Overrides the top-level `weight_nz_mode`. If both are set to different values, startup fails with a clear error. |
+| `disable_expandable_segments` | bool | `true` | Same-device mode. Removes `expandable_segments` from `PYTORCH_NPU_ALLOC_CONF`, which is mutually exclusive with the CaMemAllocator pool used by sleep mode. No effect in cross-device mode. |
+| `enable_batch_invariant` | bool | `false` | Both modes. Enables batch-invariant deterministic computation: sets `VLLM_BATCH_INVARIANT=1`, `HCCL_DETERMINISTIC=strict`, `LCCL_DETERMINISTIC=1`, and, in the worker, `torch.use_deterministic_algorithms(True)` plus batch-invariant Triton/AscendC operators. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1` and requires `weight_nz_mode=0`. Prevails over a previously set `VLLM_BATCH_INVARIANT`. |
+| `enable_dev_endpoints` | bool | `true` | Online mode. Sets `VLLM_SERVER_DEV_MODE=1` to expose the `/sleep`, `/wake_up`, `/pause`, and `/resume` HTTP endpoints. No effect in offline `LLM()` mode. Set to `false` to opt out. An explicit `VLLM_SERVER_DEV_MODE=0` is respected. |
+
+> **Note**: When `rl_config` and a top-level `additional_config` key are both set to different values for the same field (`weight_nz_mode`, `enable_sleep_mode_extra_cleanup`), startup fails with a clear error. Keep only one of them; `rl_config` is recommended for RL workloads.
+
+**Deployment modes**
+
+- **Same-device mode** (sleep/wake + IPC weight transfer): the inference engine and trainer share the same NPU card. Use `enable_sleep_mode=True` and optionally `sleep_mode_extra_cleanup=True` for extra memory.
+- **Cross-device mode** (pause/resume + HCCL weight transfer): the inference engine and trainer use different NPU cards. Use `--weight-transfer-config '{"backend": "nccl"}'`.
+
+**Example (online, same-device):**
+
+```bash
+vllm serve DeepSeek-V4 \
+    --enable-sleep-mode \
+    --enable-return-routed-experts \
+    --weight-transfer-config '{"backend": "ipc"}' \
+    --additional-config '{"rl_config": {"enabled": true, "enable_batch_invariant": true, "sleep_mode_extra_cleanup": true}}'
+```
+
+**Example (online, cross-device):**
+
+```bash
+vllm serve DeepSeek-V4 \
+    --weight-transfer-config '{"backend": "nccl"}' \
+    --additional-config '{"rl_config": {"enabled": true}}'
+```
+
+**Example (offline):**
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="DeepSeek-V4",
+    enable_sleep_mode=True,  # same-device mode only
+    additional_config={
+        "rl_config": {
+            "enabled": True,
+            "enable_batch_invariant": True,
+        },
+    },
+)
+```
+
+**Migration guide**
+
+| Before | After |
+| ------ | ----- |
+| `export VLLM_ASCEND_ENABLE_NZ=0` | `"rl_config": {"enabled": true}` (or top-level `"weight_nz_mode": 0`) |
+| `export VLLM_SERVER_DEV_MODE=1` | `"rl_config": {"enabled": true}` (or top-level `"enable_dev_endpoints": true`) |
+| `export VLLM_BATCH_INVARIANT=1` + `export HCCL_DETERMINISTIC=strict` + `export LCCL_DETERMINISTIC=1` | `"rl_config": {"enabled": true, "enable_batch_invariant": true}` |
+| top-level `"weight_nz_mode": 0` | `"rl_config": {"enabled": true, "weight_nz_mode": 0}` |
+| top-level `"enable_sleep_mode_extra_cleanup": true` | `"rl_config": {"enabled": true, "sleep_mode_extra_cleanup": true}` |
 
 ### Example
 

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -302,7 +302,7 @@ llm = LLM(
 | ------ | ----- |
 | `export VLLM_ASCEND_ENABLE_NZ=0` | `"rl_config": {"enabled": true}` |
 | `export VLLM_SERVER_DEV_MODE=1` | `"rl_config": {"enabled": true}` |
-| `export VLLM_BATCH_INVARIANT=1` + `export HCCL_DETERMINISTIC=strict` + `export LCCL_DETERMINISTIC=1` | `"rl_config": {"enabled": true, "enable_batch_invariant": true}` |
+| `export VLLM_BATCH_INVARIANT=1` | `"rl_config": {"enabled": true, "enable_batch_invariant": true}` |
 | `--attention-backend FLASH_ATTN` for FA3 consistency mode | `"rl_config": {"enabled": true, "enable_training_consistency": true}` |
 | top-level `"weight_nz_mode": 0` for RL | `"rl_config": {"enabled": true}` |
 | top-level `"enable_sleep_mode_extra_cleanup": true` | `"rl_config": {"enabled": true, "sleep_mode_extra_cleanup": true}` |

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -74,7 +74,6 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_shared_expert_dp`           | bool | `False` | Replicate shared-expert weights across TP ranks and run the shared expert with data parallelism. This option is independent of `enable_flashcomm1`; it improves performance but consumes more memory. |
 | `multistream_overlap_shared_expert` | bool | `False` | Whether to enable multi-stream shared expert. This option only takes effect on MoE models with shared experts. |
 | `enable_cpu_binding`                | bool | `True`  | Enables Ascend-native CPU binding on ARM servers. Set to `False` to disable. See [CPU Binding](../feature_guide/cpu_binding.md). |
-| `enable_sleep_mode_extra_cleanup`   | bool | `False` | Enables extra sleep-mode cleanup for RL workloads, including HCCL process-group release and ACL graph workspace cleanup. Disabled by default because wakeup may need to restore HCCL and recapture ACL graphs. |
 | `pa_shape_list`                     | list | `[]`    | The custom shape list of page attention ops.                                                              |
 | `enable_kv_nz`                      | bool | `False` | Whether to enable KV cache NZ layout. This option only takes effects on models using MLA (e.g., DeepSeek).                                      |
 | `enable_sparse_sfa_c8`              | bool | `False` | Whether to enable the packed C8 KV cache for Sparse Flash Attention in DSA models (e.g., DeepSeek V3.2 and GLM5). This option is independent of `enable_sparse_li_c8`. SFA prefill context parallelism and Ascend 950 DCP are not supported. |
@@ -245,22 +244,17 @@ ShortRequestFirst is a waiting-queue policy for FCFS synchronous or asynchronous
 
 **rl_config**
 
-`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it applies RL best-practice defaults automatically. When `enabled` is `false`, all other sub-fields are ignored.
+`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it refreshes the global Ascend configuration on every initialization, forces `AscendConfig.weight_nz_mode=0`, synchronizes `VLLM_ASCEND_ENABLE_NZ=0`, and sets `VLLM_SERVER_DEV_MODE=1`. These fixed RL behaviors are not configurable as `rl_config` sub-fields. When `enabled` is `false`, all other sub-fields are ignored.
 
-Priority is generally `rl_config` sub-fields > `additional_config` top-level keys > environment variables > code defaults. Two environment-variable exceptions are retained: an explicit `VLLM_SERVER_DEV_MODE=0` is a security opt-out, and `VLLM_BATCH_INVARIANT=1` remains enabled when `rl_config.enable_batch_invariant` is false.
+When RL mode is enabled, its fixed NZ and developer-endpoint settings take precedence over top-level configuration and environment variables. `VLLM_BATCH_INVARIANT=1` remains enabled when `rl_config.enable_batch_invariant` is false.
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `enabled` | bool | `false` | Master switch for RL mode. When `true`, all RL best-practice defaults below are applied. |
-| `refresh` | bool | `true` | Refresh the global Ascend configuration each time it is initialized. This ensures RL settings are reapplied in worker processes. Set to `false` to reuse the cached configuration for the same `VllmConfig` object. |
-| `sleep_mode_extra_cleanup` | bool | `false` | Same-device mode. Enables HCCL process-group release + ACL graph workspace cleanup during sleep, returning more NPU memory to the trainer at the cost of increased wakeup latency. Overrides the top-level `enable_sleep_mode_extra_cleanup`. |
-| `weight_nz_mode` | int | `0` | Both modes. Controls the FRACTAL_NZ weight layout conversion (`0`=disable, `2`=all). Value `1` is not supported in `rl_config` and fails during startup with a clear error. Overrides the top-level `weight_nz_mode`; conflicting values also fail during startup. |
+| `sleep_mode_extra_cleanup` | bool | `false` | Same-device mode. Enables HCCL process-group release + ACL graph workspace cleanup during sleep, returning more NPU memory to the trainer at the cost of increased wakeup latency. This option is available only under `rl_config`; the former top-level `enable_sleep_mode_extra_cleanup` key has been removed. |
 | `disable_expandable_segments` | bool | `true` | Same-device mode. Removes `expandable_segments` from `PYTORCH_NPU_ALLOC_CONF`, which is mutually exclusive with the CaMemAllocator pool used by sleep mode. No effect in cross-device mode. |
 | `enable_training_consistency` | bool | `false` | Both modes. Enables the FA3 attention backend used for training-inference consistency. Requires the `flash_attn_npu_v3` package and does not implicitly enable batch invariance. |
-| `enable_batch_invariant` | bool | `false` | Both modes. Provides an additional way to enable batch-invariant deterministic computation: when `true`, sets `VLLM_BATCH_INVARIANT=1`, `HCCL_DETERMINISTIC=strict`, and `LCCL_DETERMINISTIC=1` before workers are started. When `false`, an existing `VLLM_BATCH_INVARIANT` environment setting is preserved. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1` and requires `weight_nz_mode=0`. |
-| `enable_dev_endpoints` | bool | `true` | Online mode. Sets `VLLM_SERVER_DEV_MODE=1` to expose the `/sleep`, `/wake_up`, `/pause`, and `/resume` HTTP endpoints. No effect in offline `LLM()` mode. Set to `false` to opt out. An explicit `VLLM_SERVER_DEV_MODE=0` is respected. |
-
-> **Note**: When `rl_config` and a top-level `additional_config` key are both set to different values for the same field (`weight_nz_mode`, `enable_sleep_mode_extra_cleanup`), startup fails with a clear error. Keep only one of them; `rl_config` is recommended for RL workloads.
+| `enable_batch_invariant` | bool | `false` | Both modes. Provides an additional way to enable batch-invariant deterministic computation: when `true`, sets `VLLM_BATCH_INVARIANT=1`, `HCCL_DETERMINISTIC=strict`, and `LCCL_DETERMINISTIC=1` before workers are started. When `false`, an existing `VLLM_BATCH_INVARIANT` environment setting is preserved. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1`; RL mode already forces `weight_nz_mode=0`. |
 
 **Deployment modes**
 
@@ -307,11 +301,11 @@ llm = LLM(
 
 | Before | After |
 | ------ | ----- |
-| `export VLLM_ASCEND_ENABLE_NZ=0` | `"rl_config": {"enabled": true}` (or top-level `"weight_nz_mode": 0`) |
-| `export VLLM_SERVER_DEV_MODE=1` | `"rl_config": {"enabled": true}` (or top-level `"enable_dev_endpoints": true`) |
+| `export VLLM_ASCEND_ENABLE_NZ=0` | `"rl_config": {"enabled": true}` |
+| `export VLLM_SERVER_DEV_MODE=1` | `"rl_config": {"enabled": true}` |
 | `export VLLM_BATCH_INVARIANT=1` + `export HCCL_DETERMINISTIC=strict` + `export LCCL_DETERMINISTIC=1` | `"rl_config": {"enabled": true, "enable_batch_invariant": true}` |
 | `--attention-backend FLASH_ATTN` for FA3 consistency mode | `"rl_config": {"enabled": true, "enable_training_consistency": true}` |
-| top-level `"weight_nz_mode": 0` | `"rl_config": {"enabled": true, "weight_nz_mode": 0}` |
+| top-level `"weight_nz_mode": 0` for RL | `"rl_config": {"enabled": true}` |
 | top-level `"enable_sleep_mode_extra_cleanup": true` | `"rl_config": {"enabled": true, "sleep_mode_extra_cleanup": true}` |
 
 ### Example

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -247,15 +247,17 @@ ShortRequestFirst is a waiting-queue policy for FCFS synchronous or asynchronous
 
 `rl_config` is a one-click RL mode switch. When `enabled` is `true`, it applies RL best-practice defaults automatically. When `enabled` is `false`, all other sub-fields are ignored.
 
-Priority: `rl_config` sub-fields > `additional_config` top-level keys > environment variables > code defaults. The only exception is an explicit `VLLM_SERVER_DEV_MODE=0`, which is retained as a security opt-out and produces a warning.
+Priority is generally `rl_config` sub-fields > `additional_config` top-level keys > environment variables > code defaults. Two environment-variable exceptions are retained: an explicit `VLLM_SERVER_DEV_MODE=0` is a security opt-out, and `VLLM_BATCH_INVARIANT=1` remains enabled when `rl_config.enable_batch_invariant` is false.
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `enabled` | bool | `false` | Master switch for RL mode. When `true`, all RL best-practice defaults below are applied. |
+| `refresh` | bool | `true` | Refresh the global Ascend configuration each time it is initialized. This ensures RL settings are reapplied in worker processes. Set to `false` to reuse the cached configuration for the same `VllmConfig` object. |
 | `sleep_mode_extra_cleanup` | bool | `false` | Same-device mode. Enables HCCL process-group release + ACL graph workspace cleanup during sleep, returning more NPU memory to the trainer at the cost of increased wakeup latency. Overrides the top-level `enable_sleep_mode_extra_cleanup`. |
-| `weight_nz_mode` | int | `0` | Both modes. Disables the FRACTAL_NZ weight layout conversion (`0`=disable, `1`=quant only, `2`=all). Overrides the top-level `weight_nz_mode`. If both are set to different values, startup fails with a clear error. |
+| `weight_nz_mode` | int | `0` | Both modes. Controls the FRACTAL_NZ weight layout conversion (`0`=disable, `2`=all). Value `1` is not supported in `rl_config` and fails during startup with a clear error. Overrides the top-level `weight_nz_mode`; conflicting values also fail during startup. |
 | `disable_expandable_segments` | bool | `true` | Same-device mode. Removes `expandable_segments` from `PYTORCH_NPU_ALLOC_CONF`, which is mutually exclusive with the CaMemAllocator pool used by sleep mode. No effect in cross-device mode. |
-| `enable_batch_invariant` | bool | `false` | Both modes. Enables batch-invariant deterministic computation: sets `VLLM_BATCH_INVARIANT=1`, `HCCL_DETERMINISTIC=strict`, `LCCL_DETERMINISTIC=1`, and, in the worker, `torch.use_deterministic_algorithms(True)` plus batch-invariant Triton/AscendC operators. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1` and requires `weight_nz_mode=0`. Prevails over a previously set `VLLM_BATCH_INVARIANT`. |
+| `enable_training_consistency` | bool | `false` | Both modes. Enables the FA3 attention backend used for training-inference consistency. Requires the `flash_attn_npu_v3` package and does not implicitly enable batch invariance. |
+| `enable_batch_invariant` | bool | `false` | Both modes. Provides an additional way to enable batch-invariant deterministic computation: when `true`, sets `VLLM_BATCH_INVARIANT=1`, `HCCL_DETERMINISTIC=strict`, and `LCCL_DETERMINISTIC=1` before workers are started. When `false`, an existing `VLLM_BATCH_INVARIANT` environment setting is preserved. Requires building vllm-ascend from source with `COMPILE_CUSTOM_KERNELS=1` and requires `weight_nz_mode=0`. |
 | `enable_dev_endpoints` | bool | `true` | Online mode. Sets `VLLM_SERVER_DEV_MODE=1` to expose the `/sleep`, `/wake_up`, `/pause`, and `/resume` HTTP endpoints. No effect in offline `LLM()` mode. Set to `false` to opt out. An explicit `VLLM_SERVER_DEV_MODE=0` is respected. |
 
 > **Note**: When `rl_config` and a top-level `additional_config` key are both set to different values for the same field (`weight_nz_mode`, `enable_sleep_mode_extra_cleanup`), startup fails with a clear error. Keep only one of them; `rl_config` is recommended for RL workloads.
@@ -272,7 +274,7 @@ vllm serve DeepSeek-V4 \
     --enable-sleep-mode \
     --enable-return-routed-experts \
     --weight-transfer-config '{"backend": "ipc"}' \
-    --additional-config '{"rl_config": {"enabled": true, "enable_batch_invariant": true, "sleep_mode_extra_cleanup": true}}'
+    --additional-config '{"rl_config": {"enabled": true, "enable_training_consistency": true, "enable_batch_invariant": true, "sleep_mode_extra_cleanup": true}}'
 ```
 
 **Example (online, cross-device):**
@@ -294,6 +296,7 @@ llm = LLM(
     additional_config={
         "rl_config": {
             "enabled": True,
+            "enable_training_consistency": True,
             "enable_batch_invariant": True,
         },
     },
@@ -307,6 +310,7 @@ llm = LLM(
 | `export VLLM_ASCEND_ENABLE_NZ=0` | `"rl_config": {"enabled": true}` (or top-level `"weight_nz_mode": 0`) |
 | `export VLLM_SERVER_DEV_MODE=1` | `"rl_config": {"enabled": true}` (or top-level `"enable_dev_endpoints": true`) |
 | `export VLLM_BATCH_INVARIANT=1` + `export HCCL_DETERMINISTIC=strict` + `export LCCL_DETERMINISTIC=1` | `"rl_config": {"enabled": true, "enable_batch_invariant": true}` |
+| `--attention-backend FLASH_ATTN` for FA3 consistency mode | `"rl_config": {"enabled": true, "enable_training_consistency": true}` |
 | top-level `"weight_nz_mode": 0` | `"rl_config": {"enabled": true, "weight_nz_mode": 0}` |
 | top-level `"enable_sleep_mode_extra_cleanup": true` | `"rl_config": {"enabled": true, "sleep_mode_extra_cleanup": true}` |
 

--- a/docs/source/user_guide/feature_guide/flash_attention.md
+++ b/docs/source/user_guide/feature_guide/flash_attention.md
@@ -57,18 +57,21 @@ To install the `flash_attn_npu` wheel package, refer to: <https://github.com/Min
 
 ## Enabling Flash Attention 3
 
-To enable FA3, you need to:
+Enable FA3 through the RL configuration by setting `rl_config.enabled` and
+`rl_config.enable_training_consistency` to `true`.
 
-1. Set the environment variable `export VLLM_BATCH_INVARIANT=1` to enable batch invariant mode
-2. Specify the attention backend as `FLASH_ATTN` via the LLM parameter `attention_backend="FLASH_ATTN"`
+Batch invariant mode is independent of FA3. If it is also required, set
+`rl_config.enable_batch_invariant` to `true`. You do not need to set
+`VLLM_BATCH_INVARIANT`, `HCCL_DETERMINISTIC`, or `LCCL_DETERMINISTIC`
+manually when using this configuration path.
 
 ### Online Inference (Server Mode)
 
 To start a vLLM server with FA3 enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B \
-  --attention-backend FLASH_ATTN \
+vllm serve Qwen/Qwen3-8B \
+  --additional-config '{"rl_config": {"enabled": true, "enable_training_consistency": true}}' \
   --compilation-config '{"cudagraph_mode": "PIECEWISE"}'
 ```
 
@@ -98,9 +101,6 @@ print(response.choices[0].text)
 For offline batch inference with FA3:
 
 ```python
-import os
-os.environ["VLLM_BATCH_INVARIANT"] = "1"
-
 from vllm import LLM, SamplingParams
 
 prompts = [
@@ -118,7 +118,12 @@ sampling_params = SamplingParams(
 llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
-    attention_backend="FLASH_ATTN",
+    additional_config={
+        "rl_config": {
+            "enabled": True,
+            "enable_training_consistency": True,
+        },
+    },
     compilation_config={"cudagraph_mode": "PIECEWISE"},
 )
 

--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -33,7 +33,12 @@ By default, sleep mode only releases memory managed by the sleep-mode allocator.
 llm = LLM(
     "Qwen/Qwen2.5-0.5B-Instruct",
     enable_sleep_mode=True,
-    additional_config={"enable_sleep_mode_extra_cleanup": True},
+    additional_config={
+        "rl_config": {
+            "enabled": True,
+            "sleep_mode_extra_cleanup": True,
+        }
+    },
 )
 ```
 
@@ -42,10 +47,10 @@ For online serving, pass the same option through `--additional-config`:
 ```bash
 vllm serve Qwen/Qwen2.5-0.5B-Instruct \
     --enable-sleep-mode \
-    --additional-config '{"enable_sleep_mode_extra_cleanup": true}'
+    --additional-config '{"rl_config": {"enabled": true, "sleep_mode_extra_cleanup": true}}'
 ```
 
-When `enable_sleep_mode_extra_cleanup` is enabled, `sleep()` additionally:
+When `rl_config.sleep_mode_extra_cleanup` is enabled, `sleep()` additionally:
 
 - clears ACL graph attention workspaces and invalidates captured ACL graph caches when ACL graph is enabled;
 - resets the model runner graph manager so ACL graphs can be captured again after wakeup;
@@ -55,7 +60,7 @@ During `wake_up()`, vLLM Ascend restores the HCCL process groups, refreshes MoE 
 
 !!! note
 
-    Extra cleanup trades lower sleep-time NPU memory usage for longer wakeup latency. In particular, if ACL graph is enabled, `wake_up()` must call `capture_model()` again after the model state has been restored. Keep `enable_sleep_mode_extra_cleanup` disabled when lower wakeup latency is more important than releasing HCCL and ACL graph workspace memory.
+    Extra cleanup trades lower sleep-time NPU memory usage for longer wakeup latency. In particular, if ACL graph is enabled, `wake_up()` must call `capture_model()` again after the model state has been restored. Keep `rl_config.sleep_mode_extra_cleanup` disabled when lower wakeup latency is more important than releasing HCCL and ACL graph workspace memory. The former top-level `enable_sleep_mode_extra_cleanup` option has been removed.
 
 For level 2 sleep, wakeup can be split into two phases:
 

--- a/tests/e2e/pull_request/one_card/test_attention_fa3.py
+++ b/tests/e2e/pull_request/one_card/test_attention_fa3.py
@@ -20,6 +20,7 @@ os.environ["VLLM_BATCH_INVARIANT"] = "1"
 MODEL_NAME = "Qwen/Qwen3-0.6B"
 MAX_MODEL_LEN = 512
 MAX_TOKENS = 32
+FA3_ADDITIONAL_CONFIG = {"rl_config": {"enabled": True, "enable_training_consistency": True}}
 
 SHORT_PROMPTS = [
     "The capital of France is",
@@ -86,7 +87,7 @@ def test_fa3_vs_fia_single_prompt():
     """
     single_prompt = ["Explain quantum computing in simple terms."]
     fia_outputs = _generate_with_backend(single_prompt)
-    fa3_outputs = _generate_with_backend(single_prompt, attention_backend="FLASH_ATTN")
+    fa3_outputs = _generate_with_backend(single_prompt, additional_config=FA3_ADDITIONAL_CONFIG)
     _assert_outputs_match(fia_outputs, fa3_outputs, label="[SinglePrompt] ")
 
 
@@ -105,7 +106,7 @@ def test_fa3_vs_fia_mixed_lengths():
         LONG_PROMPT[:MAX_MODEL_LEN],
     ]
     fia_outputs = _generate_with_backend(mixed_prompts)
-    fa3_outputs = _generate_with_backend(mixed_prompts, attention_backend="FLASH_ATTN")
+    fa3_outputs = _generate_with_backend(mixed_prompts, additional_config=FA3_ADDITIONAL_CONFIG)
     _assert_outputs_match(fia_outputs, fa3_outputs, label="[MixedLen] ")
 
 
@@ -114,7 +115,11 @@ def test_fa3_vs_fia_with_chunkprefill():
     """Compare FA3 and FIA with single token generation where chunkprefill is used."""
     fia_outputs = _generate_with_backend(SHORT_PROMPTS, max_tokens=2, max_num_seqs=2, max_num_batched_tokens=5)
     fa3_outputs = _generate_with_backend(
-        SHORT_PROMPTS, attention_backend="FLASH_ATTN", max_tokens=2, max_num_seqs=2, max_num_batched_tokens=5
+        SHORT_PROMPTS,
+        additional_config=FA3_ADDITIONAL_CONFIG,
+        max_tokens=2,
+        max_num_seqs=2,
+        max_num_batched_tokens=5,
     )
     _assert_outputs_match(fia_outputs, fa3_outputs, label="[Chunkprefill] ")
 
@@ -123,7 +128,7 @@ def test_fa3_vs_fia_with_chunkprefill():
 def test_fa3_vs_fia_logprobs():
     """Compare FA3 and FIA logprobs for fine-grained numerical verification."""
     fia_logprobs = _generate_logprobs_with_backend(SHORT_PROMPTS[:1])
-    fa3_logprobs = _generate_logprobs_with_backend(SHORT_PROMPTS[:1], attention_backend="FLASH_ATTN")
+    fa3_logprobs = _generate_logprobs_with_backend(SHORT_PROMPTS[:1], additional_config=FA3_ADDITIONAL_CONFIG)
 
     for i, (fia_out, fa3_out) in enumerate(zip(fia_logprobs, fa3_logprobs)):
         fia_ids, _, fia_lp = fia_out

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -624,9 +624,11 @@ class TestAscendConfig(TestBase):
             ascend_config = init_ascend_config(VllmConfig())
 
         self.assertFalse(ascend_config.rl_config.enabled)
+        self.assertTrue(ascend_config.rl_config.refresh)
         self.assertFalse(ascend_config.rl_config.sleep_mode_extra_cleanup)
         self.assertEqual(ascend_config.rl_config.weight_nz_mode, 0)
         self.assertTrue(ascend_config.rl_config.disable_expandable_segments)
+        self.assertFalse(ascend_config.rl_config.enable_training_consistency)
         self.assertFalse(ascend_config.rl_config.enable_batch_invariant)
         self.assertTrue(ascend_config.rl_config.enable_dev_endpoints)
 
@@ -641,7 +643,40 @@ class TestAscendConfig(TestBase):
             self.assertEqual(ascend_config.weight_nz_mode, 0)
             self.assertEqual(os.environ.get("VLLM_ASCEND_ENABLE_NZ"), "0")
             self.assertEqual(os.environ.get("VLLM_SERVER_DEV_MODE"), "1")
+            self.assertNotIn("VLLM_BATCH_INVARIANT", os.environ)
             self.assertFalse(ascend_config.enable_sleep_mode_extra_cleanup)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_refreshes_by_default(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
+
+        first_config = init_ascend_config(test_vllm_config)
+        second_config = init_ascend_config(test_vllm_config)
+
+        self.assertIsNot(first_config, second_config)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_can_disable_refresh(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True, "refresh": False}}
+
+        first_config = init_ascend_config(test_vllm_config)
+        second_config = init_ascend_config(test_vllm_config)
+
+        self.assertIs(first_config, second_config)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_training_consistency_is_enabled(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True, "enable_training_consistency": True}}
+
+        ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertTrue(ascend_config.rl_config.enable_training_consistency)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -714,12 +749,12 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_explicitly_disables_batch_invariant(self, mock_fix_incompatible_config):
+    def test_rl_config_does_not_disable_batch_invariant_env(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {"rl_config": {"enabled": True, "enable_batch_invariant": False}}
         with patch.dict(os.environ, {"VLLM_BATCH_INVARIANT": "1"}, clear=True):
             init_ascend_config(test_vllm_config)
-            self.assertEqual(os.environ["VLLM_BATCH_INVARIANT"], "0")
+            self.assertEqual(os.environ["VLLM_BATCH_INVARIANT"], "1")
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -781,9 +816,11 @@ class TestRlConfig(TestBase):
         config = RlConfig()
 
         self.assertFalse(config.enabled)
+        self.assertTrue(config.refresh)
         self.assertFalse(config.sleep_mode_extra_cleanup)
         self.assertEqual(config.weight_nz_mode, 0)
         self.assertTrue(config.disable_expandable_segments)
+        self.assertFalse(config.enable_training_consistency)
         self.assertFalse(config.enable_batch_invariant)
         self.assertTrue(config.enable_dev_endpoints)
 
@@ -791,17 +828,21 @@ class TestRlConfig(TestBase):
         config = RlConfig(
             {
                 "enabled": True,
+                "refresh": False,
                 "sleep_mode_extra_cleanup": True,
                 "disable_expandable_segments": False,
+                "enable_training_consistency": True,
                 "enable_batch_invariant": True,
                 "enable_dev_endpoints": False,
             }
         )
 
         self.assertTrue(config.enabled)
+        self.assertFalse(config.refresh)
         self.assertTrue(config.sleep_mode_extra_cleanup)
         self.assertEqual(config.weight_nz_mode, 0)
         self.assertFalse(config.disable_expandable_segments)
+        self.assertTrue(config.enable_training_consistency)
         self.assertTrue(config.enable_batch_invariant)
         self.assertFalse(config.enable_dev_endpoints)
 
@@ -816,12 +857,12 @@ class TestRlConfig(TestBase):
             RlConfig({"enable_batch_invariant": 1})
 
     def test_weight_nz_mode_validation(self):
-        with self.assertRaisesRegex(ValueError, "must be 0, 1 or 2"):
+        with self.assertRaisesRegex(ValueError, "must be 0 or 2"):
             RlConfig({"weight_nz_mode": 5})
         with self.assertRaisesRegex(ValueError, "must be an int"):
             RlConfig({"weight_nz_mode": True})
-        with self.assertRaisesRegex(ValueError, "requires rl_config.weight_nz_mode=0"):
-            RlConfig({"enable_batch_invariant": True, "weight_nz_mode": 1})
+        with self.assertRaisesRegex(ValueError, "weight_nz_mode=1 is not supported"):
+            RlConfig({"weight_nz_mode": 1})
 
     def test_non_dict_rejected(self):
         with self.assertRaisesRegex(ValueError, "must be a dict"):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -713,9 +713,9 @@ class TestAscendConfig(TestBase):
         }
         with patch.dict(os.environ, {}, clear=True):
             ascend_config = init_ascend_config(test_vllm_config)
+            self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "0")
 
         self.assertEqual(ascend_config.weight_nz_mode, 0)
-        self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "0")
         mock_warning.assert_called_once_with(
             "RL config requires weight_nz_mode=0; overriding AscendConfig.weight_nz_mode from %s to 0.",
             2,
@@ -796,7 +796,7 @@ class TestAscendConfig(TestBase):
             init_ascend_config(test_vllm_config)
             self.assertNotIn("expandable_segments", os.environ["PYTORCH_NPU_ALLOC_CONF"])
             self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], "page_size:1g")
-        mock_info.assert_called_once_with(
+        mock_info.assert_any_call(
             "Removed expandable_segments from PYTORCH_NPU_ALLOC_CONF: %s",
             "page_size:1g",
         )

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -703,8 +703,9 @@ class TestAscendConfig(TestBase):
             self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], allocator_config)
 
     @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.warning")
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_overrides_top_level_weight_nz_mode(self, mock_fix_incompatible_config):
+    def test_rl_config_overrides_top_level_weight_nz_mode(self, mock_fix_incompatible_config, mock_warning):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "rl_config": {"enabled": True},
@@ -715,6 +716,25 @@ class TestAscendConfig(TestBase):
 
         self.assertEqual(ascend_config.weight_nz_mode, 0)
         self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "0")
+        mock_warning.assert_called_once_with(
+            "RL config requires weight_nz_mode=0; overriding AscendConfig.weight_nz_mode from %s to 0.",
+            2,
+        )
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.warning")
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_keeps_zero_weight_nz_mode_without_warning(self, mock_fix_incompatible_config, mock_warning):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "rl_config": {"enabled": True},
+            "weight_nz_mode": 0,
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertEqual(ascend_config.weight_nz_mode, 0)
+        mock_warning.assert_not_called()
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -26,6 +26,7 @@ from vllm_ascend.ascend_config import (
     AscendConfig,
     DyntraLBConfig,
     EplbConfig,
+    RlConfig,
     SchedulerConfig,
     ShortRequestFirstConfig,
     clear_ascend_config,
@@ -55,11 +56,13 @@ class TestAscendConfig(TestBase):
         total_num_kv_heads: int = 8,
         is_deepseek_mla: bool = False,
         num_experts: int = 0,
+        enable_sleep_mode: bool = False,
     ):
         return SimpleNamespace(
             is_deepseek_mla=is_deepseek_mla,
             use_mla=is_deepseek_mla,
             enforce_eager=True,
+            enable_sleep_mode=enable_sleep_mode,
             model_arch_config=SimpleNamespace(total_num_attention_heads=total_num_attention_heads),
             get_total_num_kv_heads=lambda: total_num_kv_heads,
             get_num_experts=lambda: num_experts,
@@ -613,6 +616,243 @@ class TestAscendConfig(TestBase):
         second_ascend_config = init_ascend_config(second_vllm_config)
         self.assertIsNot(first_ascend_config, second_ascend_config)
         self.assertTrue(second_ascend_config.ascend_compilation_config.enable_npugraph_ex)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_defaults_when_unset(self, mock_fix_incompatible_config):
+        with patch.dict(os.environ, {}, clear=True):
+            ascend_config = init_ascend_config(VllmConfig())
+
+        self.assertFalse(ascend_config.rl_config.enabled)
+        self.assertFalse(ascend_config.rl_config.sleep_mode_extra_cleanup)
+        self.assertEqual(ascend_config.rl_config.weight_nz_mode, 0)
+        self.assertTrue(ascend_config.rl_config.disable_expandable_segments)
+        self.assertFalse(ascend_config.rl_config.enable_batch_invariant)
+        self.assertTrue(ascend_config.rl_config.enable_dev_endpoints)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_enabled_applies_best_practice_defaults(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
+        with patch.dict(os.environ, {}, clear=True):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+            self.assertEqual(ascend_config.weight_nz_mode, 0)
+            self.assertEqual(os.environ.get("VLLM_ASCEND_ENABLE_NZ"), "0")
+            self.assertEqual(os.environ.get("VLLM_SERVER_DEV_MODE"), "1")
+            self.assertFalse(ascend_config.enable_sleep_mode_extra_cleanup)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_disabled_is_noop(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": False, "weight_nz_mode": 0}}
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"}, clear=True):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+            # rl_config is a no-op when the master switch is off: the env var is
+            # neither overridden by the sub-field nor rewritten by rl_config.
+            self.assertEqual(ascend_config.weight_nz_mode, 2)
+            self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "2")
+            self.assertNotIn("VLLM_SERVER_DEV_MODE", os.environ)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_conflict_with_top_level_raises(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "rl_config": {"enabled": True},
+            "weight_nz_mode": 2,
+        }
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            self.assertRaisesRegex(ValueError, "conflicts with additional_config.weight_nz_mode"),
+        ):
+            init_ascend_config(test_vllm_config)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_matching_top_level_is_allowed(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "rl_config": {"enabled": True},
+            "weight_nz_mode": 0,
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertEqual(ascend_config.weight_nz_mode, 0)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_cleanup_conflict_with_top_level_raises(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "rl_config": {"enabled": True, "sleep_mode_extra_cleanup": True},
+            "enable_sleep_mode_extra_cleanup": False,
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            "conflicts with additional_config.enable_sleep_mode_extra_cleanup",
+        ):
+            init_ascend_config(test_vllm_config)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_batch_invariant_overrides_env(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True, "enable_batch_invariant": True}}
+        with patch.dict(os.environ, {"VLLM_BATCH_INVARIANT": "0"}, clear=True):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+            # rl_config prevails over the environment variable.
+            self.assertEqual(os.environ["VLLM_BATCH_INVARIANT"], "1")
+            self.assertEqual(os.environ["HCCL_DETERMINISTIC"], "strict")
+            self.assertEqual(os.environ["LCCL_DETERMINISTIC"], "1")
+            self.assertTrue(ascend_config.rl_config.enable_batch_invariant)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_explicitly_disables_batch_invariant(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True, "enable_batch_invariant": False}}
+        with patch.dict(os.environ, {"VLLM_BATCH_INVARIANT": "1"}, clear=True):
+            init_ascend_config(test_vllm_config)
+            self.assertEqual(os.environ["VLLM_BATCH_INVARIANT"], "0")
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    @patch("vllm_ascend.ascend_config.logger.warning")
+    def test_rl_config_dev_endpoints_respects_env_optout(self, mock_warning, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
+        with patch.dict(os.environ, {"VLLM_SERVER_DEV_MODE": "0"}, clear=True):
+            init_ascend_config(test_vllm_config)
+            self.assertEqual(os.environ["VLLM_SERVER_DEV_MODE"], "0")
+        mock_warning.assert_called_once()
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_dev_endpoints_explicit_optout(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True, "enable_dev_endpoints": False}}
+        with patch.dict(os.environ, {"VLLM_SERVER_DEV_MODE": "1"}, clear=True):
+            init_ascend_config(test_vllm_config)
+            self.assertEqual(os.environ["VLLM_SERVER_DEV_MODE"], "0")
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_disable_expandable_segments_same_device(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.model_config = self._make_model_config(enable_sleep_mode=True)
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
+        with patch.dict(
+            os.environ,
+            {"PYTORCH_NPU_ALLOC_CONF": "page_size:1g,expandable_segments:True"},
+            clear=True,
+        ):
+            init_ascend_config(test_vllm_config)
+            self.assertNotIn("expandable_segments", os.environ["PYTORCH_NPU_ALLOC_CONF"])
+            self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], "page_size:1g")
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_keeps_allocator_config_cross_device(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.model_config = self._make_model_config(enable_sleep_mode=False)
+        test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
+        alloc_config = "page_size:1g,expandable_segments:True"
+        with patch.dict(os.environ, {"PYTORCH_NPU_ALLOC_CONF": alloc_config}, clear=True):
+            init_ascend_config(test_vllm_config)
+            self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], alloc_config)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_rl_config_non_dict_rejected(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"rl_config": "enabled"}
+        with self.assertRaisesRegex(ValueError, "rl_config must be a dict"):
+            init_ascend_config(test_vllm_config)
+
+
+class TestRlConfig(TestBase):
+    def test_defaults(self):
+        config = RlConfig()
+
+        self.assertFalse(config.enabled)
+        self.assertFalse(config.sleep_mode_extra_cleanup)
+        self.assertEqual(config.weight_nz_mode, 0)
+        self.assertTrue(config.disable_expandable_segments)
+        self.assertFalse(config.enable_batch_invariant)
+        self.assertTrue(config.enable_dev_endpoints)
+
+    def test_explicit_values(self):
+        config = RlConfig(
+            {
+                "enabled": True,
+                "sleep_mode_extra_cleanup": True,
+                "disable_expandable_segments": False,
+                "enable_batch_invariant": True,
+                "enable_dev_endpoints": False,
+            }
+        )
+
+        self.assertTrue(config.enabled)
+        self.assertTrue(config.sleep_mode_extra_cleanup)
+        self.assertEqual(config.weight_nz_mode, 0)
+        self.assertFalse(config.disable_expandable_segments)
+        self.assertTrue(config.enable_batch_invariant)
+        self.assertFalse(config.enable_dev_endpoints)
+
+    def test_unknown_key_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unknown rl_config keys"):
+            RlConfig({"foo": True})
+
+    def test_bool_validation(self):
+        with self.assertRaisesRegex(ValueError, "enabled must be a bool"):
+            RlConfig({"enabled": "yes"})
+        with self.assertRaisesRegex(ValueError, "enable_batch_invariant must be a bool"):
+            RlConfig({"enable_batch_invariant": 1})
+
+    def test_weight_nz_mode_validation(self):
+        with self.assertRaisesRegex(ValueError, "must be 0, 1 or 2"):
+            RlConfig({"weight_nz_mode": 5})
+        with self.assertRaisesRegex(ValueError, "must be an int"):
+            RlConfig({"weight_nz_mode": True})
+        with self.assertRaisesRegex(ValueError, "requires rl_config.weight_nz_mode=0"):
+            RlConfig({"enable_batch_invariant": True, "weight_nz_mode": 1})
+
+    def test_non_dict_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be a dict"):
+            RlConfig(["enabled"])
+
+    def test_disable_expandable_segments_strips_env(self):
+        from vllm_ascend.platform import _disable_expandable_segments
+
+        with patch.dict(
+            os.environ,
+            {"PYTORCH_NPU_ALLOC_CONF": "page_size:1g,expandable_segments:True"},
+            clear=True,
+        ):
+            _disable_expandable_segments()
+            self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], "page_size:1g")
+
+        with patch.dict(os.environ, {}, clear=True):
+            # Missing/empty env var is a no-op.
+            _disable_expandable_segments()
+            self.assertNotIn("PYTORCH_NPU_ALLOC_CONF", os.environ)
+
+    def test_disable_expandable_segments_matches_exact_option(self):
+        from vllm_ascend.platform import _disable_expandable_segments
+
+        with patch.dict(
+            os.environ,
+            {"PYTORCH_NPU_ALLOC_CONF": "my_expandable_segments:True, expandable_segments:False ,page_size:1g"},
+            clear=True,
+        ):
+            _disable_expandable_segments()
+            self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], "my_expandable_segments:True,page_size:1g")
 
 
 class TestShortRequestFirstConfig(TestBase):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -625,7 +625,6 @@ class TestAscendConfig(TestBase):
 
         self.assertFalse(ascend_config.rl_config.enabled)
         self.assertFalse(ascend_config.rl_config.sleep_mode_extra_cleanup)
-        self.assertTrue(ascend_config.rl_config.disable_expandable_segments)
         self.assertFalse(ascend_config.rl_config.enable_training_consistency)
         self.assertFalse(ascend_config.rl_config.enable_batch_invariant)
 
@@ -731,8 +730,8 @@ class TestAscendConfig(TestBase):
 
             # rl_config prevails over the environment variable.
             self.assertEqual(os.environ["VLLM_BATCH_INVARIANT"], "1")
-            self.assertEqual(os.environ["HCCL_DETERMINISTIC"], "strict")
-            self.assertEqual(os.environ["LCCL_DETERMINISTIC"], "1")
+            self.assertNotIn("HCCL_DETERMINISTIC", os.environ)
+            self.assertNotIn("LCCL_DETERMINISTIC", os.environ)
             self.assertTrue(ascend_config.rl_config.enable_batch_invariant)
 
     @_clean_up_ascend_config
@@ -755,9 +754,10 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_disable_expandable_segments_same_device(self, mock_fix_incompatible_config):
+    @patch("vllm_ascend.platform.logger.info")
+    def test_rl_config_removes_expandable_segments(self, mock_info, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
-        test_vllm_config.model_config = self._make_model_config(enable_sleep_mode=True)
+        test_vllm_config.model_config = self._make_model_config(enable_sleep_mode=False)
         test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
         with patch.dict(
             os.environ,
@@ -767,17 +767,10 @@ class TestAscendConfig(TestBase):
             init_ascend_config(test_vllm_config)
             self.assertNotIn("expandable_segments", os.environ["PYTORCH_NPU_ALLOC_CONF"])
             self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], "page_size:1g")
-
-    @_clean_up_ascend_config
-    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_keeps_allocator_config_cross_device(self, mock_fix_incompatible_config):
-        test_vllm_config = VllmConfig()
-        test_vllm_config.model_config = self._make_model_config(enable_sleep_mode=False)
-        test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
-        alloc_config = "page_size:1g,expandable_segments:True"
-        with patch.dict(os.environ, {"PYTORCH_NPU_ALLOC_CONF": alloc_config}, clear=True):
-            init_ascend_config(test_vllm_config)
-            self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], alloc_config)
+        mock_info.assert_called_once_with(
+            "Removed expandable_segments from PYTORCH_NPU_ALLOC_CONF: %s",
+            "page_size:1g",
+        )
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -794,7 +787,6 @@ class TestRlConfig(TestBase):
 
         self.assertFalse(config.enabled)
         self.assertFalse(config.sleep_mode_extra_cleanup)
-        self.assertTrue(config.disable_expandable_segments)
         self.assertFalse(config.enable_training_consistency)
         self.assertFalse(config.enable_batch_invariant)
 
@@ -803,7 +795,6 @@ class TestRlConfig(TestBase):
             {
                 "enabled": True,
                 "sleep_mode_extra_cleanup": True,
-                "disable_expandable_segments": False,
                 "enable_training_consistency": True,
                 "enable_batch_invariant": True,
             }
@@ -811,7 +802,6 @@ class TestRlConfig(TestBase):
 
         self.assertTrue(config.enabled)
         self.assertTrue(config.sleep_mode_extra_cleanup)
-        self.assertFalse(config.disable_expandable_segments)
         self.assertTrue(config.enable_training_consistency)
         self.assertTrue(config.enable_batch_invariant)
 
@@ -826,7 +816,7 @@ class TestRlConfig(TestBase):
             RlConfig({"enable_batch_invariant": 1})
 
     def test_fixed_fields_cannot_be_configured(self):
-        for key in ("refresh", "weight_nz_mode", "enable_dev_endpoints"):
+        for key in ("refresh", "weight_nz_mode", "enable_dev_endpoints", "disable_expandable_segments"):
             with self.subTest(key=key), self.assertRaisesRegex(ValueError, f"Unknown rl_config keys.*{key}"):
                 RlConfig({key: True})
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -683,7 +683,15 @@ class TestAscendConfig(TestBase):
                 "enable_batch_invariant": True,
             }
         }
-        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"}, clear=True):
+        allocator_config = "page_size:1g,expandable_segments:True"
+        with patch.dict(
+            os.environ,
+            {
+                "VLLM_ASCEND_ENABLE_NZ": "2",
+                "PYTORCH_NPU_ALLOC_CONF": allocator_config,
+            },
+            clear=True,
+        ):
             ascend_config = init_ascend_config(test_vllm_config)
 
             # rl_config is a no-op when the master switch is off: the env var is
@@ -692,6 +700,7 @@ class TestAscendConfig(TestBase):
             self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "2")
             self.assertNotIn("VLLM_SERVER_DEV_MODE", os.environ)
             self.assertNotIn("VLLM_BATCH_INVARIANT", os.environ)
+            self.assertEqual(os.environ["PYTORCH_NPU_ALLOC_CONF"], allocator_config)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -624,13 +624,10 @@ class TestAscendConfig(TestBase):
             ascend_config = init_ascend_config(VllmConfig())
 
         self.assertFalse(ascend_config.rl_config.enabled)
-        self.assertTrue(ascend_config.rl_config.refresh)
         self.assertFalse(ascend_config.rl_config.sleep_mode_extra_cleanup)
-        self.assertEqual(ascend_config.rl_config.weight_nz_mode, 0)
         self.assertTrue(ascend_config.rl_config.disable_expandable_segments)
         self.assertFalse(ascend_config.rl_config.enable_training_consistency)
         self.assertFalse(ascend_config.rl_config.enable_batch_invariant)
-        self.assertTrue(ascend_config.rl_config.enable_dev_endpoints)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -644,7 +641,7 @@ class TestAscendConfig(TestBase):
             self.assertEqual(os.environ.get("VLLM_ASCEND_ENABLE_NZ"), "0")
             self.assertEqual(os.environ.get("VLLM_SERVER_DEV_MODE"), "1")
             self.assertNotIn("VLLM_BATCH_INVARIANT", os.environ)
-            self.assertFalse(ascend_config.enable_sleep_mode_extra_cleanup)
+            self.assertFalse(ascend_config.rl_config.sleep_mode_extra_cleanup)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -659,14 +656,12 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_can_disable_refresh(self, mock_fix_incompatible_config):
+    def test_rl_config_refresh_cannot_be_configured(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {"rl_config": {"enabled": True, "refresh": False}}
 
-        first_config = init_ascend_config(test_vllm_config)
-        second_config = init_ascend_config(test_vllm_config)
-
-        self.assertIs(first_config, second_config)
+        with self.assertRaisesRegex(ValueError, "Unknown rl_config keys.*refresh"):
+            init_ascend_config(test_vllm_config)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -682,7 +677,13 @@ class TestAscendConfig(TestBase):
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_rl_config_disabled_is_noop(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
-        test_vllm_config.additional_config = {"rl_config": {"enabled": False, "weight_nz_mode": 0}}
+        test_vllm_config.additional_config = {
+            "rl_config": {
+                "enabled": False,
+                "sleep_mode_extra_cleanup": True,
+                "enable_batch_invariant": True,
+            }
+        }
         with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "2"}, clear=True):
             ascend_config = init_ascend_config(test_vllm_config)
 
@@ -691,45 +692,32 @@ class TestAscendConfig(TestBase):
             self.assertEqual(ascend_config.weight_nz_mode, 2)
             self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "2")
             self.assertNotIn("VLLM_SERVER_DEV_MODE", os.environ)
+            self.assertNotIn("VLLM_BATCH_INVARIANT", os.environ)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_conflict_with_top_level_raises(self, mock_fix_incompatible_config):
+    def test_rl_config_overrides_top_level_weight_nz_mode(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
             "rl_config": {"enabled": True},
             "weight_nz_mode": 2,
         }
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            self.assertRaisesRegex(ValueError, "conflicts with additional_config.weight_nz_mode"),
-        ):
-            init_ascend_config(test_vllm_config)
-
-    @_clean_up_ascend_config
-    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_matching_top_level_is_allowed(self, mock_fix_incompatible_config):
-        test_vllm_config = VllmConfig()
-        test_vllm_config.additional_config = {
-            "rl_config": {"enabled": True},
-            "weight_nz_mode": 0,
-        }
         with patch.dict(os.environ, {}, clear=True):
             ascend_config = init_ascend_config(test_vllm_config)
 
         self.assertEqual(ascend_config.weight_nz_mode, 0)
+        self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "0")
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_cleanup_conflict_with_top_level_raises(self, mock_fix_incompatible_config):
+    def test_top_level_sleep_mode_extra_cleanup_is_removed(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {
-            "rl_config": {"enabled": True, "sleep_mode_extra_cleanup": True},
-            "enable_sleep_mode_extra_cleanup": False,
+            "enable_sleep_mode_extra_cleanup": True,
         }
         with self.assertRaisesRegex(
             ValueError,
-            "conflicts with additional_config.enable_sleep_mode_extra_cleanup",
+            "has been removed.*rl_config.sleep_mode_extra_cleanup",
         ):
             init_ascend_config(test_vllm_config)
 
@@ -758,23 +746,12 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    @patch("vllm_ascend.ascend_config.logger.warning")
-    def test_rl_config_dev_endpoints_respects_env_optout(self, mock_warning, mock_fix_incompatible_config):
+    def test_rl_config_always_enables_dev_endpoints(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.additional_config = {"rl_config": {"enabled": True}}
         with patch.dict(os.environ, {"VLLM_SERVER_DEV_MODE": "0"}, clear=True):
             init_ascend_config(test_vllm_config)
-            self.assertEqual(os.environ["VLLM_SERVER_DEV_MODE"], "0")
-        mock_warning.assert_called_once()
-
-    @_clean_up_ascend_config
-    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_rl_config_dev_endpoints_explicit_optout(self, mock_fix_incompatible_config):
-        test_vllm_config = VllmConfig()
-        test_vllm_config.additional_config = {"rl_config": {"enabled": True, "enable_dev_endpoints": False}}
-        with patch.dict(os.environ, {"VLLM_SERVER_DEV_MODE": "1"}, clear=True):
-            init_ascend_config(test_vllm_config)
-            self.assertEqual(os.environ["VLLM_SERVER_DEV_MODE"], "0")
+            self.assertEqual(os.environ["VLLM_SERVER_DEV_MODE"], "1")
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -816,35 +793,27 @@ class TestRlConfig(TestBase):
         config = RlConfig()
 
         self.assertFalse(config.enabled)
-        self.assertTrue(config.refresh)
         self.assertFalse(config.sleep_mode_extra_cleanup)
-        self.assertEqual(config.weight_nz_mode, 0)
         self.assertTrue(config.disable_expandable_segments)
         self.assertFalse(config.enable_training_consistency)
         self.assertFalse(config.enable_batch_invariant)
-        self.assertTrue(config.enable_dev_endpoints)
 
     def test_explicit_values(self):
         config = RlConfig(
             {
                 "enabled": True,
-                "refresh": False,
                 "sleep_mode_extra_cleanup": True,
                 "disable_expandable_segments": False,
                 "enable_training_consistency": True,
                 "enable_batch_invariant": True,
-                "enable_dev_endpoints": False,
             }
         )
 
         self.assertTrue(config.enabled)
-        self.assertFalse(config.refresh)
         self.assertTrue(config.sleep_mode_extra_cleanup)
-        self.assertEqual(config.weight_nz_mode, 0)
         self.assertFalse(config.disable_expandable_segments)
         self.assertTrue(config.enable_training_consistency)
         self.assertTrue(config.enable_batch_invariant)
-        self.assertFalse(config.enable_dev_endpoints)
 
     def test_unknown_key_rejected(self):
         with self.assertRaisesRegex(ValueError, "Unknown rl_config keys"):
@@ -856,13 +825,10 @@ class TestRlConfig(TestBase):
         with self.assertRaisesRegex(ValueError, "enable_batch_invariant must be a bool"):
             RlConfig({"enable_batch_invariant": 1})
 
-    def test_weight_nz_mode_validation(self):
-        with self.assertRaisesRegex(ValueError, "must be 0 or 2"):
-            RlConfig({"weight_nz_mode": 5})
-        with self.assertRaisesRegex(ValueError, "must be an int"):
-            RlConfig({"weight_nz_mode": True})
-        with self.assertRaisesRegex(ValueError, "weight_nz_mode=1 is not supported"):
-            RlConfig({"weight_nz_mode": 1})
+    def test_fixed_fields_cannot_be_configured(self):
+        for key in ("refresh", "weight_nz_mode", "enable_dev_endpoints"):
+            with self.subTest(key=key), self.assertRaisesRegex(ValueError, f"Unknown rl_config keys.*{key}"):
+                RlConfig({key: True})
 
     def test_non_dict_rejected(self):
         with self.assertRaisesRegex(ValueError, "must be a dict"):

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -10,7 +10,7 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
-from vllm_ascend.platform import NPUPlatform, _enable_fa3_for_training_consistency, _validate_eplb_config
+from vllm_ascend.platform import NPUPlatform, _validate_eplb_config
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
@@ -1350,31 +1350,10 @@ class TestNPUPlatform(TestBase):
         result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
         self.assertEqual(result, "vllm_ascend.attention.attention_v1.AscendAttentionBackend")
 
-    def test_training_consistency_selects_fa3(self):
-        vllm_config = MagicMock()
-        ascend_config = MagicMock()
-        ascend_config.rl_config.enabled = True
-        ascend_config.rl_config.enable_training_consistency = True
-
-        _enable_fa3_for_training_consistency(vllm_config, ascend_config)
-
-        self.assertEqual(vllm_config.attention_config.backend, AttentionBackendEnum.FLASH_ATTN)
-
-    def test_training_consistency_is_ignored_when_rl_config_is_disabled(self):
-        vllm_config = MagicMock()
-        vllm_config.attention_config.backend = None
-        ascend_config = MagicMock()
-        ascend_config.rl_config.enabled = False
-        ascend_config.rl_config.enable_training_consistency = True
-
-        _enable_fa3_for_training_consistency(vllm_config, ascend_config)
-
-        self.assertIsNone(vllm_config.attention_config.backend)
-
     @patch("vllm_ascend.platform.import_module")
     @patch("vllm_ascend.platform.util.find_spec", return_value=object())
     @patch("vllm_ascend.platform.get_ascend_config")
-    def test_get_attn_backend_cls_fa3_uses_training_consistency(
+    def test_get_attn_backend_cls_fa3_uses_training_consistency_without_selected_backend(
         self, mock_get_ascend_config, mock_find_spec, mock_import_module
     ):
         mock_get_ascend_config.return_value.rl_config.enabled = True
@@ -1389,7 +1368,7 @@ class TestNPUPlatform(TestBase):
             use_sparse=False,
         )
 
-        result = self.platform.get_attn_backend_cls(AttentionBackendEnum.FLASH_ATTN, attn_selector_config)
+        result = self.platform.get_attn_backend_cls(None, attn_selector_config)
 
         self.assertEqual(result, "vllm_ascend.attention.fa3_v1.AscendFABackend")
         mock_find_spec.assert_called_once_with("flash_attn_npu_v3")

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -5,11 +5,12 @@ import pytest
 import torch
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.platforms import PlatformEnum
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
-from vllm_ascend.platform import NPUPlatform, _validate_eplb_config
+from vllm_ascend.platform import NPUPlatform, _enable_fa3_for_training_consistency, _validate_eplb_config
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
@@ -1347,6 +1348,68 @@ class TestNPUPlatform(TestBase):
             use_sparse=False,
         )
         result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
+        self.assertEqual(result, "vllm_ascend.attention.attention_v1.AscendAttentionBackend")
+
+    def test_training_consistency_selects_fa3(self):
+        vllm_config = MagicMock()
+        ascend_config = MagicMock()
+        ascend_config.rl_config.enabled = True
+        ascend_config.rl_config.enable_training_consistency = True
+
+        _enable_fa3_for_training_consistency(vllm_config, ascend_config)
+
+        self.assertEqual(vllm_config.attention_config.backend, AttentionBackendEnum.FLASH_ATTN)
+
+    def test_training_consistency_is_ignored_when_rl_config_is_disabled(self):
+        vllm_config = MagicMock()
+        vllm_config.attention_config.backend = None
+        ascend_config = MagicMock()
+        ascend_config.rl_config.enabled = False
+        ascend_config.rl_config.enable_training_consistency = True
+
+        _enable_fa3_for_training_consistency(vllm_config, ascend_config)
+
+        self.assertIsNone(vllm_config.attention_config.backend)
+
+    @patch("vllm_ascend.platform.import_module")
+    @patch("vllm_ascend.platform.util.find_spec", return_value=object())
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_fa3_uses_training_consistency(
+        self, mock_get_ascend_config, mock_find_spec, mock_import_module
+    ):
+        mock_get_ascend_config.return_value.rl_config.enabled = True
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = True
+        mock_import_module.return_value.flash_attn_with_kvcache = MagicMock()
+        attn_selector_config = AttentionSelectorConfig(
+            dtype=torch.float16,
+            head_size=0,
+            kv_cache_dtype=None,
+            block_size=128,
+            use_mla=False,
+            use_sparse=False,
+        )
+
+        result = self.platform.get_attn_backend_cls(AttentionBackendEnum.FLASH_ATTN, attn_selector_config)
+
+        self.assertEqual(result, "vllm_ascend.attention.fa3_v1.AscendFABackend")
+        mock_find_spec.assert_called_once_with("flash_attn_npu_v3")
+
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_fa3_disabled_without_training_consistency(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.rl_config.enabled = True
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = False
+        attn_selector_config = AttentionSelectorConfig(
+            dtype=torch.float16,
+            head_size=0,
+            kv_cache_dtype=None,
+            block_size=128,
+            use_mla=False,
+            use_sparse=False,
+            use_batch_invariant=True,
+        )
+
+        result = self.platform.get_attn_backend_cls(AttentionBackendEnum.FLASH_ATTN, attn_selector_config)
+
         self.assertEqual(result, "vllm_ascend.attention.attention_v1.AscendAttentionBackend")
 
     def test_get_punica_wrapper(self):

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1326,7 +1326,10 @@ class TestNPUPlatform(TestBase):
         self.platform.check_and_update_config(vllm_config)
         self.assertEqual(vllm_config.compilation_config.custom_ops, [])
 
-    def test_get_attn_backend_cls_use_v1_and_mla(self):
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_use_v1_and_mla(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.rl_config.enabled = False
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = False
         attn_selector_config = AttentionSelectorConfig(
             dtype=torch.float16,
             head_size=0,
@@ -1338,7 +1341,10 @@ class TestNPUPlatform(TestBase):
         result = self.platform.get_attn_backend_cls("ascend", attn_selector_config)
         self.assertEqual(result, "vllm_ascend.attention.mla_v1.AscendMLABackend")
 
-    def test_get_attn_backend_cls_use_v1_only(self):
+    @patch("vllm_ascend.platform.get_ascend_config")
+    def test_get_attn_backend_cls_use_v1_only(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.rl_config.enabled = False
+        mock_get_ascend_config.return_value.rl_config.enable_training_consistency = False
         attn_selector_config = AttentionSelectorConfig(
             dtype=torch.float16,
             head_size=0,

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -1640,18 +1640,23 @@ class TestNPUWorkerWeightUpdate(TestBase):
         engine.parse_init_info.assert_called_once_with(init_info)
         engine.init_transfer_engine.assert_called_once_with("typed_init")
 
-    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
-    def test_start_weight_update_dispatches_to_engine(self):
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_start_weight_update_dispatches_to_engine(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.weight_nz_mode = 0
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
 
-        worker.start_weight_update()
+        # The runtime AscendConfig is authoritative even when the deprecated
+        # environment variable still carries a stale import-time value.
+        with patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"}):
+            worker.start_weight_update()
 
         engine.start_weight_update.assert_called_once_with()
         self.assertTrue(worker._weight_update_active)
 
-    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
-    def test_start_weight_update_rejects_reentry(self):
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_start_weight_update_rejects_reentry(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.weight_nz_mode = 0
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
         worker._weight_update_active = True
@@ -1659,12 +1664,16 @@ class TestNPUWorkerWeightUpdate(TestBase):
         with self.assertRaises(RuntimeError):
             worker.start_weight_update()
 
-    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"})
-    def test_start_weight_update_rejects_nz(self):
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_start_weight_update_rejects_nz(self, mock_get_ascend_config):
+        mock_get_ascend_config.return_value.weight_nz_mode = 1
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
 
-        with self.assertRaises(ValueError):
+        with (
+            patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"}),
+            self.assertRaises(ValueError),
+        ):
             worker.start_weight_update()
 
     def test_update_weights_requires_start(self):

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -360,7 +360,8 @@ class TestNPUWorker(TestBase):
     def test_wake_up_mode_enabled(self, mock_get_config, mock_allocator_class):
         mock_config = MagicMock()
         mock_config.weight_nz_mode = 0
-        mock_config.enable_sleep_mode_extra_cleanup = True
+        mock_config.rl_config.enabled = True
+        mock_config.rl_config.sleep_mode_extra_cleanup = True
         mock_get_config.return_value = mock_config
         """Test wake_up method when sleep mode is enabled"""
         from vllm_ascend.worker.worker import NPUWorker
@@ -425,7 +426,10 @@ class TestNPUWorker(TestBase):
             )
             for model in (target_model, draft_model)
         ]
-        mock_get_config.return_value = SimpleNamespace(weight_nz_mode=0, enable_sleep_mode_extra_cleanup=False)
+        mock_get_config.return_value = SimpleNamespace(
+            weight_nz_mode=0,
+            rl_config=SimpleNamespace(enabled=False, sleep_mode_extra_cleanup=True),
+        )
 
         with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
             worker = NPUWorker()

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -355,6 +355,25 @@ class TestNPUWorker(TestBase):
             self.assertEqual(worker.cache_config.num_gpu_blocks, 100)
             self.assertEqual(worker.cache_config.num_cpu_blocks, 50)
 
+    @patch("torch.npu.mem_get_info", side_effect=[(100, 200), (150, 200)])
+    @patch("vllm_ascend.worker.worker.CaMemAllocator")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_sleep_uses_rl_extra_cleanup(self, mock_get_config, mock_allocator_class, mock_mem_get_info):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        mock_get_config.return_value = SimpleNamespace(
+            rl_config=SimpleNamespace(enabled=True, sleep_mode_extra_cleanup=True)
+        )
+        with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
+            worker = NPUWorker()
+        worker.sleep_wakeup_manager = MagicMock()
+
+        worker.sleep()
+
+        worker.sleep_wakeup_manager.sleep.assert_called_once_with()
+        mock_allocator_class.get_instance.return_value.sleep.assert_called_once_with(offload_tags=("weights",))
+        self.assertEqual(mock_mem_get_info.call_count, 2)
+
     @patch("vllm_ascend.worker.worker.CaMemAllocator")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     def test_wake_up_mode_enabled(self, mock_get_config, mock_allocator_class):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -325,6 +325,9 @@ class AscendConfig:
         )
         self._validate_sparse_c8_kv_offload_compatibility()
 
+        self.rl_config = RlConfig(additional_config.get("rl_config", {}))
+        self.rl_config.apply(self, additional_config)
+
     def _validate_mc2_hierarchy_comm(self) -> None:
         if not self.enable_mc2_hierarchy_comm:
             return
@@ -537,6 +540,99 @@ class AscendConfig:
 
     def update_compile_ranges_split_points(self):
         return
+
+
+class RlConfig:
+    """Unified defaults for reinforcement-learning workloads."""
+
+    enabled: bool
+    sleep_mode_extra_cleanup: bool
+    weight_nz_mode: int
+    disable_expandable_segments: bool
+    enable_batch_invariant: bool
+    enable_dev_endpoints: bool
+
+    _TOP_LEVEL_KEYS = {
+        "sleep_mode_extra_cleanup": "enable_sleep_mode_extra_cleanup",
+        "weight_nz_mode": "weight_nz_mode",
+    }
+    _DEFAULTS = {
+        "enabled": False,
+        "sleep_mode_extra_cleanup": False,
+        "weight_nz_mode": 0,
+        "disable_expandable_segments": True,
+        "enable_batch_invariant": False,
+        "enable_dev_endpoints": True,
+    }
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        config = {} if config is None else config
+        if not isinstance(config, dict):
+            raise ValueError(f"additional_config.rl_config must be a dict, got {type(config).__name__}.")
+
+        unknown_keys = set(config) - self._DEFAULTS.keys()
+        if unknown_keys:
+            raise ValueError(f"Unknown rl_config keys: {sorted(unknown_keys)}")
+
+        self._explicit_keys = frozenset(config)
+        for key, default in self._DEFAULTS.items():
+            setattr(self, key, config.get(key, default))
+        self._validate()
+
+    def _validate(self) -> None:
+        for key in self._DEFAULTS.keys() - {"weight_nz_mode"}:
+            value = getattr(self, key)
+            if not isinstance(value, bool):
+                raise ValueError(f"rl_config.{key} must be a bool, got {type(value).__name__}: {value}.")
+        if not isinstance(self.weight_nz_mode, int) or isinstance(self.weight_nz_mode, bool):
+            raise ValueError("rl_config.weight_nz_mode must be an int with value 0, 1 or 2.")
+        if self.weight_nz_mode not in (0, 1, 2):
+            raise ValueError(f"rl_config.weight_nz_mode must be 0, 1 or 2, got {self.weight_nz_mode!r}.")
+        if self.enable_batch_invariant and self.weight_nz_mode != 0:
+            raise ValueError("rl_config.enable_batch_invariant requires rl_config.weight_nz_mode=0.")
+
+    def _check_top_level_conflicts(self, additional_config: dict[str, Any]) -> None:
+        for rl_key, top_level_key in self._TOP_LEVEL_KEYS.items():
+            if top_level_key not in additional_config:
+                continue
+            rl_value = getattr(self, rl_key)
+            if additional_config[top_level_key] != rl_value:
+                raise ValueError(
+                    f"rl_config.{rl_key}={rl_value} conflicts with "
+                    f"additional_config.{top_level_key}={additional_config[top_level_key]}. "
+                    "Remove the top-level key when using rl_config."
+                )
+
+    def apply(self, ascend_config: "AscendConfig", additional_config: dict[str, Any]) -> None:
+        if not self.enabled:
+            return
+
+        self._check_top_level_conflicts(additional_config)
+        ascend_config.weight_nz_mode = self.weight_nz_mode
+        ascend_config.enable_sleep_mode_extra_cleanup = self.sleep_mode_extra_cleanup
+        os.environ["VLLM_ASCEND_ENABLE_NZ"] = str(self.weight_nz_mode)
+
+        model_config = getattr(ascend_config.vllm_config, "model_config", None)
+        if self.disable_expandable_segments and getattr(model_config, "enable_sleep_mode", False):
+            from vllm_ascend.platform import _disable_expandable_segments
+
+            _disable_expandable_segments()
+
+        if "enable_batch_invariant" in self._explicit_keys or self.enable_batch_invariant:
+            os.environ["VLLM_BATCH_INVARIANT"] = "1" if self.enable_batch_invariant else "0"
+        if self.enable_batch_invariant:
+            os.environ["HCCL_DETERMINISTIC"] = "strict"
+            os.environ["LCCL_DETERMINISTIC"] = "1"
+
+        # An explicit administrator opt-out takes precedence because the dev
+        # endpoints expose process-control APIs such as sleep and wake_up.
+        if self.enable_dev_endpoints and os.environ.get("VLLM_SERVER_DEV_MODE") == "0":
+            logger.warning(
+                "rl_config requested developer endpoints, but VLLM_SERVER_DEV_MODE=0 "
+                "is explicitly set; keeping the endpoints disabled."
+            )
+        else:
+            os.environ["VLLM_SERVER_DEV_MODE"] = "1" if self.enable_dev_endpoints else "0"
 
 
 class DynamicSpecConfig:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -546,9 +546,11 @@ class RlConfig:
     """Unified defaults for reinforcement-learning workloads."""
 
     enabled: bool
+    refresh: bool
     sleep_mode_extra_cleanup: bool
     weight_nz_mode: int
     disable_expandable_segments: bool
+    enable_training_consistency: bool
     enable_batch_invariant: bool
     enable_dev_endpoints: bool
 
@@ -558,9 +560,11 @@ class RlConfig:
     }
     _DEFAULTS = {
         "enabled": False,
+        "refresh": True,
         "sleep_mode_extra_cleanup": False,
         "weight_nz_mode": 0,
         "disable_expandable_segments": True,
+        "enable_training_consistency": False,
         "enable_batch_invariant": False,
         "enable_dev_endpoints": True,
     }
@@ -585,9 +589,14 @@ class RlConfig:
             if not isinstance(value, bool):
                 raise ValueError(f"rl_config.{key} must be a bool, got {type(value).__name__}: {value}.")
         if not isinstance(self.weight_nz_mode, int) or isinstance(self.weight_nz_mode, bool):
-            raise ValueError("rl_config.weight_nz_mode must be an int with value 0, 1 or 2.")
-        if self.weight_nz_mode not in (0, 1, 2):
-            raise ValueError(f"rl_config.weight_nz_mode must be 0, 1 or 2, got {self.weight_nz_mode!r}.")
+            raise ValueError("rl_config.weight_nz_mode must be an int with value 0 or 2.")
+        if self.weight_nz_mode == 1:
+            raise ValueError(
+                "rl_config.weight_nz_mode=1 is not supported for RL workloads. "
+                "Use rl_config.weight_nz_mode=0 (the default) instead."
+            )
+        if self.weight_nz_mode not in (0, 2):
+            raise ValueError(f"rl_config.weight_nz_mode must be 0 or 2, got {self.weight_nz_mode!r}.")
         if self.enable_batch_invariant and self.weight_nz_mode != 0:
             raise ValueError("rl_config.enable_batch_invariant requires rl_config.weight_nz_mode=0.")
 
@@ -618,9 +627,10 @@ class RlConfig:
 
             _disable_expandable_segments()
 
-        if "enable_batch_invariant" in self._explicit_keys or self.enable_batch_invariant:
-            os.environ["VLLM_BATCH_INVARIANT"] = "1" if self.enable_batch_invariant else "0"
+        # rl_config provides an additional way to enable batch invariance. It
+        # must not disable a value explicitly supplied through the environment.
         if self.enable_batch_invariant:
+            os.environ["VLLM_BATCH_INVARIANT"] = "1"
             os.environ["HCCL_DETERMINISTIC"] = "strict"
             os.environ["LCCL_DETERMINISTIC"] = "1"
 
@@ -1349,6 +1359,9 @@ def _is_ascend_config_initialized(config: AscendConfig | None) -> bool:
 def init_ascend_config(vllm_config):
     additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
     refresh = additional_config.get("refresh", False) if additional_config else False
+    rl_config = additional_config.get("rl_config", {})
+    if isinstance(rl_config, dict) and rl_config.get("enabled", False):
+        refresh = refresh or rl_config.get("refresh", RlConfig._DEFAULTS["refresh"])
     global _ASCEND_CONFIG
     if (
         _ASCEND_CONFIG is not None

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -35,6 +35,11 @@ class AscendConfig:
     def __init__(self, vllm_config: "VllmConfig"):
         self.vllm_config = vllm_config
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
+        if "enable_sleep_mode_extra_cleanup" in additional_config:
+            raise ValueError(
+                "additional_config.enable_sleep_mode_extra_cleanup has been removed. "
+                "Use additional_config.rl_config.sleep_mode_extra_cleanup instead."
+            )
         self._check_mooncake_c8_kv_cache_quant(vllm_config)
 
         xlite_graph_config = additional_config.get("xlite_graph_config", {})
@@ -148,7 +153,6 @@ class AscendConfig:
                 "only guaranteed when the recompute scheduler is enabled."
             )
         self.enable_cpu_binding = additional_config.get("enable_cpu_binding", True)
-        self.enable_sleep_mode_extra_cleanup = additional_config.get("enable_sleep_mode_extra_cleanup", False)
         self.multistream_dsv4_dsa_overlap = additional_config.get("multistream_dsv4_dsa_overlap", True)
         self.enable_prefill_mc2 = bool(additional_config.get("enable_prefill_mc2", False))
 
@@ -326,7 +330,7 @@ class AscendConfig:
         self._validate_sparse_c8_kv_offload_compatibility()
 
         self.rl_config = RlConfig(additional_config.get("rl_config", {}))
-        self.rl_config.apply(self, additional_config)
+        self.rl_config.apply(self)
 
     def _validate_mc2_hierarchy_comm(self) -> None:
         if not self.enable_mc2_hierarchy_comm:
@@ -546,27 +550,17 @@ class RlConfig:
     """Unified defaults for reinforcement-learning workloads."""
 
     enabled: bool
-    refresh: bool
     sleep_mode_extra_cleanup: bool
-    weight_nz_mode: int
     disable_expandable_segments: bool
     enable_training_consistency: bool
     enable_batch_invariant: bool
-    enable_dev_endpoints: bool
 
-    _TOP_LEVEL_KEYS = {
-        "sleep_mode_extra_cleanup": "enable_sleep_mode_extra_cleanup",
-        "weight_nz_mode": "weight_nz_mode",
-    }
     _DEFAULTS = {
         "enabled": False,
-        "refresh": True,
         "sleep_mode_extra_cleanup": False,
-        "weight_nz_mode": 0,
         "disable_expandable_segments": True,
         "enable_training_consistency": False,
         "enable_batch_invariant": False,
-        "enable_dev_endpoints": True,
     }
 
     def __init__(self, config: dict[str, Any] | None = None):
@@ -578,48 +572,22 @@ class RlConfig:
         if unknown_keys:
             raise ValueError(f"Unknown rl_config keys: {sorted(unknown_keys)}")
 
-        self._explicit_keys = frozenset(config)
         for key, default in self._DEFAULTS.items():
             setattr(self, key, config.get(key, default))
         self._validate()
 
     def _validate(self) -> None:
-        for key in self._DEFAULTS.keys() - {"weight_nz_mode"}:
+        for key in self._DEFAULTS:
             value = getattr(self, key)
             if not isinstance(value, bool):
                 raise ValueError(f"rl_config.{key} must be a bool, got {type(value).__name__}: {value}.")
-        if not isinstance(self.weight_nz_mode, int) or isinstance(self.weight_nz_mode, bool):
-            raise ValueError("rl_config.weight_nz_mode must be an int with value 0 or 2.")
-        if self.weight_nz_mode == 1:
-            raise ValueError(
-                "rl_config.weight_nz_mode=1 is not supported for RL workloads. "
-                "Use rl_config.weight_nz_mode=0 (the default) instead."
-            )
-        if self.weight_nz_mode not in (0, 2):
-            raise ValueError(f"rl_config.weight_nz_mode must be 0 or 2, got {self.weight_nz_mode!r}.")
-        if self.enable_batch_invariant and self.weight_nz_mode != 0:
-            raise ValueError("rl_config.enable_batch_invariant requires rl_config.weight_nz_mode=0.")
 
-    def _check_top_level_conflicts(self, additional_config: dict[str, Any]) -> None:
-        for rl_key, top_level_key in self._TOP_LEVEL_KEYS.items():
-            if top_level_key not in additional_config:
-                continue
-            rl_value = getattr(self, rl_key)
-            if additional_config[top_level_key] != rl_value:
-                raise ValueError(
-                    f"rl_config.{rl_key}={rl_value} conflicts with "
-                    f"additional_config.{top_level_key}={additional_config[top_level_key]}. "
-                    "Remove the top-level key when using rl_config."
-                )
-
-    def apply(self, ascend_config: "AscendConfig", additional_config: dict[str, Any]) -> None:
+    def apply(self, ascend_config: "AscendConfig") -> None:
         if not self.enabled:
             return
 
-        self._check_top_level_conflicts(additional_config)
-        ascend_config.weight_nz_mode = self.weight_nz_mode
-        ascend_config.enable_sleep_mode_extra_cleanup = self.sleep_mode_extra_cleanup
-        os.environ["VLLM_ASCEND_ENABLE_NZ"] = str(self.weight_nz_mode)
+        ascend_config.weight_nz_mode = 0
+        os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
 
         model_config = getattr(ascend_config.vllm_config, "model_config", None)
         if self.disable_expandable_segments and getattr(model_config, "enable_sleep_mode", False):
@@ -634,15 +602,7 @@ class RlConfig:
             os.environ["HCCL_DETERMINISTIC"] = "strict"
             os.environ["LCCL_DETERMINISTIC"] = "1"
 
-        # An explicit administrator opt-out takes precedence because the dev
-        # endpoints expose process-control APIs such as sleep and wake_up.
-        if self.enable_dev_endpoints and os.environ.get("VLLM_SERVER_DEV_MODE") == "0":
-            logger.warning(
-                "rl_config requested developer endpoints, but VLLM_SERVER_DEV_MODE=0 "
-                "is explicitly set; keeping the endpoints disabled."
-            )
-        else:
-            os.environ["VLLM_SERVER_DEV_MODE"] = "1" if self.enable_dev_endpoints else "0"
+        os.environ["VLLM_SERVER_DEV_MODE"] = "1"
 
 
 class DynamicSpecConfig:
@@ -1361,7 +1321,7 @@ def init_ascend_config(vllm_config):
     refresh = additional_config.get("refresh", False) if additional_config else False
     rl_config = additional_config.get("rl_config", {})
     if isinstance(rl_config, dict) and rl_config.get("enabled", False):
-        refresh = refresh or rl_config.get("refresh", RlConfig._DEFAULTS["refresh"])
+        refresh = True
     global _ASCEND_CONFIG
     if (
         _ASCEND_CONFIG is not None

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -551,14 +551,12 @@ class RlConfig:
 
     enabled: bool
     sleep_mode_extra_cleanup: bool
-    disable_expandable_segments: bool
     enable_training_consistency: bool
     enable_batch_invariant: bool
 
     _DEFAULTS = {
         "enabled": False,
         "sleep_mode_extra_cleanup": False,
-        "disable_expandable_segments": True,
         "enable_training_consistency": False,
         "enable_batch_invariant": False,
     }
@@ -589,18 +587,14 @@ class RlConfig:
         ascend_config.weight_nz_mode = 0
         os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
 
-        model_config = getattr(ascend_config.vllm_config, "model_config", None)
-        if self.disable_expandable_segments and getattr(model_config, "enable_sleep_mode", False):
-            from vllm_ascend.platform import _disable_expandable_segments
+        from vllm_ascend.platform import _disable_expandable_segments
 
-            _disable_expandable_segments()
+        _disable_expandable_segments()
 
         # rl_config provides an additional way to enable batch invariance. It
         # must not disable a value explicitly supplied through the environment.
         if self.enable_batch_invariant:
             os.environ["VLLM_BATCH_INVARIANT"] = "1"
-            os.environ["HCCL_DETERMINISTIC"] = "strict"
-            os.environ["LCCL_DETERMINISTIC"] = "1"
 
         os.environ["VLLM_SERVER_DEV_MODE"] = "1"
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -584,6 +584,11 @@ class RlConfig:
         if not self.enabled:
             return
 
+        if ascend_config.weight_nz_mode != 0:
+            logger.warning(
+                "RL config requires weight_nz_mode=0; overriding AscendConfig.weight_nz_mode from %s to 0.",
+                ascend_config.weight_nz_mode,
+            )
         ascend_config.weight_nz_mode = 0
         os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -33,7 +33,7 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
 # isort: off
 from vllm_ascend.utils import (
@@ -376,6 +376,7 @@ class NPUPlatform(Platform):
         # ascend_config is only used for verification, this object must NOT be modified here
         ascend_config = init_ascend_config(vllm_config)
         _check_ascend_config(vllm_config, ascend_config)
+        _enable_fa3_for_training_consistency(vllm_config, ascend_config)
 
         # 6.Update compilation / cudagraph modes (ascend_config -> vllm_config).
         _update_compilation_modes(vllm_config, ascend_config)
@@ -1252,10 +1253,17 @@ def _disable_expandable_segments() -> None:
         logger.info("Removed expandable_segments from PYTORCH_NPU_ALLOC_CONF: %s", updated_configs)
 
 
-def _validate_fa3_backend(key, attn_selector_config):
-    if not attn_selector_config.use_batch_invariant:
+def _enable_fa3_for_training_consistency(vllm_config: VllmConfig, ascend_config) -> None:
+    rl_config = ascend_config.rl_config
+    if rl_config.enabled and rl_config.enable_training_consistency:
+        vllm_config.attention_config.backend = AttentionBackendEnum.FLASH_ATTN
+
+
+def _validate_fa3_backend(key, _attn_selector_config):
+    rl_config = get_ascend_config().rl_config
+    if not (rl_config.enabled and rl_config.enable_training_consistency):
         logger.info(
-            "FA3 will not be enabled when not in training-inference consistency scenario. "
+            "FA3 will not be enabled when rl_config.enable_training_consistency is false. "
             "Note that Ascend NPU will use its registered plugin backend instead."
         )
         return False

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,8 +31,6 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
-
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 
 # isort: off
@@ -217,7 +215,7 @@ class NPUPlatform(Platform):
         use_compress = getattr(attn_selector_config, "use_compress", False)
         key = (attn_selector_config.use_mla, attn_selector_config.use_sparse)
 
-        if selected_backend == AttentionBackendEnum.FLASH_ATTN and _validate_fa3_backend(key, attn_selector_config):
+        if _validate_fa3_backend(key, attn_selector_config):
             return "vllm_ascend.attention.fa3_v1.AscendFABackend"
 
         backend_map = {
@@ -376,7 +374,6 @@ class NPUPlatform(Platform):
         # ascend_config is only used for verification, this object must NOT be modified here
         ascend_config = init_ascend_config(vllm_config)
         _check_ascend_config(vllm_config, ascend_config)
-        _enable_fa3_for_training_consistency(vllm_config, ascend_config)
 
         # 6.Update compilation / cudagraph modes (ascend_config -> vllm_config).
         _update_compilation_modes(vllm_config, ascend_config)
@@ -665,10 +662,10 @@ def _fix_incompatible_config(vllm_config: VllmConfig) -> None:
             )
             att_config.flash_attn_version = None
 
-        # Notify user that the backend will be managed by Ascend plugins,
-        # and for training-inference consistency, when att_config.backend
-        # == AttentionBackendEnum.FLASH_ATTN,it is NOT reset to None
-        if getattr(att_config, "backend", None) is not None and att_config.backend != AttentionBackendEnum.FLASH_ATTN:
+        # Notify the user that the backend will be managed by Ascend plugins.
+        # FA3 is selected directly in get_attn_backend_cls when RL training
+        # consistency is enabled, so it does not depend on this field.
+        if getattr(att_config, "backend", None) is not None:
             logger.info(
                 "User specified attention backend '%s'. Note that Ascend NPU "
                 "will use its registered plugin backend instead. Resetting to None.",
@@ -1251,12 +1248,6 @@ def _disable_expandable_segments() -> None:
     if updated_configs != npu_alloc_configs:
         os.environ["PYTORCH_NPU_ALLOC_CONF"] = updated_configs
         logger.info("Removed expandable_segments from PYTORCH_NPU_ALLOC_CONF: %s", updated_configs)
-
-
-def _enable_fa3_for_training_consistency(vllm_config: VllmConfig, ascend_config) -> None:
-    rl_config = ascend_config.rl_config
-    if rl_config.enabled and rl_config.enable_training_consistency:
-        vllm_config.attention_config.backend = AttentionBackendEnum.FLASH_ATTN
 
 
 def _validate_fa3_backend(key, _attn_selector_config):

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1251,13 +1251,7 @@ def _disable_expandable_segments() -> None:
 
 
 def _validate_fa3_backend(key, _attn_selector_config):
-    try:
-        rl_config = get_ascend_config().rl_config
-    except RuntimeError:
-        # Backend resolution can run in unit tests or other lightweight paths
-        # before an AscendConfig is created. Without RL configuration, FA3
-        # must not be selected.
-        return False
+    rl_config = get_ascend_config().rl_config
     if not (rl_config.enabled and rl_config.enable_training_consistency):
         logger.info(
             "FA3 will not be enabled when rl_config.enable_training_consistency is false. "

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1251,7 +1251,13 @@ def _disable_expandable_segments() -> None:
 
 
 def _validate_fa3_backend(key, _attn_selector_config):
-    rl_config = get_ascend_config().rl_config
+    try:
+        rl_config = get_ascend_config().rl_config
+    except RuntimeError:
+        # Backend resolution can run in unit tests or other lightweight paths
+        # before an AscendConfig is created. Without RL configuration, FA3
+        # must not be selected.
+        return False
     if not (rl_config.enabled and rl_config.enable_training_consistency):
         logger.info(
             "FA3 will not be enabled when rl_config.enable_training_consistency is false. "

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1235,6 +1235,23 @@ def _set_pytorch_npu_alloc_env(vllm_config: VllmConfig) -> None:
         logger.info("Set PYTORCH_NPU_ALLOC_CONF=%s", npu_alloc_configs)
 
 
+def _disable_expandable_segments() -> None:
+    """Remove the allocator option that conflicts with sleep mode."""
+    npu_alloc_configs = os.getenv("PYTORCH_NPU_ALLOC_CONF", "")
+    if not npu_alloc_configs:
+        return
+
+    filtered_configs = [
+        config.strip()
+        for config in npu_alloc_configs.split(",")
+        if config.strip() and not config.strip().startswith("expandable_segments:")
+    ]
+    updated_configs = ",".join(filtered_configs)
+    if updated_configs != npu_alloc_configs:
+        os.environ["PYTORCH_NPU_ALLOC_CONF"] = updated_configs
+        logger.info("Removed expandable_segments from PYTORCH_NPU_ALLOC_CONF: %s", updated_configs)
+
+
 def _validate_fa3_backend(key, attn_selector_config):
     if not attn_selector_config.use_batch_invariant:
         logger.info(

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -248,7 +248,9 @@ class NPUWorker(WorkerBase):
         if nz_mode:
             raise ValueError(
                 "FRACTAL_NZ mode is enabled. This may cause model parameter precision issues "
-                "in the RL scenarios. Please set weight_nz_mode=0 via --additional-config."
+                "in the RL scenarios. Please set weight_nz_mode=0 via --additional-config, "
+                "or enable additional_config.rl_config (enabled: true) which disables NZ "
+                "automatically."
             )
         allocator = CaMemAllocator.get_instance()
         allocator.wake_up(tags=tags)
@@ -282,11 +284,12 @@ class NPUWorker(WorkerBase):
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
     def _check_nz_disabled(self) -> None:
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+        if get_ascend_config().weight_nz_mode:
             raise ValueError(
                 "FRACTAL_NZ mode is enabled. This may cause model parameter "
-                "precision issues in the RL scenarios. Please set "
-                "VLLM_ASCEND_ENABLE_NZ=0."
+                "precision issues in the RL scenarios. Please set weight_nz_mode=0 "
+                "via --additional-config, or enable additional_config.rl_config "
+                "(enabled: true) which disables NZ automatically."
             )
 
     def start_weight_update(self) -> None:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -225,7 +225,8 @@ class NPUWorker(WorkerBase):
             model = self.model_runner.model
             self._sleep_saved_buffers = {name: buffer.cpu().clone() for name, buffer in model.named_buffers()}
 
-        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
+        rl_config = get_ascend_config().rl_config
+        cleanup_enabled = rl_config.enabled and rl_config.sleep_mode_extra_cleanup
         if cleanup_enabled:
             self.sleep_wakeup_manager.sleep()
 
@@ -266,7 +267,8 @@ class NPUWorker(WorkerBase):
         if tags is None or "kv_cache" in tags:
             self.model_runner.post_kv_cache_wake_up()
 
-        cleanup_enabled = getattr(get_ascend_config(), "enable_sleep_mode_extra_cleanup", False)
+        rl_config = get_ascend_config().rl_config
+        cleanup_enabled = rl_config.enabled and rl_config.sleep_mode_extra_cleanup
         if cleanup_enabled:
             self.sleep_wakeup_manager.wakeup(tags)
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR implements a unified RL configuration under `additional_config.rl_config`, based on RFC #13706.

When `rl_config.enabled=true`, vLLM Ascend applies these fixed RL defaults:

- refreshes the global Ascend configuration on every initialization, including worker initialization;
- forces `AscendConfig.weight_nz_mode=0`, logs a warning when overriding a non-zero value, and synchronizes `VLLM_ASCEND_ENABLE_NZ=0`;
- sets `VLLM_SERVER_DEV_MODE=1`;
- removes `expandable_segments` from `PYTORCH_NPU_ALLOC_CONF` and logs the resulting allocator configuration;
- optionally selects FA3 directly in `get_attn_backend_cls` through `enable_training_consistency`, without mutating `attention_config.backend`;
- optionally enables batch-invariant mode by setting only `VLLM_BATCH_INVARIANT=1`;
- optionally performs extra sleep-mode cleanup through `rl_config.sleep_mode_extra_cleanup`.

`refresh`, `weight_nz_mode`, `enable_dev_endpoints`, and `disable_expandable_segments` are intentionally not accepted as `rl_config` fields. The former top-level `enable_sleep_mode_extra_cleanup` option has also been removed; startup reports a migration error directing users to `rl_config.sleep_mode_extra_cleanup`.

The worker-side batch-invariant initialization remains responsible for setting `HCCL_DETERMINISTIC=strict` and `LCCL_DETERMINISTIC=1`, avoiding duplicated environment setup in RL configuration.

Fixes #13706

### Does this PR introduce _any_ user-facing change?

Yes. The configurable RL options are now limited to:

```json
{
  "rl_config": {
    "enabled": true,
    "sleep_mode_extra_cleanup": false,
    "enable_training_consistency": false,
    "enable_batch_invariant": false
  }
}
```

Enabling RL mode always refreshes Ascend configuration, disables weight NZ, enables developer endpoints, and removes `expandable_segments`. These fixed behaviors cannot be disabled through RL sub-fields.

The migration guide now reflects that the legacy batch-invariant path required only `VLLM_BATCH_INVARIANT=1`; HCCL/LCCL deterministic variables are initialized internally. The FA3 usage guide now enables the backend through `rl_config.enable_training_consistency`, with batch invariance documented as an independent optional setting.

### Startup effectiveness analysis

| Setting | Where it is applied | Why it is effective after service startup | Test guarantee |
| --- | --- | --- | --- |
| `enabled` / refresh | `init_ascend_config()` cache gate | The same `VllmConfig` is rebuilt whenever RL is enabled; workers also call `init_ascend_config()` before normal worker initialization | `TestAscendConfig.test_rl_config_refreshes_by_default`<br>`TestNPUWorker.test_init_npu_worker_normal_case` |
| Fixed NZ=0 | `RlConfig.apply()` in driver and worker config initialization | Applied before model loading and weight-update operations; both runtime config and legacy environment consumers observe 0 | `TestAscendConfig.test_rl_config_enabled_applies_best_practice_defaults`<br>`TestAscendConfig.test_rl_config_overrides_top_level_weight_nz_mode`<br>`TestAscendConfig.test_rl_config_keeps_zero_weight_nz_mode_without_warning`<br>`TestNPUWorkerWeightUpdate.test_start_weight_update_dispatches_to_engine` |
| Developer endpoints | `RlConfig.apply()` during `VllmConfig` creation | The online server creates the engine config before `build_app()` checks `VLLM_SERVER_DEV_MODE` and registers dev routes | `TestAscendConfig.test_rl_config_always_enables_dev_endpoints` |
| Allocator cleanup | `RlConfig.apply()` calls `_disable_expandable_segments()` unconditionally | Runs during config creation, before NPU device/allocator initialization; an explicit `expandable_segments:True` entry is removed and logged | `TestAscendConfig.test_rl_config_removes_expandable_segments`<br>`TestRlConfig.test_disable_expandable_segments_strips_env`<br>`TestRlConfig.test_disable_expandable_segments_matches_exact_option` |
| `sleep_mode_extra_cleanup` | Read directly in worker `sleep()` / `wake_up()` | Evaluated at the operation boundary, and guarded by the RL master switch | `TestNPUWorker.test_sleep_uses_rl_extra_cleanup`<br>`TestNPUWorker.test_wake_up_mode_enabled`<br>`TestNPUWorker.test_wake_up_does_not_transpose_moe_weights` |
| `enable_training_consistency` | `get_attn_backend_cls()` validates the active RL config and returns the FA3 backend directly | FA3 selection no longer writes or depends on `attention_config.backend`; validation runs during backend resolution and falls back to the registered Ascend backend when the RL flag is disabled | `TestNPUPlatform.test_get_attn_backend_cls_fa3_uses_training_consistency_without_selected_backend`<br>`TestNPUPlatform.test_get_attn_backend_cls_fa3_disabled_without_training_consistency` |
| `enable_batch_invariant` | RL config sets `VLLM_BATCH_INVARIANT=1`; worker `init_batch_invariance()` sets HCCL/LCCL variables and registers kernels | Worker config initialization precedes `_init_worker_distributed_environment()`, so the total switch is visible when batch-invariant initialization runs | `TestAscendConfig.test_rl_config_batch_invariant_overrides_env`<br>`TestAscendConfig.test_rl_config_does_not_disable_batch_invariant_env`<br>`TestBatchInvariant.test_init_batch_invariance`<br>`TestBatchInvariant.test_override_envs_for_invariance` |

### Detailed test design

| Area | Case | Expected result | Implemented test functions |
| --- | --- | --- | --- |
| Backward compatibility | `rl_config` absent | Existing Ascend defaults and environment fallback are unchanged | `TestAscendConfig.test_rl_config_defaults_when_unset` |
| Master switch | `enabled=false` with cleanup and batch-invariant fields true | No RL NZ, endpoint, batch, allocator, or cleanup side effects | `TestAscendConfig.test_rl_config_disabled_is_noop`<br>`TestNPUWorker.test_wake_up_does_not_transpose_moe_weights` |
| Fixed-field validation | Configure `refresh`, `weight_nz_mode`, `enable_dev_endpoints`, or `disable_expandable_segments` | Initialization fails with an unknown-key error | `TestRlConfig.test_fixed_fields_cannot_be_configured`<br>`TestAscendConfig.test_rl_config_refresh_cannot_be_configured` |
| NZ priority and override visibility | Top-level `weight_nz_mode=2` plus RL enabled | Runtime Ascend config and legacy NZ environment are forced to 0, and a warning reports the overridden value | `TestAscendConfig.test_rl_config_overrides_top_level_weight_nz_mode` |
| NZ no-op logging | Top-level `weight_nz_mode=0` plus RL enabled | The value remains 0 without emitting an override warning | `TestAscendConfig.test_rl_config_keeps_zero_weight_nz_mode_without_warning` |
| Sleep cleanup migration | Use removed top-level `enable_sleep_mode_extra_cleanup` | Clear migration error points to `rl_config.sleep_mode_extra_cleanup` | `TestAscendConfig.test_top_level_sleep_mode_extra_cleanup_is_removed` |
| Batch enable path | Existing `VLLM_BATCH_INVARIANT=0` plus RL flag true | Only `VLLM_BATCH_INVARIANT` changes during config application; worker init sets HCCL/LCCL values | `TestAscendConfig.test_rl_config_batch_invariant_overrides_env`<br>`TestBatchInvariant.test_override_envs_for_invariance` |
| Batch environment precedence | Existing `VLLM_BATCH_INVARIANT=1` plus RL flag false | Existing environment setting remains enabled | `TestAscendConfig.test_rl_config_does_not_disable_batch_invariant_env` |
| Allocator option | `PYTORCH_NPU_ALLOC_CONF` contains `expandable_segments:True` and unrelated options | Expandable segments is removed, unrelated options remain, and an info log is emitted | `TestAscendConfig.test_rl_config_removes_expandable_segments` |
| Allocator exact matching | Similar option name plus exact expandable option | Only the exact `expandable_segments:` key is removed | `TestRlConfig.test_disable_expandable_segments_matches_exact_option` |
| FA3 package/backend | Consistency enabled/disabled while `selected_backend` is unset or explicitly `FLASH_ATTN` | Active RL training consistency directly returns FA3 after package/capability validation; otherwise the registered Ascend backend is used | `TestNPUPlatform.test_get_attn_backend_cls_fa3_uses_training_consistency_without_selected_backend`<br>`TestNPUPlatform.test_get_attn_backend_cls_fa3_disabled_without_training_consistency` |
| Runtime NZ guard | Environment and runtime AscendConfig disagree | Runtime AscendConfig is authoritative for weight updates | `TestNPUWorkerWeightUpdate.test_start_weight_update_dispatches_to_engine`<br>`TestNPUWorkerWeightUpdate.test_start_weight_update_rejects_nz` |

### How was this patch tested?

Local checks:

```bash
python -m compileall -q vllm_ascend/ascend_config.py vllm_ascend/platform.py vllm_ascend/worker/worker.py tests/ut/test_ascend_config.py tests/ut/test_platform.py tests/ut/test_batch_invariant.py tests/ut/worker/a2/test_worker_v1.py tests/e2e/pull_request/one_card/test_attention_fa3.py
ruff check vllm_ascend/ascend_config.py vllm_ascend/platform.py vllm_ascend/worker/worker.py tests/ut/test_ascend_config.py tests/ut/test_platform.py tests/ut/test_batch_invariant.py tests/ut/worker/a2/test_worker_v1.py tests/e2e/pull_request/one_card/test_attention_fa3.py
ruff format --check vllm_ascend/ascend_config.py vllm_ascend/platform.py vllm_ascend/worker/worker.py tests/ut/test_ascend_config.py tests/ut/test_platform.py tests/ut/test_batch_invariant.py tests/ut/worker/a2/test_worker_v1.py tests/e2e/pull_request/one_card/test_attention_fa3.py
git diff --check
```

Python compilation, Ruff lint/format, diff checks, and isolated RL startup-behavior checks pass locally. The focused pytest suite is covered by the listed tests; local collection is currently blocked because the available Windows test environment cannot import the `vllm` package, so full execution is delegated to CI/NPU validation.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
