### PR TITLE
[BugFix][P/D] Return KV params when P stops on EOS

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
@@ -277,6 +277,24 @@ class TestMooncakeHybridConnectorScheduler(unittest.TestCase):
         self.assertEqual(params["num_prompt_blocks"], 2)
         self.assertIn("req1", scheduler._reqs_need_send)
 
+    def test_request_finished_accepts_stopped_prefill_request(self):
+        scheduler = self._make_scheduler()
+        request = MockRequest(
+            "req1",
+            prompt_token_ids=list(range(129)),
+            kv_transfer_params={"do_remote_decode": True},
+            status=RequestStatus.FINISHED_STOPPED,
+        )
+        block_ids = (list(range(10)), [100, 101, 102, 103])
+
+        delay_free, params = scheduler.request_finished_all_groups(request, block_ids)
+
+        self.assertTrue(delay_free)
+        self.assertIsNotNone(params)
+        self.assertEqual(params["remote_block_ids"], ([0], [100, 101]))
+        self.assertEqual(params["num_prompt_blocks"], 2)
+        self.assertIn("req1", scheduler._reqs_need_send)
+
     def test_request_finished_uses_num_prompt_tokens(self):
         scheduler = self._make_scheduler()
         request = MockRequest(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1461,7 +1461,11 @@ class MooncakeConnectorScheduler:
         if (
             params is None
             or not params.get("do_remote_decode")
-            or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
+            or request.status
+            not in (
+                RequestStatus.FINISHED_LENGTH_CAPPED,
+                RequestStatus.FINISHED_STOPPED,
+            )
         ):
             return False, None
 


### PR DESCRIPTION
### What this PR does / why we need it?

For the synthetic P-side one-token request used by PD deployment, an EOS token can cause vLLM to mark the request as `FINISHED_STOPPED`. MooncakeHybridConnector previously generated KV transfer parameters only for `FINISHED_LENGTH_CAPPED`, so the PD proxy could receive null `kv_transfer_params`.

This change accepts `FINISHED_STOPPED` as a valid completion status and adds a regression unit test.

### Does this PR introduce _any_ user-facing change?

Yes. This fixes KV transfer parameter generation for MooncakeHybridConnector in P/D deployment. No API changes are introduced.

### How was this patch tested?

- `python -m py_compile vllm_ascend\\distributed\\kv_transfer\\kv_p2p\\mooncake_hybrid_connector.py tests\\ut\\kv_offload\\test_mooncake_hybrid_connector.py`
- `git diff --check`
- The targeted pytest could not be collected in this environment because `torch` is not installed.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
