### PR TITLE
[Doc][Misc] Update stable release version in documentation banners to v0.23.0

### DIFF
--- a/docs/hooks/macros_main.py
+++ b/docs/hooks/macros_main.py
@@ -15,14 +15,14 @@ UI_STRINGS = {
     "en": {
         "banner_preview": "You are viewing the latest developer preview docs.",
         "banner_link": "Click here",
-        "banner_suffix": "to view docs for the latest stable release (v0.18.0).",
+        "banner_suffix": "to view docs for the latest stable release (v0.23.0).",
         "btn_report": "report issue",
         "aria_report": "Report a documentation issue",
     },
     "zh": {
         "banner_preview": "您正在查看最新的开发者预览版文档。",
         "banner_link": "点击此处",
-        "banner_suffix": "查看最新稳定版（v0.18.0）的文档。",
+        "banner_suffix": "查看最新稳定版（v0.23.0）的文档。",
         "btn_report": "反馈问题",
         "aria_report": "报告文档问题",
     },

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -24,7 +24,7 @@
 {% if not config.extra.is_release %}
 <div class="md-announce">
   {{ t.banner_preview }}
-  <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">{{ t.banner_link }}</a>
+  <a href="https://docs.vllm.ai/projects/ascend/en/v0.23.0">{{ t.banner_link }}</a>
   {{ t.banner_suffix }}
 </div>
 {% endif %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -24,7 +24,7 @@
 {% if not config.extra.is_release %}
 <div class="md-announce">
   {{ t.banner_preview }}
-  <a href="https://docs.vllm.ai/projects/ascend/en/v0.23.0">{{ t.banner_link }}</a>
+  <a href="https://docs.vllm.ai/projects/ascend/{{ 'zh-cn' if config.extra.docs_lang == 'zh' else 'en' }}/v0.23.0">{{ t.banner_link }}</a>
   {{ t.banner_suffix }}
 </div>
 {% endif %}


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the stable release version in the documentation banners from v0.18.0 to v0.23.0 in both English and Chinese macro configurations, as well as the main HTML template.
Set the language path based on `config.extra.docs_lang` to preserve the user's language preference when they click the link from the Chinese preview docs.

### Does this PR introduce _any_ user-facing change?
No, documentation-only updates are not considered user-facing changes.

### How was this patch tested?
No tests were added as this is a documentation-only update.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
