### PR TITLE
[BugFix][Config] Validate MC2 hierarchy and profiling timing

### DIFF
--- a/tests/ut/core/test_profiling_chunk.py
+++ b/tests/ut/core/test_profiling_chunk.py
@@ -76,8 +76,16 @@ class TestProfilingChunkConfig(TestBase):
     def test_default_values(self):
         cfg = ProfilingChunkConfig()
         self.assertFalse(cfg.enabled)
+        self.assertFalse(cfg.need_timing)
         self.assertAlmostEqual(cfg.smooth_factor, 1.0)
         self.assertEqual(cfg.min_chunk, 4096)
+
+    @patch("vllm_ascend.ascend_config.logger.warning")
+    def test_need_timing_is_disabled_when_profiling_chunk_is_disabled(self, mock_warning):
+        cfg = ProfilingChunkConfig({"enabled": False, "need_timing": True})
+
+        self.assertFalse(cfg.need_timing)
+        mock_warning.assert_called_once()
 
     def test_invalid_smooth_factor_raises(self):
         with self.assertRaises(ValueError):

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -32,7 +32,7 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
-from vllm_ascend.utils import clear_enable_sp, enable_sp, shared_expert_dp_enabled
+from vllm_ascend.utils import AscendDeviceType, clear_enable_sp, enable_sp, shared_expert_dp_enabled
 
 
 class TestAscendConfig(TestBase):
@@ -54,6 +54,7 @@ class TestAscendConfig(TestBase):
         total_num_attention_heads: int = 32,
         total_num_kv_heads: int = 8,
         is_deepseek_mla: bool = False,
+        num_experts: int = 0,
     ):
         return SimpleNamespace(
             is_deepseek_mla=is_deepseek_mla,
@@ -61,7 +62,27 @@ class TestAscendConfig(TestBase):
             enforce_eager=True,
             model_arch_config=SimpleNamespace(total_num_attention_heads=total_num_attention_heads),
             get_total_num_kv_heads=lambda: total_num_kv_heads,
+            get_num_experts=lambda: num_experts,
         )
+
+    @classmethod
+    def _make_mc2_hierarchy_vllm_config(
+        cls,
+        num_experts: int,
+        *,
+        dynamic_eplb: bool = False,
+        num_redundant_experts: int = 0,
+    ):
+        vllm_config = VllmConfig()
+        vllm_config.model_config = cls._make_model_config(num_experts=num_experts)
+        vllm_config.additional_config = {
+            "enable_mc2_hierarchy_comm": True,
+            "eplb_config": {
+                "dynamic_eplb": dynamic_eplb,
+                "num_redundant_experts": num_redundant_experts,
+            },
+        }
+        return vllm_config
 
     @staticmethod
     def _make_sparse_li_c8_config(quant_description):
@@ -117,6 +138,52 @@ class TestAscendConfig(TestBase):
         )
         with self.assertRaisesRegex(ValueError, "load_collection_phase must be one of"):
             EplbConfig({"load_collection_phase": "prompt"})
+
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    def test_mc2_hierarchy_comm_rejects_a5(self, _mock_device_type):
+        vllm_config = self._make_mc2_hierarchy_vllm_config(512)
+
+        with self.assertRaisesRegex(NotImplementedError, "only supported on A2 and A3"):
+            AscendConfig(vllm_config)
+
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    def test_mc2_hierarchy_comm_rejects_more_than_512_experts(self, _mock_device_type):
+        vllm_config = self._make_mc2_hierarchy_vllm_config(513)
+
+        with self.assertRaisesRegex(ValueError, "at most 512 experts"):
+            AscendConfig(vllm_config)
+
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    def test_mc2_hierarchy_comm_counts_dynamic_eplb_redundancy(self, _mock_device_type):
+        vllm_config = self._make_mc2_hierarchy_vllm_config(
+            480,
+            dynamic_eplb=True,
+            num_redundant_experts=33,
+        )
+
+        with (
+            patch.dict(os.environ, {"DYNAMIC_EPLB": "true"}),
+            self.assertRaisesRegex(
+                ValueError,
+                r"513 experts \(480 logical experts \+ 33 EPLB redundant experts\)",
+            ),
+        ):
+            AscendConfig(vllm_config)
+
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    def test_mc2_hierarchy_comm_ignores_redundancy_when_dynamic_eplb_is_disabled(self, _mock_device_type):
+        vllm_config = self._make_mc2_hierarchy_vllm_config(480, num_redundant_experts=33)
+
+        AscendConfig(vllm_config)
+
+    @patch("vllm_ascend.utils.get_ascend_device_type")
+    def test_mc2_hierarchy_comm_accepts_512_experts_on_a2_and_a3(self, mock_device_type):
+        for device_type in (AscendDeviceType.A2, AscendDeviceType.A3):
+            with self.subTest(device_type=device_type):
+                mock_device_type.return_value = device_type
+                vllm_config = self._make_mc2_hierarchy_vllm_config(512)
+
+                AscendConfig(vllm_config)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -776,7 +776,7 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.vllm_config = MagicMock()
         runner.vllm_config.model_config.enable_return_routed_experts = False
         runner.ascend_config = SimpleNamespace(
-            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=False, need_timing=False))
         )
         runner.execute_model_state = None
         runner.speculative_config = None
