### PR TITLE
[Performance][Ops] Support stride-aware recurrent KDA state updates

### DIFF
--- a/csrc/attention/recurrent_kda/README.md
+++ b/csrc/attention/recurrent_kda/README.md
@@ -32,7 +32,7 @@ out = torch.ops._C_ascend.recurrent_kda(
     - `safe_gate=False`：`gate = -exp(A_log) * softplus(g + dt_bias)`。
     - `safe_gate=True`：`gate = lower_bound * sigmoid(exp(A_log) * (g + dt_bias))`。
 - `use_beta_sigmoid_in_kernel=True` 时，kernel 使用 `sigmoid(beta)`；若 `allow_neg_eigval=True`，再乘 2。
-- `_C_ascend`/aclnn 入口支持非连续 state，并通过临时连续 tensor 回写原 view。
+- `_C_ascend`/aclnn 入口保留非连续 state 的 storage、stride 和 offset，kernel 按真实 stride 直接读写；仅允许 slot/head 外层维存在间隔，内部二维 state 矩阵必须行主序稠密。
 
 每个 token 的 recurrent 更新为：
 
@@ -52,5 +52,5 @@ o_t = S @ (q_t * scale)
   末项不得超过输入 token capacity，各相邻差值必须不超过 8。末项小于 capacity 时，仅有效 token
   对应的输出和 state 更新有定义，padding tail 输出不作保证。
 - 仅支持 `layout="BSND"` 和 `layout="TND"`。
-- 仅支持 `state_v_first=True`，state layout 为 `[state_capacity,HV,V,K]`；底层 aclnn 接口要求显式传入可变 state。
-- `HV` 必须能被 `H` 整除；`H/HV <= 256`。底层 kernel 支持 `K=128,V=128/256`，当前 Kimi K3 torch 入口收窄为 `K=V=128`。
+- Kimi K3 Torch 入口固定 `state_v_first=True`，state layout 为 `[state_capacity,HV,V,K]`；底层 aclnn/kernel 同时支持 V-first 和 `[state_capacity,HV,K,V]` 的 K-first 布局。
+- `HV` 必须能被 `H` 整除；`H/HV <= 256`。底层 kernel 与 Kimi K3 Torch 入口均支持 `K=128,V=128/256`。

--- a/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
@@ -11,7 +11,6 @@
 #include "aclnn_recurrent_kda.h"
 #include "recurrent_kda.h"
 
-#include "aclnn_kernels/cast.h"
 #include "aclnn_kernels/common/op_error_check.h"
 #include "aclnn_kernels/contiguous.h"
 #include "opdev/common_types.h"
@@ -45,8 +44,8 @@ struct RecurrentKdaParams {
     const aclTensor *value = nullptr;
     const aclTensor *gate = nullptr;
     const aclTensor *beta = nullptr;
-    aclTensor *stateRef = nullptr;
-    const aclTensor *cuSeqlens = nullptr;
+    aclTensor *initialStateRef = nullptr;
+    const aclTensor *cuSeqlensOptional = nullptr;
     const aclTensor *ssmStateIndicesOptional = nullptr;
     const aclTensor *aLogOptional = nullptr;
     const aclTensor *dtBiasOptional = nullptr;
@@ -54,14 +53,16 @@ struct RecurrentKdaParams {
     const char *layout = "BSND";
     double scale = 1.0;
     bool outputFinalState = false;
+    bool inplaceFinalState = true;
     bool useQkL2normInKernel = false;
     bool useGateInKernel = false;
     bool useBetaSigmoidInKernel = false;
     bool allowNegEigval = false;
     bool safeGate = false;
     double lowerBound = -5.0;
-    bool stateVFirst = true;
-    const aclTensor *out = nullptr;
+    bool stateVFirst = false;
+    const aclTensor *attnOut = nullptr;
+    const aclTensor *finalState = nullptr;
 };
 
 static const std::initializer_list<op::DataType> QKV_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
@@ -74,17 +75,17 @@ static const std::initializer_list<op::DataType> F32_TYPE_SUPPORT_LIST = {op::Da
 static const std::initializer_list<op::DataType> INT_TYPE_SUPPORT_LIST = {op::DataType::DT_INT32,
                                                                           op::DataType::DT_INT64};
 
-size_t Rank(const aclTensor *tensor)
+static size_t Rank(const aclTensor *tensor)
 {
     return tensor->GetViewShape().GetDimNum();
 }
 
-int64_t Dim(const aclTensor *tensor, size_t idx)
+static int64_t Dim(const aclTensor *tensor, size_t idx)
 {
     return tensor->GetViewShape().GetDim(idx);
 }
 
-bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
+static bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
 {
     if (Rank(lhs) != Rank(rhs)) {
         return false;
@@ -97,7 +98,7 @@ bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
     return true;
 }
 
-bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
+static bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
 {
     if (layout == nullptr || std::strcmp(layout, "BSND") == 0) {
         parsed = RecurrentKdaLayout::BSND;
@@ -113,8 +114,12 @@ bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
 
 bool CheckCuSeqlensShape(const aclTensor *cuSeqlens, const char *opName)
 {
+    if (cuSeqlens == nullptr) {
+        return true;
+    }
     if (Rank(cuSeqlens) != 1 || Dim(cuSeqlens, DIM0) < 2) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "%s: cu_seqlens must be a 1D tensor with at least two elements.", opName);
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID,
+                "%s: cuSeqlensOptional must be a 1D tensor with at least two elements.", opName);
         return false;
     }
     return true;
@@ -187,31 +192,33 @@ bool CheckShape(const RecurrentKdaParams &params, RecurrentKdaLayout layout)
                 kDim, vDim);
         return false;
     }
-    if (!CheckCuSeqlensShape(params.cuSeqlens, "npu_recurrent_kda")) {
+    if (!CheckCuSeqlensShape(params.cuSeqlensOptional, "npu_recurrent_kda")) {
         return false;
     }
-    int64_t seqNum = Dim(params.cuSeqlens, DIM0) - 1;
-    if (!params.stateVFirst) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: state_v_first=false is not supported.");
+    int64_t seqNum = params.cuSeqlensOptional == nullptr ?
+        ((layout == RecurrentKdaLayout::BSND) ? batch : 1) :
+        Dim(params.cuSeqlensOptional, DIM0) - 1;
+    if (Rank(params.initialStateRef) != 4) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: initialStateRef must be rank 4.");
         return false;
     }
-    if (Rank(params.stateRef) != 4) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID,
-                "npu_recurrent_kda: state must be rank 4 [state_capacity, HV, V, K].");
-        return false;
-    }
-    int64_t stateCapacity = Dim(params.stateRef, DIM0);
-    if (stateCapacity <= 0 ||
-        Dim(params.stateRef, DIM1) != hv || Dim(params.stateRef, DIM2) != vDim ||
-        Dim(params.stateRef, DIM3) != kDim ||
+    int64_t stateCapacity = Dim(params.initialStateRef, DIM0);
+    bool stateTailMatches = params.stateVFirst ?
+        (Dim(params.initialStateRef, DIM2) == vDim && Dim(params.initialStateRef, DIM3) == kDim) :
+        (Dim(params.initialStateRef, DIM2) == kDim && Dim(params.initialStateRef, DIM3) == vDim);
+    if (stateCapacity <= 0 || Dim(params.initialStateRef, DIM1) != hv || !stateTailMatches ||
         (params.ssmStateIndicesOptional == nullptr && stateCapacity != seqNum)) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID,
-                "npu_recurrent_kda: state must be [state_capacity, HV, V, K]; without ssm_state_indices, "
-                "state_capacity must equal seq_num.");
+                "npu_recurrent_kda: state must be [state_capacity,HV,V,K] when stateVFirst=true or "
+                "[state_capacity,HV,K,V] otherwise; without ssmStateIndicesOptional, state_capacity must equal seq_num.");
         return false;
     }
-    if (!SameShape(params.out, params.value)) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: out output shape must match value.");
+    if (!SameShape(params.attnOut, params.value)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: attnOut shape must match value.");
+        return false;
+    }
+    if (!SameShape(params.finalState, params.initialStateRef)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: finalState shape must match initialStateRef.");
         return false;
     }
     if (params.ssmStateIndicesOptional != nullptr) {
@@ -266,9 +273,9 @@ bool CheckNotNull(const RecurrentKdaParams &params)
     OP_CHECK_NULL(params.value, return false);
     OP_CHECK_NULL(params.gate, return false);
     OP_CHECK_NULL(params.beta, return false);
-    OP_CHECK_NULL(params.stateRef, return false);
-    OP_CHECK_NULL(params.cuSeqlens, return false);
-    OP_CHECK_NULL(params.out, return false);
+    OP_CHECK_NULL(params.initialStateRef, return false);
+    OP_CHECK_NULL(params.attnOut, return false);
+    OP_CHECK_NULL(params.finalState, return false);
     return true;
 }
 
@@ -279,9 +286,16 @@ bool CheckDtypeValid(const RecurrentKdaParams &params)
     OP_CHECK_DTYPE_NOT_SUPPORT(params.value, QKV_TYPE_SUPPORT_LIST, return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.gate, GATE_TYPE_SUPPORT_LIST, return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.beta, GATE_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.stateRef, STATE_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.out, QKV_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.cuSeqlens, INT_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.initialStateRef, STATE_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.attnOut, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.finalState, STATE_TYPE_SUPPORT_LIST, return false);
+    if (params.finalState->GetDataType() != params.initialStateRef->GetDataType()) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: finalState dtype must match initialStateRef.");
+        return false;
+    }
+    if (params.cuSeqlensOptional != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(params.cuSeqlensOptional, INT_TYPE_SUPPORT_LIST, return false);
+    }
     if (params.ssmStateIndicesOptional != nullptr) {
         OP_CHECK_DTYPE_NOT_SUPPORT(params.ssmStateIndicesOptional, INT_TYPE_SUPPORT_LIST, return false);
     }
@@ -321,46 +335,27 @@ void SetInputOriginalShape(RecurrentKdaParams &params)
     SetTensorOriginalShape(params.value);
     SetTensorOriginalShape(params.gate);
     SetTensorOriginalShape(params.beta);
-    SetTensorOriginalShape(params.stateRef);
-    SetTensorOriginalShape(params.cuSeqlens);
+    SetTensorOriginalShape(params.initialStateRef);
+    SetTensorOriginalShape(params.cuSeqlensOptional);
     SetTensorOriginalShape(params.ssmStateIndicesOptional);
     SetTensorOriginalShape(params.aLogOptional);
     SetTensorOriginalShape(params.dtBiasOptional);
     SetTensorOriginalShape(params.numAcceptedTokensOptional);
 }
 
