### PR TITLE
feat(examples): add GET /v1/models to load-balance proxy

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -11,7 +11,7 @@
 #
 # Features:
 # - Load balances requests to multiple prefiller and decoder servers.
-# - Supports OpenAI-compatible /v1/completions and /v1/chat/completions endpoints.
+# - Supports OpenAI-compatible /v1/models, /v1/completions and /v1/chat/completions endpoints.
 # - Streams responses from backend servers to clients.
 #
 # Prerequisites:
@@ -1177,6 +1177,27 @@ async def adjust_instances_impl(adjust_mode: str, request: Request):
 
 def parse_server_addresses(instances: list[str]) -> list[tuple[str, int]]:
     return [(host, int(port)) for host, port in (instance.split(":") for instance in instances)]
+
+
+@app.get("/v1/models")
+async def list_models(request: Request):
+    """Forward GET /v1/models to any live prefiller/decoder backend."""
+    runtime = get_runtime()
+    await runtime.sync_clients()
+    snapshot = runtime.scheduler.get_snapshot()
+    candidates = [(ServerRole.PREFILL, inst) for inst in snapshot["prefill_instances"]] + [
+        (ServerRole.DECODE, inst) for inst in snapshot["decode_instances"]
+    ]
+    for role, server in candidates:
+        key = server_key(server["host"], server["port"])
+        try:
+            client = await runtime.get_client(role, key)
+            resp = await client.get("/models", headers=auth_headers(next_req_id()))
+            resp.raise_for_status()
+            return JSONResponse(status_code=resp.status_code, content=resp.json())
+        except Exception as exc:
+            logger.warning("Failed to fetch /v1/models from %s: %s", key, exc)
+    return JSONResponse(status_code=503, content={"detail": "No available backend instances"})
 
 
 @app.post("/v1/completions")


### PR DESCRIPTION
## Summary
The disaggregated-prefill load-balance proxy example claims OpenAI compatibility but only exposed `/v1/completions` and `/v1/chat/completions`. Clients that call `GET /v1/models` on startup (OpenAI Python SDK, opencode CLI, etc.) got 404.

## Changes
- Add `GET /v1/models` that forwards to any live prefiller/decoder backend (same `/models` path already used by health checks).
- Return 503 if no backend can serve the list.

## Test plan
- [ ] Start proxy with prefiller + decoder; `curl http://host:port/v1/models` returns backend payload
- [ ] `client.models.list()` succeeds with OpenAI Python SDK
- [ ] Existing `/v1/chat/completions` path unchanged

Fixes #13798

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
