### PR TITLE
[Refactor] Optimize and decompose the MoE MLP stage

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py
@@ -252,8 +252,9 @@ def test_token_dispatcher_with_all_gather_quant(
         ),
         token_dispatch_output=token_dispatch_output,
         use_fusion_ops=False,
+        output_dtype=dtype,
     )
-    expert_output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+    expert_output, _ = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
     combined_output = dispatcher.token_combine(
         hidden_states=expert_output, combine_metadata=combine_metadata, bias=None
     )

--- a/tests/ut/_310p/fused_moe/test_moe_mlp_310.py
+++ b/tests/ut/_310p/fused_moe/test_moe_mlp_310.py
@@ -47,6 +47,7 @@ def build_mlp_compute_input_fixture(
         topk_scales=None,
         weights=MoEWeights(w1=w1, w2=w2, w1_scale=w1_scale, w2_scale=w2_scale),
         quant=MoEQuantParams(quant_type=QuantType.W8A8 if with_quant else QuantType.NONE),
+        output_dtype=hidden_states.dtype,
         fusion=False,
         activation="silu",
         need_trans=False,

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -4,6 +4,7 @@ import torch
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from tests.ut.base import TestBase
+from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.moe_comm_method import (
     AllGatherCommImpl,
     AlltoAllCommImpl,
@@ -61,6 +62,7 @@ class TestMoECommMethod(TestBase):
         # Mock forward context
         mock_context = MagicMock()
         mock_context.moe_comm_method = "all_gather"
+        mock_context.moe_comm_type = MoECommType.ALLGATHER
         mock_get_forward_context.return_value = mock_context
 
         # Mock prepare finalize
@@ -174,10 +176,10 @@ class TestMoECommMethod(TestBase):
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAllGather")
-    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.unified_apply_mlp")
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.MoEMLPPlanner.execute")
     @patch("torch.npu.current_stream", MagicMock())
     def test_fused_experts_method(
-        self, mock_unified_apply_mlp, mock_token_dispatcher, mock_prepare_finalize, mock_get_forward_context
+        self, mock_execute_mlp, mock_token_dispatcher, mock_prepare_finalize, mock_get_forward_context
     ):
         # Mock forward context
         mock_context = MagicMock()
@@ -199,7 +201,7 @@ class TestMoECommMethod(TestBase):
         mock_td_instance = MagicMock()
         dispatch_topk_weights = torch.tensor([[0.5, 0.5], [0.3, 0.7], [0.8, 0.2], [0.6, 0.4]])
         mock_td_instance.token_dispatch.return_value = MoETokenDispatchOutput(
-            hidden_states=torch.randn(6, 8),
+            hidden_states=torch.zeros(6, 8, dtype=torch.int8),
             group_list=torch.tensor([2, 2, 2]),
             group_list_type=1,
             combine_metadata=MoEAllGatherCombineMetadata(
@@ -211,11 +213,11 @@ class TestMoECommMethod(TestBase):
         mock_td_instance.token_combine.return_value = torch.randn(4, 8)
         mock_token_dispatcher.return_value = mock_td_instance
 
-        # Mock unified_apply_mlp returns (tensor, event) tuple
-        mock_unified_apply_mlp.return_value = (torch.randn(6, 8), MagicMock())
+        # Mock the cached MLP planner result.
+        mock_execute_mlp.return_value = (torch.randn(6, 8), MagicMock())
 
         # Create instance
-        comm_impl = AllGatherCommImpl(self.moe_config)
+        comm_impl = AllGatherCommImpl(self.moe_config, output_dtype=torch.float16)
 
         # Test fused_experts method
         hidden_states = torch.randn(4, 8).contiguous()
@@ -257,14 +259,15 @@ class TestMoECommMethod(TestBase):
         # Verify token_dispatch was called
         mock_td_instance.token_dispatch.assert_called_once()
 
-        # Verify unified_apply_mlp was called
-        mock_unified_apply_mlp.assert_called_once()
-        mlp_compute_input = mock_unified_apply_mlp.call_args.kwargs["mlp_compute_input"]
+        # Verify the cached MLP planner was called.
+        mock_execute_mlp.assert_called_once()
+        mlp_compute_input = mock_execute_mlp.call_args.args[0]
         self.assertFalse(mlp_compute_input.fusion)
         self.assertFalse(mlp_compute_input.quant.is_mxfp)
+        self.assertEqual(mlp_compute_input.output_dtype, torch.float16)
 
         # Verify token_combine was called
         mock_td_instance.token_combine.assert_called_once_with(
-            hidden_states=mock_unified_apply_mlp.return_value[0],
+            hidden_states=mock_execute_mlp.return_value[0],
             combine_metadata=mock_td_instance.token_dispatch.return_value.combine_metadata,
         )

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -16,6 +16,18 @@ from vllm_ascend.ops.fused_moe.moe_mlp import (
     quant_apply_mlp,
     unified_apply_mlp,
     unquant_apply_mlp,
+    weight_only_apply_mlp,
+)
+from vllm_ascend.ops.fused_moe.moe_mlp_activation import (
+    MoEMLPActivationKind,
+    apply_unquantized_activation,
+    resolve_mlp_activation,
+)
+from vllm_ascend.ops.fused_moe.moe_mlp_plan import (
+    GateUpKernel,
+    MoEMLPPlanKey,
+    MoEMLPPlanner,
+    build_mlp_plan,
 )
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEMlpComputeInput,
@@ -62,17 +74,155 @@ class TestCumsumGroupList(unittest.TestCase):
                 self.assertIn("This feature is under development.", str(excinfo.exception))
 
 
-class TestW4A8RuntimeFlags(unittest.TestCase):
-    def test_w4a8_per_channel_gmm_swiglu_flag(self):
-        self.assertTrue(
-            MoEQuantParams(quant_type=QuantType.W4A8, is_per_channel_weight=True).use_w4a8_per_channel_gmm_swiglu
+class TestMoEMLPPlanSelection(unittest.TestCase):
+    def _key(self, quant_type, activation=MoEMLPActivationKind.SWIGLU, **kwargs):
+        return MoEMLPPlanKey(
+            quant_type=quant_type,
+            activation=activation,
+            fusion=kwargs.get("fusion", False),
+            dynamic_eplb=kwargs.get("dynamic_eplb", False),
+            group_list_type=kwargs.get("group_list_type", 1),
+            custom_op_enabled=kwargs.get("custom_op_enabled", True),
+            moe_comm_type=kwargs.get("moe_comm_type", MoECommType.ALLGATHER),
         )
-        self.assertFalse(
-            MoEQuantParams(quant_type=QuantType.W4A8, is_per_channel_weight=False).use_w4a8_per_channel_gmm_swiglu
+
+    def test_w4a8_always_selects_per_channel_path(self):
+        plan = build_mlp_plan(self._key(QuantType.W4A8))
+        self.assertFalse(hasattr(plan, "family"))
+        self.assertEqual(plan.gate_up_kernel, GateUpKernel.W4A8_PER_CHANNEL)
+
+    def test_w4a8_gelu_uses_decomposed_per_channel_path(self):
+        plan = build_mlp_plan(self._key(QuantType.W4A8, MoEMLPActivationKind.GELU_TANH))
+        self.assertEqual(plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+
+    def test_comm_type_is_a_plan_dimension(self):
+        fields = set(MoEMLPPlanKey.__dataclass_fields__)
+        self.assertIn("moe_comm_type", fields)
+
+    def test_dequant_swiglu_is_selected_only_for_mc2(self):
+        mc2_plan = build_mlp_plan(self._key(QuantType.W8A8, moe_comm_type=MoECommType.MC2))
+        allgather_plan = build_mlp_plan(self._key(QuantType.W8A8, moe_comm_type=MoECommType.ALLGATHER))
+        alltoall_plan = build_mlp_plan(self._key(QuantType.W8A8, moe_comm_type=MoECommType.ALLTOALL))
+
+        self.assertEqual(mc2_plan.gate_up_kernel, GateUpKernel.DEQUANT_SWIGLU)
+        self.assertEqual(allgather_plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+        self.assertEqual(alltoall_plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+
+    def test_mxfp_swiglu_selects_fused_kernel(self):
+        plan = build_mlp_plan(self._key(QuantType.W4A8MXFP, fusion=False))
+        self.assertEqual(plan.gate_up_kernel, GateUpKernel.FUSED)
+
+    def test_w4a16_selects_weight_only_plan(self):
+        plan = build_mlp_plan(self._key(QuantType.W4A16, MoEMLPActivationKind.GELU))
+        self.assertEqual(plan.gate_up_kernel, GateUpKernel.ANTIQUANT)
+
+    def test_gelu_never_selects_fused_swiglu(self):
+        plan = build_mlp_plan(self._key(QuantType.W8A8, MoEMLPActivationKind.GELU_TANH, fusion=True))
+        self.assertEqual(plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+
+    def test_swigluoai_never_selects_standard_fused_swiglu(self):
+        for quant_type in (QuantType.W8A8, QuantType.W4A8):
+            with self.subTest(quant_type=quant_type):
+                plan = build_mlp_plan(self._key(quant_type, MoEMLPActivationKind.SWIGLUOAI, fusion=True))
+                self.assertEqual(plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+
+    def test_swigluoai_uninterleave_selects_dequant_swiglu(self):
+        mc2_plan = build_mlp_plan(
+            self._key(
+                QuantType.W8A8,
+                MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE,
+                fusion=True,
+                moe_comm_type=MoECommType.MC2,
+            )
         )
-        self.assertFalse(
-            MoEQuantParams(quant_type=QuantType.W8A8, is_per_channel_weight=True).use_w4a8_per_channel_gmm_swiglu
+        allgather_plan = build_mlp_plan(
+            self._key(
+                QuantType.W8A8,
+                MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE,
+                fusion=True,
+                moe_comm_type=MoECommType.ALLGATHER,
+            )
         )
+
+        self.assertEqual(mc2_plan.gate_up_kernel, GateUpKernel.DEQUANT_SWIGLU)
+        self.assertEqual(allgather_plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+
+    def test_planner_caches_static_kernel_decisions(self):
+        planner = MoEMLPPlanner(custom_op_enabled=False)
+        request = SimpleNamespace(
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            activation="silu",
+            fusion=True,
+            dynamic_eplb=False,
+            group_list_type=0,
+            moe_comm_type=MoECommType.ALLGATHER,
+        )
+        self.assertIs(planner.get_plan(request), planner.get_plan(request))
+
+    def test_planner_reselects_when_comm_type_changes_between_forwards(self):
+        planner = MoEMLPPlanner(custom_op_enabled=False)
+        common_request = {
+            "quant": MoEQuantParams(quant_type=QuantType.W8A8),
+            "activation": "silu",
+            "fusion": False,
+            "dynamic_eplb": False,
+            "group_list_type": 0,
+        }
+        allgather_request = SimpleNamespace(
+            **common_request,
+            moe_comm_type=MoECommType.ALLGATHER,
+        )
+        mc2_request = SimpleNamespace(
+            **common_request,
+            moe_comm_type=MoECommType.MC2,
+        )
+
+        allgather_plan = planner.get_plan(allgather_request)
+        mc2_plan = planner.get_plan(mc2_request)
+
+        self.assertEqual(allgather_plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+        self.assertEqual(mc2_plan.gate_up_kernel, GateUpKernel.DEQUANT_SWIGLU)
+        self.assertIs(planner.get_plan(allgather_request), allgather_plan)
+        self.assertIs(planner.get_plan(mc2_request), mc2_plan)
+
+    def test_planner_resolves_custom_op_capability_lazily(self):
+        request = SimpleNamespace(
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            activation="silu",
+            fusion=True,
+            dynamic_eplb=True,
+            group_list_type=0,
+            moe_comm_type=MoECommType.ALLGATHER,
+        )
+        with patch("vllm_ascend.ops.fused_moe.moe_mlp_plan.enable_custom_op", return_value=False) as mock_enable:
+            planner = MoEMLPPlanner()
+            mock_enable.assert_not_called()
+            planner.get_plan(request)
+            planner.get_plan(request)
+        mock_enable.assert_called_once_with()
+
+
+class TestMoEMLPActivation(unittest.TestCase):
+    def test_unquantized_swigluoai_forwards_activation_parameters(self):
+        hidden_states = torch.zeros(2, 8)
+        expected = torch.zeros(2, 4)
+        with patch(
+            "vllm_ascend.ops.fused_moe.moe_mlp_activation.AscendSwigluOAIAndMul.swiglu_oai_forward",
+            return_value=expected,
+        ) as mock_oai:
+            output = apply_unquantized_activation(
+                hidden_states,
+                MoEMLPActivationKind.SWIGLUOAI,
+                hidden_size=8,
+                swiglu_limit=6.0,
+                swiglu_alpha=1.5,
+                swiglu_beta=0.0,
+            )
+
+        self.assertIs(output, expected)
+        mock_oai.assert_called_once()
+        torch.testing.assert_close(mock_oai.call_args.args[0], hidden_states.view(-1, 8))
+        self.assertEqual(mock_oai.call_args.kwargs, {"alpha": 1.5, "limit": 6.0})
 
 
 class TestUnifiedApplyMlpRequest(unittest.TestCase):
@@ -126,6 +276,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                 w2_bias=torch.randn(1, 8),
             ),
             quant=MoEQuantParams(quant_type=QuantType.NONE),
+            output_dtype=hidden_states.dtype,
             fusion=False,
             activation="silu",
             need_trans=False,
@@ -172,6 +323,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                             use_bf16=False,
                         ),
                     ),
+                    output_dtype=torch.float16,
                     fusion=True,
                     activation="silu",
                     need_trans=False,
@@ -188,12 +340,153 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                 mock_quant.assert_called_once()
                 quant_kwargs = mock_quant.call_args.kwargs
                 self.assertTrue(quant_kwargs["use_mxfp_quant"])
-                self.assertTrue(quant_kwargs["fusion"])
-                self.assertTrue(quant_kwargs["dynamic_eplb"])
+                self.assertTrue(quant_kwargs["kernel_plan"].key.fusion)
+                self.assertTrue(quant_kwargs["kernel_plan"].key.dynamic_eplb)
                 self.assertEqual(quant_kwargs["act_quant_type"], mxfp_dtype)
                 self.assertEqual(quant_kwargs["weight_quant_type"], mxfp_dtype)
                 self.assertFalse(quant_kwargs["use_bf16"])
                 mock_unquant.assert_not_called()
+
+    def test_request_weight_only_path_uses_dedicated_executor(self):
+        hidden_states = torch.randn(2, 8)
+        expected = (torch.randn(2, 8), MagicMock())
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=hidden_states,
+            group_list=torch.tensor([2, 2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=torch.randn(1, 16, 8),
+                w2=torch.randn(1, 8, 8),
+                w1_scale=torch.randn(1, 16),
+                w2_scale=torch.randn(1, 8),
+                w1_offset=torch.randn(1, 16),
+                w2_offset=torch.randn(1, 8),
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W4A16),
+            output_dtype=torch.bfloat16,
+            fusion=False,
+            activation="silu",
+        )
+
+        with (
+            patch(f"{MOE_MLP}.weight_only_apply_mlp", return_value=expected) as mock_weight_only,
+            patch(f"{MOE_MLP}.quant_apply_mlp") as mock_quant,
+            patch(f"{MOE_MLP}.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        mock_weight_only.assert_called_once()
+        mock_quant.assert_not_called()
+        mock_unquant.assert_not_called()
+
+    def test_request_quant_path_passes_w4a8_per_channel_plan(self):
+        hidden_states = torch.randn(2, 8)
+        expected = torch.randn(2, 8)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=hidden_states,
+            group_list=torch.tensor([2, 2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=torch.randn(2, 1),
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=torch.randn(1, 16, 8),
+                w2=torch.randn(1, 8, 8),
+                w1_scale=[torch.randn(1, 16)],
+                w2_scale=[torch.randn(1, 8)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W4A8),
+            output_dtype=torch.bfloat16,
+            fusion=False,
+            activation="silu",
+            need_trans=False,
+            dynamic_eplb=False,
+        )
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp_plan.enable_custom_op", return_value=False),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertTrue(output is expected)
+        quant_kwargs = mock_quant.call_args.kwargs
+        kernel_plan = quant_kwargs["kernel_plan"]
+        self.assertEqual(kernel_plan.gate_up_kernel, GateUpKernel.DECOMPOSED)
+        mock_unquant.assert_not_called()
+
+    def test_request_quant_path_passes_swiglustep_activation(self):
+        expected = torch.randn(1, 2)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=torch.ones((1, 2), dtype=torch.float32),
+            group_list=torch.tensor([1], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones((1, 2, 4), dtype=torch.float32)],
+                w2=[torch.ones((1, 2, 2), dtype=torch.float32)],
+                w1_scale=[torch.ones((1,), dtype=torch.float32)],
+                w2_scale=[torch.ones((1,), dtype=torch.float32)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            output_dtype=torch.bfloat16,
+            fusion=True,
+            activation=MoEActivation.SWIGLUSTEP,
+            swiglu_limit=5.0,
+        )
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertTrue(output is expected)
+        quant_kwargs = mock_quant.call_args.kwargs
+        self.assertEqual(
+            quant_kwargs["kernel_plan"].key.activation,
+            MoEMLPActivationKind.SWIGLUSTEP,
+        )
+        self.assertEqual(quant_kwargs["swiglu_limit"], 5.0)
+        mock_unquant.assert_not_called()
+
+    def test_request_quant_path_passes_gelu_activation(self):
+        expected = torch.randn(1, 2)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=torch.ones((1, 2), dtype=torch.float32),
+            group_list=torch.tensor([1], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones((1, 2, 4), dtype=torch.float32)],
+                w2=[torch.ones((1, 2, 2), dtype=torch.float32)],
+                w1_scale=[torch.ones((1,), dtype=torch.float32)],
+                w2_scale=[torch.ones((1,), dtype=torch.float32)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            output_dtype=torch.bfloat16,
+            fusion=True,
+            activation=MoEActivation.GELU_TANH,
+        )
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertTrue(output is expected)
+        quant_kwargs = mock_quant.call_args.kwargs
+        self.assertEqual(
+            quant_kwargs["kernel_plan"].key.activation,
+            MoEMLPActivationKind.GELU_TANH,
+        )
+        mock_unquant.assert_not_called()
 
     def test_active_quantized_lora_uses_registered_backend(self):
         expected = (torch.randn(2, 8), None)
@@ -210,6 +503,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                 w2_scale=[torch.ones(1, 8)],
             ),
             quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            output_dtype=torch.bfloat16,
             fusion=True,
             expanded_row_idx=torch.tensor([0, 1], dtype=torch.int32),
             topk_ids=torch.tensor([[0], [0]], dtype=torch.int32),
@@ -244,6 +538,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                 w2_scale=[torch.ones(1, 8)],
             ),
             quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            output_dtype=torch.bfloat16,
             fusion=True,
             lora_context=SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=True)),
         )
@@ -257,101 +552,6 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertIs(output, expected)
         mock_quant.assert_called_once()
         mock_lora.assert_not_called()
-
-    def test_request_quant_path_passes_w4a8_per_channel_flag(self):
-        hidden_states = torch.randn(2, 8)
-        expected = torch.randn(2, 8)
-        mlp_compute_input = MoEMlpComputeInput(
-            hidden_states=hidden_states,
-            group_list=torch.tensor([2, 2], dtype=torch.int64),
-            group_list_type=1,
-            dynamic_scale=torch.randn(2, 1),
-            topk_scales=None,
-            weights=MoEWeights(
-                w1=torch.randn(1, 16, 8),
-                w2=torch.randn(1, 8, 8),
-                w1_scale=[torch.randn(1, 16)],
-                w2_scale=[torch.randn(1, 8)],
-            ),
-            quant=MoEQuantParams(quant_type=QuantType.W4A8, is_per_channel_weight=True),
-            fusion=False,
-            activation="silu",
-            need_trans=False,
-            dynamic_eplb=False,
-        )
-
-        with (
-            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
-            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
-        ):
-            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
-
-        self.assertTrue(output is expected)
-        quant_kwargs = mock_quant.call_args.kwargs
-        self.assertTrue(quant_kwargs["use_w4a8_per_channel_gmm_swiglu"])
-        mock_unquant.assert_not_called()
-
-    def test_request_quant_path_passes_swiglustep_activation(self):
-        expected = torch.randn(1, 2)
-        mlp_compute_input = MoEMlpComputeInput(
-            hidden_states=torch.ones((1, 2), dtype=torch.float32),
-            group_list=torch.tensor([1], dtype=torch.int64),
-            group_list_type=1,
-            dynamic_scale=None,
-            topk_scales=None,
-            weights=MoEWeights(
-                w1=[torch.ones((1, 2, 4), dtype=torch.float32)],
-                w2=[torch.ones((1, 2, 2), dtype=torch.float32)],
-                w1_scale=[torch.ones((1,), dtype=torch.float32)],
-                w2_scale=[torch.ones((1,), dtype=torch.float32)],
-            ),
-            quant=MoEQuantParams(quant_type=QuantType.W8A8),
-            fusion=True,
-            activation=MoEActivation.SWIGLUSTEP,
-            swiglu_limit=5.0,
-        )
-
-        with (
-            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
-            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
-        ):
-            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
-
-        self.assertTrue(output is expected)
-        quant_kwargs = mock_quant.call_args.kwargs
-        self.assertEqual(quant_kwargs["activation"], MoEActivation.SWIGLUSTEP)
-        self.assertEqual(quant_kwargs["swiglu_limit"], 5.0)
-        mock_unquant.assert_not_called()
-
-    def test_request_quant_path_passes_gelu_activation(self):
-        expected = torch.randn(1, 2)
-        mlp_compute_input = MoEMlpComputeInput(
-            hidden_states=torch.ones((1, 2), dtype=torch.float32),
-            group_list=torch.tensor([1], dtype=torch.int64),
-            group_list_type=1,
-            dynamic_scale=None,
-            topk_scales=None,
-            weights=MoEWeights(
-                w1=[torch.ones((1, 2, 4), dtype=torch.float32)],
-                w2=[torch.ones((1, 2, 2), dtype=torch.float32)],
-                w1_scale=[torch.ones((1,), dtype=torch.float32)],
-                w2_scale=[torch.ones((1,), dtype=torch.float32)],
-            ),
-            quant=MoEQuantParams(quant_type=QuantType.W8A8),
-            fusion=True,
-            activation=MoEActivation.GELU_TANH,
-        )
-
-        with (
-            patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp", return_value=expected) as mock_quant,
-            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp") as mock_unquant,
-        ):
-            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
-
-        self.assertTrue(output is expected)
-        quant_kwargs = mock_quant.call_args.kwargs
-        self.assertEqual(quant_kwargs["activation"], MoEActivation.GELU_TANH)
-        mock_unquant.assert_not_called()
 
 
 def _patch_npu_stream():
@@ -409,54 +609,44 @@ class _GeluPathBase(unittest.TestCase):
         group_list=None,
         dynamic_scale=None,
     ):
+        kernel_plan = build_mlp_plan(
+            MoEMLPPlanKey(
+                quant_type=QuantType.W8A8,
+                activation=resolve_mlp_activation(activation),
+                fusion=False,
+                dynamic_eplb=False,
+                group_list_type=group_list_type,
+                custom_op_enabled=False,
+                moe_comm_type=MoECommType.MC2,
+            )
+        )
         return dict(
             hidden_states=torch.randn(1, 4),
             w1=torch.randn(1, 8, 4),
             w1_scale=[torch.randn(1, 8, dtype=w1_scale_dtype)],
             w2=torch.randn(1, 4, 1),
             w2_scale=[torch.randn(1, 4, dtype=w2_scale_dtype)],
+            output_dtype=torch.bfloat16,
             group_list=group_list if group_list is not None else torch.tensor([1], dtype=torch.int64),
             group_list_type=group_list_type,
             dynamic_scale=dynamic_scale if dynamic_scale is not None else torch.randn(1, 1),
             w1_scale_bias=w1_scale_bias,
             w2_scale_bias=w2_scale_bias,
-            w1_offset=None,
-            w2_offset=None,
-            fusion=False,
-            dynamic_eplb=False,
             use_mxfp_quant=False,
             mxfp_quant_dtype=None,
             act_quant_type=torch.int8,
             weight_quant_type=torch.float8_e4m3fn,
             use_bf16=True,
-            activation=activation,
             swiglu_limit=0.0,
-            use_w4a8_per_channel_gmm_swiglu=False,
+            kernel_plan=kernel_plan,
         )
 
 
 class TestQuantApplyMlpGeluPath(_GeluPathBase):
     """GELU path: dispatch, math, and layout coverage.
 
-    In the in-branch/guard variant the GELU path runs through the existing
-    branch preamble. Stub `_EXTRA_CTX` in setUp so each test can focus on the
-    GELU dispatch/math.
+    Kernel selection is resolved by the MLP plan before execution.
     """
-
-    def setUp(self):
-        # Configurable forward-context mock; default moe_comm_type is not MC2.
-        self._ctx_mock = MagicMock()
-        self._ctx_mock.moe_comm_type = -1
-        self._patches = [
-            patch(f"{MOE_MLP}._EXTRA_CTX", self._ctx_mock),
-        ]
-        for p in self._patches:
-            p.start()
-        self.addCleanup(self._stop_patches)
-
-    def _stop_patches(self):
-        for p in self._patches:
-            p.stop()
 
     def test_w8a8_gelu_tanh_applies_correct_activation(self):
         """W8A8 + gelu_tanh: GMM1(dequant) -> gelu(tanh)·up -> requant -> GMM2."""
@@ -510,11 +700,18 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
             patch.object(DeviceOperator, "npu_grouped_matmul_gmm2") as mock_gmm2,
             patch(f"{MOE_MLP}.dispose_tensor"),
         ):
-            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
-            # Switch to the W4A16 antiquant layout.
-            kwargs["w1_offset"] = torch.randn(1, 8, 4)
-            kwargs["w2_offset"] = torch.randn(1, 4, 1)
-            out, out_evt = quant_apply_mlp(**kwargs)
+            out, out_evt = weight_only_apply_mlp(
+                hidden_states=torch.randn(1, 4),
+                w1=torch.randn(1, 8, 4),
+                w1_scale=torch.randn(1, 8),
+                w1_offset=torch.randn(1, 8, 4),
+                w2=torch.randn(1, 4, 1),
+                w2_scale=torch.randn(1, 4),
+                w2_offset=torch.randn(1, 4, 1),
+                group_list=torch.tensor([1], dtype=torch.int64),
+                output_dtype=torch.bfloat16,
+                activation=MoEMLPActivationKind.GELU_TANH,
+            )
 
         self.assertEqual(mock_gmm.call_count, 2)
         # Both GMM calls use antiquant (not scale/per_token_scale).
@@ -531,78 +728,149 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
         self.assertIs(out, gmm2_out)
         self.assertIs(out_evt, evt)
 
-    def test_w8a8_gelu_with_scale_bias_sets_bias_and_bfloat16(self):
-        """W8A8 + gelu + scale_bias: bias1/bias2 passed, output dtype bfloat16,
-        and group_list_type 0 -> 1 conversion applied."""
+    def test_w4a8_gelu_uses_bfloat16_intermediate_and_model_output_dtype(self):
+        """W4A8 keeps its BF16 GMM1 contract but restores model dtype in GMM2."""
         w1_sb = [torch.zeros(1)]
         w2_sb = [torch.zeros(1)]
         with (
             _mock_w8a8_gelu_compute(torch.zeros(1, 8), gmm2_out=torch.zeros(1, 2)) as m,
             patch("torch.cat", wraps=torch.cat) as mock_cat,
         ):
-            quant_apply_mlp(
-                **self._common_w8a8_kwargs(
-                    activation=MoEActivation.GELU_TANH,
-                    w1_scale_bias=w1_sb,
-                    w2_scale_bias=w2_sb,
+            kwargs = self._common_w8a8_kwargs(
+                activation=MoEActivation.GELU_TANH,
+                w1_scale_bias=w1_sb,
+                w2_scale_bias=w2_sb,
+                group_list_type=0,
+                group_list=torch.tensor([0, 1], dtype=torch.int64),
+            )
+            kwargs["kernel_plan"] = build_mlp_plan(
+                MoEMLPPlanKey(
+                    quant_type=QuantType.W4A8,
+                    activation=MoEMLPActivationKind.GELU_TANH,
+                    fusion=False,
+                    dynamic_eplb=False,
                     group_list_type=0,
-                    group_list=torch.tensor([0, 1], dtype=torch.int64),
+                    custom_op_enabled=False,
                 )
             )
+            kwargs["output_dtype"] = torch.float16
+            quant_apply_mlp(**kwargs)
         # bias1 propagated to GMM1.
         self.assertIs(m.gmm.call_args.kwargs["bias"], w1_sb)
+        self.assertEqual(m.gmm.call_args.kwargs["output_dtype"], torch.bfloat16)
+        self.assertIs(m.gmm2.call_args.kwargs["bias"], w2_sb)
+        self.assertEqual(m.gmm2.call_args.kwargs["fallback_output_dtype"], torch.float16)
         # group_list_type 0 -> 1 conversion invoked (torch.cat + torch.diff).
         self.assertTrue(mock_cat.called)
 
-    def test_w8a8_gelu_converts_w1_scale_dtype_to_output_dtype(self):
-        """When w1_scale dtype != _output_dtype, it is cast before GMM1."""
-        # w1_scale fp32, w2_scale bf16 -> _output_dtype = bfloat16, so the GELU
-        # path must cast w1_scale to bfloat16 before GMM1.
-        with _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m:
-            quant_apply_mlp(
-                **self._common_w8a8_kwargs(
-                    activation=MoEActivation.GELU_TANH,
-                    w1_scale_dtype=torch.float32,
-                    w2_scale_dtype=torch.bfloat16,
-                )
+    def test_w4a8_per_channel_requires_both_scale_biases(self):
+        kernel_plan = build_mlp_plan(
+            MoEMLPPlanKey(
+                quant_type=QuantType.W4A8,
+                activation=MoEMLPActivationKind.GELU_TANH,
+                fusion=False,
+                dynamic_eplb=False,
+                group_list_type=1,
+                custom_op_enabled=False,
             )
-        self.assertEqual(m.gmm.call_args.kwargs["scale"][0].dtype, torch.bfloat16)
+        )
+        scale_bias = [torch.zeros(1)]
 
-    def test_alltoall_dynamic_eplb_swigluoai_passes_all_w1_scales_to_gmm1(self):
-        self._ctx_mock.moe_comm_type = MoECommType.ALLTOALL
+        for w1_scale_bias, w2_scale_bias in (
+            (None, None),
+            (scale_bias, None),
+            (None, scale_bias),
+        ):
+            with self.subTest(w1_scale_bias=w1_scale_bias, w2_scale_bias=w2_scale_bias):
+                kwargs = self._common_w8a8_kwargs(
+                    activation=MoEActivation.GELU_TANH,
+                    w1_scale_bias=w1_scale_bias,
+                    w2_scale_bias=w2_scale_bias,
+                )
+                kwargs["kernel_plan"] = kernel_plan
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "W4A8 per-channel MLP requires both w1_scale_bias and w2_scale_bias",
+                ):
+                    quant_apply_mlp(**kwargs)
+
+    def test_w8a8_dynamic_eplb_swigluoai_passes_all_scales_to_gmm1(self):
         scale0 = torch.arange(8, dtype=torch.float32)
         scale1 = torch.arange(8, 16, dtype=torch.float32)
+        kwargs = self._common_w8a8_kwargs(activation="swigluoai_uninterleave")
+        kwargs.update(
+            {
+                "w1": [torch.randn(8, 4), torch.randn(8, 4)],
+                "w1_scale": [scale0, scale1],
+                "w2": [torch.randn(4, 4), torch.randn(4, 4)],
+                "w2_scale": [torch.randn(4), torch.randn(4)],
+                "group_list": torch.tensor([1, 1], dtype=torch.int64),
+                "kernel_plan": build_mlp_plan(
+                    MoEMLPPlanKey(
+                        quant_type=QuantType.W8A8,
+                        activation=MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE,
+                        fusion=False,
+                        dynamic_eplb=True,
+                        group_list_type=1,
+                        custom_op_enabled=False,
+                        moe_comm_type=MoECommType.ALLTOALL,
+                    )
+                ),
+            }
+        )
+
         with (
-            _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m,
+            _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as mocks,
             patch("torch_npu.npu_clipped_swiglu", return_value=torch.zeros(1, 4), create=True),
-            patch.object(DeviceOperator, "npu_dynamic_quant", return_value=(torch.zeros(1, 4), torch.ones(1))),
         ):
+            quant_apply_mlp(**kwargs)
+
+        gmm1_scales = mocks.gmm.call_args.kwargs["scale"]
+        self.assertEqual(len(gmm1_scales), 2)
+        torch.testing.assert_close(gmm1_scales[0], scale0.bfloat16())
+        torch.testing.assert_close(gmm1_scales[1], scale1.bfloat16())
+
+    def test_w8a8_gelu_uses_explicit_output_dtype_when_hidden_is_quantized(self):
+        """The explicit model dtype, rather than w2_scale dtype, controls GMM output."""
+        with _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m:
             kwargs = self._common_w8a8_kwargs(
-                activation="swigluoai_uninterleave",
-                w2_scale_dtype=torch.bfloat16,
+                activation=MoEActivation.GELU_TANH,
+                w1_scale_dtype=torch.float32,
+                w2_scale_dtype=torch.float32,
             )
-            kwargs.update(
-                {
-                    "w1": [torch.randn(8, 4), torch.randn(8, 4)],
-                    "w1_scale": [scale0, scale1],
-                    "w2": [torch.randn(4, 4), torch.randn(4, 4)],
-                    "w2_scale": [
-                        torch.randn(4, dtype=torch.bfloat16),
-                        torch.randn(4, dtype=torch.bfloat16),
-                    ],
-                    "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                    "dynamic_eplb": True,
-                }
-            )
+            kwargs["hidden_states"] = torch.zeros(1, 4, dtype=torch.int8)
+            kwargs["output_dtype"] = torch.float16
+            quant_apply_mlp(**kwargs)
+        self.assertEqual(m.gmm2.call_args.kwargs["input_dtype"], torch.float16)
+        self.assertIsNone(m.gmm2.call_args.kwargs["bias"])
+        self.assertEqual(m.gmm2.call_args.kwargs["fallback_output_dtype"], torch.float16)
+
+    def test_mxfp_gelu_decomposed_gmm1_outputs_bfloat16(self):
+        """MXFP decomposed activations require a BF16 GMM1 output."""
+        kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
+        kwargs.update(
+            use_mxfp_quant=True,
+            mxfp_quant_dtype=QuantType.W8A8MXFP,
+            kernel_plan=build_mlp_plan(
+                MoEMLPPlanKey(
+                    quant_type=QuantType.W8A8MXFP,
+                    activation=MoEMLPActivationKind.GELU_TANH,
+                    fusion=False,
+                    dynamic_eplb=False,
+                    group_list_type=1,
+                    custom_op_enabled=False,
+                )
+            ),
+        )
+
+        with _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m:
             quant_apply_mlp(**kwargs)
 
         gmm1_kwargs = m.gmm.call_args.kwargs
-        self.assertEqual(len(gmm1_kwargs["weight"]), 2)
-        self.assertEqual(len(gmm1_kwargs["scale"]), 2)
-        self.assertEqual(gmm1_kwargs["scale"][0].dtype, torch.bfloat16)
-        self.assertEqual(gmm1_kwargs["scale"][1].dtype, torch.bfloat16)
-        torch.testing.assert_close(gmm1_kwargs["scale"][0], scale0.bfloat16())
-        torch.testing.assert_close(gmm1_kwargs["scale"][1], scale1.bfloat16())
+        self.assertEqual(gmm1_kwargs["output_dtype"], torch.bfloat16)
+        self.assertEqual(gmm1_kwargs["scale_dtype"], torch_npu.float8_e8m0fnu)
+        self.assertEqual(gmm1_kwargs["per_token_scale_dtype"], torch_npu.float8_e8m0fnu)
 
     def test_gelu_path_does_not_call_swiglu_op(self):
         """GELU path must use torch.gelu, never the SwiGLU NPU op."""
@@ -611,12 +879,18 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
         mock_swiglu.assert_not_called()
 
     def test_fusion_on_gelu_skips_fused_swiglu_quant(self):
-        """Guard: with fusion ON (default), GELU must still skip the fused
-        npu_grouped_matmul_swiglu_quant op and use the non-fused GELU path.
-        This is the case that breaks without the ``and not is_gelu_activation``
-        guard on use_gmm_swiglu_quant_fusion."""
+        """A GELU plan must not select the fused SwiGLU quant kernel."""
         kwargs = self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH)
-        kwargs["fusion"] = True  # -> use_gmm_swiglu_quant_fusion = True
+        kwargs["kernel_plan"] = build_mlp_plan(
+            MoEMLPPlanKey(
+                quant_type=QuantType.W8A8,
+                activation=MoEMLPActivationKind.GELU_TANH,
+                fusion=True,
+                dynamic_eplb=False,
+                group_list_type=1,
+                custom_op_enabled=True,
+            )
+        )
         with (
             _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m,
             patch.object(DeviceOperator, "npu_grouped_matmul_swiglu_quant") as mock_fused,
@@ -628,25 +902,21 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
         self.assertIn("scale", m.gmm.call_args.kwargs)
         self.assertIn("per_token_scale", m.gmm.call_args.kwargs)
 
-    def test_mc2_gelu_skips_mc2_fused_branch(self):
-        """Guard: under MC2 comm, GELU must skip the all-fused MC2 branch and
-        use the non-fused GELU path. Without the ``and not is_gelu_activation``
-        guard on the MC2 entry, GELU+MC2 would hit npu_dequant_swiglu_quant."""
-        self._ctx_mock.moe_comm_type = MoECommType.MC2  # force is_mc2 True
+    def test_gelu_plan_skips_fused_swiglu_branch(self):
+        """GELU uses the decomposed plan independently of communication."""
         with (
             _mock_w8a8_gelu_compute(torch.zeros(1, 8)) as m,
-            patch("torch.ops._C_ascend.npu_dequant_swiglu_quant", create=True) as mock_mc2_fused,
-            patch.object(DeviceOperator, "npu_grouped_matmul_swiglu_quant") as mock_fused,
+            patch("torch.ops._C_ascend.npu_dequant_swiglu_quant", create=True) as mock_dequant_fused,
+            patch.object(DeviceOperator, "npu_grouped_matmul_swiglu_quant") as mock_grouped_fused,
         ):
             quant_apply_mlp(**self._common_w8a8_kwargs(activation=MoEActivation.GELU_TANH))
-        # MC2 fused SwiGLU op must NOT be called for GELU.
-        mock_mc2_fused.assert_not_called()
-        mock_fused.assert_not_called()
+        # The fused SwiGLU op must not be called for GELU.
+        mock_dequant_fused.assert_not_called()
+        mock_grouped_fused.assert_not_called()
         # Non-fused dequant GMM1 IS used instead.
         self.assertIn("scale", m.gmm.call_args.kwargs)
 
-    def test_mc2_dynamic_eplb_swigluoai_stacks_w1_scale(self):
-        self._ctx_mock.moe_comm_type = MoECommType.MC2
+    def test_dynamic_eplb_swigluoai_stacks_w1_scale(self):
         gate_up_out = torch.zeros(1, 8, dtype=torch.int32)
         expected = torch.zeros(1, 4, dtype=torch.float32)
         scale0 = torch.arange(8, dtype=torch.bfloat16)
@@ -660,7 +930,6 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
                 "w2": [torch.randn(4, 4), torch.randn(4, 4)],
                 "w2_scale": [torch.randn(4), torch.randn(4)],
                 "group_list": torch.tensor([1, 1], dtype=torch.int64),
-                "dynamic_eplb": True,
             }
         )
 
@@ -684,8 +953,7 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
         torch.testing.assert_close(weight_scale[1], scale1.float())
         self.assertIs(out, expected)
 
-    def test_mc2_swigluoai_preserves_single_list_w1_scale_shape(self):
-        self._ctx_mock.moe_comm_type = MoECommType.MC2
+    def test_swigluoai_preserves_single_list_w1_scale_shape(self):
         gate_up_out = torch.zeros(1, 8, dtype=torch.int32)
         expected = torch.zeros(1, 4, dtype=torch.float32)
         weight_scale = torch.arange(12, dtype=torch.bfloat16).view(3, 4)
@@ -698,7 +966,6 @@ class TestQuantApplyMlpGeluPath(_GeluPathBase):
                 "w2": [torch.randn(4, 4)],
                 "w2_scale": [torch.randn(4)],
                 "group_list": torch.tensor([1], dtype=torch.int64),
-                "dynamic_eplb": False,
             }
         )
 
@@ -728,13 +995,17 @@ class TestQuantApplyMlpNoGeluImpact(_GeluPathBase):
     def _run_non_gelu(self, activation):
         with (
             _mock_w8a8_gelu_compute(torch.zeros(1, 8)),
-            patch(f"{MOE_MLP}._EXTRA_CTX") as mock_ctx,
-            patch(f"{MOE_MLP}.HAS_TRITON", False),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp_activation.HAS_TRITON", False),
             patch("torch_npu.npu_swiglu", return_value=torch.zeros(1, 4), create=True) as mock_swiglu,
             patch("torch.nn.functional.gelu") as mock_gelu,
         ):
-            mock_ctx.moe_comm_type = -1  # not MoECommType.MC2
-            quant_apply_mlp(**self._common_w8a8_kwargs(activation=activation))
+            kwargs = self._common_w8a8_kwargs(activation=activation)
+            key = kwargs["kernel_plan"].key
+            kwargs["kernel_plan"] = type(kwargs["kernel_plan"])(
+                key=key,
+                gate_up_kernel=GateUpKernel.DECOMPOSED,
+            )
+            quant_apply_mlp(**kwargs)
         return mock_gelu, mock_swiglu
 
     def test_silu_activation_skips_gelu_path(self):
@@ -747,8 +1018,24 @@ class TestQuantApplyMlpNoGeluImpact(_GeluPathBase):
         mock_gelu, _ = self._run_non_gelu(MoEActivation.SWIGLUSTEP)
         mock_gelu.assert_not_called()
 
-    def test_swigluoai_activation_skips_gelu_path(self):
-        mock_gelu, _ = self._run_non_gelu(MoEActivation.SWIGLUOAI)
+    def test_swigluoai_activation_uses_oai_formula(self):
+        gate_up_out = torch.zeros(1, 8)
+        activated = torch.zeros(1, 4)
+        with (
+            _mock_w8a8_gelu_compute(gate_up_out),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp_activation.AscendSwigluOAIAndMul.swiglu_oai_forward",
+                return_value=activated,
+            ) as mock_oai,
+            patch("torch_npu.npu_swiglu", create=True) as mock_swiglu,
+            patch("torch.nn.functional.gelu") as mock_gelu,
+        ):
+            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.SWIGLUOAI)
+            kwargs.update(swiglu_alpha=1.5, swiglu_limit=6.0)
+            quant_apply_mlp(**kwargs)
+
+        mock_oai.assert_called_once_with(gate_up_out, alpha=1.5, limit=6.0)
+        mock_swiglu.assert_not_called()
         mock_gelu.assert_not_called()
 
 

--- a/tests/ut/ops/test_moe_runtime_args.py
+++ b/tests/ut/ops/test_moe_runtime_args.py
@@ -19,6 +19,7 @@ import unittest
 import torch
 
 import vllm_ascend.ops.fused_moe.moe_runtime_args as runtime_args
+from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
     MoETokenDispatchOutput,
@@ -219,6 +220,8 @@ class TestMoERuntimeArgs(unittest.TestCase):
                     fused_experts_input=fused_experts_input,
                     token_dispatch_output=token_dispatch_output,
                     use_fusion_ops=True,
+                    moe_comm_type=MoECommType.MC2,
+                    output_dtype=torch.float16,
                 )
 
                 self.assertIs(mlp_compute_input.hidden_states, token_dispatch_output.hidden_states)
@@ -226,6 +229,8 @@ class TestMoERuntimeArgs(unittest.TestCase):
                 self.assertIs(mlp_compute_input.weights.w1_scale, fused_experts_input.weights.w1_scale)
                 self.assertIs(mlp_compute_input.weights.w2_scale, fused_experts_input.weights.w2_scale)
                 self.assertEqual(mlp_compute_input.fusion, expected_fusion)
+                self.assertEqual(mlp_compute_input.output_dtype, torch.float16)
+                self.assertEqual(mlp_compute_input.moe_comm_type, MoECommType.MC2)
                 self.assertTrue(mlp_compute_input.quant.is_mxfp)
                 assert mlp_compute_input.quant.mxfp is not None
                 self.assertEqual(mlp_compute_input.quant.mxfp.act_quant_type, mxfp_dtype)

--- a/tests/ut/quantization/methods/test_w4a8.py
+++ b/tests/ut/quantization/methods/test_w4a8.py
@@ -251,8 +251,8 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         layer.ascend_pertoken_scale = pertoken_scale
         layer.activation = "silu"
         layer.apply_router_weight_on_input = False
-        layer.swiglu_alpha = 1.0
-        layer.swiglu_beta = 0.0
+        layer.swiglu_alpha = 1.5
+        layer.swiglu_beta = 0.25
 
         mock_fused_input = Mock()
         mock_fused_input.hidden_states = x
@@ -279,8 +279,10 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         build_kwargs = mock_build_input.call_args.kwargs
         self.assertTrue(torch.equal(build_kwargs["hidden_states"], x))
         self.assertEqual(build_kwargs["quant_type"], self.quant_method.quant_type)
-        self.assertTrue(build_kwargs["is_per_channel_weight"])
+        self.assertNotIn("is_per_channel_weight", build_kwargs)
         self.assertEqual(build_kwargs["activation"], "silu")
+        self.assertEqual(build_kwargs["swiglu_alpha"], 1.5)
+        self.assertEqual(build_kwargs["swiglu_beta"], 0.25)
         self.assertEqual(build_kwargs["apply_router_weight_on_input"], False)
 
         mock_comm.fused_experts.assert_called_once()

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -16,6 +16,7 @@
 #
 import torch
 import torch.nn.functional as F
+from vllm.config import get_current_vllm_config
 from vllm.distributed import get_dp_group, get_ep_group, get_tp_group
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import (
@@ -81,7 +82,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._quant_method,
             )
 
-        setup_moe_comm_method(self.moe_config)
+        output_dtype = get_current_vllm_config().model_config.dtype
+        setup_moe_comm_method(self.moe_config, output_dtype=output_dtype)
 
     @property
     def is_internal_router(self) -> bool:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -26,7 +26,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe import moe_utils
-from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
+from vllm_ascend.ops.fused_moe.moe_mlp_plan import MoEMLPPlanner
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEFusedExpertsInput,
     MoEMlpComputeInput,
@@ -55,14 +55,14 @@ def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | No
     return _MoECommMethods.get(moe_comm_type)
 
 
-def setup_moe_comm_method(moe_config):
+def setup_moe_comm_method(moe_config, output_dtype: torch.dtype | None = None):
     if moe_config.ep_size > 1:
-        _MoECommMethods[MoECommType.ALLTOALL] = AlltoAllCommImpl(moe_config)
-        _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
-        _MoECommMethods[MoECommType.MC2] = MC2CommImpl(moe_config)
-        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(moe_config)
+        _MoECommMethods[MoECommType.ALLTOALL] = AlltoAllCommImpl(moe_config, output_dtype)
+        _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config, output_dtype)
+        _MoECommMethods[MoECommType.MC2] = MC2CommImpl(moe_config, output_dtype)
+        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(moe_config, output_dtype)
     else:
-        _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
+        _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config, output_dtype)
 
 
 def set_gmmswigluquant_method():