-const aclTensor *MaybeCast(const aclTensor *tensor, DataType dataType, aclOpExecutor *executor)
-{
-    if (tensor == nullptr || tensor->GetDataType() == dataType) {
-        return tensor;
-    }
-    return l0op::Cast(tensor, dataType, executor);
-}
-
 aclnnStatus PreProcess(RecurrentKdaParams &params, aclOpExecutor *executor)
 {
-    bool hasSsmStateIndices = params.ssmStateIndicesOptional != nullptr;
-    bool hasNumAcceptedTokens = params.numAcceptedTokensOptional != nullptr;
     SetInputOriginalShape(params);
     CHECK_RET(DataContiguous(params.query, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.key, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.value, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.gate, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.beta, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(DataContiguous(params.cuSeqlens, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguous(params.cuSeqlensOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.ssmStateIndicesOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.aLogOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.dtBiasOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.numAcceptedTokensOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    params.gate = MaybeCast(params.gate, DataType::DT_FLOAT, executor);
-    params.beta = MaybeCast(params.beta, DataType::DT_FLOAT, executor);
-    params.cuSeqlens = MaybeCast(params.cuSeqlens, DataType::DT_INT64, executor);
-    params.ssmStateIndicesOptional = MaybeCast(params.ssmStateIndicesOptional, DataType::DT_INT64, executor);
-    params.numAcceptedTokensOptional = MaybeCast(params.numAcceptedTokensOptional, DataType::DT_INT64, executor);
-    CHECK_RET(params.gate != nullptr && params.beta != nullptr && params.cuSeqlens != nullptr,
-              ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(!hasSsmStateIndices || params.ssmStateIndicesOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(!hasNumAcceptedTokens || params.numAcceptedTokensOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
     if (params.ssmStateIndicesOptional == nullptr && params.numAcceptedTokensOptional != nullptr) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID,
                 "npu_recurrent_kda: num_accepted_tokens requires ssm_state_indices.");
@@ -376,8 +371,8 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
@@ -385,6 +380,7 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const char *layout,
     double scale,
     bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -392,25 +388,28 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     uint64_t *workspaceSize,
     aclOpExecutor **executor)
 {
     L2_DFX_PHASE_1(aclnnRecurrentKda,
-                   DFX_IN(query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional,
-                          aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale, outputFinalState,
-                          useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate,
-                          lowerBound, stateVFirst),
-                   DFX_OUT(out, stateRef));
+                   DFX_IN(query, key, value, gate, beta, initialStateRef, cuSeqlensOptional,
+                          ssmStateIndicesOptional, aLogOptional, dtBiasOptional, numAcceptedTokensOptional,
+                          layout, scale, outputFinalState, inplaceFinalState, useQkL2normInKernel,
+                          useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound,
+                          stateVFirst),
+                   DFX_OUT(attnOut, initialStateRef, finalState));
 
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
     auto executorPtr = uniqueExecutor.get();
 
-    RecurrentKdaParams params{query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional,
-                              aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale,
-                              outputFinalState, useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel,
-                              allowNegEigval, safeGate, lowerBound, stateVFirst, out};
+    RecurrentKdaParams params{query, key, value, gate, beta, initialStateRef, cuSeqlensOptional,
+                              ssmStateIndicesOptional, aLogOptional, dtBiasOptional,
+                              numAcceptedTokensOptional, layout, scale, outputFinalState, inplaceFinalState,
+                              useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel,
+                              allowNegEigval, safeGate, lowerBound, stateVFirst, attnOut, finalState};
 
     CHECK_RET(CheckNotNull(params), ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckDtypeValid(params), ACLNN_ERR_PARAM_INVALID);
@@ -419,23 +418,43 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     CHECK_RET(CheckShape(params, parsedLayout), ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(PreProcess(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
 
-    aclTensor *stateForKernel = params.stateRef;
-    bool stateNeedViewCopy = !IsContiguous(params.stateRef);
-    if (stateNeedViewCopy) {
-        const aclTensor *contiguousState = params.stateRef;
-        CHECK_RET(DataContiguous(contiguousState, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-        stateForKernel = const_cast<aclTensor *>(contiguousState);
+    aclTensor *initialStateForKernel = params.initialStateRef;
+    if (!IsContiguous(initialStateForKernel)) {
+        initialStateForKernel = executorPtr->CreateView(
+            initialStateForKernel,
+            initialStateForKernel->GetViewShape(),
+            initialStateForKernel->GetStorageShape(),
+            initialStateForKernel->GetViewStrides(),
+            initialStateForKernel->GetViewOffset());
+        CHECK_RET(initialStateForKernel != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+    const aclTensor *finalStateForKernel = params.finalState;
+    if (!params.inplaceFinalState || params.outputFinalState) {
+        if (!IsContiguous(finalStateForKernel)) {
+            finalStateForKernel = executorPtr->CreateView(
+                finalStateForKernel,
+                finalStateForKernel->GetViewShape(),
+                finalStateForKernel->GetStorageShape(),
+                finalStateForKernel->GetViewStrides(),
+                finalStateForKernel->GetViewOffset());
+            CHECK_RET(finalStateForKernel != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        }
     }
 
-    auto result = l0op::RecurrentKda(params.query, params.key, params.value, params.gate, params.beta,
-                                     stateForKernel, params.cuSeqlens, params.ssmStateIndicesOptional,
-                                     params.aLogOptional, params.dtBiasOptional, params.numAcceptedTokensOptional,
-                                     params.layout, params.scale, params.useQkL2normInKernel,
-                                     params.useGateInKernel, params.useBetaSigmoidInKernel, params.allowNegEigval,
-                                     params.safeGate, params.lowerBound, params.stateVFirst, params.out, executorPtr);
-    CHECK_RET(result[0] != nullptr && result[1] != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    if (stateNeedViewCopy) {
-        CHECK_RET(l0op::ViewCopy(result[1], params.stateRef, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto result = l0op::RecurrentKda(
+        params.query, params.key, params.value, params.gate, params.beta, initialStateForKernel,
+        params.cuSeqlensOptional, params.ssmStateIndicesOptional, params.aLogOptional,
+        params.dtBiasOptional, params.numAcceptedTokensOptional, params.layout, params.scale,
+        params.outputFinalState, params.inplaceFinalState, params.useQkL2normInKernel,
+        params.useGateInKernel, params.useBetaSigmoidInKernel, params.allowNegEigval,
+        params.safeGate, params.lowerBound, params.stateVFirst, params.attnOut,
+        finalStateForKernel, executorPtr);
+    CHECK_RET(result[0] != nullptr && result[1] != nullptr && result[2] != nullptr,
+              ACLNN_ERR_INNER_NULLPTR);
+    if (params.inplaceFinalState && params.outputFinalState &&
+        params.finalState != params.initialStateRef) {
+        CHECK_RET(l0op::ViewCopy(result[1], params.finalState, executorPtr) != nullptr,
+                  ACLNN_ERR_INNER_NULLPTR);
     }
 
     *workspaceSize = uniqueExecutor->GetWorkspaceSize();

--- a/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.h
@@ -20,8 +20,8 @@ ACLNN_API aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
@@ -29,6 +29,7 @@ ACLNN_API aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const char *layout,
     double scale,
     bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -36,7 +37,8 @@ ACLNN_API aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     uint64_t *workspaceSize,
     aclOpExecutor **executor);
 

--- a/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.cpp
@@ -23,20 +23,22 @@ namespace l0op {
 
 OP_TYPE_REGISTER(RecurrentKda);
 
-const std::array<const aclTensor *, 2> RecurrentKda(
+const std::array<const aclTensor *, 3> RecurrentKda(
     const aclTensor *query,
     const aclTensor *key,
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
     const aclTensor *numAcceptedTokensOptional,
     const char *layout,
     double scale,
+    bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -44,28 +46,31 @@ const std::array<const aclTensor *, 2> RecurrentKda(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     aclOpExecutor *executor)
 {
-    L0_DFX(RecurrentKda, query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional,
-           aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale, useQkL2normInKernel,
-           useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound, stateVFirst, out,
-           stateRef);
+    L0_DFX(RecurrentKda, query, key, value, gate, beta, initialStateRef, cuSeqlensOptional,
+           ssmStateIndicesOptional, aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale,
+           outputFinalState, inplaceFinalState, useQkL2normInKernel, useGateInKernel,
+           useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound, stateVFirst, attnOut,
+           initialStateRef, finalState);
 
     float scaleAttr = static_cast<float>(scale);
     float lowerBoundAttr = static_cast<float>(lowerBound);
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
         RecurrentKda,
-        OP_INPUT(query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional, aLogOptional,
-                 dtBiasOptional, numAcceptedTokensOptional),
-        OP_OUTPUT(out, stateRef),
-        OP_ATTR(layout, scaleAttr, useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel, allowNegEigval,
-                safeGate, lowerBoundAttr, stateVFirst));
+        OP_INPUT(query, key, value, gate, beta, initialStateRef, cuSeqlensOptional, ssmStateIndicesOptional,
+                 aLogOptional, dtBiasOptional, numAcceptedTokensOptional),
+        OP_OUTPUT(attnOut, initialStateRef, finalState),
+        OP_ATTR(layout, scaleAttr, outputFinalState, inplaceFinalState, useQkL2normInKernel,
+                useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBoundAttr,
+                stateVFirst));
     if (ret != ACLNN_SUCCESS) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID, "RecurrentKda ADD_TO_LAUNCHER_LIST_AICORE failed.");
-        return {nullptr, nullptr};
+        return {nullptr, nullptr, nullptr};
     }
 
-    return {out, stateRef};
+    return {attnOut, initialStateRef, finalState};
 }
 } // namespace l0op

--- a/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.h
@@ -12,20 +12,22 @@
 #include <array>
 
 namespace l0op {
-const std::array<const aclTensor *, 2> RecurrentKda(
+const std::array<const aclTensor *, 3> RecurrentKda(
     const aclTensor *query,
     const aclTensor *key,
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
     const aclTensor *numAcceptedTokensOptional,
     const char *layout,
     double scale,
+    bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -33,7 +35,8 @@ const std::array<const aclTensor *, 2> RecurrentKda(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     aclOpExecutor *executor);
 }
 

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_def.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_def.cpp
@@ -16,56 +16,58 @@ public:
     explicit RecurrentKda(const char *name) : OpDef(name)
     {
         const std::initializer_list<ge::DataType> qkvTypes = {ge::DT_BF16, ge::DT_BF16};
-        const std::initializer_list<ge::DataType> f32Types = {ge::DT_FLOAT, ge::DT_FLOAT};
+        const std::initializer_list<ge::DataType> floatTypes = {ge::DT_FLOAT, ge::DT_FLOAT};
         const std::initializer_list<ge::DataType> stateTypes = {ge::DT_BF16, ge::DT_FLOAT};
-        const std::initializer_list<ge::DataType> i64Types = {ge::DT_INT64, ge::DT_INT64};
-        const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND, ge::FORMAT_ND};
 
-        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("gate").ParamType(REQUIRED).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
-        this->Input("beta").ParamType(REQUIRED).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
-        this->Input("state")
+        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("gate").ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
+        this->Input("beta").ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
+        this->Input("initial_state")
             .ParamType(REQUIRED)
             .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .FormatList({ge::FORMAT_ND})
             .IgnoreContiguous();
         this->Input("cu_seqlens")
-            .ParamType(REQUIRED)
-            .DataType(i64Types)
-            .Format(formats)
-            .UnknownShapeFormat(formats);
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+            .FormatList({ge::FORMAT_ND});
         this->Input("ssm_state_indices")
             .ParamType(OPTIONAL)
-            .DataType(i64Types)
-            .Format(formats)
-            .UnknownShapeFormat(formats);
-        this->Input("A_log").ParamType(OPTIONAL).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
-        this->Input("dt_bias").ParamType(OPTIONAL).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
+            .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+            .FormatList({ge::FORMAT_ND});
+        this->Input("A_log").ParamType(OPTIONAL).DataType(floatTypes).FormatList({ge::FORMAT_ND});
+        this->Input("dt_bias").ParamType(OPTIONAL).DataType(floatTypes).FormatList({ge::FORMAT_ND});
         this->Input("num_accepted_tokens")
             .ParamType(OPTIONAL)
-            .DataType(i64Types)
-            .Format(formats)
-            .UnknownShapeFormat(formats);
-        this->Output("out").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Output("state")
+            .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("attn_out").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Output("initial_state")
             .ParamType(REQUIRED)
             .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Output("final_state")
+            .ParamType(REQUIRED)
+            .DataType(stateTypes)
+            .FormatList({ge::FORMAT_ND})
             .IgnoreContiguous();
 
         this->Attr("layout").AttrType(OPTIONAL).String("BSND");
         this->Attr("scale").AttrType(OPTIONAL).Float(1.0);
+        this->Attr("output_final_state").AttrType(OPTIONAL).Bool(false);
+        this->Attr("inplace_final_state").AttrType(OPTIONAL).Bool(true);
         this->Attr("use_qk_l2norm_in_kernel").AttrType(OPTIONAL).Bool(false);
         this->Attr("use_gate_in_kernel").AttrType(OPTIONAL).Bool(false);
         this->Attr("use_beta_sigmoid_in_kernel").AttrType(OPTIONAL).Bool(false);
         this->Attr("allow_neg_eigval").AttrType(OPTIONAL).Bool(false);
         this->Attr("safe_gate").AttrType(OPTIONAL).Bool(false);
         this->Attr("lower_bound").AttrType(OPTIONAL).Float(-5.0);
-        this->Attr("state_v_first").AttrType(OPTIONAL).Bool(true);
+        this->Attr("state_v_first").AttrType(OPTIONAL).Bool(false);
 
         OpAICoreConfig aicConfig;
         aicConfig.DynamicCompileStaticFlag(true)

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_infershape.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_infershape.cpp
@@ -23,6 +23,7 @@ const size_t STATE_INDEX = 5;
 
 const size_t DIM_0 = 0;
 const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
 
 static ge::graphStatus InferShapeRecurrentKda(InferShapeContext *context)
 {
@@ -35,13 +36,16 @@ static ge::graphStatus InferShapeRecurrentKda(InferShapeContext *context)
     auto shapeValue = context->GetInputShape(VALUE_INDEX);
     auto shapeInitialState = context->GetInputShape(STATE_INDEX);
     auto shapeOut = context->GetOutputShape(DIM_0);
-    auto shapeFinalState = context->GetOutputShape(DIM_1);
-    if (shapeValue == nullptr || shapeInitialState == nullptr || shapeOut == nullptr || shapeFinalState == nullptr) {
+    auto shapeInitialStateOut = context->GetOutputShape(DIM_1);
+    auto shapeFinalState = context->GetOutputShape(DIM_2);
+    if (shapeValue == nullptr || shapeInitialState == nullptr || shapeOut == nullptr ||
+        shapeInitialStateOut == nullptr || shapeFinalState == nullptr) {
         OP_LOGE(opName, "[InferShape] shape is null");
         return ge::GRAPH_FAILED;
     }
 
     *shapeOut = *shapeValue;
+    *shapeInitialStateOut = *shapeInitialState;
     *shapeFinalState = *shapeInitialState;
 
     return ge::GRAPH_SUCCESS;
@@ -51,6 +55,7 @@ static ge::graphStatus InferDataTypeRecurrentKda(gert::InferDataTypeContext *con
 {
     context->SetOutputDataType(0, ge::DT_BF16);
     context->SetOutputDataType(1, context->GetInputDataType(STATE_INDEX));
+    context->SetOutputDataType(2, context->GetInputDataType(STATE_INDEX));
     return ge::GRAPH_SUCCESS;
 }
 

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling.cpp
@@ -34,15 +34,20 @@ const size_t A_LOG_INDEX = 8;
 const size_t DT_BIAS_INDEX = 9;
 const size_t ACC_TOKEN_INDEX = 10;
 
+const size_t INITIAL_STATE_OUTPUT_INDEX = 1;
+const size_t FINAL_STATE_OUTPUT_INDEX = 2;
+
 const size_t ATTR_LAYOUT_INDEX = 0;
 const size_t ATTR_SCALE_INDEX = 1;
-const size_t ATTR_USE_QK_L2NORM_INDEX = 2;
-const size_t ATTR_USE_GATE_INDEX = 3;
-const size_t ATTR_USE_BETA_SIGMOID_INDEX = 4;
-const size_t ATTR_ALLOW_NEG_EIGVAL_INDEX = 5;
-const size_t ATTR_SAFE_GATE_INDEX = 6;
-const size_t ATTR_LOWER_BOUND_INDEX = 7;
-const size_t ATTR_STATE_V_FIRST_INDEX = 8;
+const size_t ATTR_OUTPUT_FINAL_STATE_INDEX = 2;
+const size_t ATTR_INPLACE_FINAL_STATE_INDEX = 3;
+const size_t ATTR_USE_QK_L2NORM_INDEX = 4;
+const size_t ATTR_USE_GATE_INDEX = 5;
+const size_t ATTR_USE_BETA_SIGMOID_INDEX = 6;
+const size_t ATTR_ALLOW_NEG_EIGVAL_INDEX = 7;
+const size_t ATTR_SAFE_GATE_INDEX = 8;
+const size_t ATTR_LOWER_BOUND_INDEX = 9;
+const size_t ATTR_STATE_V_FIRST_INDEX = 10;
 
 void RecurrentKdaTiling::InitCompileInfo()
 {
@@ -70,6 +75,18 @@ void CopyOptionalOriginShape(gert::TilingContext *context, size_t index, gert::S
         dst = shape->GetOriginShape();
     }
 }
+
+template <typename StrideType>
+void CopyStateStrides(const StrideType *src, std::array<int64_t, RKDA_STATE_DIM_NUM> &dst, bool &hasStrides)
+{
+    if (src == nullptr || src->GetDimNum() != RKDA_STATE_DIM_NUM) {
+        return;
+    }
+    for (size_t i = 0; i < RKDA_STATE_DIM_NUM; ++i) {
+        dst[i] = src->GetStride(i);
+    }
+    hasStrides = true;
+}
 } // namespace
 
 RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
@@ -82,7 +99,15 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.gateShape = context_->GetInputShape(GATE_INDEX)->GetOriginShape();
     ctx.betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
     ctx.stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
-    ctx.cuSeqlensShape = context_->GetInputShape(CU_SEQLENS_INDEX)->GetOriginShape();
+    CopyStateStrides(context_->GetInputStride(STATE_INDEX), ctx.stateInStrides, ctx.hasStateInStrides);
+    const size_t stateOutputIndex = tilingData_.inplaceFinalState == 1 ?
+                                    INITIAL_STATE_OUTPUT_INDEX : FINAL_STATE_OUTPUT_INDEX;
+    CopyStateStrides(context_->GetOutputStride(stateOutputIndex), ctx.stateOutStrides, ctx.hasStateOutStrides);
+    if (!ctx.hasStateOutStrides && tilingData_.inplaceFinalState == 1 && ctx.hasStateInStrides) {
+        ctx.stateOutStrides = ctx.stateInStrides;
+        ctx.hasStateOutStrides = true;
+    }
+    CopyOptionalOriginShape(context_, CU_SEQLENS_INDEX, ctx.cuSeqlensShape);
     CopyOptionalOriginShape(context_, SSM_STATE_INDICES_INDEX, ctx.ssmStateShape);
     CopyOptionalOriginShape(context_, A_LOG_INDEX, ctx.aLogShape);
     CopyOptionalOriginShape(context_, DT_BIAS_INDEX, ctx.dtBiasShape);
@@ -90,9 +115,21 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.aivNum = compileInfo_.aivNum;
     ctx.ubSize = compileInfo_.ubSize;
     ctx.stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    ctx.gateDtype = context_->GetInputDesc(GATE_INDEX)->GetDataType();
+    ctx.betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
+    if (context_->GetOptionalInputDesc(CU_SEQLENS_INDEX) != nullptr) {
+        ctx.cuSeqlensDtype = context_->GetOptionalInputDesc(CU_SEQLENS_INDEX)->GetDataType();
+    }
+    if (context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX) != nullptr) {
+        ctx.ssmStateIndicesDtype = context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType();
+    }
+    if (context_->GetOptionalInputDesc(ACC_TOKEN_INDEX) != nullptr) {
+        ctx.acceptedTokensDtype = context_->GetOptionalInputDesc(ACC_TOKEN_INDEX)->GetDataType();
+    }
     ctx.scale = tilingData_.scale;
     ctx.lowerBound = tilingData_.lowerBound;
     ctx.layout = tilingData_.layout;
+    ctx.hasCuSeqlens = tilingData_.hasCuSeqlens;
     ctx.hasSsmStateIndices = tilingData_.hasSsmStateIndices;
     ctx.hasALog = tilingData_.hasALog;
     ctx.hasDtBias = tilingData_.hasDtBias;
@@ -103,6 +140,8 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.allowNegEigval = tilingData_.allowNegEigval;
     ctx.safeGate = tilingData_.safeGate;
     ctx.stateVFirst = tilingData_.stateVFirst;
+    ctx.outputFinalState = tilingData_.outputFinalState;
+    ctx.inplaceFinalState = tilingData_.inplaceFinalState;
     return ctx;
 }
 
@@ -194,9 +233,7 @@ ge::graphStatus RecurrentKdaTiling::CheckContext()
     OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(BETA_INDEX));
     OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(STATE_INDEX));
     OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(STATE_INDEX));
-    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(CU_SEQLENS_INDEX));
-    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(CU_SEQLENS_INDEX));
-    return ge::GRAPH_SUCCESS;
+     return ge::GRAPH_SUCCESS;
 }
 
 ge::graphStatus RecurrentKdaTiling::AnalyzeDtype()
@@ -211,18 +248,23 @@ ge::graphStatus RecurrentKdaTiling::AnalyzeDtype()
     auto gateDtype = context_->GetInputDesc(GATE_INDEX)->GetDataType();
     auto betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
     auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
-    OP_CHECK_IF(gateDtype != ge::DT_FLOAT || betaDtype != ge::DT_FLOAT,
-                OP_LOGE(context_->GetNodeName(), "gate and beta dtype should be float32 after aclnn preprocessing"),
+    OP_CHECK_IF((gateDtype != ge::DT_FLOAT && gateDtype != ge::DT_BF16 && gateDtype != ge::DT_FLOAT16) ||
+                    (betaDtype != ge::DT_FLOAT && betaDtype != ge::DT_BF16 && betaDtype != ge::DT_FLOAT16),
+                OP_LOGE(context_->GetNodeName(), "gate and beta dtype should be float32, bfloat16 or float16"),
                 return ge::GRAPH_FAILED);
     OP_CHECK_IF(stateDtype != ge::DT_FLOAT && stateDtype != ge::DT_BF16,
                 OP_LOGE(context_->GetNodeName(), "initial_state dtype should be bfloat16 or float32"),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(context_->GetInputDesc(CU_SEQLENS_INDEX)->GetDataType() != ge::DT_INT64,
-                OP_LOGE(context_->GetNodeName(), "cu_seqlens dtype should be int64"),
-                return ge::GRAPH_FAILED);
+    if (context_->GetOptionalInputDesc(CU_SEQLENS_INDEX) != nullptr) {
+        auto dtype = context_->GetOptionalInputDesc(CU_SEQLENS_INDEX)->GetDataType();
+        OP_CHECK_IF(dtype != ge::DT_INT32 && dtype != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "cu_seqlens dtype should be int32 or int64"),
+                    return ge::GRAPH_FAILED);
+    }
     if (context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX) != nullptr) {
-        OP_CHECK_IF(context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType() != ge::DT_INT64,
-                    OP_LOGE(context_->GetNodeName(), "ssm_state_indices dtype should be int64"),
+        auto dtype = context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType();
+        OP_CHECK_IF(dtype != ge::DT_INT32 && dtype != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "ssm_state_indices dtype should be int32 or int64"),
                     return ge::GRAPH_FAILED);
     }
     if (context_->GetOptionalInputDesc(A_LOG_INDEX) != nullptr) {
@@ -236,8 +278,9 @@ ge::graphStatus RecurrentKdaTiling::AnalyzeDtype()
                     return ge::GRAPH_FAILED);
     }
     if (context_->GetOptionalInputDesc(ACC_TOKEN_INDEX) != nullptr) {
-        OP_CHECK_IF(context_->GetOptionalInputDesc(ACC_TOKEN_INDEX)->GetDataType() != ge::DT_INT64,
-                    OP_LOGE(context_->GetNodeName(), "num_accepted_tokens dtype should be int64"),
+        auto dtype = context_->GetOptionalInputDesc(ACC_TOKEN_INDEX)->GetDataType();
+        OP_CHECK_IF(dtype != ge::DT_INT32 && dtype != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "num_accepted_tokens dtype should be int32 or int64"),
                     return ge::GRAPH_FAILED);
     }
     return ge::GRAPH_SUCCESS;
@@ -265,12 +308,12 @@ ge::graphStatus RecurrentKdaTiling::AnalyzeFormat()
         !CheckFormat(context_->GetInputDesc(VALUE_INDEX)->GetStorageFormat(), "value") ||
         !CheckFormat(context_->GetInputDesc(GATE_INDEX)->GetStorageFormat(), "gate") ||
         !CheckFormat(context_->GetInputDesc(BETA_INDEX)->GetStorageFormat(), "beta") ||
-        !CheckFormat(context_->GetInputDesc(STATE_INDEX)->GetStorageFormat(), "initial_state") ||
-        !CheckFormat(context_->GetInputDesc(CU_SEQLENS_INDEX)->GetStorageFormat(), "cu_seqlens")) {
+        !CheckFormat(context_->GetInputDesc(STATE_INDEX)->GetStorageFormat(), "initial_state")) {
         return ge::GRAPH_FAILED;
     }
 
-    const std::array<std::pair<size_t, const char *>, 4> optionalInputs = {{
+    const std::array<std::pair<size_t, const char *>, 5> optionalInputs = {{
+        {CU_SEQLENS_INDEX, "cu_seqlens"},
         {SSM_STATE_INDICES_INDEX, "ssm_state_indices"},
         {A_LOG_INDEX, "A_log"},
         {DT_BIAS_INDEX, "dt_bias"},
@@ -299,6 +342,8 @@ ge::graphStatus RecurrentKdaTiling::GetAttrsInfo()
         return ge::GRAPH_FAILED;
     }
     tilingData_.scale = *attrs->GetAttrPointer<float>(ATTR_SCALE_INDEX);
+    tilingData_.outputFinalState = *attrs->GetAttrPointer<bool>(ATTR_OUTPUT_FINAL_STATE_INDEX) ? 1 : 0;
+    tilingData_.inplaceFinalState = *attrs->GetAttrPointer<bool>(ATTR_INPLACE_FINAL_STATE_INDEX) ? 1 : 0;
     tilingData_.useQkL2norm = *attrs->GetAttrPointer<bool>(ATTR_USE_QK_L2NORM_INDEX) ? 1 : 0;
     tilingData_.useGateInKernel = *attrs->GetAttrPointer<bool>(ATTR_USE_GATE_INDEX) ? 1 : 0;
     tilingData_.useBetaSigmoid = *attrs->GetAttrPointer<bool>(ATTR_USE_BETA_SIGMOID_INDEX) ? 1 : 0;
@@ -311,6 +356,7 @@ ge::graphStatus RecurrentKdaTiling::GetAttrsInfo()
 
 ge::graphStatus RecurrentKdaTiling::GetOptionalInput()
 {
+    tilingData_.hasCuSeqlens = (context_->GetOptionalInputDesc(CU_SEQLENS_INDEX) == nullptr) ? 0 : 1;
     tilingData_.hasSsmStateIndices = (context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX) == nullptr) ? 0 : 1;
     tilingData_.hasALog = (context_->GetOptionalInputDesc(A_LOG_INDEX) == nullptr) ? 0 : 1;
     tilingData_.hasDtBias = (context_->GetOptionalInputDesc(DT_BIAS_INDEX) == nullptr) ? 0 : 1;
@@ -338,6 +384,7 @@ void RecurrentKdaTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "scale: [%f]", tilingData_.scale);
     OP_LOGD(context_->GetNodeName(), "lowerBound: [%f]", tilingData_.lowerBound);
     OP_LOGD(context_->GetNodeName(), "layout: [%u]", tilingData_.layout);
+    OP_LOGD(context_->GetNodeName(), "hasCuSeqlens: [%u]", tilingData_.hasCuSeqlens);
     OP_LOGD(context_->GetNodeName(), "hasSsmStateIndices: [%u]", tilingData_.hasSsmStateIndices);
     OP_LOGD(context_->GetNodeName(), "hasALog: [%u]", tilingData_.hasALog);
     OP_LOGD(context_->GetNodeName(), "hasDtBias: [%u]", tilingData_.hasDtBias);
@@ -348,6 +395,13 @@ void RecurrentKdaTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "allowNegEigval: [%u]", tilingData_.allowNegEigval);
     OP_LOGD(context_->GetNodeName(), "safeGate: [%u]", tilingData_.safeGate);
     OP_LOGD(context_->GetNodeName(), "stateVFirst: [%u]", tilingData_.stateVFirst);
+    OP_LOGD(context_->GetNodeName(), "outputFinalState: [%u]", tilingData_.outputFinalState);
+    OP_LOGD(context_->GetNodeName(), "inplaceFinalState: [%u]", tilingData_.inplaceFinalState);
+    OP_LOGD(context_->GetNodeName(), "gateDtype: [%u]", tilingData_.gateDtype);
+    OP_LOGD(context_->GetNodeName(), "betaDtype: [%u]", tilingData_.betaDtype);
+    OP_LOGD(context_->GetNodeName(), "cuSeqlensDtype: [%u]", tilingData_.cuSeqlensDtype);
+    OP_LOGD(context_->GetNodeName(), "ssmStateIndicesDtype: [%u]", tilingData_.ssmStateIndicesDtype);
+    OP_LOGD(context_->GetNodeName(), "acceptedTokensDtype: [%u]", tilingData_.acceptedTokensDtype);
 }
 
 ge::graphStatus RecurrentKdaTiling::CalUbSize()

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
@@ -62,6 +62,7 @@ struct RecurrentKdaTilingContext {
     float scale = 1.0f;
     float lowerBound = -5.0f;
     uint32_t layout = RKDA_LAYOUT_BSND;
+    uint32_t hasCuSeqlens = 0;
     uint32_t hasSsmStateIndices = 0;
     uint32_t hasALog = 0;
     uint32_t hasDtBias = 0;
@@ -71,8 +72,19 @@ struct RecurrentKdaTilingContext {
     uint32_t useBetaSigmoid = 0;
     uint32_t allowNegEigval = 0;
     uint32_t safeGate = 0;
-    uint32_t stateVFirst = 1;
+    uint32_t stateVFirst = 0;
+    uint32_t outputFinalState = 0;
+    uint32_t inplaceFinalState = 1;
     ge::DataType stateDtype = ge::DT_BF16;
+    ge::DataType gateDtype = ge::DT_FLOAT;
+    ge::DataType betaDtype = ge::DT_FLOAT;
+    ge::DataType cuSeqlensDtype = ge::DT_INT64;
+    ge::DataType ssmStateIndicesDtype = ge::DT_INT64;
+    ge::DataType acceptedTokensDtype = ge::DT_INT64;
+    std::array<int64_t, RKDA_STATE_DIM_NUM> stateInStrides = {};
+    std::array<int64_t, RKDA_STATE_DIM_NUM> stateOutStrides = {};
+    bool hasStateInStrides = false;
+    bool hasStateOutStrides = false;
     uint64_t aivNum = 0;
     uint64_t ubSize = 0;
 };
@@ -146,6 +158,63 @@ private:
 
     RecurrentKdaTilingContext ctx_;
 
+    std::array<int64_t, RKDA_STATE_DIM_NUM> ResolveStateStrides(bool output) const
+    {
+        const bool hasStrides = output ? ctx_.hasStateOutStrides : ctx_.hasStateInStrides;
+        if (hasStrides) {
+            return output ? ctx_.stateOutStrides : ctx_.stateInStrides;
+        }
+        const auto &shape = ctx_.stateShape;
+        std::array<int64_t, RKDA_STATE_DIM_NUM> strides = {};
+        strides[RKDA_DIM_3] = 1;
+        strides[RKDA_DIM_2] = shape.GetDim(RKDA_DIM_3);
+        strides[RKDA_DIM_1] = shape.GetDim(RKDA_DIM_2) * strides[RKDA_DIM_2];
+        strides[RKDA_DIM_0] = shape.GetDim(RKDA_DIM_1) * strides[RKDA_DIM_1];
+        return strides;
+    }
+
+    ge::graphStatus ValidateStateStrides(
+        const std::array<int64_t, RKDA_STATE_DIM_NUM> &strides, const char *name) const
+    {
+        for (size_t i = 0; i < RKDA_STATE_DIM_NUM; ++i) {
+            OP_CHECK_IF(strides[i] <= 0,
+                        OP_LOGE(ctx_.nodeName, "%s stride[%zu] must be positive, but it is %ld.",
+                                name, i, strides[i]),
+                        return ge::GRAPH_FAILED);
+        }
+        const auto &shape = ctx_.stateShape;
+        const int64_t denseRow = shape.GetDim(RKDA_DIM_3);
+        const int64_t densePlane = shape.GetDim(RKDA_DIM_2) * denseRow;
+        OP_CHECK_IF(strides[RKDA_DIM_3] != 1 || strides[RKDA_DIM_2] != denseRow,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s must keep its inner state matrix dense: stride[3]=1 and stride[2]=%ld, "
+                            "but got [%ld, %ld, %ld, %ld].",
+                            name, denseRow, strides[RKDA_DIM_0], strides[RKDA_DIM_1],
+                            strides[RKDA_DIM_2], strides[RKDA_DIM_3]),
+                    return ge::GRAPH_FAILED);
+        const int64_t minSlotStride =
+            (shape.GetDim(RKDA_DIM_1) - 1) * strides[RKDA_DIM_1] + densePlane;
+        OP_CHECK_IF(strides[RKDA_DIM_1] < densePlane ||
+                        strides[RKDA_DIM_0] < minSlotStride,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s outer strides overlap state rows or heads: [%ld, %ld, %ld, %ld].",
+                            name, strides[RKDA_DIM_0], strides[RKDA_DIM_1],
+                            strides[RKDA_DIM_2], strides[RKDA_DIM_3]),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CheckStateStrides() const
+    {
+        if (ValidateStateStrides(ResolveStateStrides(false), "initial_state") != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        if (ValidateStateStrides(ResolveStateStrides(true), "state output") != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
     bool CheckDim(const gert::Shape &shape, const size_t dim, const std::string &dimDesc) const
     {
         if (shape.GetDimNum() != dim) {
@@ -168,23 +237,28 @@ private:
         return true;
     }
 
-    int64_t SeqNum(const gert::Shape &cuSeqlensShape) const
+    int64_t SeqNum(const gert::Shape &queryShape, const gert::Shape &cuSeqlensShape) const
     {
-        return cuSeqlensShape.GetDim(RKDA_DIM_0) - 1;
+        if (ctx_.hasCuSeqlens) {
+            return cuSeqlensShape.GetDim(RKDA_DIM_0) - 1;
+        }
+        return ctx_.layout == RKDA_LAYOUT_BSND ? queryShape.GetDim(RKDA_DIM_0) : 1;
     }
 
     ge::graphStatus CheckMetadataShapes(const gert::Shape &queryShape, const gert::Shape &cuSeqlensShape) const
     {
-        if (!CheckDim(cuSeqlensShape, RKDA_METADATA_RANK1, "cu_seqlens")) {
-            return ge::GRAPH_FAILED;
+        if (ctx_.hasCuSeqlens) {
+            if (!CheckDim(cuSeqlensShape, RKDA_METADATA_RANK1, "cu_seqlens")) {
+                return ge::GRAPH_FAILED;
+            }
+            OP_CHECK_IF(cuSeqlensShape.GetDim(RKDA_DIM_0) < 2,
+                        OP_LOGE(ctx_.nodeName, "cu_seqlens must contain at least 2 elements."),
+                        return ge::GRAPH_FAILED);
         }
-        OP_CHECK_IF(cuSeqlensShape.GetDim(RKDA_DIM_0) < 2,
-                    OP_LOGE(ctx_.nodeName, "cu_seqlens must contain at least 2 elements."),
-                    return ge::GRAPH_FAILED);
         int64_t totalTokens =
             (ctx_.layout == RKDA_LAYOUT_TND) ? queryShape.GetDim(RKDA_DIM_0) :
             queryShape.GetDim(RKDA_DIM_0) * queryShape.GetDim(RKDA_DIM_1);
-        int64_t seqNum = cuSeqlensShape.GetDim(RKDA_DIM_0) - 1;
+        int64_t seqNum = SeqNum(queryShape, cuSeqlensShape);
 
         if (ctx_.hasSsmStateIndices) {
             size_t rank = ctx_.ssmStateShape.GetDimNum();
@@ -315,19 +389,22 @@ private:
         if (!CheckDim(stateShape, RKDA_STATE_DIM_NUM, "initial_state")) {
             return ge::GRAPH_FAILED;
         }
-        OP_CHECK_IF(!ctx_.stateVFirst,
-                    OP_LOGE(ctx_.nodeName, "state_v_first=false is not supported by RecurrentKda."),
-                    return ge::GRAPH_FAILED);
-        int64_t seqNum = SeqNum(cuSeqlensShape);
+        int64_t seqNum = SeqNum(queryShape, cuSeqlensShape);
+        bool stateTailMatches = ctx_.stateVFirst ?
+            (stateShape.GetDim(RKDA_DIM_2) == vDim && stateShape.GetDim(RKDA_DIM_3) == kDim) :
+            (stateShape.GetDim(RKDA_DIM_2) == kDim && stateShape.GetDim(RKDA_DIM_3) == vDim);
         OP_CHECK_IF(stateShape.GetDim(RKDA_DIM_0) <= 0 ||
                         (!ctx_.hasSsmStateIndices && stateShape.GetDim(RKDA_DIM_0) != seqNum) ||
-                        stateShape.GetDim(RKDA_DIM_1) != hvNum ||
-                        stateShape.GetDim(RKDA_DIM_2) != vDim ||
-                        stateShape.GetDim(RKDA_DIM_3) != kDim,
+                        stateShape.GetDim(RKDA_DIM_1) != hvNum || !stateTailMatches,
                     OP_LOGE(ctx_.nodeName,
-                            "state must be [state_capacity, HV, V, K]; without ssm_state_indices, "
+                            "state must be [state_capacity, HV, V, K] when state_v_first=true or "
+                            "[state_capacity, HV, K, V] otherwise; without ssm_state_indices, "
                             "state_capacity must equal seq_num."),
                     return ge::GRAPH_FAILED);
+
+        if (CheckStateStrides() != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
 
         if (CheckMetadataShapes(queryShape, cuSeqlensShape) != ge::GRAPH_SUCCESS ||
             CheckOptionalGateShapes(hvNum, kDim) != ge::GRAPH_SUCCESS) {
@@ -347,7 +424,7 @@ private:
             tiling.dk = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_2));
             tiling.nv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_1));
             tiling.dv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_2));
-            tiling.b = static_cast<uint32_t>(cuSeqlensShape.GetDim(RKDA_DIM_0) - 1);
+            tiling.b = static_cast<uint32_t>(SeqNum(queryShape, cuSeqlensShape));
         } else {
             tiling.seqLen = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_1));
             tiling.t = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_0) * queryShape.GetDim(RKDA_DIM_1));
@@ -355,14 +432,25 @@ private:
             tiling.dk = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_3));
             tiling.nv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_2));
             tiling.dv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_3));
-            tiling.b = static_cast<uint32_t>(cuSeqlensShape.GetDim(RKDA_DIM_0) - 1);
+            tiling.b = static_cast<uint32_t>(SeqNum(queryShape, cuSeqlensShape));
         }
         tiling.sBlockNum = static_cast<uint32_t>(stateShape.GetDim(RKDA_DIM_0));
         tiling.ssmStateStride = (ctx_.hasSsmStateIndices && ctx_.ssmStateShape.GetDimNum() == RKDA_METADATA_RANK2) ?
                                 static_cast<uint32_t>(ctx_.ssmStateShape.GetDim(RKDA_DIM_1)) : 0;
+        const auto stateInStrides = ResolveStateStrides(false);
+        const auto stateOutStrides = ResolveStateStrides(true);
+        tiling.stateInStride0 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_0]);
+        tiling.stateInStride1 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_1]);
+        tiling.stateInStride2 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_2]);
+        tiling.stateInStride3 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_3]);
+        tiling.stateOutStride0 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_0]);
+        tiling.stateOutStride1 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_1]);
+        tiling.stateOutStride2 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_2]);
+        tiling.stateOutStride3 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_3]);
         tiling.scale = ctx_.scale;
         tiling.lowerBound = ctx_.lowerBound;
         tiling.layout = ctx_.layout;
