### PR TITLE
[v0.25.1rc][BugFix][Worker] Synchronize ACLGraph mode across MC2 DP ranks

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -37,7 +37,7 @@ class TestSyncMetadataAcrossDP(unittest.TestCase):
         runner.dp_size = 2
         runner.dp_rank = 0
         runner.vllm_config = MagicMock()
-        runner._use_aclgraph = MagicMock(return_value=True)
+        runner.use_aclgraph = True
         mock_get_dp_group.return_value.cpu_group = "cpu_group"
         mock_all_reduce.side_effect = lambda tensor, **_: tensor.fill_(CUDAGraphMode.NONE.value)
 

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 import torch
+import torch.distributed as dist
+from vllm.config import CUDAGraphMode
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.v1.kv_cache_interface import (
@@ -17,6 +19,39 @@ from vllm.v1.kv_cache_interface import (
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+class TestSyncMetadataAcrossDP(unittest.TestCase):
+    @patch("vllm_ascend.worker.model_runner_v1.is_moe_model", return_value=True)
+    @patch("vllm_ascend.worker.model_runner_v1.should_skip_allreduce_across_dp_group", return_value=True)
+    @patch("vllm_ascend.worker.model_runner_v1.get_dp_group")
+    @patch("vllm_ascend.worker.model_runner_v1.dist.all_reduce")
+    def test_syncs_graph_mode_when_mc2_skips_token_sync(
+        self,
+        mock_all_reduce,
+        mock_get_dp_group,
+        _mock_should_skip,
+        _mock_is_moe,
+    ):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.dp_size = 2
+        runner.dp_rank = 0
+        runner.vllm_config = MagicMock()
+        runner._use_aclgraph = MagicMock(return_value=True)
+        mock_get_dp_group.return_value.cpu_group = "cpu_group"
+        mock_all_reduce.side_effect = lambda tensor, **_: tensor.fill_(CUDAGraphMode.NONE.value)
+
+        num_tokens, tokens_across_dp, graph_mode = runner._sync_metadata_across_dp(
+            num_tokens=8,
+            cudagraph_mode=CUDAGraphMode.FULL,
+        )
+
+        self.assertEqual(num_tokens, 8)
+        torch.testing.assert_close(tokens_across_dp, torch.tensor([8, 8], dtype=torch.int32))
+        self.assertEqual(graph_mode, CUDAGraphMode.NONE)
+        mock_all_reduce.assert_called_once()
+        self.assertEqual(mock_all_reduce.call_args.kwargs["op"], dist.ReduceOp.MIN)
+        self.assertEqual(mock_all_reduce.call_args.kwargs["group"], "cpu_group")
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -159,6 +159,7 @@ from vllm_ascend.utils import (
     get_c_env,
     global_stream,
     is_hidden_state_cache_spec,
+    is_moe_model,
     kv_cache_spec_uses_sparse_c8,
     lmhead_tp_enable,
     oproj_tp_enable,
@@ -647,6 +648,11 @@ class NPUModelRunner(GPUModelRunner):
             return num_tokens, None, cudagraph_mode
 
         if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
+            if not is_draft_model and is_moe_model(self.vllm_config) and self._use_aclgraph():
+                # MC2 supports per-rank token counts, but graph/eager HCCL submissions must match across DP ranks.
+                mode_tensor = torch.tensor(cudagraph_mode.value, device="cpu", dtype=torch.int32)
+                dist.all_reduce(mode_tensor, op=dist.ReduceOp.MIN, group=get_dp_group().cpu_group)
+                cudagraph_mode = CUDAGraphMode(mode_tensor.item())
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -648,7 +648,7 @@ class NPUModelRunner(GPUModelRunner):
             return num_tokens, None, cudagraph_mode
 
         if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
-            if not is_draft_model and is_moe_model(self.vllm_config) and self._use_aclgraph():
+            if not is_draft_model and is_moe_model(self.vllm_config) and self.use_aclgraph:
                 # MC2 supports per-rank token counts, but graph/eager HCCL submissions must match across DP ranks.
                 mode_tensor = torch.tensor(cudagraph_mode.value, device="cpu", dtype=torch.int32)
                 dist.all_reduce(mode_tensor, op=dist.ReduceOp.MIN, group=get_dp_group().cpu_group)


### PR DESCRIPTION
### What this PR does / why we need it?

When MC2 supports uneven token counts, `_sync_metadata_across_dp()` skips the
token-count all-reduce. The same early return also skipped ACLGraph mode
synchronization, allowing active and idle DP ranks to submit graph and eager
work into the same EP collective at a variable-length batch tail.

This patch preserves per-rank token counts and synchronizes only
`CUDAGraphMode` for the main MoE model when ACLGraph is enabled. It uses a
minimum reduction on the DP CPU group so that if any rank requires eager
execution, all ranks use eager execution for that step. The eager DSpark
drafter is unchanged.

Fixes #13826

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Variable-length DP/EP requests no longer hang
when MC2 skips token-count synchronization and DP ranks choose different graph
modes.

### How was this patch tested?

- `pytest -q tests/ut/worker/a2/test_model_runner_v1.py` (`19 passed`)
- `ruff check`, `ruff format --check`, and `git diff --check`
- `SKIP=actionlint,gitleaks-offline-scan uv run --with pre-commit bash format.sh ci`
  (all remaining hooks passed; `actionlint` was skipped because its first-time
  Go toolchain download stalled, and the release branch's gitleaks script is
  not executable)
- A2 real-service validation with the original variable-length workload:
  two consecutive runs completed `128/128`, with zero failed requests, zero
  service errors, all 32 decode endpoints healthy, and all ranks returning to
  `Running=0`, `Waiting=0`

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
