### PR TITLE
[Test][Misc] Restore weekly use case

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -104,6 +104,9 @@ a3:
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
         size: 4
+      - name: DeepSeek-V4-Pro-w4a8-prefix-cache-PD
+        config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
+        size: 4
       - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
         config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
         size: 2

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -89,27 +89,12 @@ a3:
       - name: multi-node-deepseek-v3.2-W8A8-EP
         config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
         size: 4
-      - name: multi-node-deepseek-v3.1
-        config_file_path: DeepSeek-V3.1-BF16.yaml
-        size: 2
-      - name: multi-node-GLM-5.2-w8a8-A3
-        config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
-        size: 2
-      - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
-        config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
-        size: 2
-      - name: DeepSeek-V4-flash-w8a8-PD-prefix
-        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
-        size: 2
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
         size: 4
       - name: DeepSeek-V4-Pro-w4a8-prefix-cache-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
         size: 4
-      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
-        size: 2
   double_node:
     test_config:
       - name: multi-node-qwen3-dp
@@ -132,6 +117,21 @@ a3:
         size: 2
       - name: multi-node-GLM-5.1-W8A8C8-A3_64k_128k_90_50
         config_file_path: GLM-5.1-W8A8C8-A3_64k_128k_90_50.yaml
+        size: 2
+      - name: multi-node-deepseek-v3.1
+        config_file_path: DeepSeek-V3.1-BF16.yaml
+        size: 2
+      - name: multi-node-GLM-5.2-w8a8-A3
+        config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
+        size: 2
+      - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
+        config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
+        size: 2
+      - name: DeepSeek-V4-flash-w8a8-PD-prefix
+        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
+        size: 2
+      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
+        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
         size: 2
   single_node:
     test_config:

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -40,7 +40,7 @@ a3:
         config_file_path: DeepSeek-V4-flash-w8a8-PD-no-prefix.yaml
         size: 2
       - name: DeepSeek-V4-flash-w8a8-PD-prefix
-        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
+        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix-weekly.yaml
         size: 2
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
@@ -236,7 +236,7 @@ a3:
         config_file_path: Qwen3.6-35B-A3B-w4a8-A3.yaml
       - name: Kimi-K2.6-w4a8-A3
         os: linux-aarch64-a3-16
-        config_file_path: Kimi-K2.6-w4a8-A3.yaml
+        config_file_path: Kimi-K2.6-w4a8-A3-weekly.yaml
       - name: Kimi-K2.7-w4a8-A3
         os: linux-aarch64-a3-16
         config_file_path: Kimi-K2.7-w4a8-A3.yaml

--- a/tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
@@ -288,28 +288,6 @@ templates:
       - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
 
 benchmarks:
-  perf_TPOT50_64_1_prefix90_warmup:
-    case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in65536-bs512-prefix90-ds
-    request_conf: vllm_api_stream_chat
-    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
-    num_prompts: 4
-    max_out_len: 1
-    batch_size: 4
-    request_rate: 0
-    baseline: 0
-    threshold: 0.95
-  perf_TPOT50_64_1_prefix90:
-    case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in65536-bs512-prefix90-ds
-    request_conf: vllm_api_stream_chat
-    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
-    num_prompts: 384
-    max_out_len: 1024
-    batch_size: 96
-    request_rate: 2.5
-    baseline: 1951.6
-    threshold: 0.95
   perf_TPOT50_128k_1_prefix_warmup:
     case_type: performance
     dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds

