### PR TITLE
[BugFix][CI] Fix GLM5.2 DSpark CI

### DIFF
--- a/tests/e2e/pull_request/eight_card/test_glm5_2.py
+++ b/tests/e2e/pull_request/eight_card/test_glm5_2.py
@@ -88,7 +88,6 @@ def _run_speculative_decoding(
     return acceptance_per_pos
 
 
-@pytest.mark.skip(reason="No confidence_head tensors were found in the checkpoint, fix me")
 @pytest.mark.e2e_model(MAIN_MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",
@@ -117,7 +116,7 @@ def test_glm_5_2_dspark_acceptance_tp8() -> None:
         num_speculative_tokens=DSPARK_NUM_SPECULATIVE_TOKENS,
         compilation_config=CompilationConfig(
             cudagraph_mode="FULL_DECODE_ONLY",
-            cudagraph_capture_sizes=[6, 8, 16, 18],
+            cudagraph_capture_sizes=[8, 16, 24, 32],
         ),
     )
 

--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -55,7 +55,9 @@ class TestQwen3DSparkWeightLoading:
             ) as mock_get_rotation_matrix,
             patch.object(qwen3_dspark.Qwen3DSparkForCausalLM, "load_weights") as mock_parent_load_weights,
         ):
-            model.load_weights(weights_to_load)
+            # DefaultModelLoader passes a one-shot iterator. Exercise that path
+            # so materializing the weights before rotation cannot exhaust them.
+            model.load_weights(iter(weights_to_load))
 
         mock_get_rotation_matrix.assert_called_once_with(rotation_path)
         mock_parent_load_weights.assert_called_once()

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -31,6 +31,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.utils import vllm_version_is
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
 # num_query_total, the out-of-bounds regime.
@@ -329,7 +330,13 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
         ("hf_config", "expected_sample_from_anchor", "expected_num_query_per_req"),
         [
             pytest.param(SimpleNamespace(), True, _NUM_SPECULATIVE_TOKENS),
-            pytest.param(SimpleNamespace(sample_from_anchor=False), False, 1 + _NUM_SPECULATIVE_TOKENS),
+            pytest.param(
+                SimpleNamespace(dspark_bonus_anchor=True)
+                if vllm_version_is("0.26.0")
+                else SimpleNamespace(sample_from_anchor=False),
+                False,
+                1 + _NUM_SPECULATIVE_TOKENS,
+            ),
         ],
     )
     def test_configures_anchor_sampling(

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -99,7 +99,7 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
         if self.rotation_path is not None:
             processed_weights: list[tuple[str, torch.Tensor]] = []
             rotation_weight = get_rotataion_matrix(self.rotation_path)
-            for name, loaded_weight in weights:
+            for name, loaded_weight in all_weights:
                 if "fc." in name:
                     loaded_weight = process_weight(loaded_weight, rotation_weight)
                 processed_weights.append((name, loaded_weight))

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -16,6 +16,7 @@ from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
+from vllm_ascend.utils import vllm_version_is
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -39,7 +40,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "DSpark probabilistic draft sampling is not supported on the v1 "
                 "model runner; use greedy (the default) instead."
             )
-        self.sample_from_anchor = getattr(self.draft_model_config.hf_config, "sample_from_anchor", True)
+        if vllm_version_is("0.26.0"):
+            self.sample_from_anchor = not getattr(self.draft_model_config.hf_config, "dspark_bonus_anchor", False)
+        else:
+            self.sample_from_anchor = getattr(self.draft_model_config.hf_config, "sample_from_anchor", True)
         if self.sample_from_anchor:
             self.num_query_per_req = self.num_speculative_tokens
         else:


### PR DESCRIPTION
### What this PR does / why we need it?
https://github.com/vllm-project/vllm-ascend/pull/13530 conflicts with https://github.com/vllm-project/vllm-ascend/pull/13216, and causes `confidence_head` tensors missing in `load_weights()`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests all pass.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