+        tiling.hasCuSeqlens = ctx_.hasCuSeqlens;
         tiling.hasSsmStateIndices = ctx_.hasSsmStateIndices;
         tiling.hasALog = ctx_.hasALog;
         tiling.hasDtBias = ctx_.hasDtBias;
@@ -373,6 +461,13 @@ private:
         tiling.allowNegEigval = ctx_.allowNegEigval;
         tiling.safeGate = ctx_.safeGate;
         tiling.stateVFirst = ctx_.stateVFirst;
+        tiling.outputFinalState = ctx_.outputFinalState;
+        tiling.inplaceFinalState = ctx_.inplaceFinalState;
+        tiling.gateDtype = ctx_.gateDtype == ge::DT_FLOAT ? 0 : (ctx_.gateDtype == ge::DT_BF16 ? 1 : 2);
+        tiling.betaDtype = ctx_.betaDtype == ge::DT_FLOAT ? 0 : (ctx_.betaDtype == ge::DT_BF16 ? 1 : 2);
+        tiling.cuSeqlensDtype = ctx_.cuSeqlensDtype == ge::DT_INT32 ? 0 : 1;
+        tiling.ssmStateIndicesDtype = ctx_.ssmStateIndicesDtype == ge::DT_INT32 ? 0 : 1;
+        tiling.acceptedTokensDtype = ctx_.acceptedTokensDtype == ge::DT_INT32 ? 0 : 1;
     }
 
     ge::graphStatus CheckShapeValueRangeAndRule(const RecurrentKdaTilingData &tiling) const
