### PR TITLE
[BugFix][Docker][v0.24.0rc] Build and package vLLM Rust tool parser artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-910b-ubuntu22.04-py3.12
+FROM quay.io/ascend/cann:9.0.1-910b-ubuntu22.04-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -48,8 +48,34 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     else \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends curl make unzip && \
+    rm -rf /var/lib/apt/lists/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.12
+FROM quay.io/ascend/cann:9.1.0-beta.1-310p-ubuntu22.04-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -42,8 +42,34 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     else \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends curl make unzip && \
+    rm -rf /var/lib/apt/lists/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.1.0-beta.1-310p-openeuler24.03-py3.12
+FROM quay.io/ascend/cann:9.1.0-beta.1-310p-openeuler24.03-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -41,8 +41,33 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     else \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN yum install -y curl make unzip && \
+    rm -rf /var/cache/yum/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-a3-ubuntu22.04-py3.12
+FROM quay.io/ascend/cann:9.0.1-a3-ubuntu22.04-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -50,8 +50,34 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     else \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends curl make unzip && \
+    rm -rf /var/lib/apt/lists/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-a3-openeuler24.03-py3.12
+FROM quay.io/ascend/cann:9.0.1-a3-openeuler24.03-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -47,8 +47,33 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     else \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN yum install -y curl make unzip && \
+    rm -rf /var/cache/yum/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-950-ubuntu22.04-py3.12
+FROM quay.io/ascend/cann:9.0.1-950-ubuntu22.04-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -43,8 +43,34 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.24.0
 RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends curl make unzip && \
+    rm -rf /var/lib/apt/lists/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-950-openeuler24.03-py3.12
+FROM quay.io/ascend/cann:9.0.1-950-openeuler24.03-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -40,8 +40,33 @@ RUN pip config set global.index-url ${PIP_INDEX_URL} && \
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.24.0
 RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN yum install -y curl make unzip && \
