### PR TITLE
[CI]Skip error glm5.2 dspark test

### DIFF
--- a/tests/e2e/pull_request/eight_card/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/test_glm5_2.py
@@ -88,6 +88,7 @@ def _run_speculative_decoding(
     return acceptance_per_pos
 
 
+@pytest.mark.skip(reason="No confidence_head tensors were found in the checkpoint, fix me")
 @pytest.mark.e2e_model(MAIN_MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",


### PR DESCRIPTION
### What this PR does / why we need it?

This PR temporarily skips the GLM-5.2 DSpark acceptance test (`test_glm_5_2_dspark_acceptance_tp8`) because the required `confidence_head` tensors were not found in the checkpoint.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
