### PR TITLE
[Refactor][Ops] Align routing replay capture with upstream

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -20,6 +20,7 @@ from vllm_ascend.ops.fused_moe.routed_experts import (
 )
 from vllm_ascend.ops.fused_moe.router import fused_topk_router as fused_topk_router_module
 from vllm_ascend.ops.fused_moe.router.fused_topk_router import AscendFusedTopKRouter
+from vllm_ascend.ops.fused_moe.router.grouped_topk_router import AscendGroupedTopKRouter
 from vllm_ascend.ops.fused_moe.shared_experts import AscendSharedExperts, FusedMoEEvents
 from vllm_ascend.quantization.quant_type import QuantType
 
@@ -389,6 +390,81 @@ def test_routed_experts_select_experts_validates_router_logits(monkeypatch):
     torch.testing.assert_close(result_weights, topk_weights.to(hidden_states.dtype))
     assert torch.equal(result_ids, topk_ids)
     assert routed_experts.router._select_experts.call_args.kwargs["input_ids"] is input_ids
+
+
+def _build_routing_replay_experts(router, log2phy):
+    routed_experts = AscendRoutedExperts.__new__(AscendRoutedExperts)
+    routed_experts.router = router
+    routed_experts.moe_config = SimpleNamespace(num_experts=4)
+    routed_experts.global_redundant_expert_num = 0
+    routed_experts.n_shared_experts = 0
+    routed_experts.log2phy = log2phy
+    return routed_experts
+
+
+def test_routing_replay_captures_logical_ids_before_ascend_mapping(monkeypatch):
+    router = AscendGroupedTopKRouter(
+        top_k=2,
+        global_num_experts=4,
+        num_expert_group=None,
+        topk_group=None,
+    )
+    capturer = MagicMock()
+    router.set_capture_fn(lambda topk_ids: capturer.capture(2, topk_ids))
+    log2phy = torch.tensor([10, 11, 12, 13], dtype=torch.int64)
+    routed_experts = _build_routing_replay_experts(router, log2phy)
+    monkeypatch.setattr(
+        routed_experts_module,
+        "get_moe_num_logical_experts",
+        lambda *args, **kwargs: 4,
+    )
+    hidden_states = torch.randn(2, 4)
+    router_logits = torch.tensor(
+        [[0.1, 0.9, 0.2, 0.8], [0.7, 0.2, 0.6, 0.1]],
+        dtype=torch.float32,
+    )
+
+    _, physical_ids = routed_experts._select_experts(
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+        enable_force_load_balance=False,
+    )
+
+    logical_ids = capturer.capture.call_args.args[1]
+    capturer.capture.assert_called_once()
+    torch.testing.assert_close(physical_ids, log2phy[logical_ids])
+    assert torch.all(logical_ids < log2phy.numel())
+
+
+def test_routing_replay_disabled_keeps_ascend_routing_unchanged(monkeypatch):
+    router = AscendGroupedTopKRouter(
+        top_k=2,
+        global_num_experts=4,
+        num_expert_group=None,
+        topk_group=None,
+    )
+    log2phy = torch.tensor([10, 11, 12, 13], dtype=torch.int64)
+    routed_experts = _build_routing_replay_experts(router, log2phy)
+    monkeypatch.setattr(
+        routed_experts_module,
+        "get_moe_num_logical_experts",
+        lambda *args, **kwargs: 4,
+    )
+    hidden_states = torch.randn(2, 4)
+    router_logits = torch.tensor(
+        [[0.1, 0.9, 0.2, 0.8], [0.7, 0.2, 0.6, 0.1]],
+        dtype=torch.float32,
+    )
+
+    _, physical_ids = routed_experts._select_experts(
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+        enable_force_load_balance=False,
+    )
+
+    assert router.capture_fn is None
+    expected_logical_ids = torch.tensor([[1, 3], [0, 2]], dtype=torch.int64)
+    torch.testing.assert_close(physical_ids, log2phy[expected_logical_ids])
 
 
 def test_hash_router_uses_explicit_input_ids(monkeypatch):

