### PR TITLE
[BugFix] Handle zero-byte Mooncake completion for partial prefix hits

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1156,7 +1156,10 @@ class TestCoreFunctionality(unittest.TestCase):
 
                 mock_transfer.assert_called_once_with(self.test_req)
                 mock_send.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
-                self.thread.task_tracker.update_done_task_count.assert_called_once_with("req1")
+                self.thread.task_tracker.update_done_task_count.assert_called_once_with(
+                    "req1",
+                    report_finished=True,
+                )
                 self.mock_queue.task_done.assert_called_once()
                 expected_errors = {1, 2} if transfer_error else set()
                 self.assertEqual(self.thread.get_and_clear_invalid_block_ids(), expected_errors)
@@ -1167,13 +1170,17 @@ class TestCoreFunctionality(unittest.TestCase):
         req = dict(self.test_req)
         req["local_block_ids"] = ([],)
         req["remote_block_ids"] = ([3, 4],)
+        req["report_finished"] = False
 
         self.thread._handle_request(req)
 
         self.engine.batch_transfer_sync_read.assert_not_called()
         mock_free_remote_port.assert_called_once_with("req1", "localhost", {6666: 1})
         mock_send_done.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
-        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with(
+            "req1",
+            report_finished=False,
+        )
         self.mock_queue.task_done.assert_called_once()
 
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
@@ -1841,6 +1848,16 @@ class TestKVCacheTaskTracker(unittest.TestCase):
         self.assertEqual(len(result_delayed), 0)
         self.assertEqual(len(self.tracker.reqs_to_process), 0)
 
+    def test_update_done_task_count_without_reporting_completion(self):
+        self.tracker.add_req_to_process("req_1")
+        self.tracker.add_delayed_request("req_1", time.time())
+
+        self.tracker.update_done_task_count("req_1", report_finished=False)
+
+        self.assertEqual(self.tracker.finished_requests, set())
+        self.assertEqual(self.tracker.delayed_free_requests, {})
+        self.assertEqual(self.tracker.reqs_to_process, set())
+
     def test_updtate_add_delayed_request(self) -> None:
         self.tracker.update_done_task_count("req2")
         self.tracker.add_delayed_request("req2", time.time())
@@ -2200,6 +2217,37 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertEqual(self.scheduler._reqs_need_recv["req1"][0], request)
         self.assertEqual(self.scheduler._reqs_need_recv["req1"][1], ([4, 5, 6],))
         self.assertEqual(self.scheduler._reqs_need_recv["req1"][2], ([1, 2, 4, 5, 6],))
+
+    def test_update_state_after_alloc_preserves_hybrid_groups_for_zero_byte_completion(self):
+        request = MockRequest(
+            "req1",
+            kv_transfer_params={
+                "do_remote_prefill": True,
+                "remote_block_ids": ([1, 2, 3], [4]),
+                "remote_engine_id": "remote",
+                "remote_request_id": "remote_req1",
+                "remote_host": "localhost",
+                "remote_port": 5000,
+            },
+        )
+        blocks = MagicMock()
+        self.scheduler.kv_cache_groups = [MockKVCacheGroup(), MockKVCacheGroup()]
+
+        self.scheduler.update_state_after_alloc(request, blocks, 0)
+
+        self.assertIn("req1", self.scheduler._reqs_need_recv)
+        self.assertIn("req1", self.scheduler._reqs_in_batch)
+        self.assertEqual(
+            self.scheduler._reqs_need_recv["req1"][1],
+            ([], []),
+        )
+        self.assertEqual(
+            self.scheduler._reqs_need_recv["req1"][2],
+            tuple(),
+        )
+        blocks.get_unhashed_block_ids_all_groups.assert_not_called()
+        blocks.get_block_ids.assert_not_called()
+        self.assertFalse(request.kv_transfer_params["do_remote_prefill"])
 
     def test_request_finished_no_remote_decode(self):
         request = MockRequest("req1")

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -98,6 +98,56 @@ def test_mrv2_advertises_standardized_shared_kv_backing():
     assert NPUModelRunner.supports_standardized_shared_kv_backing is True
 
 
