### PR TITLE
[BugFix][Spec Decode] Preserve RNG state for zero-draft requests

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -907,6 +907,7 @@ estimated_times:
   tests/ut/quantization/methods/a2/test_w8a8_dynamic.py: 30
   tests/ut/quantization/methods/a2/test_w8a8_static.py: 40
   tests/ut/sample/a2/test_gumbel_sampling.py: 110
+  tests/ut/sample/a2/test_rejection_sampler_rng.py: 60
   tests/ut/spec_decode/a2/test_eagle_proposer.py: 50
   tests/ut/worker/a2/test_block_table.py: 30
   tests/ut/worker/a2/test_model_runner_v1.py: 30

--- a/tests/ut/sample/a2/test_rejection_sampler_rng.py
+++ b/tests/ut/sample/a2/test_rejection_sampler_rng.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from itertools import accumulate
+from types import SimpleNamespace
+
+import torch
+
+from vllm_ascend.sample.rejection_sampler import sample_recovered_tokens
+
+DEVICE = torch.device("npu:0")
+VOCAB_SIZE = 128
+
+
+def make_generator(seed: int) -> torch.Generator:
+    return torch.Generator(device=DEVICE).manual_seed(seed)
+
+
+def expected_state_after_draw(seed: int) -> torch.Tensor:
+    generator = make_generator(seed)
+    torch.empty(VOCAB_SIZE, dtype=torch.float32, device=DEVICE).exponential_(generator=generator)
+    torch.npu.synchronize()
+    return generator.get_state()
+
+
+def run_sample(
+    num_draft_tokens: list[int],
+    generators: dict[int, torch.Generator],
+) -> torch.Tensor:
+    total_num_draft_tokens = sum(num_draft_tokens)
+    cu_num_draft_tokens = torch.tensor(list(accumulate(num_draft_tokens)), dtype=torch.int32, device=DEVICE)
+    draft_token_ids = torch.zeros(total_num_draft_tokens, dtype=torch.int64, device=DEVICE)
+    weights = torch.arange(1, VOCAB_SIZE + 1, dtype=torch.float32, device=DEVICE)
+    target_probs = (weights / weights.sum()).repeat(total_num_draft_tokens, 1)
+
+    output = sample_recovered_tokens(
+        max(max(num_draft_tokens), 1),
+        num_draft_tokens,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        None,
+        target_probs,
+        SimpleNamespace(generators=generators),
+        DEVICE,
+    )
+    torch.npu.synchronize()
+    return output
+
+
+def test_zero_draft_preserves_generator_state() -> None:
+    generator = make_generator(101)
+    state_before = generator.get_state().clone()
+
+    output = run_sample([0], {0: generator})
+
+    assert output.numel() == 0
+    assert torch.equal(generator.get_state(), state_before)
+
+
+def test_active_draft_advances_generator_state() -> None:
+    seed = 202
+    generator = make_generator(seed)
+    state_before = generator.get_state().clone()
+
+    run_sample([1], {0: generator})
+
+    assert not torch.equal(generator.get_state(), state_before)
+    assert torch.equal(generator.get_state(), expected_state_after_draw(seed))
+
+
+def test_mixed_batch_advances_only_active_generators() -> None:
+    num_draft_tokens = [0, 1, 0, 2]
+    seeds = [301, 302, 303, 304]
+    generators = {i: make_generator(seed) for i, seed in enumerate(seeds)}
+    states_before = {i: generator.get_state().clone() for i, generator in generators.items()}
+
+    run_sample(num_draft_tokens, generators)
+
+    for i, num_drafts in enumerate(num_draft_tokens):
+        state_after = generators[i].get_state()
+        if num_drafts == 0:
+            assert torch.equal(state_after, states_before[i])
+        else:
+            assert torch.equal(state_after, expected_state_after_draw(seeds[i]))
+
+
+def test_request_generators_are_independent() -> None:
+    generator_a = make_generator(401)
+    generator_b = make_generator(402)
+    mixed_output = run_sample([1, 2], {0: generator_a, 1: generator_b})
+
+    control_a = make_generator(401)
+    control_b = make_generator(402)
+    output_a = run_sample([1], {0: control_a})
+    output_b = run_sample([2], {0: control_b})
+
+    assert torch.equal(generator_a.get_state(), control_a.get_state())
+    assert torch.equal(generator_b.get_state(), control_b.get_state())
+    assert torch.equal(mixed_output[:1], output_a)
+    assert torch.equal(mixed_output[1:], output_b)
+
+
+def test_zero_draft_round_matches_skipped_round() -> None:
+    after_zero_round = make_generator(501)
+    skipped_zero_round = make_generator(501)
+
+    run_sample([0], {0: after_zero_round})
+    actual = run_sample([1], {0: after_zero_round})
+    control = run_sample([1], {0: skipped_zero_round})
+
+    assert torch.equal(actual, control)
+    assert torch.equal(after_zero_round.get_state(), skipped_zero_round.get_state())
+
+
+def test_partial_generator_dict_honors_draft_activity() -> None:
+    zero_draft_generator = make_generator(601)
+    active_generator = make_generator(602)
+    zero_state_before = zero_draft_generator.get_state().clone()
+
+    run_sample([0, 1, 2], {0: zero_draft_generator, 2: active_generator})
+
+    assert torch.equal(zero_draft_generator.get_state(), zero_state_before)
+    assert torch.equal(active_generator.get_state(), expected_state_after_draw(602))
+
+
+def test_without_generators_remains_seeded() -> None:
+    torch.npu.manual_seed(701)
+    first = run_sample([1, 2], {})
+    torch.npu.manual_seed(701)
+    second = run_sample([1, 2], {})
+
+    assert torch.equal(first, second)

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -972,13 +972,11 @@ def sample_recovered_tokens(
     )
     q.exponential_()
 
