### PR TITLE
[v0.23.0][Refactor][DSA] Backport TP weight switching (#12982)

### DIFF
--- a/tests/ut/attention/test_dsa_cp_o_proj_tp.py
+++ b/tests/ut/attention/test_dsa_cp_o_proj_tp.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import torch
+
+if "torch_npu._inductor" not in sys.modules:
+    sys.modules["torch_npu._inductor"] = MagicMock()
+
+from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
+from vllm_ascend.quantization.tp_weight_switch import (
+    TPWeightGatherSpec,
+    TPWeightSwitchMixin,
+)
+
+
+class _OProjLinearMethod(TPWeightSwitchMixin):
+    supports_tp_weight_switch = True
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+
+
+class TestAscendDSACPOProjTPParams(unittest.TestCase):
+    class _OProj(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_size = 8
+            self.input_size_per_partition = 4
+            self.output_size = 3
+            self.output_size_per_partition = 3
+            self.weight = torch.nn.Parameter(torch.randn(4, 3), requires_grad=False)
+            self.weight_scale = torch.nn.Parameter(torch.randn(2, 3), requires_grad=False)
+            self.quant_method: Any = SimpleNamespace(quant_method=_OProjLinearMethod())
+
+    def setUp(self):
+        AscendDSACPImpl.o_proj_full_pools.clear()
+
+    def _make_impl(self):
+        impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+        impl.tp_size = 2
+        impl.tp_group = object()
+        impl.wo_a = self._OProj()
+        impl.wo_b = self._OProj()
+        impl._o_proj_tp_weight_switch_enabled = False
+        return impl
+
+    def test_get_tp_weight_switch_method_unwraps_adapter_and_rejects_unsupported(self):
+        layer = self._OProj()
+
+        method = AscendDSACPImpl._get_tp_weight_switch_method(layer)
+
+        self.assertIs(method, layer.quant_method.quant_method)
+        layer.quant_method = object()
+        with self.assertRaisesRegex(RuntimeError, "TP weight-switch capable"):
+            AscendDSACPImpl._get_tp_weight_switch_method(layer)
+
+    def test_enable_o_proj_switch_initializes_both_layers_once_with_cloned_tp_storage(self):
+        impl = self._make_impl()
+        original_ptrs = (impl.wo_a.weight.data_ptr(), impl.wo_b.weight.data_ptr())
+
+        impl._enable_o_proj_tp_full_weight_switch()
+
+        self.assertTrue(impl._o_proj_tp_weight_switch_enabled)
+        self.assertNotEqual(impl.wo_a.weight.data_ptr(), original_ptrs[0])
+        self.assertNotEqual(impl.wo_b.weight.data_ptr(), original_ptrs[1])
+        self.assertEqual(
+            impl.wo_a.weight.data_ptr(),
+            impl.wo_a_tp_weight_state.gather_parts["weight"].tp_tensor.data_ptr(),
+        )
+        self.assertEqual(
+            impl.wo_b.weight.data_ptr(),
+            impl.wo_b_tp_weight_state.gather_parts["weight"].tp_tensor.data_ptr(),
+        )
+        self.assertEqual(len(AscendDSACPImpl.o_proj_full_pools), 4)
+
+        wo_a_state = impl.wo_a_tp_weight_state
+        wo_b_state = impl.wo_b_tp_weight_state
+        impl._enable_o_proj_tp_full_weight_switch()
+        self.assertIs(impl.wo_a_tp_weight_state, wo_a_state)
+        self.assertIs(impl.wo_b_tp_weight_state, wo_b_state)
+
+    def test_maybe_all_gather_honors_enable_flag_for_both_layers(self):
+        impl = self._make_impl()
+        impl._enable_o_proj_tp_full_weight_switch()
+        impl.wo_a_tp_weight_method.all_gather_tp_weight = MagicMock()
+        impl.wo_b_tp_weight_method.all_gather_tp_weight = MagicMock()
+
+        impl._maybe_all_gather_o_proj_full_weight(False)
+
+        impl.wo_a_tp_weight_method.all_gather_tp_weight.assert_not_called()
+        impl.wo_b_tp_weight_method.all_gather_tp_weight.assert_not_called()
+
+        impl._maybe_all_gather_o_proj_full_weight(True)
+
+        impl.wo_a_tp_weight_method.all_gather_tp_weight.assert_called_once_with(
+            impl.wo_a_tp_weight_state,
+            impl.tp_group,
+        )
+        impl.wo_b_tp_weight_method.all_gather_tp_weight.assert_called_once_with(
+            impl.wo_b_tp_weight_state,
+            impl.tp_group,
+        )
+
+    def test_switch_o_proj_between_full_and_tp_storage(self):
+        impl = self._make_impl()
+        impl._enable_o_proj_tp_full_weight_switch()
+        tp_ptrs = (impl.wo_a.weight.data_ptr(), impl.wo_b.weight.data_ptr())
+        full_ptrs = (
+            impl.wo_a_tp_weight_state.gather_parts["weight"].full_tensor.data_ptr(),
+            impl.wo_b_tp_weight_state.gather_parts["weight"].full_tensor.data_ptr(),
+        )
+
+        impl._switch_o_proj_to_full_weight()
+
+        self.assertEqual(impl.wo_a.weight.data_ptr(), full_ptrs[0])
+        self.assertEqual(impl.wo_b.weight.data_ptr(), full_ptrs[1])
+
+        impl._switch_o_proj_to_tp_weight()
+
+        self.assertEqual(impl.wo_a.weight.data_ptr(), tp_ptrs[0])
+        self.assertEqual(impl.wo_b.weight.data_ptr(), tp_ptrs[1])

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -386,6 +386,7 @@ for _pkg, _path in _vllm_ascend_package_paths.items():
         sys.modules[_pkg] = _make_pkg(_pkg, _path)
 
 _distributed_utils = types.ModuleType("vllm_ascend.distributed.utils")
+_distributed_utils.all_gather_async = MagicMock()  # type: ignore[attr-defined]
 _distributed_utils.get_decode_context_model_parallel_rank = MagicMock(  # type: ignore[attr-defined]
     return_value=0
 )

--- a/tests/ut/quantization/test_tp_weight_switch.py
+++ b/tests/ut/quantization/test_tp_weight_switch.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.quantization.tp_weight_switch import (
+    TPWeightGatherSpec,
+    TPWeightRepeatSpec,
+    TPWeightSwitchMixin,
+)
+
+
+class _TestLinearMethod(TPWeightSwitchMixin):
+    supports_tp_weight_switch = True
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+    tp_weight_repeat_specs = (TPWeightRepeatSpec("input_scale"),)
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1),
+        TPWeightGatherSpec("weight_scale", gather_dim=1),
+    )
+
+
+def _input_sharded_layer() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_size=8,
+        input_size_per_partition=4,
+        output_size=3,
+        output_size_per_partition=3,
+        weight=torch.arange(12, dtype=torch.float32).reshape(4, 3),
+        weight_scale=torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        input_scale=torch.tensor([2.0]),
+    )
+
+
+def _output_sharded_layer() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_size=4,
+        input_size_per_partition=4,
+        output_size=6,
+        output_size_per_partition=3,
+        weight=torch.arange(12, dtype=torch.float32).reshape(4, 3),
+        weight_scale=torch.arange(12, dtype=torch.float32).reshape(2, 3, 2),
+        input_scale=torch.tensor([2.0]),
+    )
+
+
+def test_split_tensor_for_tp_supports_nonzero_and_negative_dims() -> None:
+    tensor = torch.arange(24).reshape(4, 6)
+
+    shard = TPWeightSwitchMixin.split_tensor_for_tp(tensor, tp_size=3, tp_rank=1, dim=-1)
+
+    torch.testing.assert_close(shard, tensor[:, 2:4])
+    assert shard.is_contiguous()
+
+
+def test_split_tensor_for_tp_rejects_non_divisible_dimension() -> None:
+    with pytest.raises(RuntimeError, match="not divisible"):
+        TPWeightSwitchMixin.split_tensor_for_tp(torch.empty(3, 5), tp_size=2, tp_rank=0, dim=1)
+
+
+def test_enable_input_sharded_state_builds_gather_and_repeat_tensors() -> None:
+    layer = _input_sharded_layer()
+    method = _TestLinearMethod()
+
+    state = method.enable_tp_weight_switch(layer, tp_size=2)
+
+    assert set(state.gather_parts) == {"weight", "weight_scale"}
+    assert state.gather_parts["weight"].full_tensor.shape == (8, 3)
+    assert state.gather_parts["weight_scale"].full_tensor.shape == (4, 3)
+    assert state.gather_parts["weight"].tp_tensor.data_ptr() == layer.weight.data_ptr()
+    torch.testing.assert_close(state.repeat_parts["input_scale"].full_tensor, torch.tensor([2.0, 2.0]))
+
+
+def test_enable_output_sharded_state_moves_gather_dim_and_reuses_pool() -> None:
+    method = _TestLinearMethod()
+    pool: dict[object, torch.Tensor] = {}
+
+    first = method.enable_tp_weight_switch(
+        _output_sharded_layer(),
+        tp_size=2,
+        pool=pool,
+        pool_key_prefix="shared",
+    )
+    second = method.enable_tp_weight_switch(
+        _output_sharded_layer(),
+        tp_size=2,
+        pool=pool,
+        pool_key_prefix="shared",
+    )
+
+    weight_part = first.gather_parts["weight"]
+    scale_part = first.gather_parts["weight_scale"]
+    assert weight_part.gather_input.shape == (3, 4)
+    assert weight_part.full_tensor.shape == (4, 6)
+    assert scale_part.gather_input.shape == (3, 2, 2)
+    assert scale_part.full_tensor.shape == (2, 6, 2)
+    assert second.gather_parts["weight"].gather_output.data_ptr() == weight_part.gather_output.data_ptr()
+    assert second.gather_parts["weight_scale"].gather_output.data_ptr() == scale_part.gather_output.data_ptr()
+
+
+def test_all_gather_wait_and_switch_restore_tp_storage() -> None:
+    layer = _input_sharded_layer()
+    method = _TestLinearMethod()
+    state = method.enable_tp_weight_switch(layer, tp_size=2)
+    original_ptrs = {name: getattr(layer, name).data_ptr() for name in ("weight", "weight_scale", "input_scale")}
+    handles: list[MagicMock] = []
+
+    def fake_all_gather_async(gather_input, group, *, output, async_op):
+        del group
+        assert async_op
+        output.copy_(torch.cat((gather_input, gather_input + 100), dim=0))
+        handle = MagicMock()
+        handles.append(handle)
+        return output, handle
+
+    with patch(
+        "vllm_ascend.distributed.utils.all_gather_async",
+        side_effect=fake_all_gather_async,
+    ):
+        method.all_gather_tp_weight(state, group=object())
+
+    assert state.handles == handles
+    method.wait_tp_weight_all_gather(state)
+    assert not state.handles
+    for handle in handles:
+        handle.wait.assert_called_once_with()
+
+    method.switch_tp_weight(layer, state, use_full_weight=True)
+    assert layer.weight.data_ptr() == state.gather_parts["weight"].full_tensor.data_ptr()
+    assert layer.weight_scale.data_ptr() == state.gather_parts["weight_scale"].full_tensor.data_ptr()
+    assert layer.input_scale.data_ptr() == state.repeat_parts["input_scale"].full_tensor.data_ptr()
+
+    method.switch_tp_weight(layer, state, use_full_weight=False)
+    for name, ptr in original_ptrs.items():
+        assert getattr(layer, name).data_ptr() == ptr
+
+
+@pytest.mark.parametrize(
+    ("layer", "message"),
+    [
+        (
+            SimpleNamespace(
+                input_size=4,
+                input_size_per_partition=4,
+                output_size=3,
+                output_size_per_partition=3,
+            ),
+            "exactly one TP-sharded axis",
+        ),
+        (
+            SimpleNamespace(
+                input_size=8,
+                input_size_per_partition=4,
+                output_size=6,
+                output_size_per_partition=3,
+            ),
+            "exactly one TP-sharded axis",
+        ),
+    ],
+)
+def test_enable_rejects_zero_or_two_sharded_axes(layer: SimpleNamespace, message: str) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        _TestLinearMethod().enable_tp_weight_switch(layer, tp_size=2)
+
+
+def test_enable_rejects_unsupported_method_and_missing_attribute() -> None:
+    with pytest.raises(RuntimeError, match="does not support"):
+        TPWeightSwitchMixin().enable_tp_weight_switch(_input_sharded_layer(), tp_size=2)
+
+    layer = _input_sharded_layer()
+    del layer.weight_scale
+    with pytest.raises(RuntimeError, match="weight_scale"):
+        _TestLinearMethod().enable_tp_weight_switch(layer, tp_size=2)
+
+
+def test_all_gather_rejects_a_second_launch_while_pending() -> None:
+    state = _TestLinearMethod().enable_tp_weight_switch(_input_sharded_layer(), tp_size=2)
+    state.handles.append(MagicMock())
+
+    with pytest.raises(RuntimeError, match="still pending"):
+        _TestLinearMethod().all_gather_tp_weight(state, group=object())

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import ClassVar, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 import torch
 import torch.distributed as dist

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -22,11 +22,11 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
+from vllm_ascend.quantization.tp_weight_switch import TPWeightSwitchMixin, TPWeightSwitchState
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_dsa_cp_with_o_proj_tp,
@@ -930,10 +930,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
     understand this class
     """
 
-    wo_a_full_pool: ClassVar[torch.Tensor | None] = None
-    wo_a_full_weight_scale_pool: ClassVar[torch.Tensor | None] = None
-    wo_b_full_pool: ClassVar[torch.Tensor | None] = None
-    wo_b_full_weight_scale_pool: ClassVar[torch.Tensor | None] = None
+    o_proj_full_pools: ClassVar[dict[Any, torch.Tensor]] = {}
 
     def __init__(
         self,
@@ -982,11 +979,8 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
 
-        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and (
-            get_ascend_device_type() == AscendDeviceType.A5
-        )
-        self._wo_a_dynamic_quant = False
-        self._wo_b_dynamic_quant = False
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
+        self._o_proj_tp_weight_switch_enabled = False
 
         self.eps = kwargs["eps"]
 
@@ -1063,122 +1057,89 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 f"got {self.attn_sink.numel()} heads, expected {self.num_heads}."
             )
         if self.enable_dsa_cp_with_o_proj_tp:
-            self._maybe_init_o_proj_tp_full_params()
+            self._enable_o_proj_tp_full_weight_switch()
 
     @staticmethod
-    def _check_dynamic_quant(layer: torch.nn.Module) -> bool:
-        return get_ascend_device_type() in {AscendDeviceType.A5} and hasattr(layer, "weight_scale")
-
-    def _maybe_init_o_proj_tp_full_params(self) -> None:
-        self._wo_a_dynamic_quant = type(self)._check_dynamic_quant(self.wo_a)
-        self._wo_b_dynamic_quant = type(self)._check_dynamic_quant(self.wo_b)
-        if AscendDSACPImpl.wo_a_full_pool is None:
-            sample = self.wo_a.weight
-            AscendDSACPImpl.wo_a_full_pool = torch.empty(
-                (sample.shape[0] * self.tp_size, *sample.shape[1:]),
-                dtype=sample.dtype,
-                device=sample.device,
+    def _get_tp_weight_switch_method(layer: torch.nn.Module) -> TPWeightSwitchMixin:
+        quant_method = layer.quant_method
+        linear_method = getattr(quant_method, "quant_method", quant_method)
+        if not isinstance(linear_method, TPWeightSwitchMixin) or not linear_method.supports_tp_weight_switch:
+            raise RuntimeError(
+                "DSA-CP o_proj TP full-weight switching requires a TP weight-switch capable method, "
+                f"got {type(linear_method).__name__}."
             )
-        self.wo_a_tp_weight = self.wo_a.weight.clone().detach().contiguous()
-        self.wo_a.weight.set_(self.wo_a_tp_weight)
-        if AscendDSACPImpl.wo_b_full_pool is None:
-            sample = self.wo_b.weight
-            AscendDSACPImpl.wo_b_full_pool = torch.empty(
-                (sample.shape[0] * self.tp_size, *sample.shape[1:]),
-                dtype=sample.dtype,
-                device=sample.device,
-            )
-        self.wo_b_tp_weight = self.wo_b.weight.clone().detach().contiguous()
-        self.wo_b.weight.set_(self.wo_b_tp_weight)
+        return linear_method
 
-        if self._wo_a_dynamic_quant:
-            if AscendDSACPImpl.wo_a_full_weight_scale_pool is None:
-                sample = self.wo_a.weight_scale
-                AscendDSACPImpl.wo_a_full_weight_scale_pool = torch.empty(
-                    (sample.shape[0] * self.tp_size, *sample.shape[1:]),
-                    dtype=sample.dtype,
-                    device=sample.device,
-                )
-            self.wo_a_tp_weight_scale = self.wo_a.weight_scale.clone().detach().contiguous()
-            self.wo_a.weight_scale.set_(self.wo_a_tp_weight_scale)
-        if self._wo_b_dynamic_quant:
-            if AscendDSACPImpl.wo_b_full_weight_scale_pool is None:
-                sample = self.wo_b.weight_scale
-                AscendDSACPImpl.wo_b_full_weight_scale_pool = torch.empty(
-                    (sample.shape[0] * self.tp_size, *sample.shape[1:]),
-                    dtype=sample.dtype,
-                    device=sample.device,
-                )
-            self.wo_b_tp_weight_scale = self.wo_b.weight_scale.clone().detach().contiguous()
-            self.wo_b.weight_scale.set_(self.wo_b_tp_weight_scale)
+    def _enable_linear_tp_weight_switch(
+        self,
+        layer: torch.nn.Module,
+        name: str,
+    ) -> tuple[TPWeightSwitchMixin, TPWeightSwitchState]:
+        linear_method = self._get_tp_weight_switch_method(layer)
+        state = linear_method.enable_tp_weight_switch(
+            layer,
+            self.tp_size,
+            pool=AscendDSACPImpl.o_proj_full_pools,
+            pool_key_prefix=(type(linear_method).__qualname__, name, "dsa_cp_o_proj"),
+            clone_tp_tensors=True,
+        )
+        return linear_method, state
+
+    def _enable_o_proj_tp_full_weight_switch(self) -> None:
+        """Allocate o_proj TP/full buffers when the DSA-CP backend is enabled."""
+        if self._o_proj_tp_weight_switch_enabled:
+            return
+        self.wo_a_tp_weight_method, self.wo_a_tp_weight_state = self._enable_linear_tp_weight_switch(
+            self.wo_a,
+            "wo_a",
+        )
+        self.wo_b_tp_weight_method, self.wo_b_tp_weight_state = self._enable_linear_tp_weight_switch(
+            self.wo_b,
+            "wo_b",
+        )
+        self._o_proj_tp_weight_switch_enabled = True
 
     def _maybe_all_gather_o_proj_full_weight(
         self,
         enabled: bool,
-    ) -> list[torch.distributed.Work]:
-        if not enabled:
-            return []
-        handles = []
-        assert AscendDSACPImpl.wo_a_full_pool is not None
-        _, weight_handle = all_gather_async(
-            self.wo_a_tp_weight,
-            self.tp_group,
-            output=AscendDSACPImpl.wo_a_full_pool,
-        )
-        if weight_handle is not None:
-            handles.append(weight_handle)
-        assert AscendDSACPImpl.wo_b_full_pool is not None
-        _, wo_b_weight_handle = all_gather_async(
-            self.wo_b_tp_weight,
-            self.tp_group,
-            output=AscendDSACPImpl.wo_b_full_pool,
-        )
-        if wo_b_weight_handle is not None:
-            handles.append(wo_b_weight_handle)
-        if self._wo_a_dynamic_quant:
-            assert AscendDSACPImpl.wo_a_full_weight_scale_pool is not None
-            _, weight_scale_handle = all_gather_async(
-                self.wo_a_tp_weight_scale,
-                self.tp_group,
-                output=AscendDSACPImpl.wo_a_full_weight_scale_pool,
-            )
-            if weight_scale_handle is not None:
-                handles.append(weight_scale_handle)
-        if self._wo_b_dynamic_quant:
-            assert AscendDSACPImpl.wo_b_full_weight_scale_pool is not None
-            _, wo_b_weight_scale_handle = all_gather_async(
-                self.wo_b_tp_weight_scale,
-                self.tp_group,
-                output=AscendDSACPImpl.wo_b_full_weight_scale_pool,
-            )
-            if wo_b_weight_scale_handle is not None:
-                handles.append(wo_b_weight_scale_handle)
-        return handles
-
-    def _switch_o_proj_to_full_weight(
-        self,
-        handles: list[torch.distributed.Work],
     ) -> None:
-        for handle in handles:
-            handle.wait()
-        assert AscendDSACPImpl.wo_a_full_pool is not None
-        self.wo_a.weight.set_(AscendDSACPImpl.wo_a_full_pool)
-        if self._wo_a_dynamic_quant:
-            assert AscendDSACPImpl.wo_a_full_weight_scale_pool is not None
-            self.wo_a.weight_scale.set_(AscendDSACPImpl.wo_a_full_weight_scale_pool)
-        assert AscendDSACPImpl.wo_b_full_pool is not None
-        self.wo_b.weight.set_(AscendDSACPImpl.wo_b_full_pool)
-        if self._wo_b_dynamic_quant:
-            assert AscendDSACPImpl.wo_b_full_weight_scale_pool is not None
-            self.wo_b.weight_scale.set_(AscendDSACPImpl.wo_b_full_weight_scale_pool)
+        if not enabled:
+            return
+        self._enable_o_proj_tp_full_weight_switch()
+        self.wo_a_tp_weight_method.all_gather_tp_weight(
+            self.wo_a_tp_weight_state,
+            self.tp_group,
+        )
+        self.wo_b_tp_weight_method.all_gather_tp_weight(
+            self.wo_b_tp_weight_state,
+            self.tp_group,
+        )
+
+    def _switch_o_proj_to_full_weight(self) -> None:
+        self.wo_a_tp_weight_method.wait_tp_weight_all_gather(self.wo_a_tp_weight_state)
+        self.wo_b_tp_weight_method.wait_tp_weight_all_gather(self.wo_b_tp_weight_state)
+        self.wo_a_tp_weight_method.switch_tp_weight(
+            self.wo_a,
+            self.wo_a_tp_weight_state,
+            use_full_weight=True,
+        )
+        self.wo_b_tp_weight_method.switch_tp_weight(
+            self.wo_b,
+            self.wo_b_tp_weight_state,
+            use_full_weight=True,
+        )
 
     def _switch_o_proj_to_tp_weight(self) -> None:
-        self.wo_a.weight.set_(self.wo_a_tp_weight)
-        if self._wo_a_dynamic_quant:
-            self.wo_a.weight_scale.set_(self.wo_a_tp_weight_scale)
-        self.wo_b.weight.set_(self.wo_b_tp_weight)
-        if self._wo_b_dynamic_quant:
-            self.wo_b.weight_scale.set_(self.wo_b_tp_weight_scale)
+        self.wo_a_tp_weight_method.switch_tp_weight(
+            self.wo_a,
+            self.wo_a_tp_weight_state,
+            use_full_weight=False,
+        )
+        self.wo_b_tp_weight_method.switch_tp_weight(
+            self.wo_b,
+            self.wo_b_tp_weight_state,
+            use_full_weight=False,
+        )
 
     def _apply_wo_b(
         self,
@@ -1188,6 +1149,39 @@ class AscendDSACPImpl(DSAAttentionImpl):
         if not full_weight:
             return self.wo_b(o_proj_input)
         return self.wo_b.quant_method.apply(self.wo_b, o_proj_input, bias=None)
+
+    def _get_batched_wo_a_weight(self, num_groups: int) -> torch.Tensor:
+        """Return wo_a in the DSA batched-matmul layout [group, input, rank]."""
+        weight = self.wo_a.weight
+        if weight.ndim == 3:
+            if weight.shape[0] == num_groups:
+                return weight
+            if weight.shape[1] == num_groups:
+                return weight.permute(1, 0, 2)
+            raise RuntimeError(
+                "DSA-CP wo_a weight has no group axis matching the o_proj input: "
+                f"weight_shape={tuple(weight.shape)}, num_groups={num_groups}."
+            )
+
+        linear_method = getattr(self.wo_a.quant_method, "quant_method", self.wo_a.quant_method)
+        if isinstance(linear_method, AscendUnquantizedLinearMethod):
+            return weight.reshape(num_groups, -1, weight.shape[-1]).transpose(1, 2)
+        return weight.reshape(weight.shape[0], num_groups, -1).permute(1, 0, 2)
+
+    def _get_batched_wo_a_scale(self, num_groups: int) -> torch.Tensor:
+        """Move the output-sharded wo_a scale's group axis to the front."""
+        scale = self.wo_a.weight_scale
+        if scale.ndim == 1:
+            return scale.reshape(num_groups, -1)
+        if scale.shape[0] == num_groups:
+            return scale
+        if scale.shape[1] % num_groups != 0:
+            raise RuntimeError(
+                "DSA-CP wo_a scale cannot be reshaped by o_proj group: "
+                f"scale_shape={tuple(scale.shape)}, num_groups={num_groups}."
+            )
+        scale = scale.reshape(scale.shape[0], num_groups, -1, *scale.shape[2:])
+        return scale.permute(1, 0, 2, *range(3, scale.ndim))
 
     def forward(  # type: ignore[override]
         self,
@@ -1214,7 +1208,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 AscendAttentionState.SpecDecoding,
             }
         )