@@ -89,12 +89,14 @@ class FusedExpertsResult:
 class MoECommMethod(ABC):
     """Base class for MoE communication methods."""
 
-    def __init__(self, moe_config: FusedMoEConfig):
+    def __init__(self, moe_config: FusedMoEConfig, output_dtype: torch.dtype | None = None):
         self.moe_config = moe_config
+        self.output_dtype = output_dtype
 
         self.token_dispatcher = self._get_token_dispatcher()
         self.prepare_finalize = self._get_prepare_finalize()
         self.use_fusion_ops = set_gmmswigluquant_method()
+        self.mlp_planner = MoEMLPPlanner()
         self.lora_context = None
 
     def set_lora_context(self, lora_context) -> None:
@@ -140,9 +142,13 @@ class MoECommMethod(ABC):
             torch.float8_e4m3fn,
             torch.uint8,
         ], f"Unsupported hidden_states dtype: {fused_experts_input.hidden_states.dtype}"
+        if self.output_dtype is None:
+            raise RuntimeError("MoE output_dtype must be configured before MLP execution.")
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         assert moe_comm_method is not None, "Missing communication context"
+        moe_comm_type = _EXTRA_CTX.moe_comm_type
+        assert moe_comm_type is not None, "Missing communication type"
 
         before_dispatch_evt = torch.npu.current_stream().record_event()
 