@@ -446,7 +541,7 @@ private:
     int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
     {
         int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk);
-        usedUbBytes += RKDA_MAX_MTP * (4 * aDv + 8 * aDk + 4 * aNv);
+        usedUbBytes += RKDA_MAX_MTP * (4 * aDv + 12 * aDk + 4 * aNv);
         return usedUbBytes;
     }
 

--- a/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -60,14 +60,24 @@ public:
     {
         B_ = tilingData->b;
         T_ = tilingData->t;
+        seqLen_ = tilingData->seqLen;
         NK_ = tilingData->nk;
         realK_ = tilingData->dk;
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         stateCapacity_ = tilingData->sBlockNum;
         ssmStateStride_ = tilingData->ssmStateStride;
+        stateInStride0_ = tilingData->stateInStride0;
+        stateInStride1_ = tilingData->stateInStride1;
+        stateInStride2_ = tilingData->stateInStride2;
+        stateInStride3_ = tilingData->stateInStride3;
+        stateOutStride0_ = tilingData->stateOutStride0;
+        stateOutStride1_ = tilingData->stateOutStride1;
+        stateOutStride2_ = tilingData->stateOutStride2;
+        stateOutStride3_ = tilingData->stateOutStride3;
         scale_ = tilingData->scale;
         lowerBound_ = tilingData->lowerBound;
+        hasCuSeqlens_ = (tilingData->hasCuSeqlens == 1);
         hasSsmStateIndices_ = (tilingData->hasSsmStateIndices == 1);
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasALog_ = (tilingData->hasALog == 1);
@@ -77,6 +87,13 @@ public:
         useBetaSigmoid_ = (tilingData->useBetaSigmoid == 1);
         allowNegEigval_ = (tilingData->allowNegEigval == 1);
         safeGate_ = (tilingData->safeGate == 1);
+        stateVFirst_ = (tilingData->stateVFirst == 1);
+        shouldStoreState_ = (tilingData->inplaceFinalState == 1 || tilingData->outputFinalState == 1);
+        gateDtype_ = tilingData->gateDtype;
+        betaDtype_ = tilingData->betaDtype;
+        cuSeqlensDtype_ = tilingData->cuSeqlensDtype;
+        ssmStateIndicesDtype_ = tilingData->ssmStateIndicesDtype;
+        acceptedTokensDtype_ = tilingData->acceptedTokensDtype;
         useAddFoldReduce_ = (RKDA_ENABLE_ADD_FOLD_REDUCE != 0);
         vStep_ = tilingData->vStep;
         stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
@@ -106,14 +123,21 @@ public:
         queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
         keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
         valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
-        gateGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
-        betaGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        gateFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
+        gateBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.gate);
+        gateFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.gate);
+        betaFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        betaBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.beta);
+        betaFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.beta);
         initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
