### PR TITLE
[BugFix][MRV2] Fix EAGLE3 startup crash and FlashComm1 FULL-graph capture under MRV2

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -31,6 +31,7 @@ class MoECommType(Enum):
 
 
 _MRV2_IN_PROFILE_RUN: ContextVar[bool] = ContextVar("_MRV2_IN_PROFILE_RUN", default=False)
+_MRV2_IS_DRAFT_FORWARD: ContextVar[bool] = ContextVar("_MRV2_IS_DRAFT_FORWARD", default=False)
 _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
     "w8a8",
     "w4a8",
@@ -64,6 +65,26 @@ def override_mrv2_in_profile_run(enabled: bool):
 
 def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
+
+
+@contextmanager
+def override_mrv2_is_draft_forward():
+    """Mark the enclosed forward path as a speculative-draft forward.
+
+    MRv2 builds the base forward context inside upstream vLLM, so Ascend's
+    platform hook cannot tell whether the current forward is the target or
+    the draft model. A ContextVar keeps this MRv2-only state scoped to the
+    draft forward without adding default fallback behavior.
+    """
+    token = _MRV2_IS_DRAFT_FORWARD.set(True)
+    try:
+        yield
+    finally:
+        _MRV2_IS_DRAFT_FORWARD.reset(token)
+
+
+def get_mrv2_is_draft_forward() -> bool:
+    return _MRV2_IS_DRAFT_FORWARD.get()
 
 
 def _cann_megamoe_supported_by_config(vllm_config: VllmConfig) -> bool:

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -77,7 +77,15 @@ def _maybe_pad_and_reduce_impl(x: torch.Tensor, is_ep_comm: bool = False) -> tor
 
     flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (enable_sp_by_pass() and is_ep_comm)
 
-    if not flash_comm_v1_enabled or (_EXTRA_CTX.is_draft_model and is_vl_model() and not is_ep_comm):
+    if (
+        not flash_comm_v1_enabled
+        # The MRv2 platform hook already decided whether this draft forward
+        # may use FlashComm1 (MoE drafters may, dense drafters may not).
+        # Do not let the compile-pass SP backdoor re-enable it for dense
+        # drafters (embeds reduce-scattered vs full hidden states).
+        or (_EXTRA_CTX.is_draft_model and not _EXTRA_CTX.flash_comm_v1_enabled)
+        or (_EXTRA_CTX.is_draft_model and is_vl_model() and not is_ep_comm)
+    ):
         return tensor_model_parallel_all_reduce(x)
 
     dp_metadata = forward_context.dp_metadata
