### PR TITLE
[BugFix][Worker] Preserve async accepted-token snapshot

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -20,6 +20,57 @@ from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
+class TestNPUModelRunnerAcceptedTokens(unittest.TestCase):
+    @patch("vllm_ascend.worker.model_runner_v1.mamba_utils.postprocess_mamba_align_gpu")
+    def test_postprocess_writes_accepted_counts_to_independent_snapshot(self, mock_postprocess):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.speculative_config = object()
+        runner.model_config = SimpleNamespace(is_hybrid=True)
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+        runner.num_accepted_tokens = SimpleNamespace(
+            cpu=torch.zeros(2, dtype=torch.int32),
+            gpu=torch.zeros(2, dtype=torch.int32),
+        )
+        persistent_counts = torch.ones(2, dtype=torch.int32)
+        runner.input_batch = SimpleNamespace(num_accepted_tokens_cpu_tensor=persistent_counts)
+        runner.kv_cache_config = object()
+        runner.compilation_config = SimpleNamespace(static_forward_context={})
+        runner.model = SimpleNamespace(get_mamba_state_copy_func=lambda: ())
+        runner.num_accepted_tokens_event = MagicMock()
+        runner._get_mamba_bufs = MagicMock()
+
+        runner._update_states_after_model_execute(
+            torch.tensor([[10, 11, -1], [20, -1, -1]]),
+            MagicMock(),
+        )
+
+        self.assertIs(
+            mock_postprocess.call_args.kwargs["num_accepted_tokens_cpu_tensor"],
+            runner.num_accepted_tokens.cpu,
+        )
+        self.assertIsNot(
+            mock_postprocess.call_args.kwargs["num_accepted_tokens_cpu_tensor"],
+            persistent_counts,
+        )
+        runner.num_accepted_tokens_event.record.assert_called_once_with()
+
+    def test_remap_uses_snapshot_after_persistent_row_is_overwritten(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        previous_counts = np.ones(16, dtype=np.int32)
+        previous_counts[4] = 3
+        previous_counts[11] = 4
+        persistent_counts = np.ones(16, dtype=np.int32)
+
+        runner.num_accepted_tokens = SimpleNamespace(np=previous_counts)
+        runner.prev_positions = SimpleNamespace(np=np.array([11, -1, 4] + [-1] * 13, dtype=np.int64))
+        runner.input_batch = SimpleNamespace(num_accepted_tokens_cpu=persistent_counts)
+
+        runner._remap_num_accepted_tokens(num_reqs=3)
+
+        np.testing.assert_array_equal(previous_counts[:3], [4, 1, 3])
+        np.testing.assert_array_equal(persistent_counts[:3], [4, 1, 3])
+
+
 class TestNPUModelRunnerKVCache(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -24,6 +24,7 @@ class TestNPUModelRunnerAcceptedTokens(unittest.TestCase):
     @patch("vllm_ascend.worker.model_runner_v1.mamba_utils.postprocess_mamba_align_gpu")
     def test_postprocess_writes_accepted_counts_to_independent_snapshot(self, mock_postprocess):
         runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.use_async_scheduling = True
         runner.speculative_config = object()
         runner.model_config = SimpleNamespace(is_hybrid=True)
         runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
@@ -54,6 +55,20 @@ class TestNPUModelRunnerAcceptedTokens(unittest.TestCase):
         )
         runner.num_accepted_tokens_event.record.assert_called_once_with()
 
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.GPUModelRunner._update_states_after_model_execute",
+        autospec=True,
+    )
+    def test_non_async_postprocess_delegates_to_upstream(self, mock_postprocess):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.use_async_scheduling = False
+        output_token_ids = torch.tensor([[10, -1]])
+        scheduler_output = MagicMock()
+
+        runner._update_states_after_model_execute(output_token_ids, scheduler_output)
+
+        mock_postprocess.assert_called_once_with(runner, output_token_ids, scheduler_output)
+
     def test_remap_uses_snapshot_after_persistent_row_is_overwritten(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         previous_counts = np.ones(16, dtype=np.int32)
@@ -64,11 +79,38 @@ class TestNPUModelRunnerAcceptedTokens(unittest.TestCase):
         runner.num_accepted_tokens = SimpleNamespace(np=previous_counts)
         runner.prev_positions = SimpleNamespace(np=np.array([11, -1, 4] + [-1] * 13, dtype=np.int64))
         runner.input_batch = SimpleNamespace(num_accepted_tokens_cpu=persistent_counts)
+        runner.use_async_scheduling = True
 
-        runner._remap_num_accepted_tokens(num_reqs=3)
+        runner._sync_num_accepted_tokens(num_reqs=3, has_prev_mapping=True)
 
         np.testing.assert_array_equal(previous_counts[:3], [4, 1, 3])
         np.testing.assert_array_equal(persistent_counts[:3], [4, 1, 3])
+
+    def test_async_without_previous_mapping_initializes_current_rows(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        snapshot = np.array([0, 4, 3, 9], dtype=np.int32)
+        persistent_counts = np.array([7, 8, 6, 5], dtype=np.int32)
+        runner.num_accepted_tokens = SimpleNamespace(np=snapshot)
+        runner.input_batch = SimpleNamespace(num_accepted_tokens_cpu=persistent_counts)
+        runner.use_async_scheduling = True
+
+        runner._sync_num_accepted_tokens(num_reqs=3, has_prev_mapping=False)
+
+        np.testing.assert_array_equal(snapshot, [1, 1, 1, 9])
+        np.testing.assert_array_equal(persistent_counts, [1, 1, 1, 5])
+
+    def test_non_async_sync_uses_condensed_input_batch_rows(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        snapshot = np.array([4, 2, 9], dtype=np.int32)
+        persistent_counts = np.array([2, 1, 7], dtype=np.int32)
+        runner.num_accepted_tokens = SimpleNamespace(np=snapshot)
+        runner.input_batch = SimpleNamespace(num_accepted_tokens_cpu=persistent_counts)
+        runner.use_async_scheduling = False
+
+        runner._sync_num_accepted_tokens(num_reqs=2, has_prev_mapping=False)
+
+        np.testing.assert_array_equal(snapshot, [2, 1, 9])
+        np.testing.assert_array_equal(persistent_counts, [2, 1, 7])
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -805,6 +805,11 @@ class NPUModelRunner(GPUModelRunner):
         self, output_token_ids: torch.Tensor, scheduler_output: "SchedulerOutput"
     ) -> None:
         """Update cached hybrid-model states after model execution."""
+        if not self.use_async_scheduling:
+            return super()._update_states_after_model_execute(
+                output_token_ids, scheduler_output
+            )
+
         if not self.speculative_config or not self.model_config.is_hybrid:
             return
 
@@ -847,6 +852,21 @@ class NPUModelRunner(GPUModelRunner):
         accepted[:num_reqs] = accepted[np.where(new_mask, 0, prev_idx)]
         accepted[:num_reqs][new_mask] = 1
         self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted[:num_reqs]
+
+    def _sync_num_accepted_tokens(
+        self, num_reqs: int, has_prev_mapping: bool
+    ) -> None:
+        """Sync accepted counts while preserving their scheduling-mode owner."""
+        if self.use_async_scheduling:
+            if has_prev_mapping:
+                self._remap_num_accepted_tokens(num_reqs)
+            else:
+                self.num_accepted_tokens.np[:num_reqs].fill(1)
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs].fill(1)
+        else:
+            self.num_accepted_tokens.np[:num_reqs] = (
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+            )
 
     def _pad_query_start_loc_for_fia(
         self,
@@ -1119,14 +1139,9 @@ class NPUModelRunner(GPUModelRunner):
         # _update_states_after_model_execute for hybrid models).
         if self.num_accepted_tokens_event is not None:
             self.num_accepted_tokens_event.synchronize()
-            # Async mode: condense() reordered indices, use prev_positions mapping
-            if self.use_async_scheduling and prev_req_id_to_index:
-                self._remap_num_accepted_tokens(num_reqs)
-            else:
-                # Non-async mode: use values directly
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
-                    self.num_accepted_tokens.np[:num_reqs]
-                )
+            self._sync_num_accepted_tokens(
+                num_reqs, has_prev_mapping=bool(prev_req_id_to_index)
+            )
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
         else:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -801,6 +801,53 @@ class NPUModelRunner(GPUModelRunner):
         self._apply_pp_sampled_tokens_from_scheduler_output(scheduler_output)
         return super()._update_states(scheduler_output)
 
+    def _update_states_after_model_execute(
+        self, output_token_ids: torch.Tensor, scheduler_output: "SchedulerOutput"
+    ) -> None:
+        """Update cached hybrid-model states after model execution."""
+        if not self.speculative_config or not self.model_config.is_hybrid:
+            return
+
+        num_reqs = output_token_ids.size(0)
+        self.num_accepted_tokens.gpu[:num_reqs] = (output_token_ids != -1).sum(dim=1)
+
+        if self.cache_config.mamba_cache_mode == "align":
+            mamba_utils.postprocess_mamba_align_gpu(
+                bufs=self._get_mamba_bufs(),
+                num_reqs=num_reqs,
+                num_accepted_tokens_gpu=self.num_accepted_tokens.gpu,
+                num_accepted_tokens_cpu_tensor=self.num_accepted_tokens.cpu,
+                input_batch=self.input_batch,
+                kv_cache_config=self.kv_cache_config,
+                forward_context=self.compilation_config.static_forward_context,
+                mamba_state_copy_funcs=self.model.get_mamba_state_copy_func(),
+            )
+        else:
+            self.num_accepted_tokens.copy_to_cpu(num_reqs)
+
+            if self.cache_config.mamba_cache_mode == "all":
+                mamba_utils.postprocess_mamba_all(
+                    scheduler_output,
+                    self.kv_cache_config,
+                    self.input_batch,
+                    self.requests,
+                    self.mamba_state_idx,
+                    self.num_spec_tokens,
+                    num_reqs,
+                )
+
+        assert self.num_accepted_tokens_event is not None
+        self.num_accepted_tokens_event.record()
+
+    def _remap_num_accepted_tokens(self, num_reqs: int) -> None:
+        """Map the previous iteration's accepted counts to current rows."""
+        prev_idx = self.prev_positions.np[:num_reqs]
+        new_mask = prev_idx < 0
+        accepted = self.num_accepted_tokens.np
+        accepted[:num_reqs] = accepted[np.where(new_mask, 0, prev_idx)]
+        accepted[:num_reqs][new_mask] = 1
+        self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted[:num_reqs]
+
     def _pad_query_start_loc_for_fia(
         self,
         query_start_loc: torch.Tensor,
@@ -1074,21 +1121,11 @@ class NPUModelRunner(GPUModelRunner):
             self.num_accepted_tokens_event.synchronize()
             # Async mode: condense() reordered indices, use prev_positions mapping
             if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[
-                        np.where(new_mask, 0, prev_idx)
-                    ]
-                )
-                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
-                    self.num_accepted_tokens.np[:num_reqs]
-                )
+                self._remap_num_accepted_tokens(num_reqs)
             else:
                 # Non-async mode: use values directly
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
+                    self.num_accepted_tokens.np[:num_reqs]
                 )
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
@@ -1970,10 +2007,8 @@ class NPUModelRunner(GPUModelRunner):
 
                 pad_attn = cudagraph_mode == CUDAGraphMode.FULL
 