--- a/tests/ut/worker/test_routing_replay.py
+++ b/tests/ut/worker/test_routing_replay.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+from torch import nn
+from vllm.model_executor.layers.fused_moe import (
+    routed_experts_capturer as routed_experts_capturer_module,
+)
+
+from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
+from vllm_ascend.ops.fused_moe.router.grouped_topk_router import (
+    AscendGroupedTopKRouter,
+)
+from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+def test_upstream_routed_experts_binder_supports_ascend_router():
+    assert "_bind_routed_experts_capturer" not in NPUModelRunner.__dict__
+
+    router = AscendGroupedTopKRouter(
+        top_k=2,
+        global_num_experts=4,
+        num_expert_group=None,
+        topk_group=None,
+    )
+    routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(is_monolithic=False),
+    )
+    moe_runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(moe_runner)
+    moe_runner.layer_name = "model.layers.3.mlp.experts"
+    moe_runner.router = router
+    moe_runner.routed_experts = routed_experts
+
+    model = nn.Module()
+    model.add_module("moe", moe_runner)
+    model_runner = NPUModelRunner.__new__(NPUModelRunner)
+    model_runner.model = model
+    capturer = MagicMock()
+
+    binder = getattr(model_runner, "_bind_routed_experts_capturer", None)
+    if binder is not None:
+        binder(capturer)
+    else:
+        bind_routed_experts_capturer = vars(routed_experts_capturer_module).get("bind_routed_experts_capturer")
+        assert bind_routed_experts_capturer is not None
+        bind_routed_experts_capturer(model, capturer)
+
+    assert callable(router.capture_fn)
+    topk_ids = torch.tensor([[1, 2]], dtype=torch.int32)
+    router.capture_fn(topk_ids)
+    capturer.capture.assert_called_once_with(3, topk_ids)

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -450,17 +450,6 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         if self.log2phy is not None:
             topk_ids = self.log2phy[topk_ids]
 
-        try:
-            _vllm_config = get_current_vllm_config()
-
-            model_config = None if _vllm_config is None else _vllm_config.model_config
-            if model_config is not None and model_config.enable_return_routed_experts:
-                capturer = getattr(self, "_ascend_routed_experts_capturer", None)
-                if capturer is not None:
-                    capturer.capture(layer_id=self.layer_id, topk_ids=topk_ids)
-        except Exception:
-            pass
-
         num_shared_experts = self.n_shared_experts
         if num_shared_experts is None:
             num_shared_experts = 0

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3731,15 +3731,6 @@ class NPUModelRunner(GPUModelRunner):
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
 
-    def _bind_routed_experts_capturer(self, capturer=None) -> None:
-        # test_qwen3_moe_routing_replay
-        from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
-
-        for module in self.compilation_config.static_forward_context.values():
-            if isinstance(module, AscendMoERunner):
-                module._ascend_routed_experts_capturer = capturer
-                module.routed_experts._ascend_routed_experts_capturer = capturer
-
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()
         aligned_addr = (data_ptr + alignment - 1) // alignment * alignment


### PR DESCRIPTION
### What this PR does / why we need it?

Related to #13220.

Routing replay capture was still wired through an Ascend-specific model-runner override and a manual hook in `AscendRoutedExperts`. The override replaced the upstream binder on the vLLM 0.26 path, while the manual hook ran after Ascend `log2phy` mapping and could therefore export physical rather than logical expert IDs. Its broad exception handler could also hide incomplete capture results.

This PR aligns Ascend with the upstream MoE router capture contract:

- use the upstream binder to attach capture callbacks to Ascend routers;
- capture logical top-k expert IDs inside the router before EPLB or `log2phy` mapping;
- remove the legacy capturer plumbing and post-mapping manual capture path;
- retain the Ascend `RoutedExpertsCapturer.capture` patch for DP, SP, AllToAll, and MC2 token-layout normalization;
- add coverage for binder compatibility, logical-to-physical mapping order, and routing with no capture callback.

### Does this PR introduce _any_ user-facing change?

Yes. When routed expert export is enabled, Ascend now consistently returns logical expert IDs before EPLB or `log2phy` mapping, matching the upstream vLLM contract. Behavior is unchanged when routed expert export is disabled.

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
