### PR TITLE
[BugFix] [w8a8_mxfp8] Reuse weight address in graph and RL scenario

### DIFF
--- a/tests/ut/quantization/methods/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8.py
@@ -67,7 +67,9 @@ class TestAscendW8A8MXFP8LinearMethod(TestBase):
         # The transformed weight/scale must also stay contiguous, since ACL
         # graph capture expects contiguous weight/scale tensors.
         layer = nn.Module()
-        layer.weight = nn.Parameter(torch.randint(0, 255, (128, 256), dtype=torch.uint8).to(torch.float8_e4m3fn), requires_grad=False)
+        layer.weight = nn.Parameter(
+            torch.randint(0, 255, (128, 256), dtype=torch.uint8).to(torch.float8_e4m3fn), requires_grad=False
+        )
         layer.weight_scale = nn.Parameter(torch.randint(0, 255, (128, 8), dtype=torch.uint8), requires_grad=False)
         self.scheme.process_weights_after_loading(layer)
         transform_weight_ptr = layer._mxfp8_weight_buf.data_ptr()

--- a/tests/ut/quantization/methods/test_w8a8_mxfp8.py
+++ b/tests/ut/quantization/methods/test_w8a8_mxfp8.py
@@ -60,6 +60,41 @@ class TestAscendW8A8MXFP8LinearMethod(TestBase):
         self.assertEqual(layer.weight_scale.shape, original_scale_shape)
         self.assertFalse(layer._mxfp8_transformed)
 
+    def test_transform_buffer_data_ptr_stable_across_reloads(self):
+        # The transformed buffer is what the ACL graph captures and replays.
+        # It must keep a stable data_ptr across RL weight reloads so graph
+        # replay never reads stale/freed memory and produces garbled output.
+        # The transformed weight/scale must also stay contiguous, since ACL
+        # graph capture expects contiguous weight/scale tensors.
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randint(0, 255, (128, 256), dtype=torch.uint8).to(torch.float8_e4m3fn), requires_grad=False)
+        layer.weight_scale = nn.Parameter(torch.randint(0, 255, (128, 8), dtype=torch.uint8), requires_grad=False)
+        self.scheme.process_weights_after_loading(layer)
+        transform_weight_ptr = layer._mxfp8_weight_buf.data_ptr()
+        transform_scale_ptr = layer._mxfp8_scale_buf.data_ptr()
+        # Buffers and the weight/scale views over them must be contiguous.
+        self.assertTrue(layer._mxfp8_weight_buf.is_contiguous())
+        self.assertTrue(layer._mxfp8_scale_buf.is_contiguous())
+        self.assertTrue(layer.weight.data.is_contiguous())
+        self.assertTrue(layer.weight_scale.data.is_contiguous())
+        for _ in range(3):
+            self.scheme.restore_weights_for_rl_loading(layer)
+            # Simulate model.load_weights() writing new data via copy_.
+            new_w = torch.randint(0, 255, layer.weight.shape, dtype=torch.uint8).to(torch.float8_e4m3fn)
+            new_s = torch.randint(0, 255, layer.weight_scale.shape, dtype=torch.uint8)
+            layer.weight.data.copy_(new_w)
+            layer.weight_scale.data.copy_(new_s)
+            self.scheme.process_weights_after_loading(layer)
+            self.assertEqual(layer._mxfp8_weight_buf.data_ptr(), transform_weight_ptr)
+            self.assertEqual(layer._mxfp8_scale_buf.data_ptr(), transform_scale_ptr)
+            self.assertEqual(layer.weight.data.data_ptr(), transform_weight_ptr)
+            self.assertEqual(layer.weight_scale.data.data_ptr(), transform_scale_ptr)
+            # Contiguity must be preserved across reloads.
+            self.assertTrue(layer._mxfp8_weight_buf.is_contiguous())
+            self.assertTrue(layer._mxfp8_scale_buf.is_contiguous())
+            self.assertTrue(layer.weight.data.is_contiguous())
+            self.assertTrue(layer.weight_scale.data.is_contiguous())
+
     @patch("vllm_ascend.quantization.methods.w8a8_mxfp8.torch_npu")
     def test_apply(self, mock_torch_npu):
         dynamic_scale = torch.randint(0, 255, (32, 8), dtype=torch.uint8)

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -123,6 +123,12 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         this method stores original shapes and can be called multiple times safely.
         Use restore_weights_for_rl_loading() before weight reload, then call this
         method again after loading.
