### PR TITLE
[Feature][Observability] Support MS Metrics provider with multiple YAML configs and external handlers

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -663,6 +663,14 @@
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py
     - tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
 
+- name: ms_metrics_observability
+  optional: true
+  cpu_only: true
+  source_file_dependencies:
+    - vllm_ascend/observability
+  tests:
+    - tests/ut/observability/test_ms_metrics_provider.py
+
 # === Features ===
 - name: quantization_gqa_mla_c8
   optional: false

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -12,6 +12,7 @@ This section provides comprehensive documentation for using vLLM Ascend in produ
 
 - **[Environment Variables](configuration/env_vars.md)** — Configure vLLM Ascend via environment variables
 - **[Additional Configuration](configuration/additional_config.md)** — Additional configuration options
+- **[MS Service Metric](ms_service_metric.md)** — Enable metrics and add vLLM Ascend metric points
 
 ## Feature Guide
 

--- a/docs/source/user_guide/ms_service_metric.md
+++ b/docs/source/user_guide/ms_service_metric.md
@@ -1,0 +1,67 @@
+# MS Service Metric
+
+MS Service Metric collects vLLM Ascend runtime metrics through function hooks and exposes them in Prometheus format. Install `ms_service_metric` separately before using this integration; vLLM Ascend itself does not require it to run inference.
+
+For installation, configuration syntax, and complete usage, see the [MS Service Metric documentation](https://gitcode.com/Ascend/msserviceprofiler/blob/master/ms_service_metric/README.md).
+
+## Basic Usage
+
+Enable metric collection before starting the service:
+
+```bash
+export PROMETHEUS_MULTIPROC_DIR=/dev/shm/vllm_metrics
+mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+
+ms-service-metric on
+vllm serve <model-path>
+```
+
+`PROMETHEUS_MULTIPROC_DIR` stores the Prometheus multiprocess metric files. Use a separate directory for each service instance. Before restarting a service for validation, remove stale files only after confirming that no running service is using the directory.
+
+After sending inference requests, query the vLLM metrics endpoint:
+
+```bash
+curl http://127.0.0.1:8000/metrics
+```
+
+The output can be scraped by Prometheus and visualized in Grafana. Use `ms-service-metric off` to disable collection.
+
+## Custom Metric Configuration
+
+Set `MS_SERVICE_METRIC_CONFIG_PATH` before starting vLLM. It can point to either one YAML file or a directory containing multiple YAML files:
+
+```bash
+# Load one YAML file.
+export MS_SERVICE_METRIC_CONFIG_PATH=/data/custom_metrics/custom.yaml
+
+# Or load all first-level .yaml and .yml files in one directory.
+export MS_SERVICE_METRIC_CONFIG_PATH=/data/custom_metrics
+
+ms-service-metric on
+vllm serve <model-path>
+```
+
+Directory mode loads first-level `.yaml` and `.yml` files in filename order and does not scan subdirectories recursively. The configured directory is also the root for external Handler modules referenced by `module:function` in these YAML files. Users are responsible for maintaining their custom YAML files and Handler implementations.
+
+Run `ms-service-metric restart` after changing YAML configuration. Restart the vLLM service after changing Handler Python code because imported Python modules are not reloaded dynamically.
+
+## Adding a Metric Point
+
+vLLM Ascend-owned metric configurations are stored as YAML files in `vllm_ascend/observability/config/`. All YAML files in this directory are loaded automatically.
+
+1. Identify the target function and add its fully qualified `module:Class.method` name as `symbol`.
+2. Reuse a stable handler from `ms_service_metric.provider_handlers` when it provides the required data processing.
+3. For Ascend-specific processing, add a handler to `vllm_ascend/observability/handlers.py` and reference it as `vllm_ascend.observability.handlers:function_name`.
+4. Add the metric name and Prometheus type under `metrics`, then update `tests/ut/observability/test_ms_metrics_provider.py`.
+
+Example:
+
+```yaml
+- symbol: vllm_ascend.worker.model_runner_v1:NPUModelRunner.execute_model
+  handler: ms_service_metric.provider_handlers:model_runner_phase_handler
+  metrics:
+    - name: executor:model_runner_execute_model:duration
+      type: histogram
+```
+
+Keep configurations and handlers aligned with the vLLM Ascend implementation. A missing symbol disables only the affected metric and must not affect inference.

--- a/setup.py
+++ b/setup.py
@@ -535,6 +535,9 @@ setup(
         "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     packages=find_packages(exclude=("docs", "examples", "tests*", "csrc")),
+    package_data={
+        "vllm_ascend.observability": ["config/*.yaml"],
+    },
     python_requires=">=3.10",
     install_requires=get_requirements(),
     ext_modules=ext_modules,
@@ -547,6 +550,9 @@ setup(
             "ascend_model_loader = vllm_ascend:register_model_loader",
             "ascend_service_profiling = vllm_ascend:register_service_profiling",
             "ascend_model = vllm_ascend:register_model",
+        ],
+        "ms_service_metric.providers": [
+            "vllm-ascend = vllm_ascend.observability:get_metric_provider",
         ],
     },
 )

