### PR TITLE
[Feature][KV Pool][v0.26.0rc] Support MTP and sparse C8 in layerwise prefill offload

### DIFF
--- a/docs/source/user_guide/feature_guide/layerwise_kv_pool.md
+++ b/docs/source/user_guide/feature_guide/layerwise_kv_pool.md
@@ -11,7 +11,8 @@ disaggregation** (`kv_role: "kv_producer"` / `"kv_consumer"`) scenarios. See the
 [KV Pool guide](kv_pool.md) for the general KV Pool architecture and backend
 setup.
 
-For Prefill-side NPU memory reduction through cross-layer KV buffer reuse, see
+For Prefill-side NPU memory reduction through cross-layer KV buffer reuse,
+including MTP and sparse C8 layouts, see
 [Layerwise Prefill KV Cache Offload](layerwise_prefill_kv_offload.md).
 
 ## How It Works (Brief)

--- a/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
+++ b/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
@@ -68,14 +68,14 @@ transfer bandwidth.
 | :--- | :--- | :--- |
 | `use_layerwise` | `false` | Enables layer-by-layer KV transfer. |
 | `backend` | `"mooncake"` | Must be `"memcache"` for shared-buffer layerwise offload. |
-| `layerwise_num_shared_buffers` | Number of base transformer layers | Number of reusable buffers assigned to non-independent layers. If omitted, no cross-layer buffer reuse is enabled. The value must be at least `1`. |
-| `layerwise_independent_layers` | `[0]` | Base transformer layers that keep dedicated buffers. Accepts a list of integers or `"all"`. Negative indices are resolved against the base transformer layers. |
+| `layerwise_num_shared_buffers` | Number of cache-bearing layers | Number of reusable buffers assigned to non-independent layers. If omitted, no cross-layer buffer reuse is enabled. The value must be at least `1`. |
+| `layerwise_independent_layers` | `[0]` | Cache-bearing layers that keep dedicated buffers. Accepts a list of integers or `"all"`. Negative indices are resolved against all cache-bearing layers, including MTP layers. |
 
 ## Buffer Layout
 
 Let:
 
-- `N` be the number of base transformer layers;
+- `N` be the number of physical layers, including MTP layers;
 - `I` be the number of independent layers;
 - `R = N - I` be the number of reusable layers;
 - `B` be `layerwise_num_shared_buffers`.
@@ -103,18 +103,23 @@ Layer 4 reuses layer 1's physical buffer, layer 7 reuses layer 4's buffer, and
 so on. Before loading layer 4, the transfer thread waits until layer 1 has
 finished saving.
 
-For the supported uniform KV layout, the approximate logical-to-physical
-memory factor is `N / (I + min(B, R))`.
+For a uniform KV layout, the approximate logical-to-physical memory factor is
+`N / (I + min(B, R))`. For sparse C8, components can have different page
+sizes, so the implementation calculates the factor from the actual main and
+indexer page bytes instead of using the layer count alone.
 
 ## Request Flow
 
 ### Initialization
 
-1. Layers are assigned to dedicated or shared physical KV buffers.
-2. KV cache tensor descriptors assigned to the same buffer are merged.
-3. The worker registers the resulting physical buffers with Memcache and
-   adjusts the logical KV cache memory budget according to the reduction in
-   allocated buffers.
+1. The KV cache planner maps logical layer names to physical layer indices.
+2. Base transformer layers keep their normal indices. MTP layers are appended
+   after the base layers.
+3. Layers are assigned to dedicated or shared physical KV buffers.
+4. KV cache tensor descriptors assigned to the same buffer are merged by
+   component.
+5. The worker registers the resulting physical buffers with Memcache and
+   adjusts the logical KV cache memory budget according to the bytes saved.
 
 ### Prefill Execution
 
@@ -134,12 +139,42 @@ During each Prefill step:
    save. Attention computation continues while this save and later prefetches
    run on the transfer thread.
 
+## MTP and Sparse C8 Layouts
+
+### MTP
+
+MTP layers use names such as `mtp.0.self_attn` and are placed after the base
+transformer layers in the physical layout. They participate in buffer
+assignment, transfer event allocation, and memory accounting.
+
+Because negative independent-layer indices use the complete physical layout,
+`-1` refers to the last MTP layer when MTP is enabled, not the last base
+transformer layer.
+
+### Sparse C8
+
+An SFA layer can contain separate cache components:
+
+- the main MLA/SFA KV cache;
+- the sparse indexer cache;
+- their corresponding C8 scale data when enabled.
+
+The planner keeps main and indexer components separate when merging logical
+layers into physical slots. Transfer addresses and allocation sizes are
+derived from each layer's real component offsets and page bytes. This allows
+MTP and sparse C8 layouts to use the same layerwise offload pipeline without
+assuming that every layer has one uniform tensor layout.
+
+Layers sharing one physical buffer must have equal page size within each
+component. An incompatible layout is rejected during initialization instead
+of being transferred with incorrect offsets.
+
 ## Verification
 
 The following log messages indicate that shared-buffer offload is active:
 
 ```text
-Layerwise KV cache reuse merged ... tensor descriptors into ... shared buffers.
+Layerwise KV cache reuse merged ... descriptors into ... descriptors across ... physical buffers.
 Layerwise KV cache reuse uses ... buffers for ... layers; scale logical KV budget by ...
 ```
 
@@ -149,7 +184,7 @@ If the first message is absent, check that:
 - `use_layerwise` is `true`;
 - `layerwise_num_shared_buffers` is smaller than the number of reusable
   layers;
-- the model exposes one uniform KV cache tensor per base transformer layer.
+- all expected base and MTP layer cache specifications are present.
 
 ## Limitations
 
@@ -157,5 +192,5 @@ If the first message is absent, check that:
 - TP-size mismatch is not supported with layerwise KV transfer.
 - Context-parallel configurations have not been validated with shared-buffer
   layerwise offload.
-- MTP, multiple KV cache groups, and non-uniform or compressed KV layouts are
-  not supported by the base layer-reuse implementation.
+- Multiple KV cache groups are supported only for separated SFA main/indexer
+  cache layouts. General hybrid or compressed KV layouts are not supported.

--- a/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
+++ b/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
@@ -29,7 +29,7 @@ Layerwise Prefill offload currently requires:
 - `use_layerwise: true`;
 - an MLA, SFA, or DSA attention backend with the layerwise wait/save
   integration;
-- identical KV cache tensor sizes and cache specs for layers that share a
+- compatible KV cache specifications and tensor sizes for layers that share a
   buffer;
 - eager execution; graph mode is not currently supported.
 
@@ -73,7 +73,7 @@ transfer bandwidth.
 
 ## Buffer Layout
 
-Let:
+For a uniform KV cache layout, let:
 
 - `N` be the number of physical layers, including MTP layers;
 - `I` be the number of independent layers;
@@ -103,10 +103,18 @@ Layer 4 reuses layer 1's physical buffer, layer 7 reuses layer 4's buffer, and
 so on. Before loading layer 4, the transfer thread waits until layer 1 has
 finished saving.
 
-For a uniform KV layout, the approximate logical-to-physical memory factor is
-`N / (I + min(B, R))`. For sparse C8, components can have different page
-sizes, so the implementation calculates the factor from the actual main and
-indexer page bytes instead of using the layer count alone.
+When physical layers have different KV cache layouts, the planner first groups
+them by their complete cache signature. Each signature gets its own reusable
+slots, so incompatible layouts never share storage. The physical slot count is
+then:
+
+```text
+I + sum(min(B, reusable layers with signature S) for each signature S)
+```
+
+For a uniform layout, the approximate logical-to-physical memory factor remains
+`N / (I + min(B, R))`. For heterogeneous layouts, the implementation calculates
+the factor from the actual cache page bytes assigned to every physical slot.
 
 ## Request Flow
 
@@ -115,10 +123,11 @@ indexer page bytes instead of using the layer count alone.
 1. The KV cache planner maps logical layer names to physical layer indices.
 2. Base transformer layers keep their normal indices. MTP layers are appended
    after the base layers.
-3. Layers are assigned to dedicated or shared physical KV buffers.
-4. KV cache tensor descriptors assigned to the same buffer are merged by
-   component.
-5. The worker registers the resulting physical buffers with Memcache and
+3. The planner builds the complete KV cache signature of each physical layer.
+4. Compatible layers are assigned to dedicated or shared physical KV buffers.
+5. Corresponding KV cache tensor descriptors assigned to the same buffer are
+   merged.
+6. The worker registers the resulting physical buffers with Memcache and
    adjusts the logical KV cache memory budget according to the bytes saved.
 
 ### Prefill Execution
@@ -153,21 +162,21 @@ transformer layer.
 
 ### Sparse C8
 
-An SFA layer can contain separate cache components:
+An SFA layer can contain separate cache entries:
 
 - the main MLA/SFA KV cache;
 - the sparse indexer cache;
 - their corresponding C8 scale data when enabled.
 
-The planner keeps main and indexer components separate when merging logical
-layers into physical slots. Transfer addresses and allocation sizes are
-derived from each layer's real component offsets and page bytes. This allows
-MTP and sparse C8 layouts to use the same layerwise offload pipeline without
-assuming that every layer has one uniform tensor layout.
+The planner does not identify these entries by model-specific names. It builds
+the physical layer's signature from their actual KV cache specifications and
+only reuses a buffer when the complete signature matches. Transfer addresses and
+allocation sizes are derived from each group's real per-layer offsets and page
+bytes. This allows MTP and sparse C8 layouts to use the same layerwise offload
+pipeline without assuming that every layer has one tensor.
 
-Layers sharing one physical buffer must have equal page size within each
-component. An incompatible layout is rejected during initialization instead
-of being transferred with incorrect offsets.
+An incompatible layout receives a separate buffer pool instead of being
+transferred through an incorrectly sized buffer.
 
 ## Verification
 
@@ -192,5 +201,6 @@ If the first message is absent, check that:
 - TP-size mismatch is not supported with layerwise KV transfer.
 - Context-parallel configurations have not been validated with shared-buffer
   layerwise offload.
-- Multiple KV cache groups are supported only for separated SFA main/indexer
-  cache layouts. General hybrid or compressed KV layouts are not supported.
+- Multiple non-packed attention KV cache groups are supported. State-cache
+  groups and packed or pre-shared KV cache tensor descriptors are not
+  supported by shared-buffer reuse.

--- a/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
+++ b/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
@@ -103,18 +103,25 @@ Layer 4 reuses layer 1's physical buffer, layer 7 reuses layer 4's buffer, and
 so on. Before loading layer 4, the transfer thread waits until layer 1 has
 finished saving.
 
-When cache-bearing layers have different KV cache layouts, the planner first
-groups them by their complete cache signature. Each signature gets its own
-reusable buffer pool, so incompatible layouts never share storage. The number
-of physical KV buffers is then:
+When cache-bearing layers have different KV cache layouts, the planner groups
+them by their **main** attention cache spec (not the whole-layer signature).
+Layers whose main specs match share one reusable buffer pool: within each
+physical buffer the main KV tensor is shared by every layer in the buffer,
+while an auxiliary component (for example the SFA indexer cache) is shared only
+by the subset of layers that actually own it. A buffer that holds only main-only
+layers gets **no** auxiliary allocation at all — the auxiliary component is
+provisioned on demand, per buffer, instead of unconditionally for every buffer.
+The number of main buffer assignments is then:
 
 ```text
-I + sum(min(B, reusable layers with signature S) for each signature S)
+I + sum(min(B, reusable layers with main spec S) for each main spec S)
 ```
 
 For a uniform layout, the approximate logical-to-physical memory factor remains
 `N / (I + min(B, R))`. For heterogeneous layouts, the implementation calculates
-the factor from the actual cache page bytes assigned to every physical buffer.
+the factor from the actual cache page bytes assigned to every physical buffer
+(main counted once per buffer, and the optional indexer counted once per buffer
+that owns it).
 
 ## Request Flow
 
@@ -123,8 +130,7 @@ the factor from the actual cache page bytes assigned to every physical buffer.
 1. The KV cache planner maps logical layer names to cache-bearing layer indices.
 2. Base transformer layers keep their normal indices. MTP layers are appended
    after the base layers.
-3. The planner builds the complete KV cache signature of each cache-bearing
-   layer.
+3. The planner groups cache-bearing layers by their main KV cache spec.
 4. Compatible layers are assigned to dedicated or shared physical KV buffers.
 5. Corresponding KV cache tensor descriptors assigned to the same buffer are
    merged.
@@ -166,18 +172,20 @@ transformer layer.
 An SFA layer can contain separate cache entries:
 
 - the main MLA/SFA KV cache;
-- the sparse indexer cache;
-- their corresponding C8 scale data when enabled.
+- the optional sparse indexer cache, whose name ends with
+  `.indexer.k_cache`.
 
-The planner does not identify these entries by model-specific names. It builds
-the physical layer's signature from their actual KV cache specifications and
-only reuses a buffer when the complete signature matches. Transfer addresses and
-allocation sizes are derived from each group's real per-layer offsets and page
-bytes. This allows MTP and sparse C8 layouts to use the same layerwise offload
-pipeline without assuming that every layer has one tensor.
+The planner groups reusable layers by their main cache spec. The optional
+indexer follows the main buffer assignment and is allocated only for buffers
+that contain an indexer-bearing layer. C8 scale storage, when enabled, is part
+of the corresponding cache spec and physical allocation.
 
-An incompatible layout receives a separate buffer pool instead of being
-transferred through an incorrectly sized buffer.
+Before tensor descriptors are merged, the implementation verifies that every
+main cache sharing a buffer has the same spec and size, and performs the same
+check for indexer caches. Unsupported multi-entry layouts or incompatible
+descriptors raise an error instead of sharing an incorrectly sized buffer.
+Transfer addresses and allocation sizes are derived from each group's actual
+per-layer offsets and page bytes.
 
 ## Verification
 

--- a/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
+++ b/docs/source/user_guide/feature_guide/layerwise_prefill_kv_offload.md
@@ -103,10 +103,10 @@ Layer 4 reuses layer 1's physical buffer, layer 7 reuses layer 4's buffer, and
 so on. Before loading layer 4, the transfer thread waits until layer 1 has
 finished saving.
 
-When physical layers have different KV cache layouts, the planner first groups
-them by their complete cache signature. Each signature gets its own reusable
-slots, so incompatible layouts never share storage. The physical slot count is
-then:
+When cache-bearing layers have different KV cache layouts, the planner first
+groups them by their complete cache signature. Each signature gets its own
+reusable buffer pool, so incompatible layouts never share storage. The number
+of physical KV buffers is then:
 
 ```text
 I + sum(min(B, reusable layers with signature S) for each signature S)
@@ -114,16 +114,17 @@ I + sum(min(B, reusable layers with signature S) for each signature S)
 
 For a uniform layout, the approximate logical-to-physical memory factor remains
 `N / (I + min(B, R))`. For heterogeneous layouts, the implementation calculates
-the factor from the actual cache page bytes assigned to every physical slot.
+the factor from the actual cache page bytes assigned to every physical buffer.
 
 ## Request Flow
 
 ### Initialization
 
-1. The KV cache planner maps logical layer names to physical layer indices.
+1. The KV cache planner maps logical layer names to cache-bearing layer indices.
 2. Base transformer layers keep their normal indices. MTP layers are appended
    after the base layers.
-3. The planner builds the complete KV cache signature of each physical layer.
+3. The planner builds the complete KV cache signature of each cache-bearing
+   layer.
 4. Compatible layers are assigned to dedicated or shared physical KV buffers.
 5. Corresponding KV cache tensor descriptors assigned to the same buffer are
    merged.
@@ -183,8 +184,8 @@ transferred through an incorrectly sized buffer.
 The following log messages indicate that shared-buffer offload is active:
 
 ```text