+
+        Address stability for ACL graph:
+        The transformed buffer is what the ACL graph captures and replays. It is
+        allocated once and cached on the layer; subsequent calls copy the
+        (re)loaded original-shape data in place into the cached buffer so its
+        data_ptr never changes across RL weight reloads.
         """
 
         # Check if already transformed to avoid double transformation
@@ -140,12 +146,23 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
         n_dim, k_dim = layer.weight_scale.data.shape
         # Shape should be padded if it cannot be divided by 2
         if layer.weight_scale.data.shape[-1] % 2 != 0:
-            layer.weight_scale.data = F.pad(layer.weight_scale.data, (0, 1), mode="constant", value=0)
-            layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2 + 1, 2)
+            reshaped_scale = F.pad(layer.weight_scale.data, (0, 1), mode="constant", value=0)
+            reshaped_scale = reshaped_scale.reshape(n_dim, k_dim // 2 + 1, 2)
         else:
-            layer.weight_scale.data = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
-        layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight_scale.data = layer.weight_scale.data.transpose(0, 1).contiguous()
+            reshaped_scale = layer.weight_scale.data.reshape(n_dim, k_dim // 2, 2)
+        target_scale = reshaped_scale.transpose(0, 1)
+
+        if not hasattr(layer, "_mxfp8_weight_buf"):
+            # First call: allocate the persistent transformed buffers.
+            layer._mxfp8_weight_buf = layer.weight.data.transpose(0, 1).contiguous()
+            layer._mxfp8_scale_buf = target_scale.contiguous()
+        else:
+            # Subsequent calls (RL reload path): copy in place to keep data_ptr stable.
+            layer._mxfp8_weight_buf.copy_(layer.weight.data.transpose(0, 1).contiguous())
+            layer._mxfp8_scale_buf.copy_(target_scale.contiguous())
+
+        layer.weight.data = layer._mxfp8_weight_buf
+        layer.weight_scale.data = layer._mxfp8_scale_buf
 
         # Mark as transformed
         layer._mxfp8_transformed = True


### PR DESCRIPTION
### What this PR does / why we need it?

  In RL workflows (e.g. verl), rollout weights are reloaded into the model repeatedly, and after each reload `AscendW8A8MXFP8DynamicLinearMethod.process_weights_after_loading` is invoked again to transform the weight (transpose) and scale (reshape + transpose) into the layout consumed by ACL.

  Before this fix, every call re-allocated the transformed tensors via `.contiguous()`, so `layer.weight.data` / `layer.weight_scale.data` got a new `data_ptr` on each reload. When ACL graph mode is enabled, the graph captures the buffer addresses on the first capture and replays against them; after a reload the captured addresses point to freed/stale memory, so graph replay reads garbage and produces garbled output.

  This PR makes the transformed buffer stable across reloads:
  - On the first `process_weights_after_loading`, allocate the contiguous transformed buffers once and cache them on the layer as `_mxfp8_weight_buf` / `_mxfp8_scale_buf`.
  - On subsequent calls (the RL reload path), copy the reloaded original-shape data in place into the cached buffers via `copy_()`, then point `layer.weight.data` / `layer.weight_scale.data` back at the cached buffers.

  As a result the buffer `data_ptr` and contiguity never change across reloads, so ACL graph replay always reads the live, contiguous weights and produces correct output.

  ### Does this PR introduce _any_ user-facing change?

  No API/interface change. Behaviorally this fixes the garbled output that occurred in RL + ACL graph mode scenarios after a weight reload; non-RL and non-graph-mode paths are unaffected.

  ### How was this patch tested?

  Added `TestAscendW8A8MXFP8LinearMethod.test_transform_buffer_data_ptr_stable_across_reloads`, which:
  - Transforms once and records the `data_ptr` of `_mxfp8_weight_buf` / `_mxfp8_scale_buf`.
  - Loops 3 times over: `restore_weights_for_rl_loading` -> simulate `model.load_weights()` writing new data via `copy_()` -> `process_weights_after_loading`.
  - Asserts the buffer `data_ptr` and `layer.weight.data` / `layer.weight_scale.data` `data_ptr` stay stable, and that all four tensors remain contiguous, both after the first transform and after every reload.

  Run on an NPU machine:

  ```bash
  pytest tests/ut/quantization/methods/test_w8a8_mxfp8.py::TestAscendW8A8MXFP8LinearMethod::test_transform_buffer_data_ptr_stable_across_reloads -v
```
  Existing tests in the same file continue to pass.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
