### PR TITLE
[Test] Add Qwen3-30B A2 nightly performance cases

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -12,6 +12,12 @@ a2:
   single_node:
     test_config:
       # YAML-driven tests
+      - name: qwen3-30b-a3b-bf16-a2-performance
+        os: linux-aarch64-a2b3-4
+        config_file_path: Qwen3-30B-A3B-BF16-A2.yaml
+      - name: qwen3-30b-a3b-w8a8-a2-performance
+        os: linux-aarch64-a2b3-4
+        config_file_path: Qwen3-30B-A3B-W8A8-A2.yaml
       - name: qwen3-vl-32b-instruct-w8a8
         os: linux-aarch64-a2b3-4
         config_file_path: Qwen3-VL-32B-Instruct-W8A8.yaml

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-A3B-BF16-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-A3B-BF16-A2.yaml
@@ -1,0 +1,53 @@
+# Qwen3-30B-A3B BF16 A2 x4 throughput and latency guard.
+#
+# The throughput baseline is the mean of three stable A2 x4 measurements under
+# this exact FULL_DECODE_ONLY scenario: 804.6923, 802.1003, 800.5221 tok/s.
+# Keep the repository-standard 3% tolerance. Baseline changes require team approval.
+
+test_cases:
+  - name: "Qwen3-30B-A3B-BF16-A2-TP4"
+    model: "Qwen/Qwen3-30B-A3B"
+    envs:
+      ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3"
+      HCCL_BUFFSIZE: "512"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      LD_PRELOAD: "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2"
+      NPU_MEMORY_FRACTION: "0.95"
+      OMP_NUM_THREADS: "1"
+      OMP_PROC_BIND: "false"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      SERVER_PORT: "DEFAULT_PORT"
+      TASK_QUEUE_ENABLE: "1"
+      VLLM_ASCEND_ENABLE_NZ: "2"
+      VLLM_USE_V1: "1"
+    server_cmd:
+      - "--async-scheduling"
+      - "--tensor-parallel-size"
+      - "4"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-num-seqs"
+      - "16"
+      - "--max-model-len"
+      - "16384"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--trust-remote-code"
+      - "--additional-config"
+      - '{"enable_cpu_binding":true}'
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16]}'
+    benchmarks:
+      perf:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K-in3500-bs400
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 180
+        max_out_len: 1500
+        batch_size: 45
+        request_rate: 0
+        baseline: 802.4382
+        threshold: 0.97

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-A3B-W8A8-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-30B-A3B-W8A8-A2.yaml
@@ -1,0 +1,56 @@
+# Qwen3-30B-A3B W8A8 A2 x4 throughput and latency guard.
+#
+# The throughput baseline is the mean of three stable A2 x4 measurements under
+# this exact FULL_DECODE_ONLY scenario: 808.9002, 805.2220, 803.4938 tok/s.
+# Keep the repository-standard 3% tolerance. Baseline changes require team approval.
+
+test_cases:
+  - name: "Qwen3-30B-A3B-W8A8-A2-TP4"
+    model: "Eco-Tech/Qwen3-30B-A3B-w8a8"
+    envs:
+      ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3"
+      HCCL_BUFFSIZE: "512"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      LD_PRELOAD: "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2"
+      NPU_MEMORY_FRACTION: "0.95"
+      OMP_NUM_THREADS: "1"
+      OMP_PROC_BIND: "false"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      SERVER_PORT: "DEFAULT_PORT"
+      TASK_QUEUE_ENABLE: "1"
+      VLLM_ASCEND_ENABLE_NZ: "2"
+      VLLM_USE_V1: "1"
+    server_cmd:
+      - "--async-scheduling"
+      - "--tensor-parallel-size"
+      - "4"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-num-seqs"
+      - "16"
+      - "--max-model-len"
+      - "16384"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--trust-remote-code"
+      - "--additional-config"
+      - '{"enable_cpu_binding":true}'
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16]}'
+    server_cmd_extra:
+      - "--quantization"
+      - "ascend"
+    benchmarks:
+      perf:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K-in3500-bs400
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 180
+        max_out_len: 1500
+        batch_size: 45
+        request_rate: 0
+        baseline: 805.872
+        threshold: 0.97


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds two independent A2 four-card nightly performance guards for:

- BF16 `Qwen/Qwen3-30B-A3B`
- W8A8 `Eco-Tech/Qwen3-30B-A3B-w8a8`