-        local_attn_output, o_proj_full_handles = self._forward(
+        local_attn_output = self._forward(
             layer_name,
             hidden_states,
             kv_cache,
@@ -1232,24 +1226,28 @@ class AscendDSACPImpl(DSAAttentionImpl):
 
         # o
         if full_gather_wo_a_enabled:
-            self._switch_o_proj_to_full_weight(o_proj_full_handles)
+            self._switch_o_proj_to_full_weight()
         o_proj_groups = self.n_group if full_gather_wo_a_enabled else self.n_local_groups
         try:
             if get_ascend_device_type() in {AscendDeviceType.A5}:
                 o = o_proj_input.view(num_tokens, o_proj_groups, -1)
-                o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
-                o = torch_npu.npu_transpose_quant_batchmatmul(
-                    o,
-                    self.wo_a.weight,
-                    dtype=torch.bfloat16,
-                    bias=None,
-                    group_sizes=(0, 0, 32),
-                    x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
-                    x2_scale=self.wo_a.weight_scale.view(torch.float8_e8m0fnu),
-                    perm_x1=(1, 0, 2),
-                    perm_x2=(0, 1, 2),
-                    perm_y=(1, 0, 2),
-                )
+                wo_a_method = getattr(self.wo_a.quant_method, "quant_method", self.wo_a.quant_method)
+                if isinstance(wo_a_method, AscendUnquantizedLinearMethod):
+                    o = torch.bmm(o.transpose(0, 1), self._get_batched_wo_a_weight(o_proj_groups)).transpose(0, 1)
+                else:
+                    o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
+                    o = torch_npu.npu_transpose_quant_batchmatmul(
+                        o,
+                        self._get_batched_wo_a_weight(o_proj_groups),
+                        dtype=torch.bfloat16,
+                        bias=None,
+                        group_sizes=(0, 0, 32),
+                        x1_scale=swiglu_out_scale.view(torch.float8_e8m0fnu),
+                        x2_scale=self._get_batched_wo_a_scale(o_proj_groups).view(torch.float8_e8m0fnu),
+                        perm_x1=(1, 0, 2),
+                        perm_x2=(0, 1, 2),
+                        perm_y=(1, 0, 2),
+                    )
                 o = o.reshape(num_tokens, -1)
                 output[...] = self._apply_wo_b(o, full_gather_wo_a_enabled)
             else:
@@ -1261,7 +1259,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                     # o = torch.einsum("tgd,grd->tgr", o, wo_a)
                     o_proj_input = torch_npu.npu_transpose_batchmatmul(
                         o_proj_input,
-                        self.wo_a.weight,
+                        self._get_batched_wo_a_weight(o_proj_groups),
                         bias=None,
                         scale=None,
                         perm_x1=(1, 0, 2),
@@ -1374,7 +1372,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
-        o_proj_full_handles = self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
+        self._maybe_all_gather_o_proj_full_weight(full_gather_wo_a_enabled)
 
         kv = self.wkv(hidden_states_cache)
         kv = self.kv_norm(kv)
@@ -1503,7 +1501,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
-        return attn_output, o_proj_full_handles
+        return attn_output
 
     def _restore_tp_head_layout(
         self,

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -41,6 +41,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
+from vllm_ascend.quantization.tp_weight_switch import TPWeightGatherSpec, TPWeightSwitchMixin
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_sp,
@@ -80,8 +81,12 @@ def _should_keep_nd_for_310p_weight(weight: torch.Tensor) -> bool:
     return is_310p() and weight.ndim >= 2 and (weight.shape[-1] == 1 or weight.shape[-2] == 1)
 
 
-class AscendUnquantizedLinearMethod(UnquantizedLinearMethod):
+class AscendUnquantizedLinearMethod(TPWeightSwitchMixin, UnquantizedLinearMethod):
     """Linear method without quantization"""
+
+    tp_weight_gather_specs = (TPWeightGatherSpec("weight", gather_dim=1),)
+    tp_weight_output_gather_specs = (TPWeightGatherSpec("weight"),)
+    supports_tp_weight_switch = True
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)

--- a/vllm_ascend/quantization/compressed_tensors_config.py
+++ b/vllm_ascend/quantization/compressed_tensors_config.py
@@ -22,7 +22,7 @@ from typing import Any, Optional, cast
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy, QuantizationType
 from vllm.logger import logger
-from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS, register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
 )
 from vllm.model_executor.models.utils import WeightsMapper
 
+from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD, vllm_version_is
 
 from .methods import AscendLinearScheme, AscendMoEScheme
@@ -171,7 +172,7 @@ class AscendCompressedTensorsConfig(QuantizationConfig):
 
             # Return unquantized method if no scheme found
             if linear_scheme is None:
-                return UnquantizedLinearMethod()
+                return AscendUnquantizedLinearMethod()
 
             # Store scheme on layer for reference (optional, for debugging)
             layer.scheme = linear_scheme

--- a/vllm_ascend/quantization/methods/__init__.py
+++ b/vllm_ascend/quantization/methods/__init__.py
@@ -30,7 +30,18 @@ Usage:
 from typing import Any
 
 # Import base classes
-from .base import AscendAttentionScheme, AscendLinearScheme, AscendMoEScheme, QuantType
+from .base import (
+    AscendAttentionScheme,
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    TPWeightGatherPart,
+    TPWeightGatherSpec,
+    TPWeightRepeatPart,
+    TPWeightRepeatSpec,
+    TPWeightSwitchMixin,
+    TPWeightSwitchState,
+)
 
 # Import all scheme classes for external access
 from .fp8 import AscendW4A8MXFPDSDynamicFusedMoEMethod, AscendW8A8MXFP8DSDynamicLinearMethod
@@ -74,6 +85,12 @@ __all__ = [
     "AscendLinearScheme",
     "AscendMoEScheme",
     "QuantType",
+    "TPWeightGatherPart",
+    "TPWeightGatherSpec",
+    "TPWeightRepeatPart",
+    "TPWeightRepeatSpec",
+    "TPWeightSwitchMixin",
+    "TPWeightSwitchState",
     # Registry functions
     "register_scheme",
     "get_scheme_class",

--- a/vllm_ascend/quantization/methods/base.py
+++ b/vllm_ascend/quantization/methods/base.py
@@ -23,6 +23,27 @@ from typing import Any
 import torch
 
 from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.quantization.tp_weight_switch import (
+    TPWeightGatherPart,
+    TPWeightGatherSpec,
+    TPWeightRepeatPart,
+    TPWeightRepeatSpec,
+    TPWeightSwitchMixin,
+    TPWeightSwitchState,
+)
+
+__all__ = [
+    "AscendAttentionScheme",
+    "AscendLinearScheme",
+    "AscendMoEScheme",
+    "QuantType",
+    "TPWeightGatherPart",
+    "TPWeightGatherSpec",
+    "TPWeightRepeatPart",
+    "TPWeightRepeatSpec",
+    "TPWeightSwitchMixin",
+    "TPWeightSwitchState",
+]
 
 
 def get_moe_num_logical_experts(
@@ -39,7 +60,7 @@ def get_moe_num_logical_experts(
     return int(num_experts - global_redundant_expert_num - num_shared_experts)
 
 
-class AscendLinearScheme(ABC):
+class AscendLinearScheme(TPWeightSwitchMixin, ABC):
     """Base class for all linear quantization schemes.
 
     Subclasses must implement get_weight() and apply() methods.

--- a/vllm_ascend/quantization/methods/fp8.py
+++ b/vllm_ascend/quantization/methods/fp8.py
@@ -21,7 +21,7 @@ import torch
 import torch_npu
 from vllm.config import get_current_vllm_config
 
-from .base import QuantType
+from .base import QuantType, TPWeightGatherSpec
 from .registry import register_scheme
 from .w4a8_mxfp4 import AscendW4A8MXFPDynamicFusedMoEMethod
 from .w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
@@ -35,6 +35,15 @@ class AscendW8A8MXFP8DSDynamicLinearMethod(AscendW8A8MXFP8DynamicLinearMethod):
     """
 
     model_dtype = None
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+    supports_tp_weight_switch = True
 
     def __init__(self, quant_config):
         super().__init__()

--- a/vllm_ascend/quantization/methods/w4a4_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a4_mxfp4.py
@@ -32,7 +32,13 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import (
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    TPWeightGatherSpec,
+    get_moe_num_logical_experts,
+)
 from .registry import register_scheme
 
 
@@ -46,6 +52,15 @@ class AscendW4A4MXFP4DynamicLinearMethod(AscendLinearScheme):
     """
 
     model_dtype = None
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1),
+        TPWeightGatherSpec("weight_scale", gather_dim=1),
+    )
+    supports_tp_weight_switch = True
 
     def __init__(self):
         ensure_mxfp4_linear_available("W4A4_MXFP4 linear quantization")

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -33,13 +33,29 @@ from vllm_ascend.device.mxfp_compat import (
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import (
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    TPWeightGatherSpec,
+    get_moe_num_logical_experts,
+)
 from .registry import register_scheme
 
 
 @register_scheme("W4A8_MXFP", "linear")
 class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
     """Linear method for Ascend W4A8_MXFP (Microscaling) quantization."""
+
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1),
+        TPWeightGatherSpec("weight_scale", gather_dim=1),
+    )
+    supports_tp_weight_switch = True
 
     def __init__(self):
         ensure_mxfp4_linear_available("W8A8_MXFP8 linear quantization")

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -31,7 +31,13 @@ from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_expe
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, enable_dsa_cp, maybe_trans_nz
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import (
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    TPWeightGatherSpec,
+    get_moe_num_logical_experts,
+)
 from .registry import register_scheme
 
 
@@ -54,6 +60,13 @@ class AscendW8A8DynamicLinearMethod(AscendLinearScheme):
     """
 
     act_quant_type: torch.dtype = torch.int8
+    tp_weight_gather_specs = (TPWeightGatherSpec("weight"),)
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1),
+        TPWeightGatherSpec("weight_scale"),
+        TPWeightGatherSpec("weight_offset"),
+    )
+    supports_tp_weight_switch = True
 
     def __init__(self):
         pass

--- a/vllm_ascend/quantization/methods/w8a8_mxfp8.py
+++ b/vllm_ascend/quantization/methods/w8a8_mxfp8.py
@@ -36,7 +36,13 @@ from vllm_ascend.flash_common3_context import get_flash_common3_context
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 
-from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_logical_experts
+from .base import (
+    AscendLinearScheme,
+    AscendMoEScheme,
+    QuantType,
+    TPWeightGatherSpec,
+    get_moe_num_logical_experts,
+)
 from .registry import register_scheme
 
 
@@ -50,6 +56,15 @@ class AscendW8A8MXFP8DynamicLinearMethod(AscendLinearScheme):
     """
 
     model_dtype = None
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight"),
+        TPWeightGatherSpec("weight_scale"),
+    )
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1),
+        TPWeightGatherSpec("weight_scale", gather_dim=1),
+    )
+    supports_tp_weight_switch = True
 
     def __init__(self):
         ensure_mxfp8_linear_available("W8A8_MXFP8 linear quantization")

--- a/vllm_ascend/quantization/methods/w8a8_static.py
+++ b/vllm_ascend/quantization/methods/w8a8_static.py
@@ -26,7 +26,7 @@ from vllm_ascend.utils import (
     maybe_trans_nz,
 )
 
-from .base import AscendLinearScheme
+from .base import AscendLinearScheme, TPWeightGatherSpec, TPWeightRepeatSpec
 from .registry import register_scheme
 
 
@@ -40,6 +40,21 @@ class AscendW8A8LinearMethod(AscendLinearScheme):
 
     def __init__(self) -> None:
         pass
+
+    tp_weight_gather_specs = (TPWeightGatherSpec("weight"),)
+    tp_weight_output_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1),
+        TPWeightGatherSpec("quant_bias"),
+        TPWeightGatherSpec("deq_scale"),
+        TPWeightGatherSpec("weight_scale"),
+        TPWeightGatherSpec("weight_offset"),
+    )
+    supports_tp_weight_switch = True
+    tp_weight_repeat_specs = (
+        TPWeightRepeatSpec("aclnn_input_scale"),
+        TPWeightRepeatSpec("aclnn_input_scale_reciprocal"),
+        TPWeightRepeatSpec("aclnn_input_offset"),
+    )
 
     def get_weight(
         self,

--- a/vllm_ascend/quantization/methods/w8a8fp8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8fp8_dynamic.py
@@ -33,6 +33,7 @@ class AscendW8A8FP8DynamicLinearMethod(AscendW8A8DynamicLinearMethod):
     """
 
     act_quant_type: torch.dtype = torch.float8_e4m3fn
+    supports_tp_weight_switch = False
 
     def __init__(self):
         pass

--- a/vllm_ascend/quantization/tp_weight_switch.py
+++ b/vllm_ascend/quantization/tp_weight_switch.py
@@ -1,0 +1,296 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""TP full-weight switching support shared by compatible linear methods."""
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+import torch
+
+
+@dataclass(frozen=True)
+class TPWeightGatherSpec:
+    """Tensor attribute that should be all-gathered across TP ranks."""
+
+    attr_name: str
+    gather_dim: int = 0
+
+
+@dataclass(frozen=True)
+class TPWeightRepeatSpec:
+    """Tensor attribute that should be expanded by local repeat."""
+
+    attr_name: str
+    repeat_dim: int = 0
+
+
+@dataclass
+class TPWeightGatherPart:
+    """Runtime tensors for one all-gathered TP attribute."""
+
+    spec: TPWeightGatherSpec
+    tp_tensor: torch.Tensor
+    gather_input: torch.Tensor
+    gather_output: torch.Tensor
+    full_tensor: torch.Tensor
+
+
+@dataclass
+class TPWeightRepeatPart:
+    """Runtime tensors for one repeated TP attribute."""
+
+    spec: TPWeightRepeatSpec
+    tp_tensor: torch.Tensor
+    full_tensor: torch.Tensor
+
+
+@dataclass
+class TPWeightSwitchState:
+    """Reusable buffers and outstanding collectives for one linear layer."""
+
+    gather_parts: dict[str, TPWeightGatherPart] = field(default_factory=dict)
+    repeat_parts: dict[str, TPWeightRepeatPart] = field(default_factory=dict)
+    handles: list[torch.distributed.Work] = field(default_factory=list)
+
+
+class TPWeightSwitchMixin:
+    """Opt-in TP/full weight switching for one linear method.
+
+    Subclasses declare the direct layer attributes needed by a full-weight
+    forward after ``process_weights_after_loading()`` has completed. The
+    input-sharded specs are used by row-parallel linears and the
+    output-sharded specs by column-parallel linears. When adding support for a
+    quantization type, document the following in the subclass docstring or
+    adjacent spec declaration:
+
+    1. The post-processing layout and TP-sharded dimension of every declared
+       attribute. ``TPWeightGatherSpec.gather_dim`` must identify that exact
+       dimension, including packed or transposed weight layouts.
+    2. Every attribute that must be concatenated across TP ranks in
+       ``tp_weight_gather_specs``. This normally includes the weight and any
+       rank-distinct scale or metadata consumed by the full-weight kernel.
+    3. Every attribute that must be repeated locally in
+       ``tp_weight_repeat_specs``. Use this only when the full-weight kernel
+       expects the same rank-local value once per TP shard; rank-distinct data
+       must be gathered instead.
+    4. Both input- and output-sharded layouts when the method can be used by
+       row- and column-parallel linears. Include every quantization parameter
+       that becomes TP-sharded in each layout.
+    5. Set ``supports_tp_weight_switch = True`` only after validating every
+       declared layout. Callers use this as the common opt-in gate; it carries
+       no SFA- or DSA-CP-specific meaning.
+
+    ``attr_name`` must name a direct tensor attribute on the layer. The mixin
+    owns only reusable TP/full state and collective handles; subclasses retain
+    ownership of the attribute list and its quantization-specific semantics.
+    """
+
+    tp_weight_gather_specs: ClassVar[tuple[TPWeightGatherSpec, ...]] = ()
+    tp_weight_repeat_specs: ClassVar[tuple[TPWeightRepeatSpec, ...]] = ()
+    tp_weight_output_gather_specs: ClassVar[tuple[TPWeightGatherSpec, ...]] = ()
+    tp_weight_output_repeat_specs: ClassVar[tuple[TPWeightRepeatSpec, ...]] = ()
+    supports_tp_weight_switch: ClassVar[bool] = False
+
+    @staticmethod
+    def split_tensor_for_tp(
+        tensor: torch.Tensor,
+        tp_size: int,
+        tp_rank: int,
+        dim: int = 0,
+        contiguous: bool = True,
+    ) -> torch.Tensor:
+        """Slice one TP shard from a full tensor."""
+        dim = dim if dim >= 0 else tensor.dim() + dim
+        if tensor.shape[dim] % tp_size != 0:
+            raise RuntimeError(
+                "Cannot split tensor for TP because the target dimension is not divisible by TP size: "
+                f"shape={tuple(tensor.shape)}, dim={dim}, tp_size={tp_size}."
+            )
+        shard_size = tensor.shape[dim] // tp_size
+        shard = tensor.narrow(dim, tp_rank * shard_size, shard_size)
+        return shard.contiguous() if contiguous else shard
+
+    def enable_tp_weight_switch(
+        self,
+        layer: torch.nn.Module,
+        tp_size: int,
+        *,
+        pool: dict[Any, torch.Tensor] | None = None,
+        pool_key_prefix: Any | None = None,
+        clone_tp_tensors: bool = False,
+    ) -> TPWeightSwitchState:
+        """Allocate TP/full aliases and buffers for one compatible linear layer."""
+        if not self.supports_tp_weight_switch:
+            raise RuntimeError(f"{type(self).__name__} does not support TP weight switching.")
+
+        input_size = getattr(layer, "input_size", None)
+        input_size_per_partition = getattr(layer, "input_size_per_partition", None)
+        output_size = getattr(layer, "output_size", None)
+        output_size_per_partition = getattr(layer, "output_size_per_partition", None)
+        input_sharded = (
+            input_size is not None and input_size_per_partition is not None and input_size != input_size_per_partition
+        )
+        output_sharded = (
+            output_size is not None
+            and output_size_per_partition is not None
+            and output_size != output_size_per_partition
+        )
+        if input_sharded == output_sharded:
+            raise RuntimeError(
+                "TP weight switching requires a linear layer with exactly one TP-sharded axis, "
+                f"got input_size={input_size}, input_size_per_partition={input_size_per_partition}, "
+                f"output_size={output_size}, output_size_per_partition={output_size_per_partition}."
+            )
+        if input_sharded:
+            gather_specs = self.tp_weight_gather_specs
+            repeat_specs = self.tp_weight_repeat_specs
+            shard_axis = "input"
+        else:
+            gather_specs = self.tp_weight_output_gather_specs
+            repeat_specs = self.tp_weight_output_repeat_specs
+            shard_axis = "output"
+        if not gather_specs and not repeat_specs:
+            raise RuntimeError(
+                f"{type(self).__name__} does not declare TP weight switch specs for a {shard_axis}-sharded layer."
+            )
+
+        state = TPWeightSwitchState()
+
+        for gather_spec in gather_specs:
+            tensor = getattr(layer, gather_spec.attr_name, None)
+            if tensor is None:
+                raise RuntimeError(
+                    f"{type(self).__name__} declares TP gather attr {gather_spec.attr_name!r}, "
+                    f"but layer {getattr(layer, 'prefix', layer)} does not have it."
+                )
+            dim = gather_spec.gather_dim if gather_spec.gather_dim >= 0 else tensor.dim() + gather_spec.gather_dim
+            if dim < 0 or dim >= tensor.dim():
+                raise RuntimeError(
+                    f"Invalid TP gather dim {gather_spec.gather_dim} for attr {gather_spec.attr_name!r} "
+                    f"with shape {tuple(tensor.shape)}."
+                )
+
+            tp_tensor = tensor.clone().detach().contiguous() if clone_tp_tensors else tensor.detach()
+            if clone_tp_tensors:
+                with torch.no_grad():
+                    tensor.set_(tp_tensor)
+            full_shape_list = list(tp_tensor.shape)
+            full_shape_list[dim] *= tp_size
+            full_shape = tuple(full_shape_list)
+            if dim == 0:
+                gather_input = tp_tensor
+            else:
+                gather_input = torch.movedim(tp_tensor, dim, 0).contiguous()
+            gather_shape = (full_shape[dim], *full_shape[:dim], *full_shape[dim + 1 :])
+            pool_key = (
+                pool_key_prefix,
+                gather_spec.attr_name,
+                tp_tensor.device.type,
+                tp_tensor.device.index,
+                tp_tensor.dtype,
+                dim,
+                full_shape,
+            )
+            if pool is None:
+                gather_output = torch.empty(gather_shape, dtype=tp_tensor.dtype, device=tp_tensor.device)
+            else:
+                gather_output = pool.get(pool_key)
+                if gather_output is None:
+                    gather_output = torch.empty(gather_shape, dtype=tp_tensor.dtype, device=tp_tensor.device)
+                    pool[pool_key] = gather_output
+            if dim == 0:
+                full_tensor = gather_output
+            else:
+                full_tensor = torch.movedim(gather_output, 0, dim)
+            state.gather_parts[gather_spec.attr_name] = TPWeightGatherPart(
+                spec=gather_spec,
+                tp_tensor=tp_tensor,
+                gather_input=gather_input,
+                gather_output=gather_output,
+                full_tensor=full_tensor,
+            )
+
+        for repeat_spec in repeat_specs:
+            tensor = getattr(layer, repeat_spec.attr_name, None)
+            if tensor is None:
+                raise RuntimeError(
+                    f"{type(self).__name__} declares TP repeat attr {repeat_spec.attr_name!r}, "
+                    f"but layer {getattr(layer, 'prefix', layer)} does not have it."
+                )
+            dim = repeat_spec.repeat_dim if repeat_spec.repeat_dim >= 0 else tensor.dim() + repeat_spec.repeat_dim
+            if dim < 0 or dim >= tensor.dim():
+                raise RuntimeError(
+                    f"Invalid TP repeat dim {repeat_spec.repeat_dim} for attr {repeat_spec.attr_name!r} "
+                    f"with shape {tuple(tensor.shape)}."
+                )
+            repeats = [1] * tensor.dim()
+            repeats[dim] = tp_size
+            tp_tensor = tensor.detach()
+            state.repeat_parts[repeat_spec.attr_name] = TPWeightRepeatPart(
+                spec=repeat_spec,
+                tp_tensor=tp_tensor,
+                full_tensor=tp_tensor.repeat(*repeats),
+            )
+
+        return state
+
+    def all_gather_tp_weight(
+        self,
+        state: TPWeightSwitchState,
+        group: Any,
+        *,
+        async_op: bool = True,
+    ) -> None:
+        """All-gather every TP-sharded tensor in ``state``."""
+        from vllm_ascend.distributed.utils import all_gather_async
+
+        if state.handles:
+            raise RuntimeError("TP weight all-gather is still pending; wait before launching another one.")
+        for part in state.gather_parts.values():
+            _, handle = all_gather_async(
+                part.gather_input,
+                group,
+                output=part.gather_output,
+                async_op=async_op,
+            )
+            if handle is not None:
+                state.handles.append(handle)
+
+    @staticmethod
+    def wait_tp_weight_all_gather(state: TPWeightSwitchState) -> None:
+        try:
+            for handle in state.handles:
+                handle.wait()
+        finally:
+            state.handles.clear()
+
+    def switch_tp_weight(
+        self,
+        layer: torch.nn.Module,
+        state: TPWeightSwitchState,
+        *,
+        use_full_weight: bool,
+    ) -> None:
+        """Switch layer tensor attributes between TP-local and full views."""
+        for attr_name, gather_part in state.gather_parts.items():
+            target = gather_part.full_tensor if use_full_weight else gather_part.tp_tensor
+            with torch.no_grad():
+                getattr(layer, attr_name).set_(target)
+        for attr_name, repeat_part in state.repeat_parts.items():
+            target = repeat_part.full_tensor if use_full_weight else repeat_part.tp_tensor
+            with torch.no_grad():
+                getattr(layer, attr_name).set_(target)


### PR DESCRIPTION
### What this PR does / why we need it?

This is a selective backport of #12982 to `releases/v0.23.0`.

It moves DSA-CP o_proj tensor-parallel/full-weight switching into reusable quantization-method declarations and adds the shared `TPWeightSwitchMixin` implementation. The backport includes:

- DSA-CP o_proj gather, wait, and TP/full-weight switching through the common interface;
- input- and output-sharded gather specifications for supported unquantized and Ascend quantization methods;
- compatibility handling for the v0.23.0 compressed-tensors and MoE APIs; and
- focused unit tests for the shared switch state and DSA-CP integration.

This is intentionally not a full cherry-pick of #12982. Changes to `sfa_v1.py`, `sfa_cp.py`, and the SFA tests are excluded so that the existing v0.23.0 SFA implementation is unaffected.

### Does this PR introduce _any_ user-facing change?

Yes. DSA-CP o_proj TP/full-weight switching can use the quantization-specific tensor layouts declared by supported Ascend linear methods instead of relying on hard-coded weight and scale handling.

There is no new public API or configuration option.

### How was this patch tested?

- `git diff HEAD^ HEAD --check`
- Python AST syntax parsing for all 16 changed Python files
- Verified that `sfa_v1.py`, `sfa_cp.py`, and `test_sfa_o_proj_tp.py` have no diff in the commit

The NPU-dependent unit tests were not run locally. Recommended Ascend-container checks:

```bash
pytest -q tests/ut/quantization/test_tp_weight_switch.py \
  tests/ut/attention/test_dsa_cp_o_proj_tp.py
```

- Original change: #12982

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
