### PR TITLE
[Refactor] Remove MiniMax-M2 MoE fp32 gate patch

### DIFF
--- a/vllm_ascend/patch/worker/patch_minimax_m2.py
+++ b/vllm_ascend/patch/worker/patch_minimax_m2.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# MiniMax-M2 on Ascend: MoE all_reduce, fused attention, fp8 load dequant.
+# MiniMax-M2 on Ascend: fused attention, fp8 load dequant.
 #
 
 from collections.abc import Iterable
@@ -23,7 +23,6 @@ import torch
 from vllm.model_executor.models.minimax_m2 import (
     MiniMaxM2Attention,
     MiniMaxM2Model,
-    MiniMaxM2MoE,
 )
 from vllm.platforms import current_platform
 
@@ -40,25 +39,6 @@ FP8_DTYPES = tuple(
     )
     if hasattr(torch, dtype_name)
 )
-
-
-# ---------------------------------------------------------------------------
-# MiniMaxM2MoE.forward: keep router logits in fp32 on NPU.
-# ---------------------------------------------------------------------------
-def _patched_moe_forward(
-    self,
-    hidden_states: torch.Tensor,
-) -> torch.Tensor:
-    num_tokens, hidden_dim = hidden_states.shape
-    hidden_states = hidden_states.view(-1, hidden_dim)
-
-    # router_logits: (num_tokens, n_experts)
-    router_logits, _ = self.gate(hidden_states.to(torch.float32))
-    final_hidden_states = self.experts(hidden_states=hidden_states, router_logits=router_logits)
-    return final_hidden_states.view(num_tokens, hidden_dim)
-
-
-MiniMaxM2MoE.forward = _patched_moe_forward
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove the MiniMaxM2MoE.forward monkey-patch from `vllm_ascend/patch/worker/patch_minimax_m2.py`.
- The router GateLinear already sets `params_dtype=torch.float32` and `out_dtype=torch.float32`, so the extra `hidden_states.to(torch.float32)` cast before `self.gate` is redundant.
- Also drop the now-unused `MiniMaxM2MoE` import and the "MoE all_reduce" mention in the file header.

## Why removable

Upstream GateLinear handles fp32 computation internally; the patch only added an input cast that upstream already achieves via `out_dtype`. The MoE forward becomes identical to upstream without the patch.

## Test plan

- Environment: Atlas 800I A2 (A3), CANN 9.1.0 snapshot, vllm + vllm-ascend from source.
- Model: `/mnt/weight/MiniMax-M2.7-w8a8-QuaRot`, TP8, `--quantization ascend`.
- With the patch removed: `vllm serve` starts cleanly, chat-completion smoke tests return correct answers (`2+2 -> 4`, `123*7 -> 861`).

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