@@ -155,6 +161,8 @@ class MoECommMethod(ABC):
             fused_experts_input=fused_experts_input,
             token_dispatch_output=token_dispatch_output,
             use_fusion_ops=self.use_fusion_ops,
+            moe_comm_type=moe_comm_type,
+            output_dtype=self.output_dtype,
         )
 
         mlp_output, before_gmm2_evt = self._apply_mlp(mlp_compute_input)
@@ -174,8 +182,8 @@ class MoECommMethod(ABC):
             expert_tokens=token_dispatch_output.group_list,
         )
 
-    def _apply_mlp(self, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
-        return unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+    def _apply_mlp(self, mlp_compute_input: MoEMlpComputeInput) -> tuple[torch.Tensor, torch.npu.Event | None]:
+        return self.mlp_planner.execute(mlp_compute_input)
 
     @abstractmethod
     def _get_token_dispatcher(self) -> MoETokenDispatcher:
@@ -270,10 +278,10 @@ class FusedMC2CommImpl(MoECommMethod):
     Communication and Computation parallelism on Ascend devices.
     """
 
-    def __init__(self, moe_config):
-        super().__init__(moe_config)
+    def __init__(self, moe_config, output_dtype: torch.dtype | None = None):
+        super().__init__(moe_config, output_dtype)
         self._mega_moe_symm_buffer = None
-        self._mega_moe_weight_type = None
+        self._mega_moe_weight_type: int | None = None
         if _MEGA_MOE_SUPPORTED:
             self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops()
         if get_ascend_config().enable_fused_mc2 == 1:

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -14,77 +14,33 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
+from __future__ import annotations
 
 import torch
 import torch_npu
-from torch.nn.functional import pad
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.triton_utils import HAS_TRITON
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
+from vllm_ascend.ops.fused_moe.moe_mlp_activation import (
+    MoEMLPActivationKind,
+    apply_quantized_activation,
+    apply_unquantized_activation,
+    resolve_mlp_activation,
+)
+from vllm_ascend.ops.fused_moe.moe_mlp_group_list import convert_group_list
+from vllm_ascend.ops.fused_moe.moe_mlp_plan import GateUpKernel, MoEMLPPlan
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import (
-    dispose_tensor,
-    enable_custom_op,
-    get_ascend_device_type,
-)
-
-ASCEND_DEVICE_TYPE = get_ascend_device_type()
-
-
-def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation=None):
-    return (
-        fusion
-        and dynamic_eplb
-        and getattr(activation, "value", activation) != "swigluoai_uninterleave"
-        and enable_custom_op()
-    )
-
-
-def _gmm_swiglu_quant_fusion_enabled(use_mxfp_quant, fusion, dynamic_eplb, activation=None):
-    return (use_mxfp_quant or (fusion and not dynamic_eplb)) and (
-        getattr(activation, "value", activation) != "swigluoai_uninterleave"
-    )
+from vllm_ascend.utils import dispose_tensor
 
 
 def cumsum_group_list(
     group_list: torch.Tensor, src_list_type: int, dst_list_type: int, active_num: int = 0, expert_num: int = 0
 ) -> torch.Tensor:
-    if src_list_type not in [0, 1, 2]:
-        raise ValueError(f"group_list_type should be in [0, 1, 2], but received {src_list_type}")
-
-    if src_list_type == dst_list_type:
-        return group_list
-    if src_list_type == 1 and dst_list_type == 0:
-        return group_list.cumsum(dim=0)
-    if src_list_type == 0 and dst_list_type == 1:
-        group_diff = torch.diff(group_list)
-        new_group = torch.cat([group_list[0].unsqueeze(0), group_diff], dim=0)
-        return new_group
-    if src_list_type == 2 and dst_list_type == 0:
-        experts = pad(group_list[:, 0], (1, 0))
-        tokens = pad(group_list[:, 1].cumsum(dim=0), (1, 0))
-        cumsum_group_list = torch.full(
-            size=(expert_num,), fill_value=active_num, dtype=group_list.dtype, device=group_list.device
-        )
-
-        for i, (start, end) in enumerate(zip(experts[:-1], experts[1:])):
-            if end > start:
-                cumsum_group_list[start:end] = tokens[i]
-
-        return cumsum_group_list
-    raise NotImplementedError(
-        f"Conversion from src_list_type={src_list_type} to dst_list_type={dst_list_type} is not implemented yet. "
-        "This feature is under development."
-    )
+    """Compatibility wrapper for callers migrating to convert_group_list."""
+    return convert_group_list(group_list, src_list_type, dst_list_type, active_num, expert_num)
 
 
-def _require_single_tensor_for_swiglu_quant(
-    tensor_or_list: list[torch.Tensor] | torch.Tensor, *, name: str
-) -> torch.Tensor:
+def _require_single_tensor(tensor_or_list: list[torch.Tensor] | torch.Tensor, *, name: str) -> torch.Tensor:
     if isinstance(tensor_or_list, list):
         if len(tensor_or_list) != 1:
             raise ValueError(f"{name} must be a tensor or a single-element list, but got {len(tensor_or_list)}.")
@@ -119,21 +75,76 @@ def _prepare_swigluoai_grouped_matmul_scales(
     return [scale.to(output_dtype) if scale.dtype != output_dtype else scale for scale in scales]
 
 
+def weight_only_apply_mlp(
+    hidden_states: torch.Tensor,
+    w1: list[torch.Tensor] | torch.Tensor,
+    w1_scale: list[torch.Tensor] | torch.Tensor,
+    w1_offset: torch.Tensor,
+    w2: list[torch.Tensor] | torch.Tensor,
+    w2_scale: list[torch.Tensor] | torch.Tensor,
+    w2_offset: torch.Tensor,
+    group_list: torch.Tensor,
+    output_dtype: torch.dtype,
+    activation: MoEMLPActivationKind,
+    group_list_type: int = 1,
+    swiglu_limit: float = 0.0,
+    swiglu_alpha: float = 1.0,
+    swiglu_beta: float = 0.0,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Execute the W4A16 antiquant GMM1 -> activation -> GMM2 path."""
+    w1 = _require_single_tensor(w1, name="w1")
+    w1_scale = _require_single_tensor(w1_scale, name="w1_scale")
+    w2 = _require_single_tensor(w2, name="w2")
+    w2_scale = _require_single_tensor(w2_scale, name="w2_scale")
+
+    gate_up_out = torch_npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w1],
+        antiquant_scale=[w1_scale],
+        antiquant_offset=[w1_offset],
+        split_item=2,
+        group_list_type=group_list_type,
+        group_type=0,
+        group_list=group_list,
+        output_dtype=output_dtype,
+    )[0]
+    dispose_tensor(hidden_states)
+    gate_up_out = apply_unquantized_activation(
+        gate_up_out,
+        activation,
+        hidden_size=w1.shape[-1],
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
+
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    hidden_states = torch_npu.npu_grouped_matmul(
+        x=[gate_up_out],
+        weight=[w2],
+        antiquant_scale=[w2_scale],
+        antiquant_offset=[w2_offset],
+        split_item=2,
+        group_list_type=group_list_type,
+        group_type=0,
+        group_list=group_list,
+        output_dtype=output_dtype,
+    )[0]
+    return hidden_states, before_gmm2_evt
+
+
 def quant_apply_mlp(
     hidden_states: torch.Tensor,
     w1: list[torch.Tensor] | torch.Tensor,
     w1_scale: list[torch.Tensor] | torch.Tensor,
     w2: list[torch.Tensor] | torch.Tensor,
     w2_scale: list[torch.Tensor] | torch.Tensor,
+    output_dtype: torch.dtype,
     group_list: torch.Tensor,
     group_list_type: int = 1,
     dynamic_scale: torch.Tensor = None,
     w1_scale_bias: torch.Tensor = None,
     w2_scale_bias: torch.Tensor = None,
-    w1_offset: torch.Tensor | None = None,
-    w2_offset: torch.Tensor | None = None,
-    fusion: bool = False,
-    dynamic_eplb: bool = False,
     use_mxfp_quant: bool = False,
     mxfp_quant_dtype: QuantType | None = None,
     act_quant_type: torch.dtype = torch.float8_e4m3fn,
@@ -141,35 +152,26 @@ def quant_apply_mlp(
     scale_type: torch.dtype | None = None,
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
-    activation: str | None = None,
     swiglu_limit: float = 0.0,
     swiglu_alpha: float = 1.0,
     swiglu_beta: float = 0.0,
-    use_w4a8_per_channel_gmm_swiglu: bool = False,
-) -> torch.Tensor:
-    input_hidden_dtype = hidden_states.dtype
-    act_name = getattr(activation, "value", activation)
-    use_gmm_swiglu_quant_fusion = _gmm_swiglu_quant_fusion_enabled(
-        use_mxfp_quant,
-        fusion,
-        dynamic_eplb,
-        activation,
-    )
-    # GELU can't use the fused SwiGLU+quant ops below; fall back to the
-    # non-fused GMM -> GELU -> (re)quant -> GMM2 path for GELU activations.
-    is_gelu_activation = activation in (MoEActivation.GELU, MoEActivation.GELU_TANH)
-    is_swigluoai_uninterleave = act_name == "swigluoai_uninterleave"
+    kernel_plan: MoEMLPPlan | None = None,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    if kernel_plan is None:
+        raise ValueError("kernel_plan is required for quantized MoE MLP execution.")
+    gate_up_kernel = kernel_plan.gate_up_kernel
+    if gate_up_kernel in (GateUpKernel.UNQUANTIZED, GateUpKernel.ANTIQUANT):
+        raise ValueError(f"{gate_up_kernel} must use its dedicated MLP executor.")
+    is_w4a8_per_channel = kernel_plan.key.quant_type == QuantType.W4A8
+    if is_w4a8_per_channel and (w1_scale_bias is None or w2_scale_bias is None):
+        raise ValueError("W4A8 per-channel MLP requires both w1_scale_bias and w2_scale_bias.")
+    is_swigluoai_uninterleave = kernel_plan.key.activation == MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE
 
     if use_mxfp_quant:
         if w1_scale_bias is not None or w2_scale_bias is not None:
             raise NotImplementedError("MXFP path does not support scale_bias yet.")
-        if w1_offset is not None or w2_offset is not None:
-            raise NotImplementedError("MXFP path does not support antiquant offset yet.")
 
-    if w1_offset is not None:
-        unquantized_hidden_states = hidden_states
-        quantized_hidden_states = None
-    elif mxfp_quant_dtype == QuantType.W4A16MXFP:
+    if mxfp_quant_dtype == QuantType.W4A16MXFP:
         quantized_hidden_states = None
         pertoken_scale = None
     elif dynamic_scale is None:
@@ -183,306 +185,154 @@ def quant_apply_mlp(
         dispose_tensor(unquantized_hidden_states)
         quantized_hidden_states = None
     else:
-        unquantized_hidden_states = None
         pertoken_scale = (
             DeviceOperator.maybe_normalize_mxfp_scale_layout(dynamic_scale) if use_mxfp_quant else dynamic_scale
         )
         quantized_hidden_states = hidden_states
 
     bias1, bias2 = None, None
-    _output_dtype = w2_scale[0].dtype if isinstance(w2_scale, list) else w2_scale.dtype
+    if is_w4a8_per_channel:
+        if group_list_type == 0:
+            group_list = convert_group_list(group_list, group_list_type, 1)
+            group_list_type = 1
+        bias1 = w1_scale_bias
+        bias2 = w2_scale_bias
 
-    is_mc2 = _EXTRA_CTX.moe_comm_type == MoECommType.MC2
-    if w1_scale_bias is None and w1_offset is None and is_mc2 and not is_gelu_activation:
-        if _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation) and not use_mxfp_quant:
-            # gmm1: gate_up_proj & act_fn: swiglu
-            hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
-                x=hidden_states,
-                weight=w1,
-                weight_scale=w1_scale,
-                x_scale=pertoken_scale,
-                group_list=cumsum_group_list(group_list, group_list_type, 0),
-                swiglu_limit=swiglu_limit,
-            )
-        elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP:
-            # gmm1: gate_up_proj & act_fn: swiglu
-            hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
-                x=hidden_states,
-                weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
-                group_list=cumsum_group_list(group_list, group_list_type, 0),
-                weight_scale=_require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale"),
-                x_scale=pertoken_scale,
-                bias=None,
-                use_mxfp_quant=use_mxfp_quant,
-                act_quant_type=act_quant_type,
-                weight_quant_type=weight_quant_type,
-                swiglu_limit=swiglu_limit,
-                mxfp_quant_dtype=mxfp_quant_dtype,
-            )
-            if quantized_hidden_states is not None:
-                dispose_tensor(quantized_hidden_states)
-        elif activation == MoEActivation.SWIGLUSTEP:
-            # Step3.5/3.7 needs to clamp in swiglu: out = silu(gate).clamp(max=limit) * up.clamp(-limit, limit)
-            gmm1_kwargs = {
-                "x": [hidden_states],
-                "weight": w1 if isinstance(w1, list) else [w1],
-                "scale": [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale],
-                "bias": None,
-                "per_token_scale": [pertoken_scale],
-                "split_item": 2,
-                "group_type": 0,
-                "group_list": group_list,
-                "output_dtype": torch.bfloat16,
-            }
-            if use_mxfp_quant:
-                gmm1_kwargs.update(
-                    {
-                        "scale_dtype": torch_npu.float8_e8m0fnu,
-                        "per_token_scale_dtype": torch_npu.float8_e8m0fnu,
-                    }
-                )
-            hidden_states = torch_npu.npu_grouped_matmul(**gmm1_kwargs)[0]
-            hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=7.0)
-            hidden_states, swiglu_out_scale = DeviceOperator.npu_dynamic_quant(
-                hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
-            )
-        else:
-            # gmm1: gate_up_proj
-            hidden_states = torch_npu.npu_grouped_matmul(
-                x=[hidden_states],
-                weight=w1,
-                split_item=3,
-                group_list_type=group_list_type,
-                group_type=0,
-                group_list=group_list,
-                output_dtype=torch.int32,
-            )[0]
-            if quantized_hidden_states is not None:
-                dispose_tensor(quantized_hidden_states)
-            # act_fn: swiglu
-            dequant_swiglu_kwargs = {
-                "x": hidden_states,
-                "weight_scale": _prepare_dequant_swiglu_weight_scale(w1_scale, is_swigluoai_uninterleave),
-                "activation_scale": pertoken_scale,
-                "bias": None,
-                "quant_scale": None,
-                "quant_offset": None,
-                "group_index": cumsum_group_list(group_list, group_list_type, 1),
-                "activate_left": True,
-                "quant_mode": 1,
-            }
-            if is_swigluoai_uninterleave:
-                dequant_swiglu_kwargs.update(
-                    {
-                        "swiglu_mode": 1,
-                        "clamp_limit": swiglu_limit,
-                        "glu_alpha": swiglu_alpha,
-                        "glu_bias": swiglu_beta,
-                    }
-                )
-            hidden_states, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(**dequant_swiglu_kwargs)
-        before_gmm2_evt = torch.npu.current_stream().record_event()
-        # gmm2: down_proj
-        hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
-            hidden_states=hidden_states,
-            weight=w2,
-            weight_scale=w2_scale,
-            per_token_scale=swiglu_out_scale,
-            group_list=group_list,
-            group_list_type=group_list_type,
-            input_dtype=input_hidden_dtype,
+    if gate_up_kernel == GateUpKernel.CUSTOM_NZ:
+        hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
+            x=hidden_states,
+            weight=w1,
+            weight_scale=w1_scale,
+            x_scale=pertoken_scale,
+            group_list=cumsum_group_list(group_list, group_list_type, 0),
+            swiglu_limit=swiglu_limit,
+        )
+    elif gate_up_kernel == GateUpKernel.FUSED:
+        hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
+            x=hidden_states,
+            weight=_require_single_tensor(w1, name="w1"),
+            group_list=cumsum_group_list(group_list, group_list_type, 0),
+            weight_scale=_require_single_tensor(w1_scale, name="w1_scale"),
+            x_scale=pertoken_scale,
+            bias=None,
+            use_mxfp_quant=use_mxfp_quant,
             act_quant_type=act_quant_type,
             weight_quant_type=weight_quant_type,
