### PR TITLE
[Refactor][DSA][2/N] rectify the dsa_cp metadata data

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1,0 +1,266 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
+from vllm_ascend.device.device_op import DeviceOperator
+
+
+def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            model_type="test",
+            num_attention_heads=64,
+            index_topk=512,
+            index_n_heads=64,
+            index_head_dim=128,
+            sliding_window=4096,
+        ),
+        enable_sleep_mode=False,
+        get_head_size=lambda: 512,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=16,
+            max_num_seqs=4,
+        ),
+        speculative_config=None,
+    )
+    kv_cache_spec = SimpleNamespace(compress_ratio=compressor_ratio)
+    builder = AscendDSAMetadataBuilder(
+        kv_cache_spec=kv_cache_spec,
+        layer_names=["model.layers.0.self_attn.attn"],
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+    )
+
+    # These caches are supplied by model_runner through build() in production.
+    builder.prefill_ratio_to_sas_metadata = {}
+    builder.decode_ratio_to_sas_metadata = {}
+    builder.seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    builder.num_decodes = 2
+    return builder
+
+
+@pytest.mark.parametrize(
+    ("compressor_ratio", "expected_cmp_ratio", "expected_cmp_topk", "expected_has_cmp_kv"),
+    [
+        (1, 1, 0, False),
+        (4, 4, 512, True),
+        (8, 128, 0, True),
+        (128, 128, 0, True),
+    ],
+)
+def test_build_sas_metadata_parameters_cache_and_output_buffer(
+    compressor_ratio,
+    expected_cmp_ratio,
+    expected_cmp_topk,
+    expected_has_cmp_kv,
+):
+    builder = _make_builder(compressor_ratio)
+    metadata_cache = {}
+    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    cu_seqlens_ori_kv = torch.tensor([0, 8, 14], dtype=torch.int32)
+    cu_seqlens_cmp_kv = torch.tensor([0, 2, 4], dtype=torch.int32)
+    generated_metadata = torch.arange(1024, dtype=torch.int32)
+    output_buffer = torch.zeros_like(generated_metadata)
+    metadata_op = MagicMock(return_value=generated_metadata)
+
+    with (
+        patch(
+            "vllm_ascend.attention.dsa_v1.get_tensor_model_parallel_world_size",
+            return_value=2,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_op",
+            return_value=metadata_op,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_metadata_kwargs",
+            return_value={"device": "cpu"},
+        ),
+    ):
+        result = builder._build_sas_metadata(
+            metadata_cache=metadata_cache,
+            layer_name=f"c{compressor_ratio}",
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            max_seqlen_q=2,
+            max_seqlen_kv=8,
+            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+        )
+        cached_result = builder._build_sas_metadata(
+            metadata_cache=metadata_cache,
+            layer_name=f"c{compressor_ratio}",
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            max_seqlen_q=2,
+            max_seqlen_kv=8,
+            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+            output_buffer=output_buffer,
+        )
+
+    assert result is generated_metadata
+    assert cached_result is output_buffer
+    assert torch.equal(output_buffer, generated_metadata)
+    metadata_op.assert_called_once()
+    call_kwargs = metadata_op.call_args.kwargs
+    assert call_kwargs["device"] == "cpu"
+    assert call_kwargs["num_heads_q"] == 32
+    assert call_kwargs["cmp_ratio"] == expected_cmp_ratio
+    assert call_kwargs["cmp_topk"] == expected_cmp_topk
+    assert call_kwargs["has_cmp_kv"] is expected_has_cmp_kv
+    assert call_kwargs["cu_seqlens_q"] is query_start_loc
+    assert call_kwargs["cu_seqlens_ori_kv"] is cu_seqlens_ori_kv
+    assert call_kwargs["cu_seqlens_cmp_kv"] is cu_seqlens_cmp_kv
+    assert call_kwargs["seqused_kv"] is seq_lens
+
+
+def test_build_qli_metadata_parameters_cache_and_output_buffer():
+    builder = _make_builder()
+    metadata_cache = {}
+    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    generated_metadata = torch.arange(1024, dtype=torch.int32)
+    output_buffer = torch.zeros_like(generated_metadata)
+
+    with patch.object(
+        torch.ops._C_ascend,
+        "npu_vllm_quant_lightning_indexer_metadata",
+        create=True,
+        return_value=generated_metadata,
+    ) as metadata_op:
+        result = builder._build_qli_metadata(
+            metadata_cache=metadata_cache,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            max_seqlen_q=2,
+            max_seqlen_kv=8,
+        )
+        cached_result = builder._build_qli_metadata(
+            metadata_cache=metadata_cache,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            max_seqlen_q=2,
+            max_seqlen_kv=8,
+            output_buffer=output_buffer,
+        )
+
+    assert result is generated_metadata
+    assert cached_result is output_buffer
+    assert torch.equal(output_buffer, generated_metadata)
+    metadata_op.assert_called_once()
+    call_kwargs = metadata_op.call_args.kwargs
+    assert torch.equal(call_kwargs["actual_seq_lengths_query"], query_start_loc[1:])
+    assert torch.equal(call_kwargs["actual_seq_lengths_key"], seq_lens)
+    assert call_kwargs["max_seqlen_q"] == 2
+    assert call_kwargs["max_seqlen_k"] == 8
+    assert call_kwargs["cmp_ratio"] == 4
+
+
+def test_prefill_and_decode_sas_wrappers_route_phase_specific_inputs():
+    builder = _make_builder()
+    prefill_result = torch.full((1024,), 1, dtype=torch.int32)
+    decode_result = torch.full((1024,), 2, dtype=torch.int32)
+    builder._build_sas_metadata = MagicMock(side_effect=[prefill_result, decode_result])
+    prefill_query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    prefill_seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    seq_lens_q = torch.tensor([2, 1], dtype=torch.int32)
+    decode_query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+    decode_seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    decode_cu_seqlens_ori_kv = torch.tensor([0, 8, 14], dtype=torch.int32)
+    decode_cu_seqlens_cmp_kv = torch.tensor([0, 2, 4], dtype=torch.int32)
+
+    prefill_actual = builder._build_prefill_sas_metadata(
+        "c4",
+        prefill_query_start_loc,
+        prefill_seq_lens,
+        seq_lens_q,
+    )
+    with (
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_ori_kv",
+            return_value=decode_cu_seqlens_ori_kv,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_decode_cu_seqlens_cmp_kv",
+            return_value=decode_cu_seqlens_cmp_kv,
+        ),
+    ):
+        decode_actual = builder._build_decode_sas_metadata(
+            "c4",
+            decode_query_start_loc,
+            decode_seq_lens,
+            max_seqlen_q=1,
+            max_seqlen_kv=8,
+        )
+
+    assert prefill_actual is prefill_result
+    assert decode_actual is decode_result
+    prefill_kwargs = builder._build_sas_metadata.call_args_list[0].kwargs
+    assert prefill_kwargs["metadata_cache"] is builder.prefill_ratio_to_sas_metadata
+    assert prefill_kwargs["cu_seqlens_ori_kv"] is prefill_query_start_loc
+    assert prefill_kwargs["cu_seqlens_cmp_kv"] is None
+    assert "output_buffer" not in prefill_kwargs
+    decode_kwargs = builder._build_sas_metadata.call_args_list[1].kwargs
+    assert decode_kwargs["metadata_cache"] is builder.decode_ratio_to_sas_metadata
+    assert decode_kwargs["cu_seqlens_ori_kv"] is decode_cu_seqlens_ori_kv
+    assert decode_kwargs["cu_seqlens_cmp_kv"] is decode_cu_seqlens_cmp_kv
+    assert decode_kwargs["output_buffer"] is builder.decode_sas_metadata
+
+
+def test_prefill_and_decode_qli_wrappers_route_decode_output_buffer():
+    builder = _make_builder()
+    prefill_result = torch.full((1024,), 1, dtype=torch.int32)
+    decode_result = torch.full((1024,), 2, dtype=torch.int32)
+    builder._build_qli_metadata = MagicMock(side_effect=[prefill_result, decode_result])
+    query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    seq_lens = torch.tensor([8, 6], dtype=torch.int32)
+    seq_lens_q = torch.tensor([2, 1], dtype=torch.int32)
+
+    prefill_actual = builder._build_prefill_qli_metadata(
+        query_start_loc,
+        seq_lens,
+        seq_lens_q,
+    )
+    decode_actual = builder._build_decode_qli_metadata(
+        query_start_loc,
+        seq_lens,
+        max_seqlen_q=2,
+        max_seqlen_kv=8,
+    )
+
+    assert prefill_actual is prefill_result
+    assert decode_actual is decode_result
+    prefill_kwargs = builder._build_qli_metadata.call_args_list[0].kwargs
+    assert prefill_kwargs["metadata_cache"] is builder.prefill_ratio_to_sas_metadata
+    assert prefill_kwargs["max_seqlen_q"] == 2
+    assert prefill_kwargs["max_seqlen_kv"] == 8
+    assert "output_buffer" not in prefill_kwargs
+    decode_kwargs = builder._build_qli_metadata.call_args_list[1].kwargs
+    assert decode_kwargs["metadata_cache"] is builder.decode_ratio_to_sas_metadata

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -76,7 +76,7 @@ def test_build_sas_metadata_parameters_cache_and_output_buffer(
     expected_has_cmp_kv,
 ):
     builder = _make_builder(compressor_ratio)
