### PR TITLE
[Refactor][Quantization] Add deprecation warnings for W4A8 linear, W4A8 MoE per-group, and W8A8 PDMix MoE

### DIFF
--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -23,6 +23,7 @@ import torch
 import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
@@ -91,6 +92,10 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     """
 
     def __init__(self):
+        logger.warning_once(
+            "W4A8_DYNAMIC linear quantization is deprecated and will be removed in the next release. "
+            "Please migrate to alternative quantization methods."
+        )
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
         quant_version = vllm_config.quant_config.quant_description.get("version", "0")
@@ -351,6 +356,11 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
         # NOTE: the weights are quantized from bf16 to int4 through a per-channel quantization process
         self.is_per_channel_weight = self.group_size == 0
+        if not self.is_per_channel_weight:
+            logger.warning_once(
+                "W4A8_DYNAMIC MoE per-group quantization is deprecated and will be removed in the next release. "
+                "Please migrate to alternative quantization methods."
+            )
         quant_version = vllm_config.quant_config.quant_description.get("version", "0")
         # NOTE: new quantize weights: 2 int4 pack into int8
         self.new_quant_version = quant_version == "1.0.0"

--- a/vllm_ascend/quantization/methods/w8a8_pdmix.py
+++ b/vllm_ascend/quantization/methods/w8a8_pdmix.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import torch
 from vllm.config import get_current_vllm_config
+from vllm.logger import logger
 
 from .base import AscendLinearScheme
 from .registry import register_scheme
@@ -87,6 +88,13 @@ class AscendW8A8PDMixLinearMethod(AscendLinearScheme):
 
 @register_scheme("W8A8_MIX", "moe")
 class AscendW8A8PDMixFusedMoeMethod(AscendW8A8DynamicFusedMoEMethod):
+    def __init__(self):
+        logger.warning_once(
+            "W8A8_MIX (pd-mix) MoE quantization is deprecated and will be removed in the next release. "
+            "Please migrate to alternative quantization methods."
+        )
+        super().__init__()
+
     def get_dynamic_quant_param(
         self, num_experts: int, intermediate_size_per_partition: int, hidden_sizes: int, params_dtype: torch.dtype
     ) -> dict[str, Any]:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR deprecates several quantization methods in `vllm_ascend` that are planned for removal in the next release. It imports the vLLM logger and adds `logger.warning_once` calls to notify users to migrate to alternative quantization methods when initializing:
  - `W4A8_DYNAMIC` linear quantization
  - `W4A8_DYNAMIC` MoE per-group quantization
  - `W8A8_MIX` (pd-mix) MoE quantization

Related PR
- https://github.com/vllm-project/vllm-ascend/pull/13713

### Does this PR introduce _any_ user-facing change?
Yes, users will see deprecation warnings in the logs when using these deprecated quantization methods.

### How was this patch tested?
No new tests were added as this change only introduces deprecation warning logs.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
