### PR TITLE
[Feature] Add env switch to disable MM encoder external padding

### DIFF
--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -23,6 +23,44 @@ from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
+def test_mm_encoder_attention_310_forward_oot_without_padding():
+    layer = AscendMMEncoderAttention310.__new__(AscendMMEncoderAttention310)
+    layer.num_heads = 4
+    layer.num_kv_heads = 2
+    layer.head_size = 80
+    layer.enable_pad = False
+    layer.scale_value = layer.head_size**-0.5
+    layer.support_approximate_calculation = False
+
+    bsz, q_len, kv_len = 2, 3, 3
+    query = torch.randn(bsz, q_len, layer.num_heads, layer.head_size)
+    key = torch.randn(bsz, kv_len, layer.num_kv_heads, layer.head_size)
+    value = torch.randn(bsz, kv_len, layer.num_kv_heads, layer.head_size)
+
+    capture = {}
+
+    def fake_flash_attention_unpad(*, query, key, value, seq_len, scale_value, num_heads, num_kv_heads, out):
+        capture["query_shape"] = query.shape
+        capture["key_shape"] = key.shape
+        capture["value_shape"] = value.shape
+        out.copy_(query + 1.0)
+
+    with mock.patch(
+        "vllm_ascend._310p.ops.mm_encoder_attention.torch_npu._npu_flash_attention_unpad",
+        side_effect=fake_flash_attention_unpad,
+        create=True,
+    ):
+        out = layer.forward_oot(query, key, value)
+
+    # No external padding: q/k/v keep the original head_size instead of MAX_PAD_SIZE.
+    assert capture["query_shape"] == (bsz * q_len, layer.num_heads, layer.head_size)
+    assert capture["key_shape"] == (bsz * kv_len, layer.num_heads, layer.head_size)
+    assert capture["value_shape"] == (bsz * kv_len, layer.num_heads, layer.head_size)
+
+    assert out.shape == query.shape
+    torch.testing.assert_close(out, query + 1.0)
+
+
 def test_register_customop_overrides_mm_encoder_attention_for_310p():
     original_registered = utils._ASCEND_CUSTOMOP_IS_REIGISTERED
     try:

--- a/tests/ut/ops/test_mm_encoder_attention.py
+++ b/tests/ut/ops/test_mm_encoder_attention.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -137,6 +138,56 @@ class TestAscendMMEncoderAttentionEager(FIAMockMixin):
         self.assertEqual(out.shape, query.shape)
         self.assertEqual(self.captured["actual_seq_lengths"], [3, 10, 12])
         self.assertEqual(self.captured["q_shape"], (len(seq_lens) * max_q_len, 4, MAX_PAD_SIZE))
+
+
+class TestAscendMMEncoderAttentionPadSwitch(FIAMockMixin):
+    ENV_NAME = "VLLM_ASCEND_MM_ENCODER_ENABLE_PAD"
+
+    def setUp(self):
+        self._install_vllm_config_mock()
+        self._install_fia_mocks(capture=False)
+
+    def _make_env(self, value):
+        env = {k: v for k, v in os.environ.items() if k != self.ENV_NAME}
+        if value is not None:
+            env[self.ENV_NAME] = value
+        return env
+
+    def test_enable_pad_env_unset(self):
+        with patch.dict(os.environ, self._make_env(None)):
+            layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        self.assertTrue(layer.enable_pad)
+
+    def test_enable_pad_env_set_to_1(self):
+        with patch.dict(os.environ, self._make_env("1")):
+            layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        self.assertTrue(layer.enable_pad)
+
+    def test_enable_pad_env_set_to_0(self):
+        with patch.dict(os.environ, self._make_env("0")):
+            layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        self.assertFalse(layer.enable_pad)
+
+    def test_enable_pad_env_set_to_1_with_unsupported_head_size(self):
+        # The head_size guard is preserved: padding never applies outside (64, 128).
+        with patch.dict(os.environ, self._make_env("1")):
+            layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=128)
+        self.assertFalse(layer.enable_pad)
+
+    def test_forward_oot_without_padding(self):
+        with patch.dict(os.environ, self._make_env("0")):
+            layer = self._make_layer(num_heads=4, num_kv_heads=4, head_size=72)
+        bsz, q_len = 2, 4
+        query = torch.randn(bsz, q_len, layer.num_heads, 72, dtype=torch.bfloat16)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        cu_seqlens = torch.arange(0, (bsz + 1) * q_len, step=q_len, dtype=torch.int32)
+
+        out = layer.forward_oot(query, key, value, cu_seqlens=cu_seqlens)
+
+        self.assertEqual(out.shape, query.shape)
+        # q/k/v are fed to FIA with the original head_size, not MAX_PAD_SIZE.
+        self.assertEqual(self.captured["q_shape"], (bsz * q_len, 4, 72))
 
 
 class TestAscendMMEncoderAttentionCapture(FIAMockMixin):

--- a/vllm_ascend/_310p/ops/mm_encoder_attention.py
+++ b/vllm_ascend/_310p/ops/mm_encoder_attention.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
+import vllm_ascend.envs as envs_ascend
 
 MIN_PAD_SIZE: int = 64  # min_size to pad weight
 MAX_PAD_SIZE: int = 128  # max_size to pad weight
@@ -66,7 +67,11 @@ class AscendMMEncoderAttention310(MMEncoderAttention):
             prefix=prefix,
         )
 
-        self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
+        self.enable_pad = (
+            envs_ascend.VLLM_ASCEND_MM_ENCODER_ENABLE_PAD
+            and self.head_size > MIN_PAD_SIZE
+            and self.head_size < MAX_PAD_SIZE
+        )
         self.scale_value = self.head_size**-0.5
         self.support_approximate_calculation = is_approximate_calculation_supported()
 