-    num_draft_tensor = torch.tensor(num_draft_tokens, pin_memory=True).to(device, non_blocking=True)
-    has_draft_mask = num_draft_tensor > 0
-
     for i, generator in sampling_metadata.generators.items():
-        temp_q = torch.empty_like(q[i])
-        temp_q.exponential_(generator=generator)
-        q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
+        # Do not generate random numbers for requests with no draft tokens.
+        # This can be important for reproducibility.
+        if num_draft_tokens[i] > 0:
+            q[i].exponential_(generator=generator)
 
     recovered_token_ids = torch.empty_like(draft_token_ids)
     if HAS_TRITON:


### PR DESCRIPTION
 ### What this PR does / why we need it?

  `sample_recovered_tokens()` consumed per-request RNG for zero-draft
  requests and then discarded the generated exponential samples with
  `torch.where`. This made later rejection sampling depend on scheduling
  and batch composition.

  Use the existing Python `num_draft_tokens` data to skip generator-aware
  draws for zero-draft rows. Active-draft and unseeded sampling behavior
  remain unchanged. Add NPU regression coverage for zero, active, mixed,
  independent, partial-generator, and skipped-round cases.

  Fixes #13608

  ### Does this PR introduce _any_ user-facing change?

  No API change. Fixed-seed speculative decoding now preserves request RNG
  state during zero-draft rounds.

  ### How was this patch tested?

  - 7 new focused NPU regression tests passed
  - 31 existing NPU rejection-kernel tests passed
  - 19 rejection-sampler unit tests passed
  - 85 spec-decode unit tests passed
  - No scalar synchronization, new H2D copy, or persistent HBM growth was observed
  - `git diff --check` and relevant pinned formatting/lint hooks passed
  - Full `format.sh ci` did not complete because actionlint's Go dependency
    download timed out at the proxy
  - Ascend 910B3, CANN 9.0.0, torch 2.10.0,
    torch-npu 2.10.0.post2, triton-ascend 3.2.1
    https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