-        cuSeqlensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
-        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
+        cuSeqlensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        cuSeqlensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
+        ssmStateIndicesInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        ssmStateIndicesInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
         aLogGm_.SetGlobalBuffer((__gm__ float *)initParams.aLog);
         dtBiasGm_.SetGlobalBuffer((__gm__ float *)initParams.dtBias);
-        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
         finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
         attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
     }
@@ -153,6 +177,8 @@ public:
         broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize / sizeof(float)), buffOffset);
+        buffOffset += betaUbSize;
+        gateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
     }
 
     __aicore__ inline void SyncMte2ToV()
@@ -207,9 +233,13 @@ public:
             ReleaseEvents();
             return;
         }
-        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
-            int64_t seq0 = cuSeqlensGm_.GetValue(batch_i);
-            int64_t seq1 = cuSeqlensGm_.GetValue(batch_i + 1);
+        uint64_t vectorCoreNum = GetBlockNum();
+        uint64_t taskNum = B_ * NV_;
+        for (uint64_t taskIdx = blockIdx; taskIdx < taskNum; taskIdx += vectorCoreNum) {
+            uint64_t batch_i = taskIdx / NV_;
+            uint64_t head_i = taskIdx % NV_;
+            int64_t seq0 = SequenceStart(batch_i);
+            int64_t seq1 = SequenceEnd(batch_i);
             int64_t seqLen64 = seq1 - seq0;
             if (seqLen64 == 0) {
                 continue;
@@ -220,23 +250,13 @@ public:
                 return;
             }
 
-            uint32_t copyFlag = 0;
-            uint64_t stateSlot = batch_i;
-            for (uint64_t head_i = 0; head_i < NV_; head_i++) {
-                if (!IsCurrentTask(batch_i, head_i)) {
-                    continue;
-                }
-                copyFlag++;
-                if (copyFlag == 1) {
-                    stateSlot = ResolveInitialStateSlot(batch_i, seq0, seqLen);
-                    if (stateSlot == INVALID_STATE_SLOT) {
-                        ReleaseEvents();
-                        return;
-                    }
-                    CopyInBeta(seq0, seq1);
-                }
-                ProcessHead(batch_i, seq0, seq1, head_i, stateSlot);
+            uint64_t stateSlot = ResolveInitialStateSlot(batch_i, seq0, seqLen);
+            if (stateSlot == INVALID_STATE_SLOT) {
+                ReleaseEvents();
+                return;
             }
+            CopyInBeta(seq0, seq1);
+            ProcessHead(batch_i, seq0, seq1, head_i, stateSlot);
         }
         ReleaseEvents();
     }
@@ -244,12 +264,15 @@ public:
 private:
     __aicore__ inline bool ValidateCuSeqlens() const
     {
-        int64_t seq0 = cuSeqlensGm_.GetValue(0);
+        if (!hasCuSeqlens_) {
+            return seqLen_ <= MAX_MTP;
+        }
+        int64_t seq0 = LoadCuSeqlens(0);
         if (seq0 != 0) {
             return false;
         }
         for (uint64_t i = 0; i < B_; i++) {
-            int64_t seq1 = cuSeqlensGm_.GetValue(i + 1);
+            int64_t seq1 = LoadCuSeqlens(i + 1);
             int64_t length = seq1 - seq0;
             if (seq1 < seq0 || seq1 > static_cast<int64_t>(T_) ||
                 length > static_cast<int64_t>(MAX_MTP) ||
@@ -259,6 +282,35 @@ private:
             seq0 = seq1;
         }
         return seq0 <= static_cast<int64_t>(T_);
+    }
+
+    __aicore__ inline int64_t LoadCuSeqlens(uint64_t index) const
+    {
+        return cuSeqlensDtype_ == 0 ? static_cast<int64_t>(cuSeqlensInt32Gm_.GetValue(index)) :
+                                     cuSeqlensInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t SequenceStart(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx) : static_cast<int64_t>(batchIdx * seqLen_);
+    }
+
+    __aicore__ inline int64_t SequenceEnd(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx + 1) :
+                               static_cast<int64_t>((batchIdx + 1) * seqLen_);
+    }
+
+    __aicore__ inline int64_t LoadSsmStateIndex(uint64_t index) const
+    {
+        return ssmStateIndicesDtype_ == 0 ? static_cast<int64_t>(ssmStateIndicesInt32Gm_.GetValue(index)) :
+                                           ssmStateIndicesInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t LoadAcceptedTokens(uint64_t index) const
+    {
+        return acceptedTokensDtype_ == 0 ? static_cast<int64_t>(numAcceptedTokensInt32Gm_.GetValue(index)) :
+                                          numAcceptedTokensInt64Gm_.GetValue(index);
     }
 
     __aicore__ inline uint64_t StateMetadataOffset(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -271,7 +323,7 @@ private:
 
     __aicore__ inline uint64_t LoadStateSlot(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
     {
-        int64_t stateSlot = ssmStateIndicesGm_.GetValue(StateMetadataOffset(batchIdx, seq0, tokenIdx));
+        int64_t stateSlot = LoadSsmStateIndex(StateMetadataOffset(batchIdx, seq0, tokenIdx));
         if (stateSlot < 0 || stateSlot >= static_cast<int64_t>(stateCapacity_)) {
             return INVALID_STATE_SLOT;
         }
@@ -284,7 +336,7 @@ private:
             return batchIdx < stateCapacity_;
         }
         if (hasAcceptedTokens_) {
-            int64_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batchIdx);
+            int64_t acceptedTokenNum = LoadAcceptedTokens(batchIdx);
             if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
                 return false;
             }
@@ -304,15 +356,16 @@ private:
         }
         int64_t tokenIdx = seq0;
         if (hasAcceptedTokens_) {
-            tokenIdx = seq0 + numAcceptedTokensGm_.GetValue(batchIdx) - 1;
+            tokenIdx = seq0 + LoadAcceptedTokens(batchIdx) - 1;
         }
         return LoadStateSlot(batchIdx, seq0, tokenIdx);
     }
 
-    __aicore__ inline void CopyFloatVectorIn(LocalTensor<float> &dst, GlobalTensor<float> &src, uint64_t offset,
-                                             uint64_t count)
+    template <typename dataType>
+    __aicore__ inline void CopyVectorIn(LocalTensor<dataType> &dst, GlobalTensor<dataType> &src, uint64_t offset,
+                                        uint64_t count)
     {
-        uint64_t rowBytes = count * sizeof(float);
+        uint64_t rowBytes = count * sizeof(dataType);
         if (rowBytes >= 32 && rowBytes % 32 == 0) {
             DataCopy(dst, src[offset], static_cast<uint32_t>(count));
         } else {
@@ -379,7 +432,7 @@ private:
         float expA = hasALog_ ? ExpScalar(ReadFloat(aLogGm_, head)) : 1.0f;
 
         if (hasDtBias_) {
-            CopyFloatVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
+            CopyVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
             SyncMte2ToV();
             for (int32_t row = 0; row < seqLen; ++row) {
                 Add(gateInUb[row * alignK_], gateInUb[row * alignK_], broadTmpInUb, alignK_);
@@ -414,39 +467,67 @@ private:
         }
     }
 
+    template <typename gateType>
+    __aicore__ inline void CopyInGate(uint64_t gateOffset, int32_t seqLen)
+    {
+        LocalTensor<gateType> gateLocal = gateInQueue_.AllocTensor<gateType>();
+        Duplicate<gateType>(gateLocal, static_cast<gateType>(0), alignK_ * static_cast<uint32_t>(seqLen));
+        SyncVToMte2();
+        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen),
+                                       static_cast<uint32_t>(realK_ * sizeof(gateType)),
+                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(gateType)), 0, 0};
+        DataCopyPadExtParams<gateType> gatePadParams{
+            true, 0, static_cast<uint8_t>(alignK_ - realK_), static_cast<gateType>(0)};
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            DataCopyPad(gateLocal, gateFloatGm_[gateOffset], gateInParams, gatePadParams);
+        } else if constexpr (std::is_same<gateType, bfloat16_t>()) {
+            DataCopyPad(gateLocal, gateBf16Gm_[gateOffset], gateInParams, gatePadParams);
+        } else {
+            DataCopyPad(gateLocal, gateFp16Gm_[gateOffset], gateInParams, gatePadParams);
+        }
+        gateInQueue_.EnQue<gateType>(gateLocal);
+        gateLocal = gateInQueue_.DeQue<gateType>();
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            Adds(gateInUb, gateLocal, 0.0f, alignK_ * static_cast<uint32_t>(seqLen));
+        } else {
+            Cast(gateInUb, gateLocal, AscendC::RoundMode::CAST_NONE,
+                 alignK_ * static_cast<uint32_t>(seqLen));
+        }
+        gateInQueue_.FreeTensor(gateLocal);
+        PipeBarrier<PIPE_V>();
+    }
+
     __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
                                          uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
-        LocalTensor<float> gateLocal = gateInQueue_.AllocTensor<float>();
-        Duplicate<float>(gateLocal, 0, alignK_ * static_cast<uint32_t>(seqLen));
-        SyncVToMte2();
 
         DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
                                      static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
                                     static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
-        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
-                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
-        DataCopyPadExtParams<float> gatePadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
 
         DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
-        DataCopyPad(gateLocal, gateGm_[gateOffset], gateInParams, gatePadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
         vInQueue_.EnQue<inType>(vLocal);
-        gateInQueue_.EnQue<float>(gateLocal);
+        if (gateDtype_ == 0) {
+            CopyInGate<float>(gateOffset, seqLen);
+        } else if (gateDtype_ == 1) {
+            CopyInGate<bfloat16_t>(gateOffset, seqLen);
+        } else {
+            CopyInGate<half>(gateOffset, seqLen);
+        }
 
         qLocal = qInQueue_.DeQue<inType>();
         kLocal = kInQueue_.DeQue<inType>();
         vLocal = vInQueue_.DeQue<inType>();
-        gateInUb = gateInQueue_.DeQue<float>();
         Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
@@ -468,13 +549,27 @@ private:
         vInQueue_.FreeTensor(vLocal);
     }
 
-    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    __aicore__ inline void PrefetchState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                          uint32_t curSingleV)
     {
         LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
-        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
-                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
-        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
-        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateInStride0_ * stateSlot + stateInStride1_ * head + stateInStride2_ * vOffset;
+            DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                            static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+            DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+            DataCopyPad(stateLocal, initStateGm_[stateOffset], stateInParams, padParams);
+        } else {
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateInStride0_ * stateSlot + stateInStride1_ * head +
+                                           stateInStride2_ * k +
+                                           stateInStride3_ * (vOffset + v);
+                    stateLocal.SetValue(v * alignK_ + k, initStateGm_.GetValue(stateOffset));
+                }
+            }
+        }
         stateInQueue_.EnQue<stateType>(stateLocal);
     }
 
@@ -645,14 +740,16 @@ private:
         ProcessKQ(deltaInUb, kInUb[curQKOffset], stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV);
         AscendC::PipeBarrier<PIPE_V>();
         ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
-        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
-        if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
-        } else {
-            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        if (shouldStoreState_) {
+            LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            if constexpr (std::is_same<stateType, float32_t>()) {
+                DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+            } else {
+                Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+            }
+            stateOutQueue_.EnQue<stateType>(stateOutLocal);
         }
-        stateOutQueue_.EnQue<stateType>(stateOutLocal);
         Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
         attnOutQueue_.EnQue<outType>(attnOutLocal);
     }
@@ -665,30 +762,65 @@ private:
         attnOutQueue_.FreeTensor(attnLocal);
     }
 
-    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    __aicore__ inline void CopyOutState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                         uint32_t curSingleV)
     {
         LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
-        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
-                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
-        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateOutStride0_ * stateSlot + stateOutStride1_ * head + stateOutStride2_ * vOffset;
+            DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                          static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+            DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        } else {
+            SyncVToS();
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateOutStride0_ * stateSlot + stateOutStride1_ * head +
+                                           stateOutStride2_ * k +
+                                           stateOutStride3_ * (vOffset + v);
+                    finalStateGm_.SetValue(stateOffset, stateOutLocal.GetValue(v * alignK_ + k));
+                }
+            }
+        }
         stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    template <typename betaType>