-            scale_type=scale_type,
-            per_token_scale_type=per_token_scale_type,
-            use_bf16=use_bf16,
-            use_mxfp_quant=use_mxfp_quant,
-            bias=None,
-            fallback_output_dtype=w2_scale[0].dtype if isinstance(w2_scale, list) else w2_scale.dtype,
+            swiglu_limit=swiglu_limit,
             mxfp_quant_dtype=mxfp_quant_dtype,
         )
-    elif w1_offset is not None:
-        # gmm1: gate_up_proj
-        hidden_states = torch_npu.npu_grouped_matmul(
-            x=[unquantized_hidden_states],
-            weight=[w1],
-            antiquant_scale=[w1_scale],
-            antiquant_offset=[w1_offset],
-            split_item=2,
-            group_list_type=group_list_type,
-            group_type=0,
-            group_list=group_list,
-            output_dtype=_output_dtype,
-        )[0]
-        dispose_tensor(unquantized_hidden_states)
-        # act_fn: swiglu
-        if activation == MoEActivation.SWIGLUSTEP:
-            hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
-        elif is_gelu_activation:
-            gate, up = hidden_states.chunk(2, dim=-1)
-            approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
-            hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
-        elif is_swigluoai_uninterleave:
-            hidden_states = torch_npu.npu_clipped_swiglu(
-                hidden_states,
-                interleaved=False,
-                alpha=swiglu_alpha,
-                limit=swiglu_limit,
-                bias=swiglu_beta,
+        if quantized_hidden_states is not None:
+            dispose_tensor(quantized_hidden_states)
+    elif gate_up_kernel == GateUpKernel.DECOMPOSED:
+        gmm1_output_dtype = (
+            torch.bfloat16
+            if is_w4a8_per_channel or use_mxfp_quant or kernel_plan.key.activation == MoEMLPActivationKind.SWIGLUSTEP
+            else output_dtype
+        )
+        scale = [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale]
+        if is_swigluoai_uninterleave:
+            scale = _prepare_swigluoai_grouped_matmul_scales(w1_scale, gmm1_output_dtype)
+        gmm1_kwargs = {
+            "x": [hidden_states],
+            "weight": w1 if isinstance(w1, list) else [w1],
+            "scale": scale,
+            "bias": bias1,
+            "per_token_scale": [pertoken_scale],
+            "split_item": 2,
+            "group_type": 0,
+            "group_list": group_list,
+            "group_list_type": group_list_type,
+            "output_dtype": gmm1_output_dtype,
+        }
+        if use_mxfp_quant:
+            gmm1_kwargs.update(
+                {
+                    "scale_dtype": torch_npu.float8_e8m0fnu,
+                    "per_token_scale_dtype": torch_npu.float8_e8m0fnu,
+                }
             )
-        else:
-            hidden_states = torch_npu.npu_swiglu(hidden_states)
-        before_gmm2_evt = torch.npu.current_stream().record_event()
-        # gmm2: down_proj
+        hidden_states = torch_npu.npu_grouped_matmul(**gmm1_kwargs)[0]
+        if quantized_hidden_states is not None:
+            dispose_tensor(quantized_hidden_states)
+        hidden_states, swiglu_out_scale = apply_quantized_activation(
+            hidden_states,
+            kernel_plan.key.activation,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+            act_quant_type=act_quant_type,
+            use_mxfp_quant=use_mxfp_quant,
+            group_list=group_list,
+            group_list_type=group_list_type,
+        )
+    elif gate_up_kernel == GateUpKernel.DEQUANT_SWIGLU:
         hidden_states = torch_npu.npu_grouped_matmul(
             x=[hidden_states],
-            weight=[w2],
-            antiquant_scale=[w2_scale],
-            antiquant_offset=[w2_offset],
-            split_item=2,
+            weight=w1,
+            split_item=3,
             group_list_type=group_list_type,
             group_type=0,
             group_list=group_list,
-            output_dtype=_output_dtype,
+            output_dtype=torch.int32,
         )[0]
-    else:
-        if w1_scale_bias is not None:
-            if group_list_type == 0:
-                group_list = torch.cat([group_list[:1], torch.diff(group_list, dim=0)])
-                group_list_type = 1
-            bias1 = w1_scale_bias
-            bias2 = w2_scale_bias
-            # TODO w4a8 scene: dynamic acquisition of dtype in the future
-            _output_dtype = torch.bfloat16
-
-        if (
-            use_w4a8_per_channel_gmm_swiglu
-            and enable_custom_op()
-            and activation != MoEActivation.SWIGLUSTEP
-            and not is_gelu_activation
-            and not is_swigluoai_uninterleave
-        ):
-            hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
-                x=hidden_states,
-                weight=w1,
-                weight_scale=w1_scale if isinstance(w1_scale, list) else [w1_scale],
-                x_scale=pertoken_scale,
-                group_list=group_list,
-                weight_assist_matrix=bias1,
-                dequant_mode=0,
-                group_list_type=group_list_type,
-                swiglu_limit=swiglu_limit,
+        if quantized_hidden_states is not None:
+            dispose_tensor(quantized_hidden_states)
+        dequant_swiglu_kwargs = {
+            "x": hidden_states,
+            "weight_scale": _prepare_dequant_swiglu_weight_scale(w1_scale, is_swigluoai_uninterleave),
+            "activation_scale": pertoken_scale,
+            "bias": None,
+            "quant_scale": None,
+            "quant_offset": None,
+            "group_index": cumsum_group_list(group_list, group_list_type, 1),
+            "activate_left": True,
+            "quant_mode": 1,
+        }
+        if is_swigluoai_uninterleave:
+            dequant_swiglu_kwargs.update(
+                {
+                    "swiglu_mode": 1,
+                    "clamp_limit": swiglu_limit,
+                    "glu_alpha": swiglu_alpha,
+                    "glu_bias": swiglu_beta,
+                }
             )
-        elif (
-            _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation)
-            and not use_mxfp_quant
-            and not is_gelu_activation
-        ):
-            # gmm1: gate_up_proj & act_fn: swiglu
-            hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
-                x=hidden_states,
-                weight=w1,
-                weight_scale=w1_scale,
-                x_scale=pertoken_scale,
-                group_list=cumsum_group_list(group_list, group_list_type, 0),
-                bias=bias1,
-                swiglu_limit=swiglu_limit,
-            )
-        elif use_gmm_swiglu_quant_fusion and activation != MoEActivation.SWIGLUSTEP and not is_gelu_activation:
-            hidden_states, swiglu_out_scale, _ = DeviceOperator.npu_grouped_matmul_swiglu_quant(
-                x=hidden_states,
-                weight=_require_single_tensor_for_swiglu_quant(w1, name="w1"),
-                group_list=cumsum_group_list(group_list, group_list_type, 0),
-                weight_scale=_require_single_tensor_for_swiglu_quant(w1_scale, name="w1_scale"),
-                x_scale=pertoken_scale,
-                bias=bias1,
-                use_mxfp_quant=use_mxfp_quant,
-                act_quant_type=act_quant_type,
-                weight_quant_type=weight_quant_type,
-                swiglu_limit=swiglu_limit,
-                mxfp_quant_dtype=mxfp_quant_dtype,
-            )
-            if quantized_hidden_states is not None:
-                dispose_tensor(quantized_hidden_states)
-        else:
-            # gmm1: gate_up_proj
-            scale = [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale]
-            if is_swigluoai_uninterleave:
-                scale = _prepare_swigluoai_grouped_matmul_scales(w1_scale, _output_dtype)
-            gmm1_kwargs = {
-                "x": [hidden_states],
-                "weight": w1 if isinstance(w1, list) else [w1],
-                "scale": scale,
-                "bias": bias1,
-                "per_token_scale": [pertoken_scale],
-                "split_item": 2,
-                "group_type": 0,
-                "group_list": group_list,
-                "group_list_type": group_list_type,
-                "output_dtype": _output_dtype,
-            }
-            if use_mxfp_quant:
-                gmm1_kwargs.update(
-                    {
-                        "scale_dtype": torch_npu.float8_e8m0fnu,
-                        "per_token_scale_dtype": torch_npu.float8_e8m0fnu,
-                        "output_dtype": torch.bfloat16,
-                    }
-                )
-            hidden_states = torch_npu.npu_grouped_matmul(**gmm1_kwargs)[0]
-            if quantized_hidden_states is not None:
-                dispose_tensor(quantized_hidden_states)
-            # act_fn: swiglu
-            if activation == MoEActivation.SWIGLUSTEP:
-                hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
-                hidden_states, swiglu_out_scale = DeviceOperator.npu_dynamic_quant(
-                    hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
-                )
-            elif is_gelu_activation:
-                gate, up = hidden_states.chunk(2, dim=-1)
-                approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
-                hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
-                hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
-            elif is_swigluoai_uninterleave:
-                hidden_states = torch_npu.npu_clipped_swiglu(
-                    hidden_states,
-                    interleaved=False,
-                    alpha=swiglu_alpha,
-                    limit=swiglu_limit,
-                    bias=swiglu_beta,
-                )
-                hidden_states, swiglu_out_scale = DeviceOperator.npu_dynamic_quant(
-                    hidden_states, act_quant_type=act_quant_type, use_mxfp_quant=use_mxfp_quant
-                )
-            elif HAS_TRITON:
-                from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
-
-                hidden_states, swiglu_out_scale = swiglu_quant(
-                    hidden_states, group_list=group_list, group_list_type=group_list_type
-                )
-            else:
-                hidden_states = torch_npu.npu_swiglu(hidden_states)
-                hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
-        before_gmm2_evt = torch.npu.current_stream().record_event()
-        # gmm2: down_proj
-        hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
-            hidden_states=hidden_states,
-            weight=w2,
-            weight_scale=w2_scale,
-            per_token_scale=swiglu_out_scale,
+        hidden_states, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(**dequant_swiglu_kwargs)
+    elif gate_up_kernel == GateUpKernel.W4A8_PER_CHANNEL:
+        hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
+            x=hidden_states,
+            weight=w1,
+            weight_scale=w1_scale if isinstance(w1_scale, list) else [w1_scale],
+            x_scale=pertoken_scale,
             group_list=group_list,