+    rm -rf /var/cache/yum/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-FROM quay.io/ascend/cann:9.0.1-910b-openeuler24.03-py3.12
+FROM quay.io/ascend/cann:9.0.1-910b-openeuler24.03-py3.12 AS base
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 
@@ -47,8 +47,33 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     else \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
-# In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
+
+# Build the vLLM Rust frontend in a dedicated stage. The final stage receives
+# compiled artifacts without inheriting rustup or protoc from this stage.
+FROM base AS rust-build
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER} \
+    RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT} \
+    RUSTUP_TERM_PROGRESS_WHEN=always
+RUN yum install -y curl make unzip && \
+    rm -rf /var/cache/yum/*
+RUN cd /vllm-workspace/vllm && \
+    tools/install_protoc.sh && \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup set profile minimal && \
+    CARGO_BUILD_JOBS=4 bash build_rust.sh
+
+FROM base AS final
+COPY --from=rust-build /vllm-workspace/vllm/vllm/vllm-rs /vllm-workspace/vllm/vllm/vllm-rs
+COPY --from=rust-build /vllm-workspace/vllm/vllm/_rust_*.so /vllm-workspace/vllm/vllm/
+
+# Install vLLM in editable mode and require the prebuilt Rust frontend.
+# Remove Triton because it does not work correctly on Ascend.
+RUN VLLM_REQUIRE_RUST_FRONTEND=1 VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 


### PR DESCRIPTION
  ### What this PR does / why we need it?

  vLLM v0.24.0 includes the Rust-backed Python tool parser extension introduced by [vllm-project/vllm#44624](https://github.com/vllm-project/vllm/pull/44624).

  The vLLM-Ascend Dockerfiles clone and install vLLM in editable mode, but they do not build or copy the Rust artifacts required by the Python bridge:

  - `vllm/vllm-rs`
  - `vllm/_rust_tool_parser*.so`

  As a result, an image can be built without the PyO3 extension, but requests using a Rust-backed tool parser may fail at runtime with an error similar to:

  ```text
  ModuleNotFoundError: No module named 'vllm._rust_tool_parser'
  ```

  For example, this affects MiniMax-M3 deployments using:

  ```text
  --enable-auto-tool-choice
  --tool-call-parser minimax_m3
  ```

  This PR updates all vLLM-Ascend Dockerfile variants to:

  - Name the common CANN build stage `base`.
  - Add a dedicated `rust-build` stage.
  - Install the native tools required by Rust and protoc builds.
  - Run `tools/install_protoc.sh`.
  - Install `requirements/build/rust.txt`.
  - Install rustup with the minimal profile.
  - Build the Rust artifacts with `CARGO_BUILD_JOBS=4`.
  - Copy both `vllm-rs` and `_rust_*.so` into the final stage.
  - Set `VLLM_REQUIRE_RUST_FRONTEND=1` during the editable vLLM installation so missing Rust artifacts cause the image build to fail.
  - Allow `RUSTUP_DIST_SERVER` and `RUSTUP_UPDATE_ROOT` to be overridden for environments that require a Rust mirror.

  The Rust toolchain and protoc are isolated in the `rust-build` stage. The final stage receives only the compiled Rust artifacts and does not inherit the Rust/protoc build environment.

  The following Dockerfiles are updated consistently:

  - `Dockerfile`
  - `Dockerfile.openEuler`
  - `Dockerfile.310p`
  - `Dockerfile.310p.openEuler`
  - `Dockerfile.a3`
  - `Dockerfile.a3.openEuler`
  - `Dockerfile.a5`
  - `Dockerfile.a5.openEuler`

  No vLLM source backport is required because vLLM v0.24.0 already contains the Rust extension build and packaging support from vLLM PR #44624.

  Related: vllm-project/vllm#44624

  ### Does this PR introduce _any_ user-facing change?

  Yes.

  Docker images built from these Dockerfiles now contain the Rust tool parser extension required by Rust-backed tool parsers. Existing API requests using parsers such as `minimax_m3` no
  longer fail because `vllm._rust_tool_parser` is missing.

  There is no API schema or command-line interface change.

  Building the image now includes a Rust/protoc compilation stage, so source builds may take longer and require access to the configured Rust and protoc download sources.

  ### How was this patch tested?

  The main Ubuntu/Ascend 910B Dockerfile was built successfully on Linux/AArch64:

  ```bash
  DOCKER_BUILDKIT=1 docker build \
    --platform linux/arm64 \
    --progress=plain \
    -f Dockerfile \
    -t vllm-ascend:v0.24.0rc-rust-fix-arm64 \
    .
  ```

  For environments using a Rust mirror, the image can be built with:

  ```bash
  DOCKER_BUILDKIT=1 docker build \
    --platform linux/arm64 \
    --progress=plain \
    --build-arg RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static \
    --build-arg RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup \
    -f Dockerfile \
    -t vllm-ascend:v0.24.0rc-rust-fix-arm64 \
    .
  ```

  The resulting image can be checked with:

  ```bash
  docker run --rm \
    --entrypoint /bin/bash \
    vllm-ascend:v0.24.0rc-rust-fix-arm64 \
    -lc '
      set -euo pipefail

      test -x /vllm-workspace/vllm/vllm/vllm-rs
      echo "vllm-rs executable: OK"

      compgen -G "/vllm-workspace/vllm/vllm/_rust_*.so"
      echo "Rust shared library: OK"

      python3 -c "import vllm._rust_tool_parser as m; print(m.__file__)"
      echo "Rust tool parser import: OK"
    '
  ```

  The image was also validated with a MiniMax-M3 service configured with:

  ```text
  --reasoning-parser minimax_m3
  --enable-auto-tool-choice
  --tool-call-parser minimax_m3
  ```

  Chat completion and tool parser initialization completed without the previous missing `vllm._rust_tool_parser` error.

  No unit test was added because this change fixes Docker image assembly rather than parser behavior. The Rust parser implementation and functional tests are maintained in the upstream vLLM repository.

- vLLM version: v0.24.0
- vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350