+    __aicore__ inline void CopyInBetaTyped(int64_t seq0, int64_t seq1)
+    {
+        int64_t seqLen = seq1 - seq0;
+        uint64_t betaCount = static_cast<uint64_t>(seqLen) * NV_;
+        uint64_t betaBatchSize = Ceil(betaCount, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+        LocalTensor<betaType> betaLocal = betaInQueue_.AllocTensor<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            CopyVectorIn(betaLocal, betaFloatGm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else if constexpr (std::is_same<betaType, bfloat16_t>()) {
+            CopyVectorIn(betaLocal, betaBf16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else {
+            CopyVectorIn(betaLocal, betaFp16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        }
+        betaInQueue_.EnQue<betaType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            Adds(betaInUb, betaLocal, 0.0f, static_cast<uint32_t>(betaBatchSize));
+        } else {
+            Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, static_cast<uint32_t>(betaBatchSize));
+        }
+        betaInQueue_.FreeTensor(betaLocal);
+        PipeBarrier<PIPE_V>();
+        SyncVToS();
     }
 
     __aicore__ inline void CopyInBeta(int64_t seq0, int64_t seq1)
     {
-        int64_t seqLen = seq1 - seq0;
-        uint64_t betaBatchSize = Ceil(static_cast<uint64_t>(seqLen) * NV_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
-        LocalTensor<float> betaLocal = betaInQueue_.AllocTensor<float>();
-        CopyFloatVectorIn(betaLocal, betaGm_, static_cast<uint64_t>(seq0) * NV_,
-                          static_cast<uint64_t>(seqLen) * NV_);
-        betaInQueue_.EnQue<float>(betaLocal);
-        betaLocal = betaInQueue_.DeQue<float>();
-        DataCopy(betaInUb, betaLocal, betaBatchSize);
-        SyncMte2ToV();
-        betaInQueue_.FreeTensor(betaLocal);
-        Adds(betaInUb, betaInUb, 0.0f, betaBatchSize);
-        PipeBarrier<PIPE_V>();
-        SyncVToS();
+        if (betaDtype_ == 0) {
+            CopyInBetaTyped<float>(seq0, seq1);
+        } else if (betaDtype_ == 1) {
+            CopyInBetaTyped<bfloat16_t>(seq0, seq1);
+        } else {
+            CopyInBetaTyped<half>(seq0, seq1);
+        }
     }
 
     __aicore__ inline uint64_t StateSlotForToken(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -719,24 +851,21 @@ private:
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
         CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
-            gateInQueue_.FreeTensor(gateInUb);
             return;
         }
         uint64_t nextVOffset = 0;
         uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
-        uint64_t nextStateOffset = ((stateSlot * NV_ + head_i) * realV_) * realK_;
-        PrefetchState(nextStateOffset, nextSingleV);
+        PrefetchState(stateSlot, head_i, 0, nextSingleV);
         for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
             uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
             LoadPrefetchedState(curSingleV);
             nextVOffset = v_i + vStep_;
             if (nextVOffset < realV_) {
                 nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
-                nextStateOffset = ((stateSlot * NV_ + head_i) * realV_ + nextVOffset) * realK_;
-                PrefetchState(nextStateOffset, nextSingleV);
+                PrefetchState(stateSlot, head_i, nextVOffset, nextSingleV);
             }
             uint64_t pendingAttnOffset = 0;
-            uint64_t pendingStateOffset = 0;
+            uint64_t pendingStateSlot = 0;
             bool hasPendingAttn = false;
             bool hasPendingState = false;
             for (int64_t seq_i = seq0; seq_i < seq1; seq_i++) {
@@ -745,7 +874,7 @@ private:
                 uint64_t curVOffset = static_cast<uint64_t>(seq_i - seq0) * alignV_ + v_i;
                 uint64_t attnOffset = (static_cast<uint64_t>(seq_i) * NV_ + head_i) * realV_ + v_i;
                 uint64_t curStateSlot = StateSlotForToken(batchIdx, seq0, seq_i);
-                uint64_t curStateOutOffset = ((curStateSlot * NV_ + head_i) * realV_ + v_i) * realK_;
+                uint64_t curStateOutSlot = curStateSlot;
                 beta_ = LoadBeta(gbOffset);
                 Compute(curSingleV, curQKOffset, curVOffset);
                 if (attnOutBufferNum_ == BUFFER_NUM) {
@@ -757,43 +886,46 @@ private:
                     pendingAttnOffset = attnOffset;
                     hasPendingAttn = true;
                 }
-                if (stateOutBufferNum_ == BUFFER_NUM) {
-                    CopyOutState(curStateOutOffset, curSingleV);
-                } else {
-                    if (hasPendingState) {
-                        CopyOutState(pendingStateOffset, curSingleV);
+                if (shouldStoreState_) {
+                    if (stateOutBufferNum_ == BUFFER_NUM) {
+                        CopyOutState(curStateOutSlot, head_i, v_i, curSingleV);
+                    } else {
+                        if (hasPendingState) {
+                            CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
+                        }
+                        pendingStateSlot = curStateOutSlot;
+                        hasPendingState = true;
                     }
-                    pendingStateOffset = curStateOutOffset;
-                    hasPendingState = true;
                 }
             }
             if (hasPendingAttn) {
                 CopyOutAttn(pendingAttnOffset, curSingleV);
             }
             if (hasPendingState) {
-                CopyOutState(pendingStateOffset, curSingleV);
+                CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
             }
         }
-        gateInQueue_.FreeTensor(gateInUb);
-    }
-
-    __aicore__ inline bool IsCurrentTask(uint64_t batchIdx, uint64_t headIdx) const
-    {
-        return ((batchIdx * NV_ + headIdx) % GetBlockNum()) == blockIdx;
-    }
+     }
 
 private:
     GlobalTensor<inType> queryGm_;
     GlobalTensor<inType> keyGm_;
     GlobalTensor<inType> valueGm_;
-    GlobalTensor<float> gateGm_;
-    GlobalTensor<float> betaGm_;
+    GlobalTensor<float> gateFloatGm_;
+    GlobalTensor<bfloat16_t> gateBf16Gm_;
+    GlobalTensor<half> gateFp16Gm_;
+    GlobalTensor<float> betaFloatGm_;
+    GlobalTensor<bfloat16_t> betaBf16Gm_;
+    GlobalTensor<half> betaFp16Gm_;
     GlobalTensor<stateType> initStateGm_;
-    GlobalTensor<int64_t> cuSeqlensGm_;
-    GlobalTensor<int64_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> cuSeqlensInt32Gm_;
+    GlobalTensor<int64_t> cuSeqlensInt64Gm_;
+    GlobalTensor<int32_t> ssmStateIndicesInt32Gm_;
+    GlobalTensor<int64_t> ssmStateIndicesInt64Gm_;
     GlobalTensor<float> aLogGm_;
     GlobalTensor<float> dtBiasGm_;
-    GlobalTensor<int64_t> numAcceptedTokensGm_;
+    GlobalTensor<int32_t> numAcceptedTokensInt32Gm_;
+    GlobalTensor<int64_t> numAcceptedTokensInt64Gm_;
     GlobalTensor<stateType> finalStateGm_;
     GlobalTensor<outType> attnOutGm_;
     TPipe *pipe_;
@@ -824,6 +956,7 @@ private:
     bool eventVToSInitialized_;
     uint32_t B_;
     uint32_t T_;
+    uint32_t seqLen_;
     uint32_t NK_;
     uint32_t alignK_;
     uint32_t realK_;
@@ -832,10 +965,24 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t stateInStride0_;
+    uint64_t stateInStride1_;
+    uint64_t stateInStride2_;
+    uint64_t stateInStride3_;
+    uint64_t stateOutStride0_;
+    uint64_t stateOutStride1_;
+    uint64_t stateOutStride2_;
+    uint64_t stateOutStride3_;
     uint32_t vStep_;
     uint32_t stateOutBufferNum_;
     uint32_t attnOutBufferNum_;
     uint32_t restUbSize_;
+    uint32_t gateDtype_;
+    uint32_t betaDtype_;
+    uint32_t cuSeqlensDtype_;
+    uint32_t ssmStateIndicesDtype_;
+    uint32_t acceptedTokensDtype_;
+    bool hasCuSeqlens_;
     bool hasSsmStateIndices_;
     bool hasAcceptedTokens_;
     bool hasALog_;
@@ -845,6 +992,8 @@ private:
     bool useBetaSigmoid_;
     bool allowNegEigval_;
     bool safeGate_;
+    bool stateVFirst_;
+    bool shouldStoreState_;
     bool useAddFoldReduce_;
     float beta_;
     float scale_;

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.cpp
@@ -24,15 +24,16 @@ using namespace RecurrentKda;
 extern "C" __global__ __aicore__ void
 recurrent_kda(GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR gate, GM_ADDR beta, GM_ADDR initialState,
               GM_ADDR cuSeqlens, GM_ADDR ssmStateIndices, GM_ADDR aLog, GM_ADDR dtBias, GM_ADDR numAcceptedTokens,
-              GM_ADDR out, GM_ADDR finalState, GM_ADDR workspaceGM, GM_ADDR tilingGM)
+              GM_ADDR out, GM_ADDR initialStateOut, GM_ADDR finalState, GM_ADDR workspaceGM, GM_ADDR tilingGM)
 {
     REGISTER_TILING_DEFAULT(RecurrentKdaTilingData);
     GET_TILING_DATA(tilingData, tilingGM);
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
     TPipe pipe;
-    RKDA<bfloat16_t, bfloat16_t, DTYPE_STATE> op(&tilingData);
+    RKDA<bfloat16_t, bfloat16_t, DTYPE_INITIAL_STATE> op(&tilingData);
+    GM_ADDR stateOutput = tilingData.inplaceFinalState == 1 ? initialStateOut : finalState;
     RKDAInitParams initParams{query, key, value, gate, beta, initialState, cuSeqlens, ssmStateIndices,
-                              aLog, dtBias, numAcceptedTokens, out, finalState};
+                              aLog, dtBias, numAcceptedTokens, out, stateOutput};
     op.Init(initParams, &pipe);
     op.Process();
 }

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
@@ -57,14 +57,24 @@ public:
     {
         B_ = tilingData->b;
         T_ = tilingData->t;
+        seqLen_ = tilingData->seqLen;
         NK_ = tilingData->nk;
         realK_ = tilingData->dk;
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         stateCapacity_ = tilingData->sBlockNum;
         ssmStateStride_ = tilingData->ssmStateStride;
+        stateInStride0_ = tilingData->stateInStride0;
+        stateInStride1_ = tilingData->stateInStride1;
+        stateInStride2_ = tilingData->stateInStride2;
+        stateInStride3_ = tilingData->stateInStride3;
+        stateOutStride0_ = tilingData->stateOutStride0;
+        stateOutStride1_ = tilingData->stateOutStride1;
+        stateOutStride2_ = tilingData->stateOutStride2;
+        stateOutStride3_ = tilingData->stateOutStride3;
         scale_ = tilingData->scale;
         lowerBound_ = tilingData->lowerBound;
+        hasCuSeqlens_ = (tilingData->hasCuSeqlens == 1);
         hasSsmStateIndices_ = (tilingData->hasSsmStateIndices == 1);
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasALog_ = (tilingData->hasALog == 1);
@@ -74,6 +84,13 @@ public:
         useBetaSigmoid_ = (tilingData->useBetaSigmoid == 1);
         allowNegEigval_ = (tilingData->allowNegEigval == 1);
         safeGate_ = (tilingData->safeGate == 1);
+        stateVFirst_ = (tilingData->stateVFirst == 1);
+        shouldStoreState_ = (tilingData->inplaceFinalState == 1 || tilingData->outputFinalState == 1);
+        gateDtype_ = tilingData->gateDtype;
+        betaDtype_ = tilingData->betaDtype;
+        cuSeqlensDtype_ = tilingData->cuSeqlensDtype;
+        ssmStateIndicesDtype_ = tilingData->ssmStateIndicesDtype;
+        acceptedTokensDtype_ = tilingData->acceptedTokensDtype;
         useAddFoldReduce_ = (RKDA_ENABLE_ADD_FOLD_REDUCE != 0);
         vStep_ = tilingData->vStep;
         stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
@@ -103,14 +120,21 @@ public:
         queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
         keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
         valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
-        gateGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
-        betaGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        gateFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
+        gateBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.gate);
+        gateFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.gate);
+        betaFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        betaBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.beta);
+        betaFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.beta);
         initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
-        cuSeqlensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
-        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
+        cuSeqlensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        cuSeqlensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
+        ssmStateIndicesInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        ssmStateIndicesInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
         aLogGm_.SetGlobalBuffer((__gm__ float *)initParams.aLog);
         dtBiasGm_.SetGlobalBuffer((__gm__ float *)initParams.dtBias);
-        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
         finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
         attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
     }
@@ -150,6 +174,8 @@ public:
         broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize / sizeof(float)), buffOffset);
+        buffOffset += betaUbSize;
+        gateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
     }
 
     __aicore__ inline void SyncMte2ToV()
@@ -205,8 +231,8 @@ public:
             return;
         }
         for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