@@ -813,7 +813,7 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         runner.vllm_config = MagicMock()
         runner.vllm_config.model_config.enable_return_routed_experts = False
         runner.ascend_config = SimpleNamespace(
-            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=False))
+            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=False, need_timing=False))
         )
         runner.execute_model_state = None
         runner.speculative_config = None
@@ -838,6 +838,48 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
             runner.execute_model(scheduler_output)
 
         runner._start_dump_data.assert_called_once_with(scheduled_tokens={"req0": 1})
+
+    @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    @patch("vllm_ascend.worker.model_runner_v1.record_function_or_nullcontext")
+    def test_execute_model_ignores_need_timing_when_profiling_chunk_is_disabled(
+        self, mock_record_function, mock_get_pp_group, _mock_has_ec_transfer, _mock_has_kv_transfer_group
+    ):
+        from contextlib import nullcontext
+
+        mock_record_function.return_value = nullcontext()
+        mock_get_pp_group.return_value = SimpleNamespace(world_size=1, is_first_rank=True, is_last_rank=True)
+        runner = self._build_runner(MagicMock(spec=["start", "stop", "step"]))
+        runner.vllm_config = MagicMock()
+        runner.vllm_config.model_config.enable_return_routed_experts = False
+        runner.ascend_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(enabled=False, need_timing=True))
+        )
+        runner.execute_model_state = None
+        runner.speculative_config = None
+        runner.use_async_scheduling = False
+        runner.num_spec_tokens = 0
+        runner._draft_token_ids = None
+        runner.supports_mm_inputs = False
+        runner.model_config.is_encoder_decoder = False
+        runner.synchronize_input_prep = nullcontext
+        runner._update_states = MagicMock(return_value=None)
+        runner._sync_device = MagicMock()
+        runner.parallel_config = SimpleNamespace(
+            distributed_executor_backend="external_launcher", data_parallel_size=2, enable_dbo=False
+        )
+        runner.cache_config = SimpleNamespace(kv_sharing_fast_prefill=False)
+        runner.input_batch = SimpleNamespace(num_reqs=1, req_ids=["req0"], prev_req_id_to_index=None)
+        runner.requests = {}
+        runner._prepare_inputs = MagicMock(side_effect=RuntimeError("sentinel"))
+        scheduler_output = SimpleNamespace(total_num_scheduled_tokens=1, num_scheduled_tokens={"req0": 1})
+
+        with self.assertRaisesRegex(RuntimeError, "sentinel"):
+            runner.execute_model(scheduler_output)
+
+        runner._sync_device.assert_not_called()
+        self.assertFalse(hasattr(runner, "_execution_start_time"))
 
 
 class TestCorrectOptimisticSeqLensCpu(unittest.TestCase):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -265,6 +265,7 @@ class AscendConfig:
 
         # Enable dispatch/combine op inter-node communication by ROCE
         self.enable_mc2_hierarchy_comm = additional_config.get("enable_mc2_hierarchy_comm", False)
+        self._validate_mc2_hierarchy_comm()
 
         # Per-rank token capacity after dispatch in the mega moe (dispatch_ffn_combine) fused operator.
         # When load imbalance causes a rank to receive more tokens than this limit, the excess tokens
@@ -315,6 +316,28 @@ class AscendConfig:
             additional_config.get("sparse_kv_offload_config", {}),
         )
         self._validate_sparse_c8_kv_offload_compatibility()
+
+    def _validate_mc2_hierarchy_comm(self) -> None:
+        if not self.enable_mc2_hierarchy_comm:
+            return
+
+        from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+        device_type = get_ascend_device_type()
+        if device_type not in (AscendDeviceType.A2, AscendDeviceType.A3):
+            raise NotImplementedError(
+                f"enable_mc2_hierarchy_comm is only supported on A2 and A3, but got {device_type.name}."
+            )
+
+        num_logical_experts = self.vllm_config.model_config.get_num_experts()
+        num_redundant_experts = self.eplb_config.num_redundant_experts if self.eplb_config.dynamic_eplb else 0
+        num_experts = num_logical_experts + num_redundant_experts
+        if num_experts > 512:
+            raise ValueError(
+                "enable_mc2_hierarchy_comm supports at most 512 experts, "
+                f"but got {num_experts} experts "
+                f"({num_logical_experts} logical experts + {num_redundant_experts} EPLB redundant experts)."
+            )
 
     def _validate_sparse_c8_kv_offload_compatibility(self) -> None:
         if self.sparse_kv_offload_config.enabled and self.enable_sparse_sfa_c8:
@@ -705,6 +728,12 @@ class ProfilingChunkConfig:
         # the start to skip online calibration entirely and rely solely on
         # the startup profiling model (avoids per-step sync overhead).
         self.need_timing: bool = config.get("need_timing", self.enabled)
+        if not self.enabled and self.need_timing:
+            logger.warning(
+                "profiling_chunk_config.need_timing=True is ignored because "
+                "profiling_chunk_config.enabled=False. Setting need_timing to False."
+            )
+            self.need_timing = False
         self.max_fit_chunk: int = int(config.get("max_fit_chunk", 30))
         self._validate()
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1784,13 +1784,14 @@ class NPUModelRunner(GPUModelRunner):
             if self.vllm_config.model_config.enable_return_routed_experts and self.routed_experts_initialized:
                 self.routed_experts_capturer.clear_buffer()
 
-        if self.ascend_config.scheduler_config.profiling_chunk_config.need_timing:
+        profiling_chunk_config = self.ascend_config.scheduler_config.profiling_chunk_config
+        if profiling_chunk_config.enabled and profiling_chunk_config.need_timing:
             # Check if the scheduler signaled that calibration is complete.
             # This flag is set cross-process via scheduler_output because
             # modifying the config singleton in the scheduler process does
             # not affect this worker process.
             if getattr(scheduler_output, "disable_profiling_timing", False):
-                self.ascend_config.scheduler_config.profiling_chunk_config.need_timing = False
+                profiling_chunk_config.need_timing = False
             else:
                 self._sync_device()
                 self._execution_start_time = time.perf_counter()
@@ -2205,6 +2206,7 @@ class NPUModelRunner(GPUModelRunner):
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
+        profiling_chunk_config = self.ascend_config.scheduler_config.profiling_chunk_config
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
         pp = get_pp_group()
@@ -2365,8 +2367,10 @@ class NPUModelRunner(GPUModelRunner):
             cudagraph_stats=cudagraph_stats,
             routed_experts=None,
         )
-        if self.ascend_config.scheduler_config.profiling_chunk_config.need_timing and hasattr(
-            self, "_execution_start_time"
+        if (
+            profiling_chunk_config.enabled
+            and profiling_chunk_config.need_timing
+            and hasattr(self, "_execution_start_time")
         ):
             self._sync_device()
             model_runner_output.execution_time_ms = (time.perf_counter() - self._execution_start_time) * 1000.0


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds configuration guards for MC2 hierarchical communication and fixes a disabled profiling feature still causing timing side effects.

- Rejects `enable_mc2_hierarchy_comm` on devices other than A2 and A3.
- Rejects MC2 hierarchy configurations with more than 512 effective experts.
- Counts EPLB redundant experts in the authoritative runtime check using `len(expert_map) + global_redundant_expert_num`.
- Keeps an early validation for models whose logical expert count already exceeds 512.
- Requires both `profiling_chunk_config.enabled` and `need_timing` before the v1 model runner synchronizes the device or records execution timing.

The root causes were that the MC2 hierarchy configuration had no hardware/expert-count validation, and the v1 model runner checked only the child `need_timing` option without checking its parent feature switch.

### Does this PR introduce _any_ user-facing change?

Yes.

Invalid MC2 hierarchy configurations now fail with an actionable error before entering the unsupported operator path. Setting `profiling_chunk_config.enabled=false` now reliably disables timing behavior even when `need_timing=true` is present.

### How was this patch tested?

Added regression coverage for:

- A5 rejection and A2/A3 acceptance for MC2 hierarchy communication.
- The 512-expert boundary.
- EPLB redundant experts being included in the effective expert count.
- The hierarchy expert limit not applying when hierarchy communication is disabled.
- Disabled profiling chunk configuration suppressing v1 model-runner device synchronization and timing.

Local checks:

- `ruff format --check` on all changed Python files.
- `ruff check` on all changed Python files.
- Python syntax compilation for all changed Python files.
- `git diff --check`.
- Targeted static regression checks for the affected conditions.

The full pytest suite was not run locally because this Windows environment does not have the vLLM, Torch, or pytest runtime dependencies; CI validation is required.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