+            weight_assist_matrix=bias1,
+            dequant_mode=0,
             group_list_type=group_list_type,
-            input_dtype=input_hidden_dtype,
-            act_quant_type=act_quant_type,
-            weight_quant_type=weight_quant_type,
-            scale_type=scale_type,
-            per_token_scale_type=per_token_scale_type,
-            use_bf16=use_bf16,
-            use_mxfp_quant=use_mxfp_quant,
-            bias=bias2,
-            fallback_output_dtype=_output_dtype,
-            mxfp_quant_dtype=mxfp_quant_dtype,
+            swiglu_limit=swiglu_limit,
         )
+    else:
+        raise ValueError(f"Unsupported quantized gate/up kernel: {gate_up_kernel}")
+
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    # gmm2: down_proj
+    hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states=hidden_states,
+        weight=w2,
+        weight_scale=w2_scale,
+        per_token_scale=swiglu_out_scale,
+        group_list=group_list,
+        group_list_type=group_list_type,
+        input_dtype=output_dtype,
+        act_quant_type=act_quant_type,
+        weight_quant_type=weight_quant_type,
+        scale_type=scale_type,
+        per_token_scale_type=per_token_scale_type,
+        use_bf16=use_bf16,
+        use_mxfp_quant=use_mxfp_quant,
+        bias=bias2,
+        fallback_output_dtype=output_dtype,
+        mxfp_quant_dtype=mxfp_quant_dtype,
+    )
     return hidden_states, before_gmm2_evt
 
 
