### PR TITLE
[CI] Add Qwen3-32B W8A8 V1/V2 model runner migration guards

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -237,6 +237,20 @@ a3:
       - name: Qwen3-30B-QuaRot
         os: linux-aarch64-nightly-a3-2
         config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
+      # Qwen3-32B W8A8 exit-scenario guards: nightly reuses four_card pytest (V1 vs V2 direct compare)
+      - name: qwen3-32b-w8a8-lc-perf
+        os: linux-aarch64-nightly-a3-4
+        tests: tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
+      - name: qwen3-32b-w8a8-ll-perf
+        os: linux-aarch64-nightly-a3-4
+        tests: tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
+      - name: qwen3-32b-w8a8-aime2024-acc
+        os: linux-aarch64-nightly-a3-4
+        tests: tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
+      - name: qwen3-32b-w8a8-gpqa-acc
+        os: linux-aarch64-nightly-a3-4
+        tests: tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
+        testcase_timeout: 240
 
 a3-560t:
   multi_node:

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -329,6 +329,7 @@ jobs:
       tests: ${{ matrix.test_config.tests }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
       name: ${{ matrix.test_config.name }}
+      testcase_timeout: ${{ matrix.test_config.testcase_timeout || 120 }}
       should_run: >-
         ${{
           needs.parse-trigger.outputs.run == 'true' && (

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -623,6 +623,21 @@
     - tests/e2e/pull_request/four_card/model_runner_v2
     - tests/e2e/pull_request/four_card/test_qwen3_mrv2_eplb.py
 
+# Qwen3-32B W8A8 V1/V2 migration guards (LC/LL perf + AIME/GPQA acc).
+# TEMP gating: dependency-triggered proxy for the [MRV2] PR-title gate that the
+# CI engineering team will implement. Until then these run only when the
+# model-runner-V2 stack changes, not on every PR.
+- name: qwen3_32b_w8a8_v2_migration
+  optional: true
+  source_file_dependencies:
+    - vllm_ascend/worker/worker.py
+    - vllm_ascend/worker/v2
+  tests:
+    - tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
+    - tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
+    - tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
+    - tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
+
 # XLite
 - name: xlite
   optional: false
@@ -847,6 +862,10 @@ estimated_times:
   tests/e2e/pull_request/four_card/test_qwen3_next.py: 1540
   tests/e2e/pull_request/four_card/test_graph_mode.py: 510
   tests/e2e/pull_request/four_card/test_qwen3_mrv2_eplb.py: 420
+  tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py: 3000
+  tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py: 7200
+  tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py: 1800
+  tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py: 1200
   tests/e2e/pull_request/two_card/test_gemma4.py: 310
   tests/e2e/pull_request/eight_card/test_minimax_m3.py: 670
   tests/ut/attention/a2/test_attention_cp.py: 30

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
@@ -37,7 +37,7 @@ import os
 
 from vllm.utils.network_utils import get_open_port
 
-from tests.e2e.conftest import RemoteOpenAIServer
+from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
 MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
@@ -89,6 +89,9 @@ _SERVER_ARGS = [
 ]
 
 
+# Wait for the NPU driver to reclaim memory after the previous server exits,
+# so the next V1/V2 server does not OOM on a busy device.
+@wait_until_npu_memory_free()
 def _run_aime2024_accuracy(env):
     port = get_open_port()
     with RemoteOpenAIServer(

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
@@ -67,7 +67,7 @@ _COMMON_ENV = {
 }
 
 _V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
-_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1"}
 
 _SERVER_ARGS = [
     "--trust-remote-code",

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
@@ -40,7 +40,7 @@ from vllm.utils.network_utils import get_open_port
 from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
-MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+MODEL = os.environ.get("QWEN3_32B_W8A8_MODEL_PATH", "vllm-ascend/Qwen3-32B-W8A8")
 
 # AIME2024: 30 questions, 1 question == 100/30 == 3.33pp.
 MAX_ACCURACY_DELTA_PP = 3.33

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_aime2024_accuracy.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""PR accuracy guard for the Qwen3-32B W8A8 exit scenario (AIME2024).
+
+The same AIME2024 accuracy benchmark is run once with the V1 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=0``) and once with the V2 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=1``); the absolute V2-V1 accuracy difference must
+stay within 1 question. AIME2024 has 30 questions, so 1 question == 3.33pp.
+
+Scenario (2026-08-09 revision, eagle3 excluded until its accuracy fix lands
+upstream):
+  TP4 + async-scheduling + FULL_DECODE_ONLY + quantization (W8A8),
+  max-model-len=36864, max_out_len=32768, batch_size=64, temperature=0.6,
+  top_k=20, top_p=0.95.
+
+Measured V1 mean accuracy (3 rounds, with eagle3): 83.33%; re-measure without
+eagle3 on NPU before finalizing. Any change to the scenario parameters or
+tolerances must be approved by the team.
+"""
+
+import os
+
+from vllm.utils.network_utils import get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+from tools.aisbench import run_aisbench_cases
+
+MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+
+# AIME2024: 30 questions, 1 question == 100/30 == 3.33pp.
+MAX_ACCURACY_DELTA_PP = 3.33
+
+_BENCH_CASE = {
+    "case_type": "accuracy",
+    "dataset_path": "vllm-ascend/aime2024",
+    "request_conf": "vllm_api_general_chat",
+    "dataset_conf": "aime2024_gen_0_shot_chat_prompt",
+    "num_prompts": 30,
+    "max_out_len": 32768,
+    "batch_size": 64,
+    "top_k": 20,
+    "top_p": 0.95,
+    "baseline": 100,
+    "threshold": 100,
+}
+
+_COMMON_ENV = {
+    "ASCEND_RT_VISIBLE_DEVICES": "0,1,2,3",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "TASK_QUEUE_ENABLE": "1",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+}
+
+_V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+
+_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--max-model-len",
+    "36864",
+    "--max-num-batched-tokens",
+    "40960",
+    "--tensor-parallel-size",
+    "4",
+    "--distributed-executor-backend",
+    "mp",
+    "--async-scheduling",
+    "--quantization",
+    "ascend",
+    "--compilation-config",
+    '{"cudagraph_mode": "FULL_DECODE_ONLY"}',
+    "--gpu-memory-utilization",
+    "0.9",
+]
+
+
+def _run_aime2024_accuracy(env):
+    port = get_open_port()
+    with RemoteOpenAIServer(
+        MODEL, _SERVER_ARGS + ["--port", str(port)], server_port=port, env_dict=env, auto_port=False
+    ):
+        results = run_aisbench_cases(MODEL, port, [_BENCH_CASE])
+    accuracy = float(results[0])
+    print(f"[AIME2024 acc] accuracy: {accuracy}%")
+    return accuracy
+
+
+def test_qwen3_32b_w8a8_aime2024_v1_v2_accuracy_within_1_question():
+    v1_accuracy = _run_aime2024_accuracy(_V1_ENV)
+    v2_accuracy = _run_aime2024_accuracy(_V2_ENV)
+    delta = abs(v2_accuracy - v1_accuracy)
+    print(f"[AIME2024 acc] V1={v1_accuracy:.2f}% V2={v2_accuracy:.2f}% delta={delta:.2f}pp")
+    assert delta <= MAX_ACCURACY_DELTA_PP, (
+        f"AIME2024 accuracy regression: |V2-V1|={delta:.2f}pp exceeds the "
+        f"{MAX_ACCURACY_DELTA_PP}pp (1-question) limit "
+        f"(V1={v1_accuracy:.2f}%, V2={v2_accuracy:.2f}%)."
+    )

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
@@ -43,7 +43,7 @@ from vllm.utils.network_utils import get_open_port
 from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
-MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+MODEL = os.environ.get("QWEN3_32B_W8A8_MODEL_PATH", "vllm-ascend/Qwen3-32B-W8A8")
 
 # GPQA diamond: 198 questions.
 # Team-confirmed per-run tolerance (2026-08-09): |V2-V1| <= 3.00pp (about

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
@@ -73,7 +73,7 @@ _COMMON_ENV = {
 }
 
 _V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
-_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1"}
 
 _SERVER_ARGS = [
     "--trust-remote-code",

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
@@ -1,0 +1,118 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""PR accuracy guard for the Qwen3-32B W8A8 exit scenario (GPQA diamond).
+
+The same GPQA accuracy benchmark is run once with the V1 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=0``) and once with the V2 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=1``); the absolute V2-V1 accuracy difference must
+stay within the configured tolerance. GPQA diamond has 198 questions.
+
+Scenario (2026-08-09 revision, eagle3 excluded until its accuracy fix lands
+upstream):
+  TP4 + async-scheduling + FULL_DECODE_ONLY + quantization (W8A8),
+  max-model-len=36864, max_out_len=32768, batch_size=64, temperature=0.6,
+  top_k=20, top_p=0.95.
+
+Tolerance note: the per-run |V2-V1| gate is 3.00pp. A no-eagle3 V1/V2 GPQA
+experiment (2026-08-07, 3 rounds per runner) measured single-round
+|V2-V1| = 0.00 / 1.01 / 2.52 pp and a mean difference of +0.51 pp, so the
+3.00pp per-run gate absorbs the natural sampling fluctuation (temperature=0.6)
+without flaking. Tighten or loosen ``MAX_ACCURACY_DELTA_PP`` only with team
+approval.
+"""
+
+import os
+
+from vllm.utils.network_utils import get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+from tools.aisbench import run_aisbench_cases
+
+MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+
+# GPQA diamond: 198 questions.
+# Team-confirmed per-run tolerance (2026-08-09): |V2-V1| <= 3.00pp (about
+# 6 questions). It is loose enough for the natural sampling fluctuation seen
+# in the 2026-08-07 no-eagle3 experiment (max single-round |V2-V1| = 2.52pp).
+MAX_ACCURACY_DELTA_PP = 3.0
+
+_BENCH_CASE = {
+    "case_type": "accuracy",
+    "dataset_path": "vllm-ascend/gpqa",
+    "request_conf": "vllm_api_general_chat",
+    "dataset_conf": "gpqa_gen_0_shot_str",
+    "num_prompts": 198,
+    "max_out_len": 32768,
+    "batch_size": 64,
+    "top_k": 20,
+    "top_p": 0.95,
+    "baseline": 100,
+    "threshold": 100,
+}
+
+_COMMON_ENV = {
+    "ASCEND_RT_VISIBLE_DEVICES": "0,1,2,3",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "TASK_QUEUE_ENABLE": "1",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+}
+
+_V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+
+_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--max-model-len",
+    "36864",
+    "--max-num-batched-tokens",
+    "40960",
+    "--tensor-parallel-size",
+    "4",
+    "--distributed-executor-backend",
+    "mp",
+    "--async-scheduling",
+    "--quantization",
+    "ascend",
+    "--compilation-config",
+    '{"cudagraph_mode": "FULL_DECODE_ONLY"}',
+    "--gpu-memory-utilization",
+    "0.9",
+]
+
+
+def _run_gpqa_accuracy(env):
+    port = get_open_port()
+    with RemoteOpenAIServer(
+        MODEL, _SERVER_ARGS + ["--port", str(port)], server_port=port, env_dict=env, auto_port=False
+    ):
+        results = run_aisbench_cases(MODEL, port, [_BENCH_CASE])
+    accuracy = float(results[0])
+    print(f"[GPQA acc] accuracy: {accuracy}%")
+    return accuracy
+
+
+def test_qwen3_32b_w8a8_gpqa_v1_v2_accuracy_within_tolerance():
+    v1_accuracy = _run_gpqa_accuracy(_V1_ENV)
+    v2_accuracy = _run_gpqa_accuracy(_V2_ENV)
+    delta = abs(v2_accuracy - v1_accuracy)
+    print(f"[GPQA acc] V1={v1_accuracy:.2f}% V2={v2_accuracy:.2f}% delta={delta:.2f}pp")
+    assert delta <= MAX_ACCURACY_DELTA_PP, (
+        f"GPQA accuracy regression: |V2-V1|={delta:.2f}pp exceeds the "
+        f"{MAX_ACCURACY_DELTA_PP}pp limit "
+        f"(V1={v1_accuracy:.2f}%, V2={v2_accuracy:.2f}%)."
+    )

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_gpqa_accuracy.py
@@ -40,7 +40,7 @@ import os
 
 from vllm.utils.network_utils import get_open_port
 
-from tests.e2e.conftest import RemoteOpenAIServer
+from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
 MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
@@ -95,6 +95,9 @@ _SERVER_ARGS = [
 ]
 
 
+# Wait for the NPU driver to reclaim memory after the previous server exits,
+# so the next V1/V2 server does not OOM on a busy device.
+@wait_until_npu_memory_free()
 def _run_gpqa_accuracy(env):
     port = get_open_port()
     with RemoteOpenAIServer(

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
@@ -43,13 +43,11 @@ from vllm.utils.network_utils import get_open_port
 from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
-MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+MODEL = os.environ.get("QWEN3_32B_W8A8_MODEL_PATH", "vllm-ascend/Qwen3-32B-W8A8")
 
-# The 128k-in / 1k-out dataset repeats 90% of its prefix so prefix caching is
-# exercised; it is self-constructed by the team and this is a mock placeholder
-# id. Publish the dataset under this id on ModelScope (or switch to a local
-# path via `dataset_path_local`) before enabling the guard.
-DATASET_PATH = "vllm-ascend/GSM8K-in131072-prefix90-bs16"
+# The 128k-in dataset repeats 90% of its prefix so prefix caching is exercised.
+# Published dataset, already used by existing weekly guards.
+DATASET_PATH = "vllm-ascend/GSM8K_prefix90_in131072_bs100_qwen"
 
 # V2/V1 Total Token Throughput ratio must stay within +-3%.
 THROUGHPUT_RATIO_LOWER = 0.97

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
@@ -1,0 +1,133 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""PR performance guard for the Qwen3-32B W8A8 long-context exit scenario.
+
+Long-context high-throughput (LC): 128k input / 1k output.
+
+The same benchmark is run once with the V1 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=0``) and once with the V2 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=1``); the V2 Total Token Throughput must stay
+within +-3% of V1, so stacking/regression issues are exposed at PR time.
+
+Scenario (2026-08-09 revision):
+  TP4 + YaRN + prefix caching (90% shared prefix) + FULL_DECODE_ONLY +
+  quantization (W8A8), max-model-len=135000, num_prompts=16,
+  max_out_len=1024, batch_size (concurrency)=4.
+
+Scenario revised 2026-08-09: eagle3 is excluded until its accuracy/perf fix
+lands upstream, and prefix caching is stacked in (the dataset repeats 90% of
+its prefix). V1/V2 baselines for this scenario are to be re-measured on NPU
+before finalizing the guard. Any change to the scenario parameters or
+tolerances must be approved by the team.
+"""
+
+import os
+
+from vllm.utils.network_utils import get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+from tools.aisbench import run_aisbench_cases
+
+MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+
+# The 128k-in / 1k-out dataset repeats 90% of its prefix so prefix caching is
+# exercised; it is self-constructed by the team and this is a mock placeholder
+# id. Publish the dataset under this id on ModelScope (or switch to a local
+# path via `dataset_path_local`) before enabling the guard.
+DATASET_PATH = "vllm-ascend/GSM8K-in131072-prefix90-bs16"
+
+# V2/V1 Total Token Throughput ratio must stay within +-3%.
+THROUGHPUT_RATIO_LOWER = 0.97
+THROUGHPUT_RATIO_UPPER = 1.03
+
+_BENCH_CASE = {
+    "case_type": "performance",
+    "dataset_path": DATASET_PATH,
+    "request_conf": "vllm_api_stream_chat",
+    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_str_perf",
+    "num_prompts": 16,
+    "max_out_len": 1024,
+    "batch_size": 4,
+    "request_rate": 0,
+    # Disable the built-in absolute-baseline gate; the V1 vs V2 comparison is
+    # done below in this test.
+    "baseline": 1,
+    "threshold": 0,
+}
+
+_COMMON_ENV = {
+    "ASCEND_RT_VISIBLE_DEVICES": "0,1,2,3",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "TASK_QUEUE_ENABLE": "1",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+}
+
+_V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+
+_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--seed",
+    "1024",
+    "--max-model-len",
+    "135000",
+    "--max-num-batched-tokens",
+    "40960",
+    "--tensor-parallel-size",
+    "4",
+    "--distributed-executor-backend",
+    "mp",
+    "--enable-prefix-caching",
+    "--async-scheduling",
+    "--compilation-config",
+    '{"cudagraph_mode": "FULL_DECODE_ONLY"}',
+    "--hf-overrides",
+    (
+        '{"rope_parameters": {"rope_type": "yarn", "rope_theta": 1000000, '
+        '"factor": 4, "original_max_position_embeddings": 131072}}'
+    ),
+    "--gpu-memory-utilization",
+    "0.9",
+    "--quantization",
+    "ascend",
+]
+
+
+def _run_lc_benchmark(env):
+    port = get_open_port()
+    with RemoteOpenAIServer(
+        MODEL, _SERVER_ARGS + ["--port", str(port)], server_port=port, env_dict=env, auto_port=False
+    ):
+        results = run_aisbench_cases(MODEL, port, [_BENCH_CASE])
+    result_json = results[0][1]
+    throughput = float(result_json["Total Token Throughput"]["total"].replace("token/s", "").strip())
+    print(f"[LC perf] Total Token Throughput: {throughput} token/s")
+    return throughput
+
+
+def test_qwen3_32b_w8a8_lc_128k_v1_v2_throughput_within_3pct():
+    v1_throughput = _run_lc_benchmark(_V1_ENV)
+    v2_throughput = _run_lc_benchmark(_V2_ENV)
+    ratio = v2_throughput / v1_throughput
+    print(f"[LC perf] V1={v1_throughput:.2f} V2={v2_throughput:.2f} ratio={ratio:.4f}")
+    assert THROUGHPUT_RATIO_LOWER <= ratio <= THROUGHPUT_RATIO_UPPER, (
+        f"LC 128k/1k performance regression: V2/V1 Total Token Throughput ratio "
+        f"{ratio:.4f} (V1={v1_throughput:.2f}, V2={v2_throughput:.2f}) is outside "
+        f"[{THROUGHPUT_RATIO_LOWER}, {THROUGHPUT_RATIO_UPPER}]."
+    )

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
@@ -40,7 +40,7 @@ import os
 
 from vllm.utils.network_utils import get_open_port
 
-from tests.e2e.conftest import RemoteOpenAIServer
+from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
 MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
@@ -109,6 +109,9 @@ _SERVER_ARGS = [
 ]
 
 
+# Wait for the NPU driver to reclaim memory after the previous server exits,
+# so the next V1/V2 server does not OOM on a busy device.
+@wait_until_npu_memory_free()
 def _run_lc_benchmark(env):
     port = get_open_port()
     with RemoteOpenAIServer(

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_lc_performance.py
@@ -77,7 +77,7 @@ _COMMON_ENV = {
 }
 
 _V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
-_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1"}
 
 _SERVER_ARGS = [
     "--trust-remote-code",

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
@@ -27,8 +27,9 @@ vs V1. Being faster is allowed: the 2026-08-06 measurement showed V2 TTFT is
 
 Scenario (2026-08-09 revision, eagle3 excluded until its accuracy/perf fix
 lands upstream):
-  TP2 x DP2 + FULL_DECODE_ONLY + quantization (W8A8), max-model-len=18000,
-  num_prompts=50, max_out_len=1024, batch_size (concurrency)=2.
+  TP2 x DP2 + async-scheduling + FULL_DECODE_ONLY + quantization (W8A8),
+  max-model-len=18000, num_prompts=50, max_out_len=1024,
+  batch_size (concurrency)=2.
   Prefix caching is not enabled in this low-latency scenario.
 
 The 2026-08-06 V1 baseline (TTFT 2454.5 ms / TPOT 12.2 ms at bs=2) was
@@ -44,9 +45,11 @@ from vllm.utils.network_utils import get_open_port
 from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
-MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+MODEL = os.environ.get("QWEN3_32B_W8A8_MODEL_PATH", "vllm-ascend/Qwen3-32B-W8A8")
 
-DATASET_PATH = "vllm-ascend/GSM8K-in16384-bs50"
+# 16k-in dataset with 0% shared prefix, matching the no-prefix-caching
+# low-latency scenario. Published dataset, already used by existing weekly guards.
+DATASET_PATH = "vllm-ascend/GSM8K_prefix0_in16384_bs200_qwen"
 
 # V2 latency (TTFT/TPOT) must be at most 3% worse than V1.
 LATENCY_REGRESSION_RATIO = 1.03
@@ -88,6 +91,7 @@ _SERVER_ARGS = [
     "0",
     "--distributed-executor-backend",
     "mp",
+    "--async-scheduling",
     "--no-enable-prefix-caching",
     "--compilation-config",
     '{"cudagraph_mode": "FULL_DECODE_ONLY"}',

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
@@ -75,7 +75,7 @@ _COMMON_ENV = {
 }
 
 _V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
-_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1"}
 
 _SERVER_ARGS = [
     "--trust-remote-code",

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
@@ -41,7 +41,7 @@ import os
 
 from vllm.utils.network_utils import get_open_port
 
-from tests.e2e.conftest import RemoteOpenAIServer
+from tests.e2e.conftest import RemoteOpenAIServer, wait_until_npu_memory_free
 from tools.aisbench import run_aisbench_cases
 
 MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
@@ -102,6 +102,9 @@ def _extract_latency_ms(result_csv, metric):
     return float(str(result_csv.loc[metric, "Average"]).replace("ms", "").strip())
 
 
+# Wait for the NPU driver to reclaim memory after the previous server exits,
+# so the next V1/V2 server does not OOM on a busy device.
+@wait_until_npu_memory_free()
 def _run_ll_benchmark(env):
     port = get_open_port()
     with RemoteOpenAIServer(

--- a/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
+++ b/tests/e2e/pull_request/four_card/test_qwen3_32b_w8a8_ll_performance.py
@@ -1,0 +1,126 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""PR performance guard for the Qwen3-32B W8A8 short-context exit scenario.
+
+Short-context low-latency (LL): 16k input / 1k output.
+
+The same benchmark is run once with the V1 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=0``) and once with the V2 model runner
+(``VLLM_USE_V2_MODEL_RUNNER=1``); V2 TTFT/TPOT must not regress more than +3%
+vs V1. Being faster is allowed: the 2026-08-06 measurement showed V2 TTFT is
+~2.6% faster than V1 at bs=2, so a two-sided +-3% gate would be fragile.
+
+Scenario (2026-08-09 revision, eagle3 excluded until its accuracy/perf fix
+lands upstream):
+  TP2 x DP2 + FULL_DECODE_ONLY + quantization (W8A8), max-model-len=18000,
+  num_prompts=50, max_out_len=1024, batch_size (concurrency)=2.
+  Prefix caching is not enabled in this low-latency scenario.
+
+The 2026-08-06 V1 baseline (TTFT 2454.5 ms / TPOT 12.2 ms at bs=2) was
+measured with eagle3; re-measure without eagle3 on NPU before finalizing the
+guard. Any change to the scenario parameters or tolerances must be approved by
+the team.
+"""
+
+import os
+
+from vllm.utils.network_utils import get_open_port
+
+from tests.e2e.conftest import RemoteOpenAIServer
+from tools.aisbench import run_aisbench_cases
+
+MODEL = os.getenv("QWEN3_32B_PDMIX_PATH", "/mnt/a800_weight/qwen3-32b-pdmix")
+
+DATASET_PATH = "vllm-ascend/GSM8K-in16384-bs50"
+
+# V2 latency (TTFT/TPOT) must be at most 3% worse than V1.
+LATENCY_REGRESSION_RATIO = 1.03
+
+_BENCH_CASE = {
+    "case_type": "performance",
+    "dataset_path": DATASET_PATH,
+    "request_conf": "vllm_api_stream_chat",
+    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_str_perf",
+    "num_prompts": 50,
+    "max_out_len": 1024,
+    "batch_size": 2,
+    "request_rate": 0,
+    "baseline": 1,
+    "threshold": 0,
+}
+
+_COMMON_ENV = {
+    "ASCEND_RT_VISIBLE_DEVICES": "0,1,2,3",
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "TASK_QUEUE_ENABLE": "1",
+    "HCCL_OP_EXPANSION_MODE": "AIV",
+}
+
+_V1_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "0"}
+_V2_ENV = {**_COMMON_ENV, "VLLM_USE_V2_MODEL_RUNNER": "1", "VLLM_VERSION": "0.27.0"}
+
+_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--max-model-len",
+    "18000",
+    "--max-num-batched-tokens",
+    "40960",
+    "--tensor-parallel-size",
+    "2",
+    "--data-parallel-size",
+    "2",
+    "--data-parallel-start-rank",
+    "0",
+    "--distributed-executor-backend",
+    "mp",
+    "--no-enable-prefix-caching",
+    "--compilation-config",
+    '{"cudagraph_mode": "FULL_DECODE_ONLY"}',
+    "--gpu-memory-utilization",
+    "0.9",
+    "--quantization",
+    "ascend",
+]
+
+
+def _extract_latency_ms(result_csv, metric):
+    return float(str(result_csv.loc[metric, "Average"]).replace("ms", "").strip())
+
+
+def _run_ll_benchmark(env):
+    port = get_open_port()
+    with RemoteOpenAIServer(
+        MODEL, _SERVER_ARGS + ["--port", str(port)], server_port=port, env_dict=env, auto_port=False
+    ):
+        results = run_aisbench_cases(MODEL, port, [_BENCH_CASE])
+    result_csv = results[0][0]
+    ttft = _extract_latency_ms(result_csv, "TTFT")
+    tpot = _extract_latency_ms(result_csv, "TPOT")
+    print(f"[LL perf] TTFT={ttft} ms, TPOT={tpot} ms")
+    return ttft, tpot
+
+
+def test_qwen3_32b_w8a8_ll_16k_v1_v2_latency_within_3pct():
+    v1_ttft, v1_tpot = _run_ll_benchmark(_V1_ENV)
+    v2_ttft, v2_tpot = _run_ll_benchmark(_V2_ENV)
+    for metric, v1_value, v2_value in (("TTFT", v1_ttft, v2_ttft), ("TPOT", v1_tpot, v2_tpot)):
+        print(f"[LL perf] {metric}: V1={v1_value} ms, V2={v2_value} ms")
+        assert v2_value <= v1_value * LATENCY_REGRESSION_RATIO, (
+            f"LL 16k/1k latency regression: V2 {metric} {v2_value} ms exceeds "
+            f"V1 {v1_value} ms * {LATENCY_REGRESSION_RATIO}."
+        )


### PR DESCRIPTION
During the V1 -> V2 model runner migration, this PR adds four e2e guard tests that compare the V1 and V2 model runners in the same run for the Qwen3-32B W8A8 exit scenario, and wires them into PR CI and A3 nightly, so "no performance/accuracy regression" is enforced when features stack on top of the V2 runner.

- LC 128k/1k high-throughput: TP4 + YaRN + prefix caching (90% shared prefix) + FULL_DECODE_ONLY + W8A8; total-token throughput ratio V2/V1 within +-3%
- LL 16k/1k low-latency: TP2xDP2 + FULL_DECODE_ONLY + W8A8 (no prefix caching); TTFT/TPOT one-sided: V2 <= V1 x 1.03
- AIME2024 accuracy: 30 questions; |V2-V1| <= 3.33pp (1 question)
- GPQA accuracy: 198 questions; |V2-V1| <= 3.0pp (team-confirmed tolerance, covers observed sampling fluctuation up to 2.52pp)
- PR CI: new optional dependency-triggered group `qwen3_32b_w8a8_v2_migration` (runs only when the V2 runner stack changes; temporary proxy for the upcoming [MRV2] PR-title gate)
- Nightly: A3 multi-card entries for the four guards, GPQA with a 240-minute timeout

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
