### PR TITLE
[Doc][Misc] Fix Qwen3.6-27B typos and update max-batched-tokens value

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
+++ b/docs/source/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
@@ -161,7 +161,7 @@ docker run --rm \
 ::::{tab-item} Ascend950DT series
 :sync: 950dt
 
-Start the docker image on your each node.
+Start the docker image on each node.
 
 ```{code-block} bash
   :substitutions:
@@ -467,7 +467,7 @@ vllm serve $MODEL_PATH \
     --served-model-name qwen3.6 \
     --max-num-seqs 32 \
     --max-model-len 262144 \
-    --max-num-batched-tokens 8192 \
+    --max-num-batched-tokens 16384 \
     --trust-remote-code \
     --gpu-memory-utilization 0.90 \
     --no-enable-prefix-caching \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes a grammatical typo in the Ascend950DT series tab ("your each node" -> "each node") and updates the `--max-num-batched-tokens` parameter value from `8192` to `16384` in the Ascend950DT startup command for Qwen3.6-27B to align with the recommended configurations.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only changes, no code changes.