@@ -503,7 +353,7 @@ def unquant_apply_mlp(
     lora_context=None,
     expanded_row_idx: torch.Tensor | None = None,
     topk_ids: torch.Tensor | None = None,
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, None]:
     if need_trans:
         w1 = w1.transpose(1, 2)
         w2 = w2.transpose(1, 2)
@@ -556,32 +406,14 @@ def unquant_apply_mlp(
             lora_routing=lora_routing,
         )
 
-    act_name = getattr(activation, "value", activation)
-    if activation == MoEActivation.SWIGLUOAI:
-        num_experts, _, hidden_size = w1.shape
-        gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
-    elif act_name == "swigluoai_uninterleave":
-        gate_up_out = torch_npu.npu_clipped_swiglu(
-            gate_up_out,
-            interleaved=False,
-            alpha=swiglu_alpha,
-            limit=swiglu_limit,
-            bias=swiglu_beta,
-        )
-    elif activation == MoEActivation.SWIGLUSTEP:
-        gate_up_out = AscendSwigluStepAndMul.swiglustep_forward(gate_up_out, limit=swiglu_limit or 7.0)
-    elif activation == MoEActivation.GELU:
-        gate, up = gate_up_out.chunk(2, dim=-1)
-        gate_up_out = torch.nn.functional.gelu(gate) * up
-    elif activation == MoEActivation.GELU_TANH:
-        gate, up = gate_up_out.chunk(2, dim=-1)
-        gate_up_out = torch.nn.functional.gelu(gate, approximate="tanh") * up
-    else:
-        if swiglu_limit > 0:
-            gate, up = gate_up_out.chunk(2, dim=-1)
-            gate.clamp_(max=swiglu_limit)
-            up.clamp_(min=-swiglu_limit, max=swiglu_limit)
-        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+    gate_up_out = apply_unquantized_activation(
+        gate_up_out,
+        resolve_mlp_activation(activation),
+        hidden_size=w1.shape[-1],
+        swiglu_limit=swiglu_limit,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=swiglu_beta,
+    )
 
     if topk_scales is not None:
         gate_up_out *= topk_scales
