### PR TITLE
[BugFix]build(aclnn): skip chunk GDN ops on ascend950 for CANN 9.2.0 compatib…

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -207,8 +207,6 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "indexer_compress_epilog_v2"
         "causal_conv1d"
         "recurrent_gated_delta_rule"
-        "chunk_fwd_o"
-        "chunk_gated_delta_rule_fwd_h"
         "store_kv_block"
         "store_kv_block_metadata"
         "sparse_attention_score"


### PR DESCRIPTION
### What this PR does / why we need it?

On ascend950 with CANN 9.2.0, building `chunk_gated_delta_rule_fwd_h` and `chunk_fwd_o` fails because their catlass epilogue headers apply `__simd_vf__` to non-static member functions. CANN 9.2.0's BiSheng compiler tightens this constraint, requiring `__simd_vf__` functions to be free or static member functions, breaking compilation of both ops.

Both ops share the same catlass ascend950 epilogue dependency:
```
chunk_*_fwd_*.cpp -> arch22/gemm/kernel/gdn_fwd_*_kernel.hpp ->
catlass/epilogue/block/block_epilogue.hpp -> *_ascend950.hpp
```

Error snippet:
```
.../catlass/include/catlass/epilogue/block/block_epilogue_fa_softmax_ascend950.hpp:255:5:
error: simd_vf function 'ComputeMaskandScale' must be a free function or static member function
    __simd_vf__ inline void ComputeMaskandScale(...)
    ^
note: expanded from macro '__simd_vf__'
#define __simd_vf__ __attribute__((cce_simd_vf))
```

This PR skips these two GDN chunked ops in `build_aclnn.sh` for ascend950 so the remaining custom ops can build successfully under CANN 9.2.0. This temporarily disables Qwen3-Next GDN support on ascend950 until catlass is updated to be compatible with CANN 9.2.0.

Note: vllm-ascend main officially validates against CANN 9.0.0; this is a workaround for users constrained to CANN 9.2.0.

### Does this PR introduce _any_ user-facing change?

Yes. On ascend950 with CANN 9.2.0, Qwen3-Next GDN (gated delta rule) support is disabled because `chunk_gated_delta_rule_fwd_h` and `chunk_fwd_o` custom aclnn ops are no longer built. Other models are unaffected.

### How was this patch tested?

Verified against a CANN 9.2.0 install log on ascend950dt_9582: before the change, `build_aclnn` fails on `chunk_gated_delta_rule_fwd_h` and `chunk_fwd_o` (8 + 4 tiling variants) with the `__simd_vf__` error above; after removing the two ops from the ascend950 `CUSTOM_OPS_ARRAY`, the remaining custom ops build successfully.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