--- a/tests/ut/observability/test_ms_metrics_provider.py
+++ b/tests/ut/observability/test_ms_metrics_provider.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+import importlib.util
+import sys
+from dataclasses import dataclass
+from importlib.metadata import EntryPoint
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+import yaml
+
+_REPOSITORY_ROOT = Path(__file__).parents[3]
+_PACKAGE_ROOT = _REPOSITORY_ROOT / "vllm_ascend" / "observability"
+
+
+def _load_all_provider_configs(config_paths):
+    configs = []
+    for config_path in config_paths:
+        configs.extend(yaml.safe_load(Path(config_path).read_text(encoding="utf-8")))
+    return configs
+
+
+def _load_source(module_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(module_name, _PACKAGE_ROOT / filename)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_provider_api(monkeypatch, **attributes):
+    package = ModuleType("ms_service_metric")
+    provider_api = ModuleType("ms_service_metric.provider_api")
+    for name, value in attributes.items():
+        setattr(provider_api, name, value)
+    monkeypatch.setitem(sys.modules, "ms_service_metric", package)
+    monkeypatch.setitem(sys.modules, "ms_service_metric.provider_api", provider_api)
+
+
+def test_get_metric_provider_returns_packaged_yaml(monkeypatch):
+    @dataclass
+    class FakeMetricProvider:
+        name: str
+        config_paths: tuple[str, ...]
+        priority: int
+        owned_symbol_prefixes: tuple[str, ...]
+        framework_package: str | None = None
+        handler_module_prefixes: tuple[str, ...] = ()
+        ownership_mode: str = "overlay"
+
+    _install_provider_api(monkeypatch, MetricProvider=FakeMetricProvider)
+    provider_module = _load_source("test_vllm_ascend_metric_provider", "provider.py")
+
+    provider = provider_module.get_metric_provider()
+
+    assert provider.name == "vllm-ascend"
+    assert provider.framework_package == "vllm_ascend"
+    assert provider.ownership_mode == "overlay"
+    assert provider.owned_symbol_prefixes == ("vllm_ascend.",)
+    assert provider.handler_module_prefixes == ("vllm_ascend.observability.",)
+    assert provider.config_paths == tuple(sorted(provider.config_paths))
+    assert [Path(path).name for path in provider.config_paths] == [
+        "base_metrics.yaml",
+        "eplb_metrics.yaml",
+    ]
+    assert all(Path(path).is_file() for path in provider.config_paths)
+    config = _load_all_provider_configs(provider.config_paths)
+    assert len(config) == 12
+    assert all(item["symbol"].startswith("vllm_ascend.") for item in config)
+    assert all("id" not in item for item in config)
+    assert all(
+        item.get("handler", "").startswith(
+            (
+                "ms_service_metric.provider_handlers:",
+                "vllm_ascend.observability.handlers:",
+            )
+        )
+        for item in config
+    )
+
+
+def test_setup_registers_provider_entry_point_and_yaml_package_data():
+    setup_path = _REPOSITORY_ROOT / "setup.py"
+    syntax_tree = ast.parse(setup_path.read_text(encoding="utf-8"))
+    setup_call = next(
+        node
+        for node in ast.walk(syntax_tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "setup"
+    )
+    keywords = {keyword.arg: keyword.value for keyword in setup_call.keywords}
+    entry_points = ast.literal_eval(keywords["entry_points"])
+    package_data = ast.literal_eval(keywords["package_data"])
+
+    assert entry_points["ms_service_metric.providers"] == [
+        "vllm-ascend = vllm_ascend.observability:get_metric_provider"
+    ]
+    assert package_data["vllm_ascend.observability"] == ["config/*.yaml"]
+
+
+def test_provider_entry_point_loads_without_metric_core(monkeypatch):
+    package = ModuleType("vllm_ascend")
+    package.__path__ = [str(_REPOSITORY_ROOT / "vllm_ascend")]
+    monkeypatch.setitem(sys.modules, "vllm_ascend", package)
+    monkeypatch.delitem(sys.modules, "ms_service_metric", raising=False)
+    monkeypatch.delitem(sys.modules, "ms_service_metric.provider_api", raising=False)
+
+    entry_point = EntryPoint(
+        name="vllm-ascend",
+        value="vllm_ascend.observability:get_metric_provider",
+        group="ms_service_metric.providers",
+    )
+
+    assert callable(entry_point.load())
+
+
+def test_ascend_handler_module_loads_from_yaml_path(monkeypatch):
+    metric_type = type("MetricType", (), {"GAUGE": "gauge"})
+    _install_provider_api(
+        monkeypatch,
+        MetricType=metric_type,
+        get_metric_recorder=Mock(),
+    )
+    package = ModuleType("vllm_ascend")
+    package.__path__ = [str(_REPOSITORY_ROOT / "vllm_ascend")]
+    monkeypatch.setitem(sys.modules, "vllm_ascend", package)
+    for module_name in (
+        "vllm_ascend.observability",
+        "vllm_ascend.observability.provider",
+        "vllm_ascend.observability.handlers",
+    ):
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    handler_module = __import__(
+        "vllm_ascend.observability.handlers",
+        fromlist=["eplb_do_update_hotness_handler"],
+    )
+
+    assert callable(handler_module.eplb_do_update_hotness_handler)
+
+
+def test_provider_yaml_symbols_exist_in_current_vllm_ascend_source():
+    config_paths = sorted((_PACKAGE_ROOT / "config").glob("*.yaml"))
+    assert len(config_paths) == 2
+    config = _load_all_provider_configs(config_paths)
+
+    for item in config:
+        module_name, attribute_path = item["symbol"].split(":", 1)
+        source_path = _REPOSITORY_ROOT / Path(*module_name.split(".")).with_suffix(".py")
+        assert source_path.is_file(), f"Missing symbol module: {item['symbol']}"
+
+        syntax_tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        owner_name, method_name = attribute_path.split(".", 1)
+        owner = next(
+            (node for node in syntax_tree.body if isinstance(node, ast.ClassDef) and node.name == owner_name),
+            None,
+        )
+        assert owner is not None, f"Missing symbol owner: {item['symbol']}"
+        assert any(
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == method_name
+            for node in owner.body
+        ), f"Missing symbol method: {item['symbol']}"
+
+
+def test_eplb_handler_records_rank_zero_hotness(monkeypatch):
+    metric_type = type("MetricType", (), {"GAUGE": "gauge"})
+    metrics = Mock()
+    _install_provider_api(
+        monkeypatch,
+        MetricType=metric_type,
+        get_metric_recorder=lambda: metrics,
+    )
+    handlers = _load_source("test_vllm_ascend_metric_handlers", "handlers.py")
+    worker = type(
+        "Worker",
+        (),
+        {
+            "rank_id": 0,
+            "latest_expert_hotness": {
+                "current_mean": 2.0,
+                "current_max": 4.0,
+                "update_mean": 3.0,
+                "update_max": 6.0,
+                "current_imbalance_list": [1.1, 1.2],
+                "update_imbalance_list": [1.3, 1.4],
+            },
+        },
+    )()
+
+    result = handlers.eplb_do_update_hotness_handler(lambda _: "updated", worker)
+
+    assert result == "updated"
+    assert metrics.get_or_create_metric.call_count == 5
+    metrics.get_or_create_metric.assert_any_call(
+        "eplb:expert_hotness:current_mean",
+        metric_type="gauge",
+        label_names=["rank", "phase"],
+    )
+    metrics.get_or_create_metric.assert_any_call(
+        "eplb:expert_hotness:imbalance",
+        metric_type="gauge",
+        label_names=["rank", "phase", "layer"],
+    )
+    assert metrics.record_metric.call_count == 8
+
+
+def test_eplb_handler_registers_metrics_once_per_recorder(monkeypatch):
+    metric_type = type("MetricType", (), {"GAUGE": "gauge"})
+    first_metrics = Mock()
+    current_metrics = [first_metrics]
+    _install_provider_api(
+        monkeypatch,
+        MetricType=metric_type,
+        get_metric_recorder=lambda: current_metrics[0],
+    )
+    handlers = _load_source("test_vllm_ascend_metric_handlers_cache", "handlers.py")
+    worker = type(
+        "Worker",
+        (),
+        {
+            "rank_id": 0,
+            "latest_expert_hotness": {"current_mean": 1.0},
+        },
+    )()
+
+    handlers.eplb_do_update_hotness_handler(lambda _: "updated", worker)
+    handlers.eplb_do_update_hotness_handler(lambda _: "updated", worker)
+
+    assert first_metrics.get_or_create_metric.call_count == 5
+    assert first_metrics.record_metric.call_count == 2
+
+    second_metrics = Mock()
+    current_metrics[0] = second_metrics
+    handlers.eplb_do_update_hotness_handler(lambda _: "updated", worker)
+
+    assert second_metrics.get_or_create_metric.call_count == 5
+    second_metrics.record_metric.assert_called_once()
+
+
+def test_eplb_handler_skips_nonzero_rank(monkeypatch):
+    metric_type = type("MetricType", (), {"GAUGE": "gauge"})
+    metrics = Mock()
+    _install_provider_api(
+        monkeypatch,
+        MetricType=metric_type,
+        get_metric_recorder=lambda: metrics,
+    )
+    handlers = _load_source("test_vllm_ascend_metric_handlers_nonzero", "handlers.py")
+    worker = type("Worker", (), {"rank_id": 1})()
+
+    assert handlers.eplb_do_update_hotness_handler(lambda _: "updated", worker) == "updated"
+    metrics.record_metric.assert_not_called()
+
+
+def test_eplb_handler_given_metric_failure_then_preserves_inference_result(monkeypatch):
+    metric_type = type("MetricType", (), {"GAUGE": "gauge"})
+    metrics = Mock()
+    metrics.get_or_create_metric.side_effect = RuntimeError("registry unavailable")
+    _install_provider_api(
+        monkeypatch,
+        MetricType=metric_type,
+        get_metric_recorder=lambda: metrics,
+    )
+    handlers = _load_source("test_vllm_ascend_metric_handlers_failure", "handlers.py")
+    worker = type(
+        "Worker",
+        (),
+        {
+            "rank_id": 0,
+            "latest_expert_hotness": {"current_mean": 1.0},
+        },
+    )()
+
+    assert (
+        handlers.eplb_do_update_hotness_handler(
+            lambda _: "updated",
+            worker,
+        )
+        == "updated"
+    )

--- a/vllm_ascend/observability/__init__.py
+++ b/vllm_ascend/observability/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Observability integrations owned by vLLM Ascend."""
+
+from .provider import get_metric_provider
+
+__all__ = ["get_metric_provider"]

--- a/vllm_ascend/observability/config/base_metrics.yaml
+++ b/vllm_ascend/observability/config/base_metrics.yaml
@@ -1,0 +1,45 @@
+# Scheduler metrics remain on generic Core handlers until their business logic
+# needs to follow a vLLM Ascend implementation.
+- symbol: vllm_ascend.core.scheduler_profiling_chunk:ProfilingChunkScheduler.schedule
+  handler: ms_service_metric.provider_handlers:scheduler_scheduler_hooker
+
+- symbol: vllm_ascend.core.recompute_scheduler:RecomputeScheduler.schedule
+  handler: ms_service_metric.provider_handlers:scheduler_scheduler_hooker
+
+- symbol: vllm_ascend.patch.platform.patch_balance_schedule:BalanceScheduler.schedule
+  handler: ms_service_metric.provider_handlers:scheduler_scheduler_hooker
+
+# Model runner metrics.
+- symbol: vllm_ascend.worker.model_runner_v1:NPUModelRunner.execute_model
+  handler: ms_service_metric.provider_handlers:init_data_parallel_worker
+
+- symbol: vllm_ascend.worker.model_runner_v1:NPUModelRunner.execute_model
+  handler: ms_service_metric.provider_handlers:model_runner_phase_handler
+  metrics:
+    - name: executor:model_runner_execute_model:duration
+
+- symbol: vllm_ascend.worker.model_runner_v1:NPUModelRunner._prepare_inputs
+  handler: ms_service_metric.provider_handlers:model_runner_phase_handler
+  metrics:
+    - name: executor:prepare_inputs:duration
+
+# Memory metrics.
+- symbol: vllm_ascend.worker.worker:NPUWorker.compile_or_warm_up_model
+  handler: ms_service_metric.provider_handlers:engine_memory_phase_handler
+  metrics:
+    - name: engine:memory:total_gb
+      type: gauge
+    - name: engine:memory:utilization_ratio
+      type: gauge
+    - name: engine:memory:reserved_gb
+      type: gauge
+    - name: engine:memory:weights_gb
+      type: gauge
+    - name: engine:memory:kvcache_gb
+      type: gauge
+    - name: engine:memory:non_torch_gb
+      type: gauge
+    - name: engine:memory:activation_gb
+      type: gauge
+    - name: engine:memory:graph_gb
+      type: gauge

--- a/vllm_ascend/observability/config/eplb_metrics.yaml
+++ b/vllm_ascend/observability/config/eplb_metrics.yaml
@@ -1,0 +1,23 @@
+# EPLB hotness is the first custom handler migrated to vLLM Ascend.
+- symbol: vllm_ascend.eplb.core.eplb_worker:EplbWorker.do_update
+  handler: vllm_ascend.observability.handlers:eplb_do_update_hotness_handler
+
+- symbol: vllm_ascend.eplb.core.eplb_device_transfer_loader:D2DExpertWeightLoader.update_expert_map_and_weight
+  handler: ms_service_metric.provider_handlers:phase_all_handler
+  metrics:
+    - name: eplb:expert_weight_update:duration
+
+- symbol: vllm_ascend.eplb.adaptor.vllm_adaptor:VllmEplbAdaptor.do_update_expert_map
+  handler: ms_service_metric.provider_handlers:phase_all_handler
+  metrics:
+    - name: eplb:expert_map_update:duration
+
+- symbol: vllm_ascend.eplb.adaptor.vllm_adaptor:VllmEplbAdaptor.do_update_log2phy_map
+  handler: ms_service_metric.provider_handlers:phase_all_handler
+  metrics:
+    - name: eplb:log2phy_map_update:duration
+
+- symbol: vllm_ascend.eplb.adaptor.vllm_adaptor:VllmEplbAdaptor.do_update_expert_weight
+  handler: ms_service_metric.provider_handlers:phase_all_handler
+  metrics:
+    - name: eplb:expert_weight_replace:duration

--- a/vllm_ascend/observability/handlers.py
+++ b/vllm_ascend/observability/handlers.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM Ascend-owned metric handlers."""
+
+import logging
+from typing import Any
+
+from ms_service_metric.provider_api import (  # type: ignore[import-not-found]
+    MetricType,
+    get_metric_recorder,
+)
+
+logger = logging.getLogger(__name__)
+
+_HOTNESS_SUMMARY_METRICS = (
+    "eplb:expert_hotness:current_mean",
+    "eplb:expert_hotness:current_max",
+    "eplb:expert_hotness:update_mean",
+    "eplb:expert_hotness:update_max",
+)
+_IMBALANCE_METRIC = "eplb:expert_hotness:imbalance"
+_eplb_metrics_recorder = None
+
+
+def _register_eplb_metrics():
+    global _eplb_metrics_recorder
+
+    metrics = get_metric_recorder()
+    if metrics is _eplb_metrics_recorder:
+        return metrics
+
+    for metric_name in _HOTNESS_SUMMARY_METRICS:
+        metrics.get_or_create_metric(
+            metric_name,
+            metric_type=MetricType.GAUGE,
+            label_names=["rank", "phase"],
+        )
+    metrics.get_or_create_metric(
+        _IMBALANCE_METRIC,
+        metric_type=MetricType.GAUGE,
+        label_names=["rank", "phase", "layer"],
+    )
+    _eplb_metrics_recorder = metrics
+    return metrics
+
+
+def eplb_do_update_hotness_handler(original_func, worker, *args, **kwargs):
+    """Record the aggregated expert hotness exposed by the EPLB rank-0 worker."""
+    result = original_func(worker, *args, **kwargs)
+
+    try:
+        rank_id = getattr(worker, "rank_id", -1)
+        if rank_id != 0:
+            return result
+
+        hotness = getattr(worker, "latest_expert_hotness", None)
+        if not hotness:
+            logger.debug("Skip EPLB hotness metrics because latest_expert_hotness is missing")
+            return result
+
+        metrics = _register_eplb_metrics()
+        rank_labels = {"rank": str(rank_id), "phase": "all"}
+        for suffix in ("current_mean", "current_max", "update_mean", "update_max"):
+            value = hotness.get(suffix)
+            if value is not None:
+                metrics.record_metric(
+                    f"eplb:expert_hotness:{suffix}",
+                    value=float(value),
+                    labels=rank_labels,
+                )
+
+        for phase, key in (
+            ("current", "current_imbalance_list"),
+            ("update", "update_imbalance_list"),
+        ):
+            imbalance_values: Any = hotness.get(key)
+            if imbalance_values is None:
+                continue
+            for layer_index, value in enumerate(imbalance_values):
+                metrics.record_metric(
+                    _IMBALANCE_METRIC,
+                    value=float(value),
+                    labels={
+                        "rank": str(rank_id),
+                        "phase": phase,
+                        "layer": str(layer_index),
+                    },
+                )
+    except Exception:
+        logger.warning(
+            "Failed to record EPLB hotness metrics; inference result is preserved",
+            exc_info=True,
+        )
+
+    return result

--- a/vllm_ascend/observability/provider.py
+++ b/vllm_ascend/observability/provider.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metric configuration contributed to MS Service Metric."""
+
+from pathlib import Path
+
+
+def get_metric_provider():
+    """Return the provider lazily so vLLM Ascend has no hard Core dependency."""
+    from ms_service_metric.provider_api import MetricProvider  # type: ignore[import-not-found]
+
+    config_dir = Path(__file__).with_name("config")
+    config_paths = tuple(str(config_path) for config_path in sorted(config_dir.glob("*.yaml")))
+    return MetricProvider(
+        name="vllm-ascend",
+        config_paths=config_paths,
+        priority=200,
+        framework_package="vllm_ascend",
+        owned_symbol_prefixes=("vllm_ascend.",),
+        handler_module_prefixes=("vllm_ascend.observability.",),
+    )


### PR DESCRIPTION

### What this PR does / why we need it?

This PR integrates vLLM-Ascend with the extensible MS Metrics provider mechanism.

Previously, vLLM-Ascend-specific metric configurations and handlers had to be maintained in the `msserviceprofiler` repository. This created cross-repository maintenance overhead and made the metrics susceptible to becoming outdated when vLLM-Ascend symbols or implementations changed.

This PR:

- Registers a vLLM-Ascend metrics provider through the `ms_service_metric.providers` entry point.
- Adds the vLLM-Ascend provider in `overlay` mode, allowing its configurations to be merged with the existing Core configurations.
- Supports multiple YAML configuration files in the same directory:
  - `base_metrics.yaml`
  - `eplb_metrics.yaml`
- Moves vLLM-Ascend-specific metric configurations and handlers into the vLLM-Ascend repository.
- Adds external handlers for vLLM-Ascend runtime information, including execution phase, deployment role, memory statistics, and EPLB expert hotness.
- Keeps the base metrics and EPLB metrics separated so they can be maintained and verified independently.
- Adds unit tests for provider registration, multiple YAML discovery, configuration validity, and handler behavior.

The corresponding provider and multi-configuration capabilities have already been merged into the `Ascend/msserviceprofiler` master branch. The end-to-end validation for this PR was performed directly against that master branch, without relying on an unmerged Core implementation or a temporary provider bootstrap package.

### Does this PR introduce *any* user-facing change?

Yes.

When `ms_service_metric` is enabled, vLLM-Ascend now automatically contributes its own metric configurations through the registered provider entry point.

The observable changes are:

- vLLM-Ascend-specific metrics are loaded from the vLLM-Ascend package.
- Multiple YAML files in the provider configuration directory are discovered and loaded.
- Base execution and memory metrics are provided by `base_metrics.yaml`.
- EPLB metrics and expert hotness metrics are provided by `eplb_metrics.yaml` and the external vLLM-Ascend handlers.
- The provider uses `overlay` mode, so existing MS Metrics Core configurations remain available during migration.

This change does not alter the inference API or inference behavior when MS Metrics is disabled.

### How was this patch tested?

#### Unit tests

Unit tests were added to cover:

- Provider registration and discovery.
- `overlay` ownership mode.
- Discovery of multiple YAML files in the same configuration directory.
- Validation of `base_metrics.yaml` and `eplb_metrics.yaml`.
- External handler behavior and generated labels/values.
- Provider package and entry-point metadata.

#### Source installation validation

The patch was cherry-picked onto the vLLM-Ascend source shipped with the official `releases/v0.25.1rc` Docker image and installed in editable mode.

Validation environment:

- vLLM-Ascend baseline: `releases/v0.25.1rc`
- vLLM-Ascend baseline commit: `50e0ce60849a7b6fe6f94e1de085b6fc06e7006d`
- MS Metrics Core: `Ascend/msserviceprofiler` master
- Provider ownership mode: `overlay`

The following checks passed:

- vLLM-Ascend Provider Entry Point was uniquely registered.
- The Provider was loaded from the vLLM-Ascend source installation.
- No temporary Provider bootstrap package was present.
- `base_metrics.yaml` and `eplb_metrics.yaml` were both discovered from the same configuration directory.
- Provider discovery and single-directory multi-YAML validation passed.

#### Basic inference scenario

A non-EPLB model was started and benchmark requests were issued before collecting `/metrics`.

Results:

- `base_metrics.yaml`: 10 declared, 10 present, 0 missing.
- `eplb_metrics.yaml`: 4 declared, 0 present, 4 missing, as expected because EPLB was not enabled.
- Existing MS Metrics Core metrics continued to be exported.
<img width="1614" height="522" alt="image" src="https://github.com/user-attachments/assets/3ee80543-41bf-4c33-bab8-f91cb3a7ab8f" />

#### EPLB inference scenario

A MoE model was started with expert parallelism and dynamic EPLB enabled. Benchmark requests were issued before collecting `/metrics`.

Results:

- `base_metrics.yaml`: 10 declared, 10 present, 0 missing.
- `eplb_metrics.yaml`: 4 declared, 4 present, 0 missing.
- External handlers successfully exported EPLB expert hotness metrics, including:
  - `vllm_profiling_eplb:expert_hotness:current_mean`
  - `vllm_profiling_eplb:expert_hotness:current_max`
  - `vllm_profiling_eplb:expert_hotness:update_mean`
  - `vllm_profiling_eplb:expert_hotness:update_max`
 
<img width="1623" height="799" alt="image" src="https://github.com/user-attachments/assets/534b5962-6ffd-425b-9e9f-6f0ff38a1b49" />

The attached screenshots show the metric coverage results for both the basic and EPLB scenarios.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