-            int64_t seq0 = cuSeqlensGm_.GetValue(batch_i);
-            int64_t seq1 = cuSeqlensGm_.GetValue(batch_i + 1);
+            int64_t seq0 = SequenceStart(batch_i);
+            int64_t seq1 = SequenceEnd(batch_i);
             int64_t seqLen64 = seq1 - seq0;
             if (seqLen64 == 0) {
                 continue;
@@ -241,12 +267,15 @@ public:
 private:
     __aicore__ inline bool ValidateCuSeqlens() const
     {
-        int64_t seq0 = cuSeqlensGm_.GetValue(0);
+        if (!hasCuSeqlens_) {
+            return seqLen_ <= MAX_MTP;
+        }
+        int64_t seq0 = LoadCuSeqlens(0);
         if (seq0 != 0) {
             return false;
         }
         for (uint64_t i = 0; i < B_; i++) {
-            int64_t seq1 = cuSeqlensGm_.GetValue(i + 1);
+            int64_t seq1 = LoadCuSeqlens(i + 1);
             int64_t length = seq1 - seq0;
             if (seq1 < seq0 || seq1 > static_cast<int64_t>(T_) ||
                 length > static_cast<int64_t>(MAX_MTP) ||
@@ -256,6 +285,35 @@ private:
             seq0 = seq1;
         }
         return seq0 <= static_cast<int64_t>(T_);
+    }
+
+    __aicore__ inline int64_t LoadCuSeqlens(uint64_t index) const
+    {
+        return cuSeqlensDtype_ == 0 ? static_cast<int64_t>(cuSeqlensInt32Gm_.GetValue(index)) :
+                                     cuSeqlensInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t SequenceStart(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx) : static_cast<int64_t>(batchIdx * seqLen_);
+    }
+
+    __aicore__ inline int64_t SequenceEnd(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx + 1) :
+                               static_cast<int64_t>((batchIdx + 1) * seqLen_);
+    }
+
+    __aicore__ inline int64_t LoadSsmStateIndex(uint64_t index) const
+    {
+        return ssmStateIndicesDtype_ == 0 ? static_cast<int64_t>(ssmStateIndicesInt32Gm_.GetValue(index)) :
+                                           ssmStateIndicesInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t LoadAcceptedTokens(uint64_t index) const
+    {
+        return acceptedTokensDtype_ == 0 ? static_cast<int64_t>(numAcceptedTokensInt32Gm_.GetValue(index)) :
+                                          numAcceptedTokensInt64Gm_.GetValue(index);
     }
 
     __aicore__ inline uint64_t StateMetadataOffset(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -268,7 +326,7 @@ private:
 
     __aicore__ inline uint64_t LoadStateSlot(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
     {
-        int64_t stateSlot = ssmStateIndicesGm_.GetValue(StateMetadataOffset(batchIdx, seq0, tokenIdx));
+        int64_t stateSlot = LoadSsmStateIndex(StateMetadataOffset(batchIdx, seq0, tokenIdx));
         if (stateSlot < 0 || stateSlot >= static_cast<int64_t>(stateCapacity_)) {
             return INVALID_STATE_SLOT;
         }
@@ -281,7 +339,7 @@ private:
             return batchIdx < stateCapacity_;
         }
         if (hasAcceptedTokens_) {
-            int64_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batchIdx);
+            int64_t acceptedTokenNum = LoadAcceptedTokens(batchIdx);
             if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
                 return false;
             }
@@ -301,15 +359,16 @@ private:
         }
         int64_t tokenIdx = seq0;
         if (hasAcceptedTokens_) {
-            tokenIdx = seq0 + numAcceptedTokensGm_.GetValue(batchIdx) - 1;
+            tokenIdx = seq0 + LoadAcceptedTokens(batchIdx) - 1;
         }
         return LoadStateSlot(batchIdx, seq0, tokenIdx);
     }
 
-    __aicore__ inline void CopyFloatVectorIn(LocalTensor<float> &dst, GlobalTensor<float> &src, uint64_t offset,
-                                             uint64_t count)
+    template <typename dataType>
+    __aicore__ inline void CopyVectorIn(LocalTensor<dataType> &dst, GlobalTensor<dataType> &src, uint64_t offset,
+                                        uint64_t count)
     {
-        uint64_t rowBytes = count * sizeof(float);
+        uint64_t rowBytes = count * sizeof(dataType);
         if (rowBytes >= 32 && rowBytes % 32 == 0) {
             DataCopy(dst, src[offset], static_cast<uint32_t>(count));
         } else {
@@ -376,7 +435,7 @@ private:
         float expA = hasALog_ ? ExpScalar(ReadFloat(aLogGm_, head)) : 1.0f;
 
         if (hasDtBias_) {
-            CopyFloatVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
+            CopyVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
             SyncMte2ToV();
             for (int32_t row = 0; row < seqLen; ++row) {
                 Add(gateInUb[row * alignK_], gateInUb[row * alignK_], broadTmpInUb, alignK_);
@@ -411,39 +470,67 @@ private:
         }
     }
 
+    template <typename gateType>
+    __aicore__ inline void CopyInGate(uint64_t gateOffset, int32_t seqLen)
+    {
+        LocalTensor<gateType> gateLocal = gateInQueue_.AllocTensor<gateType>();
+        Duplicate<gateType>(gateLocal, static_cast<gateType>(0), alignK_ * static_cast<uint32_t>(seqLen));
+        SyncVToMte2();
+        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen),
+                                       static_cast<uint32_t>(realK_ * sizeof(gateType)),
+                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(gateType)), 0, 0};
+        DataCopyPadExtParams<gateType> gatePadParams{
+            true, 0, static_cast<uint8_t>(alignK_ - realK_), static_cast<gateType>(0)};
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            DataCopyPad(gateLocal, gateFloatGm_[gateOffset], gateInParams, gatePadParams);
+        } else if constexpr (std::is_same<gateType, bfloat16_t>()) {
+            DataCopyPad(gateLocal, gateBf16Gm_[gateOffset], gateInParams, gatePadParams);
+        } else {
+            DataCopyPad(gateLocal, gateFp16Gm_[gateOffset], gateInParams, gatePadParams);
+        }
+        gateInQueue_.EnQue<gateType>(gateLocal);
+        gateLocal = gateInQueue_.DeQue<gateType>();
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            Adds(gateInUb, gateLocal, 0.0f, alignK_ * static_cast<uint32_t>(seqLen));
+        } else {
+            Cast(gateInUb, gateLocal, AscendC::RoundMode::CAST_NONE,
+                 alignK_ * static_cast<uint32_t>(seqLen));
+        }
+        gateInQueue_.FreeTensor(gateLocal);
+        PipeBarrier<PIPE_V>();
+    }
+
     __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
                                          uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
-        LocalTensor<float> gateLocal = gateInQueue_.AllocTensor<float>();
-        Duplicate<float>(gateLocal, 0, alignK_ * static_cast<uint32_t>(seqLen));
-        SyncVToMte2();
 
         DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
                                      static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
                                     static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
-        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
-                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
-        DataCopyPadExtParams<float> gatePadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
 
         DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
-        DataCopyPad(gateLocal, gateGm_[gateOffset], gateInParams, gatePadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
         vInQueue_.EnQue<inType>(vLocal);
-        gateInQueue_.EnQue<float>(gateLocal);
+        if (gateDtype_ == 0) {
+            CopyInGate<float>(gateOffset, seqLen);
+        } else if (gateDtype_ == 1) {
+            CopyInGate<bfloat16_t>(gateOffset, seqLen);
+        } else {
+            CopyInGate<half>(gateOffset, seqLen);
+        }
 
         qLocal = qInQueue_.DeQue<inType>();
         kLocal = kInQueue_.DeQue<inType>();
         vLocal = vInQueue_.DeQue<inType>();
-        gateInUb = gateInQueue_.DeQue<float>();
         Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
@@ -465,13 +552,27 @@ private:
         vInQueue_.FreeTensor(vLocal);
     }
 
-    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    __aicore__ inline void PrefetchState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                          uint32_t curSingleV)
     {
         LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
-        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
-                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
-        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
-        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateInStride0_ * stateSlot + stateInStride1_ * head + stateInStride2_ * vOffset;
+            DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                            static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+            DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+            DataCopyPad(stateLocal, initStateGm_[stateOffset], stateInParams, padParams);
+        } else {
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateInStride0_ * stateSlot + stateInStride1_ * head +
+                                           stateInStride2_ * k +
+                                           stateInStride3_ * (vOffset + v);
+                    stateLocal.SetValue(v * alignK_ + k, initStateGm_.GetValue(stateOffset));
+                }
+            }
+        }
         stateInQueue_.EnQue<stateType>(stateLocal);
     }
 
@@ -598,14 +699,16 @@ private:
         MatVecMul(stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV, false);
         AscendC::PipeBarrier<PIPE_V>();
         ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
-        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
-        if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
-        } else {
-            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        if (shouldStoreState_) {
+            LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            if constexpr (std::is_same<stateType, float32_t>()) {
+                DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+            } else {
+                Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+            }
+            stateOutQueue_.EnQue<stateType>(stateOutLocal);
         }
-        stateOutQueue_.EnQue<stateType>(stateOutLocal);
         Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
         attnOutQueue_.EnQue<outType>(attnOutLocal);
     }
@@ -618,30 +721,65 @@ private:
         attnOutQueue_.FreeTensor(attnLocal);
     }
 
-    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    __aicore__ inline void CopyOutState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                         uint32_t curSingleV)
     {
         LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
-        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
-                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
-        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateOutStride0_ * stateSlot + stateOutStride1_ * head + stateOutStride2_ * vOffset;
+            DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                          static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+            DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        } else {
+            SyncVToS();
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateOutStride0_ * stateSlot + stateOutStride1_ * head +
+                                           stateOutStride2_ * k +
+                                           stateOutStride3_ * (vOffset + v);
+                    finalStateGm_.SetValue(stateOffset, stateOutLocal.GetValue(v * alignK_ + k));
+                }
+            }
+        }
         stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    template <typename betaType>