-Layerwise KV cache reuse merged ... descriptors into ... descriptors across ... physical buffers.
-Layerwise KV cache reuse uses ... buffers for ... layers; scale logical KV budget by ...
+Layerwise KV cache reuse merged ... descriptors into ... descriptors using ... buffer assignments.
+Layerwise KV cache reuse maps ... layers onto ... buffer assignments; scale logical KV budget by ...
 ```
 
 If the first message is absent, check that:

--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -110,7 +110,7 @@ class TestAscendSFAOProjTPParams(TestBase):
         impl.has_indexer = False
         impl.skip_topk = True
         impl.enable_sparse_sfa_c8 = False
-        impl.is_kv_producer = False
+        impl.is_kv_producer = True
         impl.preprocess_type = PreprocessType.NATIVE
         impl.q_lora_rank = 8
         impl.kv_lora_rank = 4
@@ -140,11 +140,11 @@ class TestAscendSFAOProjTPParams(TestBase):
         attn_metadata.dcp_context = None
         attn_metadata.dsa_cp_context = None
         attn_metadata.num_input_tokens = 1
-
         with (
             patch("vllm_ascend.attention.sfa_v1.wait_for_kv_layer_from_connector"),
             patch("vllm_ascend.attention.sfa_v1.record_attention_compute_start") as record_gate,
             patch("vllm_ascend.attention.sfa_v1.maybe_save_kv_layer_to_connector") as save_layer,
+            patch("vllm_ascend.attention.sfa_v1.notify_kv_cache_written") as notify_cache_written,
         ):
             result = impl.forward(
                 layer_name=impl.layer_name,
@@ -155,6 +155,7 @@ class TestAscendSFAOProjTPParams(TestBase):
             )
 
         self.assertIs(result, output)
+        notify_cache_written.assert_called_once_with(impl.layer_name)
         record_gate.assert_called_once_with()
         save_layer.assert_called_once_with(impl.layer_name, list(kv_cache))
         impl.o_proj.assert_not_called()

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -175,7 +175,11 @@ class _FakeKVCacheSpec:
         return self.block_size * num_kv_heads * head_size * int(dtype_size or 1) * 2
 
 
-class _FakeFullAttentionSpec(_FakeKVCacheSpec):
+class _FakeAttentionSpec(_FakeKVCacheSpec):
+    pass
+
+
+class _FakeFullAttentionSpec(_FakeAttentionSpec):
     pass
 
 
@@ -321,6 +325,7 @@ _single_type_mod.spec_manager_map = {  # type: ignore[attr-defined]
 
 _kv_interface_mod: Any = sys.modules["vllm.v1.kv_cache_interface"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
 _kv_interface_mod.KVCacheSpec = _FakeKVCacheSpec  # type: ignore[attr-defined]
+_kv_interface_mod.AttentionSpec = _FakeAttentionSpec  # type: ignore[attr-defined]
 _kv_interface_mod.FullAttentionSpec = _FakeFullAttentionSpec  # type: ignore[attr-defined]
 _kv_interface_mod.SlidingWindowSpec = _FakeSlidingWindowSpec  # type: ignore[attr-defined]
 _kv_interface_mod.MambaSpec = _FakeMambaSpec  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -526,6 +526,40 @@ class TestReqMeta(unittest.TestCase):
         self.assertEqual(meta.save_end_token, 32)
         self.assertEqual(meta.target_token_len, 33)
 
+    def test_from_request_tracker_defers_c8_boundary_without_hash(self):
+        tracker = RequestTracker(
+            req_id="r1",
+            token_len=128,
+            allocated_block_ids=list(range(8)),
+            num_saved_tokens=0,
+        )
+
+        partial_meta = ReqMeta.from_request_tracker(
+            tracker,
+            cache_transfer_granularity=128,
+            block_hashes=[f"h{i}".encode() for i in range(7)],
+            save_partial_block=True,
+            hash_block_size=16,
+        )
+
+        self.assertIsNotNone(partial_meta)
+        self.assertTrue(partial_meta.can_save)
+        self.assertEqual(partial_meta.save_end_token, 0)
+        self.assertEqual(tracker.num_saved_tokens, 0)
+
+        full_meta = ReqMeta.from_request_tracker(
+            tracker,
+            cache_transfer_granularity=128,
+            block_hashes=[f"h{i}".encode() for i in range(8)],
+            save_partial_block=True,
+            hash_block_size=16,
+        )
+
+        self.assertIsNotNone(full_meta)
+        self.assertTrue(full_meta.can_save)
+        self.assertEqual(full_meta.save_end_token, 128)
+        self.assertEqual(tracker.num_saved_tokens, 128)
+
     def test_from_request_tracker_no_discard(self):
         tracker = RequestTracker(
             req_id="r1",

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -100,7 +100,7 @@ class TestLayerBatchBuilder(unittest.TestCase):
             {0: [10, 20, 30]},
             {0: [100, 200, 300]},
             group_num_layers={0: 2},
-            group_layer_offsets={0: [0, 2, 3]},
+            group_layer_cache_entry_offsets={0: [0, 2, 3]},
         )
         builder = LayerBatchBuilder(
             database,

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -45,6 +45,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     KVCacheStoreRecvingThread,
     KVCacheStoreSendingThread,
     KVTransferThread,
+    LayerBatchBuilder,
 )
 
 
@@ -89,6 +90,43 @@ class MaskedFakeTokenDatabase(FakeTokenDatabase):
             return True
         block_idx = start // self.get_block_size(kv_cache_group_id)
         return block_idx < len(masks[kv_cache_group_id]) and masks[kv_cache_group_id][block_idx]
+
+
+class TestLayerBatchBuilder(unittest.TestCase):
+    def test_uses_real_offsets_for_variable_cache_entries_per_layer(self):
+        database = FakeTokenDatabase()
+        database.set_group_buffers(
+            {0: [1000, 2000, 3000]},
+            {0: [10, 20, 30]},
+            {0: [100, 200, 300]},
+            group_num_layers={0: 2},
+            group_layer_offsets={0: [0, 2, 3]},
+        )
+        builder = LayerBatchBuilder(
+            database,
+            my_key_index=0,
+            num_ranks_per_layer=1,
+            page_size_bytes=60,
+            num_layers=2,
+        )
+
+        layer_0 = builder._build_transfer_arrays(
+            np.asarray([2]),
+            np.asarray([500]),
+            layer_id=0,
+        )
+        layer_1 = builder._build_transfer_arrays(
+            np.asarray([2]),
+            np.asarray([500]),
+            layer_id=1,
+        )
+
+        np.testing.assert_array_equal(layer_0[0], [1200, 2400])
+        np.testing.assert_array_equal(layer_0[1], [10, 20])
+        np.testing.assert_array_equal(layer_0[2], [500, 510])
+        np.testing.assert_array_equal(layer_1[0], [3600])
+        np.testing.assert_array_equal(layer_1[1], [30])
+        np.testing.assert_array_equal(layer_1[2], [530])
 
 
 class TestKVTransferThread(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -3,16 +3,15 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from vllm.v1.kv_cache_interface import (
-    FullAttentionSpec,
-    KVCacheTensor,
-    UniformTypeKVCacheSpecs,
-)
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheTensor, UniformTypeKVCacheSpecs
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     apply_layerwise_kv_cache_plan,
     build_layerwise_cache_layout,
+    build_layerwise_reuse_layout,
     get_gva_layerwise_config,
+    validate_layerwise_reuse_layout,
 )
 
 
@@ -41,7 +40,13 @@ def test_no_reuse_skips_topology_validation():
     ]
     kv_cache_config = SimpleNamespace(
         kv_cache_tensors=original_tensors.copy(),
-        kv_cache_groups=[object(), object()],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=[tensor.shared_by[0] for tensor in original_tensors],
+                kv_cache_spec=MagicMock(),
+            ),
+            SimpleNamespace(layer_names=[], kv_cache_spec=MagicMock()),
+        ],
     )
 
     apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2))
@@ -51,23 +56,12 @@ def test_no_reuse_skips_topology_validation():
 
 def test_base_layers_are_merged_into_shared_slots():
     original_tensors = [KVCacheTensor(size=16, shared_by=[f"model.layers.{layer}.self_attn"]) for layer in range(6)]
-    layer_names = [tensor.shared_by[0] for tensor in original_tensors]
-    layer_spec = FullAttentionSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=4,
-        head_size_v=4,
-        dtype=torch.int8,
-    )
     kv_cache_config = SimpleNamespace(
         kv_cache_tensors=original_tensors,
         kv_cache_groups=[
             SimpleNamespace(
-                layer_names=layer_names,
-                kv_cache_spec=UniformTypeKVCacheSpecs(
-                    block_size=2,
-                    kv_cache_specs={layer_name: layer_spec for layer_name in layer_names},
-                ),
+                layer_names=[tensor.shared_by[0] for tensor in original_tensors],
+                kv_cache_spec=MagicMock(),
             )
         ],
     )
@@ -79,44 +73,6 @@ def test_base_layers_are_merged_into_shared_slots():
         ["model.layers.1.self_attn", "model.layers.3.self_attn", "model.layers.5.self_attn"],
         ["model.layers.2.self_attn", "model.layers.4.self_attn"],
     ]
-
-
-def test_equal_tensor_sizes_reject_incompatible_cache_specs():
-    layer_names = [f"model.layers.{layer}.self_attn" for layer in range(4)]
-    first_spec = FullAttentionSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=8,
-        head_size_v=8,
-        dtype=torch.int8,
-    )
-    incompatible_spec = FullAttentionSpec(
-        block_size=2,
-        num_kv_heads=2,
-        head_size=4,
-        head_size_v=4,
-        dtype=torch.int8,
-    )
-    layer_specs = {layer_name: first_spec for layer_name in layer_names}
-    layer_specs[layer_names[2]] = incompatible_spec
-    kv_cache_config = SimpleNamespace(
-        kv_cache_tensors=[KVCacheTensor(size=32, shared_by=[layer_name]) for layer_name in layer_names],
-        kv_cache_groups=[
-            SimpleNamespace(
-                layer_names=layer_names,
-                kv_cache_spec=UniformTypeKVCacheSpecs(
-                    block_size=2,
-                    kv_cache_specs=layer_specs,
-                ),
-            )
-        ],
-    )
-
-    with pytest.raises(ValueError, match="identical cache specs"):
-        apply_layerwise_kv_cache_plan(
-            kv_cache_config,
-            _make_vllm_config(4, 1),
-        )
 
 
 def test_default_layout_keeps_one_buffer_per_layer():
@@ -207,3 +163,184 @@ def test_gva_config_is_scoped_to_memcache_layerwise_connector():
 
     assert get_gva_layerwise_config(multi_config) is ascend_store_config
     assert get_gva_layerwise_config(unsupported) is None
+
+
+def test_equal_tensor_sizes_reject_incompatible_cache_specs():
+    layer_names = [f"model.layers.{layer}.self_attn" for layer in range(4)]
+    first_spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        head_size_v=8,
+        dtype=torch.int8,
+    )
+    incompatible_spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=2,
+        head_size=4,
+        head_size_v=4,
+        dtype=torch.int8,
+    )
+    layer_specs = {layer_name: first_spec for layer_name in layer_names}
+    layer_specs[layer_names[2]] = incompatible_spec
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[KVCacheTensor(size=32, shared_by=[layer_name]) for layer_name in layer_names],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=layer_specs,
+                ),
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="identical main cache specs"):
+        apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(4, 1))
+
+
+def test_partial_layout_skips_tensor_merge():
+    layer_names = [
+        "model.layers.0.self_attn",
+        "model.layers.1.self_attn",
+    ]
+    original_tensors = [KVCacheTensor(size=16, shared_by=[layer_name]) for layer_name in layer_names]
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=original_tensors.copy(),
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=MagicMock(),
+            )
+        ],
+    )
+    vllm_config = _make_vllm_config(4, 1)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config)
+
+    assert kv_cache_config.kv_cache_tensors == original_tensors
+
+
+def test_layout_includes_mtp_and_sparse_c8_indexer():
+    main_spec = AscendMLAAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.int8,
+        cache_sparse_c8=True,
+    )
+    indexer_spec = AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.int8,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+        cache_sparse_c8=True,
+    )
+    specs = {
+        **{f"model.layers.{layer}.self_attn.attn": main_spec for layer in range(4)},
+        "model.mtp.0.self_attn.attn": main_spec,
+        "model.layers.2.self_attn.indexer.k_cache": indexer_spec,
+    }
+
+    layout, slots = build_layerwise_reuse_layout(
+        specs,
+        4,
+        {"layerwise_num_shared_buffers": 2},
+    )
+
+    assert 4 in layout
+    assert layout[2]["indexer"] == "model.layers.2.self_attn.indexer.k_cache"
+    assert sorted(layer for slot in slots for layer in slot) == list(range(5))
+
+
+def test_multi_group_accepts_sfa_main_and_indexer():
+    main_name = "model.layers.0.self_attn.attn"
+    indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+    main_spec = AscendMLAAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.bfloat16,
+    )
+    indexer_spec = AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.int8,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+    )
+
+    validate_layerwise_reuse_layout(
+        SimpleNamespace(kv_cache_groups=[object(), object()]),
+        {
+            main_name: main_spec,
+            indexer_name: indexer_spec,
+        },
+        {
+            0: {
+                "main": main_name,
+                "indexer": indexer_name,
+            }
+        },
+    )
+
+
+def test_multi_group_rejects_non_sfa_topology():
+    layer_name = "model.layers.0.self_attn.attn"
+    full_spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        head_size_v=8,
+        dtype=torch.bfloat16,
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="only for separated SFA main/indexer caches",
+    ):
+        validate_layerwise_reuse_layout(
+            SimpleNamespace(kv_cache_groups=[object(), object()]),
+            {layer_name: full_spec},
+            {0: {"main": layer_name}},
+        )
+
+
+def test_multi_group_requires_mla_main_for_indexer():
+    main_name = "model.layers.0.self_attn.attn"
+    indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+    main_spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        head_size_v=8,
+        dtype=torch.bfloat16,
+    )
+    indexer_spec = AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.int8,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+    )
+
+    with pytest.raises(NotImplementedError, match="unsupported cache specs"):
+        validate_layerwise_reuse_layout(
+            SimpleNamespace(kv_cache_groups=[object(), object()]),
+            {
+                main_name: main_spec,
+                indexer_name: indexer_spec,
+            },
+            {
+                0: {
+                    "main": main_name,
+                    "indexer": indexer_name,
+                }
+            },
+        )

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -3,16 +3,34 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheTensor, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheTensor,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
-    _validate_layerwise_reuse_layout,
     apply_layerwise_kv_cache_plan,
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
 )
+
+
+def _make_full_attention_spec(
+    *,
+    num_kv_heads: int = 1,
+    head_size: int = 8,
+) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        head_size_v=head_size,
+        dtype=torch.int8,
+    )
 
 
 def _make_vllm_config(num_layers: int, num_shared_buffers: int):
@@ -33,19 +51,27 @@ def _make_vllm_config(num_layers: int, num_shared_buffers: int):
 
 
 def test_no_reuse_skips_topology_validation():
+    spec = MambaSpec(
+        block_size=2,
+        shapes=((1,),),
+        dtypes=(torch.int8,),
+    )
     original_tensors = [
         KVCacheTensor(size=16, shared_by=["model.layers.0.self_attn"]),
         KVCacheTensor(size=16, shared_by=["model.layers.1.self_attn"]),
         KVCacheTensor(size=16, shared_by=["model.mtp.0.self_attn"]),
     ]
+    layer_names = [tensor.shared_by[0] for tensor in original_tensors]
     kv_cache_config = SimpleNamespace(
         kv_cache_tensors=original_tensors.copy(),
         kv_cache_groups=[
             SimpleNamespace(
-                layer_names=[tensor.shared_by[0] for tensor in original_tensors],
-                kv_cache_spec=MagicMock(),
-            ),
-            SimpleNamespace(layer_names=[], kv_cache_spec=MagicMock()),
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
         ],
     )
 
@@ -56,12 +82,17 @@ def test_no_reuse_skips_topology_validation():
 
 def test_base_layers_are_merged_into_shared_slots():
     original_tensors = [KVCacheTensor(size=16, shared_by=[f"model.layers.{layer}.self_attn"]) for layer in range(6)]
+    layer_names = [tensor.shared_by[0] for tensor in original_tensors]
+    spec = _make_full_attention_spec()
     kv_cache_config = SimpleNamespace(
         kv_cache_tensors=original_tensors,
         kv_cache_groups=[
             SimpleNamespace(
-                layer_names=[tensor.shared_by[0] for tensor in original_tensors],
-                kv_cache_spec=MagicMock(),
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
             )
         ],
     )
@@ -165,21 +196,12 @@ def test_gva_config_is_scoped_to_memcache_layerwise_connector():
     assert get_gva_layerwise_config(unsupported) is None
 
 
-def test_equal_tensor_sizes_reject_incompatible_cache_specs():
+def test_incompatible_cache_specs_use_separate_slots():
     layer_names = [f"model.layers.{layer}.self_attn" for layer in range(4)]
-    first_spec = FullAttentionSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=8,
-        head_size_v=8,
-        dtype=torch.int8,
-    )
-    incompatible_spec = FullAttentionSpec(
-        block_size=2,
+    first_spec = _make_full_attention_spec()
+    incompatible_spec = _make_full_attention_spec(
         num_kv_heads=2,
         head_size=4,
-        head_size_v=4,
-        dtype=torch.int8,
     )
     layer_specs = {layer_name: first_spec for layer_name in layer_names}
     layer_specs[layer_names[2]] = incompatible_spec
@@ -196,8 +218,13 @@ def test_equal_tensor_sizes_reject_incompatible_cache_specs():
         ],
     )
 
-    with pytest.raises(ValueError, match="identical main cache specs"):
-        apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(4, 1))
+    apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(4, 1))
+
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        [layer_names[0]],
+        [layer_names[1], layer_names[3]],
+        [layer_names[2]],
+    ]
 
 
 def test_partial_layout_skips_tensor_merge():
@@ -206,12 +233,16 @@ def test_partial_layout_skips_tensor_merge():
         "model.layers.1.self_attn",
     ]
     original_tensors = [KVCacheTensor(size=16, shared_by=[layer_name]) for layer_name in layer_names]
+    spec = _make_full_attention_spec()
     kv_cache_config = SimpleNamespace(
         kv_cache_tensors=original_tensors.copy(),
         kv_cache_groups=[
             SimpleNamespace(
                 layer_names=layer_names,
-                kv_cache_spec=MagicMock(),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
             )
         ],
     )
@@ -223,43 +254,72 @@ def test_partial_layout_skips_tensor_merge():
     assert kv_cache_config.kv_cache_tensors == original_tensors
 
 
-def test_layout_includes_mtp_and_sparse_c8_indexer():
-    main_spec = AscendMLAAttentionSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=8,
-        dtype=torch.int8,
-        cache_sparse_c8=True,
-    )
-    indexer_spec = AscendSFAIndexerCacheSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=4,
-        dtype=torch.int8,
-        scale_dim=1,
-        scale_dtype=torch.float16,
-        cache_sparse_c8=True,
-    )
+def test_layout_includes_mtp_layers():
+    spec = _make_full_attention_spec()
     specs = {
-        **{f"model.layers.{layer}.self_attn.attn": main_spec for layer in range(4)},
-        "model.mtp.0.self_attn.attn": main_spec,
-        "model.layers.2.self_attn.indexer.k_cache": indexer_spec,
+        **{f"model.layers.{layer}.self_attn": spec for layer in range(4)},
+        "model.mtp.0.self_attn": spec,
     }
 
-    layout, slots = build_layerwise_reuse_layout(
+    layout = build_layerwise_reuse_layout(
         specs,
         4,
         {"layerwise_num_shared_buffers": 2},
     )
 
-    assert 4 in layout
-    assert layout[2]["indexer"] == "model.layers.2.self_attn.indexer.k_cache"
-    assert sorted(layer for slot in slots for layer in slot) == list(range(5))
+    assert 4 in layout.layer_entries
+    assert layout.storage_slots == [[0], [1, 3], [2, 4]]
+    assert layout.prefetch_layer_map == {3: 1, 4: 2}
 
 
-def test_multi_group_accepts_sfa_main_and_indexer():
-    main_name = "model.layers.0.self_attn.attn"
-    indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+def test_complete_physical_cache_signature_controls_reuse():
+    main_spec = AscendMLAAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.int8,
+        cache_sparse_sfa_c8=True,
+    )
+    indexer_spec = AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.int8,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+        cache_sparse_li_c8=True,
+    )
+    specs = {
+        **{f"model.layers.{layer}.self_attn.attn": main_spec for layer in range(6)},
+        **{f"model.layers.{layer}.self_attn.indexer.k_cache": indexer_spec for layer in (1, 3, 5)},
+    }
+
+    layout = build_layerwise_reuse_layout(
+        specs,
+        6,
+        {
+            "layerwise_num_shared_buffers": 1,
+            "layerwise_independent_layers": [],
+        },
+    )
+
+    assert layout.storage_slots == [[0, 2, 4], [1, 3, 5]]
+    assert layout.prefetch_layer_map == {
+        2: 0,
+        4: 2,
+        3: 1,
+        5: 3,
+    }
+    assert len(layout.layer_entries[0]) == 1
+    assert len(layout.layer_entries[1]) == 2
+
+
+def test_multi_group_sfa_descriptors_are_merged_by_signature():
+    main_names = [
+        *(f"model.layers.{layer}.self_attn.attn" for layer in range(4)),
+        "model.mtp.0.self_attn.attn",
+    ]
+    indexer_names = [f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in (1, 2, 4)]
     main_spec = AscendMLAAttentionSpec(
         block_size=2,
         num_kv_heads=1,
@@ -274,73 +334,88 @@ def test_multi_group_accepts_sfa_main_and_indexer():
         scale_dim=1,
         scale_dtype=torch.float16,
     )
-
-    _validate_layerwise_reuse_layout(
-        SimpleNamespace(kv_cache_groups=[object(), object()]),
-        {
-            main_name: main_spec,
-            indexer_name: indexer_spec,
-        },
-        {
-            0: {
-                "main": main_name,
-                "indexer": indexer_name,
-            }
-        },
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[
+            *(KVCacheTensor(size=main_spec.page_size_bytes, shared_by=[name]) for name in main_names),
+            *(KVCacheTensor(size=indexer_spec.page_size_bytes, shared_by=[name]) for name in indexer_names),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=main_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(main_names, main_spec),
+                ),
+            ),
+            SimpleNamespace(
+                layer_names=indexer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(indexer_names, indexer_spec),
+                ),
+            ),
+        ],
     )
 
+    apply_layerwise_kv_cache_plan(
+        kv_cache_config,
+        _make_vllm_config(4, 1),
+    )
 
-def test_multi_group_rejects_non_sfa_topology():
-    layer_name = "model.layers.0.self_attn.attn"
-    full_spec = FullAttentionSpec(
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        [main_names[0]],
+        [main_names[1], main_names[2], main_names[4]],
+        [indexer_names[0], indexer_names[1], indexer_names[2]],
+        [main_names[3]],
+    ]
+
+
+def test_non_attention_cache_spec_is_rejected():
+    mamba_spec = MambaSpec(
         block_size=2,
-        num_kv_heads=1,
-        head_size=8,
-        head_size_v=8,
-        dtype=torch.bfloat16,
+        shapes=((1,),),
+        dtypes=(torch.int8,),
     )
+    layer_specs = {f"model.layers.{layer}.mixer": mamba_spec for layer in range(3)}
 
-    with pytest.raises(
-        NotImplementedError,
-        match="only for separated SFA main/indexer caches",
-    ):
-        _validate_layerwise_reuse_layout(
-            SimpleNamespace(kv_cache_groups=[object(), object()]),
-            {layer_name: full_spec},
-            {0: {"main": layer_name}},
+    with pytest.raises(NotImplementedError, match="attention cache specs only"):
+        build_layerwise_reuse_layout(
+            layer_specs,
+            3,
+            {"layerwise_num_shared_buffers": 1},
         )
 
 
-def test_multi_group_requires_mla_main_for_indexer():
-    main_name = "model.layers.0.self_attn.attn"
-    indexer_name = "model.layers.0.self_attn.indexer.k_cache"
-    main_spec = FullAttentionSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=8,
-        head_size_v=8,
-        dtype=torch.bfloat16,
-    )
-    indexer_spec = AscendSFAIndexerCacheSpec(
-        block_size=2,
-        num_kv_heads=1,
-        head_size=4,
-        dtype=torch.int8,
-        scale_dim=1,
-        scale_dtype=torch.float16,
+def test_packed_cache_tensor_descriptors_are_rejected():
+    layer_names = [
+        "model.layers.0.self_attn",
+        "model.layers.1.self_attn",
+        "model.layers.2.self_attn",
+    ]
+    spec = _make_full_attention_spec()
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=16,
+                shared_by=[layer_name],
+                offset=8,
+                block_stride=32,
+            )
+            for layer_name in layer_names
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
     )
 
-    with pytest.raises(NotImplementedError, match="unsupported cache specs"):
-        _validate_layerwise_reuse_layout(
-            SimpleNamespace(kv_cache_groups=[object(), object()]),
-            {
-                main_name: main_spec,
-                indexer_name: indexer_spec,
-            },
-            {
-                0: {
-                    "main": main_name,
-                    "indexer": indexer_name,
-                }
-            },
+    with pytest.raises(NotImplementedError, match="pre-shared or packed"):
+        apply_layerwise_kv_cache_plan(
+            kv_cache_config,
+            _make_vllm_config(3, 1),
         )

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -16,6 +16,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
+    get_layerwise_physical_layer_index,
 )
 
 
@@ -270,6 +271,22 @@ def test_layout_includes_mtp_layers():
     assert 4 in layout.layer_entries
     assert layout.storage_slots == [[0], [1, 3], [2, 4]]
     assert layout.prefetch_layer_map == {3: 1, 4: 2}
+
+
+@pytest.mark.parametrize(
+    ("layer_name", "expected"),
+    [
+        ("model.mtp.0.self_attn", 4),
+        ("mtp.layers.0.self_attn", 4),
+        ("model.mtp.layers.1.self_attn", 5),
+        ("model.layers.4.self_attn", 4),
+    ],
+)
+def test_physical_layer_index_supports_mtp_names(
+    layer_name,
+    expected,
+):
+    assert get_layerwise_physical_layer_index(layer_name, 4) == expected
 
 
 def test_complete_physical_cache_signature_controls_reuse():

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -268,8 +268,8 @@ def test_layout_includes_mtp_layers():
         {"layerwise_num_shared_buffers": 2},
     )
 
-    assert 4 in layout.layer_entries
-    assert layout.shared_buffer_layers == [[0], [1, 3], [2, 4]]
+    assert 4 in layout.layer_cache_specs
+    assert layout.buffer_slots == ((0,), (1, 3), (2, 4))
     assert layout.prefetch_layer_map == {3: 1, 4: 2}
 
 
@@ -289,7 +289,7 @@ def test_physical_layer_index_supports_mtp_names(
     assert get_layerwise_physical_layer_index(layer_name, 4) == expected
 
 
-def test_complete_physical_cache_signature_controls_reuse():
+def test_main_spec_controls_reuse_regardless_of_indexer():
     main_spec = AscendMLAAttentionSpec(
         block_size=2,
         num_kv_heads=1,
@@ -320,18 +320,71 @@ def test_complete_physical_cache_signature_controls_reuse():
         },
     )
 
-    assert layout.shared_buffer_layers == [[0, 2, 4], [1, 3, 5]]
-    assert layout.prefetch_layer_map == {
-        2: 0,
-        4: 2,
-        3: 1,
-        5: 3,
+    # Identical main specs put every layer in one buffer; the indexer subset rides along.
+    assert layout.buffer_slots == ((0, 1, 2, 3, 4, 5),)
+    assert tuple(layer for layer in layout.buffer_slots[0] if layout.layer_cache_specs[layer].indexer is not None) == (
+        1,
+        3,
+        5,
+    )
+    assert layout.prefetch_layer_map == {1: 0, 2: 1, 3: 2, 4: 3, 5: 4}
+    assert layout.layer_cache_specs[0].indexer is None
+    assert layout.layer_cache_specs[1].indexer is not None
+
+
+def test_cache_spec_roles_do_not_depend_on_order():
+    main_spec = _make_sfa_main_spec()
+    indexer_spec = _make_sfa_indexer_spec()
+    indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+    main_name = "model.layers.0.self_attn.attn"
+    specs = {
+        indexer_name: indexer_spec,
+        main_name: main_spec,
+        "model.layers.1.self_attn.attn": main_spec,
     }
-    assert len(layout.layer_entries[0]) == 1
-    assert len(layout.layer_entries[1]) == 2
+
+    layout = build_layerwise_reuse_layout(
+        specs,
+        2,
+        {
+            "layerwise_num_shared_buffers": 1,
+            "layerwise_independent_layers": [],
+        },
+    )
+
+    assert layout.layer_cache_specs[0].main.layer_name == main_name
+    assert layout.layer_cache_specs[0].indexer is not None
+    assert layout.layer_cache_specs[0].indexer.layer_name == indexer_name
 
 
-def test_multi_group_sfa_descriptors_are_merged_by_signature():
+def test_single_indexer_spec_is_the_primary_spec():
+    indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+    layout = build_layerwise_reuse_layout(
+        {indexer_name: _make_sfa_indexer_spec()},
+        1,
+        {"layerwise_num_shared_buffers": 1},
+    )
+
+    assert layout.layer_cache_specs[0].main.layer_name == indexer_name
+    assert layout.layer_cache_specs[0].indexer is None
+
+
+def test_ambiguous_multi_spec_layer_is_rejected():
+    main_spec = _make_sfa_main_spec()
+    specs = {
+        "model.layers.0.self_attn.attn": main_spec,
+        "model.layers.0.self_attn.other_cache": main_spec,
+    }
+
+    with pytest.raises(ValueError, match="multiple cache specs"):
+        build_layerwise_reuse_layout(
+            specs,
+            1,
+            {"layerwise_num_shared_buffers": 1},
+        )
+
+
+def test_multi_group_sfa_descriptors_are_merged_by_main_component():
     main_names = [
         *(f"model.layers.{layer}.self_attn.attn" for layer in range(4)),
         "model.mtp.0.self_attn.attn",
@@ -379,12 +432,95 @@ def test_multi_group_sfa_descriptors_are_merged_by_signature():
         _make_vllm_config(4, 1),
     )
 
+    # One independent main tensor, one main tensor shared by every reused layer (incl.
+    # MTP), and one indexer tensor shared only by the indexer-bearing layers.
     assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
         [main_names[0]],
-        [main_names[1], main_names[2], main_names[4]],
-        [indexer_names[0], indexer_names[1], indexer_names[2]],
-        [main_names[3]],
+        [main_names[1], main_names[2], main_names[3], main_names[4]],
+        indexer_names,
     ]
+
+
+def _make_sfa_main_spec(dtype=torch.int8) -> AscendMLAAttentionSpec:
+    return AscendMLAAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=dtype,
+        cache_sparse_sfa_c8=True,
+    )
+
+
+def _make_sfa_indexer_spec() -> AscendSFAIndexerCacheSpec:
+    return AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.int8,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+        cache_sparse_li_c8=True,
+    )
+
+
+def test_component_sharing_merges_main_across_a_and_b_layers():
+    # GLM5.2/SFA: A-class layers own main + indexer, B-class layers own main only. Every
+    # main spec is identical, so one buffer's main tensor is shared by all layers in the
+    # buffer while its indexer tensor is shared only by the buffer's A-class layers.
+    main_spec = _make_sfa_main_spec()
+    indexer_spec = _make_sfa_indexer_spec()
+    a_layers = [1, 4]  # main + indexer
+    b_layers = [2, 3, 5]  # main only
+    # physical layer 0 is independent; layers 1..5 are reused; 6 = MTP (main only).
+    main_by_layer = {
+        0: "model.layers.0.self_attn.attn",
+        **{layer: f"model.layers.{layer}.self_attn.attn" for layer in (*a_layers, *b_layers)},
+        6: "model.mtp.0.self_attn.attn",
+    }
+    indexer_by_layer = {layer: f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in a_layers}
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[
+            *(KVCacheTensor(size=main_spec.page_size_bytes, shared_by=[name]) for name in main_by_layer.values()),
+            *(KVCacheTensor(size=indexer_spec.page_size_bytes, shared_by=[name]) for name in indexer_by_layer.values()),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=list(main_by_layer.values()),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(main_by_layer.values(), main_spec),
+                ),
+            ),
+            SimpleNamespace(
+                layer_names=list(indexer_by_layer.values()),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(indexer_by_layer.values(), indexer_spec),
+                ),
+            ),
+        ],
+    )
+
+    apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(6, 2))
+
+    main_shared_by = []
+    indexer_shared_by = []
+    for tensor in kv_cache_config.kv_cache_tensors:
+        names = list(tensor.shared_by)
+        if any(".indexer." in name for name in names):
+            indexer_shared_by.append(names)
+        else:
+            main_shared_by.append(names)
+
+    # 1 independent layer + 2 reused buffers == 3 main tensors.
+    assert len(main_shared_by) == 3
+    # The independent layer keeps its own main; every reused layer's main (incl. MTP)
+    # lands in exactly one shared main tensor.
+    assert main_shared_by[0] == [main_by_layer[0]]
+    merged_reused_main = sorted(name for names in main_shared_by[1:] for name in names)
+    assert merged_reused_main == sorted(main_by_layer[layer] for layer in (1, 2, 3, 4, 5, 6))
+    # Indexer layers follow their main slots, so layers 1 and 4 use separate tensors.
+    assert indexer_shared_by == [[indexer_by_layer[1]], [indexer_by_layer[4]]]
 
 
 def test_non_attention_cache_spec_is_rejected():

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -7,11 +7,11 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheTensor, Uniform
 
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
+    _validate_layerwise_reuse_layout,
     apply_layerwise_kv_cache_plan,
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
-    validate_layerwise_reuse_layout,
 )
 
 
@@ -275,7 +275,7 @@ def test_multi_group_accepts_sfa_main_and_indexer():
         scale_dtype=torch.float16,
     )
 
-    validate_layerwise_reuse_layout(
+    _validate_layerwise_reuse_layout(
         SimpleNamespace(kv_cache_groups=[object(), object()]),
         {
             main_name: main_spec,
@@ -304,7 +304,7 @@ def test_multi_group_rejects_non_sfa_topology():
         NotImplementedError,
         match="only for separated SFA main/indexer caches",
     ):
-        validate_layerwise_reuse_layout(
+        _validate_layerwise_reuse_layout(
             SimpleNamespace(kv_cache_groups=[object(), object()]),
             {layer_name: full_spec},
             {0: {"main": layer_name}},
@@ -331,7 +331,7 @@ def test_multi_group_requires_mla_main_for_indexer():
     )
 
     with pytest.raises(NotImplementedError, match="unsupported cache specs"):
-        validate_layerwise_reuse_layout(
+        _validate_layerwise_reuse_layout(
             SimpleNamespace(kv_cache_groups=[object(), object()]),
             {
                 main_name: main_spec,

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -117,7 +117,7 @@ def test_default_layout_keeps_one_buffer_per_layer():
     assert len(layout.storage_indices) == 27
 
 
-def test_reuse_layout_matches_round_robin_storage_slots():
+def test_reuse_layout_matches_round_robin_buffer_assignments():
     layout = build_layerwise_cache_layout(27, {"layerwise_num_shared_buffers": 6})
 
     assert layout.has_layer_reuse is True
@@ -269,7 +269,7 @@ def test_layout_includes_mtp_layers():
     )
 
     assert 4 in layout.layer_entries
-    assert layout.storage_slots == [[0], [1, 3], [2, 4]]
+    assert layout.shared_buffer_layers == [[0], [1, 3], [2, 4]]
     assert layout.prefetch_layer_map == {3: 1, 4: 2}
 
 
@@ -320,7 +320,7 @@ def test_complete_physical_cache_signature_controls_reuse():
         },
     )
 
-    assert layout.storage_slots == [[0, 2, 4], [1, 3, 5]]
+    assert layout.shared_buffer_layers == [[0, 2, 4], [1, 3, 5]]
     assert layout.prefetch_layer_map == {
         2: 0,
         4: 2,

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -155,6 +155,32 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(scheduler.load_specs["r1"].kvpool_store_skip_tokens, 64)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_layerwise_mtp_hit_uses_safe_load_extent(self, mock_client_cls):
+        scheduler = KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
+        scheduler.use_layerwise = True
+        scheduler.use_gva_layerwise = True
+        scheduler.use_eagle = True
+        scheduler.cache_transfer_granularity = 16
+        scheduler._get_layerwise_gva_hit_tokens = MagicMock(return_value=64)
+
+        request = MagicMock()
+        request.prompt_token_ids = list(range(64))
+        request.num_tokens = 64
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 4
+
+        need, is_async = scheduler.get_num_new_matched_tokens(request, 48)
+
+        self.assertEqual(need, 0)
+        self.assertFalse(is_async)
+        load_spec = scheduler.load_specs["r1"]
+        self.assertEqual(load_spec.kvpool_cached_tokens, 48)
+        self.assertEqual(load_spec.kvpool_store_skip_tokens, 64)
+        self.assertTrue(load_spec.can_load)
+        scheduler.update_state_after_alloc(request, MagicMock(), 0)
+        self.assertTrue(load_spec.can_load)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_full_hbm_hit_skips_external_lookup(self, mock_client_cls):
         scheduler = KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
         request = MagicMock()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -17,6 +17,7 @@
 
 import threading
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -170,6 +171,39 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.cache_coordinator.find_longest_cache_hit.assert_called_once()
         self.assertFalse(worker.cache_coordinator.find_longest_cache_hit.call_args.kwargs["apply_eagle"])
         worker.token_database.process_tokens.assert_not_called()
+
+    def test_layerwise_multi_group_layout_includes_mtp(self):
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 4
+        worker.num_kv_cache_groups = 2
+        worker.hf_config = SimpleNamespace(num_hidden_layers=4)
+        worker.use_gva_layerwise = True
+        worker._extra_config = {"layerwise_num_shared_buffers": 2}
+        worker.kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[
+                        *(f"model.layers.{layer}.self_attn.attn" for layer in range(4)),
+                        "model.mtp.0.self_attn.attn",
+                    ]
+                ),
+                SimpleNamespace(
+                    layer_names=[
+                        *(f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in range(4)),
+                    ]
+                ),
+            ]
+        )
+
+        worker._init_layerwise_config()
+
+        self.assertEqual(worker.num_layers, 5)
+        self.assertEqual(worker.physical_layer_to_group_layers[4], [(0, 4)])
+        self.assertTrue(worker.layerwise_offload)
+        self.assertEqual(worker.independent_layers, [0])
+        self.assertEqual(len(worker.layer_load_tasks), 5)
+        self.assertEqual(len(worker.layer_save_tasks), 5)
 
 
 class TestKVPoolWorkerInit(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1703,7 +1703,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         assert save_request.save_keys is not None
         partial_key = save_request.save_keys[0]
         self.assertIn("@partial@r1@0@1@20@", partial_key)
-        self.assertEqual(save_request.partial_save_gvas_by_group, [101])
+        self.assertEqual(save_request.partial_save_gva_per_group, [101])
         save_range = worker.layer_save_tasks[1][0].block_ranges[0]
         self.assertEqual(save_range.partial_block_index, 1)
 
@@ -1741,7 +1741,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         queried_keys = worker.m_store.batch_get_key_info.call_args.args[0]
         self.assertIn(partial_key, queried_keys)
         self.assertNotIn(partial_key, worker._allocated_gvas)
-        self.assertEqual(load_request.partial_load_gvas_by_group, [202])
+        self.assertEqual(load_request.partial_load_gva_per_group, [202])
         self.assertEqual(worker.layer_load_tasks[0], [])
         block_range = worker.layer_load_tasks[1][0].block_ranges[0]
         self.assertEqual(
@@ -1815,7 +1815,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         )
         sleep.assert_called_once()
         self.assertEqual(request.load_keys, [worker._make_layerwise_gva_key(0, "h0"), partial_key])
-        self.assertEqual(request.partial_load_gvas_by_group, [202])
+        self.assertEqual(request.partial_load_gva_per_group, [202])
         self.assertEqual(worker.get_block_ids_with_load_errors(), set())
 
     def test_multi_group_load_failure_stops_before_forward(self):
@@ -1892,8 +1892,8 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
                 kvpool_cached_tokens=33,
                 can_load=True,
             ),
-            partial_save_gvas_by_group=[301],
-            partial_load_gvas_by_group=[302],
+            partial_save_gva_per_group=[301],
+            partial_load_gva_per_group=[302],
         )
 
         worker._process_save_for_layer_batch([request], 1)

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1629,6 +1629,55 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         self.assertEqual((independent_range.start_block, independent_range.end_block), (1, 2))
         self.assertEqual((reused_range.start_block, reused_range.end_block), (0, 2))
 
+    def test_mtp_load_uses_safe_extent_not_store_skip_extent(self):
+        worker = self._make_worker()
+        worker.use_eagle = True
+        worker.layerwise_offload = True
+        worker.independent_layers = [0, 1]
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids=[0, 1],
+            block_hashes=["h0", "h1"],
+            load_spec=LoadSpec(
+                vllm_cached_tokens=16,
+                kvpool_cached_tokens=16,
+                can_load=True,
+                kvpool_store_skip_tokens=32,
+            ),
+        )
+
+        worker._process_load_for_layer_batch([request], 1)
+
+        self.assertEqual(worker.layer_load_tasks[1], [])
+
+    def test_mtp_gva_prepare_uses_safe_extent_not_store_skip_extent(self):
+        worker = self._make_gva_worker()
+        worker.use_eagle = True
+        key_info = MagicMock()
+        key_info.size.return_value = 64
+        key_info.gva_list.return_value = [201]
+        worker.m_store.batch_get_key_info.return_value = [key_info]
+        worker.m_store.batch_add_lease.return_value = [0]
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids_by_group=[[0, 1]],
+            block_ids_by_group_np=[np.asarray([0, 1], dtype=np.int64)],
+            block_hashes=["h0", "h1"],
+            load_spec=LoadSpec(
+                vllm_cached_tokens=16,
+                kvpool_cached_tokens=16,
+                can_load=True,
+                kvpool_store_skip_tokens=32,
+            ),
+        )
+
+        worker._prepare_load_gvas([request])
+
+        queried_keys = worker.m_store.batch_get_key_info.call_args.args[0]
+        self.assertEqual(len(queried_keys), 1)
+
     def test_full_pool_hit_uses_verified_extent(self):
         worker = self._make_gva_worker()
         worker.independent_layers = [0]

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1774,6 +1774,47 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         self.assertEqual(request.load_keys, [])
         self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
 
+    def test_multi_group_load_failure_stops_before_forward(self):
+        worker = self._make_gva_worker(2)
+        valid_info = MagicMock()
+        valid_info.size.return_value = 64
+        valid_info.gva_list.return_value = [201]
+        missing_info = MagicMock()
+        missing_info.size.return_value = 0
+        missing_info.gva_list.return_value = []
+        worker.m_store.batch_get_key_info.side_effect = [
+            [valid_info],
+            [missing_info],
+        ]
+        worker.m_store.batch_add_lease.return_value = [0]
+        request = self._make_gva_request(
+            num_groups=2,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=16,
+                kvpool_cached_tokens=16,
+                can_load=True,
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "multi-group KV load failed",
+        ):
+            worker._prepare_load_gvas([request])
+
+        group0_key = worker._make_layerwise_gva_key(0, "h0")
+        worker.m_store.batch_remove_lease.assert_called_once_with([group0_key])
+
+    def test_worker_physical_layer_index_supports_mtp_layers_namespace(self):
+        worker = self._make_worker()
+
+        self.assertEqual(
+            worker._extract_physical_layer_index(
+                "mtp.layers.0.self_attn",
+            ),
+            worker.num_layers,
+        )
+
     def test_evicted_allocated_gva_is_reallocated(self):
         worker = self._make_gva_worker()
         key = worker._make_layerwise_gva_key(0, "h0")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1774,6 +1774,50 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         self.assertEqual(request.load_keys, [])
         self.assertEqual(worker.get_block_ids_with_load_errors(), {7})
 
+    def test_partial_lease_retries_until_snapshot_is_readable(self):
+        worker = self._make_gva_worker()
+        full_info = MagicMock()
+        full_info.size.return_value = 64
+        full_info.gva_list.return_value = [201]
+        partial_info = MagicMock()
+        partial_info.size.return_value = 64
+        partial_info.gva_list.return_value = [202]
+        worker.m_store.batch_get_key_info.return_value = [
+            full_info,
+            partial_info,
+        ]
+        worker.m_store.batch_add_lease.side_effect = [
+            [0, -3101],
+            [0],
+        ]
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            target_token_len=24,
+            block_ids=[7, 8],
+            block_hashes=["h0"],
+            load_spec=LoadSpec(
+                vllm_cached_tokens=20,
+                kvpool_cached_tokens=20,
+                can_load=True,
+            ),
+            block_ids_np=np.asarray([7, 8], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8], dtype=np.int64)],
+        )
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.time.sleep") as sleep:
+            worker._prepare_load_gvas([request])
+
+        partial_key = worker._make_layerwise_partial_key(request, 0, 1, 20)
+        self.assertEqual(
+            worker.m_store.batch_add_lease.call_args_list[1].args[0],
+            [partial_key],
+        )
+        sleep.assert_called_once()
+        self.assertEqual(request.load_keys, [worker._make_layerwise_gva_key(0, "h0"), partial_key])
+        self.assertEqual(request.partial_load_gvas_by_group, [202])
+        self.assertEqual(worker.get_block_ids_with_load_errors(), set())
+
     def test_multi_group_load_failure_stops_before_forward(self):
         worker = self._make_gva_worker(2)
         valid_info = MagicMock()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -173,6 +173,9 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.token_database.process_tokens.assert_not_called()
 
     def test_layerwise_multi_group_layout_includes_mtp(self):
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
         cls = self._make_worker_class()
         worker = object.__new__(cls)
         worker.num_layers = 4
@@ -180,18 +183,32 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.hf_config = SimpleNamespace(num_hidden_layers=4)
         worker.use_gva_layerwise = True
         worker._extra_config = {"layerwise_num_shared_buffers": 2}
+        main_spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        indexer_spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.float16,
+        )
         worker.kv_cache_config = SimpleNamespace(
             kv_cache_groups=[
                 SimpleNamespace(
                     layer_names=[
                         *(f"model.layers.{layer}.self_attn.attn" for layer in range(4)),
                         "model.mtp.0.self_attn.attn",
-                    ]
+                    ],
+                    kv_cache_spec=main_spec,
                 ),
                 SimpleNamespace(
                     layer_names=[
                         *(f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in range(4)),
-                    ]
+                    ],
+                    kv_cache_spec=indexer_spec,
                 ),
             ]
         )

--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -58,6 +58,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector imp
     ReqMeta,
     SendReqInfo,
     SendTask,
+    UniformTypeKVCacheSpecs,
     ensure_zmq_recv,
     ensure_zmq_send,
     group_concurrent_contiguous,
@@ -188,16 +189,23 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
             chunk_finish=False,
         )
 
-    def test_handle_request_completes_reuse_gate_on_error(self):
+    def test_final_layer_transfer_error_completes_reuse_gate_and_request(self):
+        req_meta = self.req_meta_base
+        req_meta.chunk_finish = True
         callback = MagicMock()
         self.thread.reuse_completion_callback = callback
         self.thread._transfer_kv_cache = MagicMock(side_effect=RuntimeError("write failed"))
-        task = SendTask(layer_idx=2)
+        task = SendTask(
+            send_request={"req": req_meta},
+            layer_idx=2,
+            layer_name="layer2",
+        )
         self.thread.send_queue.put(task)
 
         self.thread._handle_request(task)
 
         callback.assert_called_once_with(2, "write failed")
+        self.thread.callback_func.assert_called_once_with("req", req_meta, 0, trans_flag=False)
         self.assertEqual(self.thread.send_queue.unfinished_tasks, 0)
 
     @patch(
@@ -319,7 +327,114 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
         self.thread._transfer_kv_cache(send_task)
         self.engine.batch_transfer_sync_write.assert_not_called()
 
-    def test_transfer_negative_return_is_reuse_error(self):
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.group_concurrent_contiguous",
+        side_effect=group_concurrent_contiguous,
+    )
+    def test_transfer_merges_main_and_indexer_components(self, _mock_group):
+        main_name = "model.layers.0.self_attn.attn"
+        indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+        self.thread.layer_metadata = {
+            main_name: _make_layer_metadata(
+                tensor_group_idx=[0, 0],
+                kv_caches_base_addr=[1000, 2000],
+                block_len=[64, 64],
+                block_size_scale=[1, 1],
+            ),
+            indexer_name: _make_layer_metadata(
+                tensor_group_idx=[0, 0],
+                kv_caches_base_addr=[3000, 3500],
+                block_len=[32, 4],
+                block_size_scale=[1, 1],
+            ),
+        }
+        self.thread.kv_cache_specs = [MagicMock(block_size=16)]
+        req_meta = self.req_meta_base
+        req_meta.local_block_ids = [[5, 6]]
+        req_meta.remote_block_ids = [[10, 11]]
+        req_meta.remote_layer_metadata = {
+            main_name: _make_layer_metadata(
+                tensor_group_idx=[0, 0],
+                kv_caches_base_addr=[4000, 5000],
+                block_len=[64, 64],
+                block_size_scale=[1, 1],
+            ),
+            indexer_name: _make_layer_metadata(
+                tensor_group_idx=[0, 0],
+                kv_caches_base_addr=[6000, 6500],
+                block_len=[32, 4],
+                block_size_scale=[1, 1],
+            ),
+        }
+        send_task = SendTask(
+            send_request={"req": req_meta},
+            wait_event=MagicMock(),
+            layer_idx=0,
+            layer_name=main_name,
+            layer_names=[main_name, indexer_name],
+        )
+
+        self.thread._transfer_kv_cache(send_task)
+
+        self.engine.batch_transfer_sync_write.assert_called_once_with(
+            "127.0.0.1:6000",
+            [1000 + 5 * 64, 2000 + 5 * 64, 3000 + 5 * 32, 3500 + 5 * 4],
+            [4000 + 10 * 64, 5000 + 10 * 64, 6000 + 10 * 32, 6500 + 10 * 4],
+            [2 * 64, 2 * 64, 2 * 32, 2 * 4],
+        )
+
+    def test_quantized_main_staging_buffer_not_used_for_indexer(self):
+        main_name = "model.layers.0.self_attn.attn"
+        indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+        self.thread.enable_kv_quant = True
+        self.thread.layer_metadata = {
+            main_name: _make_layer_metadata(
+                tensor_group_idx=[0],
+                kv_caches_base_addr=[1000, 2000],
+                block_len=[64, 64],
+            ),
+            indexer_name: _make_layer_metadata(
+                tensor_group_idx=[0],
+                kv_caches_base_addr=[3000],
+                block_len=[32],
+            ),
+        }
+        self.thread.kv_cache_specs = [MagicMock(block_size=16)]
+        req_meta = self.req_meta_base
+        req_meta.local_block_ids = [[5, 6]]
+        req_meta.remote_block_ids = [[10, 11]]
+        req_meta.remote_layer_metadata = {
+            main_name: _make_layer_metadata(
+                tensor_group_idx=[0],
+                kv_caches_base_addr=[4000, 5000],
+                block_len=[64, 64],
+            ),
+            indexer_name: _make_layer_metadata(
+                tensor_group_idx=[0],
+                kv_caches_base_addr=[6000],
+                block_len=[32],
+            ),
+        }
+        send_task = SendTask(
+            k_quant_cache=MagicMock(),
+            v_quant_cache=MagicMock(),
+            layer_name=main_name,
+            layer_names=[main_name, indexer_name],
+        )
+
+        src, dst, length = self.thread.get_transfer_meta(
+            send_task,
+            "req",
+            req_meta,
+            indexer_name,
+            0,
+        )
+
+        self.assertEqual(src, [3000 + 5 * 32])
+        self.assertEqual(dst, [6000 + 10 * 32])
+        self.assertEqual(length, [2 * 32])
+
+    def test_transfer_negative_return_reports_reuse_error(self):
         self.engine.batch_transfer_sync_write.return_value = -1
         send_task = SendTask(
             send_request={"req2": self.req_meta_base},
@@ -329,9 +444,9 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
             group_rearrange_block_ids=[[5, 8]],
         )
 
-        with self.assertRaisesRegex(RuntimeError, "ret=-1"):
-            self.thread._transfer_kv_cache(send_task)
+        error = self.thread._transfer_kv_cache(send_task)
 
+        self.assertIn("ret=-1", error or "")
         self.assertIn("req2", self.thread.failed_reqs)
 
     @patch(
@@ -374,9 +489,25 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
             layer_name="layer2",
             group_rearrange_block_ids=[[]],
         )
-        self.thread._transfer_kv_cache(send_task)
+        self.thread.send_queue.put(send_task)
+        self.thread._handle_request(send_task)
 
         self.thread.callback_func.assert_called_once()
+
+    def test_final_layer_metadata_error_sends_failed_completion(self):
+        req_meta = self.req_meta_base
+        req_meta.chunk_finish = True
+        send_task = SendTask(
+            failed_requests={"req": req_meta},
+            wait_event=MagicMock(),
+            layer_idx=2,
+            layer_name="layer2",
+        )
+        self.thread.send_queue.put(send_task)
+
+        self.thread._handle_request(send_task)
+
+        self.thread.callback_func.assert_called_once_with("req", req_meta, 0, trans_flag=False)
 
 
 class TestKVCacheRecvingLayerThread(unittest.TestCase):
@@ -1074,6 +1205,17 @@ class TestMooncakeLayerwiseConnector(unittest.TestCase):
         connector.request_finished(request, [1, 2, 3])
         mock_method.assert_called_once_with(request, [1, 2, 3])
 
+    def test_cache_written_hook_delegates_to_worker(self):
+        connector = MooncakeLayerwiseConnector.__new__(MooncakeLayerwiseConnector)
+        connector._is_kv_producer = True
+        connector._connector_metadata = MooncakeLayerwiseConnectorMetadata()
+        connector._connector_metadata.requests["req"] = MagicMock()
+        connector.connector_worker = MagicMock()
+
+        connector.on_kv_cache_written("layer0")
+
+        connector.connector_worker.on_kv_cache_written.assert_called_once_with("layer0")
+
 
 def test_layerwise_reuse_state_tracks_shared_physical_slots():
     worker = MooncakeLayerwiseConnectorWorker.__new__(MooncakeLayerwiseConnectorWorker)
@@ -1116,6 +1258,63 @@ def test_layerwise_reuse_wait_propagates_mooncake_error():
 
     with unittest.TestCase().assertRaisesRegex(RuntimeError, "write failed"):
         worker.wait_for_layer_reuse(4)
+
+
+def _make_worker_for_cache_write_event_test():
+    worker = MooncakeLayerwiseConnectorWorker.__new__(MooncakeLayerwiseConnectorWorker)
+    worker.vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_producer=True),
+    )
+    worker.current_layer = 0
+    worker.total_layers = 1
+    worker.index_to_name = {0: ["layer0"]}
+    worker.layer_metadata = {"layer0": _make_layer_metadata(tensor_group_idx=[0])}
+    worker._cache_write_events = [None]
+    worker.pd_head_ratio = 1
+    worker.enable_c8_quant = False
+    worker.enable_kv_quant = False
+    worker.kv_cache_specs = [MagicMock()]
+    worker.kv_send_layer_thread = MagicMock()
+    worker.update_decoder_info = MagicMock(side_effect=lambda _req_id, req_meta: req_meta)
+    worker._mark_layer_reuse_pending = MagicMock()
+
+    connector_metadata = MooncakeLayerwiseConnectorMetadata()
+    req_meta = MagicMock()
+    req_meta.local_block_ids = [[1]]
+    connector_metadata.requests["req"] = req_meta
+    return worker, connector_metadata
+
+
+def test_mooncake_save_consumes_early_cache_write_event():
+    worker, connector_metadata = _make_worker_for_cache_write_event_test()
+    cache_write_event = MagicMock()
+
+    with patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.npu.Event",
+        return_value=cache_write_event,
+    ):
+        worker.on_kv_cache_written("layer0")
+        worker.save_kv_layer("layer0", [MagicMock(), MagicMock()], MagicMock(), connector_metadata)
+
+    cache_write_event.record.assert_called_once_with()
+    queued_send_task = worker.kv_send_layer_thread.send_queue.put.call_args.args[0]
+    assert queued_send_task.wait_event is cache_write_event
+    assert worker._cache_write_events == [None]
+
+
+def test_mooncake_save_records_fallback_event_without_early_hook():
+    worker, connector_metadata = _make_worker_for_cache_write_event_test()
+    fallback_event = MagicMock()
+
+    with patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.npu.Event",
+        return_value=fallback_event,
+    ):
+        worker.save_kv_layer("layer0", [MagicMock(), MagicMock()], MagicMock(), connector_metadata)
+
+    fallback_event.record.assert_called_once_with()
+    queued_send_task = worker.kv_send_layer_thread.send_queue.put.call_args.args[0]
+    assert queued_send_task.wait_event is fallback_event
 
 
 class TestMooncakeLayerwiseConnectorWorker(unittest.TestCase):
@@ -1240,3 +1439,162 @@ class TestMooncakeLayerwiseConnectorWorker(unittest.TestCase):
         worker.register_kv_caches(mla_caches)
         self.assertTrue(worker.use_mla)
         self.assertEqual(len(worker.layer_metadata["encoder.layer.0"].block_len), 2)
+
+    def test_register_kv_caches_rejects_sparse_sfa_c8_main_cache(self):
+        layer_name = "model.layers.0.self_attn.attn"
+        group = MagicMock()
+        group.kv_cache_spec = UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={layer_name: SimpleNamespace(block_size=16, cache_sparse_sfa_c8=True)},
+        )
+        group.layer_names = [layer_name]
+        kv_cache_config = MagicMock()
+        kv_cache_config.kv_cache_groups = [group]
+        kv_cache_config.kv_cache_tensors = []
+        kv_cache_config.num_blocks = 10
+        worker = MooncakeLayerwiseConnectorWorker(self.vllm_config, kv_cache_config, self.engine_id)
+
+        with self.assertRaisesRegex(NotImplementedError, "does not support sparse SFA C8 packed main KV cache"):
+            worker.register_kv_caches({layer_name: (MagicMock(),)})
+
+        self.assertEqual(worker.layer_metadata, {})
+
+    def test_register_kv_caches_groups_optional_indexer_by_physical_layer(self):
+        main_0 = "model.layers.0.self_attn.attn"
+        indexer_0 = "model.layers.0.self_attn.indexer.k_cache"
+        main_1 = "model.layers.1.self_attn.attn"
+        group = MagicMock()
+        group.kv_cache_spec = MagicMock(block_size=16)
+        group.layer_names = [main_0, indexer_0, main_1]
+        kv_cache_config = MagicMock()
+        kv_cache_config.kv_cache_groups = [group]
+        kv_cache_config.kv_cache_tensors = []
+        kv_cache_config.num_blocks = 10
+
+        def make_cache(addr, tensor_count=2):
+            caches = []
+            for offset in range(tensor_count):
+                cache = MagicMock()
+                cache.shape = (10, 16, 1, 16)
+                cache.data_ptr.return_value = addr + offset * 0x1000
+                cache.element_size.return_value = 4
+                caches.append(cache)
+            return tuple(caches)
+
+        kv_caches = {
+            main_0: make_cache(0x10000),
+            indexer_0: make_cache(0x20000, tensor_count=1),
+            main_1: make_cache(0x30000),
+        }
+        worker = MooncakeLayerwiseConnectorWorker(self.vllm_config, kv_cache_config, self.engine_id)
+
+        worker.register_kv_caches(kv_caches)
+
+        self.assertEqual(worker.index_to_name[0], [main_0, indexer_0])
+        self.assertEqual(worker.index_to_name[1], [main_1])
+        self.assertEqual(worker.total_layers, 2)
+
+    def test_register_kv_caches_rejects_dcp_replicated_indexer_scale(self):
+        main_name = "model.layers.0.self_attn.attn"
+        indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+        group = MagicMock()
+        group.kv_cache_spec = MagicMock(block_size=16)
+        group.layer_names = [main_name, indexer_name]
+        kv_cache_config = MagicMock()
+        kv_cache_config.kv_cache_groups = [group]
+        kv_cache_config.kv_cache_tensors = []
+        kv_cache_config.num_blocks = 10
+
+        main_cache = MagicMock()
+        main_cache.shape = (10, 16, 1, 16)
+        main_cache.data_ptr.return_value = 0x10000
+        main_cache.element_size.return_value = 4
+        indexer_cache = MagicMock()
+        indexer_cache.shape = (20, 16, 1, 16)
+        indexer_cache.data_ptr.return_value = 0x20000
+        indexer_cache.element_size.return_value = 4
+        worker = MooncakeLayerwiseConnectorWorker(self.vllm_config, kv_cache_config, self.engine_id)
+
+        with (
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.global_te.register_buffer"
+            ) as register_buffer,
+            self.assertRaisesRegex(NotImplementedError, "DCP replicated indexer cache"),
+        ):
+            worker.register_kv_caches(
+                {
+                    main_name: (main_cache,),
+                    indexer_name: (indexer_cache,),
+                }
+            )
+
+        register_buffer.assert_not_called()
+
+    def test_register_kv_caches_rejects_components_in_different_groups(self):
+        main_name = "model.layers.0.self_attn.attn"
+        indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+        main_group = MagicMock()
+        main_group.kv_cache_spec = MagicMock(block_size=16)
+        main_group.layer_names = [main_name]
+        indexer_group = MagicMock()
+        indexer_group.kv_cache_spec = MagicMock(block_size=16)
+        indexer_group.layer_names = [indexer_name]
+        kv_cache_config = MagicMock()
+        kv_cache_config.kv_cache_groups = [main_group, indexer_group]
+        kv_cache_config.kv_cache_tensors = []
+        kv_cache_config.num_blocks = 10
+
+        def make_cache(addr, tensor_count):
+            caches = []
+            for offset in range(tensor_count):
+                cache = MagicMock()
+                cache.shape = (10, 16, 1, 16)
+                cache.data_ptr.return_value = addr + offset * 0x1000
+                cache.element_size.return_value = 4
+                caches.append(cache)
+            return tuple(caches)
+
+        kv_caches = {
+            main_name: make_cache(0x10000, 2),
+            indexer_name: make_cache(0x20000, 1),
+        }
+        worker = MooncakeLayerwiseConnectorWorker(self.vllm_config, kv_cache_config, self.engine_id)
+
+        with self.assertRaisesRegex(AssertionError, "must share one KV cache group"):
+            worker.register_kv_caches(kv_caches)
+
+    def test_register_kv_caches_uses_main_cache_for_quant_staging_buffer(self):
+        main_name = "model.layers.0.self_attn.attn"
+        indexer_name = "model.layers.0.self_attn.indexer.k_cache"
+        group = MagicMock()
+        group.kv_cache_spec = MagicMock(block_size=16)
+        group.layer_names = [indexer_name, main_name]
+        kv_cache_config = MagicMock()
+        kv_cache_config.kv_cache_groups = [group]
+        kv_cache_config.kv_cache_tensors = []
+        kv_cache_config.num_blocks = 10
+
+        indexer_cache = MagicMock()
+        indexer_cache.shape = (10, 16, 1, 16)
+        indexer_cache.data_ptr.return_value = 0x10000
+        indexer_cache.element_size.return_value = 4
+        main_k_cache = MagicMock()
+        main_k_cache.shape = (10, 16, 1, 16)
+        main_k_cache.data_ptr.return_value = 0x20000
+        main_k_cache.element_size.return_value = 4
+        main_v_cache = MagicMock()
+        main_v_cache.shape = (10, 16, 1, 16)
+        main_v_cache.data_ptr.return_value = 0x30000
+        main_v_cache.element_size.return_value = 4
+        main_cache = (main_k_cache, main_v_cache)
+        kv_caches = {
+            indexer_name: (indexer_cache,),
+            main_name: main_cache,
+        }
+        worker = MooncakeLayerwiseConnectorWorker(self.vllm_config, kv_cache_config, self.engine_id)
+        worker.enable_kv_quant = True
+        worker.create_kv_buffer = MagicMock()
+
+        worker.register_kv_caches(kv_caches)
+
+        worker.create_kv_buffer.assert_called_once_with(main_cache)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -116,6 +116,42 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(k_cache_raw.numel(), kv_cache_spec.page_size_bytes)
         self.assertEqual(v_cache_raw.numel(), kv_cache_spec.page_size_bytes)
 
+    def test_sparse_c8_indexer_reuses_raw_cache_from_shared_descriptor(self):
+        runner = self._build_runner()
+        layer_names = [
+            "model.layers.1.self_attn.indexer.k_cache",
+            "model.layers.3.self_attn.indexer.k_cache",
+        ]
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_c8=True,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=indexer_spec.page_size_bytes * 2,
+                    shared_by=layer_names,
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=layer_names,
+                    kv_cache_spec=indexer_spec,
+                )
+            ],
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+
+        assert raw_caches[layer_names[0]][0] is raw_caches[layer_names[1]][0]
+        assert raw_caches[layer_names[0]][1] is raw_caches[layer_names[1]][1]
+
     def test_reshape_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()
         runner.sparse_kv_offload_enabled = False

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call, patch
 import numpy as np
 import torch
 from vllm.model_executor.layers.attention import MLAAttention
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -115,6 +116,46 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache_raw.numel(), kv_cache_spec.page_size_bytes)
         self.assertEqual(v_cache_raw.numel(), kv_cache_spec.page_size_bytes)
+
+    def test_get_layer_kv_cache_specs_restores_sfa_indexer_spec(self):
+        runner = self._build_runner()
+        layer_name = "model.layers.1.self_attn.indexer.k_cache"
+        grouped_spec = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+        )
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+        )
+        indexer_layer = MagicMock(spec=AttentionLayerBase)
+        indexer_layer.get_kv_cache_spec.return_value = indexer_spec
+        runner.compilation_config = SimpleNamespace(
+            static_forward_context={layer_name: indexer_layer},
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=2,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=grouped_spec.page_size_bytes * 2,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=grouped_spec,
+                )
+            ],
+        )
+
+        layer_specs = runner._get_layer_kv_cache_specs(kv_cache_config)
+
+        self.assertIs(layer_specs[layer_name], indexer_spec)
 
     def test_sparse_c8_indexer_reuses_raw_cache_from_shared_descriptor(self):
         runner = self._build_runner()

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -129,7 +129,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             dtype=torch.int8,
             scale_dim=1,
             scale_dtype=torch.float16,
-            cache_sparse_c8=True,
+            cache_sparse_li_c8=True,
         )
         kv_cache_config = KVCacheConfig(
             num_blocks=2,

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -53,6 +53,97 @@ class TestNPUWorker(TestBase):
         self.distributed_init_method = "tcp://localhost:12345"
         self.is_driver_worker = False
 
+    def test_sparse_c8_layer_reuse_memory_factor_counts_slot_components(self):
+        from vllm_ascend.core.kv_cache_interface import (
+            AscendMLAAttentionSpec,
+            AscendSFAIndexerCacheSpec,
+        )
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 6
+        main_spec = AscendMLAAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.int8,
+            cache_sparse_c8=True,
+        )
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_c8=True,
+        )
+        specs = {
+            **{f"model.layers.{layer}.self_attn.attn": main_spec for layer in range(6)},
+            **{f"model.layers.{layer}.self_attn.indexer.k_cache": indexer_spec for layer in (1, 2, 4)},
+        }
+
+        num_layers, num_slots, factor = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {"layerwise_num_shared_buffers": 2},
+        )
+
+        expected_logical_bytes = 6 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
+        expected_physical_bytes = 4 * main_spec.page_size_bytes + 2 * indexer_spec.page_size_bytes
+        self.assertEqual((num_layers, num_slots), (6, 4))
+        self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
+
+    def test_incomplete_layer_layout_does_not_scale_memory_budget(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 4
+        specs = {
+            "model.layers.0.self_attn.attn": MagicMock(),
+            "model.layers.1.self_attn.attn": MagicMock(),
+        }
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+        )
+
+        self.assertEqual(memory_info, (2, 2, 1.0))
+
+    @patch(
+        "vllm_ascend.worker.worker.build_layerwise_reuse_layout",
+        side_effect=AssertionError("layout should not be built"),
+    )
+    def test_no_reuse_does_not_build_layerwise_memory_layout(
+        self,
+        _mock_build_layout,
+    ):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        specs = {
+            "model.layers.0.self_attn.attn": MagicMock(),
+            "model.layers.1.self_attn.attn": MagicMock(),
+            "model.mtp.0.self_attn.attn": MagicMock(),
+        }
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {"layerwise_num_shared_buffers": 3},
+        )
+
+        self.assertEqual(memory_info, (3, 3, 1.0))
+
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.ops")
     @patch("vllm_ascend.worker.worker._register_atb_extensions")

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 from vllm.config import CacheConfig, ModelConfig, ParallelConfig, ProfilerConfig, VllmConfig
+from vllm.v1.kv_cache_interface import FullAttentionSpec
 
 from tests.ut.base import TestBase
 
@@ -53,7 +54,7 @@ class TestNPUWorker(TestBase):
         self.distributed_init_method = "tcp://localhost:12345"
         self.is_driver_worker = False
 
-    def test_sparse_c8_layer_reuse_memory_factor_counts_slot_components(self):
+    def test_layer_reuse_memory_factor_counts_complete_slot_signatures(self):
         from vllm_ascend.core.kv_cache_interface import (
             AscendMLAAttentionSpec,
             AscendSFAIndexerCacheSpec,
@@ -69,7 +70,7 @@ class TestNPUWorker(TestBase):
             num_kv_heads=1,
             head_size=8,
             dtype=torch.int8,
-            cache_sparse_c8=True,
+            cache_sparse_sfa_c8=True,
         )
         indexer_spec = AscendSFAIndexerCacheSpec(
             block_size=2,
@@ -78,7 +79,7 @@ class TestNPUWorker(TestBase):
             dtype=torch.int8,
             scale_dim=1,
             scale_dtype=torch.float16,
-            cache_sparse_c8=True,
+            cache_sparse_li_c8=True,
         )
         specs = {
             **{f"model.layers.{layer}.self_attn.attn": main_spec for layer in range(6)},
@@ -91,8 +92,8 @@ class TestNPUWorker(TestBase):
         )
 
         expected_logical_bytes = 6 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
-        expected_physical_bytes = 4 * main_spec.page_size_bytes + 2 * indexer_spec.page_size_bytes
-        self.assertEqual((num_layers, num_slots), (6, 4))
+        expected_physical_bytes = 5 * main_spec.page_size_bytes + 2 * indexer_spec.page_size_bytes
+        self.assertEqual((num_layers, num_slots), (6, 5))
         self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
 
     def test_incomplete_layer_layout_does_not_scale_memory_budget(self):
@@ -117,24 +118,24 @@ class TestNPUWorker(TestBase):
 
         self.assertEqual(memory_info, (2, 2, 1.0))
 
-    @patch(
-        "vllm_ascend.worker.worker.build_layerwise_reuse_layout",
-        side_effect=AssertionError("layout should not be built"),
-    )
-    def test_no_reuse_does_not_build_layerwise_memory_layout(
-        self,
-        _mock_build_layout,
-    ):
+    def test_no_reuse_does_not_scale_layerwise_memory_layout(self):
         from vllm_ascend.worker.worker import NPUWorker
 
         worker = NPUWorker.__new__(NPUWorker)
         worker.model_config = MagicMock()
         worker.parallel_config = MagicMock()
         worker.model_config.get_num_layers.return_value = 2
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            head_size_v=8,
+            dtype=torch.int8,
+        )
         specs = {
-            "model.layers.0.self_attn.attn": MagicMock(),
-            "model.layers.1.self_attn.attn": MagicMock(),
-            "model.mtp.0.self_attn.attn": MagicMock(),
+            "model.layers.0.self_attn.attn": spec,
+            "model.layers.1.self_attn.attn": spec,
+            "model.mtp.0.self_attn.attn": spec,
         }
 
         memory_info = worker._get_layerwise_kv_cache_memory_info(

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -92,7 +92,8 @@ class TestNPUWorker(TestBase):
         )
 
         expected_logical_bytes = 6 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
-        expected_physical_bytes = 3 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
+        # Both reused slots contain indexer layers; the independent slot does not.
+        expected_physical_bytes = 3 * main_spec.page_size_bytes + 2 * indexer_spec.page_size_bytes
         self.assertEqual((num_layers, num_slots), (6, 3))
         self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
 

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -590,6 +590,7 @@ class TestNPUWorker(TestBase):
         mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         with patch.object(NPUWorker, "__init__", lambda x, **kwargs: None):
             worker = NPUWorker()
+            worker.vllm_config = MagicMock(kv_transfer_config=None)
             mock_model_runner = MagicMock()
             worker.model_runner = mock_model_runner
 

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -54,7 +54,7 @@ class TestNPUWorker(TestBase):
         self.distributed_init_method = "tcp://localhost:12345"
         self.is_driver_worker = False
 
-    def test_layer_reuse_memory_factor_counts_complete_slot_signatures(self):
+    def test_layer_reuse_memory_factor_merges_main_components(self):
         from vllm_ascend.core.kv_cache_interface import (
             AscendMLAAttentionSpec,
             AscendSFAIndexerCacheSpec,
@@ -92,8 +92,56 @@ class TestNPUWorker(TestBase):
         )
 
         expected_logical_bytes = 6 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
-        expected_physical_bytes = 5 * main_spec.page_size_bytes + 2 * indexer_spec.page_size_bytes
-        self.assertEqual((num_layers, num_slots), (6, 5))
+        expected_physical_bytes = 3 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
+        self.assertEqual((num_layers, num_slots), (6, 3))
+        self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
+
+    def test_layer_reuse_memory_factor_counts_components_per_buffer(self):
+        from vllm_ascend.core.kv_cache_interface import (
+            AscendMLAAttentionSpec,
+            AscendSFAIndexerCacheSpec,
+        )
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 6
+        main_spec = AscendMLAAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.int8,
+            cache_sparse_sfa_c8=True,
+        )
+        indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_li_c8=True,
+        )
+        # A/B-mixed with MTP: layers 0,1,4 have main + indexer; layers 2,3,5 and MTP are
+        # main-only. Main is shared by all reused layers; indexer only by A-class layers.
+        specs = {
+            **{f"model.layers.{layer}.self_attn.attn": main_spec for layer in range(6)},
+            **{f"model.layers.{layer}.self_attn.indexer.k_cache": indexer_spec for layer in (0, 1, 4)},
+            "model.mtp.0.self_attn.attn": main_spec,
+        }
+
+        num_layers, num_slots, factor = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {"layerwise_num_shared_buffers": 2},
+        )
+
+        # Layer 0 independent; reused layers split into buffers [1,3,5] and [2,4,6] -> 3
+        # main tensors. Each reused buffer holds an A-class layer (1 and 4), so indexer is
+        # counted once per buffer: independent + both reused == 3 indexer slots.
+        expected_logical_bytes = 7 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
+        expected_physical_bytes = 3 * main_spec.page_size_bytes + 3 * indexer_spec.page_size_bytes
+        self.assertEqual((num_layers, num_slots), (7, 3))
         self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
 
     def test_incomplete_layer_layout_does_not_scale_memory_budget(self):

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1975,9 +1975,6 @@ class AscendSFAImpl(MLAAttentionImpl):
                 assert k_li is not None
                 k_li = self._get_full_kv(k_li, attn_metadata)
 
-        if kv_cache is not None and self.is_kv_producer:
-            attn_metadata.reshape_cache_event = torch.npu.Event()
-
         if kv_cache is not None and self.has_indexer:
             assert k_li is not None
             use_li_c8_reshape_optim = self._use_li_c8_reshape_optim()

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -2014,6 +2014,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                             slot_mapping.view(-1, 1),
                             k_li_scale.view(-1, k_li_scale.shape[-1]),
                         )
+        # Notify for every layer that wrote the cache, not just indexer layers:
+        # by this point all of the layer's KV (main + indexer) has been
+        # scattered, so the connector can start the outgoing transfer.
+        if kv_cache is not None:
             notify_kv_cache_written(self.layer_name or "")
 
         if self.enable_dsa_cp and attn_metadata.dsa_cp_context is not None:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -136,6 +136,8 @@ class SendTask:
     v_quant_cache: torch.Tensor | None = None
     layer_idx: int = 0
     layer_name: str = ""
+    layer_names: list[str] = field(default_factory=list)
+    failed_requests: dict[str, ReqMeta] = field(default_factory=dict)
     # trans block info
     group_rearrange_block_ids: list[list[int]] | None = None
     group_num_blocks: list[int] | None = None
@@ -278,25 +280,53 @@ class KVCacheSendingLayerThread(threading.Thread):
     def _handle_request(self, send_task: SendTask):
         error: str | None = None
         try:
-            self._transfer_kv_cache(send_task)
+            error = self._transfer_kv_cache(send_task)
         except Exception as e:
             error = str(e)
-            logger.error(
-                "Failed to transfer KV cache. layer_idx=%s, error=%s. Check transfer engine and memory state.",
-                send_task.layer_idx,
-                e,
-            )
+            self.failed_reqs.update(send_task.send_request)
         finally:
+            if error is not None:
+                logger.error(
+                    "Failed to transfer KV cache. layer_idx=%s, error=%s. Check transfer engine and memory state.",
+                    send_task.layer_idx,
+                    error,
+                )
+            self.failed_reqs.update(send_task.failed_requests)
+            if send_task.layer_idx == (self.total_layers - 1):
+                completion_requests = {
+                    **send_task.send_request,
+                    **send_task.failed_requests,
+                }
+                if completion_requests:
+                    primary_group_idx = self.layer_metadata[send_task.layer_name].tensor_group_idx[0]
+                    for req_id, req_meta in completion_requests.items():
+                        if not req_meta.chunk_finish:
+                            continue
+                        transfer_succeeded = req_id not in self.failed_reqs
+                        self.callback_func(
+                            req_id,
+                            req_meta,
+                            primary_group_idx,
+                            trans_flag=transfer_succeeded,
+                        )
+                        if not transfer_succeeded:
+                            self.failed_reqs.discard(req_id)
             if self.reuse_completion_callback is not None:
                 self.reuse_completion_callback(send_task.layer_idx, error)
             self.send_queue.task_done()
 
-    def get_transfer_meta(self, send_task: SendTask, req_id: str, req_meta: ReqMeta, layer_group_idx: int):
+    def get_transfer_meta(
+        self,
+        send_task: SendTask,
+        req_id: str,
+        req_meta: ReqMeta,
+        layer_name: str,
+        layer_group_idx: int,
+    ):
         src_list: list[int] = []
         dst_list: list[int] = []
         length_list: list[int] = []
 
-        layer_name = send_task.layer_name
         layer_kv_cache_spec = self.kv_cache_specs[layer_group_idx]
         remote_block_ids = req_meta.remote_block_ids[layer_group_idx]
         remote_layer_metadata = req_meta.remote_layer_metadata[layer_name]
@@ -373,7 +403,10 @@ class KVCacheSendingLayerThread(threading.Thread):
                 )
                 length_list.append(local_ssm_len)
         else:
-            if self.pd_head_ratio == 1:
+            use_staging_buffer = layer_name == send_task.layer_name and (
+                send_task.k_cache is not None or send_task.k_quant_cache is not None
+            )
+            if self.pd_head_ratio == 1 or not use_staging_buffer:
                 layer_local_kv_base_addr = local_layer_metadata.kv_caches_base_addr
                 layer_remote_kv_base_addr = remote_layer_metadata.kv_caches_base_addr
                 block_lens = local_layer_metadata.block_len
@@ -381,7 +414,11 @@ class KVCacheSendingLayerThread(threading.Thread):
                     remote_block_ids, local_block_ids
                 )
                 # kv cache quantization scenario
-                if (self.enable_kv_quant or self.enable_c8_quant) and send_task.k_quant_cache is not None:
+                if (
+                    use_staging_buffer
+                    and (self.enable_kv_quant or self.enable_c8_quant)
+                    and send_task.k_quant_cache is not None
+                ):
                     assert len(block_lens) == 2, "Quantization block length must be 2!"
                     if self.enable_kv_quant:
                         quant_block_lens = [block_lens[0] // 2, block_lens[1]]
@@ -453,9 +490,7 @@ class KVCacheSendingLayerThread(threading.Thread):
                         length_list.append(block_len)
         return (src_list, dst_list, length_list)
 
-    def _transfer_kv_cache(self, send_task: SendTask):
-        layer_name = send_task.layer_name
-        layer_group_idx = self.layer_metadata[layer_name].tensor_group_idx[0]
+    def _transfer_kv_cache(self, send_task: SendTask) -> str | None:
         key = send_task.k_cache
         value = send_task.v_cache
         if self.pd_head_ratio > 1 and key is not None and value is not None:
@@ -475,16 +510,24 @@ class KVCacheSendingLayerThread(threading.Thread):
 
         # Merge transmission tasks of the same session
         session_meta: dict[str, TransferMeta] = {}
+        layer_names = send_task.layer_names or [send_task.layer_name]
+        layer_group_idx = self.layer_metadata[send_task.layer_name].tensor_group_idx[0]
         for req_id, req_meta in send_task.send_request.items():
             session_id = f"{req_meta.remote_host}:{req_meta.remote_te_rpc_port}"
             if session_id not in session_meta:
                 session_meta[session_id] = TransferMeta(src=[], dst=[], length=[], req_ids=[])
 
-            (src_list, dst_list, length_list) = self.get_transfer_meta(send_task, req_id, req_meta, layer_group_idx)
-
-            session_meta[session_id].src.extend(src_list)
-            session_meta[session_id].dst.extend(dst_list)
-            session_meta[session_id].length.extend(length_list)
+            for layer_name in layer_names:
+                src_list, dst_list, length_list = self.get_transfer_meta(
+                    send_task,
+                    req_id,
+                    req_meta,
+                    layer_name,
+                    layer_group_idx,
+                )
+                session_meta[session_id].src.extend(src_list)
+                session_meta[session_id].dst.extend(dst_list)
+                session_meta[session_id].length.extend(length_list)
             session_meta[session_id].req_ids.append(req_id)
 
         if send_task.k_quant_cache is not None:
@@ -524,18 +567,7 @@ class KVCacheSendingLayerThread(threading.Thread):
                         session_id,
                         req_transfer_elapsed,
                     )
-                if send_task.layer_idx == (self.total_layers - 1):
-                    for req_id in transfer_meta.req_ids:
-                        req_meta = send_task.send_request[req_id]
-                        if req_meta.chunk_finish:
-                            if req_id in self.failed_reqs:
-                                self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=False)
-                                self.failed_reqs.discard(req_id)
-                            else:
-                                self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=True)
-
-        if transfer_errors:
-            raise RuntimeError("; ".join(transfer_errors))
+        return "; ".join(transfer_errors) if transfer_errors else None
 
 
 class KVCacheRecvingLayerThread(threading.Thread):
@@ -792,6 +824,15 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_layer_reuse(self, layer_idx: int) -> None:
         assert self.connector_worker is not None
         self.connector_worker.wait_for_layer_reuse(layer_idx)
+
+    def on_kv_cache_written(self, layer_name: str = "") -> None:
+        if not self._is_kv_producer or not self.has_connector_metadata():
+            return
+        assert isinstance(self._connector_metadata, MooncakeLayerwiseConnectorMetadata)
+        if not self._connector_metadata.requests:
+            return
+        assert self.connector_worker is not None
+        self.connector_worker.on_kv_cache_written(layer_name)
 
     def save_kv_layer(
         self, layer_name: str, kv_layer: list[torch.Tensor], attn_metadata: "AttentionMetadata", **kwargs
@@ -1199,6 +1240,7 @@ class MooncakeLayerwiseConnectorWorker:
         self._storage_send_errors: dict[int, str] = {}
         self._pending_reuse_layers: set[int] = set()
         self._layerwise_reuse_lock = threading.Lock()
+        self._cache_write_events: list[torch.npu.Event | None] = [None] * self.total_layers
 
         self.block_size: list[int] = [spec.block_size for spec in self.kv_cache_specs]
         self.kernel_block_size_scale: list[int] = [1 for _ in range(self.num_kv_cache_groups)]
@@ -1351,8 +1393,8 @@ class MooncakeLayerwiseConnectorWorker:
 
         ptrs = []
         lengths = []
-        use_kv_buffer = False
         kv_buffer = None
+        group_block_size_scales: dict[int, int] = {}
         for layer_name, kv_cache_tuple in kv_caches.items():
             if isinstance(kv_cache_tuple, (list, tuple)) is False:
                 kv_cache_tuple = [kv_cache_tuple]
@@ -1360,14 +1402,17 @@ class MooncakeLayerwiseConnectorWorker:
             layer_kv_cache_spec = kv_cache_groups[layer_kv_group_id].kv_cache_spec
             if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                 layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
+            if getattr(layer_kv_cache_spec, "cache_sparse_sfa_c8", False) is True:
+                raise NotImplementedError(
+                    "Mooncake layerwise connector does not support sparse SFA C8 packed main KV cache yet."
+                )
             if (
                 (self.pd_head_ratio > 1 and (isinstance(layer_kv_cache_spec, (FullAttentionSpec, SlidingWindowSpec))))
                 or self.enable_kv_quant
                 or self.enable_c8_quant
             ):
                 self.attn_resharding_group_idx.add(layer_kv_group_id)
-                if use_kv_buffer is False:
-                    use_kv_buffer = True
+                if kv_buffer is None and "indexer" not in layer_name.lower():
                     kv_buffer = kv_cache_tuple
             single_layer_meta = LayerMetadata([], [], [], [])
             for single_kv_cache in kv_cache_tuple:
@@ -1378,6 +1423,15 @@ class MooncakeLayerwiseConnectorWorker:
                     "The external block size must be an integer multiple of the kernel block size."
                 )
                 block_size_scale = tensor_num_blocks // num_blocks
+                group_block_size_scale = group_block_size_scales.setdefault(
+                    layer_kv_group_id,
+                    block_size_scale,
+                )
+                if group_block_size_scale != block_size_scale:
+                    raise NotImplementedError(
+                        "Mooncake layerwise connector does not support KV cache components "
+                        "with different block size scales in one group, including DCP replicated indexer cache."
+                    )
                 block_shape = single_kv_cache.shape[block_start_rank:]
                 single_layer_meta.tensor_group_idx.append(layer_kv_group_id)
                 single_layer_meta.kv_caches_base_addr.append(single_kv_cache.data_ptr())
@@ -1413,7 +1467,7 @@ class MooncakeLayerwiseConnectorWorker:
         validate_register_region_count(register_regions)
         global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
 
-        if use_kv_buffer:
+        if kv_buffer is not None:
             self.create_kv_buffer(kv_buffer)
 
         model_type = self.vllm_config.model_config.hf_text_config.model_type
@@ -1423,14 +1477,18 @@ class MooncakeLayerwiseConnectorWorker:
             if "mtp" in layer_name:
                 mtp_layer_name = layer_name
                 continue
-            self.index_to_name[extract_layer_index(layer_name, num_attn_module)].append(layer_name)
-            assert len(self.index_to_name[extract_layer_index(layer_name, num_attn_module)]) == 1, (
-                "Mooncake Layerwise Connector does not support multiple `attn_module` in one layer now."
+            layer_idx = extract_layer_index(layer_name, num_attn_module)
+            self.index_to_name[layer_idx].append(layer_name)
+        for layer_names in self.index_to_name.values():
+            layer_names.sort(key=lambda name: "indexer" in name.lower())
+            primary_group_idx = self.layer_metadata[layer_names[0]].tensor_group_idx[0]
+            assert all(self.layer_metadata[name].tensor_group_idx[0] == primary_group_idx for name in layer_names), (
+                f"Mooncake layerwise merged components must share one KV cache group. layer_names={layer_names}"
             )
         if mtp_layer_name != "":
             self.index_to_name[max(self.index_to_name.keys()) + 1].append(mtp_layer_name)
-        if self.total_layers < len(self.layer_metadata.keys()):
-            self.total_layers = len(self.layer_metadata.keys())
+        if self.index_to_name:
+            self.total_layers = max(self.total_layers, max(self.index_to_name) + 1)
 
         self._init_layerwise_reuse_state()
 
@@ -1687,6 +1745,7 @@ class MooncakeLayerwiseConnectorWorker:
     def start_load_kv(self, metadata: MooncakeLayerwiseConnectorMetadata):
         """Start loading KV blocks from remote engine."""
         self.current_layer = 0
+        self._cache_write_events = [None] * self.total_layers
         if self.vllm_config.kv_transfer_config.is_kv_consumer:
             for req_id, meta in metadata.requests.items():
                 if meta.do_virtual:
@@ -1771,6 +1830,21 @@ class MooncakeLayerwiseConnectorWorker:
                     )
                     send_task.group_seq_start_tensor[i] = torch.tensor([0], dtype=torch.int32, device=device)
 
+    def on_kv_cache_written(self, layer_name: str) -> None:
+        if self.current_layer >= self.total_layers:
+            return
+        layer_names = self.index_to_name[self.current_layer]
+        if not layer_names:
+            raise RuntimeError(f"Mooncake layerwise metadata is missing physical layer {self.current_layer}")
+        if layer_name and layer_name not in layer_names:
+            raise RuntimeError(
+                f"Mooncake layer hook {layer_name!r} does not belong to physical layer {self.current_layer}: "
+                f"{layer_names}"
+            )
+        cache_write_event = torch.npu.Event()
+        cache_write_event.record()
+        self._cache_write_events[self.current_layer] = cache_write_event
+
     def save_kv_layer(
         self,
         layer_name: str,
@@ -1784,24 +1858,24 @@ class MooncakeLayerwiseConnectorWorker:
             if self.current_layer >= self.total_layers:
                 self.current_layer += 1
                 return
-            # get reshape and cache event
+            layer_names = self.index_to_name[self.current_layer]
+            if not layer_names:
+                raise RuntimeError(f"Mooncake layerwise metadata is missing physical layer {self.current_layer}")
+            # Use the scatter-time event recorded by on_kv_cache_written.
+            # The fallback preserves correctness for attention paths that do
+            # not call the early hook, but gives up transfer/compute overlap.
             if layer_name == "":
-                layer_name = self.index_to_name[self.current_layer][0]
-            if (
-                isinstance(attn_metadata, dict)
-                and hasattr(attn_metadata[layer_name], "reshape_cache_event")
-                and attn_metadata[layer_name].reshape_cache_event is not None
-            ):
-                reshape_cache_event = attn_metadata[layer_name].reshape_cache_event
-            elif (
-                attn_metadata
-                and hasattr(attn_metadata, "reshape_cache_event")
-                and attn_metadata.reshape_cache_event is not None
-            ):
-                reshape_cache_event = attn_metadata.reshape_cache_event
-            else:
-                reshape_cache_event = torch.npu.Event()
-                reshape_cache_event.record()
+                layer_name = layer_names[0]
+            elif layer_name not in layer_names:
+                raise RuntimeError(
+                    f"Mooncake layer hook {layer_name!r} does not belong to physical layer {self.current_layer}: "
+                    f"{layer_names}"
+                )
+            cache_write_event = self._cache_write_events[self.current_layer]
+            self._cache_write_events[self.current_layer] = None
+            if cache_write_event is None:
+                cache_write_event = torch.npu.Event()
+                cache_write_event.record()
             send_task = connector_metadata.send_task
             layer_group_idx = self.layer_metadata[layer_name].tensor_group_idx[0]
             keys = None
@@ -1819,7 +1893,7 @@ class MooncakeLayerwiseConnectorWorker:
             ):
                 assert self.resharding_stream is not None
                 with npu_stream_switch(self.resharding_stream):
-                    reshape_cache_event.wait()
+                    cache_write_event.wait()
                     device = self.k_buffer.device  # type: ignore
                     # Initialize buffers
                     keys = torch.empty(
@@ -1890,19 +1964,19 @@ class MooncakeLayerwiseConnectorWorker:
                         quant_values = self.get_nz_cache(values, layer_group_idx)
 
             assert self.kv_send_layer_thread is not None
-            assert reshape_cache_event is not None
             layer_send_task = SendTask(
-                wait_event=reshape_cache_event,
+                wait_event=cache_write_event,
                 k_cache=keys,
                 v_cache=values,
                 k_quant_cache=quant_keys,
                 v_quant_cache=quant_values,
                 layer_idx=self.current_layer,
                 layer_name=layer_name,
+                layer_names=layer_names,
                 group_rearrange_block_ids=send_task.group_rearrange_block_ids,
             )
             for req_id, req_meta in connector_metadata.requests.items():
-                if len(req_meta.local_block_ids[layer_group_idx]) == 0:
+                if len(req_meta.local_block_ids) <= layer_group_idx or not req_meta.local_block_ids[layer_group_idx]:
                     continue
                 try:
                     req_meta_update = self.update_decoder_info(req_id, req_meta)
@@ -1913,6 +1987,7 @@ class MooncakeLayerwiseConnectorWorker:
                         self.current_layer,
                         e,
                     )
+                    layer_send_task.failed_requests[req_id] = req_meta
                     continue
                 logger.debug("Add request %s to kv send layer thread. req_meta_update=%r", req_id, req_meta_update)
                 layer_send_task.send_request[req_id] = req_meta_update

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -266,6 +266,7 @@ class ChunkedTokenDatabase:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
+        self.group_layer_offsets: dict[int, list[int]] = {}
         self.group_cache_families: dict[str, dict[int, str]] = {
             "kv": {},
             "state": {},
@@ -373,6 +374,7 @@ class ChunkedTokenDatabase:
         cache_role: str = "kv",
         group_cache_families: dict[int, str] | None = None,
         group_num_layers: dict[int, int] | None = None,
+        group_layer_offsets: dict[int, list[int]] | None = None,
     ) -> None:
         if cache_role == "state":
             # Keep the interface for future explicit state groups, but this
@@ -382,6 +384,7 @@ class ChunkedTokenDatabase:
             self.group_kv_caches_base_addr = group_kv_caches_base_addr
             self.group_block_len = group_block_len
             self.group_block_stride = group_block_stride or {}
+            self.group_layer_offsets = group_layer_offsets or {}
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
             self._key_prefix_cache.clear()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -266,7 +266,7 @@ class ChunkedTokenDatabase:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
-        self.group_layer_offsets: dict[int, list[int]] = {}
+        self.group_layer_cache_entry_offsets: dict[int, list[int]] = {}
         self.group_cache_families: dict[str, dict[int, str]] = {
             "kv": {},
             "state": {},
@@ -374,7 +374,7 @@ class ChunkedTokenDatabase:
         cache_role: str = "kv",
         group_cache_families: dict[int, str] | None = None,
         group_num_layers: dict[int, int] | None = None,
-        group_layer_offsets: dict[int, list[int]] | None = None,
+        group_layer_cache_entry_offsets: dict[int, list[int]] | None = None,
     ) -> None:
         if cache_role == "state":
             # Keep the interface for future explicit state groups, but this
@@ -384,7 +384,7 @@ class ChunkedTokenDatabase:
             self.group_kv_caches_base_addr = group_kv_caches_base_addr
             self.group_block_len = group_block_len
             self.group_block_stride = group_block_stride or {}
-            self.group_layer_offsets = group_layer_offsets or {}
+            self.group_layer_cache_entry_offsets = group_layer_cache_entry_offsets or {}
         if group_cache_families is not None:
             self.group_cache_families[cache_role] = group_cache_families.copy()
             self._key_prefix_cache.clear()
@@ -922,8 +922,8 @@ class ReqMeta:
         load_block_gvas_np: np.ndarray | None = None,
         load_block_gvas_by_group_np: list[np.ndarray] | None = None,
         load_gva_block_offset: int = 0,
-        partial_save_gvas_by_group: list[int] | None = None,
-        partial_load_gvas_by_group: list[int] | None = None,
+        partial_save_gva_per_group: list[int] | None = None,
+        partial_load_gva_per_group: list[int] | None = None,
     ) -> None:
         if token_len_chunk is None:
             token_len_chunk = 0 if save_end_token is None else save_end_token
@@ -960,8 +960,8 @@ class ReqMeta:
         self.load_block_gvas_np = load_block_gvas_np
         self.load_block_gvas_by_group_np = load_block_gvas_by_group_np
         self.load_gva_block_offset = load_gva_block_offset
-        self.partial_save_gvas_by_group = partial_save_gvas_by_group or []
-        self.partial_load_gvas_by_group = partial_load_gvas_by_group or []
+        self.partial_save_gva_per_group = partial_save_gva_per_group or []
+        self.partial_load_gva_per_group = partial_load_gva_per_group or []
 
     @property
     def block_ids(self) -> list[int]:
@@ -987,8 +987,8 @@ class ReqMeta:
     block_gvas_by_group_np: list[np.ndarray] | None = None
     gva_block_offset: int = 0
     load_block_gvas_by_group_np: list[np.ndarray] | None = None
-    partial_save_gvas_by_group: list[int] = field(default_factory=list)
-    partial_load_gvas_by_group: list[int] = field(default_factory=list)
+    partial_save_gva_per_group: list[int] = field(default_factory=list)
+    partial_load_gva_per_group: list[int] = field(default_factory=list)
 
     @staticmethod
     def from_request_tracker(
@@ -1002,6 +1002,7 @@ class ReqMeta:
         original_block_size: list[int] | int | None = None,
         kv_cache_group_families: list[str] | None = None,
         save_partial_block: bool = False,
+        hash_block_size: int | None = None,
     ) -> ReqMeta | None:
         """Create the request metadata from a request tracker."""
         if block_hashes is None:
@@ -1022,14 +1023,20 @@ class ReqMeta:
             if discard_partial_chunks
             else target_token_len
         )
+        hash_block_size = hash_block_size or cache_transfer_granularity
+        assert cache_transfer_granularity % hash_block_size == 0
+        # Request hashes use hash_block_size, which may be finer than the
+        # transfer granularity used to advance num_saved_tokens.
+        hashes_per_transfer_block = cache_transfer_granularity // hash_block_size
         full_block_count = target_token_len // cache_transfer_granularity
+        available_full_block_count = len(block_hashes) // hashes_per_transfer_block
         boundary_without_hash = (
             target_token_len > 0
             and target_token_len % cache_transfer_granularity == 0
-            and full_block_count > len(block_hashes)
+            and full_block_count > available_full_block_count
         )
         if boundary_without_hash:
-            num_tokens_to_save = len(block_hashes) * cache_transfer_granularity
+            num_tokens_to_save = available_full_block_count * cache_transfer_granularity
         if tracker.last_block_gva is not None and (
             target_token_len % cache_transfer_granularity != 0 or boundary_without_hash
         ):
@@ -1039,11 +1046,11 @@ class ReqMeta:
         else:
             partial_block_index = None
 
-        has_partial_block = save_partial_block and (
+        should_save_partial_block = save_partial_block and (
             target_token_len % cache_transfer_granularity != 0 or boundary_without_hash
         )
         skip_save = skip_save or (
-            num_tokens_to_save < chunk_boundary and partial_block_index is None and not has_partial_block
+            num_tokens_to_save < chunk_boundary and partial_block_index is None and not should_save_partial_block
         )
         if skip_save and load_spec is None:
             return None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -60,13 +60,13 @@ class LayerBatchBuilder:
         )
         group_block_stride = token_database.group_block_stride.get(group_id, token_database.group_block_len[group_id])
         self._block_stride_np = np.asarray(group_block_stride, dtype=np.int64)
-        layer_offsets = token_database.group_layer_offsets.get(group_id)
-        if layer_offsets is None:
+        layer_cache_entry_offsets = token_database.group_layer_cache_entry_offsets.get(group_id)
+        if layer_cache_entry_offsets is None:
             caches_per_layer = max(1, self._block_len_np.shape[0] // max(1, num_layers))
-            layer_offsets = [
+            layer_cache_entry_offsets = [
                 min(layer * caches_per_layer, self._block_len_np.shape[0]) for layer in range(num_layers + 1)
             ]
-        self._layer_offsets_np = np.asarray(layer_offsets, dtype=np.int64)
+        self._layer_cache_entry_offsets_np = np.asarray(layer_cache_entry_offsets, dtype=np.int64)
         self._block_ids_buf: np.ndarray | None = None
         self._block_gvas_buf: np.ndarray | None = None
 
@@ -105,8 +105,8 @@ class LayerBatchBuilder:
         base_gvas_arr: np.ndarray,
         layer_id: int,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        base_offset = int(self._layer_offsets_np[layer_id])
-        end_offset = int(self._layer_offsets_np[layer_id + 1])
+        base_offset = int(self._layer_cache_entry_offsets_np[layer_id])
+        end_offset = int(self._layer_cache_entry_offsets_np[layer_id + 1])
         layer_base_addrs = self._kv_caches_base_addr_np[base_offset:end_offset]
         layer_block_len = self._block_len_np[base_offset:end_offset]
         layer_block_stride = self._block_stride_np[base_offset:end_offset]
@@ -240,11 +240,11 @@ class LayerBatchBuilder:
 
             if block_range.partial_block_index is not None:
                 partial_block_gva = None
-                partial_gvas_by_group = (
-                    request.partial_save_gvas_by_group if is_save else request.partial_load_gvas_by_group
+                partial_gva_per_group = (
+                    request.partial_save_gva_per_group if is_save else request.partial_load_gva_per_group
                 )
-                if task.group_id < len(partial_gvas_by_group):
-                    partial_block_gva = partial_gvas_by_group[task.group_id]
+                if task.group_id < len(partial_gva_per_group):
+                    partial_block_gva = partial_gva_per_group[task.group_id]
                 if partial_block_gva is None:
                     partial_block_gva = request.last_block_gva
                 assert partial_block_gva is not None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -60,11 +60,13 @@ class LayerBatchBuilder:
         )
         group_block_stride = token_database.group_block_stride.get(group_id, token_database.group_block_len[group_id])
         self._block_stride_np = np.asarray(group_block_stride, dtype=np.int64)
-        # group_block_len[group_id] / kv_caches_base_addr[group_id] are laid out flat as
-        # [layer0_caches..., layer1_caches..., ...]; the per-layer stride is the
-        # total length divided by the number of layers (mirrors
-        # ChunkedTokenDatabase caches_per_layer computation).
-        self._caches_per_layer = max(1, self._block_len_np.shape[0] // max(1, num_layers))
+        layer_offsets = token_database.group_layer_offsets.get(group_id)
+        if layer_offsets is None:
+            caches_per_layer = max(1, self._block_len_np.shape[0] // max(1, num_layers))
+            layer_offsets = [
+                min(layer * caches_per_layer, self._block_len_np.shape[0]) for layer in range(num_layers + 1)
+            ]
+        self._layer_offsets_np = np.asarray(layer_offsets, dtype=np.int64)
         self._block_ids_buf: np.ndarray | None = None
         self._block_gvas_buf: np.ndarray | None = None
 
@@ -103,20 +105,16 @@ class LayerBatchBuilder:
         base_gvas_arr: np.ndarray,
         layer_id: int,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        caches_per_layer = self._caches_per_layer
-        # group_* arrays are laid out flat as [layer0_caches..., layer1_caches...];
-        # slice the per-layer window for ``layer_id``. Using the full length as the
-        # stride (the old behaviour) overshoots for layer_id >= 1 and yields empty
-        # slices -> broadcast errors.
-        base_offset = layer_id * caches_per_layer
-        layer_base_addrs = self._kv_caches_base_addr_np[base_offset : base_offset + caches_per_layer]
-        layer_block_len = self._block_len_np[base_offset : base_offset + caches_per_layer]
-        layer_block_stride = self._block_stride_np[base_offset : base_offset + caches_per_layer]
+        base_offset = int(self._layer_offsets_np[layer_id])
+        end_offset = int(self._layer_offsets_np[layer_id + 1])
+        layer_base_addrs = self._kv_caches_base_addr_np[base_offset:end_offset]
+        layer_block_len = self._block_len_np[base_offset:end_offset]
+        layer_block_stride = self._block_stride_np[base_offset:end_offset]
         # Per-cache inner offsets within one layer's page: [0, len0, len0+len1, ...].
         layer_inner_offsets = np.concatenate(
             (np.zeros(1, dtype=np.int64), np.cumsum(layer_block_len[:-1], dtype=np.int64))
         )
-        rank_layer_offset = layer_id * self.page_size_bytes
+        rank_layer_offset = int(self._block_len_np[:base_offset].sum())
         if base_gvas_arr.size > 0 and np.any(base_gvas_arr <= 0):
             zero_count = int(np.sum(base_gvas_arr <= 0))
             logger.warning(
@@ -132,7 +130,7 @@ class LayerBatchBuilder:
             "base_gvas=%s",
             layer_id,
             self.page_size_bytes,
-            caches_per_layer,
+            end_offset - base_offset,
             rank_layer_offset,
             layer_block_len.tolist(),
             layer_inner_offsets.tolist(),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -18,6 +18,7 @@ _NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
 _PREFETCH_LAYERS = "layerwise_prefetch_layers"
 _INDEPENDENT_LAYERS = "layerwise_independent_layers"
 _DEFAULT_MAX_PREFETCH_LAYERS = 8
+_INDEXER_CACHE_SUFFIX = ".indexer.k_cache"
 
 
 def get_layerwise_physical_layer_index(layer_name: str, base_layers: int) -> int:
@@ -45,15 +46,21 @@ class LayerwiseCacheLayout:
 
 
 @dataclass(frozen=True)
-class LayerwiseCacheEntry:
+class NamedKVCacheSpec:
     layer_name: str
     spec: KVCacheSpec
 
 
 @dataclass(frozen=True)
+class LayerwiseLayerCacheSpecs:
+    main: NamedKVCacheSpec
+    indexer: NamedKVCacheSpec | None = None
+
+
+@dataclass(frozen=True)
 class LayerwiseReuseLayout:
-    layer_entries: dict[int, tuple[LayerwiseCacheEntry, ...]]
-    shared_buffer_layers: list[list[int]]
+    layer_cache_specs: dict[int, LayerwiseLayerCacheSpecs]
+    buffer_slots: tuple[tuple[int, ...], ...]
     prefetch_layer_map: dict[int, int]
     independent_layers: list[int]
     num_prefetch_layers: int
@@ -191,37 +198,43 @@ def build_layerwise_reuse_layout(
     base_layers: int,
     extra_config: dict[str, Any],
 ) -> LayerwiseReuseLayout:
-    """Build reusable physical-layer slots from complete cache signatures."""
-    entries_by_layer: dict[int, list[LayerwiseCacheEntry]] = {}
+    """Build reusable physical-layer slots by grouping layers on their main cache spec."""
+    named_specs_by_layer: dict[int, list[NamedKVCacheSpec]] = {}
     for layer_name, layer_spec in layer_specs.items():
         physical_layer = get_layerwise_physical_layer_index(layer_name, base_layers)
-        entries_by_layer.setdefault(physical_layer, []).append(LayerwiseCacheEntry(layer_name, layer_spec))
+        named_specs_by_layer.setdefault(physical_layer, []).append(NamedKVCacheSpec(layer_name, layer_spec))
 
-    physical_layers = sorted(entries_by_layer)
+    physical_layers = sorted(named_specs_by_layer)
     base_layout = build_layerwise_cache_layout(len(physical_layers), extra_config)
     independent_layers = [physical_layers[index] for index in base_layout.independent_layers]
     independent_layer_set = set(independent_layers)
 
-    layer_entries = {
-        physical_layer: tuple(
-            sorted(
-                entries,
-                key=lambda entry: (
-                    type(entry.spec).__module__,
-                    type(entry.spec).__qualname__,
-                    repr(entry.spec),
-                    entry.layer_name,
-                ),
-            )
-        )
-        for physical_layer, entries in entries_by_layer.items()
-    }
+    layer_cache_specs: dict[int, LayerwiseLayerCacheSpecs] = {}
+    for physical_layer, named_specs in named_specs_by_layer.items():
+        if len(named_specs) == 1:
+            layer_cache_specs[physical_layer] = LayerwiseLayerCacheSpecs(main=named_specs[0])
+            continue
 
-    signature_buckets: list[tuple[tuple[KVCacheSpec, ...], list[int]]] = []
+        indexer_specs = [spec for spec in named_specs if spec.layer_name.endswith(_INDEXER_CACHE_SUFFIX)]
+        main_specs = [spec for spec in named_specs if not spec.layer_name.endswith(_INDEXER_CACHE_SUFFIX)]
+        if len(main_specs) != 1 or len(indexer_specs) != 1:
+            raise ValueError(
+                f"Physical layer {physical_layer} with multiple cache specs must have "
+                f"exactly one main spec and one '{_INDEXER_CACHE_SUFFIX}' spec; "
+                f"got {[spec.layer_name for spec in named_specs]}."
+            )
+        layer_cache_specs[physical_layer] = LayerwiseLayerCacheSpecs(
+            main=main_specs[0],
+            indexer=indexer_specs[0],
+        )
+
+    signature_buckets: list[tuple[KVCacheSpec, list[int]]] = []
     for physical_layer in physical_layers:
         if physical_layer in independent_layer_set:
             continue
-        signature = tuple(entry.spec for entry in layer_entries[physical_layer])
+        # TODO(lf): Plan shared buffers independently for every cache spec.
+        # Slots are grouped by main spec. Indexer specs are validated separately.
+        signature = layer_cache_specs[physical_layer].main.spec
         for bucket_signature, bucket_layers in signature_buckets:
             if signature == bucket_signature:
                 bucket_layers.append(physical_layer)
@@ -229,33 +242,33 @@ def build_layerwise_reuse_layout(
         else:
             signature_buckets.append((signature, [physical_layer]))
 
-    shared_buffer_layers = [[layer] for layer in independent_layers]
+    buffer_slots: list[tuple[int, ...]] = [(layer,) for layer in independent_layers]
     prefetch_layer_map: dict[int, int] = {}
     for _, bucket_layers in signature_buckets:
         num_shared_buffers = min(base_layout.num_shared_buffers, len(bucket_layers))
         for buffer_index in range(num_shared_buffers):
-            layers_sharing_buffer = bucket_layers[buffer_index::num_shared_buffers]
-            shared_buffer_layers.append(layers_sharing_buffer)
+            layers_sharing_buffer = tuple(bucket_layers[buffer_index::num_shared_buffers])
+            buffer_slots.append(layers_sharing_buffer)
             for owner_index in range(1, len(layers_sharing_buffer)):
                 prefetch_layer_map[layers_sharing_buffer[owner_index]] = layers_sharing_buffer[owner_index - 1]
 
     if prefetch_layer_map:
-        unsupported_entries = [
-            entry
-            for entries in layer_entries.values()
-            for entry in entries
-            if not isinstance(entry.spec, AttentionSpec)
+        unsupported_specs = [
+            named_spec
+            for named_specs in named_specs_by_layer.values()
+            for named_spec in named_specs
+            if not isinstance(named_spec.spec, AttentionSpec)
         ]
-        if unsupported_entries:
-            entry = unsupported_entries[0]
+        if unsupported_specs:
+            named_spec = unsupported_specs[0]
             raise NotImplementedError(
                 "Layerwise KV cache reuse supports attention cache specs only; "
-                f"{entry.layer_name} uses {type(entry.spec).__name__}."
+                f"{named_spec.layer_name} uses {type(named_spec.spec).__name__}."
             )
 
     return LayerwiseReuseLayout(
-        layer_entries=layer_entries,
-        shared_buffer_layers=shared_buffer_layers,
+        layer_cache_specs=layer_cache_specs,
+        buffer_slots=tuple(buffer_slots),
         prefetch_layer_map=prefetch_layer_map,
         independent_layers=independent_layers,
         num_prefetch_layers=base_layout.num_prefetch_layers,
@@ -283,7 +296,7 @@ def apply_layerwise_kv_cache_plan(
         base_layers,
         extra_config,
     )
-    actual_layers = len(reuse_layout.layer_entries)
+    actual_layers = len(reuse_layout.layer_cache_specs)
     if not reuse_layout.has_layer_reuse:
         return
     if any(len(tensor.shared_by) != 1 or tensor.offset != 0 or tensor.block_stride != 0 for tensor in old_tensors):
@@ -306,33 +319,39 @@ def apply_layerwise_kv_cache_plan(
         )
 
     tensors_by_name = {tensor.shared_by[0]: tensor for tensor in old_tensors}
-    new_tensors: list[KVCacheTensor] = []
-    for layers_sharing_buffer in reuse_layout.shared_buffer_layers:
-        first_layer = layers_sharing_buffer[0]
-        num_cache_entries = len(reuse_layout.layer_entries[first_layer])
-        for entry_index in range(num_cache_entries):
-            shared_by = [reuse_layout.layer_entries[layer][entry_index].layer_name for layer in layers_sharing_buffer]
-            component_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
-            tensor_sizes = {tensor.size for tensor in component_tensors}
-            if len(tensor_sizes) != 1:
-                raise ValueError(
-                    "Layers sharing layerwise KV buffers must have equal tensor sizes for every cache entry."
-                )
-            reference_spec = layer_specs[shared_by[0]]
-            if any(layer_specs[layer_name] != reference_spec for layer_name in shared_by[1:]):
-                raise ValueError(
-                    "Layers sharing layerwise KV buffers must have identical cache specs for every cache entry."
-                )
-            new_tensors.append(
-                KVCacheTensor(
-                    shared_by=shared_by,
-                    size=component_tensors[0].size,
-                )
+
+    def _merge_specs(named_specs: list[NamedKVCacheSpec]) -> None:
+        shared_by = [named_spec.layer_name for named_spec in named_specs]
+        cache_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
+        tensor_sizes = {tensor.size for tensor in cache_tensors}
+        if len(tensor_sizes) != 1:
+            raise ValueError("Layers sharing layerwise KV buffers must have equal tensor sizes for every cache spec.")
+        reference_spec = layer_specs[shared_by[0]]
+        if any(layer_specs[layer_name] != reference_spec for layer_name in shared_by[1:]):
+            raise ValueError(
+                "Layers sharing layerwise KV buffers must have identical cache specs for every named cache spec."
             )
+        new_tensors.append(
+            KVCacheTensor(
+                shared_by=shared_by,
+                size=cache_tensors[0].size,
+            )
+        )
+
+    new_tensors: list[KVCacheTensor] = []
+    for slot in reuse_layout.buffer_slots:
+        _merge_specs([reuse_layout.layer_cache_specs[layer].main for layer in slot])
+        indexer_specs: list[NamedKVCacheSpec] = []
+        for layer in slot:
+            indexer = reuse_layout.layer_cache_specs[layer].indexer
+            if indexer is not None:
+                indexer_specs.append(indexer)
+        if indexer_specs:
+            _merge_specs(indexer_specs)
     kv_cache_config.kv_cache_tensors = new_tensors
     logger.info(
         "Layerwise KV cache reuse merged %d descriptors into %d descriptors using %d buffer assignments.",
         len(old_tensors),
         len(new_tensors),
-        len(reuse_layout.shared_buffer_layers),
+        len(reuse_layout.buffer_slots),
     )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -21,12 +21,15 @@ _DEFAULT_MAX_PREFETCH_LAYERS = 8
 
 
 def get_layerwise_physical_layer_index(layer_name: str, base_layers: int) -> int:
+    match = re.search(
+        r"(?:^|\.)mtp(?:\.layers)?\.(\d+)(?:\.|$)",
+        layer_name,
+    )
+    if match:
+        return base_layers + int(match.group(1))
     match = re.search(r"layers\.(\d+)", layer_name)
     if match:
         return int(match.group(1))
-    match = re.search(r"mtp\.(\d+)", layer_name)
-    if match:
-        return base_layers + int(match.group(1))
     match = re.search(r"(\d+)", layer_name)
     return int(match.group(1)) if match else 0
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -153,7 +153,7 @@ def build_layerwise_cache_layout(
     )
 
 
-def get_layer_kv_cache_specs(kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
+def _get_layer_kv_cache_specs(kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
     """Expand group specs into a cache spec for every logical layer."""
     layer_specs: dict[str, KVCacheSpec] = {}
     for group in kv_cache_config.kv_cache_groups:
@@ -191,7 +191,7 @@ def build_layerwise_reuse_layout(
     return layer_layout, storage_slots
 
 
-def validate_layerwise_reuse_layout(
+def _validate_layerwise_reuse_layout(
     kv_cache_config: KVCacheConfig,
     layer_specs: dict[str, KVCacheSpec],
     layer_layout: dict[int, dict[str, str]],
@@ -255,7 +255,7 @@ def apply_layerwise_kv_cache_plan(
         raise NotImplementedError("Layerwise KV cache reuse requires one KV cache tensor descriptor per layer.")
 
     base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
-    layer_specs = get_layer_kv_cache_specs(kv_cache_config)
+    layer_specs = _get_layer_kv_cache_specs(kv_cache_config)
     layer_layout, storage_slots = build_layerwise_reuse_layout(
         layer_specs,
         base_layers,
@@ -265,7 +265,7 @@ def apply_layerwise_kv_cache_plan(
     if len(storage_slots) >= actual_layers:
         return
 
-    validate_layerwise_reuse_layout(
+    _validate_layerwise_reuse_layout(
         kv_cache_config,
         layer_specs,
         layer_layout,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -53,7 +53,7 @@ class LayerwiseCacheEntry:
 @dataclass(frozen=True)
 class LayerwiseReuseLayout:
     layer_entries: dict[int, tuple[LayerwiseCacheEntry, ...]]
-    storage_slots: list[list[int]]
+    shared_buffer_layers: list[list[int]]
     prefetch_layer_map: dict[int, int]
     independent_layers: list[int]
     num_prefetch_layers: int
@@ -229,15 +229,15 @@ def build_layerwise_reuse_layout(
         else:
             signature_buckets.append((signature, [physical_layer]))
 
-    storage_slots = [[layer] for layer in independent_layers]
+    shared_buffer_layers = [[layer] for layer in independent_layers]
     prefetch_layer_map: dict[int, int] = {}
     for _, bucket_layers in signature_buckets:
-        slot_count = min(base_layout.num_shared_buffers, len(bucket_layers))
-        for slot_index in range(slot_count):
-            slot_layers = bucket_layers[slot_index::slot_count]
-            storage_slots.append(slot_layers)
-            for owner_index in range(1, len(slot_layers)):
-                prefetch_layer_map[slot_layers[owner_index]] = slot_layers[owner_index - 1]
+        num_shared_buffers = min(base_layout.num_shared_buffers, len(bucket_layers))
+        for buffer_index in range(num_shared_buffers):
+            layers_sharing_buffer = bucket_layers[buffer_index::num_shared_buffers]
+            shared_buffer_layers.append(layers_sharing_buffer)
+            for owner_index in range(1, len(layers_sharing_buffer)):
+                prefetch_layer_map[layers_sharing_buffer[owner_index]] = layers_sharing_buffer[owner_index - 1]
 
     if prefetch_layer_map:
         unsupported_entries = [
@@ -255,7 +255,7 @@ def build_layerwise_reuse_layout(
 
     return LayerwiseReuseLayout(
         layer_entries=layer_entries,
-        storage_slots=storage_slots,
+        shared_buffer_layers=shared_buffer_layers,
         prefetch_layer_map=prefetch_layer_map,
         independent_layers=independent_layers,
         num_prefetch_layers=base_layout.num_prefetch_layers,
@@ -267,7 +267,7 @@ def apply_layerwise_kv_cache_plan(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
 ) -> None:
-    """Rewrite logical layer tensors into shared physical KV cache slots."""
+    """Rewrite logical layer tensors to use shared physical KV buffers."""
     extra_config = get_gva_layerwise_config(vllm_config.kv_transfer_config)
     if extra_config is None:
         return
@@ -307,18 +307,21 @@ def apply_layerwise_kv_cache_plan(
 
     tensors_by_name = {tensor.shared_by[0]: tensor for tensor in old_tensors}
     new_tensors: list[KVCacheTensor] = []
-    for physical_layers in reuse_layout.storage_slots:
-        reference_entries = reuse_layout.layer_entries[physical_layers[0]]
-        for entry_index in range(len(reference_entries)):
-            shared_by = [reuse_layout.layer_entries[layer][entry_index].layer_name for layer in physical_layers]
+    for layers_sharing_buffer in reuse_layout.shared_buffer_layers:
+        first_layer = layers_sharing_buffer[0]
+        num_cache_entries = len(reuse_layout.layer_entries[first_layer])
+        for entry_index in range(num_cache_entries):
+            shared_by = [reuse_layout.layer_entries[layer][entry_index].layer_name for layer in layers_sharing_buffer]
             component_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
-            slot_sizes = {tensor.size for tensor in component_tensors}
-            if len(slot_sizes) != 1:
-                raise ValueError("Layers sharing a layerwise slot must have equal tensor sizes for every cache entry.")
+            tensor_sizes = {tensor.size for tensor in component_tensors}
+            if len(tensor_sizes) != 1:
+                raise ValueError(
+                    "Layers sharing layerwise KV buffers must have equal tensor sizes for every cache entry."
+                )
             reference_spec = layer_specs[shared_by[0]]
             if any(layer_specs[layer_name] != reference_spec for layer_name in shared_by[1:]):
                 raise ValueError(
-                    "Layers sharing a layerwise slot must have identical cache specs for every cache entry."
+                    "Layers sharing layerwise KV buffers must have identical cache specs for every cache entry."
                 )
             new_tensors.append(
                 KVCacheTensor(
@@ -328,8 +331,8 @@ def apply_layerwise_kv_cache_plan(
             )
     kv_cache_config.kv_cache_tensors = new_tensors
     logger.info(
-        "Layerwise KV cache reuse merged %d descriptors into %d descriptors across %d physical buffers.",
+        "Layerwise KV cache reuse merged %d descriptors into %d descriptors using %d buffer assignments.",
         len(old_tensors),
         len(new_tensors),
-        len(reuse_layout.storage_slots),
+        len(reuse_layout.shared_buffer_layers),
     )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import regex as re
 from vllm.config import VllmConfig
 from vllm.logger import logger
 from vllm.v1.kv_cache_interface import (
@@ -12,10 +13,23 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+
 _NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
 _PREFETCH_LAYERS = "layerwise_prefetch_layers"
 _INDEPENDENT_LAYERS = "layerwise_independent_layers"
 _DEFAULT_MAX_PREFETCH_LAYERS = 8
+
+
+def get_layerwise_physical_layer_index(layer_name: str, base_layers: int) -> int:
+    match = re.search(r"layers\.(\d+)", layer_name)
+    if match:
+        return int(match.group(1))
+    match = re.search(r"mtp\.(\d+)", layer_name)
+    if match:
+        return base_layers + int(match.group(1))
+    match = re.search(r"(\d+)", layer_name)
+    return int(match.group(1)) if match else 0
 
 
 @dataclass(frozen=True)
@@ -139,10 +153,8 @@ def build_layerwise_cache_layout(
     )
 
 
-def _get_layer_kv_cache_specs(
-    kv_cache_config: KVCacheConfig,
-) -> dict[str, KVCacheSpec]:
-    """Expand a group spec into the cache spec used by each logical layer."""
+def get_layer_kv_cache_specs(kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
+    """Expand group specs into a cache spec for every logical layer."""
     layer_specs: dict[str, KVCacheSpec] = {}
     for group in kv_cache_config.kv_cache_groups:
         group_spec = group.kv_cache_spec
@@ -154,6 +166,79 @@ def _get_layer_kv_cache_specs(
     return layer_specs
 
 
+def build_layerwise_reuse_layout(
+    layer_specs: dict[str, KVCacheSpec],
+    base_layers: int,
+    extra_config: dict[str, Any],
+) -> tuple[dict[int, dict[str, str]], list[list[int]]]:
+    """Build the main/indexer components assigned to each physical slot."""
+    layer_layout: dict[int, dict[str, str]] = {}
+    for layer_name, layer_spec in layer_specs.items():
+        physical_layer = get_layerwise_physical_layer_index(layer_name, base_layers)
+        component = "indexer" if isinstance(layer_spec, AscendSFAIndexerCacheSpec) else "main"
+        components = layer_layout.setdefault(physical_layer, {})
+        if component in components:
+            raise NotImplementedError(
+                f"Layerwise reuse found multiple {component} descriptors for physical layer {physical_layer}."
+            )
+        components[component] = layer_name
+
+    physical_layers = sorted(layer_layout)
+    if any("main" not in layer_layout[layer] for layer in physical_layers):
+        raise RuntimeError("Every physical layer must provide a main KV cache for layerwise reuse.")
+    layout = build_layerwise_cache_layout(len(physical_layers), extra_config)
+    storage_slots = [[physical_layers[index] for index in slot] for slot in layout.storage_indices]
+    return layer_layout, storage_slots
+
+
+def validate_layerwise_reuse_layout(
+    kv_cache_config: KVCacheConfig,
+    layer_specs: dict[str, KVCacheSpec],
+    layer_layout: dict[int, dict[str, str]],
+) -> None:
+    """Validate topologies supported by physical layer buffer reuse."""
+    if len(kv_cache_config.kv_cache_groups) == 1:
+        return
+
+    indexer_layer_names = {
+        layer_name
+        for layer_name, layer_spec in layer_specs.items()
+        if isinstance(layer_spec, AscendSFAIndexerCacheSpec)
+    }
+    if not indexer_layer_names:
+        raise NotImplementedError(
+            "Layerwise KV cache reuse supports multiple KV cache groups only for separated SFA main/indexer caches."
+        )
+
+    unsupported_specs = {
+        layer_name: type(layer_spec).__name__
+        for layer_name, layer_spec in layer_specs.items()
+        if not isinstance(
+            layer_spec,
+            (AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec),
+        )
+    }
+    if unsupported_specs:
+        details = ", ".join(f"{layer_name}={spec_name}" for layer_name, spec_name in sorted(unsupported_specs.items()))
+        raise NotImplementedError(
+            "Layerwise multi-group buffer reuse only supports SFA "
+            f"main/indexer cache specs; unsupported cache specs: {details}."
+        )
+
+    for physical_layer, components in layer_layout.items():
+        indexer_layer_name = components.get("indexer")
+        if indexer_layer_name is None:
+            continue
+        main_layer_name = components.get("main")
+        if main_layer_name is None or not isinstance(
+            layer_specs[main_layer_name],
+            AscendMLAAttentionSpec,
+        ):
+            raise RuntimeError(
+                f"SFA indexer cache requires an Ascend MLA main cache at physical layer {physical_layer}."
+            )
+
+
 def apply_layerwise_kv_cache_plan(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
@@ -163,41 +248,68 @@ def apply_layerwise_kv_cache_plan(
     if extra_config is None:
         return
 
-    base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
-    layout = build_layerwise_cache_layout(base_layers, extra_config)
-    if not layout.has_layer_reuse:
-        return
-
-    if len(kv_cache_config.kv_cache_groups) != 1:
-        raise NotImplementedError("Layerwise KV cache reuse requires one KV cache group.")
-
     old_tensors = kv_cache_config.kv_cache_tensors
     if len(old_tensors) <= 1:
         return
     if any(len(tensor.shared_by) != 1 for tensor in old_tensors):
         raise NotImplementedError("Layerwise KV cache reuse requires one KV cache tensor descriptor per layer.")
-    if len(old_tensors) != base_layers:
-        raise NotImplementedError("Layerwise KV cache reuse currently supports base transformer layers only.")
 
-    layer_names = [tensor.shared_by[0] for tensor in old_tensors]
-    layer_specs = _get_layer_kv_cache_specs(kv_cache_config)
-    new_tensors = []
-    for slot in layout.storage_indices:
-        slot_sizes = {old_tensors[index].size for index in slot}
-        if len(slot_sizes) != 1:
-            raise ValueError("Layers sharing a layerwise KV buffer must have equal tensor sizes.")
-        reference_spec = layer_specs[layer_names[slot[0]]]
-        if any(layer_specs[layer_names[index]] != reference_spec for index in slot[1:]):
-            raise ValueError("Layers sharing a layerwise KV buffer must have identical cache specs.")
-        new_tensors.append(
-            KVCacheTensor(
-                shared_by=[layer_names[index] for index in slot],
-                size=old_tensors[slot[0]].size,
-            )
+    base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+    layer_specs = get_layer_kv_cache_specs(kv_cache_config)
+    layer_layout, storage_slots = build_layerwise_reuse_layout(
+        layer_specs,
+        base_layers,
+        extra_config,
+    )
+    actual_layers = len(layer_layout)
+    if len(storage_slots) >= actual_layers:
+        return
+
+    validate_layerwise_reuse_layout(
+        kv_cache_config,
+        layer_specs,
+        layer_layout,
+    )
+    if actual_layers < base_layers:
+        logger.warning(
+            "Layer reuse expected at least %d layers, got %d; skip tensor merge.",
+            base_layers,
+            actual_layers,
         )
+        return
+    if actual_layers > base_layers:
+        logger.info(
+            "Layer reuse includes %d base and %d MTP/spec-decode layer(s).",
+            base_layers,
+            actual_layers - base_layers,
+        )
+
+    tensors_by_name = {tensor.shared_by[0]: tensor for tensor in old_tensors}
+    new_tensors: list[KVCacheTensor] = []
+    for physical_layers in storage_slots:
+        for component in ("main", "indexer"):
+            shared_by = [
+                layer_layout[layer][component] for layer in physical_layers if component in layer_layout[layer]
+            ]
+            if not shared_by:
+                continue
+            component_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
+            slot_sizes = {tensor.size for tensor in component_tensors}
+            if len(slot_sizes) != 1:
+                raise ValueError(f"Layers sharing a layerwise slot must have equal {component} tensor sizes.")
+            reference_spec = layer_specs[shared_by[0]]
+            if any(layer_specs[layer_name] != reference_spec for layer_name in shared_by[1:]):
+                raise ValueError(f"Layers sharing a layerwise slot must have identical {component} cache specs.")
+            new_tensors.append(
+                KVCacheTensor(
+                    shared_by=shared_by,
+                    size=component_tensors[0].size,
+                )
+            )
     kv_cache_config.kv_cache_tensors = new_tensors
     logger.info(
-        "Layerwise KV cache reuse merged %d tensor descriptors into %d shared buffers.",
+        "Layerwise KV cache reuse merged %d descriptors into %d descriptors across %d physical buffers.",
         len(old_tensors),
         len(new_tensors),
+        len(storage_slots),
     )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -7,13 +7,12 @@ import regex as re
 from vllm.config import VllmConfig
 from vllm.logger import logger
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
     KVCacheTensor,
     UniformTypeKVCacheSpecs,
 )
-
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 
 _NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
 _PREFETCH_LAYERS = "layerwise_prefetch_layers"
@@ -39,6 +38,22 @@ class LayerwiseCacheLayout:
     independent_layers: list[int]
     prefetch_layer_map: dict[int, int]
     storage_indices: list[list[int]]
+    has_layer_reuse: bool
+
+
+@dataclass(frozen=True)
+class LayerwiseCacheEntry:
+    layer_name: str
+    spec: KVCacheSpec
+
+
+@dataclass(frozen=True)
+class LayerwiseReuseLayout:
+    layer_entries: dict[int, tuple[LayerwiseCacheEntry, ...]]
+    storage_slots: list[list[int]]
+    prefetch_layer_map: dict[int, int]
+    independent_layers: list[int]
+    num_prefetch_layers: int
     has_layer_reuse: bool
 
 
@@ -153,7 +168,9 @@ def build_layerwise_cache_layout(
     )
 
 
-def _get_layer_kv_cache_specs(kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
+def get_layerwise_kv_cache_specs(
+    kv_cache_config: KVCacheConfig,
+) -> dict[str, KVCacheSpec]:
     """Expand group specs into a cache spec for every logical layer."""
     layer_specs: dict[str, KVCacheSpec] = {}
     for group in kv_cache_config.kv_cache_groups:
@@ -170,73 +187,77 @@ def build_layerwise_reuse_layout(
     layer_specs: dict[str, KVCacheSpec],
     base_layers: int,
     extra_config: dict[str, Any],
-) -> tuple[dict[int, dict[str, str]], list[list[int]]]:
-    """Build the main/indexer components assigned to each physical slot."""
-    layer_layout: dict[int, dict[str, str]] = {}
+) -> LayerwiseReuseLayout:
+    """Build reusable physical-layer slots from complete cache signatures."""
+    entries_by_layer: dict[int, list[LayerwiseCacheEntry]] = {}
     for layer_name, layer_spec in layer_specs.items():
         physical_layer = get_layerwise_physical_layer_index(layer_name, base_layers)
-        component = "indexer" if isinstance(layer_spec, AscendSFAIndexerCacheSpec) else "main"
-        components = layer_layout.setdefault(physical_layer, {})
-        if component in components:
-            raise NotImplementedError(
-                f"Layerwise reuse found multiple {component} descriptors for physical layer {physical_layer}."
+        entries_by_layer.setdefault(physical_layer, []).append(LayerwiseCacheEntry(layer_name, layer_spec))
+
+    physical_layers = sorted(entries_by_layer)
+    base_layout = build_layerwise_cache_layout(len(physical_layers), extra_config)
+    independent_layers = [physical_layers[index] for index in base_layout.independent_layers]
+    independent_layer_set = set(independent_layers)
+
+    layer_entries = {
+        physical_layer: tuple(
+            sorted(
+                entries,
+                key=lambda entry: (
+                    type(entry.spec).__module__,
+                    type(entry.spec).__qualname__,
+                    repr(entry.spec),
+                    entry.layer_name,
+                ),
             )
-        components[component] = layer_name
-
-    physical_layers = sorted(layer_layout)
-    if any("main" not in layer_layout[layer] for layer in physical_layers):
-        raise RuntimeError("Every physical layer must provide a main KV cache for layerwise reuse.")
-    layout = build_layerwise_cache_layout(len(physical_layers), extra_config)
-    storage_slots = [[physical_layers[index] for index in slot] for slot in layout.storage_indices]
-    return layer_layout, storage_slots
-
-
-def _validate_layerwise_reuse_layout(
-    kv_cache_config: KVCacheConfig,
-    layer_specs: dict[str, KVCacheSpec],
-    layer_layout: dict[int, dict[str, str]],
-) -> None:
-    """Validate topologies supported by physical layer buffer reuse."""
-    if len(kv_cache_config.kv_cache_groups) == 1:
-        return
-
-    indexer_layer_names = {
-        layer_name
-        for layer_name, layer_spec in layer_specs.items()
-        if isinstance(layer_spec, AscendSFAIndexerCacheSpec)
+        )
+        for physical_layer, entries in entries_by_layer.items()
     }
-    if not indexer_layer_names:
-        raise NotImplementedError(
-            "Layerwise KV cache reuse supports multiple KV cache groups only for separated SFA main/indexer caches."
-        )
 
-    unsupported_specs = {
-        layer_name: type(layer_spec).__name__
-        for layer_name, layer_spec in layer_specs.items()
-        if not isinstance(
-            layer_spec,
-            (AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec),
-        )
-    }
-    if unsupported_specs:
-        details = ", ".join(f"{layer_name}={spec_name}" for layer_name, spec_name in sorted(unsupported_specs.items()))
-        raise NotImplementedError(
-            "Layerwise multi-group buffer reuse only supports SFA "
-            f"main/indexer cache specs; unsupported cache specs: {details}."
-        )
-
-    for physical_layer, components in layer_layout.items():
-        indexer_layer_name = components.get("indexer")
-        if indexer_layer_name is None:
+    signature_buckets: list[tuple[tuple[KVCacheSpec, ...], list[int]]] = []
+    for physical_layer in physical_layers:
+        if physical_layer in independent_layer_set:
             continue
-        main_layer_name = components.get("main")
-        if main_layer_name is None or not isinstance(
-            layer_specs[main_layer_name],
-            AscendMLAAttentionSpec,
-        ):
-            raise RuntimeError(
-                f"SFA indexer cache requires an Ascend MLA main cache at physical layer {physical_layer}."
+        signature = tuple(entry.spec for entry in layer_entries[physical_layer])
+        for bucket_signature, bucket_layers in signature_buckets:
+            if signature == bucket_signature:
+                bucket_layers.append(physical_layer)
+                break
+        else:
+            signature_buckets.append((signature, [physical_layer]))
+
+    storage_slots = [[layer] for layer in independent_layers]
+    prefetch_layer_map: dict[int, int] = {}
+    for _, bucket_layers in signature_buckets:
+        slot_count = min(base_layout.num_shared_buffers, len(bucket_layers))
+        for slot_index in range(slot_count):
+            slot_layers = bucket_layers[slot_index::slot_count]
+            storage_slots.append(slot_layers)
+            for owner_index in range(1, len(slot_layers)):
+                prefetch_layer_map[slot_layers[owner_index]] = slot_layers[owner_index - 1]
+
+    if prefetch_layer_map:
+        unsupported_entries = [
+            entry
+            for entries in layer_entries.values()
+            for entry in entries
+            if not isinstance(entry.spec, AttentionSpec)
+        ]
+        if unsupported_entries:
+            entry = unsupported_entries[0]
+            raise NotImplementedError(
+                "Layerwise KV cache reuse supports attention cache specs only; "
+                f"{entry.layer_name} uses {type(entry.spec).__name__}."
             )
+
+    return LayerwiseReuseLayout(
+        layer_entries=layer_entries,
+        storage_slots=storage_slots,
+        prefetch_layer_map=prefetch_layer_map,
+        independent_layers=independent_layers,
+        num_prefetch_layers=base_layout.num_prefetch_layers,
+        has_layer_reuse=bool(prefetch_layer_map),
+    )
 
 
 def apply_layerwise_kv_cache_plan(
@@ -251,25 +272,22 @@ def apply_layerwise_kv_cache_plan(
     old_tensors = kv_cache_config.kv_cache_tensors
     if len(old_tensors) <= 1:
         return
-    if any(len(tensor.shared_by) != 1 for tensor in old_tensors):
-        raise NotImplementedError("Layerwise KV cache reuse requires one KV cache tensor descriptor per layer.")
 
     base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
-    layer_specs = _get_layer_kv_cache_specs(kv_cache_config)
-    layer_layout, storage_slots = build_layerwise_reuse_layout(
+    layer_specs = get_layerwise_kv_cache_specs(kv_cache_config)
+    reuse_layout = build_layerwise_reuse_layout(
         layer_specs,
         base_layers,
         extra_config,
     )
-    actual_layers = len(layer_layout)
-    if len(storage_slots) >= actual_layers:
+    actual_layers = len(reuse_layout.layer_entries)
+    if not reuse_layout.has_layer_reuse:
         return
+    if any(len(tensor.shared_by) != 1 or tensor.offset != 0 or tensor.block_stride != 0 for tensor in old_tensors):
+        raise NotImplementedError(
+            "Layerwise KV cache reuse does not support pre-shared or packed KV cache tensor descriptors."
+        )
 
-    _validate_layerwise_reuse_layout(
-        kv_cache_config,
-        layer_specs,
-        layer_layout,
-    )
     if actual_layers < base_layers:
         logger.warning(
             "Layer reuse expected at least %d layers, got %d; skip tensor merge.",
@@ -286,20 +304,19 @@ def apply_layerwise_kv_cache_plan(
 
     tensors_by_name = {tensor.shared_by[0]: tensor for tensor in old_tensors}
     new_tensors: list[KVCacheTensor] = []
-    for physical_layers in storage_slots:
-        for component in ("main", "indexer"):
-            shared_by = [
-                layer_layout[layer][component] for layer in physical_layers if component in layer_layout[layer]
-            ]
-            if not shared_by:
-                continue
+    for physical_layers in reuse_layout.storage_slots:
+        reference_entries = reuse_layout.layer_entries[physical_layers[0]]
+        for entry_index in range(len(reference_entries)):
+            shared_by = [reuse_layout.layer_entries[layer][entry_index].layer_name for layer in physical_layers]
             component_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
             slot_sizes = {tensor.size for tensor in component_tensors}
             if len(slot_sizes) != 1:
-                raise ValueError(f"Layers sharing a layerwise slot must have equal {component} tensor sizes.")
+                raise ValueError("Layers sharing a layerwise slot must have equal tensor sizes for every cache entry.")
             reference_spec = layer_specs[shared_by[0]]
             if any(layer_specs[layer_name] != reference_spec for layer_name in shared_by[1:]):
-                raise ValueError(f"Layers sharing a layerwise slot must have identical {component} cache specs.")
+                raise ValueError(
+                    "Layers sharing a layerwise slot must have identical cache specs for every cache entry."
+                )
             new_tensors.append(
                 KVCacheTensor(
                     shared_by=shared_by,
@@ -311,5 +328,5 @@ def apply_layerwise_kv_cache_plan(
         "Layerwise KV cache reuse merged %d descriptors into %d descriptors across %d physical buffers.",
         len(old_tensors),
         len(new_tensors),
-        len(storage_slots),
+        len(reuse_layout.storage_slots),
     )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -733,6 +733,7 @@ class KVPoolScheduler:
             original_block_size=self.original_block_size,
             kv_cache_group_families=self.kv_cache_group_families,
             save_partial_block=self.layerwise_offload,
+            hash_block_size=self.hash_block_size,
         )
 
     def _process_new_request(
@@ -942,6 +943,7 @@ class KVPoolScheduler:
             discard_partial_chunks=self._discard_partial_chunks,
             original_block_size=self.original_block_size,
             kv_cache_group_families=self.kv_cache_group_families,
+            hash_block_size=self.hash_block_size,
         )
 
     def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -45,6 +45,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
+    build_layerwise_reuse_layout,
+    get_gva_layerwise_config,
+    get_layerwise_kv_cache_specs,
 )
 
 
@@ -191,10 +194,24 @@ class KVPoolScheduler:
         self.num_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
         self.layerwise_offload = False
         if self.use_gva_layerwise:
-            self.layerwise_offload = build_layerwise_cache_layout(
-                self.num_layers,
-                vllm_config.kv_transfer_config.kv_connector_extra_config,
-            ).has_layer_reuse
+            extra_config = get_gva_layerwise_config(vllm_config.kv_transfer_config)
+            if kv_cache_config is not None and extra_config is not None:
+                reuse_layout = build_layerwise_reuse_layout(
+                    get_layerwise_kv_cache_specs(kv_cache_config),
+                    self.num_layers,
+                    extra_config,
+                )
+                if reuse_layout.layer_entries:
+                    self.num_layers = max(
+                        self.num_layers,
+                        max(reuse_layout.layer_entries) + 1,
+                    )
+                self.layerwise_offload = reuse_layout.has_layer_reuse
+            else:
+                self.layerwise_offload = build_layerwise_cache_layout(
+                    self.num_layers,
+                    vllm_config.kv_transfer_config.kv_connector_extra_config,
+                ).has_layer_reuse
         self.model_name = model_config.model.split("/")[-1]
 
         # Keep this in sync with pool_worker.py because it affects GVA allocation size.

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -201,10 +201,10 @@ class KVPoolScheduler:
                     self.num_layers,
                     extra_config,
                 )
-                if reuse_layout.layer_entries:
+                if reuse_layout.layer_cache_specs:
                     self.num_layers = max(
                         self.num_layers,
-                        max(reuse_layout.layer_entries) + 1,
+                        max(reuse_layout.layer_cache_specs) + 1,
                     )
                 self.layerwise_offload = reuse_layout.has_layer_reuse
             else:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -112,6 +112,9 @@ class KVPoolScheduler:
         self.num_speculative_blocks = (
             vllm_config.speculative_config.num_speculative_tokens if vllm_config.speculative_config else 0
         )
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        use_eagle_fn = getattr(speculative_config, "use_eagle", None)
+        self.use_eagle = use_eagle_fn() is True if callable(use_eagle_fn) else False
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
@@ -575,6 +578,12 @@ class KVPoolScheduler:
             return 0, False
 
         store_skip_tokens = num_external_hit_tokens
+        if self.use_layerwise and self.use_eagle:
+            # TODO(lf): Support loading the trailing block as dirty data.
+            num_external_hit_tokens = max(
+                num_computed_tokens,
+                num_external_hit_tokens - self.lcm_block_size,
+            )
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 
@@ -594,7 +603,7 @@ class KVPoolScheduler:
         # In layerwise mode, even when vLLM has local cached tokens, we still
         # need to load KV cache from the pool because layerwise transfer loads
         # per-layer data that may not be in HBM.
-        force_layerwise_load = self.use_layerwise and num_external_hit_tokens > 0
+        force_layerwise_load = self.use_layerwise and store_skip_tokens > 0
         if need_to_allocate <= 0 and not force_layerwise_load:
             return 0, False
 
@@ -641,8 +650,9 @@ class KVPoolScheduler:
 
         if num_external_tokens == 0:
             # No need to load anything
-            self.load_specs[request.request_id].can_load = (
-                self.use_layerwise and self.load_specs[request.request_id].kvpool_cached_tokens > 0
+            load_spec = self.load_specs[request.request_id]
+            self.load_specs[request.request_id].can_load = self.use_layerwise and (
+                load_spec.kvpool_cached_tokens > 0 or bool(load_spec.kvpool_store_skip_tokens)
             )
             logger.debug(
                 "KV pool load spec updated req=%s because num_external_tokens=0 "

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import math
 import threading
+import time
 from collections.abc import Callable, Generator
 from typing import Any
 
@@ -82,6 +83,12 @@ from vllm_ascend.memcache_comm_fence import (
 # read lease before batch_copy(G2L); the lease must cover the asynchronous
 # multi-layer load time.
 LAYERWISE_READ_LEASE_TTL_MS = 5 * 60 * 1000
+
+# A partial snapshot can be visible to readers before the rank responsible for
+# saving it has published its final layer.
+MEMCACHE_UNMATCHED_STATE = -3101
+PARTIAL_LEASE_RETRY_COUNT = 10
+PARTIAL_LEASE_RETRY_INTERVAL_S = 0.001
 
 
 class KVPoolWorker:
@@ -1477,6 +1484,22 @@ class KVPoolWorker:
                     leased_keys = []
                     for gva_index, lease_res in zip(valid_gva_indices, lease_results):
                         block_idx = block_indices[gva_index]
+                        if lease_res == MEMCACHE_UNMATCHED_STATE and block_idx == partial_block_index:
+                            partial_key = keys[gva_index]
+                            for retry in range(1, PARTIAL_LEASE_RETRY_COUNT + 1):
+                                time.sleep(PARTIAL_LEASE_RETRY_INTERVAL_S)
+                                retry_results = self.m_store.batch_add_lease(
+                                    [partial_key],
+                                    LAYERWISE_READ_LEASE_TTL_MS,
+                                )
+                                if len(retry_results) != 1:
+                                    raise RuntimeError(
+                                        "MemCache partial lease retry returned "
+                                        f"unexpected number of results: {len(retry_results)}"
+                                    )
+                                lease_res = retry_results[0]
+                                if lease_res != MEMCACHE_UNMATCHED_STATE:
+                                    break
                         block_id = int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else None
                         if lease_res == 0:
                             leased_keys.append(keys[gva_index])

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -722,7 +722,7 @@ class KVPoolWorker:
                 continue
             layer_names_by_physical.setdefault(phys, []).append(layer_name)
 
-        layer_offsets = [0]
+        layer_cache_entry_offsets = [0]
         for phys in sorted(layer_names_by_physical):
             for layer_name in sorted(layer_names_by_physical[phys]):
                 cache_or_caches = self.kv_caches[layer_name]
@@ -732,11 +732,11 @@ class KVPoolWorker:
                     group_addrs.append(base_addr)
                     group_block_lens.append(block_len)
                     group_block_strides.append(block_stride)
-            layer_offsets.append(len(group_addrs))
+            layer_cache_entry_offsets.append(len(group_addrs))
         self.group_kv_caches_base_addr[group_id] = group_addrs
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides
-        self.group_layer_offsets[group_id] = layer_offsets
+        self.group_layer_cache_entry_offsets[group_id] = layer_cache_entry_offsets
         self.group_num_layers[group_id] = len(layer_names_by_physical)
 
     def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
@@ -778,7 +778,7 @@ class KVPoolWorker:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
-        self.group_layer_offsets: dict[int, list[int]] = {}
+        self.group_layer_cache_entry_offsets: dict[int, list[int]] = {}
         self.kv_caches = kv_caches
         self.group_kv_cache_families: dict[int, str] = {
             group_id: self._get_group_family(self.kv_cache_group_families, group_id)
@@ -848,7 +848,7 @@ class KVPoolWorker:
             cache_role="kv",
             group_cache_families=self.group_kv_cache_families,
             group_num_layers=self.group_num_layers,
-            group_layer_offsets=self.group_layer_offsets,
+            group_layer_cache_entry_offsets=self.group_layer_cache_entry_offsets,
         )
 
         if self.tp_mismatch:
@@ -1120,8 +1120,8 @@ class KVPoolWorker:
             if not self.layerwise_offload or layer_id in self.independent_layers:
                 partial_block_index = None
             partial_gva = (
-                request.partial_load_gvas_by_group[group_id]
-                if group_id < len(request.partial_load_gvas_by_group)
+                request.partial_load_gva_per_group[group_id]
+                if group_id < len(request.partial_load_gva_per_group)
                 else request.last_block_gva
             )
             if partial_gva is None or partial_gva <= 0:
@@ -1224,7 +1224,7 @@ class KVPoolWorker:
             all_group_gvas: list[np.ndarray] = []
             all_group_block_ids: list[np.ndarray] = []
             all_group_save_keys: list[str] = []
-            request.partial_save_gvas_by_group = [0] * self.num_kv_cache_groups
+            request.partial_save_gva_per_group = [0] * self.num_kv_cache_groups
             for group_id in range(self.num_kv_cache_groups):
                 group_block_size = self.grouped_block_size[group_id]
                 cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
@@ -1337,7 +1337,7 @@ class KVPoolWorker:
                             )
                     # Partial keys are request-scoped; do not retain them forever.
                     self._allocated_gvas.pop(partial_key, None)
-                    request.partial_save_gvas_by_group[group_id] = partial_gva
+                    request.partial_save_gva_per_group[group_id] = partial_gva
 
                 logger.debug(
                     "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
@@ -1392,7 +1392,7 @@ class KVPoolWorker:
 
             all_group_load_gvas: list[np.ndarray] = []
             all_group_load_keys: list[str] = []
-            request.partial_load_gvas_by_group = [0] * self.num_kv_cache_groups
+            request.partial_load_gva_per_group = [0] * self.num_kv_cache_groups
             for group_id in range(self.num_kv_cache_groups):
                 group_block_size = self.grouped_block_size[group_id]
                 cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
@@ -1566,7 +1566,7 @@ class KVPoolWorker:
                         full_gvas[load_start_block + i] = gva
                 all_group_load_gvas.append(np.asarray(full_gvas, dtype=np.int64))
                 if partial_block_index is not None and len(gvas) > normal_gva_count:
-                    request.partial_load_gvas_by_group[group_id] = gvas[normal_gva_count]
+                    request.partial_load_gva_per_group[group_id] = gvas[normal_gva_count]
 
             if all_group_load_gvas:
                 request.load_keys = all_group_load_keys

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -356,7 +356,7 @@ class KVPoolWorker:
                 phys_to_layer_idx: dict[int, int] = {}
                 for layer_name in group_spec.layer_names:
                     physical_layer = self._extract_physical_layer_index(layer_name)
-                    if physical_layer >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
+                    if physical_layer >= self.num_layers:
                         continue
                     if physical_layer not in phys_to_layer_idx:
                         phys_to_layer_idx[physical_layer] = len(phys_to_layer_idx)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -67,6 +67,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_cache_layout,
     build_layerwise_reuse_layout,
     get_layerwise_kv_cache_specs,
+    get_layerwise_physical_layer_index,
 )
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
@@ -696,20 +697,12 @@ class KVPoolWorker:
             return cache.storage().data_ptr()
 
     def _extract_physical_layer_index(self, layer_name: str) -> int:
-        import regex as re
-
-        m = re.search(r"layers\.(\d+)", layer_name)
-        if m:
-            return int(m.group(1))
-        # MTP layers have names like "mtp.0.self_attn.xxx" without "layers."
-        # prefix. Map them after the main model layers.
-        if ".mtp." in f".{layer_name}.":
-            m = re.search(r"mtp\.(\d+)", layer_name)
-            if m:
-                num_hidden_layers = getattr(self.hf_config, "num_hidden_layers", self.num_layers)
-                return num_hidden_layers + int(m.group(1))
-        m = re.search(r"(\d+)", layer_name)
-        return int(m.group(1)) if m else 0
+        base_layers = getattr(
+            self.hf_config,
+            "num_hidden_layers",
+            self.num_layers,
+        )
+        return get_layerwise_physical_layer_index(layer_name, base_layers)
 
     def _infer_cache_group_metadata(self, group_id: int, layer_names: list[str]):
         group_addrs: list[int] = []
@@ -1508,16 +1501,25 @@ class KVPoolWorker:
                 # failures, as the scheduler cannot handle inconsistent KV
                 # cache state across groups (see PR #9701 for rationale).
                 if invalid_block_ids:
-                    if len(request.block_ids_by_group) == 1:
+                    if self.num_kv_cache_groups == 1:
                         with self._invalid_block_ids_lock:
                             self._invalid_block_ids.update(invalid_block_ids)
                     else:
-                        logger.error(
-                            "KV load failed for hybrid request %s. "
-                            "Skip invalid-block fallback to avoid scheduler crash. "
-                            "failed_blocks=%s",
-                            request.req_id,
-                            invalid_block_ids,
+                        leased_keys_to_release = list(
+                            dict.fromkeys(
+                                [
+                                    *all_group_load_keys,
+                                    *leased_keys,
+                                ]
+                            )
+                        )
+                        if leased_keys_to_release:
+                            self.m_store.batch_remove_lease(leased_keys_to_release)
+                        raise RuntimeError(
+                            "Layerwise multi-group KV load failed and cannot "
+                            "safely fall back to per-block recomputation: "
+                            f"request={request.req_id}, "
+                            f"failed_blocks={invalid_block_ids}"
                         )
                 all_group_load_keys.extend(leased_keys)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -155,6 +155,9 @@ class KVPoolWorker:
         self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
         self.use_hybrid = self._uses_hybrid_kv_cache(vllm_config, kv_cache_config)
         self.use_mamba = self._uses_mamba_kv_cache(self.use_hybrid, kv_cache_config)
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        use_eagle_fn = getattr(speculative_config, "use_eagle", None)
+        self.use_eagle = use_eagle_fn() is True if callable(use_eagle_fn) else False
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
@@ -1094,11 +1097,9 @@ class KVPoolWorker:
         for request in requests:
             if request.load_spec is None or not request.load_spec.can_load:
                 continue
-            cached_tokens = (
-                request.load_spec.kvpool_store_skip_tokens
-                if request.load_spec.kvpool_store_skip_tokens is not None
-                else request.load_spec.kvpool_cached_tokens
-            )
+            cached_tokens = request.load_spec.kvpool_cached_tokens
+            if not getattr(self, "use_eagle", False) and request.load_spec.kvpool_store_skip_tokens is not None:
+                cached_tokens = request.load_spec.kvpool_store_skip_tokens
             group_block_hashes = get_block_hashes(
                 request.block_hashes,
                 block_size,
@@ -1383,11 +1384,9 @@ class KVPoolWorker:
         for request in requests:
             if request.load_spec is None or not request.load_spec.can_load:
                 continue
-            cached_tokens = (
-                request.load_spec.kvpool_store_skip_tokens
-                if request.load_spec.kvpool_store_skip_tokens is not None
-                else request.load_spec.kvpool_cached_tokens
-            )
+            cached_tokens = request.load_spec.kvpool_cached_tokens
+            if not getattr(self, "use_eagle", False) and request.load_spec.kvpool_store_skip_tokens is not None:
+                cached_tokens = request.load_spec.kvpool_store_skip_tokens
             block_hashes = request.block_hashes
 
             all_group_load_gvas: list[np.ndarray] = []

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -63,7 +63,10 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     record_failed_blocks,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
+    LayerwiseReuseLayout,
     build_layerwise_cache_layout,
+    build_layerwise_reuse_layout,
+    get_layerwise_kv_cache_specs,
 )
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
@@ -329,12 +332,17 @@ class KVPoolWorker:
     def _init_layerwise_config(self) -> None:
         # Build mapping: physical_layer -> [(group_id, layer_idx_in_group), ...]
         # layer_idx_in_group is the index of the physical layer within the
-        # group (not the index in layer_names). Multiple layer_names at the
-        # same physical layer (e.g. indexer.k_cache + attn) are treated as
-        # multiple cache tensors of ONE layer (caches_per_layer > 1).
+        # group (not the index in layer_names). Multiple cache names at the
+        # same physical layer are treated as entries of one layer.
         self.physical_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
+        self._layerwise_reuse_layout: LayerwiseReuseLayout | None = None
 
         if self.kv_cache_config is not None:
+            base_layers = getattr(
+                self.hf_config,
+                "num_hidden_layers",
+                self.num_layers,
+            )
             physical_layers = {
                 self._extract_physical_layer_index(layer_name)
                 for group_spec in self.kv_cache_config.kv_cache_groups
@@ -349,17 +357,24 @@ class KVPoolWorker:
                         effective_num_layers,
                     )
                     self.num_layers = effective_num_layers
+            if self.use_gva_layerwise:
+                self._layerwise_reuse_layout = build_layerwise_reuse_layout(
+                    get_layerwise_kv_cache_specs(self.kv_cache_config),
+                    base_layers,
+                    self._extra_config,
+                )
 
         if self.kv_cache_config is not None and self.num_kv_cache_groups > 1:
             for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
-                # Map each unique physical layer to a sequential layer_idx_in_group
-                phys_to_layer_idx: dict[int, int] = {}
+                physical_layers = set()
                 for layer_name in group_spec.layer_names:
                     physical_layer = self._extract_physical_layer_index(layer_name)
                     if physical_layer >= self.num_layers:
                         continue
-                    if physical_layer not in phys_to_layer_idx:
-                        phys_to_layer_idx[physical_layer] = len(phys_to_layer_idx)
+                    physical_layers.add(physical_layer)
+                phys_to_layer_idx = {
+                    physical_layer: layer_index for layer_index, physical_layer in enumerate(sorted(physical_layers))
+                }
 
                 # Add one entry per unique physical layer (no duplicates)
                 for physical_layer, layer_idx_in_group in phys_to_layer_idx.items():
@@ -369,11 +384,10 @@ class KVPoolWorker:
                         existing.append(entry)
 
                 logger.info(
-                    "layerwise group %d: %d layer_names, %d unique physical layers, caches_per_layer=%d",
+                    "layerwise group %d: %d layer_names, %d unique physical layers",
                     group_id,
                     len(group_spec.layer_names),
                     len(phys_to_layer_idx),
-                    len(group_spec.layer_names) // max(1, len(phys_to_layer_idx)),
                 )
 
         self.layer_load_tasks: list[list[LayerTransferTask]] = [[] for _ in range(self.num_layers)]
@@ -386,11 +400,20 @@ class KVPoolWorker:
         self.independent_layers: list[int] = []
         self.prefetch_layer_map: dict[int, int] = {}
         if self.use_gva_layerwise:
-            cache_layout = build_layerwise_cache_layout(self.num_layers, self._extra_config)
-            self.layerwise_offload = cache_layout.has_layer_reuse
-            self.independent_layers = cache_layout.independent_layers
-            self.prefetch_layer_map = cache_layout.prefetch_layer_map
-            self.num_prefetch_layers = cache_layout.num_prefetch_layers
+            if self._layerwise_reuse_layout is None:
+                cache_layout = build_layerwise_cache_layout(
+                    self.num_layers,
+                    self._extra_config,
+                )
+                self.layerwise_offload = cache_layout.has_layer_reuse
+                self.independent_layers = cache_layout.independent_layers
+                self.prefetch_layer_map = cache_layout.prefetch_layer_map
+                self.num_prefetch_layers = cache_layout.num_prefetch_layers
+            else:
+                self.layerwise_offload = self._layerwise_reuse_layout.has_layer_reuse
+                self.independent_layers = self._layerwise_reuse_layout.independent_layers
+                self.prefetch_layer_map = self._layerwise_reuse_layout.prefetch_layer_map
+                self.num_prefetch_layers = self._layerwise_reuse_layout.num_prefetch_layers
         else:
             self.num_prefetch_layers = int(self._extra_config.get("layerwise_prefetch_layers", 1))
         self.sync_save_events: list[torch.npu.Event] | None = None
@@ -700,14 +723,8 @@ class KVPoolWorker:
             layer_names_by_physical.setdefault(phys, []).append(layer_name)
 
         layer_offsets = [0]
-        physical_layer_order = (
-            sorted(layer_names_by_physical) if self.num_kv_cache_groups == 1 else layer_names_by_physical
-        )
-        for phys in physical_layer_order:
-            for layer_name in sorted(
-                layer_names_by_physical[phys],
-                key=lambda name: "indexer" in name,
-            ):
+        for phys in sorted(layer_names_by_physical):
+            for layer_name in sorted(layer_names_by_physical[phys]):
                 cache_or_caches = self.kv_caches[layer_name]
                 for cache in self._as_cache_tuple(cache_or_caches):
                     base_addr = cache.data_ptr()
@@ -822,11 +839,6 @@ class KVPoolWorker:
             )
             self.layer_load_tasks = [[] for _ in range(self.num_layers)]
             self.layer_save_tasks = [[] for _ in range(self.num_layers)]
-            cache_layout = build_layerwise_cache_layout(self.num_layers, self._extra_config)
-            self.layerwise_offload = cache_layout.has_layer_reuse
-            self.independent_layers = cache_layout.independent_layers
-            self.prefetch_layer_map = cache_layout.prefetch_layer_map
-            self.num_prefetch_layers = cache_layout.num_prefetch_layers
 
         self.page_size_bytes = sum(self.block_len)
         self.token_database.set_group_buffers(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -334,6 +334,22 @@ class KVPoolWorker:
         # multiple cache tensors of ONE layer (caches_per_layer > 1).
         self.physical_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
 
+        if self.kv_cache_config is not None:
+            physical_layers = {
+                self._extract_physical_layer_index(layer_name)
+                for group_spec in self.kv_cache_config.kv_cache_groups
+                for layer_name in group_spec.layer_names
+            }
+            if physical_layers:
+                effective_num_layers = max(self.num_layers, max(physical_layers) + 1)
+                if effective_num_layers != self.num_layers:
+                    logger.info(
+                        "KVPoolWorker: updated num_layers %d -> %d from cache group layout.",
+                        self.num_layers,
+                        effective_num_layers,
+                    )
+                    self.num_layers = effective_num_layers
+
         if self.kv_cache_config is not None and self.num_kv_cache_groups > 1:
             for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
                 # Map each unique physical layer to a sequential layer_idx_in_group
@@ -391,10 +407,7 @@ class KVPoolWorker:
         for group_id in range(self.num_kv_cache_groups):
             group_num_layers = self.group_num_layers.get(group_id, self.num_layers)
             group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
-            if group_block_len and group_num_layers > 0:
-                group_page_size = sum(group_block_len) // group_num_layers
-            else:
-                group_page_size = self.page_size_bytes
+            group_page_size = sum(group_block_len) if group_block_len else self.page_size_bytes
             builders.append(
                 LayerBatchBuilder(
                     self.token_database,
@@ -679,23 +692,35 @@ class KVPoolWorker:
         group_addrs: list[int] = []
         group_block_lens: list[int] = []
         group_block_strides: list[int] = []
-        physical_layers = set()
+        layer_names_by_physical: dict[int, list[str]] = {}
         for layer_name in layer_names:
             phys = self._extract_physical_layer_index(layer_name)
-            if phys >= getattr(self.hf_config, "num_hidden_layers", self.num_layers):
+            if phys >= self.num_layers and self.num_kv_cache_groups > 1:
                 continue
-            physical_layers.add(phys)
-            cache_or_caches = self.kv_caches[layer_name]
-            for cache in self._as_cache_tuple(cache_or_caches):
-                base_addr = cache.data_ptr()
-                block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
-                group_addrs.append(base_addr)
-                group_block_lens.append(block_len)
-                group_block_strides.append(block_stride)
+            layer_names_by_physical.setdefault(phys, []).append(layer_name)
+
+        layer_offsets = [0]
+        physical_layer_order = (
+            sorted(layer_names_by_physical) if self.num_kv_cache_groups == 1 else layer_names_by_physical
+        )
+        for phys in physical_layer_order:
+            for layer_name in sorted(
+                layer_names_by_physical[phys],
+                key=lambda name: "indexer" in name,
+            ):
+                cache_or_caches = self.kv_caches[layer_name]
+                for cache in self._as_cache_tuple(cache_or_caches):
+                    base_addr = cache.data_ptr()
+                    block_len, block_stride, _, _ = self._get_cache_block_metadata(cache)
+                    group_addrs.append(base_addr)
+                    group_block_lens.append(block_len)
+                    group_block_strides.append(block_stride)
+            layer_offsets.append(len(group_addrs))
         self.group_kv_caches_base_addr[group_id] = group_addrs
         self.group_block_len[group_id] = group_block_lens
         self.group_block_stride[group_id] = group_block_strides
-        self.group_num_layers[group_id] = len(physical_layers)
+        self.group_layer_offsets[group_id] = layer_offsets
+        self.group_num_layers[group_id] = len(layer_names_by_physical)
 
     def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
         """
@@ -736,6 +761,7 @@ class KVPoolWorker:
         self.group_kv_caches_base_addr: dict[int, list[int]] = {}
         self.group_block_len: dict[int, list[int]] = {}
         self.group_block_stride: dict[int, list[int]] = {}
+        self.group_layer_offsets: dict[int, list[int]] = {}
         self.kv_caches = kv_caches
         self.group_kv_cache_families: dict[int, str] = {
             group_id: self._get_group_family(self.kv_cache_group_families, group_id)
@@ -794,6 +820,13 @@ class KVPoolWorker:
                 original_num_layers,
                 self.num_layers,
             )
+            self.layer_load_tasks = [[] for _ in range(self.num_layers)]
+            self.layer_save_tasks = [[] for _ in range(self.num_layers)]
+            cache_layout = build_layerwise_cache_layout(self.num_layers, self._extra_config)
+            self.layerwise_offload = cache_layout.has_layer_reuse
+            self.independent_layers = cache_layout.independent_layers
+            self.prefetch_layer_map = cache_layout.prefetch_layer_map
+            self.num_prefetch_layers = cache_layout.num_prefetch_layers
 
         self.page_size_bytes = sum(self.block_len)
         self.token_database.set_group_buffers(
@@ -803,6 +836,7 @@ class KVPoolWorker:
             cache_role="kv",
             group_cache_families=self.group_kv_cache_families,
             group_num_layers=self.group_num_layers,
+            group_layer_offsets=self.group_layer_offsets,
         )
 
         if self.tp_mismatch:
@@ -1184,13 +1218,8 @@ class KVPoolWorker:
                 cache_family = self._get_group_family(self.kv_cache_group_families, group_id)
                 ratio = max(infer_cache_family_ratio(cache_family), 1)
                 effective_block_size = group_block_size * ratio
-                group_num_layers = self.group_num_layers.get(group_id, self.num_layers)
                 group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
-                if group_block_len and group_num_layers > 0:
-                    group_page_size = sum(group_block_len) // group_num_layers
-                else:
-                    group_page_size = self.page_size_bytes
-                alloc_size = group_page_size * group_num_layers
+                alloc_size = sum(group_block_len) if group_block_len else self.page_size_bytes
 
                 group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
                 block_ids_by_group = (

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3846,6 +3846,11 @@ class NPUModelRunner(GPUModelRunner):
         return kv_caches
 
     def _get_layer_kv_cache_specs(self, kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
+        compilation_config = getattr(self, "compilation_config", None)
+        if compilation_config is None:
+            compilation_config = getattr(self.vllm_config, "compilation_config", None)
+        static_forward_context = getattr(compilation_config, "static_forward_context", None)
+
         layer_kv_cache_spec: dict[str, KVCacheSpec] = {}
         for group_kv_cache_spec in kv_cache_config.kv_cache_groups:
             group_spec = group_kv_cache_spec.kv_cache_spec
@@ -3854,6 +3859,12 @@ class NPUModelRunner(GPUModelRunner):
                     layer_kv_cache_spec[layer_name] = group_spec.kv_cache_specs[layer_name]
                 else:
                     layer_kv_cache_spec[layer_name] = group_spec
+                if static_forward_context is not None:
+                    attn_layer = static_forward_context.get(layer_name)
+                    if isinstance(attn_layer, AttentionLayerBase):
+                        spec = attn_layer.get_kv_cache_spec(self.vllm_config)
+                        if isinstance(spec, AscendSFAIndexerCacheSpec):
+                            layer_kv_cache_spec[layer_name] = spec
         return layer_kv_cache_spec
 
     def _get_attention_kv_cache_dims(self, layer_name: str, kv_cache_spec: AttentionSpec) -> tuple[int, int]:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -972,13 +972,17 @@ class NPUWorker(WorkerBase):
         )
         if not reuse_layout.has_layer_reuse:
             return num_layers, num_layers, 1.0
-        num_buffer_assignments = len(reuse_layout.shared_buffer_layers)
+        num_buffer_assignments = len(reuse_layout.buffer_slots)
 
         logical_page_bytes = sum(spec.page_size_bytes for spec in kv_cache_spec.values())
-        physical_page_bytes = sum(
-            sum(entry.spec.page_size_bytes for entry in reuse_layout.layer_entries[layers_sharing_buffer[0]])
-            for layers_sharing_buffer in reuse_layout.shared_buffer_layers
-        )
+        physical_page_bytes = 0
+        for slot in reuse_layout.buffer_slots:
+            physical_page_bytes += reuse_layout.layer_cache_specs[slot[0]].main.spec.page_size_bytes
+            for layer in slot:
+                indexer = reuse_layout.layer_cache_specs[layer].indexer
+                if indexer is not None:
+                    physical_page_bytes += indexer.spec.page_size_bytes
+                    break
         return num_layers, num_buffer_assignments, logical_page_bytes / physical_page_bytes
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -63,7 +63,9 @@ from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     build_layerwise_cache_layout,
+    build_layerwise_reuse_layout,
     get_gva_layerwise_config,
+    get_layerwise_physical_layer_index,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     get_host_device_memory_usage_ratio,
@@ -594,15 +596,19 @@ class NPUWorker(WorkerBase):
 
         extra_config = get_gva_layerwise_config(self.vllm_config.kv_transfer_config)
         if extra_config is not None:
-            num_layers = self.model_config.get_num_layers(self.parallel_config)
-            layout = build_layerwise_cache_layout(num_layers, extra_config)
-            if layout.has_layer_reuse:
-                num_tensors = len(layout.storage_indices)
-                factor = num_layers / num_tensors
+            memory_info = getattr(self, "_gva_layerwise_memory_info", None)
+            if memory_info is None:
+                num_layers = self.model_config.get_num_layers(self.parallel_config)
+                layout = build_layerwise_cache_layout(num_layers, extra_config)
+                num_slots = len(layout.storage_indices)
+                factor = num_layers / num_slots if layout.has_layer_reuse else 1.0
+            else:
+                num_layers, num_slots, factor = memory_info
+            if factor != 1.0:
                 self.available_kv_cache_memory_bytes = int(self.available_kv_cache_memory_bytes * factor)
                 logger.info(
                     "Layerwise KV cache reuse uses %d buffers for %d layers; scale logical KV budget by %.3f.",
-                    num_tensors,
+                    num_slots,
                     num_layers,
                     factor,
                 )
@@ -946,8 +952,56 @@ class NPUWorker(WorkerBase):
             return {(pp_rank, pcp_rank, tp_rank): metadata}
         return {(pp_rank, tp_rank): metadata}
 
+    def _get_layerwise_kv_cache_memory_info(
+        self,
+        kv_cache_spec: dict[str, KVCacheSpec],
+        extra_config: dict[str, Any],
+    ) -> tuple[int, int, float]:
+        if not kv_cache_spec:
+            return 0, 0, 1.0
+        base_layers = self.model_config.get_num_layers(self.parallel_config)
+        physical_layers = {get_layerwise_physical_layer_index(layer_name, base_layers) for layer_name in kv_cache_spec}
+        num_layers = len(physical_layers)
+        if num_layers < base_layers:
+            return num_layers, num_layers, 1.0
+        layout = build_layerwise_cache_layout(num_layers, extra_config)
+        if not layout.has_layer_reuse:
+            return num_layers, num_layers, 1.0
+        num_slots = len(layout.storage_indices)
+
+        layer_layout, storage_slots = build_layerwise_reuse_layout(
+            kv_cache_spec,
+            base_layers,
+            extra_config,
+        )
+        if len(layer_layout) != num_layers or len(storage_slots) != num_slots:
+            raise RuntimeError("Layerwise KV cache memory layout does not match the physical layer reuse plan.")
+
+        logical_page_bytes = sum(spec.page_size_bytes for spec in kv_cache_spec.values())
+        physical_page_bytes = 0
+        for slot_layers in storage_slots:
+            for component in ("main", "indexer"):
+                component_specs = [
+                    kv_cache_spec[layer_layout[layer][component]]
+                    for layer in slot_layers
+                    if component in layer_layout[layer]
+                ]
+                if not component_specs:
+                    continue
+                page_sizes = {spec.page_size_bytes for spec in component_specs}
+                if len(page_sizes) != 1:
+                    raise ValueError(f"Layers sharing a layerwise slot must have equal {component} page sizes.")
+                physical_page_bytes += page_sizes.pop()
+        return num_layers, num_slots, logical_page_bytes / physical_page_bytes
+
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         kv_cache_spec = self.model_runner.get_kv_cache_spec()
+        extra_config = get_gva_layerwise_config(self.vllm_config.kv_transfer_config)
+        if extra_config is not None:
+            self._gva_layerwise_memory_info = self._get_layerwise_kv_cache_memory_info(
+                kv_cache_spec,
+                extra_config,
+            )
         if get_ascend_config().sparse_kv_offload_config.enabled:
             # reserve kv_cache_spec for sparse kv offload memory profile usage.
             self.kv_cache_spec = kv_cache_spec

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -600,16 +600,17 @@ class NPUWorker(WorkerBase):
             if memory_info is None:
                 num_layers = self.model_config.get_num_layers(self.parallel_config)
                 layout = build_layerwise_cache_layout(num_layers, extra_config)
-                num_slots = len(layout.storage_indices)
-                factor = num_layers / num_slots if layout.has_layer_reuse else 1.0
+                num_buffer_assignments = len(layout.storage_indices)
+                factor = num_layers / num_buffer_assignments if layout.has_layer_reuse else 1.0
             else:
-                num_layers, num_slots, factor = memory_info
+                num_layers, num_buffer_assignments, factor = memory_info
             if factor != 1.0:
                 self.available_kv_cache_memory_bytes = int(self.available_kv_cache_memory_bytes * factor)
                 logger.info(
-                    "Layerwise KV cache reuse uses %d buffers for %d layers; scale logical KV budget by %.3f.",
-                    num_slots,
+                    "Layerwise KV cache reuse maps %d layers onto %d buffer assignments; "
+                    "scale logical KV budget by %.3f.",
                     num_layers,
+                    num_buffer_assignments,
                     factor,
                 )
 
@@ -971,14 +972,14 @@ class NPUWorker(WorkerBase):
         )
         if not reuse_layout.has_layer_reuse:
             return num_layers, num_layers, 1.0
-        num_slots = len(reuse_layout.storage_slots)
+        num_buffer_assignments = len(reuse_layout.shared_buffer_layers)
 
         logical_page_bytes = sum(spec.page_size_bytes for spec in kv_cache_spec.values())
         physical_page_bytes = sum(
-            sum(entry.spec.page_size_bytes for entry in reuse_layout.layer_entries[slot_layers[0]])
-            for slot_layers in reuse_layout.storage_slots
+            sum(entry.spec.page_size_bytes for entry in reuse_layout.layer_entries[layers_sharing_buffer[0]])
+            for layers_sharing_buffer in reuse_layout.shared_buffer_layers
         )
-        return num_layers, num_slots, logical_page_bytes / physical_page_bytes
+        return num_layers, num_buffer_assignments, logical_page_bytes / physical_page_bytes
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         kv_cache_spec = self.model_runner.get_kv_cache_spec()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -964,34 +964,20 @@ class NPUWorker(WorkerBase):
         num_layers = len(physical_layers)
         if num_layers < base_layers:
             return num_layers, num_layers, 1.0
-        layout = build_layerwise_cache_layout(num_layers, extra_config)
-        if not layout.has_layer_reuse:
-            return num_layers, num_layers, 1.0
-        num_slots = len(layout.storage_indices)
-
-        layer_layout, storage_slots = build_layerwise_reuse_layout(
+        reuse_layout = build_layerwise_reuse_layout(
             kv_cache_spec,
             base_layers,
             extra_config,
         )
-        if len(layer_layout) != num_layers or len(storage_slots) != num_slots:
-            raise RuntimeError("Layerwise KV cache memory layout does not match the physical layer reuse plan.")
+        if not reuse_layout.has_layer_reuse:
+            return num_layers, num_layers, 1.0
+        num_slots = len(reuse_layout.storage_slots)
 
         logical_page_bytes = sum(spec.page_size_bytes for spec in kv_cache_spec.values())
-        physical_page_bytes = 0
-        for slot_layers in storage_slots:
-            for component in ("main", "indexer"):
-                component_specs = [
-                    kv_cache_spec[layer_layout[layer][component]]
-                    for layer in slot_layers
-                    if component in layer_layout[layer]
-                ]
-                if not component_specs:
-                    continue
-                page_sizes = {spec.page_size_bytes for spec in component_specs}
-                if len(page_sizes) != 1:
-                    raise ValueError(f"Layers sharing a layerwise slot must have equal {component} page sizes.")
-                physical_page_bytes += page_sizes.pop()
+        physical_page_bytes = sum(
+            sum(entry.spec.page_size_bytes for entry in reuse_layout.layer_entries[slot_layers[0]])
+            for slot_layers in reuse_layout.storage_slots
+        )
         return num_layers, num_slots, logical_page_bytes / physical_page_bytes
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:


### PR DESCRIPTION
### What this PR does / why we need it?

> [!NOTE]
> This is the `releases/v0.26.0rc` backport of #12853 and the second PR in a stacked series.
> It depends on #13816. Until that PR is merged, the GitHub diff will also contain its layerwise buffer reuse changes.

This PR extends the layerwise KV Pool to support MTP layers, separated SFA main/indexer cache groups, and sparse C8 indexer caches in the prefill offload path.

Models using speculative decoding may introduce MTP layers beyond the base transformer layers. Sparse attention models can also use distinct main and indexer cache layouts, where a sparse C8 indexer contains data and scale tensors. The layerwise KV Pool must preserve those physical layouts while applying buffer reuse.

The main changes include:

- Extending physical layer planning to include MTP layers.
- Supporting heterogeneous SFA main and indexer cache specs.
- Supporting a variable number of cache tensors per physical layer.
- Adding per-layer cache offsets for correct layerwise transfer addresses.
- Allocating and registering sparse C8 indexer data and scale tensors.
- Updating scheduling and logical memory accounting for the complete physical layer set.
- Preserving MTP cache-hit replay boundaries.
- Validating multi-group layouts and retaining safe fallbacks for incomplete layouts.
- Restoring the physical SFA indexer spec when vLLM grouping exposes a generic attention spec.
- Treating `AscendSFAIndexerCacheSpec` as an MLA cache spec to avoid GQA misclassification.

The last two items carry the code-level fixes corresponding to #12846 and #12849 that were present in the original main-based branch ancestry but absent from the release branch.

Merge order: #13711 → #13816 → this PR → the SFA PD RD2H connector PR.

### Does this PR introduce _any_ user-facing change?

Yes. Layerwise prefill offload can now be used with supported MTP and sparse C8 SFA cache layouts on the v0.26.0 release branch.

### How was this patch tested?

- Added and updated unit tests for MTP mapping, heterogeneous main/indexer layouts, sparse C8 data/scale allocation, multi-group validation, memory accounting, and MTP replay boundaries.
- Added regression coverage for recovering an SFA indexer spec after KV cache grouping downgrades it to a generic attention spec.
- `bash format.sh ci` passed all repository hooks on the complete rebased stack.
- `git diff --check`, commit sign-off checks, duplicate patch checks, and Python syntax/import scans passed.
- The focused pytest command was attempted locally but could not load `tests/ut/conftest.py` because the local environment does not provide the `vllm` package; runtime and NPU validation are pending CI.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