Following maintainer feedback that the previous 1570-second PR E2E was too long for the pull-request path, both scenarios use the repository's YAML-driven single-node nightly framework and are registered only in the A2 nightly matrix. They are separate jobs/configs so each model has an independent benchmark result and Artifact.

Both jobs use the same TP4 workload:

- async scheduling
- `max_num_seqs=16`
- 16K model length and batched-token limit
- `FULL_DECODE_ONLY` graph mode
- capture sizes `[1, 2, 4, 8, 16]`
- AISBench `GSM8K-in3500-bs400`
- 180 prompts, 1500 maximum output tokens, batch size 45
- W8A8 additionally uses `--quantization ascend`

The routes are scoped to `linux-aarch64-a2b3-4`; unrelated nightly and PR E2E cases are unchanged.

### Baseline measurements and validation

The first three successful A2 x4 runs establish the baseline. Runs 4 and 5 are independent post-guard validations and are not folded back into the baseline.

| Run | BF16 throughput (tok/s) | BF16 TPOT (ms) | BF16 TTFT (ms) | W8A8 throughput (tok/s) | W8A8 TPOT (ms) | W8A8 TTFT (ms) | Guard |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| [1](https://github.com/vllm-project/vllm-ascend/actions/runs/33846958670) | 804.6923 | 18.5 | 46344.3 | 808.9002 | 18.3 | 45697.1 | Baseline input |
| [2](https://github.com/vllm-project/vllm-ascend/actions/runs/33857709181) | 802.1003 | 18.6 | 46413.3 | 805.2220 | 18.4 | 45900.8 | Baseline input |
| [3](https://github.com/vllm-project/vllm-ascend/actions/runs/34224770167) | 800.5221 | 18.6 | 46466.8 | 803.4938 | 18.4 | 45969.4 | Baseline input |
| [4](https://github.com/vllm-project/vllm-ascend/actions/runs/34303330149) | 787.0243 | 18.9 | 47156.2 | 800.7120 | 18.4 | 46118.6 | Pass |
| [5](https://github.com/vllm-project/vllm-ascend/actions/runs/34303456698) | 791.6659 | 18.8 | 47007.3 | 796.4301 | 18.5 | 46349.4 | Pass |

For runs 1-3, the arithmetic means are:

- BF16: throughput `802.4382 tok/s`, TPOT `18.5667 ms`, TTFT `46408.1 ms`
- W8A8: throughput `805.8720 tok/s`, TPOT `18.3667 ms`, TTFT `45855.8 ms`

The throughput range divided by the mean is 0.52% for BF16 and 0.67% for W8A8. TPOT and TTFT vary by less than 1%, so the baseline measurements are stable.

The YAML `baseline` is the runs 1-3 throughput mean. `threshold: 0.97` follows the existing nightly performance convention and allows up to a 3% throughput regression:

- BF16: baseline `802.4382`, effective lower bound `778.3651 tok/s`
- W8A8: baseline `805.8720`, effective lower bound `781.6958 tok/s`

Both post-guard validation runs passed these lower bounds. The baseline is intentionally unchanged after validation.

The current YAML-driven nightly framework applies `baseline` and `threshold` to Output Token Throughput. TPOT and TTFT are retained above as measured reference metrics.

Artifacts:

- Run 1: https://github.com/vllm-project/vllm-ascend/actions/runs/33846958670/artifacts/9928454440
- Run 2: https://github.com/vllm-project/vllm-ascend/actions/runs/33857709181/artifacts/9932897782
- Run 3: https://github.com/vllm-project/vllm-ascend/actions/runs/34224770167/artifacts/10057050240
- Run 4: https://github.com/vllm-project/vllm-ascend/actions/runs/34303330149/artifacts/10086841736
- Run 5: https://github.com/vllm-project/vllm-ascend/actions/runs/34303456698/artifacts/10086851961

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

- Parsed both model YAML files successfully.
- Completed three stable baseline runs for both BF16 and W8A8.
- Completed two additional independent runs with all throughput guards passing.
- Verified each configuration contains exactly one test case and produces an independent Artifact.
- Verified both registrations resolve only to `linux-aarch64-a2b3-4`.
- Verified the final diff contains one DCO-signed commit and only the nightly matrix registration plus the two model YAML files.

### Nightly trigger

```text
/nightly qwen3-30b-a3b-bf16-a2-performance qwen3-30b-a3b-w8a8-a2-performance
```

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd