### PR TITLE
[BugFix][0.23.0] Guard SFA DSA-CP graph padding sequence lengths

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -556,6 +556,57 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert metadata.num_actual_tokens == common_attn_metadata.num_actual_tokens
         assert metadata.slot_mapping.shape == (100, 4, 1024)
 
+    @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
+    @patch("vllm_ascend.attention.sfa_v1.get_tp_group")
+    def test_dsa_cp_metadata_builder_masks_graph_padding(
+        self,
+        mock_get_tp_group,
+        mock_get_cos_and_sin_mla,
+    ):
+        # TP8, graph size 80 and MTP3 produce 20 four-token request slots. With
+        # nine real requests, rank 6 splits a padded slot at its local boundary.
+        tp_group = MagicMock()
+        tp_group.world_size = 8
+        tp_group.rank_in_group = 6
+        mock_get_tp_group.return_value = tp_group
+        mock_get_cos_and_sin_mla.return_value = (
+            torch.zeros(80, 1, 1, 64),
+            torch.zeros(80, 1, 1, 64),
+        )
+
+        builder = AscendSFAMetadataBuilder.__new__(AscendSFAMetadataBuilder)
+        builder.kernel_block_size = 128
+        builder.model_config = MagicMock()
+        builder.model_config.get_head_size.return_value = 64
+        builder.attn_mask_builder = MagicMock()
+        builder.enable_dsa_cp = True
+        builder.actual_seq_lengths_query = torch.zeros(21, dtype=torch.int32)
+        builder.actual_seq_lengths_key = torch.zeros(21, dtype=torch.int32)
+        builder.spec_actual_seq_lengths_query = None
+        builder.spec_actual_seq_lengths_key = None
+        builder.metadata_cls = AscendSFAMetadata
+
+        common_attn_metadata = MagicMock()
+        common_attn_metadata.num_reqs = 20
+        common_attn_metadata.num_actual_tokens = 36
+        common_attn_metadata.num_input_tokens = 80
+        common_attn_metadata.query_start_loc = torch.arange(0, 81, 4, dtype=torch.int32)
+        common_attn_metadata.seq_lens = torch.zeros(20, dtype=torch.int32)
+        common_attn_metadata.seq_lens[:9] = torch.arange(128, 137, dtype=torch.int32)
+        common_attn_metadata._seq_lens_cpu = common_attn_metadata.seq_lens.clone()
+        common_attn_metadata.seq_lens_cpu = common_attn_metadata.seq_lens.clone()
+        common_attn_metadata.block_table_tensor = torch.zeros(20, 1, dtype=torch.int32)
+        common_attn_metadata.slot_mapping = torch.arange(80, dtype=torch.int64)
+        common_attn_metadata.positions = torch.arange(80, dtype=torch.int64)
+        common_attn_metadata.attn_state = AscendAttentionState.DecodeOnly
+        common_attn_metadata.causal = True
+
+        metadata = builder._build(common_attn_metadata)
+
+        local_seq_lens = metadata.dsa_cp_context.actual_seq_lengths_key
+        assert local_seq_lens[17].item() == 0
+        assert torch.all(local_seq_lens >= 0)
+
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
     @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp", return_value=False)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -461,7 +461,12 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
             local_query_lens = torch.cumsum(num_local_tokens.clamp(min=0), dim=0)
             offset = global_end - req_local_end  # request tokens on later ranks
-            local_key_lens = torch.where(num_local_tokens > 0, seq_lens - offset, 0)
+            valid_local_req = (num_local_tokens > 0) & (seq_lens > 0)
+            local_key_lens = torch.where(
+                valid_local_req,
+                torch.clamp_min(seq_lens - offset, 0),
+                torch.zeros_like(seq_lens),
+            )
 
             actual_seq_lengths_query[:num_segs] = local_query_lens
             actual_seq_lengths_key[:num_segs] = local_key_lens


### PR DESCRIPTION
### What this PR does / why we need it?

This adds the DSA-CP graph-padding sequence-length safeguard to the SFA v1 metadata builder on the `releases/v0.23.0` branch. It is the v0.23.0 counterpart of the fix proposed for main in #13779.

In graph mode, padded request slots can keep fixed query positions while their global `seq_lens` values are zero. If one of these padded slots crosses a rank-local token boundary, the previous `seq_lens - offset` calculation can produce a negative `actual_seq_lengths_key` and pass invalid metadata to sparse attention.

This PR:

- requires both a non-empty rank-local request slice and a positive global sequence length;
- clamps candidate rank-local key sequence lengths to zero;
- adds a regression test for the TP=8, graph-size=80, MTP3-style rank-6 boundary case where the old calculation produced `-2`.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes.

It prevents invalid negative SFA key sequence metadata for affected DSA-CP graph-padding layouts on v0.23.0.

### How was this patch tested?

Added `test_dsa_cp_metadata_builder_masks_graph_padding` in `tests/ut/attention/a2/test_sfa_v1.py`. The test reproduces the TP=8, graph-size=80, rank-6 boundary case and verifies the padded local key sequence length is zero and all generated key sequence lengths are non-negative.

Local checks completed:

- `git diff --check`
- Ruff lint and format checks for both changed Python files
- codespell for both changed Python files
- Python AST syntax parsing for both changed Python files

The `torch/torch_npu` unit test was not executed on the local PC because this repository requires NPU-dependent tests to run in an Ascend container. Run:

```bash
pytest -sv tests/ut/attention/a2/test_sfa_v1.py::TestAscendSFAMetadataBuilder::test_dsa_cp_metadata_builder_masks_graph_padding
```

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