-    metadata_cache = {}
+    metadata_cache: dict[str, torch.Tensor] = {}
     query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
     seq_lens = torch.tensor([8, 6], dtype=torch.int32)
     cu_seqlens_ori_kv = torch.tensor([0, 8, 14], dtype=torch.int32)
@@ -141,7 +141,7 @@ def test_build_sas_metadata_parameters_cache_and_output_buffer(
 
 def test_build_qli_metadata_parameters_cache_and_output_buffer():
     builder = _make_builder()
-    metadata_cache = {}
+    metadata_cache: dict[str, torch.Tensor] = {}
     query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
     seq_lens = torch.tensor([8, 6], dtype=torch.int32)
     generated_metadata = torch.arange(1024, dtype=torch.int32)

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -149,13 +149,7 @@ M = TypeVar("M", bound=AscendDSAMetadata)
 
 
 class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
-    # Does this backend/builder support ACL Graphs for attention (default: no).
-    aclgraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     hadamard = None
-    start_pos_prefill: torch.Tensor
-    req_sas_metadata: torch.Tensor
-    req_qli_metadata: torch.Tensor
-    block_size: int = 128
     """
     NOTE: Please read the comment at the top of the file before trying to
     understand this class
@@ -186,6 +180,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.slot_mapping: torch.Tensor = None
         self.seq_lens: torch.Tensor = None
         self.seq_lens_cpu: torch.Tensor = None
+        self.block_size: int = 128
 
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
         hf_config = self.model_config.hf_config

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -207,9 +207,6 @@ class AscendDSAPrefillMetadata:
 class AscendDSADecodeMetadata:
     block_table: torch.Tensor
     seq_lens: torch.Tensor
-    max_seqlen_q: int
-    seq_lens_list: list[int]
-    max_seq_lens: int
     slot_mapping: torch.Tensor | None
     block_size: int
 

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -624,17 +624,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             tp_size = get_tensor_model_parallel_world_size()
             n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
             index_topk = self.model_config.hf_config.index_topk
-            cmp_ratio = (
-                1
-                if self.compressor_ratio <= 1
-                else 4
-                if self.compressor_ratio == 4
-                else 128
-            )
+            cmp_ratio = 1 if self.compressor_ratio <= 1 else 4 if self.compressor_ratio == 4 else 128
             metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(
-                self.seqused_q.device
-            )
+            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
             sas_metadata = metadata_op(
                 **metadata_kwargs,
                 num_heads_q=n_local_heads,
@@ -859,9 +851,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 self._zero_i32,
                 self.cu_seqlens_ori_kv,
             )
-            cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(
-                self.cu_seqlens_cmp_kv
-            )
+            cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
         return self._build_sas_metadata(
             metadata_cache=self.decode_ratio_to_sas_metadata,
             layer_name=layer_name,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -181,16 +181,11 @@ class AscendDSAPrefillMetadata:
     """Prefill Specific Metadata for Ascend"""
 
     attn_mask: torch.Tensor
-    query_lens: torch.Tensor
     seq_lens: torch.Tensor
-    context_lens: torch.Tensor
-    input_positions: torch.Tensor
     query_start_loc: torch.Tensor
     block_table: torch.Tensor
     slot_mapping: torch.Tensor | None
     block_size: int
-    max_query_len: int
-    max_seq_lens: int
 
     num_compressed_tokens: int | None = None
     sin: torch.Tensor = None
@@ -210,12 +205,8 @@ class AscendDSAPrefillMetadata:
 
 @dataclass
 class AscendDSADecodeMetadata:
-    # Input positions for rotrary embeddings since for MLA the rotary
-    # position embeddings are applied inside the attention backend
-    input_positions: torch.Tensor
     block_table: torch.Tensor
     seq_lens: torch.Tensor
-    max_seqlen_kv: int
     max_seqlen_q: int
     seq_lens_list: list[int]
     max_seq_lens: int
@@ -224,14 +215,10 @@ class AscendDSADecodeMetadata:
 
     num_compressed_tokens: int | None = None
     query_start_loc: torch.tensor = None
-    query_start_loc_cpu: torch.tensor = None
-    attn_mask: torch.Tensor | None = None
     sin: torch.Tensor = None
     cos: torch.Tensor = None
     full_compress_sin: torch.Tensor = None
     full_compress_cos: torch.Tensor = None
-    cp_seq_len: torch.Tensor = None
-    batch_seq_mask: torch.Tensor = None
     start_pos: torch.Tensor = None
     num_reqs_actual: int | None = None
     sas_metadata: torch.Tensor = None
@@ -260,13 +247,8 @@ class AscendDSAMetadata:
     num_decode_tokens: int
     num_prefills: int
 
-    # For logging.
-    num_input_tokens: int = 0  # Number of tokens including padding.
-
-    query_lens: list[int] | None = None
     # The dimension of the attention heads
     head_dim: int | None = None
-    attn_mask: torch.Tensor = None
     # chunked prefill by default if no attn_states passed
     attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill
 
@@ -358,16 +340,7 @@ def build_dspark_swa_indices(
 
 
 class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
-    # Does this backend/builder support ACL Graphs for attention (default: no).
-    aclgraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     hadamard = None
-    start_pos_prefill: torch.Tensor | None = None
-    start_pos_decode: torch.Tensor | None = None
-    decode_sas_metadata: torch.Tensor | None = None
-    decode_qli_metadata: torch.Tensor | None = None
-    prefill_ratio_to_sas_metadata: dict | None = None
-    decode_ratio_to_sas_metadata: dict | None = None
-    block_size: int = 128
     """
     NOTE: Please read the comment at the top of the file before trying to
     understand this class
@@ -418,36 +391,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.num_prefill_tokens = 0
         self.num_actual_tokens: int | None = None
         self.block_table: torch.Tensor = None
-        self.slot_mapping: torch.Tensor = None
-        self.graph_pad_size = 0
-        self.query_lens: torch.Tensor = None
+        self.prefill_ratio_to_sas_metadata: dict | None = None
+        self.decode_ratio_to_sas_metadata: dict | None = None
+        self.block_size: int = 128
         self.seq_lens: torch.Tensor = None
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
-        hf_config = self.model_config.hf_config
-
-        if AscendDSAMetadataBuilder.hadamard is None:
-            if hf_config.model_type == "deepseek_v4":
-                indexer_head_dim = hf_config.index_head_dim
-                try:
-                    from scipy.linalg import hadamard  # type: ignore[import-untyped]
-                except ImportError as e:
-                    raise ImportError("Please install scipy") from e
-                log_dim = math.ceil(math.log2(indexer_head_dim))
-                dim_padded = 2**log_dim
-                if self.vllm_config.model_config.enable_sleep_mode:
-                    # Sleep mode allocates KV inside CaMemAllocator; tag Hadamard so
-                    # sleep/wake does not treat it as KV cache.
-                    from vllm_ascend.device_allocator.camem import CaMemAllocator
-
-                    allocator = CaMemAllocator.get_instance()
-                    with allocator.use_allocation_tag(CaMemAllocator.sleep_persistent_tag):
-                        AscendDSAMetadataBuilder.hadamard = torch.tensor(
-                            hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
-                        ).to(torch.bfloat16)
-                else:
-                    AscendDSAMetadataBuilder.hadamard = torch.tensor(
-                        hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
-                    ).to(torch.bfloat16)
+        self._init_hadamard()
         self.start_pos_prefill = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.start_pos_decode = torch.zeros(scheduler_config.max_num_seqs, dtype=torch.int32, device=self.device)
         self.decode_sas_metadata = torch.zeros(1024, dtype=torch.int32, device=self.device)
@@ -459,6 +408,36 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         # Note(qcs): we use two dimension slot_mapping for kvcache with shape
         # [block_nums, block_size, head_num, head_dim]
         self.slot_mapping = torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
+
+    def _init_hadamard(self) -> None:
+        if AscendDSAMetadataBuilder.hadamard is not None:
+            return
+
+        hf_config = self.model_config.hf_config
+        if hf_config.model_type != "deepseek_v4":
+            return
+
+        indexer_head_dim = hf_config.index_head_dim
+        try:
+            from scipy.linalg import hadamard  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise ImportError("Please install scipy") from e
+        log_dim = math.ceil(math.log2(indexer_head_dim))
+        dim_padded = 2**log_dim
+        if self.vllm_config.model_config.enable_sleep_mode:
+            # Sleep mode allocates KV inside CaMemAllocator; tag Hadamard so
+            # sleep/wake does not treat it as KV cache.
+            from vllm_ascend.device_allocator.camem import CaMemAllocator
+
+            allocator = CaMemAllocator.get_instance()
+            with allocator.use_allocation_tag(CaMemAllocator.sleep_persistent_tag):
+                AscendDSAMetadataBuilder.hadamard = torch.tensor(
+                    hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
+                ).to(torch.bfloat16)
+        else:
+            AscendDSAMetadataBuilder.hadamard = torch.tensor(
+                hadamard(dim_padded, dtype=float), dtype=torch.float, device=self.device
+            ).to(torch.bfloat16)
 
     @classmethod
     def get_cudagraph_support(
@@ -526,7 +505,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
     def _num_compressor_metadata_rows(
         self,
         build_step: int,
-        common_attn_metadata: AscendCommonAttentionMetadata,
     ) -> int:
         if build_step == BUILD_METADATA_STEP_PREFILL:
             num_tokens = self.num_prefill_tokens
@@ -579,11 +557,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.common_ratio_to_sas_metadata["sin"] = sin
             self.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
             self.common_ratio_to_sas_metadata["seq_lens"] = self.seq_lens
-
-            query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
-            query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-            self.query_lens = query_seq_lens_cpu[:num_reqs]
-            self.common_ratio_to_sas_metadata["query_lens"] = self.query_lens
         else:
             self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (
                 self.common_ratio_to_sas_metadata["num_decodes"],
@@ -596,12 +569,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             input_positions = self.common_ratio_to_sas_metadata["input_positions"]
             cos, sin = self.common_ratio_to_sas_metadata["cos"], self.common_ratio_to_sas_metadata["sin"]
             self.seq_lens = self.common_ratio_to_sas_metadata["seq_lens"]
-            self.query_lens = self.common_ratio_to_sas_metadata["query_lens"]
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
         self.slot_mapping[:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(slot_mapping, self.block_size)
 
-        self.graph_pad_size = common_attn_metadata.graph_pad_size
         block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_PREFILL)
         self.block_table = common_attn_metadata.block_table_tensor[:block_table_size]
 
@@ -619,15 +590,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             decode_metadata = self.build_decode_metadata(common_prefix_len, common_attn_metadata, num_reqs_actual)
 
         return self.metadata_cls(  # type: ignore
-            num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=self.num_actual_tokens,
-            query_lens=self.query_lens,
             slot_mapping=None,
             head_dim=self.model_config.get_head_size(),
             num_decodes=self.num_decodes,
             num_decode_tokens=self.num_decode_tokens,
             num_prefills=self.num_prefills,
-            attn_mask=None,
             attn_state=common_attn_metadata.attn_state,
             prefill=prefill_metadata,
             decode=decode_metadata,
@@ -637,6 +605,137 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos=cos,
             sin=sin,
             hadamard=AscendDSAMetadataBuilder.hadamard,
+        )
+
+    def _build_sas_metadata(
+        self,
+        metadata_cache: dict,
+        layer_name: str,
+        query_start_loc: torch.Tensor,
+        seq_lens: torch.Tensor,
+        max_seqlen_q: int | torch.Tensor,
+        max_seqlen_kv: int | torch.Tensor,
+        cu_seqlens_ori_kv: torch.Tensor | None,
+        cu_seqlens_cmp_kv: torch.Tensor | None,
+        output_buffer: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        sas_metadata = metadata_cache.get(layer_name)
+        if sas_metadata is None:
+            tp_size = get_tensor_model_parallel_world_size()
+            n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
+            index_topk = self.model_config.hf_config.index_topk
+            cmp_ratio = (
+                1
+                if self.compressor_ratio <= 1
+                else 4
+                if self.compressor_ratio == 4
+                else 128
+            )
+            metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
+            metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(
+                self.seqused_q.device
+            )
+            sas_metadata = metadata_op(
+                **metadata_kwargs,
+                num_heads_q=n_local_heads,
+                num_heads_kv=1,
+                head_dim=self.model_config.get_head_size(),
+                cu_seqlens_q=query_start_loc,
+                cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+                cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+                seqused_q=self.seqused_q,
+                seqused_kv=seq_lens,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_kv=max_seqlen_kv,
+                batch_size=len(seq_lens),
+                cmp_topk=index_topk if self.compressor_ratio == 4 else 0,
+                cmp_ratio=cmp_ratio,
+                ori_mask_mode=4,  # 4:sliding window
+                cmp_mask_mode=3,  # 3:causal
+                ori_win_left=self.model_config.hf_config.sliding_window - 1,
+                ori_win_right=0,
+                layout_q="TND",
+                layout_kv="PA_ND",
+                has_ori_kv=True,
+                has_cmp_kv=self.compressor_ratio > 1,
+            )
+            metadata_cache[layer_name] = sas_metadata
+
+        if output_buffer is not None:
+            output_buffer[:1024] = sas_metadata
+            return output_buffer
+        return sas_metadata
+
+    def _build_qli_metadata(
+        self,
+        metadata_cache: dict,
+        query_start_loc: torch.Tensor,
+        seq_lens: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+        output_buffer: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        qli_metadata = metadata_cache.get("qli")
+        if qli_metadata is None:
+            qli_metadata = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
+                actual_seq_lengths_query=query_start_loc[1:].clone(),
+                actual_seq_lengths_key=seq_lens.clone(),
+                num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
+                num_heads_k=1,
+                head_dim=self.model_config.hf_config.index_head_dim,  # 128
+                query_quant_mode=0,
+                key_quant_mode=0,
+                batch_size=len(seq_lens),
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_kv,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=self.model_config.hf_config.index_topk,  # 512
+                sparse_mode=3,
+                pre_tokens=(1 << 63) - 1,
+                next_tokens=(1 << 63) - 1,
+                cmp_ratio=4,
+                device=str(self.seqused_q.device),
+            )
+            metadata_cache["qli"] = qli_metadata
+
+        if output_buffer is not None:
+            output_buffer[:1024] = qli_metadata
+            return output_buffer
+        return qli_metadata
+
+    def _build_prefill_sas_metadata(
+        self,
+        layer_name: str,
+        prefill_query_start_loc: torch.Tensor,
+        prefill_seq_lens: torch.Tensor,
+        seq_lens_q: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self.prefill_ratio_to_sas_metadata is not None
+        return self._build_sas_metadata(
+            metadata_cache=self.prefill_ratio_to_sas_metadata,
+            layer_name=layer_name,
+            query_start_loc=prefill_query_start_loc,
+            seq_lens=prefill_seq_lens,
+            max_seqlen_q=seq_lens_q.max(),
+            max_seqlen_kv=prefill_seq_lens.max(),
+            cu_seqlens_ori_kv=prefill_query_start_loc,
+            cu_seqlens_cmp_kv=None,
+        )
+
+    def _build_prefill_qli_metadata(
+        self,
+        prefill_query_start_loc: torch.Tensor,
+        prefill_seq_lens: torch.Tensor,
+        seq_lens_q: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self.prefill_ratio_to_sas_metadata is not None
+        return self._build_qli_metadata(
+            metadata_cache=self.prefill_ratio_to_sas_metadata,
+            query_start_loc=prefill_query_start_loc,
+            seq_lens=prefill_seq_lens,
+            max_seqlen_q=seq_lens_q.max().item(),
+            max_seqlen_kv=prefill_seq_lens.max().item(),
         )
 
     def build_prefill_metadata(
@@ -656,19 +755,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         if self.prefill_ratio_to_sas_metadata.get("prefill_input_positions", None) is None:
             input_positions = common_attn_metadata.positions[: self.num_actual_tokens].long()
-            max_query_len = self.query_lens[reqs_start:].max().item()
-            # Prefer _seq_lens_cpu (always available, updated during draft
-            # iterations) over seq_lens_cpu (None in async spec decode mode).
-            if common_attn_metadata._seq_lens_cpu is not None:
-                _seq_lens_cpu = common_attn_metadata._seq_lens_cpu
-            elif common_attn_metadata.seq_lens_cpu is not None:
-                _seq_lens_cpu = common_attn_metadata.seq_lens_cpu
-            else:
-                _seq_lens_cpu = common_attn_metadata.seq_lens.cpu()
-            max_seq_lens = _seq_lens_cpu[reqs_start:].max().item()
             self.prefill_ratio_to_sas_metadata["input_positions"] = input_positions
-            self.prefill_ratio_to_sas_metadata["max_query_len"] = max_query_len
-            self.prefill_ratio_to_sas_metadata["max_seq_lens"] = max_seq_lens
 
             prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
             prefill_input_positions = input_positions[tokens_start:]
@@ -685,8 +772,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             self.prefill_ratio_to_sas_metadata["num_prefill"] = num_prefill
         else:
             input_positions = self.prefill_ratio_to_sas_metadata["input_positions"]
-            max_query_len = self.prefill_ratio_to_sas_metadata["max_query_len"]
-            max_seq_lens = self.prefill_ratio_to_sas_metadata["max_seq_lens"]
             prefill_input_positions = self.prefill_ratio_to_sas_metadata["prefill_input_positions"]
             prefill_query_start_loc = self.prefill_ratio_to_sas_metadata["prefill_query_start_loc"]
             cos = self.prefill_ratio_to_sas_metadata["cos"]
@@ -715,7 +800,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             # launched in forward at the real compressor consumer.
             num_compressed_tokens = self._num_compressor_metadata_rows(
                 BUILD_METADATA_STEP_PREFILL,
-                common_attn_metadata,
             )
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             prefill_slot_mapping = None
@@ -723,129 +807,25 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_compressed_tokens = self.num_prefill_tokens
             prefill_slot_mapping = self.slot_mapping[tokens_start : tokens_start + self.num_prefill_tokens]
 
-        tp_size = get_tensor_model_parallel_world_size()
-        n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
-        index_topk = self.model_config.hf_config.index_topk
-
-        cu_c4_cmp_seqlen_list = None
-        cu_c128_cmp_seqlen_list = None
-
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        if self.compressor_ratio <= 1:
-            if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=prefill_query_start_loc,
-                    cu_seqlens_ori_kv=prefill_query_start_loc,
-                    cu_seqlens_cmp_kv=None,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    cmp_ratio=1,
-                    ori_mask_mode=4,  # 4:sliding window
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=False,
-                )
-            sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
-        elif self.compressor_ratio == 4:
-            if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=prefill_query_start_loc,
-                    cu_seqlens_ori_kv=prefill_query_start_loc,
-                    cu_seqlens_cmp_kv=cu_c4_cmp_seqlen_list,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    cmp_topk=index_topk,
-                    # topk=index_topk,
-                    cmp_ratio=4,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
-        else:
-            if self.prefill_ratio_to_sas_metadata.get(layer_name) is None:
-                self.prefill_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=prefill_query_start_loc,
-                    cu_seqlens_ori_kv=prefill_query_start_loc,
-                    cu_seqlens_cmp_kv=cu_c128_cmp_seqlen_list,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[reqs_start:],
-                    max_seqlen_q=seq_lens_q.max(),
-                    max_seqlen_kv=self.seq_lens[reqs_start:].max(),
-                    batch_size=len(self.seq_lens[reqs_start:]),
-                    cmp_ratio=128,  #
-                    ori_mask_mode=4,  # 4:sliding window
-                    cmp_mask_mode=3,  # 3:causal
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            sas_metadata = self.prefill_ratio_to_sas_metadata[layer_name]
-        if self.prefill_ratio_to_sas_metadata.get("qli") is None:
-            self.prefill_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
-                actual_seq_lengths_query=prefill_query_start_loc[1:].clone(),
-                actual_seq_lengths_key=self.seq_lens[reqs_start:].clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
-                num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,  # 128
-                query_quant_mode=0,
-                key_quant_mode=0,
-                batch_size=len(self.seq_lens[reqs_start:]),
-                max_seqlen_q=seq_lens_q.max().item(),
-                max_seqlen_k=self.seq_lens[reqs_start:].max().item(),
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,  # 512
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
-                cmp_ratio=4,
-                device=str(self.seqused_q.device),
-            )
-        qli_metadata = self.prefill_ratio_to_sas_metadata.get("qli")
+        sas_metadata = self._build_prefill_sas_metadata(
+            layer_name,
+            prefill_query_start_loc,
+            prefill_seq_lens,
+            seq_lens_q,
+        )
+        qli_metadata = self._build_prefill_qli_metadata(
+            prefill_query_start_loc,
+            prefill_seq_lens,
+            seq_lens_q,
+        )
 
         return AscendDSAPrefillMetadata(
             attn_mask=None,
-            query_lens=self.query_lens[reqs_start:].to(torch.int32),
             seq_lens=self.seq_lens[reqs_start:],
-            context_lens=self.seq_lens[reqs_start:],
-            input_positions=prefill_input_positions,
             block_table=self.block_table[reqs_start:, ...],
             slot_mapping=prefill_slot_mapping,
             block_size=self.block_size,
             num_compressed_tokens=num_compressed_tokens,
-            max_query_len=max_query_len,
-            max_seq_lens=max_seq_lens,
             query_start_loc=prefill_query_start_loc,
             sin=sin,
             cos=cos,
@@ -855,8 +835,60 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             num_reqs_actual=num_prefills_actual,
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
-            cu_c4_cmp_seqlen_list=cu_c4_cmp_seqlen_list,
-            cu_c128_cmp_seqlen_list=cu_c128_cmp_seqlen_list,
+            cu_c4_cmp_seqlen_list=None,
+            cu_c128_cmp_seqlen_list=None,
+        )
+
+    def _build_decode_sas_metadata(
+        self,
+        layer_name: str,
+        query_start_loc: torch.Tensor,
+        decode_seq_lens: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+    ) -> torch.Tensor:
+        assert self.decode_ratio_to_sas_metadata is not None
+        cu_seqlens_ori_kv = None
+        cu_seqlens_cmp_kv = None
+        if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
+            cu_seqlens_ori_kv = DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
+                self.decode_ratio_to_sas_metadata,
+                "cu_seqlens_ori_kv",
+                self.seq_lens,
+                self.num_decodes,
+                self._zero_i32,
+                self.cu_seqlens_ori_kv,
+            )
+            cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(
+                self.cu_seqlens_cmp_kv
+            )
+        return self._build_sas_metadata(
+            metadata_cache=self.decode_ratio_to_sas_metadata,
+            layer_name=layer_name,
+            query_start_loc=query_start_loc,
+            seq_lens=decode_seq_lens,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=max_seqlen_kv,
+            cu_seqlens_ori_kv=cu_seqlens_ori_kv,
+            cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
+            output_buffer=self.decode_sas_metadata,
+        )
+
+    def _build_decode_qli_metadata(
+        self,
+        query_start_loc: torch.Tensor,
+        decode_seq_lens: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_kv: int,
+    ) -> torch.Tensor:
+        assert self.decode_ratio_to_sas_metadata is not None
+        return self._build_qli_metadata(
+            metadata_cache=self.decode_ratio_to_sas_metadata,
+            query_start_loc=query_start_loc,
+            seq_lens=decode_seq_lens,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_kv=max_seqlen_kv,
+            output_buffer=self.decode_qli_metadata,
         )
 
     def build_decode_metadata(
@@ -885,11 +917,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 _seq_lens_cpu = common_attn_metadata.seq_lens_cpu
             else:
                 _seq_lens_cpu = common_attn_metadata.seq_lens.cpu()
-            max_seq_lens = _seq_lens_cpu[: self.num_decodes].max().item()
-            seq_lens_list = _seq_lens_cpu[: self.num_decodes].tolist()
-            self.decode_ratio_to_sas_metadata["query_start_loc_cpu"] = query_start_loc_cpu
-            self.decode_ratio_to_sas_metadata["max_seq_lens"] = max_seq_lens
-            self.decode_ratio_to_sas_metadata["seq_lens_list"] = seq_lens_list
 
             max_seqlen_kv = torch.max(_seq_lens_cpu[: self.num_decodes]).item()
             max_seqlen_q = torch.max(query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]).item()
@@ -904,16 +931,11 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             input_positions = self.decode_ratio_to_sas_metadata["input_positions"]
             cos = self.decode_ratio_to_sas_metadata["cos"]
             sin = self.decode_ratio_to_sas_metadata["sin"]
-            query_start_loc_cpu = self.decode_ratio_to_sas_metadata["query_start_loc_cpu"]
-            max_seq_lens = self.decode_ratio_to_sas_metadata["max_seq_lens"]
-            seq_lens_list = self.decode_ratio_to_sas_metadata["seq_lens_list"]
             max_seqlen_kv = self.decode_ratio_to_sas_metadata["max_seqlen_kv"]
             max_seqlen_q = self.decode_ratio_to_sas_metadata["max_seqlen_q"]
             start_pos_decode = self.decode_ratio_to_sas_metadata["start_pos_decode"]
 
         block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_DECODE)
-
-        cp_seq_len, batch_seq_mask = None, None
 
         assert self.start_pos_decode is not None
         self.start_pos_decode.fill_(0)
@@ -931,7 +953,6 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             # launched in forward at the real compressor consumer.
             num_compressed_tokens = self._num_compressor_metadata_rows(
                 BUILD_METADATA_STEP_DECODE,
-                common_attn_metadata,
             )
             full_compress_cos, full_compress_sin = get_full_cos_and_sin_dsa(layer_name)
             slot_mapping = None
@@ -944,150 +965,35 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 self.num_decodes,
             )
 
-        tp_size = get_tensor_model_parallel_world_size()
-        n_local_heads = self.model_config.hf_config.num_attention_heads // tp_size
-        index_topk = self.model_config.hf_config.index_topk
-
-        assert self.decode_sas_metadata is not None
-
-        cu_seqlens_ori_kv = DeviceOperator.get_dsa_decode_cu_seqlens_ori_kv(
-            self.decode_ratio_to_sas_metadata,
-            "cu_seqlens_ori_kv",
-            self.seq_lens,
-            self.num_decodes,
-            self._zero_i32,
-            self.cu_seqlens_ori_kv,
+        decode_seq_lens = self.seq_lens[: self.num_decodes]
+        sas_metadata = self._build_decode_sas_metadata(
+            layer_name,
+            query_start_loc,
+            decode_seq_lens,
+            max_seqlen_q,
+            max_seqlen_kv,
         )
-        metadata_op = DeviceOperator.get_dsa_sparse_attn_metadata_op()
-        metadata_kwargs = DeviceOperator.get_dsa_sparse_attn_metadata_kwargs(self.seqused_q.device)
-        cu_seqlens_cmp_kv = DeviceOperator.get_dsa_decode_cu_seqlens_cmp_kv(self.cu_seqlens_cmp_kv)
-        if self.compressor_ratio <= 1:
-            if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],  # cached
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
-                    batch_size=len(self.seq_lens[: self.num_decodes]),  # cached
-                    cmp_ratio=1,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=False,
-                )
-            self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
-        elif self.compressor_ratio == 4:
-            if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=query_start_loc,  # cached
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],  # cached
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
-                    batch_size=len(self.seq_lens[: self.num_decodes]),  # cached
-                    cmp_topk=index_topk,
-                    # topk=index_topk,
-                    cmp_ratio=4,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
-        else:
-            if self.decode_ratio_to_sas_metadata.get(layer_name) is None:
-                self.decode_ratio_to_sas_metadata[layer_name] = metadata_op(
-                    **metadata_kwargs,
-                    num_heads_q=n_local_heads,
-                    num_heads_kv=1,
-                    head_dim=self.model_config.get_head_size(),
-                    cu_seqlens_q=query_start_loc,
-                    cu_seqlens_ori_kv=cu_seqlens_ori_kv,
-                    cu_seqlens_cmp_kv=cu_seqlens_cmp_kv,
-                    seqused_q=self.seqused_q,
-                    seqused_kv=self.seq_lens[: self.num_decodes],
-                    max_seqlen_q=max_seqlen_q,
-                    max_seqlen_kv=max_seqlen_kv,
-                    batch_size=len(self.seq_lens[: self.num_decodes]),
-                    cmp_ratio=128,
-                    ori_mask_mode=4,
-                    cmp_mask_mode=3,
-                    ori_win_left=self.model_config.hf_config.sliding_window - 1,
-                    ori_win_right=0,
-                    layout_q="TND",
-                    layout_kv="PA_ND",
-                    has_ori_kv=True,
-                    has_cmp_kv=True,
-                )
-            self.decode_sas_metadata[:1024] = self.decode_ratio_to_sas_metadata[layer_name]
-        assert self.decode_qli_metadata is not None
-        if self.decode_ratio_to_sas_metadata.get("qli") is None:
-            self.decode_ratio_to_sas_metadata["qli"] = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
-                actual_seq_lengths_query=query_start_loc[1:].clone(),
-                actual_seq_lengths_key=self.seq_lens[: self.num_decodes].clone(),
-                num_heads_q=self.model_config.hf_config.index_n_heads,  # 64
-                num_heads_k=1,
-                head_dim=self.model_config.hf_config.index_head_dim,  # 128
-                query_quant_mode=0,
-                key_quant_mode=0,
-                batch_size=len(self.seq_lens[: self.num_decodes]),
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seqlen_kv,
-                layout_query="TND",
-                layout_key="PA_BSND",
-                sparse_count=self.model_config.hf_config.index_topk,  # 512
-                sparse_mode=3,
-                pre_tokens=(1 << 63) - 1,
-                next_tokens=(1 << 63) - 1,
-                cmp_ratio=4,
-                device=str(self.seqused_q.device),
-            )
-        self.decode_qli_metadata[:1024] = self.decode_ratio_to_sas_metadata.get("qli")
+        qli_metadata = self._build_decode_qli_metadata(
+            query_start_loc,
+            decode_seq_lens,
+            max_seqlen_q,
+            max_seqlen_kv,
+        )
         decode_metadata = AscendDSADecodeMetadata(
-            input_positions=input_positions,
             block_table=self.block_table[:block_table_size, ...],
             slot_mapping=slot_mapping,
             block_size=self.block_size,
             num_compressed_tokens=num_compressed_tokens,
-            seq_lens=self.seq_lens[: self.num_decodes],  # cached
-            seq_lens_list=seq_lens_list,
-            max_seq_lens=max_seq_lens,
-            max_seqlen_kv=max_seqlen_kv,
-            max_seqlen_q=max_seqlen_q,
-            attn_mask=None,
+            seq_lens=decode_seq_lens,  # cached
             query_start_loc=query_start_loc,  # cached
-            query_start_loc_cpu=query_start_loc_cpu,
             sin=sin[: self.num_decode_tokens, ...],
             cos=cos[: self.num_decode_tokens, ...],
             full_compress_sin=full_compress_sin,
             full_compress_cos=full_compress_cos,
-            cp_seq_len=cp_seq_len,
-            batch_seq_mask=batch_seq_mask,
             start_pos=self.start_pos_decode[: self.num_decodes],  # cached
             num_reqs_actual=num_decodes_actual,
-            sas_metadata=self.decode_sas_metadata,
-            qli_metadata=self.decode_qli_metadata,
+            sas_metadata=sas_metadata,
+            qli_metadata=qli_metadata,
         )
         return decode_metadata
 
