### PR TITLE
[Test][Misc] Replace HCCL_INTRA_ROCE_ENABLE with ASCEND_ENABLE_USE_FABRIC_MEM in DeepSeek-V3.1T configs

### DIFF
--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP1_128K_1K_PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP1_128K_1K_PD.yaml
@@ -61,7 +61,7 @@ env_common: &env_common
   TASK_QUEUE_ENABLE: 1
   HCCL_OP_EXPANSION_MODE: "AIV"
   VLLM_USE_V1: "1"
-  HCCL_INTRA_ROCE_ENABLE: "1"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
   LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH"
 
 env_prefill: &env_prefill

--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP1_3_5K_1_5K_PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP1_3_5K_1_5K_PD.yaml
@@ -63,7 +63,7 @@ env_common: &env_common
   TASK_QUEUE_ENABLE: 1
   HCCL_OP_EXPANSION_MODE: "AIV"
   VLLM_USE_V1: "1"
-  HCCL_INTRA_ROCE_ENABLE: "1"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
   LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH"
 
 env_prefill: &env_prefill

--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP1_PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP1_PD.yaml
@@ -63,7 +63,7 @@ env_common: &env_common
   TASK_QUEUE_ENABLE: 1
   HCCL_OP_EXPANSION_MODE: "AIV"
   VLLM_USE_V1: "1"
-  HCCL_INTRA_ROCE_ENABLE: "1"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
   LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH"
 
 env_prefill: &env_prefill

--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP3_PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_MTP3_PD.yaml
@@ -63,7 +63,7 @@ env_common: &env_common
   TASK_QUEUE_ENABLE: 1
   HCCL_OP_EXPANSION_MODE: "AIV"
   VLLM_USE_V1: "1"
-  HCCL_INTRA_ROCE_ENABLE: "1"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
   LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH"
 
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_layerwise_PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek_V3.1T_layerwise_PD.yaml
@@ -66,7 +66,7 @@ env_common: &env_common
   PYTHONHASHSEED: "0"
   ASCEND_CONNECT_TIMEOUT: "10000"
   ASCEND_TRANSFER_TIMEOUT: "10000"
-  HCCL_INTRA_ROCE_ENABLE: "1"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
   LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH"
 
 env_prefill: &env_prefill


### PR DESCRIPTION
### What this PR does / why we need it?

This PR replaces the `HCCL_INTRA_ROCE_ENABLE` environment variable with `ASCEND_ENABLE_USE_FABRIC_MEM` in 5 DeepSeek-V3.1T YAML configurations. These configurations represent A3 HCCS scenarios (`npu_per_node: 16`) which should utilize the fabric memory path for optimal performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested via existing E2E weekly multi-node tests.

- vLLM version: v0.26.0

- vLLM main: vllm-project/vllm@0351e9a