-                # NOTE(Angazenn): According to https://github.com/vllm-project/vllm/pull/30877,
-                # there should be a corresponding 'postprocess_mamba'. However, it is called inside
-                # '_update_states_after_model_execute', which is not overridden in vLLM-Ascend.
-                # We simply utilize the implementation in vLLM.
+                # postprocess_mamba runs later in
+                # _update_states_after_model_execute.
                 if self.cache_config.mamba_cache_mode == "align":
                     # preprocess_mamba reads req_state.num_computed_tokens (CPU)
                     # to decide copy operations, so we must apply deferred


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #13863.

Async scheduling can condense and reuse `InputBatch` rows before the next model iteration remaps accepted-token counts through `prev_positions`. Because the previous counts are currently stored in those mutable rows, a new request can overwrite a previous value (for example, replacing `4` with `1`). The wrong count changes the Mamba/GDN state-copy offset and can produce repeated, dropped, or garbled tokens under MTP load.

This is separate from #12255, which fixed decode-graph dispatch for shape-ambiguous prefill rows. Applying that fix reduced the failure rate but did not prevent this state-mapping failure.

This PR:

- writes async postprocessed accepted-token counts to the runner's independent CPU/GPU buffer while preserving upstream `InputBatch` ownership for non-async scheduling;
- remaps that previous-iteration snapshot when a previous-row mapping exists and initializes all-new async rows to `1`;
- adds regression coverage for the postprocess destination, a reused high batch row, an all-new async batch, and a moved non-async survivor.

### Does this PR introduce _any_ user-facing change?

Yes. Hybrid models using async scheduling with speculative decoding no longer reuse overwritten accepted-token counts after batch condensation.

### How was this patch tested?

- `PYTHONPATH=<vLLM v0.26.0 worktree> pytest -q tests/ut/worker/a2/test_model_runner_v1.py` (`25 passed`)
- `ruff check vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py`
- `ruff format --check vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py`
- `python -m compileall -q vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py`
- `git diff --check`
- The same snapshot/remap algorithm was validated with real Qwen3.6-35B-A3B-W8A8 weights on Ascend A3 TP2. With async scheduling, MTP3, prefix caching, 16 concurrent 32k/2k background requests, and 512 deterministic 8.2k foreground probes, all 512 requests returned HTTP 200 with one output hash and zero corrupt outputs at 98.82% peak KV-cache usage.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