+def test_update_requests_copies_nested_shared_kv_cache_views_once():
+    num_blocks = 3
+    backing = torch.zeros(27, dtype=torch.uint8)
+    conv_state = backing[:6].view(num_blocks, 2)
+    ssm_state = backing[6:15].view(num_blocks, 3)
+    key_cache = backing[6:15].view(num_blocks, 3)
+    value_cache = backing[15:27].view(num_blocks, 4)
+
+    for block_id in range(num_blocks):
+        conv_state[block_id].fill_(10 + block_id)
+        ssm_state[block_id].fill_(20 + block_id)
+        value_cache[block_id].fill_(30 + block_id)
+    original = {
+        "conv": conv_state.clone(),
+        "ssm": ssm_state.clone(),
+        "value": value_cache.clone(),
+    }
+
+    runner = object.__new__(NPUModelRunner)
+    nested_kv_caches = [(key_cache, value_cache), [conv_state, ssm_state]]
+    runner.kv_caches = nested_kv_caches
+    runner.kv_cache_config = SimpleNamespace(num_blocks=num_blocks)
+    runner.req_states = SimpleNamespace(
+        num_computed_tokens_np=np.empty(0, dtype=np.int32),
+        prefill_len=SimpleNamespace(np=np.empty(0, dtype=np.int32)),
+        num_computed_prefill_tokens=np.empty(0, dtype=np.int32),
+    )
+    runner.block_tables = MagicMock()
+    scheduler_output = SimpleNamespace(
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            num_computed_tokens=[],
+            new_block_ids=[],
+        ),
+        new_block_ids_to_zero=None,
+        kv_cache_block_copies=[(0, 1), (1, 2)],
+    )
+
+    NPUModelRunner.update_requests(runner, scheduler_output)
+
+    assert runner.kv_caches is nested_kv_caches
+    assert scheduler_output.kv_cache_block_copies == [(0, 1), (1, 2)]
+    torch.testing.assert_close(conv_state[1], original["conv"][0])
+    torch.testing.assert_close(conv_state[2], original["conv"][1])
+    torch.testing.assert_close(ssm_state[1], original["ssm"][0])
+    torch.testing.assert_close(ssm_state[2], original["ssm"][1])
+    torch.testing.assert_close(value_cache[1], original["value"][0])
+    torch.testing.assert_close(value_cache[2], original["value"][1])
+
+
 def test_prepare_inputs_propagates_padded_request_count():
     model_runner_path = Path(__file__).resolve().parents[3] / "vllm_ascend" / "worker" / "v2" / "model_runner.py"
     module = ast.parse(model_runner_path.read_text(encoding="utf-8"))

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -195,10 +195,11 @@ class KVCacheTaskTracker:
             self.finished_requests.add(request_id)
             self.reqs_to_process.discard(request_id)
 
-    def update_done_task_count(self, request_id: str):
+    def update_done_task_count(self, request_id: str, report_finished: bool = True):
         with self.done_task_lock:
             if request_id in self.reqs_to_process:
-                self.finished_requests.add(request_id)
+                if report_finished:
+                    self.finished_requests.add(request_id)
                 self.reqs_to_process.discard(request_id)
                 self.delayed_free_requests.pop(request_id, None)
             else:
@@ -582,6 +583,7 @@ class KVCacheRecvingThread(threading.Thread):
         shard_idx: int = 0,
         local_block_ids_replicate_k: BlockIds | None = None,
         remote_block_ids_replicate_k: BlockIds | None = None,
+        report_finished: bool = True,
     ):
         """Add a new request to the queue for processing."""
         if remote_port_send_num is None:
@@ -602,6 +604,7 @@ class KVCacheRecvingThread(threading.Thread):
             "all_task_done": all_task_done,
             "shard_idx": shard_idx,
             "remote_block_size": remote_block_size,
+            "report_finished": report_finished,
         }
         logger.debug("Adding request %s to the queue.Trans info:%s", request_id, trans_info)
         self.request_queue.put(trans_info)
@@ -758,7 +761,10 @@ class KVCacheRecvingThread(threading.Thread):
                             remote_request_id,
                             e,
                         )
-                self.task_tracker.update_done_task_count(request_id)
+                self.task_tracker.update_done_task_count(
+                    request_id,
+                    report_finished=req_meta.get("report_finished", True),
+                )
                 with self.proc_not_transfer_request_lock:
                     self.proc_not_transfer_request.pop(remote_request_id, None)
                 self._clear_failed_recv_request(request_id)
@@ -1947,7 +1953,11 @@ class MooncakeConnectorScheduler:
         if params is not None and params.get("do_remote_prefill"):
             if params.get("remote_block_ids"):
                 if all(p in params for p in ("remote_engine_id", "remote_host", "remote_port", "remote_request_id")):
-                    local_block_ids = blocks.get_unhashed_block_ids_all_groups() if num_external_tokens > 0 else []
+                    local_block_ids = (
+                        blocks.get_unhashed_block_ids_all_groups()
+                        if num_external_tokens > 0
+                        else tuple([] for _ in self.kv_cache_groups)
+                    )
                     local_full_block_ids = blocks.get_block_ids() if num_external_tokens > 0 else tuple()
                     # Get unhashed blocks to pull from remote.
                     self._reqs_need_recv[request.request_id] = (
@@ -3791,6 +3801,7 @@ class MooncakeConnectorWorker:
                         remote_block_size=meta.remote_block_size,
                         local_block_ids_replicate_k=local_block_ids_replicate_k_for_port,
                         remote_block_ids_replicate_k=remote_block_ids_replicate_k_for_port,
+                        report_finished=(getattr(meta, "num_external_tokens", 1) > 0),
                     )
 
         if self.kv_send_thread is not None and self.dcp_size == 1:

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -17,6 +17,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from collections.abc import Sequence
 from contextlib import contextmanager
 
 import numpy as np
@@ -42,6 +43,7 @@ from vllm.v1.worker.gpu.model_runner import (
     ExecuteModelState,
     GPUModelRunner,
 )
+from vllm.v1.worker.utils import copy_kv_cache_blocks_inplace
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import (
@@ -73,6 +75,18 @@ from vllm_ascend.worker.v2.spec_decode import init_speculator
 from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
 from vllm_ascend.worker.v2.states import AscendRequestState
 from vllm_ascend.worker.v2.utils import torch_cuda_wrapper
+
+
+def _flatten_kv_cache_views(
+    kv_caches: Sequence[torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...]],
+) -> list[torch.Tensor]:
+    flattened: list[torch.Tensor] = []
+    for cache in kv_caches:
+        if isinstance(cache, (list, tuple)):
+            flattened.extend(cache)
+        else:
+            flattened.append(cache)
+    return flattened
 
 
 class NPUModelRunner(GPUModelRunner):
@@ -250,6 +264,28 @@ class NPUModelRunner(GPUModelRunner):
                     self.speculator.pcp_manager = self.pcp_manager
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def update_requests(self, scheduler_output: SchedulerOutput) -> None:
+        """Let upstream copy partial-hit blocks through Ascend cache views."""
+        kv_cache_block_copies = getattr(scheduler_output, "kv_cache_block_copies", None)
+        if not kv_cache_block_copies:
+            super().update_requests(scheduler_output)
+            return
+
+        # Ascend binds Attention K/V as tuples and Mamba states as lists. The
+        # upstream copier already handles aliases and shared backing storage,
+        # but expects the runner cache collection itself to contain tensors.
+        scheduler_output.kv_cache_block_copies = None
+        try:
+            super().update_requests(scheduler_output)
+        finally:
+            scheduler_output.kv_cache_block_copies = kv_cache_block_copies
+
+        copy_kv_cache_blocks_inplace(
+            _flatten_kv_cache_views(self.kv_caches),
+            self.kv_cache_config.num_blocks,
+            kv_cache_block_copies,
+        )
 
     @torch.inference_mode()
     def execute_model(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR completes the ModelRunnerV2 path for remote-prefill partial prefix-cache
hits with the legacy `MooncakeConnector`.

It fixes two related gaps:

- When a local prefix-cache hit covers the entire request, no KV payload needs
  to be copied. The decode side must still notify the prefill side so delayed
  KV blocks can be released.
- Ascend ModelRunnerV2 binds Attention K/V caches as tuples and Mamba state
  caches as lists. The compatible vLLM block-copy helper expects a flat tensor
  collection, so copy-on-write block copies for partial hits would otherwise
  fail before the forward pass.

The patch therefore:

- preserves one empty local block-ID list per KV cache group, including hybrid
  Attention/Mamba layouts;
- sends the decode-to-prefill completion signal for zero-byte transfers;
- clears pending and delayed-release state without reporting
  `finished_recving` for requests that never started asynchronous KV loading;
  and
- temporarily flattens ModelRunnerV2's nested Ascend cache views while the
  upstream request-update path performs block copies, preserving its ordering,
  alias detection, and shared-backing deduplication.

`RecomputeScheduler` does not need a new change in this PR. Current
`vllm-ascend/main` already selects per-group hybrid prefix hits, reconciles the
local partial tail with external hits, falls back when the external cache does
not cover that tail, emits `kv_cache_block_copies`, and defers freeing retained
copy-on-write blocks until execution completes.

### Does this PR introduce _any_ user-facing change?

Yes. In disaggregated prefill/decode deployments using ModelRunnerV2 and the
legacy `MooncakeConnector`, hybrid-model requests can complete partial
prefix-cache reuse correctly, including the zero-byte transfer case.

There is no public API, CLI, or configuration change.

### How was this patch tested?

- Added connector coverage for preserving hybrid KV cache group metadata in a
  zero-byte remote-prefill request.
- Added worker coverage for sending remote completion while suppressing local
  `finished_recving` for a request with no asynchronous load.
- Added tracker coverage for clearing pending and delayed-release state.
- Added ModelRunnerV2 coverage with nested Attention/Mamba cache views sharing
  one backing allocation. The test uses chained block copies to verify that an
  aliased region is copied exactly once.
- The current revision passed pre-commit, mypy, and the full CPU unit-test job
  in CI, including the new ModelRunnerV2 regression test.
- Ran locally:

```bash
ruff format \
  vllm_ascend/worker/v2/model_runner.py \
  tests/ut/worker/test_model_runner_v2_mamba.py
ruff check \
  vllm_ascend/worker/v2/model_runner.py \
  tests/ut/worker/test_model_runner_v2_mamba.py
python -m compileall -q \
  vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py \
  vllm_ascend/worker/v2/model_runner.py \
  tests/ut/kv_offload/test_mooncake_connector.py \
  tests/ut/worker/test_model_runner_v2_mamba.py
git diff --check upstream/main...HEAD
```

NPU-dependent runtime tests were not run locally because this Windows workspace
does not provide `torch_npu`. The precision/full NPU suite is waiting for a
maintainer to add `ready-precise`, `ready-all`, or `main2main`.

### Scope and compatibility

- Rebased onto `vllm-ascend/main` at `d2eebb1b2`.
- Compatible vLLM reference: `b2f685834a6456197e7033966fdef52a23f1abcd`.
- `model_runner_v1.py` is intentionally unchanged; this adaptation targets
  ModelRunnerV2 only.
- `MooncakeConnectorV2` already handles zero-byte completion directly, so the
  connector change is limited to the still-supported legacy connector.
