### PR TITLE
[BugFix][Platform] Propagate Ascend config overrides to worker processes

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -487,6 +487,9 @@ class NPUPlatform(Platform):
         if compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
             compilation_config.mode = CompilationMode.NONE
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+            ascend_config.ascend_compilation_config.enable_static_kernel = False
+            vllm_config.additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
+            vllm_config.additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
         elif compilation_config.cudagraph_mode.requires_piecewise_compilation():
             # Our is_cuda_alike is False so we cannot reuse the assertion of upstream
             assert compilation_config.mode == CompilationMode.VLLM_COMPILE, (
@@ -515,6 +518,9 @@ class NPUPlatform(Platform):
             if get_ascend_device_type() == AscendDeviceType.A5:
                 _prune_capture_sizes_for_950(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+            ascend_config.ascend_compilation_config.enable_static_kernel = False
+            vllm_config.additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
+            vllm_config.additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():
             # We don't want to have our FX graph split for the sake of static kernel feature,
             # because it will compile multiple times, so we set splitting_ops to empty manually.
@@ -526,6 +532,9 @@ class NPUPlatform(Platform):
             compilation_config.cudagraph_mode = CUDAGraphMode.NONE
             compilation_config.mode = CompilationMode.NONE
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
+            ascend_config.ascend_compilation_config.enable_static_kernel = False
+            vllm_config.additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
+            vllm_config.additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
 
         # TODO: Remove this check when ACL Graph supports ASCEND_LAUNCH_BLOCKING=1
         # Then, we will have to discuss the error handling strategy and user experience
@@ -613,6 +622,11 @@ class NPUPlatform(Platform):
                     "(kv_role='kv_consumer')."
                 )
                 scheduler_extension_config.recompute_scheduler_enable = False
+                additional_scheduler_config = vllm_config.additional_config.get("scheduler_config")
+                if additional_scheduler_config is None:
+                    additional_scheduler_config = {}
+                    vllm_config.additional_config["scheduler_config"] = additional_scheduler_config
+                additional_scheduler_config["recompute_scheduler_enable"] = False
             elif kv_transfer_config is None or kv_role != "kv_consumer":
                 raise ValueError(
                     "recompute_scheduler_enable can only be enabled on PD-disaggregated D nodes "


### PR DESCRIPTION
### What this PR does / why we need it?

This PR synchronizes platform-derived Ascend configuration overrides back to `vllm_config.additional_config` so spawned EngineCore and worker processes reconstruct the effective values instead of stale defaults.

- Disable and propagate both `enable_npugraph_ex` and `enable_static_kernel` for `NONE`, PIECEWISE-containing, and unsupported CUDAGraph modes.
- Propagate `recompute_scheduler_enable=False` on PD producer nodes while preserving nested, missing, `None`, and legacy scheduler configuration forms.

Related: #13792, #13776.

### Does this PR introduce _any_ user-facing change?

Yes. PIECEWISE and FULL_AND_PIECEWISE modes consistently avoid the affected `npugraph_ex` path in spawned processes, and platform compatibility overrides remain consistent across process boundaries.

### How was this patch tested?

- Performed static path review for all affected CUDAGraph modes, static-kernel combinations, and PD producer/consumer scheduler configuration forms.
- Verified the commit scope and formatting with `git diff --check`.
- NPU E2E validation was not run.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