--- a/vllm_ascend/_310p/ops/mm_encoder_attention.py
+++ b/vllm_ascend/_310p/ops/mm_encoder_attention.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
+
 import vllm_ascend.envs as envs_ascend
 
 MIN_PAD_SIZE: int = 64  # min_size to pad weight

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -74,7 +74,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Whether to allow external padding in MMEncoderAttention when head_size is between 64 and 128.
     # 1 or unset: keep original padding behavior
     # 0: disable external padding and let FA score handle non-padded inputs internally.
-    "VLLM_ASCEND_MM_ENCODER_ENABLE_PAD": bool(int(os.getenv("VLLM_ASCEND_MM_ENCODER_ENABLE_PAD", "1"))),
+    "VLLM_ASCEND_MM_ENCODER_ENABLE_PAD": lambda: bool(int(os.getenv("VLLM_ASCEND_MM_ENCODER_ENABLE_PAD", "1"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,10 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Whether to allow external padding in MMEncoderAttention when head_size is between 64 and 128.
+    # 1 or unset: keep original padding behavior
+    # 0: disable external padding and let FA score handle non-padded inputs internally.
+    "VLLM_ASCEND_MM_ENCODER_ENABLE_PAD": bool(int(os.getenv("VLLM_ASCEND_MM_ENCODER_ENABLE_PAD", "1"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -30,6 +30,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.utils import weak_ref_tensors
 from vllm_ascend.worker.encoder_acl_graph import (
     get_encoder_forward_context,
@@ -71,7 +72,11 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             prefix=prefix,
         )
 
-        self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
+        self.enable_pad = (
+            envs_ascend.VLLM_ASCEND_MM_ENCODER_ENABLE_PAD
+            and self.head_size > MIN_PAD_SIZE
+            and self.head_size < MAX_PAD_SIZE
+        )
 
     def _reshape_qkv_to_3d(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds an environment variable to control whether `MMEncoderAttention` applies external padding to `q/k/v` when `head_size` is in the range `(MIN_PAD_SIZE, MAX_PAD_SIZE)`, i.e. `(64, 128)`.

Currently, `AscendMMEncoderAttention` enables padding only based on `head_size`:

```python
self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
```

When `enable_pad=True`, the forward path pads `q/k/v` to `MAX_PAD_SIZE=128` before calling the attention operator, and slices the output back to the original `head_size` afterwards.

This behavior was required by earlier FA score implementations because some operator versions had limited support for non-128-aligned head dimensions. However, newer FA score implementations are gradually adding native support for non-padded inputs and can handle the required alignment internally.

This is useful because the original padded path contains extra small operators:

- before optimization, with `enable_pad=True`: `3 * (slice + pad) + FA + slice`;
- after optimization, with `enable_pad=False`: `3 * slice + FA`.

Removing the external padding path reduces unnecessary small operators, avoids extra padded tensor construction, and avoids expanding the FA input head dimension from the original non-padded size to 128 when the operator can already handle the original shape.

### Does this PR introduce _any_ user-facing change?
This PR introduces a runtime gate, for example:

```bash
VLLM_ASCEND_MM_ENCODER_ENABLE_PAD=0
```

so that users can disable the external padding path when the underlying FA score operator already supports non-padded inputs.

The proposed behavior is:

```python
self.enable_pad = (
    envs_ascend.VLLM_ASCEND_MM_ENCODER_ENABLE_PAD
    and self.head_size > MIN_PAD_SIZE
    and self.head_size < MAX_PAD_SIZE
)
```

The original `head_size` check is intentionally preserved as a safety boundary. The new environment variable only controls whether this existing padding path is allowed; it does not force padding for unsupported dimensions.

Default behavior is unchanged:

- unset or `VLLM_ASCEND_MM_ENCODER_ENABLE_PAD=1`: keep the existing padding behavior;
- `VLLM_ASCEND_MM_ENCODER_ENABLE_PAD=0`: disable external padding and let FA score handle non-padded inputs directly.

This PR is backward compatible because the default value keeps the existing behavior.

### How was this patch tested?
- Add or update unit tests for `MMEncoderAttention` to cover:
  - env var unset: `head_size=80` keeps `enable_pad=True`;
  - `VLLM_ASCEND_MM_ENCODER_ENABLE_PAD=1`: `head_size=80` keeps `enable_pad=True`;
  - `VLLM_ASCEND_MM_ENCODER_ENABLE_PAD=0`: `head_size=80` sets `enable_pad=False`;
  - `VLLM_ASCEND_MM_ENCODER_ENABLE_PAD=1` with `head_size=128` still keeps `enable_pad=False`, proving the original `head_size` guard is preserved.
- Run existing `MMEncoderAttention` unit tests.
- Validate manually on Ascend 950 with a model whose attention interface uses `FlashAttentionScoreV4`.
- Compare profiling traces before and after disabling external padding.

This method has been validated with our own model on an Ascend 950 card. The attention interface used in the validation is `FlashAttentionScoreV4`.

Profiling comparison:

| Configuration | Operator pattern |
| --- | --- |
| `enable_pad=True` | `3 * (slice + pad) + FA + slice` |
| `enable_pad=False` | `3 * slice + FA` |

Performance result on the validated model:

| Metric | Improvement |
| --- | ---: |
| FA single-operator performance | +6.2% |
| ViT single-layer performance | +1.7% |
| Single-layer gain from eliminating small operators | about +2% |

The result shows that disabling external padding is beneficial when the backend FA score operator can natively support non-padded inputs. It improves the FA operator itself by avoiding padded head dimensions and also reduces the number of
small slice/pad operators in the ViT attention path.

The default path remains unchanged, so environments that still require external padding can continue to use the existing behavior without any configuration change.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