--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek-V4-flash-w8a8-PD-prefix-weekly.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek-V4-flash-w8a8-PD-prefix-weekly.yaml
@@ -1,0 +1,242 @@
+test_name: "DeepSeek-V4-Flash-w8a8-PD-prefix"
+model: "Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp"
+num_nodes: 2
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0 ]
+    decoder: [ 1 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 4
+    dp_rank_start: 0
+    tp_size: 4
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 16
+    dp_size_local: 16
+    dp_rank_start: 0
+    tp_size: 1
+    dp_address: "${NODE_1_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_RPC_TIMEOUT: "3600"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_EXEC_TIMEOUT: "204"
+  HCCL_CONNECT_TIMEOUT: "120"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "10"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+
+env_prefill: &env_prefill
+  <<: *env_common
+  HCCL_BUFFSIZE: "1024"
+  TASK_QUEUE_ENABLE: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+  VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "4096"
+
+env_decode: &env_decode
+  <<: *env_common
+  HCCL_BUFFSIZE: "1500"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "1048576"
+      - --max-num-batched-tokens
+      - "8192"
+      - --max-num-seqs
+      - "16"
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --speculative-config
+      - '{"num_speculative_tokens": 1,"method": "mtp"}'
+      - --trust-remote-code
+      - --block-size
+      - "32"
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --gpu-memory-utilization
+      - "0.9"
+      - --quantization
+      - "ascend"
+      - --enforce-eager
+      - --additional-config
+      - '{"enable_cpu_binding": true, "enable_dsa_cp": true}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "0", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 4}, "decode": {"dp_size": 16, "tp_size": 1}}}'
+
+  - node_index: 1
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --max-model-len
+      - "1048576"
+      - --max-num-batched-tokens
+      - "240"
+      - --max-num-seqs
+      - "60"
+      - --async-scheduling
+      - --block-size
+      - "32"
+      - --no-enable-prefix-caching
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --gpu-memory-utilization
+      - "0.95"
+      - --quantization
+      - "ascend"
+      - --speculative-config
+      - '{"num_speculative_tokens": 3,"method": "mtp"}'
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_consumer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 4}, "decode": {"dp_size": 16, "tp_size": 1}}}'
+      - --additional-config
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
+
+benchmarks:
+  perf_TPOT50_64_1_prefix90_warmup:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in65536-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1
+    batch_size: 4
+    request_rate: 0
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_64_1_prefix90:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in65536-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 512
+    max_out_len: 1024
+    batch_size: 128
+    request_rate: 4.7
+    baseline: 3883.906
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix_warmup:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1
+    batch_size: 4
+    request_rate: 0
+    baseline: 0
+    threshold: 0.95
+  perf_TPOT50_128k_1_prefix90:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in128k-bs512-prefix90-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 512
+    max_out_len: 1024
+    batch_size: 128
+    request_rate: 2.5
+    baseline: 2114.365
+    threshold: 0.95
+  perf_1M_1k_prefix90_warmup:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in1M-bs4-prefix99-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 1
+    max_out_len: 1
+    batch_size: 1
+    request_rate: 0
+    baseline: 0
+    threshold: 0.95
+  perf_1M_1k_prefix99:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in1M-bs4-prefix99-ds
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1024
+    batch_size: 1
+    request_rate: 0
+    baseline: 22.65
+    threshold: 0.95
+  acc_aime2025:
+    case_type: accuracy
+    dataset_path: vllm-ascend/aime2025
+    request_conf: vllm_api_general_chat
+    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
+    temperature: 1.0
+    top_p: 1.0
+    thinking: "true"
+    max_out_len: 65536
+    batch_size: 32
+    baseline: 90
+    threshold: 10

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.6-w4a8-A3-weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.6-w4a8-A3-weekly.yaml
@@ -1,0 +1,162 @@
+# ==========================================
+# Shared Configurations
+# ==========================================
+
+_envs: &envs
+  SERVER_PORT: "DEFAULT_PORT"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_BUFFSIZE: "1200"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  OMP_NUM_THREADS: "1"
+  LD_PRELOAD: "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD"
+  TASK_QUEUE_ENABLE: "1"
+
+_server_cmd: &server_cmd
+  - "--port"
+  - "$SERVER_PORT"
+  - "--host"
+  - "0.0.0.0"
+  - "--tensor-parallel-size"
+  - "8"
+  - "--data-parallel-size"
+  - "2"
+  - "--enable-expert-parallel"
+  - "--async-scheduling"
+  - "--max-num-seqs"
+  - "128"
+  - "--safetensors-load-strategy"
+  - 'prefetch'
+  - "--max-num-batched-tokens"
+  - "16384"
+  - "--trust-remote-code"
+  - "--quantization"
+  - "ascend"
+  - "--enable-auto-tool-choice"
+  - "--tool-call-parser"
+  - "minimax_m2"
+  - "--speculative_config"
+  - '{"method":"eagle3","model":"Eco-Tech/MiniMax-M2.7-eagle-model-short,"num_speculative_tokens":3}'
+  - "--compilation-config"
+  - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+  - "--additional-config"
+  - '{"enable_cpu_binding": true, "enable_npugraph_ex": true, "enable_static_kernel": true,"enable_fused_mc2":true,"weight_nz_mode":true,"enable_flashcomm1":true}'
+
+
+_benchmarks_acc: &benchmarks_acc
+  acc:
+    case_type: accuracy
+    dataset_path: vllm-ascend/aime2025
+    request_conf: vllm_api_general_chat
+    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
+    max_out_len: 65536
+    batch_size: 32
+    baseline: 93.33
+    threshold: 10
+    temperature: 1
+    top_p: 1
+    top_k: 40
+    ignore_eos: false
+
+_benchmarks_prefix_64k_50: &benchmarks_prefix_64k_50
+  perf_prefix_90:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix90_in65536_bs1000_Minimax
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 160
+    max_out_len: 1024
+    batch_size: 40
+    request_rate: 0
+    baseline: 808.3
+    threshold: 0.97
+
+_benchmarks_prefix_128k_50: &benchmarks_prefix_128k_50
+  perf_prefix_90:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs1000_Minimax
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 80
+    max_out_len: 1024
+    batch_size: 20
+    request_rate: 0
+    baseline: 256.4
+    threshold: 0.97
+
+_benchmarks_prefix_max: &benchmarks_prefix_max
+  perf_prefix_99:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix99_in203738_bs1_mini
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 1
+    max_out_len: 1024
+    batch_size: 1
+    request_rate: 0
+    baseline: 1
+    threshold: 0.1
+  perf_1:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix99_in203738_bs4_mini
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 1
+    max_out_len: 1024
+    batch_size: 1
+    request_rate: 0
+    baseline: 33.6
+    threshold: 0.97
+
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "MiniMax-M2.7-w8a8-acc"
+    model: "vllm-ascend/MiniMax-M2.7-w8a8-QuaRot"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--max-model-len"
+      - "204800"
+      - "--gpu-memory-utilization"
+      - "0.8"
+    benchmarks:
+      <<: *benchmarks_acc
+  - name: "MiniMax-M2.7-prefix_64k_50"
+    model: "vllm-ascend/MiniMax-M2.7-w8a8-QuaRot"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--max-model-len"
+      - "70000"
+      - "--gpu-memory-utilization"
+      - "0.8"
+    benchmarks:
+      <<: *benchmarks_prefix_64k_50
+  - name: "MiniMax-M2.7-prefix_128k_50"
+    model: "vllm-ascend/MiniMax-M2.7-w8a8-QuaRot"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--max-model-len"
+      - "196608"
+      - "--gpu-memory-utilization"
+      - "0.86"
+    benchmarks:
+      <<: *benchmarks_prefix_128k_50
+  - name: "MiniMax-M2.7-prefix_max"
+    model: "vllm-ascend/MiniMax-M2.7-w8a8-QuaRot"
+    envs:
+      <<: *envs
+    server_cmd: *server_cmd
+    server_cmd_extra:
+      - "--max-model-len"
+      - "204800"
+      - "--gpu-memory-utilization"
+      - "0.8"
+    benchmarks:
+      <<: *benchmarks_prefix_max

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.6-w4a8-A3-weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.6-w4a8-A3-weekly.yaml
@@ -35,7 +35,7 @@ _server_cmd: &server_cmd
   - "--tool-call-parser"
   - "minimax_m2"
   - "--speculative_config"
-  - '{"method":"eagle3","model":"Eco-Tech/MiniMax-M2.7-eagle-model-short,"num_speculative_tokens":3}'
+  - '{"method":"eagle3","model":"Eco-Tech/MiniMax-M2.7-eagle-model-short","num_speculative_tokens":3}'
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"


### PR DESCRIPTION
### What this PR does / why we need it?
This PR restores the weekly end-to-end test use cases, adds new configurations for DeepSeek-V4-Pro, DeepSeek-V4-Flash, and MiniMax-M2.7, and adjusts the maximum number of batched tokens for DeepSeek-V4-Pro to optimize performance.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Tested via the restored weekly and nightly end-to-end multi-node and single-node test suites.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