@@ -112,7 +120,8 @@ def _maybe_all_gather_and_maybe_unpad_fake(x: torch.Tensor, label: bool, is_ep_c
 
 
 def _maybe_pad_and_reduce_fake(x: torch.Tensor, is_ep_comm: bool = False) -> torch.Tensor:
-    if _EXTRA_CTX.flash_comm_v1_enabled or (enable_sp_by_pass() and is_ep_comm):
+    flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled or (enable_sp_by_pass() and is_ep_comm)
+    if flash_comm_v1_enabled and not (_EXTRA_CTX.is_draft_model and not _EXTRA_CTX.flash_comm_v1_enabled):
         return torch.empty(
             (x.shape[0] // get_tensor_model_parallel_world_size(), *x.shape[1:]), device=x.device, dtype=x.dtype
         )

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -46,6 +46,7 @@ from vllm_ascend.utils import (
     check_kv_extra_config,
     enable_sfa_dcp_replicated_indexer,
     get_ascend_device_type,
+    is_drafter_moe_model,
     is_moe_model,
     model_uses_sfa_sparse,
     refresh_block_size,
@@ -750,6 +751,7 @@ class NPUPlatform(Platform):
         from vllm_ascend.ascend_forward_context import (
             get_mc2_mask,
             get_mrv2_in_profile_run,
+            get_mrv2_is_draft_forward,
             select_moe_comm_method,
         )
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
@@ -772,8 +774,10 @@ class NPUPlatform(Platform):
         if not vllm_config.use_v2_model_runner:
             return {}
 
-        # is_draft_model will be removed later, so we set it to False temporarily.
-        is_draft_model = False
+        # Speculative draft forwards are wrapped by the Ascend speculators with
+        # override_mrv2_is_draft_forward(); the platform hook has no other way
+        # to tell draft and target forwards apart under MRv2.
+        is_draft_model = get_mrv2_is_draft_forward()
         # v2 has 2 graphs in eager, one for prefill, the other for decodes, this flag is aimed to distinguish them.
         is_draft_model_prefill = False
         sinks = False
@@ -793,10 +797,18 @@ class NPUPlatform(Platform):
         # if the concurrency is below the threshold,
         # the performance may degrade due to the switching of
         # communication methods.
+        # main model and drafter model may have different architecture.
+        is_context_moe_model = is_drafter_moe_model(vllm_config) if is_draft_model else is_moe_model(vllm_config)
         mmrs_fusion = True
-        if is_moe_model(vllm_config):
+        if is_context_moe_model:
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None
             mmrs_fusion = False
+        elif is_draft_model:
+            # Mirror the V1 behavior (set_ascend_forward_context): for dense
+            # drafters (e.g. eagle/eagle3), FlashComm1/SP is redundant and is
+            # not compatible with the draft forward (embeds are reduce-scattered
+            # while hidden_states stay full-sequence).
+            flash_comm_v1_enabled = False
         else:
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None and num_tokens > 1000
         pad_size = 0

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -36,6 +36,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.worker.v2.sp_utils import _all_gather_hidden_states_and_aux
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -174,7 +175,29 @@ class ModelWithContext(nn.Module):
         if self.is_draft_model_prefill:
             _EXTRA_CTX.is_draft_model_prefill = True
 
-        return self.original_model(*args, **kwargs)
+        output = self.original_model(*args, **kwargs)
+
+        # Under MRV2 + FlashComm1 the target forward returns TP-local hidden
+        # states (num_tokens / TP rows). During FULL graph capture, gather them
+        # back to the full sequence inside the graph so the capture buffers see
+        # the same row count upstream vLLM expects; the runtime path then skips
+        # its outer all-gather when the rows are already full
+        # (NPUModelRunner.execute_model). PIECEWISE keeps the TP-local output
+        # and relies on the outer all-gather exactly as before.
+        try:
+            forward_context = get_forward_context()
+        except AssertionError:
+            return output
+        if (
+            _EXTRA_CTX.flash_comm_v1_enabled
+            and not self.is_draft_model
+            and forward_context.cudagraph_runtime_mode == CUDAGraphMode.NONE
+            and not isinstance(output, IntermediateTensors)
+        ):
+            num_tokens = _EXTRA_CTX.num_tokens
+            if num_tokens is not None:
+                output = _all_gather_hidden_states_and_aux(output, num_tokens)
+        return output
 
     def get_original_model(self):
         return self.original_model

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -233,7 +233,7 @@ class NPUModelRunner(GPUModelRunner):
             and state is not None
             and _flashcomm_enabled(self.vllm_config, state.input_batch.num_tokens_after_padding)
         ):
-            num_tokens = state.input_batch.num_tokens
+            num_tokens = state.input_batch.num_tokens_after_padding
             assert state.hidden_states is not None
             gathered_output = _all_gather_hidden_states_and_aux(
                 (state.hidden_states, state.aux_hidden_states)

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -51,7 +51,7 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_tokens_capacity,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
-from vllm_ascend.utils import enable_sp
+from vllm_ascend.utils import enable_sp, set_potential_max_tokens
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
@@ -191,6 +191,7 @@ class NPUModelRunner(GPUModelRunner):
         # Set _mc2_tokens_capacity and _reserved_mc2_mask for MoE communication optimization.
         # TODO: remove set_cos_and_sin (together with update_cos_sin) when mla can properly handle cos/sin internally
         set_cos_and_sin(vllm_config, self.max_num_reqs, self.decode_query_len, self.dtype, self.device)
+        set_potential_max_tokens(vllm_config)
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
 

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -231,10 +231,11 @@ class NPUModelRunner(GPUModelRunner):
         if (
             self.is_last_pp_rank
             and state is not None
+            and state.hidden_states is not None
+            and state.hidden_states.shape[0] < state.input_batch.num_tokens_after_padding
             and _flashcomm_enabled(self.vllm_config, state.input_batch.num_tokens_after_padding)
         ):
             num_tokens = state.input_batch.num_tokens_after_padding
-            assert state.hidden_states is not None
             gathered_output = _all_gather_hidden_states_and_aux(
                 (state.hidden_states, state.aux_hidden_states)
                 if state.aux_hidden_states is not None

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -35,6 +35,7 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import AutoRegressiveSpeculator
 from vllm.v1.worker.utils import AttentionGroup
 
+from vllm_ascend.ascend_forward_context import override_mrv2_is_draft_forward
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata_wrapper
@@ -262,14 +263,15 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Override AutoRegressiveSpeculator._run_model for Ascend NPUs."""
-        last_hidden_states, hidden_states = super()._run_model(
-            num_tokens,
-            attn_metadata,
-            slot_mappings,
-            num_tokens_across_dp,
-            cudagraph_runtime_mode,
-            mm_inputs,
-        )
+        with override_mrv2_is_draft_forward():
+            last_hidden_states, hidden_states = super()._run_model(
+                num_tokens,
+                attn_metadata,
+                slot_mappings,
+                num_tokens_across_dp,
+                cudagraph_runtime_mode,
+                mm_inputs,
+            )
         self._ascend_update_seq_lens(attn_metadata)
         return last_hidden_states, hidden_states
 

--- a/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dflash/speculator.py
@@ -16,6 +16,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
     DFlashSpeculator,
 )
 
+from vllm_ascend.ascend_forward_context import override_mrv2_is_draft_forward
 from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata_wrapper
 
@@ -70,6 +71,29 @@ class AscendDFlashSpeculator(DFlashSpeculator):
         # created by super().init_cudagraph_manager without a speculator ref.
         # It needs this speculator to update full-graph params, so set it here.
         self.query_cudagraph_manager.speculator = self
+
+    @torch.inference_mode()
+    def _run_model(
+        self,
+        num_tokens: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    ) -> torch.Tensor:
+        """Override DFlashSpeculator._run_model so MRv2 marks draft forwards.
+
+        AscendDSparkSpeculator also resolves to this override via its MRO
+        (AscendDFlashSpeculator, DSparkSpeculator).
+        """
+        with override_mrv2_is_draft_forward():
+            return super()._run_model(
+                num_tokens,
+                attn_metadata,
+                slot_mappings,
+                num_tokens_across_dp,
+                cudagraph_runtime_mode,
+            )
 
     def set_attn(
         self,

--- a/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/dspark/speculator.py
@@ -30,9 +30,10 @@ from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
 
 from vllm_ascend.utils import vllm_version_is
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata_wrapper
+from vllm_ascend.worker.v2.spec_decode.dflash.speculator import AscendDFlashSpeculator
 
 
-class AscendDSparkSpeculator(DSparkSpeculator):
+class AscendDSparkSpeculator(AscendDFlashSpeculator, DSparkSpeculator):
     _speculator_name = "DSpark"
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):


### PR DESCRIPTION
## Summary

Fixes the A2 MiniMax-M2.5-w8a8-QuaRot nightly startup crash (`202608051413.raw.log`: EAGLE3 draft forward fails during dummy profile when Model Runner V2 is used together with FlashComm1 and Eagle3 speculative decoding). Four independent defects on the same MRV2 + FlashComm1 path are fixed in this PR so the nightly configuration can start and complete requests. The Qwen3-30B-A3B-W8A8 setup below was used for hardware validation as an equivalent repro of the same path; fix 2 also covers the A3 `qwen3-30b-acc` TP4 MC2-init assert.

## Root causes and fixes

1. **Draft forwards wrongly enabled FlashComm1** (`ascend_forward_context.py`, `platform.py`, `register_custom_ops.py`, 3 speculator files)

   `NPUPlatform.set_additional_forward_context` hardcoded `is_draft_model=False` and decided FlashComm1 from the *target* model only. A dense drafter (Eagle/Eagle3) under a MoE target therefore ran with FlashComm1 enabled: `embed_tokens` did a TP reduce-scatter and returned `num_tokens / TP` rows, which no longer matched the full-sequence hidden states in `llama_eagle3`'s `torch.cat`, crashing during the dummy profile run (`Expected (s72//8) in dimension 0 but got s47`).

   Fix: mirror the V1 draft branch. A new `_MRV2_IS_DRAFT_FORWARD` ContextVar is set around the Ascend speculators' `_run_model` (Eagle/Eagle3/MTP via `AscendAutoRegressiveSpeculator`, DFlash via a new override, DSpark via MRO), the platform hook reads it, and FlashComm1 is disabled for dense drafters (MoE drafters keep it). `_maybe_pad_and_reduce_impl/fake` also guard the compile-pass SP backdoor so it cannot re-enable reduce-scatter for dense drafts.

2. **MRV2 runner never initialized `_potential_max_tokens`** (`worker/v2/model_runner.py`)

   `NPUModelRunner.__init__` (v2) missed `set_potential_max_tokens` that V1 calls. With EP>1 on the KV-consumer path, `TokenDispatcherWithMC2.__init__` → `get_potential_max_tokens()` hit `assert _potential_max_tokens is not None` and every worker crashed during model loading.

   Fix: call `set_potential_max_tokens(vllm_config)` next to the sibling `set_mc2_*` calls.

3. **FlashComm1 hidden-state all-gather used the unpadded token count** (`worker/v2/model_runner.py`)

   `_all_gather_hidden_states_and_aux` restored Eagle3 aux hidden states with `input_batch.num_tokens` (unpadded) while the speculator accesses the buffer with `num_tokens_after_padding`, causing an EZ1007 `12 vs 9` shape mismatch on the first request.

   Fix: use `num_tokens_after_padding`.

4. **FULL graph capture saw TP-local hidden states** (`worker/v2/aclgraph_utils.py`, `worker/v2/model_runner.py`)

   With FlashComm1 the target forward returns TP-local hidden states (`num_tokens / TP` rows), so upstream `ModelCudaGraphManager.capture` hit `self.hidden_states[:num_tokens] = hidden_states` shape mismatches for larger capture sizes (e.g. `100 vs 96`, desc 384 with TP4).

   Fix (vllm-ascend only, no upstream vLLM change): `ModelWithContext.forward` gathers the TP-local output back to the full sequence during FULL graph capture, so the all-gather is recorded into the graph and the capture buffers see full rows. `NPUModelRunner.execute_model` skips its outer all-gather when the rows are already full. PIECEWISE keeps the TP-local output and the outer all-gather path unchanged.

## Verification

- Hardware validation (2026-08-07, A3 90.90.97.37 container `xc_vllm_A00302_01`, Qwen3-30B-A3B-W8A8 + Eagle3 + `VLLM_ASCEND_ENABLE_FLASHCOMM1=1`, TP4/EP, FULL_DECODE_ONLY, MRV2, NPU 0-3):
  - 4 workers: `Graph capturing finished in 102 secs` — 42 FULL decode graphs + prefill/decode graphs all captured (the FULL-capture TP-local fix is effective);
  - `Application startup complete`, `GET /v1/models` → 200;
  - `POST /v1/chat/completions` → 200, 15 → 32 tokens, fingerprint `tp4-ep-...` — no EZ1007 (12 vs 9) and no `cat` shape error;
  - No traceback in the whole log.
  - The workspace was verified byte-by-byte against this PR head (`a427466a`): 5/8 files identical; the other 3 only differ by upstream base drift outside these hunks.
- Static checks: `py_compile` and `git diff --check` pass for all changed files.

## Related

- Closes the same issue class as #8569 (draft + FlashComm1 startup failure).