+    __aicore__ inline void CopyInBetaTyped(int64_t seq0, int64_t seq1)
+    {
+        int64_t seqLen = seq1 - seq0;
+        uint64_t betaCount = static_cast<uint64_t>(seqLen) * NV_;
+        uint64_t betaBatchSize = Ceil(betaCount, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+        LocalTensor<betaType> betaLocal = betaInQueue_.AllocTensor<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            CopyVectorIn(betaLocal, betaFloatGm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else if constexpr (std::is_same<betaType, bfloat16_t>()) {
+            CopyVectorIn(betaLocal, betaBf16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else {
+            CopyVectorIn(betaLocal, betaFp16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        }
+        betaInQueue_.EnQue<betaType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            Adds(betaInUb, betaLocal, 0.0f, static_cast<uint32_t>(betaBatchSize));
+        } else {
+            Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, static_cast<uint32_t>(betaBatchSize));
+        }
+        betaInQueue_.FreeTensor(betaLocal);
+        PipeBarrier<PIPE_V>();
+        SyncVToS();
     }
 
     __aicore__ inline void CopyInBeta(int64_t seq0, int64_t seq1)
     {
-        int64_t seqLen = seq1 - seq0;
-        uint64_t betaBatchSize = Ceil(static_cast<uint64_t>(seqLen) * NV_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
-        LocalTensor<float> betaLocal = betaInQueue_.AllocTensor<float>();
-        CopyFloatVectorIn(betaLocal, betaGm_, static_cast<uint64_t>(seq0) * NV_,
-                          static_cast<uint64_t>(seqLen) * NV_);
-        betaInQueue_.EnQue<float>(betaLocal);
-        betaLocal = betaInQueue_.DeQue<float>();
-        DataCopy(betaInUb, betaLocal, betaBatchSize);
-        SyncMte2ToV();
-        betaInQueue_.FreeTensor(betaLocal);
-        Adds(betaInUb, betaInUb, 0.0f, betaBatchSize);
-        PipeBarrier<PIPE_V>();
-        SyncVToS();
+        if (betaDtype_ == 0) {
+            CopyInBetaTyped<float>(seq0, seq1);
+        } else if (betaDtype_ == 1) {
+            CopyInBetaTyped<bfloat16_t>(seq0, seq1);
+        } else {
+            CopyInBetaTyped<half>(seq0, seq1);
+        }
     }
 
     __aicore__ inline uint64_t StateSlotForToken(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -672,24 +810,21 @@ private:
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
         CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
-            gateInQueue_.FreeTensor(gateInUb);
             return;
         }
         uint64_t nextVOffset = 0;
         uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
-        uint64_t nextStateOffset = ((stateSlot * NV_ + head_i) * realV_) * realK_;
-        PrefetchState(nextStateOffset, nextSingleV);
+        PrefetchState(stateSlot, head_i, 0, nextSingleV);
         for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
             uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
             LoadPrefetchedState(curSingleV);
             nextVOffset = v_i + vStep_;
             if (nextVOffset < realV_) {
                 nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
-                nextStateOffset = ((stateSlot * NV_ + head_i) * realV_ + nextVOffset) * realK_;
-                PrefetchState(nextStateOffset, nextSingleV);
+                PrefetchState(stateSlot, head_i, nextVOffset, nextSingleV);
             }
             uint64_t pendingAttnOffset = 0;
-            uint64_t pendingStateOffset = 0;
+            uint64_t pendingStateSlot = 0;
             bool hasPendingAttn = false;
             bool hasPendingState = false;
             for (int64_t seq_i = seq0; seq_i < seq1; seq_i++) {
@@ -698,7 +833,7 @@ private:
                 uint64_t curVOffset = static_cast<uint64_t>(seq_i - seq0) * alignV_ + v_i;
                 uint64_t attnOffset = (static_cast<uint64_t>(seq_i) * NV_ + head_i) * realV_ + v_i;
                 uint64_t curStateSlot = StateSlotForToken(batchIdx, seq0, seq_i);
-                uint64_t curStateOutOffset = ((curStateSlot * NV_ + head_i) * realV_ + v_i) * realK_;
+                uint64_t curStateOutSlot = curStateSlot;
                 beta_ = LoadBeta(gbOffset);
                 Compute(curSingleV, curQKOffset, curVOffset);
                 if (attnOutBufferNum_ == BUFFER_NUM) {
@@ -710,25 +845,26 @@ private:
                     pendingAttnOffset = attnOffset;
                     hasPendingAttn = true;
                 }
-                if (stateOutBufferNum_ == BUFFER_NUM) {
-                    CopyOutState(curStateOutOffset, curSingleV);
-                } else {
-                    if (hasPendingState) {
-                        CopyOutState(pendingStateOffset, curSingleV);
+                if (shouldStoreState_) {
+                    if (stateOutBufferNum_ == BUFFER_NUM) {
+                        CopyOutState(curStateOutSlot, head_i, v_i, curSingleV);
+                    } else {
+                        if (hasPendingState) {
+                            CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
+                        }
+                        pendingStateSlot = curStateOutSlot;
+                        hasPendingState = true;
                     }
-                    pendingStateOffset = curStateOutOffset;
-                    hasPendingState = true;
                 }
             }
             if (hasPendingAttn) {
                 CopyOutAttn(pendingAttnOffset, curSingleV);
             }
             if (hasPendingState) {
-                CopyOutState(pendingStateOffset, curSingleV);
+                CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
             }
         }
-        gateInQueue_.FreeTensor(gateInUb);
-    }
+     }
 
     __aicore__ inline bool IsCurrentTask(uint64_t batchIdx, uint64_t headIdx) const
     {
@@ -739,14 +875,21 @@ private:
     GlobalTensor<inType> queryGm_;
     GlobalTensor<inType> keyGm_;
     GlobalTensor<inType> valueGm_;
-    GlobalTensor<float> gateGm_;
-    GlobalTensor<float> betaGm_;
+    GlobalTensor<float> gateFloatGm_;
+    GlobalTensor<bfloat16_t> gateBf16Gm_;
+    GlobalTensor<half> gateFp16Gm_;
+    GlobalTensor<float> betaFloatGm_;
+    GlobalTensor<bfloat16_t> betaBf16Gm_;
+    GlobalTensor<half> betaFp16Gm_;
     GlobalTensor<stateType> initStateGm_;
-    GlobalTensor<int64_t> cuSeqlensGm_;
-    GlobalTensor<int64_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> cuSeqlensInt32Gm_;
+    GlobalTensor<int64_t> cuSeqlensInt64Gm_;
+    GlobalTensor<int32_t> ssmStateIndicesInt32Gm_;
+    GlobalTensor<int64_t> ssmStateIndicesInt64Gm_;
     GlobalTensor<float> aLogGm_;
     GlobalTensor<float> dtBiasGm_;
-    GlobalTensor<int64_t> numAcceptedTokensGm_;
+    GlobalTensor<int32_t> numAcceptedTokensInt32Gm_;
+    GlobalTensor<int64_t> numAcceptedTokensInt64Gm_;
     GlobalTensor<stateType> finalStateGm_;
     GlobalTensor<outType> attnOutGm_;
     TPipe *pipe_;
@@ -777,6 +920,7 @@ private:
     bool eventVToSInitialized_;
     uint32_t B_;
     uint32_t T_;
+    uint32_t seqLen_;
     uint32_t NK_;
     uint32_t alignK_;
     uint32_t realK_;
@@ -785,10 +929,24 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t stateInStride0_;
+    uint64_t stateInStride1_;
+    uint64_t stateInStride2_;
+    uint64_t stateInStride3_;
+    uint64_t stateOutStride0_;
+    uint64_t stateOutStride1_;
+    uint64_t stateOutStride2_;
+    uint64_t stateOutStride3_;
     uint32_t vStep_;
     uint32_t stateOutBufferNum_;
     uint32_t attnOutBufferNum_;
     uint32_t restUbSize_;
+    uint32_t gateDtype_;
+    uint32_t betaDtype_;
+    uint32_t cuSeqlensDtype_;
+    uint32_t ssmStateIndicesDtype_;
+    uint32_t acceptedTokensDtype_;
+    bool hasCuSeqlens_;
     bool hasSsmStateIndices_;
     bool hasAcceptedTokens_;
     bool hasALog_;
@@ -798,6 +956,8 @@ private:
     bool useBetaSigmoid_;
     bool allowNegEigval_;
     bool safeGate_;
+    bool stateVFirst_;
+    bool shouldStoreState_;
     bool useAddFoldReduce_;
     float beta_;
     float scale_;

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda_struct.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda_struct.h
@@ -46,6 +46,22 @@ struct alignas(8) RecurrentKdaTilingData {
     uint32_t allowNegEigval;
     uint32_t safeGate;
     uint32_t stateVFirst;
+    uint32_t outputFinalState;
+    uint32_t inplaceFinalState;
+    uint32_t hasCuSeqlens;
+    uint32_t gateDtype;
+    uint32_t betaDtype;
+    uint32_t cuSeqlensDtype;
+    uint32_t ssmStateIndicesDtype;
+    uint32_t acceptedTokensDtype;
+    uint64_t stateInStride0;
+    uint64_t stateInStride1;
+    uint64_t stateInStride2;
+    uint64_t stateInStride3;
+    uint64_t stateOutStride0;
+    uint64_t stateOutStride1;
+    uint64_t stateOutStride2;
+    uint64_t stateOutStride3;
 };
 #pragma pack(pop)
 

--- a/csrc/attention/recurrent_kda/recurrent_kda_torch_adpt.h
+++ b/csrc/attention/recurrent_kda/recurrent_kda_torch_adpt.h
@@ -67,8 +67,8 @@ at::Tensor recurrent_kda(
                 "recurrent_kda: token and head dimensions must be positive.");
     TORCH_CHECK(hv % h == 0,
                 "recurrent_kda: HV must be divisible by H.");
-    TORCH_CHECK(k_dim == 128 && v_dim == 128,
-                "recurrent_kda: the Kimi K3 integration requires K=V=128.");
+    TORCH_CHECK(k_dim == 128 && (v_dim == 128 || v_dim == 256),
+                "recurrent_kda: the Kimi K3 integration requires K=128 and V=128 or 256.");
     TORCH_CHECK((is_tnd && value.size(0) == total_tokens && gate.size(0) == total_tokens &&
                  beta.size(0) == total_tokens && gate.size(1) == hv && gate.size(2) == k_dim &&
                  beta.size(1) == hv) ||
@@ -119,7 +119,10 @@ at::Tensor recurrent_kda(
     const at::Tensor& accepted = c10::value_or_else(
         num_accepted_tokens, [] { return at::Tensor(); });
     const char* layout = is_tnd ? "TND" : "BSND";
-    bool output_final_state = true;
+    // vLLM consumes the cache mutation through initial_state and returns only
+    // the attention output. Avoid materializing a second full state tensor.
+    bool output_final_state = false;
+    bool inplace_final_state = true;
     bool state_v_first = true;
     EXEC_NPU_CMD(
         aclnnRecurrentKda,
@@ -137,6 +140,7 @@ at::Tensor recurrent_kda(
         layout,
         scale,
         output_final_state,
+        inplace_final_state,
         use_qk_l2norm_in_kernel,
         use_gate_in_kernel,
         use_beta_sigmoid_in_kernel,
@@ -144,7 +148,8 @@ at::Tensor recurrent_kda(
         safe_gate,
         lower_bound,
         state_v_first,
-        output);
+        output,
+        final_state);
     return output;
 }
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
@@ -221,6 +221,96 @@ def test_kimi_k3_tp16_recurrent_kda_bsnd_single_token_decode_wrapper():
 
 
 @torch.inference_mode()
+def test_kimi_k3_tp16_recurrent_kda_non_contiguous_state_pool():
+    """Preserve a strided cache view while updating only selected Kimi slots."""
+    torch.manual_seed(20260806)
+    device = torch.device("npu")
+    batch, heads, dim = 4, 6, 128
+    state_capacity = 17
+    cu_seqlens_host = list(range(batch + 1))
+    state_indices_cpu = torch.tensor([9, 2, 15, 4], dtype=torch.int64)
+
+    q_cpu = torch.randn(1, batch, heads, dim, dtype=torch.bfloat16)
+    k_cpu = torch.randn_like(q_cpu)
+    v_cpu = torch.randn_like(q_cpu)
+    raw_gate_cpu = torch.randn(1, batch, heads, dim, dtype=torch.bfloat16) * 0.25
+    beta_cpu = torch.rand(1, batch, heads, dtype=torch.float32).sigmoid()
+    state_cpu = torch.randn(state_capacity, heads, dim, dim, dtype=torch.float32) * 0.01
+    a_log_cpu = torch.randn(heads, dtype=torch.float32) * 0.05
+    dt_bias_cpu = torch.randn(heads, dim, dtype=torch.float32) * 0.05
+
+    ref_out, ref_state = recurrent_kda_reference(
+        q_cpu,
+        k_cpu,
+        v_cpu,
+        raw_gate_cpu,
+        beta_cpu,
+        state_cpu,
+        cu_seqlens=cu_seqlens_host,
+        ssm_state_indices=state_indices_cpu,
+        A_log=a_log_cpu,
+        dt_bias=dt_bias_cpu,
+        layout="BSND",
+        scale=dim**-0.5,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+    )
+
+    state_pool = torch.full(
+        (state_capacity + 1, 2, heads, dim, dim),
+        7.0,
+        dtype=torch.float32,
+        device=device,
+    )
+    # Model-runner cache slots may be a strided view with a non-zero storage
+    # offset. Keep the adjacent layer as a guard against an incorrect write.
+    state_view = state_pool[1:, 0]
+    state_view.copy_(state_cpu.to(device))
+    guard_layer = state_pool[1:, 1].clone()
+    state_before = state_view.clone()
+    state_stride = state_view.stride()
+    state_storage = state_view.untyped_storage().data_ptr()
+    assert not state_view.is_contiguous()
+    assert state_view.storage_offset() > 0
+
+    out = torch.ops._C_ascend.recurrent_kda(
+        q_cpu.to(device),
+        k_cpu.to(device),
+        v_cpu.to(device),
+        raw_gate_cpu.to(device),
+        beta_cpu.to(device),
+        state_view,
+        torch.tensor(cu_seqlens_host, dtype=torch.int32, device=device),
+        state_indices_cpu.to(device),
+        a_log_cpu.to(device),
+        dt_bias_cpu.to(device),
+        scale=dim**-0.5,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=False,
+        allow_neg_eigval=False,
+        safe_gate=True,
+        lower_bound=-5.0,
+    )
+    torch.npu.synchronize()
+
+    assert state_view.stride() == state_stride
+    assert state_view.untyped_storage().data_ptr() == state_storage
+    torch.testing.assert_close(out.cpu(), ref_out, rtol=0.02, atol=0.02)
+    torch.testing.assert_close(state_view.cpu(), ref_state, rtol=0.02, atol=0.02)
+    torch.testing.assert_close(state_pool[1:, 1], guard_layer, rtol=0, atol=0)
+    used_slots = set(state_indices_cpu.tolist())
+    untouched_slots = [slot for slot in range(state_capacity) if slot not in used_slots]
+    torch.testing.assert_close(
+        state_view[untouched_slots],
+        state_before[untouched_slots],
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
 def test_kimi_k3_tp16_recurrent_kda_multistep_decode_matches_triton_and_reference():
     """Reuse real decode cache slots across steps, as the model wrapper does."""
     from torch import nn


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aligns the recurrent KDA AscendC operator with the stride-aware implementation used by Kimi K3 and fixes the host/operator contract across the Torch, aclnn, tiling, and kernel layers.

The previous implementation converted a non-contiguous recurrent-state view into a contiguous temporary tensor and copied the updated state back afterward. Kimi K3 can pass cache views with a non-zero storage offset and padded outer strides, so this path adds an unnecessary full-state copy and can lose the original storage/stride semantics.

This PR:

- Preserves the recurrent-state storage offset and outer strides and lets the kernel read and update the original state view directly.
- Keeps the inner state matrix dense while supporting both V-first and K-first state layouts at the aclnn/kernel level.
- Adds K=128 with V=128 or V=256 support to the Kimi K3 Torch entry.
- Supports optional `cu_seqlens`, INT32/INT64 sequence metadata, and FP32/BF16/FP16 gate and beta inputs without host-side casts.
- Aligns the Torch adapter, pybind/aclnn API, operator definition, infer-shape, tiling data, and kernel argument/output order.
- Adds explicit `output_final_state` and `inplace_final_state` semantics. The vLLM integration updates the input cache in place and skips materializing an unused second full-state tensor.
- Registers independent ND formats with `FormatList`, avoiding invalid FE format/type combinations.
- Retains the optimized stride-aware state update path and avoids writes to unrelated cache slots or adjacent layer storage.

### Does this PR introduce _any_ user-facing change?

Yes. Kimi K3 recurrent KDA can consume non-contiguous cache views with non-zero storage offsets directly, supports V=128/256, and avoids the redundant full-state copy in the vLLM in-place path. No new user configuration is required.

### How was this patch tested?

- Added an Ascend NPU regression case for a non-contiguous Kimi K3 state pool with a non-zero storage offset.
- Compared the operator output and updated state against the PyTorch reference implementation.
- Verified that the state view keeps the same storage pointer and strides.
- Verified that only selected cache slots are updated and adjacent/unused storage remains unchanged.
- Existing recurrent KDA single-token decode and multi-step accuracy coverage is retained.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