@@ -608,11 +440,11 @@ def unquant_apply_mlp(
     return hidden_states, None
 
 
-def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
-    """
-    Unified MoE MLP entry.
-    Quant path is dispatched by DeviceOperator with explicit typed kernel flags.
-    """
+def execute_mlp_plan(
+    kernel_plan: MoEMLPPlan,
+    mlp_compute_input: MoEMlpComputeInput,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Execute the kernels selected by an immutable MoE MLP plan."""
     hidden_states = mlp_compute_input.hidden_states
     group_list = mlp_compute_input.group_list
     group_list_type = mlp_compute_input.group_list_type
@@ -630,13 +462,12 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     w2_offset = mlp_compute_input.weights.w2_offset
     activation = mlp_compute_input.activation
     need_trans = mlp_compute_input.need_trans
-    dynamic_eplb = mlp_compute_input.dynamic_eplb
-    fusion = mlp_compute_input.fusion
     swiglu_limit = mlp_compute_input.swiglu_limit
     swiglu_alpha = mlp_compute_input.swiglu_alpha
     swiglu_beta = mlp_compute_input.swiglu_beta
 
-    if not mlp_compute_input.quant.is_quant:
+    gate_up_kernel = kernel_plan.gate_up_kernel
+    if gate_up_kernel == GateUpKernel.UNQUANTIZED:
         return unquant_apply_mlp(
             hidden_states=hidden_states,
             w1=w1,
@@ -656,6 +487,8 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
             topk_ids=mlp_compute_input.topk_ids,
         )
 
+    # Quantized MoE LoRA remains out of scope until a dedicated quantized
+    # adapter kernel is available; the existing unquantized path stays intact.
     from vllm_ascend.lora.fused_moe import has_lora
 
     if has_lora(mlp_compute_input.lora_context):
@@ -664,11 +497,33 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         return quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_compute_input)
 
     assert w1_scale is not None and w2_scale is not None
+    output_dtype = mlp_compute_input.output_dtype
+    if gate_up_kernel == GateUpKernel.ANTIQUANT:
+        assert w1_offset is not None and w2_offset is not None
+        return weight_only_apply_mlp(
+            hidden_states=hidden_states,
+            w1=w1,
+            w1_scale=w1_scale,
+            w1_offset=w1_offset,
+            w2=w2,
+            w2_scale=w2_scale,
+            w2_offset=w2_offset,
+            group_list=group_list,
+            group_list_type=group_list_type,
+            output_dtype=output_dtype,
+            activation=kernel_plan.key.activation,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+        )
+    if w1_offset is not None or w2_offset is not None:
+        raise ValueError("Antiquant offsets are only supported by the weight-only MLP path.")
+
     act_quant_type = torch.int8 if mlp_compute_input.quant.is_int_quant else torch.float8_e4m3fn
     weight_quant_type = torch.float8_e4m3fn
     scale_type = None
     per_token_scale_type = None
-    use_bf16 = hidden_states.dtype == torch.bfloat16
+    use_bf16 = output_dtype == torch.bfloat16
     use_mxfp_quant = mlp_compute_input.quant.is_mxfp
     mxfp_quant_dtype = mlp_compute_input.quant.quant_type
 
@@ -691,15 +546,12 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         w1_scale=w1_scale,
         w2=w2,
         w2_scale=w2_scale,
+        output_dtype=output_dtype,
         group_list=group_list,
         dynamic_scale=dynamic_scale,
         group_list_type=group_list_type,
         w1_scale_bias=w1_scale_bias,
         w2_scale_bias=w2_scale_bias,
-        w1_offset=w1_offset,
-        w2_offset=w2_offset,
-        fusion=fusion,
-        dynamic_eplb=dynamic_eplb,
         use_mxfp_quant=use_mxfp_quant,
         mxfp_quant_dtype=mxfp_quant_dtype,
         act_quant_type=act_quant_type,
@@ -707,9 +559,19 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         scale_type=scale_type,
         per_token_scale_type=per_token_scale_type,
         use_bf16=use_bf16,
-        activation=activation,
         swiglu_limit=swiglu_limit,
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
-        use_w4a8_per_channel_gmm_swiglu=mlp_compute_input.quant.use_w4a8_per_channel_gmm_swiglu,
+        kernel_plan=kernel_plan,
     )
+
+
+def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Compatibility entry point for callers outside MoECommMethod.
+
+    Communication methods keep a long-lived planner and therefore avoid this
+    per-call planner construction.
+    """
+    from vllm_ascend.ops.fused_moe.moe_mlp_plan import MoEMLPPlanner
+
+    return MoEMLPPlanner().execute(mlp_compute_input)

--- a/vllm_ascend/ops/fused_moe/moe_mlp_activation.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp_activation.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+import torch
+import torch_npu
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.triton_utils import HAS_TRITON
+
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
+
+
+class MoEMLPActivationKind(Enum):
+    SWIGLU = "swiglu"
+    SWIGLUSTEP = "swiglustep"
+    SWIGLUOAI = "swigluoai"
+    SWIGLUOAI_UNINTERLEAVE = "swigluoai_uninterleave"
+    GELU = "gelu"
+    GELU_TANH = "gelu_tanh"
+
+
+def resolve_mlp_activation(activation: str | MoEActivation | None) -> MoEMLPActivationKind:
+    act_name = getattr(activation, "value", activation)
+    if activation == MoEActivation.SWIGLUSTEP or act_name == "swiglustep":
+        return MoEMLPActivationKind.SWIGLUSTEP
+    if activation == MoEActivation.SWIGLUOAI or act_name == "swigluoai":
+        return MoEMLPActivationKind.SWIGLUOAI
+    if act_name == "swigluoai_uninterleave":
+        return MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE
+    if activation == MoEActivation.GELU or act_name == "gelu":
+        return MoEMLPActivationKind.GELU
+    if activation == MoEActivation.GELU_TANH or act_name == "gelu_tanh":
+        return MoEMLPActivationKind.GELU_TANH
+    return MoEMLPActivationKind.SWIGLU
+
+
+def supports_fused_swiglu(activation: MoEMLPActivationKind) -> bool:
+    return activation == MoEMLPActivationKind.SWIGLU
+
+
+def apply_unquantized_activation(
+    hidden_states: torch.Tensor,
+    activation: MoEMLPActivationKind,
+    *,
+    hidden_size: int,
+    swiglu_limit: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+) -> torch.Tensor:
+    if activation == MoEMLPActivationKind.SWIGLUOAI:
+        return AscendSwigluOAIAndMul.swiglu_oai_forward(
+            hidden_states.view(-1, hidden_size),
+            alpha=swiglu_alpha,
+            limit=swiglu_limit or 7.0,
+        )
+    if activation == MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE:
+        return torch_npu.npu_clipped_swiglu(
+            hidden_states,
+            interleaved=False,
+            alpha=swiglu_alpha,
+            limit=swiglu_limit,
+            bias=swiglu_beta,
+        )
+    if activation == MoEMLPActivationKind.SWIGLUSTEP:
+        return AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
+    if activation in (MoEMLPActivationKind.GELU, MoEMLPActivationKind.GELU_TANH):
+        gate, up = hidden_states.chunk(2, dim=-1)
+        approximate = "tanh" if activation == MoEMLPActivationKind.GELU_TANH else "none"
+        return torch.nn.functional.gelu(gate, approximate=approximate) * up
+    if swiglu_limit > 0:
+        gate, up = hidden_states.chunk(2, dim=-1)
+        gate.clamp_(max=swiglu_limit)
+        up.clamp_(min=-swiglu_limit, max=swiglu_limit)
+    return torch_npu.npu_swiglu(hidden_states)
+
+
+def apply_quantized_activation(
+    hidden_states: torch.Tensor,
+    activation: MoEMLPActivationKind,
+    *,
+    swiglu_limit: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+    act_quant_type: torch.dtype,
+    use_mxfp_quant: bool,
+    group_list: torch.Tensor,
+    group_list_type: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if activation == MoEMLPActivationKind.SWIGLUSTEP:
+        hidden_states = AscendSwigluStepAndMul.swiglustep_forward(hidden_states, limit=swiglu_limit or 7.0)
+        return DeviceOperator.npu_dynamic_quant(
+            hidden_states,
+            act_quant_type=act_quant_type,
+            use_mxfp_quant=use_mxfp_quant,
+        )
+    if activation in (MoEMLPActivationKind.GELU, MoEMLPActivationKind.GELU_TANH):
+        gate, up = hidden_states.chunk(2, dim=-1)
+        approximate = "tanh" if activation == MoEMLPActivationKind.GELU_TANH else "none"
+        hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
+        return torch_npu.npu_dynamic_quant(hidden_states)
+    if activation == MoEMLPActivationKind.SWIGLUOAI:
+        hidden_states = AscendSwigluOAIAndMul.swiglu_oai_forward(
+            hidden_states,
+            alpha=swiglu_alpha,
+            limit=swiglu_limit or 7.0,
+        )
+        return DeviceOperator.npu_dynamic_quant(
+            hidden_states,
+            act_quant_type=act_quant_type,
+            use_mxfp_quant=use_mxfp_quant,
+        )
+    if activation == MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE:
+        hidden_states = torch_npu.npu_clipped_swiglu(
+            hidden_states,
+            interleaved=False,
+            alpha=swiglu_alpha,
+            limit=swiglu_limit,
+            bias=swiglu_beta,
+        )
+        return DeviceOperator.npu_dynamic_quant(
+            hidden_states,
+            act_quant_type=act_quant_type,
+            use_mxfp_quant=use_mxfp_quant,
+        )
+    if HAS_TRITON:
+        from vllm_ascend.ops.triton.activation.swiglu_quant import swiglu_quant
+
+        return swiglu_quant(hidden_states, group_list=group_list, group_list_type=group_list_type)
+    hidden_states = torch_npu.npu_swiglu(hidden_states)
+    return torch_npu.npu_dynamic_quant(hidden_states)
+
+
+__all__ = [
+    "MoEMLPActivationKind",
+    "apply_quantized_activation",
+    "apply_unquantized_activation",
+    "resolve_mlp_activation",
+    "supports_fused_swiglu",
+]

--- a/vllm_ascend/ops/fused_moe/moe_mlp_group_list.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp_group_list.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import IntEnum
+
+import torch
+from torch.nn.functional import pad
+
+
+class GroupListType(IntEnum):
+    """Grouped-matmul expert-token metadata layouts."""
+
+    CUMULATIVE = 0
+    COUNTS = 1
+    SPARSE_COUNTS = 2
+
+
+def convert_group_list(
+    group_list: torch.Tensor,
+    src_list_type: int | GroupListType,
+    dst_list_type: int | GroupListType,
+    active_num: int = 0,
+    expert_num: int = 0,
+) -> torch.Tensor:
+    """Convert a group list at the MLP boundary.
+
+    Kernel implementations must use this helper instead of carrying their
+    own cumsum/diff conversions. This keeps the meaning of group-list types
+    consistent across GMM1, activation, and GMM2.
+    """
+
+    try:
+        src_type = GroupListType(src_list_type)
+    except ValueError as exc:
+        raise ValueError(f"group_list_type should be in [0, 1, 2], but received {src_list_type}") from exc
+    try:
+        dst_type = GroupListType(dst_list_type)
+    except ValueError as exc:
+        raise ValueError(f"group_list_type should be in [0, 1, 2], but received {dst_list_type}") from exc
+
+    if src_type == dst_type:
+        return group_list
+    if src_type == GroupListType.COUNTS and dst_type == GroupListType.CUMULATIVE:
+        return group_list.cumsum(dim=0)
+    if src_type == GroupListType.CUMULATIVE and dst_type == GroupListType.COUNTS:
+        group_diff = torch.diff(group_list)
+        return torch.cat([group_list[0].unsqueeze(0), group_diff], dim=0)
+    if src_type == GroupListType.SPARSE_COUNTS and dst_type == GroupListType.CUMULATIVE:
+        experts = pad(group_list[:, 0], (1, 0))
+        tokens = pad(group_list[:, 1].cumsum(dim=0), (1, 0))
+        cumulative_group_list = torch.full(
+            size=(expert_num,),
+            fill_value=active_num,
+            dtype=group_list.dtype,
+            device=group_list.device,
+        )
+
+        for i, (start, end) in enumerate(zip(experts[:-1], experts[1:])):
+            if end > start:
+                cumulative_group_list[start:end] = tokens[i]
+
+        return cumulative_group_list
+    raise NotImplementedError(
+        f"Conversion from src_list_type={src_type.value} to dst_list_type={dst_type.value} is not implemented yet. "
+        "This feature is under development."
+    )
+
+
+__all__ = ["GroupListType", "convert_group_list"]

--- a/vllm_ascend/ops/fused_moe/moe_mlp_plan.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp_plan.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ops.fused_moe.moe_mlp_activation import (
+    MoEMLPActivationKind,
+    resolve_mlp_activation,
+    supports_fused_swiglu,
+)
+from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
+from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import enable_custom_op
+
+MXFP_QUANT_TYPES = (
+    QuantType.W8A8MXFP,
+    QuantType.W4A4MXFP,
+    QuantType.W4A8MXFP,
+    QuantType.W4A16MXFP,
+)
+
+
+class GateUpKernel(Enum):
+    UNQUANTIZED = "unquantized"
+    ANTIQUANT = "antiquant"
+    CUSTOM_NZ = "custom_nz"
+    FUSED = "fused"
+    DEQUANT_SWIGLU = "dequant_swiglu"
+    W4A8_PER_CHANNEL = "w4a8_per_channel"
+    DECOMPOSED = "decomposed"
+
+
+@dataclass(frozen=True, slots=True)
+class MoEMLPPlanKey:
+    """Static inputs that affect MLP kernel selection.
+
+    FusedMC2 bypasses this executor. Regular MC2 remains a plan dimension
+    because it enables the GMM + dequant-SwiGLU-quant kernel sequence.
+    """
+
+    quant_type: QuantType
+    activation: MoEMLPActivationKind
+    fusion: bool
+    dynamic_eplb: bool
+    group_list_type: int
+    custom_op_enabled: bool
+    moe_comm_type: MoECommType = MoECommType.ALLGATHER
+
+
+@dataclass(frozen=True, slots=True)
+class MoEMLPPlan:
+    """Immutable kernel choices for one MoE MLP configuration."""
+
+    key: MoEMLPPlanKey
+    gate_up_kernel: GateUpKernel
+
+    def execute(self, mlp_compute_input: MoEMlpComputeInput) -> tuple[torch.Tensor, torch.npu.Event | None]:
+        # Local import keeps the plan definition independent from the kernel
+        # implementation and avoids a module import cycle.
+        from vllm_ascend.ops.fused_moe.moe_mlp import execute_mlp_plan
+
+        return execute_mlp_plan(self, mlp_compute_input)
+
+
+def build_mlp_plan(key: MoEMLPPlanKey) -> MoEMLPPlan:
+    if key.quant_type == QuantType.NONE:
+        return MoEMLPPlan(key, GateUpKernel.UNQUANTIZED)
+    if key.quant_type == QuantType.W4A16:
+        return MoEMLPPlan(key, GateUpKernel.ANTIQUANT)
+    if key.quant_type == QuantType.W4A8:
+        kernel = (
+            GateUpKernel.W4A8_PER_CHANNEL
+            if key.custom_op_enabled and supports_fused_swiglu(key.activation)
+            else GateUpKernel.DECOMPOSED
+        )
+        return MoEMLPPlan(key, kernel)
+
+    use_mxfp_quant = key.quant_type in MXFP_QUANT_TYPES
+    is_mc2 = key.moe_comm_type == MoECommType.MC2
+    if supports_fused_swiglu(key.activation):
+        if key.fusion and key.dynamic_eplb and key.custom_op_enabled and not use_mxfp_quant:
+            kernel = GateUpKernel.CUSTOM_NZ
+        elif use_mxfp_quant or (key.fusion and not key.dynamic_eplb):
+            kernel = GateUpKernel.FUSED
+        elif is_mc2:
+            kernel = GateUpKernel.DEQUANT_SWIGLU
+        else:
+            kernel = GateUpKernel.DECOMPOSED
+    elif key.activation == MoEMLPActivationKind.SWIGLUOAI_UNINTERLEAVE:
+        kernel = GateUpKernel.DEQUANT_SWIGLU if is_mc2 else GateUpKernel.DECOMPOSED
+    else:
+        kernel = GateUpKernel.DECOMPOSED
+    return MoEMLPPlan(key, kernel)
+
+
+class MoEMLPPlanner:
+    """Caches plans so static kernel decisions stay out of the hot path."""
+
+    def __init__(self, custom_op_enabled: bool | None = None) -> None:
+        self._plans: dict[MoEMLPPlanKey, MoEMLPPlan] = {}
+        self._custom_op_enabled = custom_op_enabled
+
+    def _resolve_custom_op_enabled(self) -> bool:
+        if self._custom_op_enabled is None:
+            self._custom_op_enabled = enable_custom_op()
+        return self._custom_op_enabled
+
+    def get_plan(self, mlp_compute_input: MoEMlpComputeInput) -> MoEMLPPlan:
+        quant_type = mlp_compute_input.quant.quant_type
+        activation = resolve_mlp_activation(mlp_compute_input.activation)
+        custom_op_relevant = supports_fused_swiglu(activation) and (
+            quant_type == QuantType.W4A8
+            or (
+                mlp_compute_input.fusion
+                and mlp_compute_input.dynamic_eplb
+                and quant_type not in (QuantType.NONE, QuantType.W4A16, *MXFP_QUANT_TYPES)
+            )
+        )
+        key = MoEMLPPlanKey(
+            quant_type=quant_type,
+            activation=activation,
+            fusion=mlp_compute_input.fusion,
+            dynamic_eplb=mlp_compute_input.dynamic_eplb,
+            group_list_type=mlp_compute_input.group_list_type,
+            custom_op_enabled=self._resolve_custom_op_enabled() if custom_op_relevant else False,
+            moe_comm_type=mlp_compute_input.moe_comm_type,
+        )
+        plan = self._plans.get(key)
+        if plan is None:
+            plan = build_mlp_plan(key)
+            self._plans[key] = plan
+        return plan
+
+    def execute(self, mlp_compute_input: MoEMlpComputeInput) -> tuple[torch.Tensor, torch.npu.Event | None]:
+        return self.get_plan(mlp_compute_input).execute(mlp_compute_input)
+
+
+__all__ = [
+    "GateUpKernel",
+    "MoEMLPPlan",
+    "MoEMLPPlanKey",
+    "MoEMLPPlanner",
+    "build_mlp_plan",
+]

--- a/vllm_ascend/ops/fused_moe/moe_runtime_args.py
+++ b/vllm_ascend/ops/fused_moe/moe_runtime_args.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 import torch
 
 import vllm_ascend.ops.fused_moe.moe_stage_params as _stage_params
+from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.moe_stage_contracts import (
     MoEAllGatherCombineMetadata,
     MoEAllToAllCombineMetadata,
@@ -137,7 +138,6 @@ def build_fused_experts_input(
     mxfp_scale_dtype: torch.dtype | None = None,
     mxfp_per_token_scale_dtype: torch.dtype | None = None,
     mxfp_use_bf16: bool | None = None,
-    is_per_channel_weight: bool = False,
     w1_scale: list[torch.Tensor] | torch.Tensor | None = None,
     w2_scale: list[torch.Tensor] | torch.Tensor | None = None,
     w1_scale_bias: list[torch.Tensor] | torch.Tensor | None = None,
@@ -196,7 +196,6 @@ def build_fused_experts_input(
                 mxfp_per_token_scale_dtype=mxfp_per_token_scale_dtype,
                 mxfp_use_bf16=mxfp_use_bf16,
             ),
-            is_per_channel_weight=is_per_channel_weight,
         ),
         swiglu_limit=swiglu_limit,
         swiglu_alpha=swiglu_alpha,
@@ -224,6 +223,8 @@ def build_mlp_compute_input(
     fused_experts_input: MoEFusedExpertsInput,
     token_dispatch_output: MoETokenDispatchOutput[TMoECombineMetadata],
     use_fusion_ops: bool,
+    output_dtype: torch.dtype,
+    moe_comm_type: MoECommType = MoECommType.ALLGATHER,
 ) -> MoEMlpComputeInput:
     if fused_experts_input.quant.is_mxfp and fused_experts_input.quant.mxfp is None:
         raise ValueError("fused_experts_input.quant.mxfp is required for MXFP quant types.")
@@ -248,6 +249,8 @@ def build_mlp_compute_input(
             QuantType.W4A16MXFP,
         )
         and use_fusion_ops,
+        output_dtype=output_dtype,
+        moe_comm_type=moe_comm_type,
         activation=fused_experts_input.activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,

--- a/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_contracts.py
@@ -22,6 +22,7 @@ from typing import Any, Generic, TypeVar
 import numpy as np
 import torch
 
+from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.moe_stage_params import MoEQuantParams, MoERoutingParams
 
 TMoECombineMetadata = TypeVar("TMoECombineMetadata")
@@ -142,7 +143,11 @@ class MoEMlpComputeInput:
     topk_scales: torch.Tensor | None
     weights: MoEWeights
     quant: MoEQuantParams
+    # Dtype of the dequantized MoE output. This is model execution metadata,
+    # not hidden_states.dtype because dispatch may quantize hidden_states.
+    output_dtype: torch.dtype
     fusion: bool
+    moe_comm_type: MoECommType = MoECommType.ALLGATHER
     activation: str = "silu"
     need_trans: bool = False
     dynamic_eplb: bool = False

--- a/vllm_ascend/ops/fused_moe/moe_stage_params.py
+++ b/vllm_ascend/ops/fused_moe/moe_stage_params.py
@@ -62,7 +62,6 @@ class MoEQuantParams:
     quant_type: QuantType = QuantType.NONE
     comm_quant_mode: int | None = None
     mxfp: MoEMxfpParams | None = None
-    is_per_channel_weight: bool = False
 
     @property
     def is_quant(self) -> bool:
@@ -83,10 +82,6 @@ class MoEQuantParams:
     @property
     def is_fp8(self) -> bool:
         return self.quant_type == QuantType.W8A8FP
-
-    @property
-    def use_w4a8_per_channel_gmm_swiglu(self) -> bool:
-        return self.quant_type == QuantType.W4A8 and self.is_per_channel_weight
 
     @property
     def dispatch_with_quant(self) -> bool:

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -63,7 +63,9 @@ EXPERT_TOKEN_NUMS_TYPE_COUNT = 1
 def _get_expert_token_nums_type(token_dispatch_input: MoETokenDispatchInput) -> int:
     # grouped_matmul_swiglu_quant_v2 consumes per-expert counts; existing
     # MC2 grouped-matmul paths consume prefix sums.
-    if token_dispatch_input.quant.use_w4a8_per_channel_gmm_swiglu:
+    # W4A8 supports only per-channel expert weights. Its MLP kernel consumes
+    # count-style expert-token metadata regardless of the checkpoint adapter.
+    if token_dispatch_input.quant.quant_type == QuantType.W4A8:
         return EXPERT_TOKEN_NUMS_TYPE_COUNT
     return EXPERT_TOKEN_NUMS_TYPE_CUMSUM
 

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -256,7 +256,6 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w2_scale=w2_scale,
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
-                is_per_channel_weight=True,
                 swiglu_limit=layer.swiglu_limit,
                 swiglu_alpha=layer.swiglu_alpha,
                 swiglu_beta=layer.swiglu_beta,


### PR DESCRIPTION
Resolve fused MoE MLP kernel selection in a cached immutable plan, split activation and group-list handling into dedicated modules, and remove legacy communication/per-channel runtime flags. Preserve the existing unquantized LoRA boundary and add unit coverage for quantization and activation plan selection.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
