### PR TITLE
[BugFix][Worker] Fix v2 rejection sampler always-accepting draft tokens on NPU (#13730)

### DIFF
--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -242,7 +242,7 @@ def _probabilistic_rejection_kernel(
     start_idx = tl.load(cu_num_logits_ptr + req_idx)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
     num_tokens = end_idx - start_idx
-    seed = tl.load(seed_ptr + req_state_idx)  # noqa: F841
+    seed = tl.load(seed_ptr + req_state_idx)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
 
     rejected_step = 0
@@ -284,8 +284,16 @@ def _probabilistic_rejection_kernel(
                     PADDED_VOCAB_NUM_BLOCKS,
                 )
                 target_log_prob = target_logit - target_lse
-                # NPU does not support tl_rand64; always accept the draft token.
-                u = tl.full([], 0.0, dtype=tl.float32)
+                # NPU does not support tl_rand64; emulate u ~ Uniform(0, 1]
+                # via tl.randint + tl.rand (the same pattern proven in
+                # _npu_gumbel_block_argmax above). The scalar `pos` offset
+                # yields one independent u per draft token.
+                # `includes_zero=False` semantics: clamp 0 -> 1 so that
+                # log(u) never collapses to -inf (which would make the
+                # ratio test trivially True and accept every draft).
+                pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
+                u = tl.rand(tl.randint(seed, pos), pos).to(tl.float32)
+                u = tl.where(u == 0.0, 1.0, u)
                 if HAS_DRAFT_LOGITS:
                     draft_logit = tl.load(
                         draft_logits_ptr


### PR DESCRIPTION
## Summary

Fixes #13730 — the v2 rejection sampler on NPU always accepted draft tokens for non-greedy (temperature > 0) sampling, because the probabilistic rejection test used a hardcoded `u = 0.0`.

## Root cause

`vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py`, `_probabilistic_rejection_kernel` non-greedy branch:

```python
# NPU does not support tl_rand64; always accept the draft token.
u = tl.full([], 0.0, dtype=tl.float32)
...
accepted &= target_log_prob > tl.log(u) + draft_log_prob
```

With `u = 0.0`, `log(u) = -inf`, so the ratio test `target_log_prob > -inf + draft_log_prob` is **trivially True for every draft token**. The rejection sampler degenerated into a no-op that accepted all drafts, degrading output quality for every non-greedy spec-decode request on NPU.

NPU Triton lacks `tl_rand64`, so the original port replaced the upstream `tl_rand32(seed, pos, includes_zero=False)` with a constant `0.0` instead of an equivalent random draw.

## Fix

Replace the constant with the **same NPU-proven random pattern already used in `_npu_gumbel_block_argmax` in this file** (`tl.randint` + `tl.rand`):

```python
# NPU does not support tl_rand64; emulate u ~ Uniform(0, 1] via
# tl.randint + tl.rand (the same pattern proven in _npu_gumbel_block_argmax
# above). The scalar `pos` offset yields one independent u per draft token.
# includes_zero=False semantics: clamp 0 -> 1 so that log(u) never
# collapses to -inf (which would make the ratio test trivially True).
pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
u = tl.rand(tl.randint(seed, pos), pos).to(tl.float32)
u = tl.where(u == 0.0, 1.0, u)
```

`seed` and `pos_ptr` were already loaded/passed into the kernel but unused (`seed` carried a stale `# noqa: F841`); the fix simply consumes them. The `u == 0.0 -> 1.0` clamp preserves the upstream `includes_zero=False` guarantee so `log(u)` can never be `-inf` again.

## Why not literally "one-line"

The issue title says "one-line fix", but the clamp is mandatory: `tl.rand` returns `[0, 1)` and *can* return 0 in principle; without the clamp a single zero sample would reintroduce the exact `log(0) = -inf` bug. This matches the upstream GPU baseline's `includes_zero=False` semantics.

## Tests

Adds `tests/ut/spec_decode/a2/test_rejection_sampler_utils.py` (routed to the A2 NPU runner via `tests/ut/.+/a2`), covering:
- **non-greedy low-probability draft is now rejected** across seeds (p/q ≪ 1 → rejection when u > p/q; pre-fix this never happened). The pre-fix behaviour is exactly the bug, so this test would fail on `main`.
- **non-greedy high-probability draft is still accepted** (p/q > 1 ≥ u for any u ∈ (0,1]) — guards against an inverted/over-rejecting fix.
- **greedy path unchanged**: accept on argmax match, reject on mismatch (the greedy branch never touches `u`).

Registers the new test under the `worker_v2` module in `.github/workflows/scripts/test_config.yaml` so `select-tests` picks it up when `vllm_ascend/worker/v2` changes. The `select-tests` self-test suite (12 cases) still passes.

## NPU verification (910B3)

- `tl.log(0.0) == -inf` confirmed on NPU — root cause reproduced.
- The scalar `tl.rand(tl.randint(seed, pos), pos)` form compiles and runs on NPU and returns a scalar (this was the open question in the issue; `tl.rand` was previously only used with a *vector* block offset in the gumbel path).
- Distribution is uniform: 16,384 samples → mean 0.4959 (exp 0.5), var 0.08303 (exp 1/12 ≈ 0.08333), flat 10-bucket histogram, all in (0, 1] after the clamp.
- All four kernel tests pass on NPU through the public `rejection_sample` entry point.

## Out of scope

The synthetic rejection sampling `NotImplementedError` (line ~356) also depends on a valid `u`; unblocking it is left for a follow-up since it needs `synthetic_conditional_rates` wiring.

Closes #13730

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
