### PR TITLE
[Doc][v0.23.0] Add Atlas 950 server pre-checks for multi-node deployment

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -575,6 +575,14 @@ for i in {0..15}; do hccn_tool -i $i -ip -g | grep ipaddr; done
 hccn_tool -i 0 -ping -g address x.x.x.x
 ```
 
+### Atlas 950 Series Server Pre-check
+
+This pre-check applies only to Atlas 950 series servers. Other server series can skip it.
+
+- **Prepare HiXLEP configuration paths**
+
+    When deploying an inference service on Atlas 950 series servers, verify on each server that `/lib/route.conf`, `/etc/hccl_rootinfo.json`, and the `/etc/hixlep` directory (which describes the UB link topology) exist and are configured correctly. If any of them are missing or incorrect, follow the [HiXLEP configuration file generation guide](https://gitcode.com/cann/hixl/wiki/A5%20LocalCommRes%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97.md) to generate the required content. When generating `/etc/hixlep`, use the "D2D scenario".
+
 ### Run Container In Each Node
 
 Using vLLM-ascend official container is more efficient to run multi-node environment.


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds an Atlas 950 series server pre-check section to the multi-node deployment documentation.

The new section:

- Reminds users to verify `/lib/route.conf`, `/etc/hccl_rootinfo.json`, and `/etc/hixlep` on every server.
- Explains that `/etc/hixlep` describes the UB link topology.
- Links to the HiXLEP configuration file generation guide.
- Specifies that the "D2D scenario" should be used when generating `/etc/hixlep`.
- Clarifies that this check can be skipped for other server series.

These checks help prevent multi-node deployment failures caused by missing or incorrect communication topology configuration.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
