### PR TITLE
[BugFix][Test] Restore NPU memory helper import

### DIFF
--- a/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
+++ b/tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py
@@ -22,7 +22,7 @@ import pytest
 from vllm import SamplingParams
 from vllm.v1.metrics.reader import Counter, Vector
 
-from tests.e2e.conftest import VllmRunner
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.one_card.model_runner_v2.utils import calculate_acceptance_per_pos
 
 MODELS = ["Qwen/Qwen3-0.6B", "vllm-ascend/DeepSeek-V2-Lite-W8A8"]


### PR DESCRIPTION
### What this PR does / why we need it?

Restore the `wait_until_npu_memory_free` import in the MRV2 basic E2E tests.

PR #13290 reverted the import together with the original decorator added by #12536. In the meantime, PR #13123 added three more uses of the same decorator. When #13290 was merged from its stale base, those uses remained without an import and caused the pre-commit ruff check to fail with `F821`.

### Does this PR introduce _any_ user-facing change?

No. This only fixes test linting and restores the intended test decorator import.

### How was this patch tested?

- `./.venv/bin/ruff check tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py --select F821`
- `source .venv/bin/activate && SKIP=gitleaks-offline-scan pre-commit run --files tests/e2e/pull_request/one_card/model_runner_v2/test_basic.py`
- `git diff --check`

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