@@ -1141,15 +1047,12 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             )
 
         return self.metadata_cls(  # type: ignore
-            num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=common_attn_metadata.num_actual_tokens,
-            query_lens=None,
             slot_mapping=None,
             head_dim=self.model_config.get_head_size(),
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
             num_prefills=num_prefills,
-            attn_mask=None,
             attn_state=common_attn_metadata.attn_state,
             prefill=prefill_metadata,
             decode=decode_metadata,
@@ -1216,15 +1119,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         return AscendDSAPrefillMetadata(
             attn_mask=None,
-            query_lens=None,
             seq_lens=seq_lens,
-            context_lens=None,
-            input_positions=None,  # type: ignore[arg-type]
             block_table=block_table[reqs_start:, ...],
             slot_mapping=prefill_slot_mapping,
             block_size=self.block_size,
-            max_query_len=None,  # type: ignore[arg-type]
-            max_seq_lens=None,  # type: ignore[arg-type]
             query_start_loc=prefill_query_start_loc,
             sin=sin,
             cos=cos,
@@ -1317,22 +1215,13 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         decode_sas_metadata = self.spec_sas_metadata[draft_index - 1]
 
         decode_metadata = AscendDSADecodeMetadata(
-            input_positions=None,
             block_table=block_table[:num_decodes, ...],
             slot_mapping=slot_mapping,
             block_size=self.block_size,
             seq_lens=seq_lens[:num_decodes],
-            seq_lens_list=None,  # type: ignore[arg-type]
-            max_seq_lens=None,  # type: ignore[arg-type]
-            max_seqlen_kv=None,  # type: ignore[arg-type]
-            max_seqlen_q=None,  # type: ignore[arg-type]
-            attn_mask=None,
             query_start_loc=query_start_loc,
-            query_start_loc_cpu=None,
             sin=sin[:num_decode_tokens, ...],
             cos=cos[:num_decode_tokens, ...],
-            cp_seq_len=None,
-            batch_seq_mask=None,
             start_pos=None,
             sas_metadata=decode_sas_metadata,
             qli_metadata=None,


### PR DESCRIPTION
### What this PR does / why we need it?
Rectify the dsa_v1 metadata data.  
1. Remove useless variables from AscendDSAPrefillMetadata, AscendDSADecodeMetadata, and AscendDSAMetadata.  
2. Extract the initialization Hadamard function.  
3. Unify the construction logic for sas metadata and qli metadata with different compression methods.

RFC： https://github.com/vllm-project/vllm-ascend/issues/13652
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
