### PR TITLE
[Test][FLA] Add accuracy tests for layer norm and chunk output kernels

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_o.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_o.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 
 from vllm_ascend.ops.triton.fla.chunk_o import chunk_fwd_o
@@ -18,12 +19,12 @@ def _chunk_fwd_o_reference(
     batch_size, sequence_length, num_query_heads, _ = q.shape
     num_value_heads = v.shape[2]
     chunks_per_sequence = (sequence_length + chunk_size - 1) // chunk_size
-    query_heads_per_value_head = num_value_heads // num_query_heads
+    value_heads_per_query_head = num_value_heads // num_query_heads
     output = torch.empty_like(v, dtype=torch.float32)
 
     for batch_idx in range(batch_size):
         for value_head_idx in range(num_value_heads):
-            query_head_idx = value_head_idx // query_heads_per_value_head
+            query_head_idx = value_head_idx // value_heads_per_query_head
             for chunk_idx in range(chunks_per_sequence):
                 start = chunk_idx * chunk_size
                 end = min(start + chunk_size, sequence_length)
@@ -44,10 +45,17 @@ def _chunk_fwd_o_reference(
     return output
 
 
-def test_chunk_fwd_kernel_o_accuracy():
+@pytest.mark.parametrize(
+    # (1, 70) covers a tail chunk; (2, 130) additionally exercises the
+    # per-batch state offset (boh = i_n * NT) inside the kernel.
+    ("batch_size", "sequence_length"),
+    [
+        (1, 70),
+        (2, 130),
+    ],
+)
+def test_chunk_fwd_kernel_o_accuracy(batch_size: int, sequence_length: int):
     torch.manual_seed(2026)
-    batch_size = 1
-    sequence_length = 70
     num_query_heads = 1
     num_value_heads = 2
     key_dim = 128

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_o.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_o.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm_ascend.ops.triton.fla.chunk_o import chunk_fwd_o
+
+
+def _chunk_fwd_o_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+    chunk_size: int,
+) -> torch.Tensor:
+    batch_size, sequence_length, num_query_heads, _ = q.shape
+    num_value_heads = v.shape[2]
+    chunks_per_sequence = (sequence_length + chunk_size - 1) // chunk_size
+    query_heads_per_value_head = num_value_heads // num_query_heads
+    output = torch.empty_like(v, dtype=torch.float32)
+
+    for batch_idx in range(batch_size):
+        for value_head_idx in range(num_value_heads):
+            query_head_idx = value_head_idx // query_heads_per_value_head
+            for chunk_idx in range(chunks_per_sequence):
+                start = chunk_idx * chunk_size
+                end = min(start + chunk_size, sequence_length)
+                q_chunk = q[batch_idx, start:end, query_head_idx].float()
+                k_chunk = k[batch_idx, start:end, query_head_idx].float()
+                v_chunk = v[batch_idx, start:end, value_head_idx].float()
+                g_chunk = g[batch_idx, start:end, value_head_idx].float()
+                h_chunk = h[batch_idx * chunks_per_sequence + chunk_idx, value_head_idx].float()
+
+                state_output = (q_chunk @ h_chunk) * torch.exp(g_chunk).unsqueeze(-1)
+                attention = q_chunk @ k_chunk.transpose(0, 1)
+                gate_delta = g_chunk.unsqueeze(1) - g_chunk.unsqueeze(0)
+                gate = torch.where(gate_delta <= 0, torch.exp(gate_delta), 0.0)
+                causal_mask = torch.ones_like(attention, dtype=torch.bool).tril()
+                attention = torch.where(causal_mask, attention * gate, 0.0)
+                output[batch_idx, start:end, value_head_idx] = scale * (state_output + attention @ v_chunk)
+
+    return output
+
+
+def test_chunk_fwd_kernel_o_accuracy():
+    torch.manual_seed(2026)
+    batch_size = 1
+    sequence_length = 70
+    num_query_heads = 1
+    num_value_heads = 2
+    key_dim = 128
+    value_dim = 96
+    chunk_size = 64
+    chunks_per_sequence = (sequence_length + chunk_size - 1) // chunk_size
+    scale = key_dim**-0.5
+
+    q_cpu = (torch.randn(batch_size, sequence_length, num_query_heads, key_dim) * 0.1).to(torch.bfloat16)
+    k_cpu = (torch.randn_like(q_cpu.float()) * 0.1).to(torch.bfloat16)
+    v_cpu = (torch.randn(batch_size, sequence_length, num_value_heads, value_dim) * 0.1).to(torch.bfloat16)
+    h_cpu = (torch.randn(batch_size * chunks_per_sequence, num_value_heads, key_dim, value_dim) * 0.1).to(
+        torch.bfloat16
+    )
+    # A non-increasing cumulative gate is the domain expected by safe_exp.
+    gate_steps = torch.rand(batch_size, sequence_length, num_value_heads) * 0.02
+    g_cpu = -torch.cumsum(gate_steps, dim=1)
+
+    expected = _chunk_fwd_o_reference(q_cpu, k_cpu, v_cpu, h_cpu, g_cpu, scale, chunk_size)
+    actual = chunk_fwd_o(
+        q=q_cpu.npu(),
+        k=k_cpu.npu(),
+        v=v_cpu.npu(),
+        h=h_cpu.npu(),
+        g=g_cpu.npu(),
+        scale=scale,
+        chunk_size=chunk_size,
+    )
+
+    torch.testing.assert_close(actual.float().cpu(), expected, rtol=3e-2, atol=2e-2)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_layernorm_guard.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_layernorm_guard.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.fla.layernorm_guard import _layer_norm_fwd
+
+
+def _layer_norm_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    eps: float,
+    z: torch.Tensor | None,
+    group_size: int,
+    norm_before_gate: bool,
+    is_rms_norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    rows, hidden_size = x.shape
+    num_groups = hidden_size // group_size
+    x_grouped = x.float().reshape(rows, num_groups, group_size)
+    z_grouped = None if z is None else z.float().reshape(rows, num_groups, group_size)
+
+    if z_grouped is not None and not norm_before_gate:
+        x_grouped = x_grouped * torch.nn.functional.silu(z_grouped)
+
+    if is_rms_norm:
+        mean = None
+        variance = x_grouped.square().mean(dim=-1, keepdim=True)
+        normalized = x_grouped * torch.rsqrt(variance + eps)
+    else:
+        mean = x_grouped.mean(dim=-1, keepdim=True)
+        variance = (x_grouped - mean).square().mean(dim=-1, keepdim=True)
+        normalized = (x_grouped - mean) * torch.rsqrt(variance + eps)
+
+    output = normalized * weight.float().reshape(num_groups, group_size)
+    if bias is not None:
+        output = output + bias.float().reshape(num_groups, group_size)
+    if z_grouped is not None and norm_before_gate:
+        output = output * torch.nn.functional.silu(z_grouped)
+
+    # The kernel stores statistics in group-major order: [group, row].
+    mean_flat = None if mean is None else mean.squeeze(-1).transpose(0, 1).reshape(-1)
+    rstd_flat = torch.rsqrt(variance + eps).squeeze(-1).transpose(0, 1).reshape(-1)
+    return output.reshape(rows, hidden_size), mean_flat, rstd_flat
+
+
+@pytest.mark.parametrize(
+    ("group_size", "has_bias", "has_gate", "norm_before_gate", "is_rms_norm"),
+    [
+        (256, False, True, False, True),
+        (64, True, True, True, True),
+        (64, True, False, True, False),
+        (256, True, True, False, False),
+    ],
+)
+def test_layer_norm_fwd_kernel_accuracy(
+    group_size: int,
+    has_bias: bool,
+    has_gate: bool,
+    norm_before_gate: bool,
+    is_rms_norm: bool,
+):
+    torch.manual_seed(2026)
+    rows, hidden_size = 7, 256
+    eps = 1e-6
+    x_cpu = torch.randn(rows, hidden_size, dtype=torch.bfloat16)
+    weight_cpu = torch.randn(hidden_size, dtype=torch.bfloat16)
+    bias_cpu = torch.randn(hidden_size, dtype=torch.bfloat16) if has_bias else None
+    z_cpu = torch.randn(rows, hidden_size, dtype=torch.bfloat16) if has_gate else None
+
+    expected, expected_mean, expected_rstd = _layer_norm_reference(
+        x_cpu,
+        weight_cpu,
+        bias_cpu,
+        eps,
+        z_cpu,
+        group_size,
+        norm_before_gate,
+        is_rms_norm,
+    )
+    actual, actual_mean, actual_rstd = _layer_norm_fwd(
+        x_cpu.npu(),
+        weight_cpu.npu(),
+        None if bias_cpu is None else bias_cpu.npu(),
+        eps,
+        z=None if z_cpu is None else z_cpu.npu(),
+        group_size=group_size,
+        norm_before_gate=norm_before_gate,
+        is_rms_norm=is_rms_norm,
+    )
+
+    torch.testing.assert_close(actual.float().cpu(), expected, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(actual_rstd.cpu(), expected_rstd, rtol=3e-3, atol=3e-3)
+    if is_rms_norm:
+        assert actual_mean is None
+    else:
+        assert actual_mean is not None
+        assert expected_mean is not None
+        torch.testing.assert_close(actual_mean.cpu(), expected_mean, rtol=3e-3, atol=3e-3)


### PR DESCRIPTION
### What this PR does / why we need it?

Add accuracy tests for the following FLA Triton kernels:

- `layer_norm_fwd_kernel`
- `chunk_fwd_kernel_o`

The tests compare BF16 NPU outputs against FP32 PyTorch reference implementations. They cover grouped normalization, gating, causal attention, GQA head mapping, and tail chunks.

### Does this PR introduce _any_ user-facing change?

No. This PR only adds kernel accuracy tests.

### How was this patch tested?

Tested on Ascend NPU:

- `layer_norm_fwd_kernel`: 4 passed
- `chunk_fwd_kernel_o`: 1 passed
- Total: 5 passed

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
